### PR TITLE
Added srslyStrict mode and tests to go with it.

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -29,7 +29,8 @@ function Document (obj, fields) {
   if (!this._events) this._events = {};
   this.setMaxListeners(0);
 
-  this._strictMode = this.schema.options && this.schema.options.strict;
+  this._srslyStrictMode = this.schema.options && this.schema.options.srslyStrict;
+  this._strictMode = this._srslyStrictMode || this.schema.options && this.schema.options.strict;
 
   if ('boolean' === typeof fields) {
     this._strictMode = fields;
@@ -332,6 +333,8 @@ Document.prototype.set = function (path, val, type) {
           pathtype = this.schema.pathType(prefix + key);
           if ('real' === pathtype || 'virtual' === pathtype) {
             this.set(prefix + key, path[key], constructing);
+          } else if (this._srslyStrictMode) {
+            throw new Error("Field `" + key + "` is not in schema.");
           }
         } else if (undefined !== path[key]) {
           this.set(prefix + key, path[key], constructing);

--- a/test/document.srslystrict.test.js
+++ b/test/document.srslystrict.test.js
@@ -1,0 +1,34 @@
+
+/**
+ * Test dependencies.
+ */
+
+var start = require('./common')
+  , mongoose = start.mongoose
+  , should = require('should')
+
+exports['test document really strict mode fails with extra fields'] = function () {
+  var db = mongoose.createConnection("mongodb://localhost/test-crash");
+
+  // Simple schema that is srsly strict
+  var FooSchema = new mongoose.Schema({
+      name: { type: String }
+  }, {srslyStrict: true});
+
+  // Create the model
+  var Foo = db.model('Foo', FooSchema);
+
+  // This one shouldn't cause problems.
+  var good = new Foo({name: 'bar'});
+
+  try {
+    // The extra baz field should throw and error.
+    var bad = new Foo({name: 'bar', baz: 'bam'});
+    throw new Error("Srsly strict document did not fail!");
+  } catch (e) {
+    db.close();
+    // Make sure the error is the one we are expecting.
+    should.strictEqual(e.message, "Field `baz` is not in schema.");
+  }
+
+}


### PR DESCRIPTION
If srslyStrict is passed as an option to a schema, then trying
to set attributes that are not defined in the schema will throw
an error. i.e.

```
var FooSchema = new mongoose.Schema({
  name: {type: String}
}, {srslyStrict: true});

var Foo = mongoose.model('Foo', FooSchema);

// this will throw an error because foo is not in the schema
var foo = new Foo({name: 'hai', foo: 'bar'});
```
