### PR TITLE
Added link to mongodb.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Mongoose 1.0
 
 ## What's Mongoose?
 
-Mongoose is a MongoDB object modeling tool designed to work in an asynchronous
+Mongoose is a [MongoDB](http://www.mongodb.org/) object modeling tool designed to work in an asynchronous
 environment.
 
 Defining a model is as easy as:


### PR DESCRIPTION
I just went to http://mongoosejs.com/ and wanted to know what MongoDB was, but there was no link so I think that the first reference to MongoDB should be a link to Mongo's website.
