### PR TITLE
Populate can bail out too early if empty array in the field being populated

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,4 +1,3 @@
-
 /*!
  * Module dependencies.
  */
@@ -242,12 +241,14 @@ Model.prototype.init = function init (doc, query, fn) {
             if (subobj[key]) (function (key) {
 
               total++;
-              self._populate(schema.schema.path(key), subobj[key], poppath.sub[key], done);
-              function done (err, doc) {
-                if (err) return error(err);
-                subobj[key] = doc;
-                --total || next();
-              }
+              process.nextTick(function() {
+                self._populate(schema.schema.path(key), subobj[key], poppath.sub[key], done);
+                function done (err, doc) {
+                  if (err) return error(err);
+                  subobj[key] = doc;
+                  --total || next();
+                }
+              });
             })(key);
           }
         });


### PR DESCRIPTION
Populate could bail out too early if the first document retrieved from the parent model contained an empty array in the field used for populating the child model.  The _populate method will invoke the next function immediately in this event rather than being delayed by a database read causing the loop to end immediately. In order to fix this, I wrapped the call to _populate in "process.nextTick()".
