### PR TITLE
Make post('remove') middleware provide the model that was removed. 

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -476,7 +476,7 @@ Model.prototype.remove = function remove (fn) {
       return promise.error(err);
     }
     promise.complete();
-    self.emit('remove');
+    self.emit('remove', self);
   }));
 
   return this;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3287,9 +3287,11 @@ module.exports = {
         })
       , save = false
       , remove = false
-      , init = false;
+      , init = false
+      , post = undefined;
 
-    schema.post('save', function () {
+    schema.post('save', function (arg) {
+      arg._id.should.equal(post._id)
       save = true;
     });
 
@@ -3297,7 +3299,8 @@ module.exports = {
       init = true;
     });
 
-    schema.post('remove', function () {
+    schema.post('remove', function (arg) {
+      arg._id.should.eql(post._id)
       remove = true;
     });
 
@@ -3306,13 +3309,12 @@ module.exports = {
     var db = start()
       , BlogPost = db.model('PostHookTest');
 
-    var post = new BlogPost();
+    post = new BlogPost();
 
     post.save(function (err) {
       process.nextTick(function () {
         should.strictEqual(err, null);
         save.should.be.true;
-
         BlogPost.findById(post._id, function (err, doc) {
           process.nextTick(function () {
             should.strictEqual(err, null);


### PR DESCRIPTION
currently, there's no way to know exactly what model was removed within a post('remove') middleware, rendering it reasonably non-useful. This patch provides the model that removed to the post('remove') callback.

``` javascript
ModelSchema.post('remove', function(model) {
   console.log('Removed: ', model)
})
```
