### PR TITLE
fix for hooks call - multi-level embedded documents

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -745,37 +745,37 @@ Document.prototype._registerHooks = function () {
   if (!this.save) return;
   
   this.pre('save', function (next) {
-      // we keep the error semaphore to make sure we don't
-      // call `save` unnecessarily (we only need 1 error)
-      var subdocs = 0
-        , DocumentArray = require('./types/documentarray')
-        , error = false
-        , self = this;
+    // we keep the error semaphore to make sure we don't
+    // call `save` unnecessarily (we only need 1 error)
+    var subdocs = 0
+      , DocumentArray = require('./types/documentarray')
+      , error = false
+      , self = this;
 
-      var arrays = this._activePaths
-        .map('init', 'modify', function (i) {
-          return self.getValue(i);
-        })
-        .filter(function (val) {
-          return (val && val instanceof DocumentArray && val.length);
-        });
+    var arrays = this._activePaths
+      .map('init', 'modify', function (i) {
+      return self.getValue(i);
+    })
+    .filter(function (val) {
+      return (val && val instanceof DocumentArray && val.length);
+    });
 
-      if (!arrays.length)
-        return next();
-//require('sys').puts(this.name);
-      arrays.forEach(function (array) {
-        subdocs += array.length;
-        array.forEach(function (value) {
-          if (!error)
-            value.save(function (err) {
-              if (!error) {
-                if (err) {
-                  error = true;
-                  next(err);
-                } else
-                  --subdocs || next();
-              }
-            });
+    if (!arrays.length)
+      return next();
+
+    arrays.forEach(function (array) {
+      subdocs += array.length;
+      array.forEach(function (value) {
+        if (!error)
+          value.save(function (err) {
+            if (!error) {
+              if (err) {
+                error = true;
+                next(err);
+              } else
+                --subdocs || next();
+            }
+          });
         });
       });
     }, function (err) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -456,44 +456,6 @@ Model.prototype.remove = function remove (fn) {
  */
 
 Model.prototype._registerHooks = function registerHooks () {
-  // make sure to pass along all the errors from subdocuments
-//  this.pre('save', function (next) {
-//    // we keep the error semaphore to make sure we don't
-//    // call `save` unnecessarily (we only need 1 error)
-//    var subdocs = 0
-//      , error = false
-//      , self = this;
-//
-//    var arrays = this._activePaths
-//      .map('init', 'modify', function (i) {
-//        return self.getValue(i);
-//      })
-//      .filter(function (val) {
-//        return (val && val instanceof DocumentArray && val.length);
-//      });
-//
-//    if (!arrays.length)
-//      return next();
-//
-//    arrays.forEach(function (array) {
-//      subdocs += array.length;
-//      array.forEach(function (value) {
-//        if (!error)
-//          value.save(function (err) {
-//            if (!error) {
-//              if (err) {
-//                error = true;
-//                next(err);
-//              } else
-//                --subdocs || next();
-//            }
-//          });
-//      });
-//    });
-//  }, function (err) {
-//    this.db.emit('error', err);
-//  });
-
   Document.prototype._registerHooks.call(this);
 };
 


### PR DESCRIPTION
Hi,
At the moment, the pre-save hooks doesn't get called for embedded document below the second level. This change will fix this.

Just to make it clear, i have shown the test below :

```
  var grandSchema = new Schema({ name : String });
  grandSchema.pre('save', function (next) {
      this.name = 'grand';
      next();
    });
  var childSchema = new Schema({ name : String, grand : [grandSchema]});
  childSchema.pre('save', function (next) {
      this.name = 'child';
      next();
    });
  var schema = new Schema({ name: String, child : [childSchema] });

  schema.pre('save', function (next) {
    this.name = 'parent';
    next(); 
  });

  var S = db.model('presave_hook', schema, 'presave_hook');
  var s = new S({ name : 'a' , child : [ { name : 'b', grand : [{ name : 'c'}] } ]});

  s.save(function (err, doc) {
    db.close();
    should.strictEqual(null, err);
    doc.name.should.eql('parent');
    doc.name.child[0].name.should.eql('child');
    doc.name.child[0].grand[0].name.should.eql('grand');

  });
```

Here the pre-save for the grand schema will also be called, which wasn't happening before.

Let me know if my fix has any issues. The request have test case as well.

Thanks.
