### PR TITLE
Allow setting advanced safe mode (write concern) 

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -269,7 +269,7 @@ Model.prototype.save = function save (fn) {
     , complete
 
   if (this.options.safe) {
-    options.safe = true;
+    options.safe = this.options.safe;
   }
 
   if (this.isNew) {


### PR DESCRIPTION
This patch allows setting of safe mode options like w:2 that ensure replication of data before getLastError returns in the driver.
