### PR TITLE
Make openSet allow for an options parameter but no database parameter.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -235,6 +235,7 @@ Connection.prototype.openSet = function (uris, database, options, callback) {
             options = database, database = null;
             break;
         }
+      }
       break;
     case 2:
       switch (typeof database) {


### PR DESCRIPTION
I ran into an issue where switching from `mongoose.connect` to `mongoose.connectSet` broke because I was using an options object.
This change allows you to use the same parameters for both functions (leaving out the optional database string).

Before, the code just assumed that the second parameter was the database name string, and threw an error when you passed an options object.
