### PR TITLE
[ready] fix subdoc validation error paths

### DIFF
--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -97,6 +97,23 @@ EmbeddedDocument.prototype.inspect = function () {
 };
 
 /**
+ * Invalidate
+ *
+ * Report accurate embedded paths for invalidation.
+ *
+ * @param {String} path of the field to invalidate
+ * @param {String/Error} error of the path.
+ * @api public
+ */
+
+EmbeddedDocument.prototype.invalidate = function (path, err) {
+  var index = this.parentArray.indexOf(this);
+  var parentPath = this.parentArray._path;
+  var fullPath = [parentPath, index, path].join('.');
+  this.parent.invalidate(fullPath, err);
+}
+
+/**
  * Module exports.
  */
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1273,8 +1273,12 @@ module.exports = {
   },
 
   'test validation in subdocuments': function(){
+
+    var Subsubdocs= new Schema({ required: { type: String, required: true }});
+
     var Subdocs = new Schema({
         required: { type: String, required: true }
+      , subs: [Subsubdocs]
     });
 
     mongoose.model('TestSubdocumentsValidation', new Schema({
@@ -1286,15 +1290,18 @@ module.exports = {
 
     var post = new TestSubdocumentsValidation();
 
-    post.get('items').push({ required: '' });
+    post.get('items').push({ required: '', subs: [{required: ''}] });
 
     post.save(function(err){
       err.should.be.an.instanceof(MongooseError);
       err.should.be.an.instanceof(ValidationError);
-      err.errors.required.should.be.an.instanceof(ValidatorError);
-      err.errors.required.message.should.eql('Validator "required" failed for path required');
+      err.errors['items.0.subs.0.required'].should.be.an.instanceof(ValidatorError);
+      err.errors['items.0.subs.0.required'].message.should.eql('Validator "required" failed for path required');
+      err.errors['items.0.required'].should.be.an.instanceof(ValidatorError);
+      err.errors['items.0.required'].message.should.eql('Validator "required" failed for path required');
 
       post.get('items')[0].set('required', true);
+      post.items[0].subs[0].set('required', true);
       post.save(function(err){
         should.strictEqual(err, null);
         db.close();

--- a/test/types.buffer.test.js
+++ b/test/types.buffer.test.js
@@ -78,11 +78,11 @@ module.exports = {
           t.sub.push({ name: 'Friday Friday' });
           t.save(function (err) {
             err.message.should.eql('Validation failed');
-            err.errors.buf.type.should.equal('required');
+            err.errors['sub.0.buf'].type.should.equal('required');
             t.sub[0].buf = new Buffer("well well");
             t.save(function (err) {
               err.message.should.eql('Validation failed');
-              err.errors.buf.type.should.equal('valid failed');
+              err.errors['sub.0.buf'].type.should.equal('valid failed');
 
               t.sub[0].buf = new Buffer("well well well");
               t.validate(function (err) {

--- a/test/types.document.test.js
+++ b/test/types.document.test.js
@@ -17,8 +17,18 @@ var should = require('should')
  * Setup.
  */
 
+function Dummy () {
+  mongoose.Document.call(this, {});
+}
+Dummy.prototype.__proto__ = mongoose.Document.prototype;
+Dummy.prototype.schema = new Schema;
+
 function Subdocument () {
-  EmbeddedDocument.call(this, {}, new DocumentArray);
+  var arr = new DocumentArray;
+  arr._path = 'jsconf.ar'
+  arr._parent = new Dummy;
+  arr[0] = this;
+  EmbeddedDocument.call(this, {}, arr);
 };
 
 /**
@@ -63,8 +73,9 @@ module.exports = {
       a.set('work', 'nope');
 
       a.save(function(err){
-        err.should.be.an.instanceof(ValidationError);
-        err.toString().should.eql('ValidationError: Validator "required" failed for path test, Validator failed for path work');
+        a.parent._validationError.should.be.an.instanceof(ValidationError);
+        a.parent.errors['jsconf.ar.0.work'].name.should.eql('ValidatorError');
+        a.parent._validationError.toString().should.eql('ValidationError: Validator "required" failed for path test, Validator failed for path work');
       });
     },
 


### PR DESCRIPTION
subdocument validation error paths were reported incorrectly.

``` js
var plan = new Schema({ title: { type: 'string', required: true }})
var room = new Schema({ lessonplans: [plan] });
...
var r = new Room({ lessonplans: [{ title: '' }] });
r.save(function (err) {
  // old incorrect behavior
  console.log(err.errors.title) // Validator "required" ...
  // corrected behavior
  console.log(err.errors['lessonplans.0.title']) // Validator "required" ...
})
```

closes #725
