### PR TITLE
Fix casting of RegExp within conditional statement

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -299,7 +299,7 @@ Query.prototype.cast = function (model, obj) {
                 nested = new RegExp(nested);
               }
               if ('RegExp' !== nested.constructor.name) {
-                throw new Error("$type parameter must be RegExp");
+                throw new Error("$regex parameter must be string or RegExp");
               }
               continue;
             }


### PR DESCRIPTION
Currently the following code casts the RegExps to strings if firstName and lastName are defined as strings in the Schema:

`
    var kwRe = {$regex: new RegExp(keyword, 'gi')};
    query.$or([{firstName: kwRe}, {lastName: kwRe}])
`

This patch stops casting RegExps when the query is cast
