### PR TITLE
Fixed model.remove ignoring callback

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -688,6 +688,7 @@ Model.prototype.remove = function remove (fn) {
 
   return this;
 };
+
 /**
  * Register hooks override
  *


### PR DESCRIPTION
I don't know if this behavior was intended, but it's wrong. 
If I call .remove on the same model twice for whatever reason, second call will never execute callback, which will break execution flow.
