### PR TITLE
Suggestion for single embedded document support

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -96,18 +96,38 @@ Schema.prototype.tree;
 
 Schema.prototype.add = function (obj, prefix) {
   prefix = prefix || '';
+
   for (var i in obj) {
     // make sure set of keys are in `tree`
     if (!prefix && !this.tree[i])
       this.tree[i] = obj[i];
 
-    if (obj[i].constructor.name == 'Object' && (!obj[i].type || obj[i].type.type)) {
-      if (Object.keys(obj[i]).length)
-        this.add(obj[i], prefix + i + '.');
-      else
-        this.path(prefix + i, obj[i]); // mixed type
-    } else
-      this.path(prefix + i, obj[i]);
+    // one-to-one
+    var tree = null;
+
+    if(obj[i] instanceof Schema) tree = obj[i].tree;
+    if(obj[i].type !== undefined && obj[i].type instanceof Schema) tree = obj[i].type.tree;
+    if(obj[i].type !== undefined && obj[i].type.type !== undefined && obj[i].type.type instanceof Schema) tree = obj[i].type.type.tree;
+
+    if(tree !== null) {
+      var embeddedDoc = {};
+      for(var k in tree) {
+        if(k !== 'id' && k !== '_id') {
+          embeddedDoc[k] = tree[k];
+        }
+      }
+      this.add(embeddedDoc, prefix + i + '.');
+    }
+    // normal path
+    else {
+      if (obj[i].constructor.name == 'Object' && (!obj[i].type || obj[i].type.type)) {
+        if (Object.keys(obj[i]).length)
+          this.add(obj[i], prefix + i + '.');
+        else
+          this.path(prefix + i, obj[i]); // mixed type
+      } else
+        this.path(prefix + i, obj[i]);
+    }
   }
 };
 


### PR DESCRIPTION
Hi,

One of my challenges with mongoose is to have a single embedded doc in a doc, this patch allows this kind of schema declaration:

var mongoose = require('mongoose'),
    Schema = mongoose.Schema;

mongoose.connect('mongodb://localhost/mongoose');

var PersonSchema = new Schema({
  FirstName: {type: String, required: true},
  LastName: String
});

var BlogPostSchema = new Schema({
  creator: PersonSchema
});

/**
- Define model.
  */

var BlogPost = mongoose.model('BlogPost', BlogPostSchema);
var Person = mongoose.model('Person', PersonSchema);

var person = new Person({FirstName: 'Paulo', LastName: 'Lopes'});

var post = new BlogPost({title: 'test', creator: person});

post.save(function(err) {
  if (err) return console.log(err);
  BlogPost.find({}, function(err, docs) {
    if(err) return console.log(err);
    console.log(docs[0].creator);
    docs[0].creator = null;
    docs[0].save(function(err) {
      if(err) return console.log(err);
      mongoose.disconnect();
    });
  });
});

I don't know much about the internals of mongoose but this seems to work for me... could someone review and give some feedback? Thanks
