### PR TITLE
Pass model options in query remove function

### DIFF
--- a/lib/mongoose/query.js
+++ b/lib/mongoose/query.js
@@ -845,10 +845,12 @@ Query.prototype.update = function (doc, callback) {
 
 Query.prototype.remove = function (callback) {
   this.op = 'remove';
-  var model = this.model;
+  var model = this.model
+    , options = this._optionsForExec(model);
+
   this.cast(model);
   var castQuery = this._conditions;
-  model.collection.remove(castQuery, callback);
+  model.collection.remove(castQuery, options, callback);
   return this;
 };
 


### PR DESCRIPTION
I made a simple fix to query.js so that the remove function will pass the model options when invoking the MongoDB remove command.
