### PR TITLE
V1.x

### DIFF
--- a/lib/mongoose/document.js
+++ b/lib/mongoose/document.js
@@ -507,21 +507,24 @@ Document.prototype.validate = function (next) {
 
   if (!this.activePaths.some('require', 'init', 'modify'))
     return next();
+  
+  function complete() {
+    validationError ? next(validationError) : next();
+  }
 
   function validatePath (path) {
     if (validating[path]) return;
     total++;
     process.nextTick(function(){
       var p = self.schema.path(path);
-      if (!p) return --total || next();
-
+      if (!p) return --total || complete();
+      
       p.doValidate(self.getValue(path), function (err) {
         if (err) {
           validationError = validationError || new ValidationError(self);
           validationError.errors[err.path] = err.message;
         }
-        --total ||
-          (validationError ? next(validationError) : next());
+        --total || complete();
       }, self);
     });
     validating[path] = true;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1168,6 +1168,28 @@ module.exports = {
 
   },
 
+  //GH-464
+  'test validation still fires with non-schema paths': function(){
+    
+    mongoose.model('TestNonSchemaValidation', new Schema({
+      item: { type: String, required: true }
+    }));
+
+    var db = start()
+      , TestNonSchemaValidation = db.model('TestNonSchemaValidation');
+
+    var post = new TestNonSchemaValidation({
+      foobar: "foo"
+    });
+
+    post.validate(function(err){
+      err.should.be.an.instanceof(MongooseError);
+      err.should.be.an.instanceof(ValidationError);
+      err.errors.item.should.eql('Validator "required" failed for path item');
+      db.close(); 
+    });
+  },
+
   'test setting required to false': function () {
     function validator () {
       return true;


### PR DESCRIPTION
This addresses an issue I opened, [GH-464](https://github.com/LearnBoost/mongoose/issues/464). The problem is discussed with an example there, but the bug is that hydrating a new Model object with an object with non-schema keys breaks validation. The cause is that `Document.prototype.validate` has a code path that bails to `next()` without processing `validationError`.

While the problem is already fixed on Master, it relies on the new Document invalidation approach, and wouldn't be an easy merge to the 1.x branch. This small fix specifically addresses the bug in GH-464 for now. 

Thanks for making Mongoose awesome!
