### PR TITLE
DBRef support and Model.merge

### DIFF
--- a/lib/mongoose/drivers/node-mongodb-native/dbref.js
+++ b/lib/mongoose/drivers/node-mongodb-native/dbref.js
@@ -1,0 +1,8 @@
+
+/**
+ * Module dependencies.
+ */
+
+var DBRef = require('../../../../support/node-mongodb-native/lib/mongodb/').BSONPure.DBRef;
+
+module.exports = exports = DBRef;

--- a/lib/mongoose/model.js
+++ b/lib/mongoose/model.js
@@ -531,6 +531,19 @@ Model.$where = function () {
 };
 
 /**
+ * Shortcut for merging changes (as a document) into an object.
+ *
+ * @param {Object} the document to be updated
+ * @param {Object} updated fields
+ * @api public
+ */
+Model.merge = function (obj, doc) {
+	Object.keys(doc).forEach( function(path) {
+		obj[path] = doc[path];
+    });
+}
+
+/**
  * Shortcut for creating a new Document that is automatically saved
  * to the db if valid.
  *

--- a/lib/mongoose/schema.js
+++ b/lib/mongoose/schema.js
@@ -509,6 +509,16 @@ function ObjectId () {
 }
 
 /**
+ * DBRef schema identifier. Not an actual DBRef, only used for Schemas.
+ *
+ * @api public
+ */
+function DBRef () {
+  throw new Error('This is an abstract interface. Its only purpose is to mark '
+                + 'fields as DBRef in the schema creation.');
+}
+
+/**
  * Module exports.
  */
 

--- a/lib/mongoose/schema/array.js
+++ b/lib/mongoose/schema/array.js
@@ -11,6 +11,7 @@ var SchemaType = require('../schematype')
       , Number: ArrayNumberSchema
       , String: require('./string')
       , ObjectId: require('./objectid')
+	  , DBRef: require('./dbref')
     }
   , MongooseArray = require('../types').Array
   , Query = require('../query');

--- a/lib/mongoose/schema/dbref.js
+++ b/lib/mongoose/schema/dbref.js
@@ -1,0 +1,94 @@
+
+/**
+ * Module dependencies.
+ */
+
+var SchemaType = require('../schematype')
+  , CastError = SchemaType.CastError
+  , driver = global.MONGOOSE_DRIVER_PATH || './../drivers/node-mongodb-native'
+  , dbref = require('../types/dbref')
+  , oid = require('./objectid');
+
+/**
+ * DBRef SchemaType constructor.
+ *
+ * @param {String} key
+ * @param {Object} options
+ * @api private
+ */
+
+function DBRef (key, options) {
+  SchemaType.call(this, key, options);
+};
+
+/**
+ * Inherits from SchemaType.
+ */
+
+DBRef.prototype.__proto__ = SchemaType.prototype;
+
+/**
+ * Check required
+ *
+ * @api private
+ */
+
+DBRef.prototype.checkRequired = function (value) {
+  return !!value && value instanceof dbref;
+};
+
+/**
+ * Casts to object
+ *
+ * @api private
+ */
+
+DBRef.prototype.cast = function (value) {
+  if (value === null) return value;
+
+  if (value instanceof dbref)
+    return value;
+
+  if (typeof value !== 'object')
+    throw new CastError('db reference', value);
+
+  if (value._id === null)
+    return new dbref(value.collection.name, value._id, value.db.name);
+
+  return new dbref(value["$ref"], oid.prototype.cast(value["$id"]), value["$db"]);
+};
+
+function handleSingle (val) {
+  return this.cast(val);
+}
+
+function handleArray (val) {
+  var self = this;
+  return val.map( function (m) {
+    return self.cast(m);
+  });
+}
+
+DBRef.prototype.$conditionalHandlers = {
+    '$ne': handleSingle
+  , '$in': handleArray
+  , '$nin': handleArray
+};
+DBRef.prototype.castForQuery = function ($conditional, val) {
+  var handler;
+  if (arguments.length === 2) {
+    handler = this.$conditionalHandlers[$conditional];
+    if (!handler)
+      throw new Error("Can't use " + $conditional + " with DBRef.");
+    return handler.call(this, val);
+  } else {
+    val = $conditional;
+    return this.cast(val);
+  }
+};
+
+/**
+ * Module exports.
+ */
+
+module.exports = DBRef;

--- a/lib/mongoose/schema/index.js
+++ b/lib/mongoose/schema/index.js
@@ -18,3 +18,5 @@ exports.Date = require('./date');
 exports.ObjectId = require('./objectid');
 
 exports.Mixed = require('./mixed');
+
+exports.DBRef = require('./dbref');

--- a/lib/mongoose/types/dbref.js
+++ b/lib/mongoose/types/dbref.js
@@ -1,0 +1,12 @@
+
+/**
+ * Access driver.
+ */
+
+var driver = global.MONGOOSE_DRIVER_PATH || '../drivers/node-mongodb-native';
+
+/**
+ * Module exports.
+ */
+
+module.exports = require(driver + '/dbref');

--- a/lib/mongoose/types/index.js
+++ b/lib/mongoose/types/index.js
@@ -8,3 +8,4 @@ exports.Document = require('./document');
 exports.DocumentArray = require('./documentarray');
 exports.Number = require('./number');
 exports.ObjectId = require('./objectid');
+exports.DBRef = require('./dbref');

--- a/support/node-mongodb-native/lib/mongodb/bson/bson.js
+++ b/support/node-mongodb-native/lib/mongodb/bson/bson.js
@@ -1,7 +1,8 @@
 var BinaryParser = require('./binary_parser').BinaryParser,
   Integer = require('../goog/math/integer').Integer,
   Long = require('../goog/math/long').Long,
-  Buffer = require('buffer').Buffer;
+  Buffer = require('buffer').Buffer,
+  env = require('../env');
   
 // Alias a string function
 var chr = String.fromCharCode;
@@ -573,6 +574,22 @@ var DBRef = exports.DBRef = function(namespace, oid, db) {
   this.oid = oid;
   this.db = db;
 };
+
+DBRef.prototype.fetch = function(callback) {
+  var database;
+  if (typeof this.db === "string") {
+    database = env[this.db];
+    if (database === null) {
+      throw Error("database '" + this.db + "' not registered in environment");
+    }
+  } else {
+    database = env.currentdb;
+    if (database === null) {
+      throw Error("no current database set in environment");
+    }
+  }
+  return database.dereference(this, callback);
+}
 
 /**
   Contains the a binary stream of data

--- a/support/node-mongodb-native/lib/mongodb/db.js
+++ b/support/node-mongodb-native/lib/mongodb/db.js
@@ -13,7 +13,8 @@ var QueryCommand = require('./commands/query_command').QueryCommand,
   MD5 = require('./crypto/md5').MD5,
   EventEmitter = require('events').EventEmitter,
   inherits = require('sys').inherits,
-  sys = require('sys');
+  sys = require('sys'),
+  env = require('./env');
 
 var Db = exports.Db = function(databaseName, serverConfig, options) {
   EventEmitter.call(this);
@@ -37,6 +38,10 @@ var Db = exports.Db = function(databaseName, serverConfig, options) {
   this.strict = this.options.strict == null ? false : this.options.strict;
   this.notReplied ={};
   this.isInitializing = true;
+
+  // Register database in db environment
+  env.databases[databaseName] = this;
+  env.currentdb = this;
 };
 
 inherits(Db, EventEmitter);

--- a/support/node-mongodb-native/lib/mongodb/env.js
+++ b/support/node-mongodb-native/lib/mongodb/env.js
@@ -1,0 +1,9 @@
+/* 
+ * Global database environment - shared across all databases
+ */
+
+// Cache of database instances by database name
+exports.databases = {};
+
+// Last database that was created
+exports.currentdb = null;


### PR DESCRIPTION
Hi Brian

I've created a patch which adds support for the DBRef type (something I use a lot) into mongoose, and also added a shortcut function Model.merge.

As you will see, I have also modified the embedded node-mongodb-native support module to create a fetch function on the BSON DBRef prototype that performs a db.dereference using the db instance extracted from a 'global database enviornment'.

FYI. I've forked Christian's node-mongodb-native project and patched that as well (see https://github.com/christkv/node-mongodb-native/pull/241).

Cheers
Stuart
