### PR TITLE
Correct 'this' reference in statics of model.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1679,7 +1679,7 @@ Model.compile = function compile (name, schema, collectionName, connection, base
 
   // apply statics
   for (var i in schema.statics)
-    model[i] = schema.statics[i];
+    model[i] = schema.statics[i].bind(model);
 
   // apply named scopes
   if (schema.namedScopes) schema.namedScopes.compile(model);


### PR DESCRIPTION
I have followed example of statics from docs:

``` javascript
animalSchema.statics.findByName = function (name, cb) {
  this.find({ name: new RegExp(name, 'i') }, cb);
}
```

But it seems that 'this' is global context. I think it would be possible to use Function.bind to fix it - see my commit.

Sorry that I don't know where I should write test for it, they are too chaotic for me :-)
