### PR TITLE
fix to populate engine

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -194,7 +194,7 @@ Model.prototype.init = function init (doc, query, fn) {
       var i = keys[len]
         , path = prefix + i
         , schema = self.schema.path(path)
-        , poppath = populate[path]
+        , poppath = utils.clone(populate[path])//in execution context this parametes is changed and became inconsistent
         , total = 0
 
       if (!schema && obj[i] && 'Object' === obj[i].constructor.name) {


### PR DESCRIPTION
fixed: use clone of populate[path] because it is changed in execution context and then became unusable --> so it drives to query returns different objects from what i've expected.
explanation:
in _populate method there is condition
      options.conditions || (options.conditions = {});
      options.conditions._id || (options.conditions._id = { $in: oid });
and when query returns more that one document that must be populated, then the condition on query itself became changed. so next query will never populate anything for the same path.
