### PR TITLE
Fix compatibility with datejs

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -13,6 +13,7 @@ var Document = require('./document')
   , merge = utils.merge
   , Promise = require('./promise')
   , tick = utils.tick
+  , isPrimitive = utils.isPrimitive
 
 /**
  * Model constructor
@@ -365,11 +366,11 @@ Model.prototype._delta = function _delta () {
           }
         }
 
-        obj[data.path] = val.toObject
+        obj[data.path] = (!isPrimitive(val) && val.toObject)
           ? val.toObject({ depopulate: 1 }) // MongooseArray
           : Array.isArray(val)
             ? val.map(function (mem) {
-                return mem.toObject
+                return (!isPrimitive(mem) && mem.toObject)
                   ? mem.toObject({ depopulate: 1 })
                   : mem.valueOf
                     ? mem.valueOf()

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -15,7 +15,9 @@ var SchemaType = require('../schematype')
     }
   , MongooseArray = require('../types').Array
   , Mixed = require('./mixed')
-  , Query = require('../query');
+  , Query = require('../query')
+  , utils = require('../utils')
+  , isPrimitive = utils.isPrimitive;
 
 /**
  * Array SchemaType constructor
@@ -142,13 +144,13 @@ SchemaArray.prototype.castForQuery = function ($conditional, val) {
     if (Array.isArray(val)) {
       val = val.map(function (v) {
         if (method) v = method.call(proto, v);
-        return v.toObject ? v.toObject() : v;
+        return (!isPrimitive(v) && v.toObject)? v.toObject() : v;
       });
     } else if (method) {
       val = method.call(proto, val);
     }
   }
-  return val && val.toObject ? val.toObject() : val;
+  return (val && !isPrimitive(val) && val.toObject)? val.toObject() : val;
 };
 
 SchemaArray.prototype.$conditionalHandlers = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -158,6 +158,10 @@ exports.deepEqual = function deepEqual (a, b) {
     return a.valueOf() === b.valueOf();
   }
 
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() == b.getTime();
+  }
+
   if (a.toObject) a = a.toObject();
   if (b.toObject) b = b.toObject();
 
@@ -215,17 +219,17 @@ var clone = exports.clone = function clone (obj, options) {
   if (Array.isArray(obj))
     return cloneArray(obj, options);
 
-  if (obj.toObject)
-    return obj.toObject(options);
-
-  if ('Object' === obj.constructor.name)
-    return cloneObject(obj, options);
-
   if ('Date' === obj.constructor.name || 'Function' === obj.constructor.name)
     return new obj.constructor(+obj);
 
   if ('RegExp' === obj.constructor.name)
     return new RegExp(obj.source);
+
+  if (obj.toObject)
+    return obj.toObject(options);
+
+  if ('Object' === obj.constructor.name)
+    return cloneObject(obj, options);
 
   if (obj instanceof ObjectId)
     return ObjectId.fromString(ObjectId.toString(obj));
@@ -394,4 +398,16 @@ exports.tick = function tick (callback) {
       callback.apply(self, args);
     })
   }
+}
+
+/**
+ * checks if the value is a primitive type
+ */
+exports.isPrimitive = function (val) {
+    return val instanceof Array
+        || val instanceof Boolean
+        || val instanceof Date
+        || val instanceof Number
+        || val instanceof String
+        || val instanceof RegExp;
 }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4739,8 +4739,21 @@ module.exports = {
     });
   },
 
-  'date casting test (gh-502)': function () {
+  'enhanced date casting test (datejs - gh-502)': function () {
     var db = start()
+
+    Date.prototype.toObject = function() {
+        return {
+              millisecond: 86
+            , second: 42
+            , minute: 47
+            , hour: 17
+            , day: 13
+            , week: 50
+            , month: 11
+            , year: 2011
+        };
+    };
 
     var S = new Schema({
         name: String
@@ -4766,6 +4779,7 @@ module.exports = {
         m.save(function (err) {
           should.strictEqual(err, null);
           M.remove(function (err) {
+            delete Date.prototype.toObject;
             db.close();
           });
         });


### PR DESCRIPTION
Fixes compatibility with datejs (or any other library that adds a toObject method to the Date prototype).

The fix ensures that mongoose ignores toObject methods for the standard types "Date", "Function" and "Regex" (these were currently checked for _after_ looking for a toObject method).

This fix addresses issue #502.
