### PR TITLE
Instead of just _id, objectid should be able to correctly identify standard "oid" as well

### DIFF
--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -94,6 +94,9 @@ ObjectId.prototype.cast = function (value, scope, init) {
 
   if (value._id && value._id instanceof oid)
     return value._id;
+    
+  if (value.oid && value.oid instanceof oid)
+    return value.oid;
 
   if (value.toString)
     return oid.fromString(value.toString());


### PR DESCRIPTION
The problem is that oid does not have a toString() method, thus I had a bug where I tried to populate a DBRef created by different software: The toString method 2 lines below my change resulted in an Exception (Error: Invalid ObjectId, lib/drivers/node-mongodb-native/objectid.js:31:15).

It was casted to String before in line 102, resulting in the string '[Object object]' which obviously is not of length 24.
