### PR TITLE
Do not allow `undefined` values to pass `checkRequired`

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -33,7 +33,7 @@ SchemaNumber.prototype.__proto__ = SchemaType.prototype;
 
 SchemaNumber.prototype.checkRequired = function checkRequired (value) {
   if (SchemaType._isRef(this, value, true)) {
-    return null !== value;
+    return null !== value || undefined !== value;
   } else {
     return typeof value == 'number' || value instanceof Number;
   }

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -34,7 +34,7 @@ ObjectId.prototype.__proto__ = SchemaType.prototype;
 
 ObjectId.prototype.checkRequired = function checkRequired (value) {
   if (SchemaType._isRef(this, value, true)) {
-    return null !== value;
+    return null !== value || undefined !== value;
   } else {
     return value instanceof oid;
   }

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -117,7 +117,7 @@ SchemaString.prototype.match = function(regExp){
 
 SchemaString.prototype.checkRequired = function checkRequired (value) {
   if (SchemaType._isRef(this, value, true)) {
-    return null !== value;
+    return null !== value || undefined !== value;
   } else {
     return (value instanceof String || typeof value == 'string') && value.length;
   }


### PR DESCRIPTION
Was a bit difficult setting up a dev environment and running tests (which we never managed to get working), but this change seemed rather simple.

This pull request prevents `undefined` values from passing through the `{ required: true }` setting. Previously only `null` values were checked against the value.
