### PR TITLE
Implementing Document.invalidate and improved validation errors

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,3 @@
+set ts=2
+set sw=2
+set expandtab

--- a/db.test.coffee
+++ b/db.test.coffee
@@ -1,0 +1,102 @@
+mongoose = require 'mongoose'
+step = require 'step'
+
+step(
+  ->
+    console.log "Trying basic validator"
+    db = mongoose.createConnection 'mongodb://localhost/blog'
+    next = @
+
+    FooSchema = new mongoose.Schema
+      bar: { type: String, required: true }
+
+    mongoose.model 'Foo', FooSchema
+
+    Foo = db.model 'Foo'
+
+    foo = new Foo
+
+    console.log "Saving foo"
+    foo.save (err) ->
+      console.log "Error:", err
+      console.log "foo.errors:", foo.errors
+      foo.set bar: 'baz'
+      console.log "Saving foo again"
+      foo.save (err) ->
+        console.log "Error:", err
+        console.log "Foo.errors:", foo.errors
+        db.close()
+        do next
+    return
+  ->
+    console.log ""
+    console.log "Trying custom validator"
+    db = mongoose.createConnection 'mongodb://localhost/blog'
+    next = @
+
+    BarSchema = new mongoose.Schema
+      baz: { type: String }
+
+    BarSchema.pre 'validate', (next) ->
+      console.log 'Doing custom validation'
+      (@invalidate 'baz', 'bad') if (@get 'baz') is 'bad'
+      next()
+
+    mongoose.model 'Bar', BarSchema
+
+    Bar = db.model 'Bar'
+
+    bar = new Bar
+    bar.set baz: 'bad'
+    console.log "Saving bar"
+    bar.save (err) ->
+      console.log "Error:", err
+      bar.set baz: 'good'
+      bar.save (err) ->
+        console.log "Error:", err
+        db.close()
+        do next
+    return
+
+  ->
+    console.log ""
+    console.log "Trying custom validator"
+    db = mongoose.createConnection 'mongodb://localhost/blog'
+    next = @
+    executed = false
+
+    validator = (v, fn) ->
+      setTimeout (->
+        executed = true
+        fn (v isnt '')
+      ), 50
+      return
+
+    Subdocs = new mongoose.Schema
+      required: { type: String, validate: [validator, 'async in subdocs'] }
+
+    mongoose.model 'TestSubdocumentsAsyncValidation', new mongoose.Schema
+      items: [Subdocs]
+
+    Test = db.model 'TestSubdocumentsAsyncValidation'
+
+    post = new Test()
+
+    (post.get 'items').push required: ''
+
+    console.log "Saving"
+    post.save (err) ->
+      console.log "Executed:", executed
+      console.log "Error:", err
+      executed = false
+      console.log "Saving again"
+
+      (post.get 'items')[0].set required: 'here'
+      post.save (err) ->
+        console.log "Executed:", executed
+        console.log "Error:", err
+        db.close()
+        do next
+
+    return
+)

--- a/lib/mongoose/document.js
+++ b/lib/mongoose/document.js
@@ -7,6 +7,7 @@ var EventEmitter = require('events').EventEmitter
   , MongooseError = require('./error')
   , MixedSchema = require('./schema/mixed')
   , Schema = require('./schema')
+  , ValidatorError = require('./schematype').ValidatorError
   , utils = require('./utils')
   , clone = utils.clone
   , inspect = require('util').inspect
@@ -29,6 +30,7 @@ function Document (obj) {
     self.activePaths.require(path);
   });
   this.saveError = null;
+  this.validationError = null;
   this.isNew = true;
   if (obj) this.set(obj);
   this.registerHooks();
@@ -500,25 +502,26 @@ Document.prototype.validate = function (next) {
   var total = 0
     , self = this
     , validating = {}
-    , validationError = null;
+    , complete = function() {
+        next(self.validationError);
+        self.validationError = null;
+      };
 
   if (!this.activePaths.some('require', 'init', 'modify'))
-    return next();
+    return complete();
 
   function validatePath (path) {
     if (validating[path]) return;
     total++;
     process.nextTick(function(){
       var p = self.schema.path(path);
-      if (!p) return --total || next();
+      if (!p) return --total || complete();
 
       p.doValidate(self.getValue(path), function (err) {
         if (err) {
-          validationError = validationError || new ValidationError(self);
-          validationError.errors[err.path] = err.message;
+          self.invalidate(path, err);
         }
-        --total || 
-          (validationError ? next(validationError) : next());
+        --total || complete();
       });
 
     });
@@ -531,6 +534,25 @@ Document.prototype.validate = function (next) {
 
   return this;
 };
+
+/**
+ * Marks a path as invalid, causing a subsequent validation to fail.
+ *
+ * @param {String} path of the field to invalidate
+ * @param {String/Error} error of the path.
+ * @api public
+ */
+Document.prototype.invalidate = function(path, err) {
+  if (!this.validationError) {
+    this.validationError = new ValidationError(this);
+  }
+
+  if (!err || 'string' === typeof err) {
+      err = new ValidatorError(path, err);
+  }
+
+  this.validationError.errors[path] = err;
+}
 
 /**
  * Returns if the document has been modified
@@ -743,7 +765,7 @@ function ValidationError (instance) {
 
 ValidationError.prototype.toString = function () {
   return this.name + ': ' + Object.keys(this.errors).map(function (key) {
-    return this.errors[key];
+    return String(this.errors[key]);
   }, this).join(', ');
 };
 

--- a/lib/mongoose/schematype.js
+++ b/lib/mongoose/schematype.js
@@ -264,15 +264,20 @@ SchemaType.prototype.doValidate = function (value, fn, scope) {
  * @api private
  */
 
-function ValidatorError (path, msg) {
-  msg = msg
-    ? '"' + msg + '" '
+function ValidatorError (path, type) {
+  var msg = type
+    ? '"' + type + '" '
     : '';
   MongooseError.call(this, 'Validator ' + msg + 'failed for path ' + path);
   Error.captureStackTrace(this, arguments.callee);
   this.name = 'ValidatorError';
   this.path = path;
+  this.type = type;
 };
+
+ValidatorError.prototype.toString = function() {
+  return this.message;
+}
 
 /**
  * Inherits from MongooseError

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -791,8 +791,9 @@ module.exports = {
     post.save(function(err){
       err.should.be.an.instanceof(MongooseError);
       err.should.be.an.instanceof(ValidationError);
-      err.errors.simple.should.equal('Validator "must be abc" failed for path simple');
-      post.errors.simple.should.equal('Validator "must be abc" failed for path simple');
+      err.errors.simple.should.be.an.instanceof(ValidatorError);
+      err.errors.simple.message.should.equal('Validator "must be abc" failed for path simple');
+      post.errors.simple.message.should.equal('Validator "must be abc" failed for path simple');
 
       post.set('simple', 'abc');
       post.save(function(err){
@@ -814,7 +815,7 @@ module.exports = {
     }, 'Name cannot be greater than 1 character');
     var doc = new IntrospectionValidation({name: 'hi'});
     doc.save( function (err) {
-      err.errors.name.should.equal("Validator \"Name cannot be greater than 1 character\" failed for path name");
+      err.errors.name.message.should.equal("Validator \"Name cannot be greater than 1 character\" failed for path name");
       err.name.should.equal("ValidationError");
       err.message.should.equal("Validation failed");
       db.close();
@@ -869,14 +870,20 @@ module.exports = {
       (++timesCalled).should.eql(1);
 
       (Object.keys(err.errors).length).should.eql(3);
-      err.errors.password.should.eql('Validator failed for path password');
-      err.errors.email.should.eql('Validator failed for path email');
-      err.errors.username.should.eql('Validator failed for path username');
+      err.errors.password.should.be.an.instanceof(ValidatorError);
+      err.errors.email.should.be.an.instanceof(ValidatorError);
+      err.errors.username.should.be.an.instanceof(ValidatorError);
+      err.errors.password.message.should.eql('Validator failed for path password');
+      err.errors.email.message.should.eql('Validator failed for path email');
+      err.errors.username.message.should.eql('Validator failed for path username');
 
       (Object.keys(post.errors).length).should.eql(3);
-      post.errors.password.should.eql('Validator failed for path password');
-      post.errors.email.should.eql('Validator failed for path email');
-      post.errors.username.should.eql('Validator failed for path username');
+      post.errors.password.should.be.an.instanceof(ValidatorError);
+      post.errors.email.should.be.an.instanceof(ValidatorError);
+      post.errors.username.should.be.an.instanceof(ValidatorError);
+      post.errors.password.message.should.eql('Validator failed for path password');
+      post.errors.email.message.should.eql('Validator failed for path email');
+      post.errors.username.message.should.eql('Validator failed for path username');
 
       db.close();
     });
@@ -986,7 +993,8 @@ module.exports = {
     post.save(function(err){
       err.should.be.an.instanceof(MongooseError);
       err.should.be.an.instanceof(ValidationError);
-      err.errors.required.should.eql('Validator "required" failed for path required');
+      err.errors.required.should.be.an.instanceof(ValidatorError);
+      err.errors.required.message.should.eql('Validator "required" failed for path required');
 
       post.get('items')[0].set('required', true);
       post.save(function(err){
@@ -1018,7 +1026,8 @@ module.exports = {
     post.save(function(err){
       err.should.be.an.instanceof(MongooseError);
       err.should.be.an.instanceof(ValidationError);
-      err.errors.async.should.eql('Validator "async validator" failed for path async');
+      err.errors.async.should.be.an.instanceof(ValidatorError);
+      err.errors.async.message.should.eql('Validator "async validator" failed for path async');
       executed.should.be.true;
       executed = false;
 
@@ -3803,6 +3812,166 @@ module.exports = {
       });
     })
 
+  },
+  'test standalone invalidate': function() {
+    var db = start()
+      , InvalidateSchema = null
+      , Post = null
+      , post = null;
+
+    InvalidateSchema = new Schema({
+      prop: { type: String },
+    });
+
+    mongoose.model('InvalidateSchema', InvalidateSchema);
+
+    Post = db.model('InvalidateSchema');
+    post = new Post();
+    post.set({baz: 'val'});
+    post.invalidate('baz', 'reason');
+
+    post.save(function(err){
+      err.should.be.an.instanceof(MongooseError);
+      err.should.be.an.instanceof(ValidationError);
+
+      err.errors.baz.should.be.an.instanceof(ValidatorError);
+      err.errors.baz.message.should.equal('Validator "reason" failed for path baz');
+
+      post.save(function(err){
+        should.strictEqual(err, null);
+        db.close();
+      });
+    });
+  },
+  'test simple validation middleware': function() {
+    var db = start()
+      , ValidationMiddlewareSchema = null
+      , Post = null
+      , post = null;
+
+    ValidationMiddlewareSchema = new Schema({
+      baz: { type: String }
+    });
+
+    ValidationMiddlewareSchema.pre('validate', function(next) {
+      if (this.get('baz') == 'bad') {
+        this.invalidate('baz', 'bad');
+      }
+      next();
+    });
+
+    mongoose.model('ValidationMiddleware', ValidationMiddlewareSchema);
+
+    Post = db.model('ValidationMiddleware');
+    post = new Post();
+    post.set({baz: 'bad'});
+
+    post.save(function(err){
+      err.should.be.an.instanceof(MongooseError);
+      err.should.be.an.instanceof(ValidationError);
+
+      post.set('baz', 'good');
+      post.save(function(err){
+        should.strictEqual(err, null);
+        db.close();
+      });
+    });
+  },
+  'test async validation middleware': function() {
+    var db = start()
+      , AsyncValidationMiddlewareSchema = null
+      , Post = null
+      , post = null;
+
+    AsyncValidationMiddlewareSchema = new Schema({
+      prop: { type: String }
+    });
+
+    AsyncValidationMiddlewareSchema.pre('validate', true, function(next, done) {
+      var self = this;
+      setTimeout(function() {
+        if (self.get('prop') == 'bad') {
+          self.invalidate('prop', 'bad');
+        }
+        done();
+      }, 50);
+      next();
+    });
+
+    mongoose.model('AsyncValidationMiddleware', AsyncValidationMiddlewareSchema);
+
+    Post = db.model('AsyncValidationMiddleware');
+    post = new Post();
+    post.set({prop: 'bad'});
+
+    post.save(function(err){
+      err.should.be.an.instanceof(MongooseError);
+      err.should.be.an.instanceof(ValidationError);
+
+      post.set('prop', 'good');
+      post.save(function(err){
+        should.strictEqual(err, null);
+        db.close();
+      });
+    });
+  },
+  'test complex validation middleware': function() {
+    var db = start()
+      , ComplexValidationMiddlewareSchema = null
+      , Post = null
+      , post = null
+      , abc = function(v) {
+          return v === 'abc';
+        };
+
+    ComplexValidationMiddlewareSchema = new Schema({
+      baz: { type: String },
+      abc: { type: String, validate: [abc, 'must be abc'] },
+      test: { type: String, validate: [/test/, 'must be abc'] },
+      required: { type: String, required: true }
+    });
+
+    ComplexValidationMiddlewareSchema.pre('validate', true, function(next, done) {
+      var self = this;
+      setTimeout(function() {
+        if (self.get('baz') == 'bad') {
+          self.invalidate('baz', 'bad');
+        }
+        done();
+      }, 50);
+      next();
+    });
+
+    mongoose.model('ComplexValidationMiddleware', ComplexValidationMiddlewareSchema);
+
+    Post = db.model('ComplexValidationMiddleware');
+    post = new Post();
+    post.set({
+      baz: 'bad',
+      abc: 'not abc',
+      test: 'fail'
+    });
+
+    post.save(function(err){
+      err.should.be.an.instanceof(MongooseError);
+      err.should.be.an.instanceof(ValidationError);
+      Object.keys(err.errors).length.should.equal(4);
+      err.errors.baz.should.be.an.instanceof(ValidatorError);
+      err.errors.abc.should.be.an.instanceof(ValidatorError);
+      err.errors.test.should.be.an.instanceof(ValidatorError);
+      err.errors.required.should.be.an.instanceof(ValidatorError);
+
+      post.set({
+        baz: 'good',
+        abc: 'abc',
+        test: 'test',
+        required: 'here'
+      });
+      post.save(function(err){
+        should.strictEqual(err, null);
+        db.close();
+      });
+    });
   }
 
 };


### PR DESCRIPTION
Note: This pull request is an update copy of #335, but based on the new hooks for the async validation instead of mongooses old custom hooks implementation.

When validating a document, the returned ValidationError is not very useful. It informs you of a failed path, but not the type of failure unless you are prepared to parse some strings. Instead of the ValidationError.errors object containing a string representation of the ValidatorError, it now contains the actual ValidatorError. ValidatorError has been modified to record the type of error (the message part of the validation), and ValidatorError.toString() returns the string that was used previously. This may break backwards compatibility for some users, but the benefit is large:
- Instead of parsing the ValidatorError message string to work out the path and reason, the path and reason can be extracted from the error easily.
- The previous functionality can be retained by simply casting the ValidatorError to a string.
- Using the Document.invalidate() call, other errors can be used to invalidate a document, allowing for more flexible error handling oppertunities. The document can also be invalidated before a validation pass, such as from a controller - although whether this is a sensible thing to do or not depends upon the exact application.

Tests have been provided :)
