### PR TITLE
Fix for using $regex in a query

### DIFF
--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -155,6 +155,9 @@ SchemaString.prototype.$conditionalHandlers = {
 
 SchemaString.prototype.castForQuery = function ($conditional, val) {
   var handler;
+  if ($conditional === '$regex') {
+  	return val;
+  }
   if (arguments.length === 2) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler)

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3233,6 +3233,27 @@ module.exports = {
       });
     });
   },
+  
+  'test find querying with regex operator via #run (aka #exec)': function () {
+    var db = start()
+      , BlogPost = db.model('BlogPost', collection);
+
+    BlogPost.create(
+        {title: 'interoperable find as promise'}
+      , {title: 'interoperable find as promise'}
+      , function (err, createdOne, createdTwo) {
+      should.strictEqual(err, null);
+      var query = BlogPost.find({title: { $regex: '^inter.*promise$' } });
+      query.exec(function (err, found) {
+        should.strictEqual(err, null);
+        found.length.should.equal(2);
+        found[0]._id.should.eql(createdOne._id);
+        found[1]._id.should.eql(createdTwo._id);
+        db.close();
+      });
+    });
+  },
+
 
   'test remove querying via #run (aka #exec)': function () {
     var db = start()


### PR DESCRIPTION
Using the $regex operator as so:
{title: { $regex: '^inter.*promise$' } }

fails with the message:
Can't use $regex with String.

This pull request "should" fix this.

Please confirm my test case, I can't seem to get the tests to run correctly at the moment.
