### PR TITLE
throw an Error if Model getters or setters are not functions

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -116,6 +115,7 @@ SchemaType.prototype.sparse = function (bool) {
  */
 
 SchemaType.prototype.set = function (fn) {
+  if (typeof (fn) !== 'function') { throw new Error('A setter must be a function.'); }
   this.setters.push(fn);
   return this;
 };
@@ -128,6 +128,7 @@ SchemaType.prototype.set = function (fn) {
  */
 
 SchemaType.prototype.get = function (fn) {
+  if (typeof (fn) !== 'function') { throw new Error('A getter must be a function.'); }
   this.getters.push(fn);
   return this;
 };


### PR DESCRIPTION
Fixing https://github.com/LearnBoost/mongoose/issues/704 - throw an Error if Model getters or setters are not functions
