### PR TITLE
Don't add Model getters or setters to the stack unless they are functions.

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -116,7 +115,9 @@ SchemaType.prototype.sparse = function (bool) {
  */
 
 SchemaType.prototype.set = function (fn) {
-  this.setters.push(fn);
+  if (typeof (fn) === 'function) {
+    this.setters.push(fn);
+  }
   return this;
 };
 
@@ -128,7 +129,9 @@ SchemaType.prototype.set = function (fn) {
  */
 
 SchemaType.prototype.get = function (fn) {
-  this.getters.push(fn);
+  if (typeof (fn) === 'function) {
+    this.getters.push(fn);
+  }
   return this;
 };
 


### PR DESCRIPTION
Fixing https://github.com/LearnBoost/mongoose/issues/704 - don't add Model getters or setters to the stack unless they are functions.
