### PR TITLE
Node 0.3.4+ compatability

### DIFF
--- a/lib/mongoose/schema.js
+++ b/lib/mongoose/schema.js
@@ -4,7 +4,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter
-  , Types = require('./schema/')
+  , Types = require('./schema/index.js')
   , utils = require('./utils');
 
 /**


### PR DESCRIPTION
Makes mongoose work under 0.3.4+. Related to commit https://github.com/ry/node/commit/1ac133ea6f34bb8ef493f8f908d0cdda9a3e626a that changed from path.join to path.resolve thus changing the lookup order of files for require('./file/') from 
'/dir/file/'
'/dir/file/.js'
'/dir/file/.node'
'/dir/file/index.js'
'/dir/file.js' 

to 

'/dir/file.[js,node]'
'/dir/file/index.[js,node]'

Illustration of the change: https://gist.github.com/798551 . 

Not a bug but intended behavior in node as the require order is what is described in the commit here:
https://github.com/Aikar/node/commit/0a3eff8021de38f11411369da3ea93bd9dbddd31
