### PR TITLE
Added throws option to schema

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -29,8 +29,8 @@ function Document (obj, fields) {
   if (!this._events) this._events = {};
   this.setMaxListeners(0);
 
-  this._srslyStrictMode = this.schema.options && this.schema.options.srslyStrict;
-  this._strictMode = this._srslyStrictMode || this.schema.options && this.schema.options.strict;
+  this._throws = this.schema.options && this.schema.options.throws;
+  this._strictMode = this._throws || this.schema.options && this.schema.options.strict;
 
   if ('boolean' === typeof fields) {
     this._strictMode = fields;
@@ -333,7 +333,7 @@ Document.prototype.set = function (path, val, type) {
           pathtype = this.schema.pathType(prefix + key);
           if ('real' === pathtype || 'virtual' === pathtype) {
             this.set(prefix + key, path[key], constructing);
-          } else if (this._srslyStrictMode) {
+          } else if (this._throws) {
             throw new Error("Field `" + key + "` is not in schema.");
           }
         } else if (undefined !== path[key]) {

--- a/test/document.throws.test.js
+++ b/test/document.throws.test.js
@@ -7,13 +7,13 @@ var start = require('./common')
   , mongoose = start.mongoose
   , should = require('should')
 
-exports['test document really strict mode fails with extra fields'] = function () {
+exports['test document throws mode fails with extra fields'] = function () {
   var db = mongoose.createConnection("mongodb://localhost/test-crash");
 
-  // Simple schema that is srsly strict
+  // Simple schema with throws option
   var FooSchema = new mongoose.Schema({
       name: { type: String }
-  }, {srslyStrict: true});
+  }, {throws: true});
 
   // Create the model
   var Foo = db.model('Foo', FooSchema);
@@ -24,7 +24,7 @@ exports['test document really strict mode fails with extra fields'] = function (
   try {
     // The extra baz field should throw and error.
     var bad = new Foo({name: 'bar', baz: 'bam'});
-    throw new Error("Srsly strict document did not fail!");
+    throw new Error("Document did not throw with extra fields.");
   } catch (e) {
     db.close();
     // Make sure the error is the one we are expecting.


### PR DESCRIPTION
If `throws` is passed as an option to a schema, then trying
to set attributes that are not defined in the schema will throw
an error. i.e.

``` javascript
var FooSchema = new mongoose.Schema({
  name: {type: String}
}, {throws: true});

var Foo = mongoose.model('Foo', FooSchema);

// this will throw an error because foo is not in the schema
var foo = new Foo({name: 'hai', foo: 'bar'});
```

(This was previously srslyStrict mode, but was changed to throws).
