### PR TITLE
castForQuery fix

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -125,7 +125,7 @@ SchemaNumber.prototype.castForQuery = function ($conditional, val) {
     return handler.call(this, val);
   } else {
     val = $conditional;
-    return this.cast(val);
+    return this.cast(val).valueOf();
   }
 };
 


### PR DESCRIPTION
Why Number object must be extended by MongooseNumber method for use in castForQuery?
I've got a error when i try to query MongooseNumber casted object in find(), findOne(), etc:
Invalid BSONObj size: 0 (0x00000000) first element: EOO
First element is { "num": Number }.
