### PR TITLE
ReplSetServers requires two parameters, apparently... 

### DIFF
--- a/lib/mongoose/drivers/node-mongodb-native/connection.js
+++ b/lib/mongoose/drivers/node-mongodb-native/connection.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -56,7 +55,7 @@ NativeConnection.prototype.doOpenSet = function (fn) {
       servers.push(new mongo.Server(host, ports[i], {}));
     });
 
-    this.db = new mongo.Db(this.name, new ReplSetServers(servers));
+    this.db = new mongo.Db(this.name, new ReplSetServers(servers, {}));
   }
 
   this.db.open(fn);


### PR DESCRIPTION
ReplSetServers requires two parameters, apparently... Put in an empty hash for now.  As I am new to the whole .js server side scripting, perhaps you guys have a better solution than I to this.
