### PR TITLE
Added additional check when loading embed doc in model

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -220,7 +220,9 @@ function init (self, obj, doc, prefix) {
 
     if (!schema && obj[i] && 'Object' === obj[i].constructor.name) {
       // assume nested object
-      doc[i] = {};
+        if(!doc[i]){
+          doc[i] = {};
+        }
       init(self, obj[i], doc[i], path + '.');
     } else {
       if (obj[i] === null) {


### PR DESCRIPTION
Fix for error when loading model with emded document.

For example if we have such schema

``` js
var UserSchema = new Schema({
    user_id: Number,
    location: {
        city: {type: String, 'default': 'New York'},
        country: {type: String, 'default': 'USA'}
    }
})
```

and we will load document from database with such data

``` js
{
    user_id: 10,
    location: {city: "Washington"}
}
```

we will got broken object. When we will try to get country of such user we will get undefined value.
