### PR TITLE
[ready] fixed; array#{$pop,$shift} mirror MongoDB behavior

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -111,6 +111,14 @@ MongooseArray.prototype._markModified = function (embeddedDoc, embeddedPath) {
 
 MongooseArray.prototype._registerAtomic = function (op, val) {
   var atomics = this._atomics;
+
+  if ('$pop' == op && !('$pop' in atomics)) {
+    var self = this;
+    this._parent.once('save', function () {
+      self._popped = self._shifted = null;
+    });
+  }
+
   if (op === '$pullAll' || op === '$pushAll' || op === '$addToSet') {
     atomics[op] || (atomics[op] = []);
     atomics[op] = atomics[op].concat(val);
@@ -193,13 +201,18 @@ MongooseArray.prototype.$pushAll = function (array) {
  *
  * Only works once per doc.save(). Calling this mulitple
  * times on an array before saving sends the same command
- * as calling it once.
+ * as calling it once. See MongoDB docs.
  *
  * @api public
  */
 
 MongooseArray.prototype.$pop = function () {
   this._registerAtomic('$pop', 1);
+
+  // only allow popping once
+  if (this._popped) return;
+  this._popped = true;
+
   return this.pop();
 };
 
@@ -208,13 +221,18 @@ MongooseArray.prototype.$pop = function () {
  *
  * Only works once per doc.save(). Calling this mulitple
  * times on an array before saving sends the same command
- * as calling it once.
+ * as calling it once. See MongoDB docs.
  *
  * @api public
  */
 
 MongooseArray.prototype.$shift = function $shift () {
   this._registerAtomic('$pop', -1);
+
+  // only allow shifting once
+  if (this._shifted) return;
+  this._shifted = true;
+
   return [].shift.call(this);
 };
 


### PR DESCRIPTION
Both methods utilize the atomic $pop operation. This
operation can at most remove one element at a time.
