### PR TITLE
Min/max validator fix on number paths

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -51,7 +51,7 @@ SchemaNumber.prototype.min = function (value, message) {
     });
   if (value != null)
     this.validators.push([function(v){
-      return v >= value;
+      return v === null || v >= value;
     }, 'min']);
   return this;
 };
@@ -70,7 +70,7 @@ SchemaNumber.prototype.max = function (value, message) {
     });
   if (value != null)
     this.validators.push([this.maxValidator = function(v){
-      return v <= value;
+      return v === null || v <= value;
     }, 'max']);
   return this;
 };


### PR DESCRIPTION
If number path is not required, and the value of it is null then min and max validator is fail.
I fixed it.
