### PR TITLE
Embedded docs 'isNew' is not set if the doc is added after document is saved. (failing test)

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -523,6 +523,26 @@ module.exports = {
     });
   },
 
+  'test isNew on embedded documents added after saving': function(){
+    var db = start()
+      , BlogPost = db.model('BlogPost', collection);
+
+    var post = new BlogPost({ title: 'hocus pocus' })
+    post.save(function (err) {
+      post.isNew.should.be.false;
+      post.comments.push({ title: 'Humpty Dumpty', comments: [{title: 'nested'}] });
+      post.get('comments')[0].isNew.should.be.true;
+      post.get('comments')[0].comments[0].isNew.should.be.true;
+      post.save(function (err) {
+        should.strictEqual(null, err);
+        post.isNew.should.be.false;
+        post.get('comments')[0].isNew.should.be.false;
+        post.get('comments')[0].comments[0].isNew.should.be.false;
+        db.close();
+      });
+    });
+  },
+
   'modified states are reset after save runs': function () {
     var db = start()
       , B = db.model('BlogPost', collection)


### PR DESCRIPTION
This test fails on line 539.

Adding an embedded doc with the parent doc sets the isNew flag properly (see the previous test case "test isNew on embedded documents after saving"). However, if the embedded doc is added _after_ the parent doc has already been created, the isNew flag is not set to false.
