### PR TITLE
Array $gte, $gt, $lte, $lt only being cast as number

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -211,10 +211,10 @@ SchemaArray.prototype.$conditionalHandlers = {
   , '$regex': SchemaArray.prototype.castForQuery
   , '$near': SchemaArray.prototype.castForQuery
   , '$nearSphere': SchemaArray.prototype.castForQuery
-  , '$gt': castToNumber
-  , '$gte': castToNumber
-  , '$lt': castToNumber
-  , '$lte': castToNumber
+  , '$gt': SchemaArray.prototype.castForQuery
+  , '$gte': SchemaArray.prototype.castForQuery
+  , '$lt': SchemaArray.prototype.castForQuery
+  , '$lte': SchemaArray.prototype.castForQuery
   , '$within': function(val) {
       var query = new Query(val);
       query.cast(this.casterConstructor)

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -755,6 +755,31 @@ describe('Query', function(){
       assert.deepEqual(params.ids.$elemMatch.$in[0].toString(), ids[0]);
       assert.deepEqual(params.ids.$elemMatch.$in[1].toString(), ids[1]);
     })
+
+    it('inequality operators for an array', function() {
+      var query = new Query();
+      var db = start();
+      var Product = db.model('Product');
+      var Comment = db.model('Comment');
+      db.close();
+
+      var id = new DocumentObjectId;
+      var castedComment = { _id: id, text: 'hello there' };
+      var comment = new Comment(castedComment);
+
+      var params = {
+          ids: { $gt: id }
+        , comments: { $gt: comment }
+        , strings: { $gt: 'Hi there' }
+        , numbers: { $gt: 10000 }
+      };
+
+      query.cast(Product, params);
+      assert.equal(params.ids.$gt, id);
+      assert.deepEqual(params.comments.$gt, castedComment);
+      assert.equal(params.strings.$gt, 'Hi there');
+      assert.equal(params.numbers.$gt, 10000);
+    })
   })
 
   describe('distinct', function(){


### PR DESCRIPTION
This was originally added in 8bdc3d1b for #902. Trying a query similar to this:

```
model.find({ arr: { $gt: ObjectId("4fc78a59a885233f4b349bd9") } })
```

Works in the mongo shell, but gives this error in mongoose:

```
Invalid select() argument. Must be a string or object.
```

I assume, based on the title, that the problem is that it is being cast as a number instead of using `castForQuery` as everything else is.
