### PR TITLE
$addToSet fix/workaround

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -983,6 +983,7 @@ Query.prototype._castUpdate = function (obj) {
     , path
     , val
     , ii
+    , toPassthru = []
 
   while (i--) {
     path = paths[i];
@@ -1023,6 +1024,8 @@ Query.prototype._castUpdate = function (obj) {
           // apply using model instance methods ($inc, $pull, etc)
           if ('function' === typeof cur[method]) {
             cur[method](subval);
+          } else {
+            toPassthru.push([ method, val ]);
           }
         }
       }
@@ -1030,6 +1033,13 @@ Query.prototype._castUpdate = function (obj) {
   }
 
   var delta = doc._delta();
+
+  if (toPassthru.length) {
+    delta = delta || {};
+    toPassthru.map(function(i){
+      delta[i[0]] = i[1];
+    });
+  }
   return delta;
 };
 


### PR DESCRIPTION
This is not a fix so much as it is a workaround. Prior to [I think this commit](https://github.com/LearnBoost/mongoose/commit/4ea7175afbbc4810324e944db27951654fc29299), `$addToSet` worked on `Model.update`. 

I just want it to work again without having to drop down to the native driver so that the `$set` and `$inc` modifiers on that update get the benefit of the model defaults, validators, etc.

As noted in Issue #479, using `$addToSet` (or, I guess, any of the unimplemented '$' modifiers) fails silently. This is particularly annoying (and why I'm not sure exactly which commit broke it -- I didn't notice right away that it was failing).
