### PR TITLE
Small changes for mongoose connections

### DIFF
--- a/lib/mongoose/connection.js
+++ b/lib/mongoose/connection.js
@@ -61,32 +61,71 @@ Connection.prototype.db;
 
 /**
  * Establishes the connection
+ * 
+ * The openOptions parameter is available to the driver when it creates the low level
+ * connection. See the node-mongodb-native driver instance for options that it 
+ * understands. If a single URI is being specified, the openOptions object can
+ * occur immediately after the URI. If a URI and a callback are passed, put the
+ * openOptions object at the very end of the arguments.
  *
  * @param {String} mongodb://uri
  * @return {Connection} self
  * @api public
  */
 
-Connection.prototype.open = function (host, database, port, callback) {
+Connection.prototype.open = function (host, database, port, callback, openOptions) {
   var self = this
     , uri;
 
+  this.openOptions = {};
+
+  // Variable argument parsing
+  var args = Array.prototype.slice.call(arguments,1);
+  var arg;
+
   // if we've been supplied an uri
-  if (typeof database != 'string'){
+  if ( (typeof (arg = args.shift())) === 'string') {
+    // Must be the name of the database, proceed fairly normally
+    database = arg;
+    
+    // Only if we are not considering "host" to be a URI do we look
+    // for a numeric port argument
+    if ( (typeof (arg = args.shift())) === 'number') {
+      port = arg;
+    } else {
+      port = 27017;
+      if (arg) args.unshift(arg);
+    }    
+  } else {
+    // Put it back for later tests
+    if (arg) args.unshift(arg);
+    
+    // Get our host, database, and port info from the "host" argument
     uri = url.parse(host);
     host = uri.hostname;
     port = uri.port || 27017;
-    callback = database;
+    
     database = uri.pathname.replace(/\//g, '');
-  } else {
-    callback = callback || port;
-    port = typeof port == 'number' ? port : 27017;
   }
   
+  // host, database, and port are all set, only 2 arguments to go
+  if ( (typeof (arg = args.shift())) === 'function') {
+    callback = arg;
+  } else {
+    callback = null;
+    if (arg) args.unshift(arg);
+  }
+
+  if ( (typeof (arg = args.shift())) === 'object') {
+    this.openOptions = arg;
+  } else {
+    if (arg) args.unshift(arg);
+  }
+
   // make sure we can open
   if (this.readyState != 0){
     if ('function' == typeof callback)
-      callback(new Error('Trying to open unclosed connection'));
+      callback(new Error('Trying to open unclosed connection '+this.readyState));
     return this;
   }
 
@@ -141,12 +180,17 @@ Connection.prototype.open = function (host, database, port, callback) {
  *
  * Supply a comma-separted list of mongodb:// URIs. You only need to specify
  * the database name and/or auth to one of them.
+ * 
+ * The openOptions parameter is available to the driver when it creates the low level
+ * connection. See the node-mongodb-native driver instance for options that it 
+ * understands. Add the openOptions object as the last parameter if you wish to
+ * use it.
  *
  * @param {String} comma-separated mongodb:// URIs
  * @param {Function} optional callback
  */
 
-Connection.prototype.openSet = function (uris, database, callback) {
+Connection.prototype.openSet = function (uris, database, callback, openOptions) {
   var uris = uris.split(',')
     , self = this;
 
@@ -161,12 +205,30 @@ Connection.prototype.openSet = function (uris, database, callback) {
 
   this.host = [];
   this.port = [];
+  
+  this.openOptions = {};
+  var args = Array.prototype.slice.call(arguments,1);
+  var arg;
+  
+  if ( (typeof (arg = args.shift())) === 'string') {
+    this.name = arg;
+  } else {
+    if (arg) args.unshift(arg);
+  }
+  
+  if ( (typeof (arg = args.shift())) === 'function') {
+    callback = arg;
+  } else {
+    if (arg) args.unshift(arg);
+  }
 
-  if ('function' == typeof database)
-    callback = database;
-  else
-    this.name = database;
-
+  if ( (typeof (arg = args.shift())) === 'object') {
+    this.openOptions = arg;
+  } else {
+    if (arg) args.unshift(arg);
+  }
+  
+  
   uris.forEach(function (uri) {
     var uri = url.parse(uri);
 

--- a/lib/mongoose/drivers/node-mongodb-native/connection.js
+++ b/lib/mongoose/drivers/node-mongodb-native/connection.js
@@ -26,13 +26,30 @@ NativeConnection.prototype.__proto__ = Connection.prototype;
 /**
  * Opens the connection
  * 
+ * The openOptions configured for the connection are passed to both the mongo.Server
+ * constructor as well as to the mongo.Db constructor.
+ * 
+ * From the mongodb module, interesting options are 
+ * 
+ *     For the server
+ *         auto_reconnect (default: false)
+ *         poolSize (default: 1)
+ * 
+ *     For the Db
+ *         `native_parser` - if true, use native BSON parser 
+ *         `strict` - sets *strict mode*, if true then existing collections can't be "recreated" etc.
+ *         `pk` - custom primary key factory to generate `_id` values (see Custom primary keys).
+ *         `forceServerObjectId` - generation of objectid is delegated to the mongodb server instead of the driver. default is false
+ * 
+ * Some of these may break mongoose. Use at your own risk. You have been warned.
+ * 
  * @param {Function} callback
  * @api private
  */
 
-NativeConnection.prototype.doOpen = function (fn) {
+NativeConnection.prototype.doOpen = function (fn) {  
   if (!this.db)
-    this.db = new mongo.Db(this.name, new mongo.Server(this.host, this.port));
+    this.db = new mongo.Db(this.name, new mongo.Server(this.host, this.port, this.openOptions), this.openOptions);
 
   this.db.open(fn);
 
@@ -41,7 +58,14 @@ NativeConnection.prototype.doOpen = function (fn) {
 
 /**
  * Opens a set connection
- *
+ * 
+ * See description of doOpen for openOptions. In this case the options are also passed
+ * to ReplSetServers. The additional options there are
+ * 
+ *     reconnectWait (default: 1000)
+ *     retries (default: 30)
+ *     rs_name (default: false)
+ *     read_secondary (default: false) Are reads allowed from secondaries?
  * @param {Function} callback
  * @api private
  */
@@ -52,10 +76,10 @@ NativeConnection.prototype.doOpenSet = function (fn) {
       , ports = this.port;
 
     this.host.forEach(function (host, i) {
-      servers.push(new mongo.Server(host, ports[i], {}));
+      servers.push(new mongo.Server(host, ports[i], this.openOptions));
     });
 
-    this.db = new mongo.Db(this.name, new ReplSetServers(servers, {}));
+    this.db = new mongo.Db(this.name, new ReplSetServers(servers, this.openOptions), this.openOptions);
   }
 
   this.db.open(fn);


### PR DESCRIPTION
Hey folks, here are two small changes for the mongoose connection class.

The first fixes what is probably rightfully considered a bug. If a connection failed to open it's readyState wouldn't get reset to 0, but would stay in the "connecting" state. This prevented you from later trying to re-open the connection, perhaps after your server came back to life.

The second change is more of a feature addition. I added the ability to pass options down to the native driver level when you are opening a connection. This is necessary to enable things like the auto_reconnect feature or the native BSON parser. This is in and off itself isn't big, but keeping the method signatures undisturbed meant doing some slight re-writing of how the open functions parse their arguments.

Hope you like 'em!
