### PR TITLE
[ready] added; inclusion of deselected schema paths

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -346,6 +346,7 @@ Query.prototype._applyPaths = function applyPaths () {
 
     while (ki--) {
       if ('_id' == keys[ki]) continue;
+      if ('+' == keys[ki][0]) continue;
       exclude = 0 === fields[keys[ki]];
       break;
     }
@@ -353,13 +354,26 @@ Query.prototype._applyPaths = function applyPaths () {
 
   // if selecting, apply default schematype select:true fields
   // if excluding, apply schematype select:false fields
-  // if not specified, apply both
 
   var selected = []
     , excluded = []
 
   this.model.schema.eachPath(function (path, type) {
     if ('boolean' != typeof type.selected) return;
+
+    if (fields && ('+' + path) in fields) {
+      // forced inclusion
+      delete fields['+' + path];
+
+      // if there are other fields being included, add this one
+      // if no other included fields, leave this out (implied inclusion)
+      if (false === exclude && keys.length > 1) {
+        fields[path] = 1;
+      }
+
+      return
+    };
+
     ;(type.selected ? selected : excluded).push(path);
   });
 
@@ -371,8 +385,9 @@ Query.prototype._applyPaths = function applyPaths () {
       selected.length && this.select(selected.join(' '));
       break;
     case undefined:
+      // user didn't specify fields, implies returning all fields.
+      // only need to apply excluded fields
       excluded.length && this.select('-' + excluded.join(' -'));
-      selected.length && this.select(selected.join(' '));
       break;
   }
 }
@@ -654,6 +669,7 @@ Query.prototype.centerSphere = function (path, val) {
  *
  *     query.select('a b -c');
  *     query.select({a: 1, b: 1, c: 0}); // useful if you have keys that start with "-"
+ *     query.select('+path') // force inclusion of field excluded at schema level
  *
  * @param {Object|String}
  * @api public


### PR DESCRIPTION
In the schema, we may have set a default selection for
a given path through the `select` option.

```
new Schema({
    name: 'string'
  , path: { type: 'string', select: false }
})
```

In this case we always want to exclude this path by default.

It is often desirous to retreive the document including the
previously excluded path. Previously this involved manually
selecting all fields.

```
Thing.find().select('path name').exec(callback)
```

This commit introduces the `+` prefix during field selection which
forces inclusion of the specified path, overriding the schema
option. So now we only need specify the path to include and
leave the others out as implied inclusives.

```
Thing.findOne().select('+path').exec(function (err, doc) {
  console.log(doc); // { name: 'Oz', path: 'Yellow Brick'}
});
```

closes #786
