### PR TITLE
I have a rest controller and I'm dynamically passing that value into lim...

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -676,7 +676,7 @@ Query.prototype.desc = function () {
 
 ;['limit', 'skip', 'maxscan', 'snapshot', 'batchSize'].forEach( function (method) {
   Query.prototype[method] = function (v) {
-    this.options[method] = v;
+    this.options[method] = parseInt(v);
     return this;
   };
 });


### PR DESCRIPTION
...it which turns out to be a string... Which doesn't throw an error or....

Passed in value limit("2").. by calling parseInt fixes this bug...

One could be a little safer and do something like this:

if(v != null && typeof v != 'undefined' && v.length > 0 && !isNaN(v) { 
this.options[method] = parseInt(v); 
} else { throw Error()..... }
