### PR TITLE
Allow query.ne("boolField", true)

### DIFF
--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -50,6 +50,9 @@ SchemaBoolean.prototype.cast = function (value) {
  * ignore
  */
 
+function handleSingle (val) {
+  return this.castForQuery(val);
+}
 function handleArray (val) {
   var self = this;
   return val.map(function (m) {
@@ -58,7 +61,8 @@ function handleArray (val) {
 }
 
 SchemaBoolean.$conditionalHandlers = {
-    '$in': handleArray
+    '$ne' : handleSingle
+  , '$in' : handleArray
 }
 
 /**


### PR DESCRIPTION
Currently you can't use $ne with a boolean field.  This fixes that.
