### PR TITLE
Fix overlap on small screens.

### DIFF
--- a/template.html
+++ b/template.html
@@ -12,7 +12,7 @@
       #wrap {
         background: url('/images/pattern.png') no-repeat -134px -211px;
         min-height: 600px;
-        padding-top: 30px;
+        padding: 30px 0 0 200px;
       }
 
       #page {


### PR DESCRIPTION
At low resolutions like 1024x600, the content of doc pages overlaps the menu background, as seen in [this screenshot](http://i.imgur.com/B509x.png). Adding left padding to the #wrap element fixes the overlap.
