### PR TITLE
Hi, i want to pull changes i made. it make possible serialise and deserialise the schema from json file.

### DIFF
--- a/lib/mongoose/schema.js
+++ b/lib/mongoose/schema.js
@@ -183,7 +183,7 @@ Schema.interpretAsType = function (path, obj) {
     }
     return new Types.Array(path, cast, obj);
   }
-  return new Types[type.name](path, obj);
+  return new Types[type.name||type](path, obj);
 };
 
 /**


### PR DESCRIPTION
fixed type name discover, for schema definition wich is deserialized from JSON files.
 i.e. typename is presented as string not as actual link for type.
make possible to use such specification
var some = new Schema({name:"String"});
