### PR TITLE
SchemaNumber.prototype.cast does not handle null values

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -86,18 +86,18 @@ SchemaNumber.prototype.max = function (value, message) {
 SchemaNumber.prototype.cast = function (value, doc, init) {
   if (SchemaType._isRef(this, value, init)) return value;
 
-  if (!isNaN(value)){
-    if (null === value) return value;
-    if ('' === value) return null;
-    if ('string' === typeof value) value = Number(value);
-    if (value instanceof Number) return value.valueOf();
-    if ('number' == typeof value) return value;
-    if (value.toString && !Array.isArray(value) &&
-        value.toString() == Number(value)) {
-      return new Number(ret).valueOf();
-    }
-  }
-
+	if (null === value) return value;
+	if ('' === value) return null;
+	if ('string' === typeof value) value = Number(value);
+	if (value instanceof Number) return value.valueOf();
+	if ('number' == typeof value) return value;
+	if (value.toString && !Array.isArray(value)){
+		var ret = value.toString();
+		if (ret == Number(value)) {
+			return new Number(ret).valueOf();
+		}
+	}
+  
   throw new CastError('number', value);
 };
 


### PR DESCRIPTION
Null values are throwing a CastError for the schema type of number.

Checking the code revealed a if block wrapping most everything checking isNaN(value).  If you open a node terminal and type isNaN(null), it returns false.  I don't think this was the intended behavior of the check as just inside that block is a check for null. 

Also, the last if check has "return new Number(ret).valueOf();" .  The variable ret is not defined; so any code dropping to "return new Number(ret).valueOf();" fails.

I removed if(isNaN) check as the logic of the contained if else blocks appears to handle all cases, and I set the ret variable before using it.

Here is the code if you'd like it.  I'd do more tests for you, but I am on a deadline at the moment and just need this to work.

Thanks for the awesome library.
