### PR TITLE
Fixes issue #1111

### DIFF
--- a/docs/css/guide.css
+++ b/docs/css/guide.css
@@ -110,7 +110,6 @@ li {
 #content {
   padding: 0;
   margin: 0 0 0 230px;
-  overflow-x: hidden;
 }
 #content .controls {
   padding: 5px 15px 5px 10px;


### PR DESCRIPTION
Removes `overflow-x: hidden` on the #content div to prevent the 'View on GitHub' banner overlapping the scrollbar
