### PR TITLE
Specifying BSON SubType for the toObject() method in MongooseBuffer

### DIFF
--- a/lib/types/buffer.js
+++ b/lib/types/buffer.js
@@ -153,13 +153,22 @@ MongooseBuffer.prototype.copy = function (target) {
 
 /**
  * Returns a Binary.
- *
+ * @param {Hex} BSON SubType
+ * SubTypes:
+ *  0x00: Binary/Generic
+ *  0x01: Function
+ *  0x02: Binary (Deprecated, 0x00 is new default)
+ *  0x03: UUID
+ *  0x04: MD5
+ *  0x80: User Defined
+ *  More info here: http://bsonspec.org/#/specification
  * @return {Buffer}
  * @api public
  */
 
-MongooseBuffer.prototype.toObject = function () {
-  return new Binary(this, 0x00);
+MongooseBuffer.prototype.toObject = function (subtype) {
+  subtype = typeof subtype !== 'undefined' ? subtype : 0x00
+  return new Binary(this, subtype);
 };
 
 /**


### PR DESCRIPTION
Added a small snippet to be able to use various subtypes when dealing with binary data. By default it was just using the general subtype 0x00. Let me know what you think.
