### PR TITLE
Remove mention of require.paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,10 +243,7 @@ var Post = mongoose.model(&#39;BlogPost&#39;, BlogPost);</code></pre>
 
 <p>Otherwise, you can check it in your repository and then expose it:</p>
 
-<pre><code>$ git clone git@github.com:LearnBoost/mongoose.git support/mongoose/
-
-// in your code
-require.paths.unshift(&#39;support/mongoose/lib&#39;)</code></pre>
+<pre><code>$ git clone git@github.com:LearnBoost/mongoose.git node_modules/mongoose/
 
 <p>Then you can <code>require</code> it:</p>
 


### PR DESCRIPTION
`require.paths` has been deprecated for a while now, and has been removed in Node 0.6.x; changed git fetch line to `node_modules/mongoose` instead of `support/mongoose`.
