### PR TITLE
Added back in support for database user authentication

### DIFF
--- a/lib/mongoose/connection.js
+++ b/lib/mongoose/connection.js
@@ -138,22 +138,22 @@ Connection.prototype.open = function (host, database, port, callback) {
 
 Connection.prototype.onOpen = function () {
   var self = this;
+  
   var continuation = function(){
    self.readyState = 1;
    // avoid having the collection subscribe to our event emitter
    // to prevent 0.3 warning
    for (var i in self.collections)
      self.collections[i].onOpen();
-
+     
    self.emit('open');
   };
   
   //do authentication before we continue if a database username and password exist
-  if(self.user && self.pass){
-    self.db.authenticate(self.user,self.pass,function(){
-      continuation();
-    });
-  } else continuation();
+  if(self.user && self.pass)
+    self.db.authenticate(self.user,self.pass,continuation);
+  else 
+    continuation();
 };
 
 /**


### PR DESCRIPTION
While porting my applications to the new version of Mongoose I noticed that the database user authentication was not working. This patch fixes that issue.
