### PR TITLE
Fix for "Have conflicting mods in update"

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -686,11 +685,27 @@ Document.prototype._reset = function reset () {
 Document.prototype._dirty = function _dirty () {
   var self = this;
 
-  return this._activePaths.map('modify', function (path) {
+  var all = this._activePaths.map('modify', function (path) {
     return { path: path
            , value: self.getValue(path)
            , schema: self._path(path) };
   });
+
+  // Sort dirty paths in a flat hierarchy.
+  all.sort(function(a, b) {
+    return (a.path < b.path ? -1 : (a.path > b.path ? 1 : 0));
+  });
+
+  // Ignore "foo.a" if "foo" is dirty already.
+  var minimal = [], lastReference = null;
+  all.forEach(function(item) {
+    if(item.path.indexOf(lastReference) != 0) {
+      lastReference = item.path;
+      minimal.push(item);
+    }
+  });
+
+  return minimal;
 }
 
 /**


### PR DESCRIPTION
I fixed "have conflicting mods in update" if an EmbeddedDocument and its containing Array were explicitly markModified (by splice for example).

``` coffeescript
# childs = [doc1, doc2, doc3]

# causes "childs.0" to be dirty
childs[0].set "name", "Alex"

# causes "childs" to be dirty
childs.splice 1, 1, newEmbeddedDocument

# problem: Mongo-query now contains a $set for both
# paths, causing a conflict (i.e. MongoError: have conflicting mods in update)
```

I'll take a look into writing a test for this at this weekend.
