### PR TITLE
Adding username/password to connect options

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -64,6 +64,8 @@ Connection.prototype.db;
  *   options.db      - passed to the connection db instance
  *   options.server  - passed to the connection server instance(s)
  *   options.replset - passed to the connection ReplSetServer instance
+ *   options.user    - username for authentication
+ *   options.pass    - password for authentication
  *
  *   Notes:
  *
@@ -148,6 +150,19 @@ Connection.prototype.open = function (host, database, port, options, callback) {
     var auth = uri.auth.split(':');
     this.user = auth[0];
     this.pass = auth[1];
+  
+  // Check hostname for user/pass
+  } else if (host.match(/@/) && host.split('@').shift().match(/:/)) {
+    var auth = host.split('@').shift().split(':');
+    host = host.split('@').pop();
+    this.user = auth[0];
+    this.pass = auth[1];
+    
+  // user/pass options
+  } else if (options.user && options.pass) {
+    this.user = options.user;
+    this.pass = options.pass;
+    
   } else {
     this.user = this.pass = undefined;
   }


### PR DESCRIPTION
I wanted to use mongoose with a password protected mongodb without passing the full URI to mongoose.connect().  I made an addition that parses the user/pass from the host parameter, when a string like "user:pass@the.domain.com" is used.

I also added user and pass properties to the options parameter: 

mongoose.connect("host", "database", port, {user:"user", pass:"pass"}) 

This allowed me to decouple the parts of the mongodb URL, so that I could setup different ports and users for different environments (dev, staging, prod, etc).
