### PR TITLE
remove unsafe use of total in model.js->init

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -215,8 +215,8 @@ Model.prototype.init = function init (doc, query, fn) {
         , path = prefix + i
         , schema = self.schema.path(path)
         , total = 0
+        , processing = false
         , poppath
-        , subobjprocessing = false
 
       if (!schema && obj[i] && 'Object' === obj[i].constructor.name) {
         // assume nested object
@@ -240,19 +240,19 @@ Model.prototype.init = function init (doc, query, fn) {
             key = pkeys[pi];
 
             if (subobj[key]) (function (key) {
-              subobjprocessing = true;
+              processing = true;
               total++;
               self._populate(schema.schema.path(key), subobj[key], poppath.sub[key], done);
               function done (err, doc) {
                 if (err) return error(err);
                 subobj[key] = doc;
-                --total || next();
+                --total || processing || next();
               }
             })(key);
           }
         });
-
-        if (!subobjprocessing) return next();
+        processing = false;
+        if (0 === total) return next();
 
       } else {
         self._populate(schema, obj[i], poppath, function (err, doc) {


### PR DESCRIPTION
There is an unsafe use of total in the init method (this actually triggered bug for me).
In the poppath.sub code path, if the done callback triggers before you actally execute the final test if(0 === total) test, then next will be executed one time too many and in my case, it screwed up the resulting document.
To fix this, instead of using total, I create a new variable named subobjprocessing (if you want me to change the name, let me know), and I set it to true if I'm populating anything in subobj[key].
The final test (case where nothing was populated) becomes if(!subobjprocessing) instead of if(0 === total).
