### PR TITLE
Schema should drive object population in Document.init

### DIFF
--- a/lib/mongoose/document.js
+++ b/lib/mongoose/document.js
@@ -114,7 +114,7 @@ Document.prototype.init = function (doc, fn) {
         doc[i] = {};
         init(obj[i], doc[i], path + '.');
       }else if(obj[i]){
-        doc[i] = obj[i];
+        doc[i] = self.schema.path(path).cast(obj[i],self);
       }else{
         doc[i] = null;
       }


### PR DESCRIPTION
Previously when you added a new property to an existing Schema, the value would be returned as undefined.  

This doesn't seem like desired behavior so I updated the Document.init method to allow the Schema to drive the object population and will set any property that is defined in the schema, but not in mongo, to null.
