### PR TITLE
Enabled strict mode by default

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1243,7 +1243,7 @@ Model.mapReduce = function mapReduce (o, callback) {
   var self = this;
 
   if (!Model.mapReduce.schema) {
-    var opts = { noId: true, noVirtualId: true }
+    var opts = { noId: true, noVirtualId: true, strict: false }
     Model.mapReduce.schema = new Schema({}, opts);
   }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -32,7 +32,7 @@ function Schema (obj, options) {
   // set options
   this.options = utils.options({
       safe: true
-    , strict: false
+    , strict: true
     , capped: false // { size, max, autoIndexId }
     , versionKey: '__v'
   }, options);
@@ -143,39 +143,10 @@ Schema.prototype.path = function (path, obj) {
     if (this.paths[path]) return this.paths[path];
     if (this.subpaths[path]) return this.subpaths[path];
 
-    // Sometimes path will come in as
-    // pathNameA.4.pathNameB where 4 means the index
-    // of an embedded document in an embedded array.
-    // In this case, we need to jump to the Array's
-    // schema and call path() from there to resolve to
-    // the correct path type
-
-    var last
-      , self = this
-      , subpaths = path.split(/\.(\d+)\.?/)
-                       .filter(Boolean) // removes empty strings
-
-    if (subpaths.length > 1) {
-      last = subpaths.length - 1;
-      return this.subpaths[path] = subpaths.reduce(function (val, subpath, i) {
-        if (val && !val.schema) {
-          if (i === last && !/\D/.test(subpath) && val instanceof Types.Array) {
-            return val.caster; // StringSchema, NumberSchema, etc
-          } else {
-            return val;
-          }
-        }
-
-        if (!/\D/.test(subpath)) { // 'path.0.subpath'  on path 0
-          return val;
-        }
-
-        return val ? val.schema.path(subpath)
-                   : self.path(subpath);
-      }, null);
-    }
-
-    return this.paths[subpaths[0]];
+    // subpaths?
+    return /\.\d+\.?/.test(path)
+      ? getPositionalPath(this, path)
+      : undefined;
   }
 
   // update the tree
@@ -195,7 +166,7 @@ Schema.prototype.path = function (path, obj) {
 };
 
 /**
- * Converts -- e.g., Number, [SomeSchema], 
+ * Converts -- e.g., Number, [SomeSchema],
  * { type: String, enum: ['m', 'f'] } -- into
  * the appropriate Mongoose Type, which we use
  * later for casting, validation, etc.
@@ -309,8 +280,45 @@ Schema.prototype.pathType = function (path) {
   if (path in this.paths) return 'real';
   if (path in this.virtuals) return 'virtual';
   if (path in this.nested) return 'nested';
-  return 'adhocOrUndefined';
+  if (path in this.subpaths) return 'real';
+
+  if (/\.\d+\.?/.test(path) && getPositionalPath(this, path)) {
+    return 'real';
+  } else {
+    return 'adhocOrUndefined'
+  }
 };
+
+function getPositionalPath (self, path) {
+  var subpaths = path.split(/\.(\d+)\.?/).filter(Boolean);
+  if (subpaths.length < 2) {
+    return self.paths[subpaths[0]];
+  }
+
+  var val = self.path(subpaths[0])
+    , last = subpaths.length - 1
+    , subpath;
+
+  for (var i = 1; i < subpaths.length; ++i) {
+    var subpath = subpaths[i];
+
+    if (i === last &&
+        val &&
+        !val.schema &&
+        !/\D/.test(subpath) &&
+        val instanceof Types.Array) {
+      // StringSchema, NumberSchema, etc
+      val = val.caster;
+      continue;
+    }
+
+    // 'path.0.subpath'
+    if (!/\D/.test(subpath)) continue;
+    val = val.schema.path(subpath);
+  }
+
+  return self.subpaths[path] = val;
+}
 
 /**
  * Adds a method call to the queue

--- a/test/document.strict.test.js
+++ b/test/document.strict.test.js
@@ -29,12 +29,12 @@ module.exports = {
     var lax = new Schema({
         ts  : { type: Date, default: Date.now }
       , content: String
-    });
+    }, { strict: false });
 
     var strict = new Schema({
         ts  : { type: Date, default: Date.now }
       , content: String
-    }, { strict: true });
+    });
 
     var Lax = db.model('Lax', lax);
     var Strict = db.model('Strict', strict);
@@ -93,11 +93,11 @@ module.exports = {
 
     var lax = new Schema({
         name: { last: String }
-    });
+    }, { strict: false });
 
     var strict = new Schema({
         name: { last: String }
-    }, { strict: true });
+    });
 
     var Lax = db.model('NestedLax', lax, 'nestdoc'+random());
     var Strict = db.model('NestedStrict', strict, 'nestdoc'+random());
@@ -133,15 +133,15 @@ module.exports = {
     var lax = new Schema({
         ts  : { type: Date, default: Date.now }
       , content: String
-    });
+    }, { strict: false });
 
     var strict = new Schema({
         ts  : { type: Date, default: Date.now }
       , content: String
-    }, { strict: true });
+    });
 
-    var Lax = db.model('EmbeddedLax', new Schema({ dox: [lax] }), 'embdoc'+random());
-    var Strict = db.model('EmbeddedStrict', new Schema({ dox: [strict] }), 'embdoc'+random());
+    var Lax = db.model('EmbeddedLax', new Schema({ dox: [lax] }, { strict: false }), 'embdoc'+random());
+    var Strict = db.model('EmbeddedStrict', new Schema({ dox: [strict] }, { strict: false }), 'embdoc'+random());
 
     var l = new Lax({ dox: [{content: 'sample', rouge: 'data'}] });
     l.dox[0]._strictMode.should.be.false;
@@ -184,7 +184,7 @@ module.exports = {
     var strictSchema = new Schema({
         email: String
       , prop: String
-    }, {strict: true});
+    });
 
     strictSchema
     .virtual('myvirtual')

--- a/test/model.mapreduce.test.js
+++ b/test/model.mapreduce.test.js
@@ -129,12 +129,12 @@ module.exports = {
             assert.equal('nathan', docs[3]._id);
 
             // update casting works
-            ret.findOneAndUpdate({ _id: 'aaron' }, { updated: true }, function (err, doc) {
+            ret.findOneAndUpdate({ _id: 'aaron' }, { published: true }, function (err, doc) {
               db.close();
               if (err) throw err;
               assert.ok(doc);
               assert.equal('aaron', doc._id);
-              assert.equal(true, doc.updated);
+              assert.equal(true, doc.published);
             });
           });
         });

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -52,7 +52,8 @@ mongoose.model('BlogPostB', BlogPostB);
 var collection = 'blogposts_' + random();
 
 var ModSchema = new Schema({
-  num: Number
+    num: Number
+  , str: String
 });
 mongoose.model('Mod', ModSchema);
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3592,7 +3592,7 @@ module.exports = {
 
     var t = new T({ nest: null });
 
-    should.strictEqual(t.nest.st, null);
+    should.strictEqual(t.nest.st, undefined);
     t.nest = { st: "jsconf rules" };
     t.nest.toObject().should.eql({ st: "jsconf rules" });
     t.nest.st.should.eql("jsconf rules");
@@ -4322,7 +4322,7 @@ module.exports = {
 
     InvalidateSchema = new Schema({
       prop: { type: String },
-    });
+    }, { strict: false });
 
     mongoose.model('InvalidateSchema', InvalidateSchema);
 

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -47,7 +47,7 @@ var BlogPost = new Schema({
   , numbers   : [Number]
   , owners    : [ObjectId]
   , comments  : [Comments]
-});
+}, { strict: false });
 
 BlogPost.virtual('titleWithAuthor')
   .get(function () {
@@ -67,11 +67,11 @@ BlogPost.static('woot', function(){
   return this;
 });
 
-mongoose.model('BlogPost', BlogPost);
+mongoose.model('BlogPostForUpdates', BlogPost);
 
 var collection = 'blogposts_' + random();
 
-var strictSchema = new Schema({ name: String, x: { nested: String }}, { strict: true });
+var strictSchema = new Schema({ name: String, x: { nested: String }});
 strictSchema.virtual('foo').get(function () {
   return 'i am a virtual FOO!'
 });
@@ -81,7 +81,7 @@ module.exports = {
 
   'test updating documents': function () {
     var db = start()
-      , BlogPost = db.model('BlogPost', collection)
+      , BlogPost = db.model('BlogPostForUpdates', collection)
       , title = 'Tobi ' + random()
       , author = 'Brian ' + random()
       , newTitle = 'Woot ' + random()
@@ -493,7 +493,7 @@ module.exports = {
 
   'test updating numbers atomically': function () {
     var db = start()
-      , BlogPost = db.model('BlogPost', collection)
+      , BlogPost = db.model('BlogPostForUpdates', collection)
       , totalDocs = 4
       , saveQueue = [];
 
@@ -555,7 +555,7 @@ module.exports = {
 
   'model.update passes number of affected documents': function () {
     var db = start()
-      , B = db.model('BlogPost', 'wwwwowowo'+random())
+      , B = db.model('BlogPostForUpdates', 'wwwwowowo'+random())
 
     B.create({ title: 'one'},{title:'two'},{title:'three'}, function (err) {
       should.strictEqual(null, err);

--- a/test/schema.onthefly.test.js
+++ b/test/schema.onthefly.test.js
@@ -11,7 +11,7 @@ var start = require('./common')
 
 var DecoratedSchema = new Schema({
     title     : String
-});
+}, { strict: false });
 
 mongoose.model('Decorated', DecoratedSchema);
 

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -111,7 +111,7 @@ module.exports = {
     function test3 (err, a, b) {
       assert.ifError(err);
       assert.equal(a.meta.numbers.length, 5);
-      assert.equal(a.meta.numbers.length, 5);
+      assert.equal(b.meta.numbers.length, 5);
       assert.equal(-1, a.meta.numbers.indexOf(10));
       assert.ok(~a.meta.numbers.indexOf(20));
 
@@ -123,7 +123,7 @@ module.exports = {
     }
 
     function test4 (err, a, b) {
-      assert.ok(/No matching document/.test(err));
+      assert.ok(/No matching document/.test(err), err);
       a.set('arr.0.0', 'updated');
       var d = a._delta()[0];
       assert.equal(a._doc.__v, d.__v, 'version should be added to where clause')


### PR DESCRIPTION
The smarter default. We have schemas because we care about our data.

Turn it back off with new Schema({..}, { strict: false })

closes #952
