### PR TITLE
[ready] fixed; no longer test non-required vals in string match

### DIFF
--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -99,13 +99,14 @@ SchemaString.prototype.trim = function () {
  * Sets a regexp test
  *
  * @param {RegExp} regular expression to test against
- * @param {String} optional validator message
  * @api public
  */
 
-SchemaString.prototype.match = function(regExp){
+SchemaString.prototype.match = function match (regExp) {
   this.validators.push([function(v){
-    return regExp.test(v);
+    return null != v && '' !== v
+      ? regExp.test(v)
+      : true
   }, 'regexp']);
 };
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -275,6 +275,21 @@ module.exports = {
     Test.path('simple').doValidate('a12', function(err){
       should.strictEqual(err, null);
     });
+
+    Test.path('simple').doValidate('', function(err){
+      should.strictEqual(err, null);
+    });
+    Test.path('simple').doValidate(null, function(err){
+      should.strictEqual(err, null);
+    });
+    Test.path('simple').doValidate(undefined, function(err){
+      should.strictEqual(err, null);
+    });
+    Test.path('simple').validators = [];
+    Test.path('simple').match(/[1-9]/);
+    Test.path('simple').doValidate(0, function(err){
+      err.should.be.an.instanceof(ValidatorError);
+    });
   },
 
   'test string casting': function(){


### PR DESCRIPTION
In the string `match` validator, there is no reason to test against null, undefined, or '' values as those
are validated in the "required" validator.

we'll no longer need to put extra checks in RegExps for null, undefined, or empty strings. if we want to validate these values we can enable the the `required` validator.

closes #934
