### PR TITLE
If an insert (not an update) fails, reset isNew so that there is a second chance to save the object

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -126,7 +126,7 @@ Model.prototype._populate = function populate (schema, oid, query, fn) {
     conditions._id = oid;
 
     return this
-    .model(query.model || schema.options.ref)
+    .model(schema.options.ref)
     .findOne(conditions, query.fields, query.options, fn);
   }
 
@@ -134,7 +134,7 @@ Model.prototype._populate = function populate (schema, oid, query, fn) {
     return fn(null, oid);
   }
 
-  var model = this.model(query.model || schema.caster.options.ref)
+  var model = this.model(schema.caster.options.ref)
     , conditions = query && query.conditions || {};
   conditions._id || (conditions._id = { $in: oid });
 
@@ -263,12 +263,22 @@ Model.prototype.init = function init (doc, query, fn) {
 
 function handleSave (promise, self) {
   return tick(function handleSave (err, result) {
-    if (err) return promise.error(err);
+    if (err) 
+    {
+      // tom@punkave.com: if the initial insert fails provide a second chance.
+      // (If we did this all the time we would break updates)
+      if (self.inserting)
+      {
+        self.isNew = true;
+      }
+      return promise.error(err);
+    }
 
     self._storeShard();
 
     var numAffected;
     if (result) {
+      console.log(result);
       numAffected = result.length
         ? result.length
         : result;
@@ -305,6 +315,8 @@ Model.prototype.save = function save (fn) {
     this.collection.insert(this.toObject({ depopulate: 1 }), options, complete);
     this._reset();
     this.isNew = false;
+    // tom@punkave.com: make it possible to retry the insert 
+    this.inserting = true;
     this.emit('isNew', false);
 
   } else {
@@ -351,25 +363,15 @@ Model.prototype._delta = function _delta () {
       delta.$set[data.path] = type;
 
     } else if (type._path && type.doAtomics) {
-      // MongooseArray
+      // a MongooseArray or MongooseNumber
       atomics = type._atomics;
 
       var ops = Object.keys(atomics)
         , i = ops.length
         , op;
 
-      // handle set first
-      if (atomics.$set) {
-        ops.splice(ops.indexOf('$set'), 1);
-        ops.push('$set');
-      }
-
       while (i--) {
-        op = ops[i];
-
-        if ('$set' != op && delta.$set && delta.$set[data.path]) {
-          return delta;
-        }
+        op = ops[i]
 
         if (op === '$pushAll' || op === '$pullAll') {
           if (atomics[op].length === 1) {
@@ -382,6 +384,14 @@ Model.prototype._delta = function _delta () {
 
         val = atomics[op];
         obj = delta[op] = delta[op] || {};
+
+        if (op === '$pull' || op === '$push') {
+          if ('Object' !== val.constructor.name) {
+            if (Array.isArray(val)) val = [val];
+            // TODO Should we place pull and push casting into the pull and push methods?
+            val = schema.cast(val)[0];
+          }
+        }
 
         obj[data.path] = isMongooseObject(val)
           ? val.toObject({ depopulate: 1 }) // MongooseArray
@@ -450,7 +460,11 @@ Model.prototype._where = function _where () {
     }
   }
 
-  where._id = this._doc._id;
+  var id = this._doc._id.valueOf // MongooseNumber
+    ? this._doc._id.valueOf()
+    : this._doc._id;
+
+  where._id = id;
   return where;
 }
 
@@ -785,177 +799,6 @@ Model.$where = function $where () {
 };
 
 /**
- * findOneAndUpdate
- *
- * Issues a mongodb findAndModify update command.
- *
- * Finds a matching document, updates it according to the `update`
- * arg, passing any `options`, and returns the found document
- * (if any) to the callback. The query executes immediately if
- * `callback` is passed else a Query object is returned.
- *
- * Available options:
- *
- *   `new`: bool - true to return the modified document rather than the original. defaults to true
- *   `upsert`: bool - creates the object if it doesn't exist. defaults to false.
- *   `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- *
- * Examples:
- *
- *     A.findOneAndUpdate(conditions, update, options, callback) // executes
- *     A.findOneAndUpdate(conditions, update, options)  // returns Query
- *     A.findOneAndUpdate(conditions, update, callback) // executes
- *     A.findOneAndUpdate(conditions, update)           // returns Query
- *     A.findOneAndUpdate()                             // returns Query
- *
- * @param {Object} conditions
- * @param {Object} update
- * @param {Object} options
- * @param {Function} callback
- * @api public
- */
-
-Model.findOneAndUpdate = function (conditions, update, options, callback) {
-  if ('function' == typeof options) {
-    callback = options;
-    options = null;
-  }
-  else if (1 === arguments.length) {
-    if ('function' == typeof conditions) {
-      var msg = 'Model.findOneAndUpdate(): First argument must not be a function.\n\n'
-              + '  ' + this.modelName + '.findOneAndUpdate(conditions, update, options, callback)\n'
-              + '  ' + this.modelName + '.findOneAndUpdate(conditions, update, options)\n'
-              + '  ' + this.modelName + '.findOneAndUpdate(conditions, update)\n'
-              + '  ' + this.modelName + '.findOneAndUpdate(update)\n'
-              + '  ' + this.modelName + '.findOneAndUpdate()\n';
-      throw new TypeError(msg)
-    }
-    update = conditions;
-    conditions = undefined;
-  }
-
-  var fields;
-  if (options && options.fields) {
-    fields = options.fields;
-    options.fields = undefined;
-  }
-
-  var query = new Query(conditions, options);
-  query.select(fields);
-  query.bind(this, 'findOneAndUpdate', update);
-
-  if ('undefined' == typeof callback)
-    return query;
-
-  this._applyNamedScope(query);
-  return query.findOneAndUpdate(callback);
-}
-
-/**
- * findByIdAndUpdate
- *
- * Issue a mongodb findAndModify update command by a documents id.
- *
- * @see findOneAndUpdate for details.
- */
-
-Model.findByIdAndUpdate = function (id, update, options, callback) {
-  var args;
-
-  if (1 === arguments.length) {
-    if ('function' == typeof id) {
-      var msg = 'Model.findByIdAndUpdate(): First argument must not be a function.\n\n'
-                + '  ' + this.modelName + '.findByIdAndUpdate(id, callback)\n'
-                + '  ' + this.modelName + '.findByIdAndUpdate(id)\n'
-                + '  ' + this.modelName + '.findByIdAndUpdate()\n';
-      throw new TypeError(msg)
-    }
-    return this.findOneAndUpdate({_id: id }, undefined);
-  }
-
-  args = utils.args(arguments, 1);
-  args.unshift({ _id: id });
-  return this.findOneAndUpdate.apply(this, args);
-}
-
-/**
- * findOneAndRemove
- *
- * Issue a mongodb findAndModify remove command.
- *
- * Finds a matching document, removes it, passing the found
- * document (if any) to the callback. Executes immediately if `callback`
- * is passed else a Query object is returned.
- *
- * Available options:
- *
- *   `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- *
- * Examples:
- *
- *     A.findOneAndRemove(conditions, options, callback) // executes
- *     A.findOneAndRemove(conditions, options)  // return Query
- *     A.findOneAndRemove(conditions, callback) // executes
- *     A.findOneAndRemove(conditions) // returns Query
- *     A.findOneAndRemove()           // returns Query
- *
- * @param {Object} conditions
- * @param {Function} callback
- * @api public
- */
-
-Model.findOneAndRemove = function (conditions, options, callback) {
-  if (1 === arguments.length && 'function' == typeof conditions) {
-    var msg = 'Model.findOneAndRemove(): First argument must not be a function.\n\n'
-              + '  ' + this.modelName + '.findOneAndRemove(conditions, callback)\n'
-              + '  ' + this.modelName + '.findOneAndRemove(conditions)\n'
-              + '  ' + this.modelName + '.findOneAndRemove()\n';
-    throw new TypeError(msg)
-  }
-
-  if ('function' == typeof options) {
-    callback = options;
-    options = undefined;
-  }
-
-  var fields;
-  if (options) {
-    fields = options.fields;
-    options.fields = undefined;
-  }
-
-  var query = new Query(conditions, options);
-  query.bind(this, 'findOneAndRemove');
-  query.select(fields);
-
-  if ('undefined' == typeof callback)
-    return query;
-
-  this._applyNamedScope(query);
-  return query.findOneAndRemove(callback);
-}
-
-/**
- * findByIdAndRemove
- *
- * Issue a mongodb findAndModify remove command by a documents id.
- *
- * @see findOneAndRemove for details.
- */
-
-Model.findByIdAndRemove = function (id, options, callback) {
-  if (1 === arguments.length && 'function' == typeof id) {
-    var msg = 'Model.findByIdAndRemove(): First argument must not be a function.\n\n'
-              + '  ' + this.modelName + '.findByIdAndRemove(id, callback)\n'
-              + '  ' + this.modelName + '.findByIdAndRemove(id)\n'
-              + '  ' + this.modelName + '.findByIdAndRemove()\n';
-    throw new TypeError(msg)
-  }
-
-  return this.findOneAndRemove({ _id: id }, options, callback);
-}
-
-/**
  * Shortcut for creating a new Document that is automatically saved
  * to the db if valid.
  *
@@ -991,7 +834,12 @@ Model.create = function create (doc, fn) {
     var doc = new self(arg);
     docs[i+1] = doc;
     doc.save(function (err) {
-      if (err) return promise.error(err);
+      if (err) 
+      {
+        // tom@punkave.com: grant a second chance to save from fn
+        doc.isNew = true;
+        return promise.error(err);
+      }
       --count || fn.apply(null, docs);
     });
   });


### PR DESCRIPTION
Right now if an insert fails you are stuck because the isNew flag is never set to true again. With this simple patch this issue goes away. Please see the test program in this gist, which verifies that I didn't break update() in the process of fixing this issue. (:

https://gist.github.com/2387479

This allows things like generating a more unique slug on the basis of a unique index error in a truly concurrency-safe way.
