### PR TITLE
I was getting an error from schema.js but I didn't know what triggered the error 

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -220,7 +220,7 @@ Schema.interpretAsType = function (path, obj) {
   }
   
   if (Types[type.name] == undefined){
-    throw new TypeError('Undefined type at `' + path + '`');
+    throw new TypeError('Undefined type at `' + path + '`\nDid you try nesting Schemas? You can only nest them by using DBRefs or inside Arrays\n');
   }
   return new Types[type.name](path, obj);
 };


### PR DESCRIPTION
TypeError: Invalid type `undefined`
    at Function.interpretAsType (/home/sjuul/node_modules/mongoose/lib/schema.js:223:8)
    at Schema.path (/home/sjuul/node_modules/mongoose/lib/schema.js:182:29)
    at Schema.add (/home/sjuul/node_modules/mongoose/lib/schema.js:118:12)
    at new Schema (/home/sjuul/node_modules/mongoose/lib/schema.js:39:10)
    at Object.<anonymous> (/home/sjuul/jsServer/schemas.js:10:23)
    at Module._compile (module.js:432:26)
    at Object..js (module.js:450:10)
    at Module.load (module.js:351:31)
    at Function._load (module.js:310:12)
    at Module.require (module.js:357:17)

I wanted it to warn me where it came from. So I made the function to fail earlier and throw an error that let's you know where the problem is in your schema.
I'm still getting the error but at least this fixes the part where people wont know where it came from.
