### PR TITLE
New Feature: Model#getMatcher. Supports find/update/delete without any dot notation or array notation

### DIFF
--- a/lib/mongoose/model.js
+++ b/lib/mongoose/model.js
@@ -55,6 +55,61 @@ Model.prototype.collection;
 
 Model.prototype.name;
 
+// PATCH
+/**
+ * Description
+ * -----------
+ * Retrieves a Matcher object for the Schema this Model type is bound to.
+ * A Matcher is a mapping of the properties in the Schema passed to this function in as
+ *  flat a namespace as possible to their proper dot-notation and $in syntax to be used
+ *  as query predicates when querying MongoDB.
+ *
+ * Motivation
+ * ----------
+ * The goal of this addition to the Model API is to support as complete encapsulation of the
+ *  the underlying data model in MongoDB from the client querying the model.  If the data
+ *  follows one simple rule -- all property names at all levels are unique -- then clients
+ *  can query on any combination of properties in the model by passing only a flat JSON of
+ *  of keys and values.  This is a convenient idiom in any case where the model may change
+ *  often, where the model may be dynamically selected, or where it's a severe abstraction
+ *  leakage to have to know about dot-notation and special $in syntax at the point of data access.
+ *
+ * The motivating use case for this approach was a generic REST data access API. With this approach
+ *  clients simply pass names/value pairs on the query string and query into the model with
+ *  any combination of properties in the model.
+ *
+ * Usage
+ * -----
+ * - If a property name is unique, clients can simply pass in that property name and its
+ *  value no matter what level it is in the Schema.
+ * - If a property is not unique, clients can use dot-notation path in the arg to this function 
+ *  to query on the correct property without ambiguity.
+ * - If a property stores embedded arrays in the Schema, clients don't need to know that and can
+ *  simply pass in a property name (if unique) or dot-notation name (if not unique).
+ * - All values passed in the matchArgs argument are cast to the correct Javascript value to pass
+ *   to the MongoDB native node driver.
+ *
+ * Limitations and Issues
+ * ----------------------
+ * - this code depends on private implementation details of the Schema class, in particular
+ *   the 'tree' property of that class
+ * - support for retrieving from a set of Schema objects in an embedded array using $in
+ *   is not supported fully, and the test for this case is incomplete. This is because
+ *   retrieving objects in embedded arrays in MongoDB requires passing literals that fully
+ *   match the objects in the database, but contstructed Schema objects in Mongoose add
+ *   properties for internal implementation that are then in the records in the DB but
+ *   not easily available to the client needing to match those objects in those documents exactly.
+ *
+ * @see Schema#getMatcher
+ * @see Schema#buildMatcherLookup
+ * @param {Object} matchArgs JSON properties/values to use in a query matching documents of this Model's Schema
+ * @api public
+ */
+Model.getMatcher = function (matchArgs) {
+ return this.schema.getMatcher(matchArgs);
+};
+// /PATCH
+
 /**
  * Saves the document.
  *

--- a/lib/mongoose/schema.js
+++ b/lib/mongoose/schema.js
@@ -86,6 +86,238 @@ Schema.prototype.paths;
 
 Schema.prototype.tree;
 
+// PATCH
+/**
+ * Internal helper supporting Schema#getMatcher.
+ *
+ * @see Model#getMatcher
+ * @see Schema#getMatcher
+ * @param {String} pathString dot-notation prefix for current traversal of properties in the Schema
+ * @param {Object} tree the Schema#tree property for the Schema
+ * @param {Object} matcherLookup the return value mapping flat property names to dot-notation paths, value casting functions and isArray flags
+ * @param {Number} depth depth of recursion of call
+ * @api private
+ */
+var maxDepth = 5;
+Schema.prototype.buildMatcherLookup = function (pathString, tree, matcherLookup, depth) {    
+  // Guard against arbitrarily deep recursion for properties that are 
+  //   object/Schema types with properties that are other object/Schema types forming a cycle
+  if (depth > maxDepth) {
+    return matcherLookup;
+  }
+  depth += 1;
+  
+  // Helpers
+  var MatcherLookupEntry = function (p, c, a) {
+    return {pathString : p, caster : c, isArray : a};
+  };
+  // Guard against overwriting existing entries. As documented, this function will only behave as expected
+  //  if all properties in Schema at all levels have unique names. So the function creates an entry only for
+  //  the first instance of any name encountered without qualifying it with its full dot notation path (the
+  //  entire point of using the Matcher.)  But it will create dot-notation qualified entries if there is a 
+  //  clash, so these can be accessed by full path.  
+  var makeLookupEntry = function (prop, pathString, caster, isArrayVal) {
+    var entry = MatcherLookupEntry(pathString, caster, isArrayVal);    
+    if (! matcherLookup.hasOwnProperty(prop)) {
+      matcherLookup[prop] = entry;        
+    }
+    else {
+      matcherLookup[pathString] = entry;        
+    }    
+  };
+    
+  var isArray = function (value) {
+    return Object.prototype.toString.apply(value) === '[object Array]';
+  };
+  
+  var isFunction = function (value) { 
+     return typeof value === 'function'; 
+  };  
+  
+  var isObject = function (value, literal) {
+    var type = typeof value, test = !!value && type === 'object';
+    return test && literal ? value.constructor === Object : test;
+  };  
+
+  var isMongooseSchema = function (v) {
+    return (isObject(v) && v.hasOwnProperty('paths') && v.hasOwnProperty('tree')); 
+  };
+  
+  var mongooseSchemaTreeEquals = function (s1, s2) {
+    var objLen = function (o) {
+      var l = 0;
+      for (prop in o) {
+        l += 1;
+      }
+      return l;
+    };
+    var isSamePropertyVal = function (pv1, pv2) {
+      if ( (isArray(pv1) && isArray(pv2)) || (isFunction(pv1) && isFunction(pv2)) || 
+           (isObject(pv1) && isObject(pv2)) || (isMongooseSchema(pv1) && isMongooseSchema(pv2)) ) {
+        return true;
+      }
+      return false;
+    };
+    
+    // Compare the tree property of each Schema object for same length    
+    var l1, l2;
+    if ((l1 = objLen(s1)) !== (l2 = objLen(s2))) {
+      return false; 
+    }
+        
+    // Iterate  each tree, insuring same property names and Schema data types
+    for (prop in s1) {
+      if (! prop in s2) {
+        return false;
+      }
+      else if (! isSamePropertyVal(s1[prop], s2[prop])) {
+        return false;
+      }
+    }    
+    return true;
+  };
+  
+  var noOpCaster = function (value) {
+    return value;
+  };
+  // /Helpers
+  
+  var propVal = null;
+  var curPathString = pathString;
+  var isArrayVal = false;
+  var literal = 1;
+   
+  for (prop in tree) {    
+    pathString = curPathString;
+    // Build dot-notation path
+    if (pathString.length > 0) {
+      pathString += '.';
+    }
+    pathString += prop;
+    
+    // NOTE: Depends on internal Schema property 'tree' property implementation.
+    // tree is an object with a structure mirroring the Schema definition.
+    // Properties are fields in the Schema.  Their value is:
+    //  - a casting function for the type of data the field holds, if the field is a simple type
+    //    i.e. string, number, boolean or date
+    //  - a nested object if the field contains nested objects
+    //  - a nested MongooseSchema (a specific object type) if the field holds nested Schemas
+    //  - an array if the field holds any type of value in an embedded array
+    propVal = tree[prop];
+    
+    if (isArrayVal = isArray(propVal)) {   
+      // Arrays can be empty in Mongoose, contain a compound type (object or Schema) or a simple type
+      // Arrays are empty or homogenous (have values of only one type).  So if the tree value is an array:
+      //  - if the array in the tree contains a function, then the function is the caster
+      //  - if the array in the tree contains objects or Schema objects, create two entries:
+      //   - one is recurse to build dot notation for matching single objects in arrays
+      //   - one is an entry at the array level without dot notation into the object, passing literal through
+      //     because matching more than one object using $in requires matching on an array of literal values 
+      //  - if the array in the tree is empty (which is legal in Mongoose), then we can't know what type the
+      //    array may contain, so create an entry that passes through literal values to match exactly
+      if (propVal.length === 0)
+      {
+        makeLookupEntry(prop, pathString, noOpCaster, isArrayVal);
+        continue;
+      }
+      else {
+        propVal = propVal[0];        
+      }
+    }            
+
+    if (isFunction(propVal, literal)) {
+      makeLookupEntry(prop, pathString, propVal, isArrayVal);
+    }
+    else if(isMongooseSchema(propVal)) {
+      // Embedded object in array, create entry for literal match as per comment above
+      if (isArrayVal) {
+        makeLookupEntry(prop, pathString, noOpCaster, isArrayVal);
+      }
+      
+      // If embedded Schema is a a child property of the same Schema, we know we have endless recursion, 
+      /// so just support one level of recursion from here
+      if (mongooseSchemaTreeEquals(tree, propVal.tree) && depth < maxDepth) {
+        depth = maxDepth;
+      }
+      
+      // Recurse
+      matcherLookup = this.buildMatcherLookup(pathString, propVal.tree, matcherLookup, depth);
+    }
+    else if (isObject(propVal)) {
+      if (isArrayVal) {
+        makeLookupEntry(prop, pathString, noOpCaster, isArrayVal);
+      }
+      
+      // Always recurse on embedded plain objects (not Schemas), because these aren't as much "types"
+      //  as Schemas so there isn't as clear a case of identifying self-reference children and cycles. So
+      //  just allow and guard against stack overflow
+      matcherLookup = this.buildMatcherLookup(pathString, propVal, matcherLookup, depth);      
+    }
+  }
+  
+  return matcherLookup;
+}
+
+/**
+ * Internal implementation supporting Model#getMatcher.
+ *
+ * @see Model#getMatcher
+ * @see Schema#buildMatcherLookup
+ * @param {Object} matchArgs JSON properties/values to use in a query matching documents of this Model's Schema
+ * @api private
+ */
+Schema.prototype.getMatcher = function (matchArgs) {
+  // Helper
+	var isArray = function (value) {
+	 	return Object.prototype.toString.apply(value) === '[object Array]';
+	};
+	// The JSON set of document properties/values to return
+	var pathString = '';
+	var matcherLookup = {};
+	var depth = 0;
+	matcherLookup = this.buildMatcherLookup(pathString, this.tree, matcherLookup, depth);
+	
+	// JSON in valid MongoDB dot-notation and "$in" syntax to be match pred in find(), update() and delete() Mongo calls
+	var matcher = {};
+	var propVal = null;
+	var mlEntry = null;
+	var j = 0;
+	
+	for (prop in matchArgs) {	  
+		if (matcherLookup.hasOwnProperty(prop)) {		  
+  	  propVal = matchArgs[prop];
+		  mlEntry = matcherLookup[prop];
+	
+		  // Handle embedded array cases 
+		  if (mlEntry.isArray) {		    
+		    // Client can pass in single values or array of values to match against array fields
+		    // Single values match with standard dot notation, as MongoDB transparently searches the embedded array for
+		    //  all objects matching the predicate value
+		    // Multiple values work like SQL "IN", meaning MongoDB searches the embedded array for all objects matching *any*
+		    //  of the values in the predicate.  Multiple values require "$in" operator in matcher.
+		    if (isArray(propVal)) {
+  		    // Loop over all values, cast each one
+  		    for (j = 0; j < propVal.length; j += 1) {  		      
+  		      propVal[j] = mlEntry.caster(propVal[j]);
+  		    }
+
+  		    matcher[mlEntry.pathString] = {"$in" : propVal};
+  		  }
+  		  else {
+  		    matcher[mlEntry.pathString] = mlEntry.caster(propVal);
+  		  }		    
+		  }
+		  // Matching single value field
+		  else {
+		    matcher[mlEntry.pathString] = mlEntry.caster(propVal);
+		  }
+		}
+	}
+	
+	return matcher;
+}
+// /PATCH
+
 /**
  * Sets the keys
  *

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -74,6 +74,150 @@ var collection = 'blogposts_' + random();
 
 module.exports = {
 
+  // PATCH
+  'model.matcher() should return correct MongodDB matcher object with dot notation and use it to retrieve data': function () {        
+    var db = start()
+      , BlogPost = db.model('BlogPost', collection);
+
+		// Matches attributes with simple types at root level and nested attributes
+		var testTitle = 'Dot Notation Test';		
+    var matchArgs = {title : testTitle, published : true, visitors : 5};    
+    var expectedMatcher = {title: testTitle, published: true, 'meta.visitors': 5};
+    var matcher = BlogPost.getMatcher(matchArgs);
+    
+    // Test that we get the expected matcher JSON object for the flat matchArgs
+    // matchArgs cover literal types at root level, nested object and embedded array
+    should.eql(expectedMatcher, matcher);
+    
+    // Now actually insert some data and retrieve it with find() using the matcher    
+    var post = new BlogPost({
+      title: testTitle,
+      published : true
+    });
+    post.save( function (err) {
+      should.strictEqual(null, err);
+      post.set('meta.visitors', 5);
+      post.save( function (err) {
+        should.strictEqual(null, err);
+        // Use the matcher generated from flat args here to match nested obj, embedded array        
+        BlogPost.find(matcher, function (err, found) {
+          should.strictEqual(null, err);          
+          found = found[0];     
+          // Test the values of the document returned, matching literals a base level
+          //  and also nested object and embedded array values
+          found.get('title').valueOf().should.equal(testTitle);
+          found.get('published').valueOf().should.equal(true);
+          found.get('meta.visitors').valueOf().should.equal(5);
+          db.close();
+        });
+      });
+    });    
+  },
+  
+  'model.matcher() should return correct MongodDB matcher object with dot notation for matching single simple values in embedded arrays and use it to retrieve data': function () {
+    var db = start()
+      , BlogPost = db.model('BlogPost', collection);
+
+		var testTitle = 'Dot Notation Simple Embedded Array Test';
+    var matchArgs = {title : testTitle, numbers : 4};    
+		// Numbers is array type, at root level, passed one value, so dot notation path for matching one value is simply the property name	
+    var expectedMatcher = {title: testTitle, numbers : 4};
+    var matcher = BlogPost.getMatcher(matchArgs);
+    
+    should.eql(expectedMatcher, matcher);
+    
+    var post = new BlogPost({
+      title: testTitle,
+      numbers : [4]
+    });
+    post.save( function (err) {
+      should.strictEqual(null, err);
+      BlogPost.find(matcher, function (err, found) {
+        should.strictEqual(null, err);          
+        found = found[0];     
+        found.get('title').valueOf().should.equal(testTitle);
+        found.get('numbers').should.have.length(1);
+        found.get('numbers')[0].should.equal(4);
+        db.close();
+      });
+    });    
+  },
+  
+  'model.matcher() should return correct MongodDB matcher object with $in notation for matching multiple simple values in embedded arrays and use it to retrieve data': function () {
+    var db = start()
+      , BlogPost = db.model('BlogPost', collection);
+
+		var testTitle = 'Dot Notation MutliValue Embedded Array Test';
+    var matchArgs = {title : testTitle, numbers : [4, 5]};    
+		// Numbers is array type, at root level, passed multiple values, so $in notation for matching 
+		var expectedMatcher = {title: testTitle, numbers : {'$in' : [4, 5]}};
+    var matcher = BlogPost.getMatcher(matchArgs);
+    
+    should.eql(expectedMatcher, matcher);
+    
+    var post = new BlogPost({
+      title: testTitle,
+      numbers : [4, 5, 6]
+    });
+    post.save( function (err) {
+      should.strictEqual(null, err);
+      BlogPost.find(matcher, function (err, found) {
+        should.strictEqual(null, err);          
+        found = found[0];     
+        found.get('title').valueOf().should.equal(testTitle);
+        // Test that the object returned has the array with all elements, not just those matched on the $in
+        found.get('numbers').should.have.length(3);
+        found.get('numbers').indexOf(4).should.not.equal(-1);
+        found.get('numbers').indexOf(5).should.not.equal(-1);          
+        found.get('numbers').indexOf(6).should.not.equal(-1);
+        db.close();
+      });
+    });    
+  },
+  
+  'model.matcher() should return correct MongodDB matcher object with dot notation for object type in array and use it to retrieve data': function () {        
+    var db = start()
+      , BlogPost = db.model('BlogPost', collection);
+
+		var testTitle = 'Dot Notation Object Type Embedded Array Test';
+    var matchArgs = {title : testTitle, 'comments.title' : 'Great comment!'};    
+		// Comments is array type, at root level, storing objects, passed one value, so dot notation path for matching one value is the nested property name
+    var expectedMatcher = {title: testTitle, 'comments.title' : 'Great comment!'};
+    var matcher = BlogPost.getMatcher(matchArgs);
+    
+    should.eql(expectedMatcher, matcher);
+    
+    var post = new BlogPost({
+      title: testTitle,
+      comments : [{title : 'Great comment!', date : new Date(), body : 'I totally agree!', comments : []}]
+    });
+    post.save( function (err) {
+      should.strictEqual(null, err);
+      BlogPost.find(matcher, function (err, found) {
+        should.strictEqual(null, err);          
+        found = found[0];            
+        found.get('title').valueOf().should.equal(testTitle);
+        found.get('comments').should.have.length(1);
+        found.get('comments')[0].title.should.equal('Great comment!');
+        found.get('comments')[0].body.should.equal('I totally agree!');
+        db.close();
+      });
+    });    
+  },
+  
+  'model.matcher() should return correct MongodDB matcher object with $in notation for matching multiple objects in embedded arrays': function () {
+    var testTitle = 'Dot Notation MutliValue Objects in Embedded Array Test';
+        var postDate = new Date();
+    // Matching array of embedded objects in embedded arrays requires "$in" operator and an array of literal objects that exactly match complete objects in the DB
+    var matchArgs = {title : testTitle, comments : [{title : 'First comment', date: postDate, body : 'No way', comments : [{title: 'inside'}]}]};    
+    // Numbers is array type, at root level, passed multiple values, so $in notation for matching 
+    var expectedMatcher = {title: testTitle, comments : {'$in' : [{title : 'First comment', date : postDate, body : 'No way', comments : [{title: 'inside'}]}]}};
+    var matcher = BlogPost.getMatcher(matchArgs);
+        
+    should.eql(expectedMatcher, matcher);   
+  },     
+	// /PATCH
+
   'test a model isNew flag when instantiating': function(){
     var db = start()
       , BlogPost = db.model('BlogPost', collection);


### PR DESCRIPTION
New Feature: Model#getMatcher. 

Supports find/update/delete without any dot notation or array  notation, except when property names in Schema are not unique.
## Description

A Matcher is a mapping of the properties in the Schema passed to this function in as
 flat a namespace as possible to their proper dot-notation and $in syntax to be used
 as query predicates when querying MongoDB.
## Motivation

The goal of this addition to the Model API is to support as complete encapsulation of the
 the underlying data model in MongoDB from the client querying the model.  If the data
 follows one simple rule -- all property names at all levels are unique -- then clients
 can query on any combination of properties in the model by passing only a flat JSON of
 of keys and values.  This is a convenient idiom in any case where the model may change
 often, where the model may be dynamically selected, or where it's a severe abstraction
 leakage to have to know about dot-notation and special $in syntax at the point of data access.

The motivating use case for this approach was a generic REST data access API. With this approach
 clients simply pass names/value pairs on the query string and query into the model with
 any combination of properties in the model.
## Usage
- If a property name is unique, clients can simply pass in that property name and its
  value no matter what level it is in the Schema.
- If a property is not unique, clients can use dot-notation path in the arg to this function 
  to query on the correct property without ambiguity.
- If a property stores embedded arrays in the Schema, clients don't need to know that and can
  simply pass in a property name (if unique) or dot-notation name (if not unique).
- All values passed in the matchArgs argument are cast to the correct Javascript value to pass
  to the MongoDB native node driver.
## Limitations and Issues
- this code depends on private implementation details of the Schema class, in particular
  the 'tree' property of that class
- support for retrieving from a set of Schema objects in an embedded array using $in
  is not supported fully, and the test for this case is incomplete. This is because
  retrieving objects in embedded arrays in MongoDB requires passing literals that fully
  match the objects in the database, but constructed Schema objects in Mongoose add
  properties for internal implementation that are then in the records in the DB but
  not easily available to the client needing to match those objects in those documents exactly.
