### PR TITLE
Add fixes for ref support. Cast documents to their embedded or sub types...

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -354,7 +354,12 @@ Document.prototype.set = function (path, val, type) {
         key = keys[i];
         if (null != path[key] && 'Object' === path[key].constructor.name
           && !(this._path(prefix + key) instanceof MixedSchema)) {
-          this.set(path[key], prefix + key, constructing);
+          var schema = this.schema.path(prefix + key);
+          if (schema) {
+            val = schema.cast(path[key]);
+            this.set(prefix + key, val, constructing);
+          } else
+            this.set(path[key], prefix + key, constructing);
         } else if (this._strictMode) {
           pathtype = this.schema.pathType(prefix + key);
           if ('real' === pathtype || 'virtual' === pathtype) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -1314,7 +1314,7 @@ Query.prototype._walkUpdatePath = function _walkUpdatePath (obj, op, pref) {
     if (val && 'Object' === val.constructor.name) {
       // watch for embedded doc schemas
       schema = this._getSchema(prefix + key);
-      if (schema && schema.caster && op in castOps) {
+      if (schema && (schema.caster || schema.options.ref) && op in castOps) {
         // embedded doc schema
 
         if (strict && !schema) {

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -52,13 +52,18 @@ ObjectId.prototype.checkRequired = function checkRequired (value) {
 ObjectId.prototype.cast = function (value, scope, init) {
   if (SchemaType._isRef(this, value, init)) return value;
 
+  if (value === '') return null;
   if (value === null) return value;
 
   if (value instanceof oid)
     return value;
 
-  if (value._id && value._id instanceof oid)
-    return value._id;
+  if (value._id !== undefined) {
+    if (value._id instanceof oid)
+      return value._id;
+    if ((value._id === null) || (value._id === '')) return null;
+    return oid.fromString(value._id);
+  }
 
   if (value.toString)
     return oid.fromString(value.toString());


### PR DESCRIPTION
This is the other pull which the rest of the code. When using documents with references (i.e. related documents populated using populate()) it was not treating those correctly when trying to update of query them. For this part I was unsure how to construct valid tests though so need some help with that part.
