### PR TITLE
Fix for 'CALL_NON_FUNCTION_AS_CONSTRUCTOR' error when defining a schema.

### DIFF
--- a/lib/mongoose/schema.js
+++ b/lib/mongoose/schema.js
@@ -101,7 +101,7 @@ Schema.prototype.add = function (obj, prefix) {
     if (!prefix && !this.tree[i])
       this.tree[i] = obj[i];
 
-    if (obj[i].constructor == Object && (!obj[i].type || obj[i].type.type)) {
+    if (obj[i].constructor.name == 'Object' && (!obj[i].type || obj[i].type.type)) {
       if (Object.keys(obj[i]).length)
         this.add(obj[i], prefix + i + '.');
       else
@@ -156,7 +156,7 @@ Schema.prototype.path = function (path, obj) {
  */
 
 Schema.interpretAsType = function (path, obj) {
-  if (obj.constructor != Object)
+  if (obj.constructor.name != 'Object')
     obj = { type: obj };
 
   // Get the type making sure to allow keys named "type"
@@ -166,7 +166,7 @@ Schema.interpretAsType = function (path, obj) {
     ? obj.type
     : {};
 
-  if (type.constructor == Object) {
+  if (type.constructor.name == 'Object') {
     return new Types.Mixed(path, obj);
   }
 


### PR DESCRIPTION
Which occurs when defining nested Objects or passing an Object with different constructor which happens when you return it from inside Node's sandboxing methods (`vm.runInNewContext` for instance).
