### PR TITLE
Fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,9 @@ $ npm install mongoose
 Otherwise, you can check it in your repository and then expose it:
 
 ```bash
-$ git clone git@github.com:LearnBoost/mongoose.git support/mongoose/
+$ git clone git://github.com/LearnBoost/mongoose.git node_modules/mongoose/
 ```
-```javascript
-// in your code
-require.paths.unshift('support/mongoose/lib')
-```
+And install dependency modules written on `package.json`.
 
 Then you can `require` it:
 


### PR DESCRIPTION
I fixed README.

Following reasons:
- `require.paths` is currently deprecated.
- Repository url is ssh required.
