### PR TITLE
Better detection for document instances in utils.clone()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -209,7 +209,7 @@ var clone = exports.clone = function clone (obj, options) {
   if (Array.isArray(obj))
     return cloneArray(obj, options);
 
-  if (obj.toObject)
+  if (obj._id instanceof ObjectId)
     return obj.toObject(options);
 
   if (obj.constructor == Object)


### PR DESCRIPTION
This should fix issue #482

It's not perfect since I couldn't find a way to access `Model` or `Document` from utils.js (ideally it should compare `user.constructor.__proto__ === mongoose.Model` or `user instanceof mongoose.Document`), but it's a much safer assumption.
