### PR TITLE
create api to support insertall

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -284,18 +284,22 @@ Model.prototype.save = function save (fn) {
   var promise = new Promise(fn)
     , complete = handleSave(promise, this)
     , options = {}
+    , doc = null
 
   if (this.options.safe) {
     options.safe = this.options.safe;
   }
 
   if (this.isNew) {
-    // send entire doc
-    this.collection.insert(this.toObject({ depopulate: 1 }), options, complete);
-    this._reset();
-    this.isNew = false;
-    this.emit('isNew', false);
-
+    doc = this.toObject({ depopulate: 1 });
+    if (this._massCreate) {
+      promise.complete(doc);
+    } else {
+      this.collection.insert(doc, options, complete);
+      this._reset();
+      this.isNew = false;
+      this.emit('isNew', false);
+    }
   } else {
     var delta = this._delta();
     this._reset();
@@ -782,10 +786,40 @@ Model.create = function create (doc, fn) {
 
   var self = this
     , docs = [null]
-    , promise
+    , promise = null
     , count
     , args
-
+    , insertDocs = function(docs) {
+        var _docs = []
+          , options = {};
+        docs.forEach(function(doc) {
+          doc && _docs.push(doc.toObject({
+            depopulate : 1
+          }));
+        });
+        
+        if (self.prototype.schema.options.safe) {
+          options.safe = self.prototype.schema.options.safe;
+        }
+        self.prototype.collection.insertAll(_docs, options, function(err) {
+          if (err) {
+            promise.error(err);
+          } else {
+            docs.forEach(function(doc) {
+              doc && doc.emit('save', doc);
+            });
+            fn.apply(null, docs);
+          }
+        });
+        docs.forEach(function(doc) {
+          if(doc)  {
+            doc._reset();
+            doc.isNew = false;
+            doc.emit('isNew', false);
+          }
+        });
+      };
+      
   if (Array.isArray(doc)) {
     args = doc;
   } else {
@@ -801,9 +835,10 @@ Model.create = function create (doc, fn) {
   args.forEach(function (arg, i) {
     var doc = new self(arg);
     docs[i+1] = doc;
+    doc._massCreate = true;
     doc.save(function (err) {
       if (err) return promise.error(err);
-      --count || fn.apply(null, docs);
+      --count || insertDocs(docs);
     });
   });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -2124,6 +2124,25 @@ module.exports = {
     });
   },
 
+  'test creating multiple docs' : function() {
+    var db = start()
+      , schema = new Schema({
+          name: String
+        })
+      , count = 0;
+
+    schema.post('save', function(doc){
+      ++count === 2 && db.close();
+    });
+    mongoose.model('MultiDoc', schema);
+    var Temp = db.model('MultiDoc', collection);
+  
+    Temp.create([{ name: 'doc1'}, { name: 'doc2'}], function (err, doc1, doc2) {
+      should.equal('doc1', doc1.name);
+      should.equal('doc2', doc2.name);
+    });
+  },
+  
   'test updating at least a single $push and $pushAll as a single $pushAll': function () {
     var db = start()
       , schema = new Schema({


### PR DESCRIPTION
Hi,
I have adjusted the create/save api of model.js to support insertall for multi-documents creation.

I have also added tests to validate the post save event for multiple documents and all the existing tests are working fine.

Please review it.

Thanks.
