### PR TITLE
GH 586 - add support for '$within' on Array fields

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -172,6 +172,11 @@ SchemaArray.prototype.$conditionalHandlers = {
   , '$regex': SchemaArray.prototype.castForQuery
   , '$near': SchemaArray.prototype.castForQuery
   , '$nearSphere': SchemaArray.prototype.castForQuery
+  , '$within': function(val) {
+      var query = new Query(val);
+      query.cast(this.casterConstructor)
+      return query._conditions;
+    }
   , '$maxDistance': function (val) {
       return ArrayNumberSchema.prototype.cast.call(this, val);
     }

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1607,6 +1607,23 @@ module.exports = {
     });
   },
 
+  // GH-586
+  'using $within with Arrays works (geo-spatial)': function () {
+    var db = start()
+      , Test = db.model('Geo1', geoSchema, collection + 'geospatial');
+
+    Test.create({ loc: [ 35, 50 ]}, { loc: [ -40, -90 ]}, function (err) {
+      should.strictEqual(err, null);
+      setTimeout(function () {
+        Test.find({ loc: { '$within': { '$box': [[30,40], [40,60]] }}}, function (err, docs) {
+          db.close();
+          should.strictEqual(err, null);
+          docs.length.should.equal(1);
+        });
+      }, 700);
+    });
+  },
+
   // GH-610
   'using nearSphere with Arrays works (geo-spatial)': function () {
     var db = start()


### PR DESCRIPTION
Test included.  I'm not 100% certain that using a new Query is the right thing to do here, but it seemed correct given that $within's argument could have $box or $center as a key as well as different value structures.
