### PR TITLE
Add $near to the SchemaArray $conditionalHandlers

### DIFF
--- a/lib/mongoose/schema/array.js
+++ b/lib/mongoose/schema/array.js
@@ -117,6 +117,9 @@ SchemaArray.prototype.$conditionalHandlers = {
   , '$nin': function (val) {
       return this.cast(val);
     }
+  , '$near': function (val) {
+      return this.cast(val);
+    }
 };
 SchemaArray.prototype.castForQuery = function ($conditional, val) {
   var handler;


### PR DESCRIPTION
Allow for $near queries with Arrays.

```
'path':{$near:[x,y]}
```

When using the geoSpatial indexing, order of the coordinates is important and can easily be problematic with object keys in mongo.  Arrays are a better way to ensure order and are supported in mongo natively. I added this to my codebase and it works fine. Not sure if there are other geoSpatial conditionals that this should be applied to as well ($within, etc), but I'll probably be running into the issue soon enough.
