### PR TITLE
Added code to prevent $id and $ref triggering a conditional

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -217,7 +217,7 @@ Query.prototype.cast = function (model, obj) {
       } else if ('Object' === val.constructor.name) {
 
         any$conditionals = Object.keys(val).some(function (k) {
-          return k.charAt(0) === '$';
+          return k.charAt(0) === '$' && k !== '$id' && k !== '$ref';
         });
 
         if (!any$conditionals) {


### PR DESCRIPTION
$id and $ref are useful to be cast as dbref when using mongoose-dbref and shouldn't automatically trigger conditional processing.
