### PR TITLE
Check for mongoose types rather than toObject

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -365,11 +365,11 @@ Model.prototype._delta = function _delta () {
           }
         }
 
-        obj[data.path] = val.toObject
+        obj[data.path] = (val instanceof Document || val instanceof MongooseArray || val instanceof MongooseBuffer)
           ? val.toObject({ depopulate: 1 }) // MongooseArray
           : Array.isArray(val)
             ? val.map(function (mem) {
-                return mem.toObject
+                return (mem instanceof Document || mem instanceof MongooseArray || mem instanceof MongooseBuffer)
                   ? mem.toObject({ depopulate: 1 })
                   : mem.valueOf
                     ? mem.valueOf()

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -14,8 +14,10 @@ var SchemaType = require('../schematype')
       , Buffer: require('./buffer')
     }
   , MongooseArray = require('../types').Array
+  , MongooseBuffer = require('../types').Buffer
   , Mixed = require('./mixed')
-  , Query = require('../query');
+  , Query = require('../query')
+  , Document = require('../document');
 
 /**
  * Array SchemaType constructor
@@ -142,13 +144,14 @@ SchemaArray.prototype.castForQuery = function ($conditional, val) {
     if (Array.isArray(val)) {
       val = val.map(function (v) {
         if (method) v = method.call(proto, v);
-        return v.toObject ? v.toObject() : v;
+        return (v instanceof Document || v instanceof MongooseArray || v instanceof MongooseBuffer)?
+            v.toObject() : v;
       });
     } else if (method) {
       val = method.call(proto, val);
     }
   }
-  return val && val.toObject ? val.toObject() : val;
+  return (val && (val instanceof Document || val instanceof MongooseArray || val instanceof MongooseBuffer))? val.toObject() : val;
 };
 
 SchemaArray.prototype.$conditionalHandlers = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,9 @@
 
 var EventEmitter = require('events').EventEmitter
   , ObjectId = require('./types/objectid')
+  , Document
+  , MongooseArray
+  , MongooseBuffer
 
 /**
  * Produces a collection name from a model name
@@ -158,8 +161,13 @@ exports.deepEqual = function deepEqual (a, b) {
     return a.valueOf() === b.valueOf();
   }
 
-  if (a.toObject) a = a.toObject();
-  if (b.toObject) b = b.toObject();
+  Document || (Document = require('./document'));
+  MongooseArray || (MongooseArray = require('./types').Array);
+  MongooseBuffer || (MongooseBuffer = require('./types').Buffer);
+  if (a instanceof Document || a instanceof MongooseArray || a instanceof MongooseBuffer)
+    a = a.toObject();
+  if (b instanceof Document || b instanceof MongooseArray || b instanceof MongooseBuffer)
+    b = b.toObject();
 
   try {
     var ka = Object.keys(a),
@@ -215,7 +223,10 @@ var clone = exports.clone = function clone (obj, options) {
   if (Array.isArray(obj))
     return cloneArray(obj, options);
 
-  if (obj.toObject)
+  Document || (Document = require('./document'));
+  MongooseArray || (MongooseArray = require('./types').Array);
+  MongooseBuffer || (MongooseBuffer = require('./types').Buffer);
+  if (obj instanceof Document || obj instanceof MongooseArray || obj instanceof MongooseBuffer)
     return obj.toObject(options);
 
   if ('Object' === obj.constructor.name)

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4739,8 +4739,21 @@ module.exports = {
     });
   },
 
-  'date casting test (gh-502)': function () {
+  'enhanced date casting test (datejs - gh-502)': function () {
     var db = start()
+
+    Date.prototype.toObject = function() {
+        return {
+              millisecond: 86
+            , second: 42
+            , minute: 47
+            , hour: 17
+            , day: 13
+            , week: 50
+            , month: 11
+            , year: 2011
+        };
+    };
 
     var S = new Schema({
         name: String
@@ -4766,6 +4779,7 @@ module.exports = {
         m.save(function (err) {
           should.strictEqual(err, null);
           M.remove(function (err) {
+            delete Date.prototype.toObject;
             db.close();
           });
         });


### PR DESCRIPTION
Specifically Document, MongooseArray and MongooseBuffer.

This is an alternative to #646.

Currently it checkes 'instanceof' for all three types in every case where a toObject check previously occurred.  This could probably be made neater by having a common base MongooseObject, or some similar technique, but that would be too large a change for this pull request.
