### PR TITLE
[ready] Use driver version 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   , "keywords": ["mongodb", "mongoose", "orm", "data", "datastore", "nosql", "odm", "sql"]
   , "dependencies": {
         "hooks": "0.2.1"
-      , "mongodb": "0.9.9-7"
+      , "mongodb": "1.0.0"
     }
   , "devDependencies": {
         "should": "0.2.1"


### PR DESCRIPTION
which fixes some replica set connectivity issues when a node goes down
