### PR TITLE
Add multiple validators to a schema type

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -144,12 +144,12 @@ SchemaType.prototype.get = function (fn) {
  */
 
 SchemaType.prototype.validate = function (obj, error) {
-  if ('function' == typeof obj && 'string' == typeof error) {
+  if ('function' == typeof obj) {
     this.validators.push([obj, error]);  
   }
   else {
     for (var i in arguments) {
-      this.validators.push([arguments[i].func, arguments[i].error]);
+      this.validators.push([arguments[i].validator, arguments[i].msg]);
     }
   }
   return this;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -482,6 +482,41 @@ module.exports = {
     Animal.path('isFerret').cast('1').should.be.true;
   },
 
+'test async multiple validators': function(beforeExit){
+    var executed = 0;
+    
+    function validator (value, fn) {
+      setTimeout(function(){
+        executed++;
+        fn(value === true);
+      }, 50);
+    };
+
+    var Animal = new Schema({
+      ferret: { 
+        type: Boolean, 
+        validate: [
+          {
+            'validator': validator,
+            'msg': 'validator1'
+          },
+          {
+            'validator': validator,
+            'msg': 'validator2'
+          },
+        ],
+      }
+    });
+
+    Animal.path('ferret').doValidate(true, function(err){
+      should.strictEqual(err, null);
+    });
+
+    beforeExit(function(){
+      executed.should.eql(2);
+    });
+  },
+
   'test async validators': function(beforeExit){
     var executed = 0;
     


### PR DESCRIPTION
The ticket for this pull request is the following: https://github.com/LearnBoost/mongoose/issues/718

Now multiple validators can be added to a schema type in the declaration stage.
I changed the key names of the validator object to 'validator' instead of 'func' and 'msg' instead of 'error'

All the previous tests are passing and I added a new to test to check adding multiple validators.
