### PR TITLE
Add tailable method to Query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -796,7 +796,7 @@ Query.prototype.hint = function (v, multi) {
 /**
  * slaveOk
  *
- * Sets slaveOk option
+ * Sets slaveOk option.
  *
  *     new Query().slaveOk() <== true
  *     new Query().slaveOk(true)
@@ -808,6 +808,24 @@ Query.prototype.hint = function (v, multi) {
 
 Query.prototype.slaveOk = function (v) {
   this.options.slaveOk = arguments.length ? !!v : true;
+  return this;
+};
+
+/**
+ * tailable
+ *
+ * Sets tailable option.
+ *
+ *     new Query().tailable() <== true
+ *     new Query().tailable(true)
+ *     new Query().tailable(false)
+ *
+ * @param {Boolean} v (defaults to true)
+ * @api public
+ */
+
+Query.prototype.tailable = function (v) {
+  this.options.tailable = arguments.length ? !!v : true;
   return this;
 };
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -818,6 +818,20 @@ module.exports = {
     query.options.slaveOk.should.be.false;
   },
 
+  'test Query#tailable': function () {
+    var query = new Query();
+    query.tailable();
+    query.options.tailable.should.be.true;
+
+    var query = new Query();
+    query.tailable(true);
+    query.options.tailable.should.be.true;
+
+    var query = new Query();
+    query.tailable(false);
+    query.options.tailable.should.be.false;
+  },
+
   'Query#comment': function () {
     var query = new Query;
     'function'.should.equal(typeof query.comment);


### PR DESCRIPTION
For use in QueryStreams, e.g.

``` js
var stream = Model.where('name', 'Kevin').tailable().stream();
stream.on(function(doc) {
    console.log(doc);
});
```

Let me know if I missed anything or if this should be simplified, i.e. combining with `Query.slaveOk` method to reduce duplicate code.
