### PR TITLE
Fix init hook invokation when finding docs

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1551,7 +1551,9 @@ Query.prototype.findOne = function (callback) {
     var casted = new model(undefined, fields, true);
     casted.init(doc, self, function (err) {
       if (err) return promise.error(err);
-      promise.complete(casted);
+      setTimeout(function(){
+        promise.complete(casted);
+      }, 0);
     });
   }));
 


### PR DESCRIPTION
When querying docs (with a query or with Model finders), I figured out that 'init' middleware are properly invoked on each rehydrated models.

But weirdly, the corresponding Model 'init' method is not invoked on the last rehydrated model.

I made a unit test in 'model.querying.test.js' to show this, and propose a fix. 
Just comment my fix to reproduce the bug.

``` javascript

Query.prototype.execFind = function (callback) {
    // ...

    for (var i = 0, l = docs.length; i < l; i++) {
      arr[i] = new model(undefined, fields, true);
      arr[i].init(docs[i], self, function (err) {
        if (err) return promise.error(err);
        --count || promise.complete(arr); /* setTimeout(function() {
          promise.complete(arr);
        }, 0); */
      });
    }
```

Thanks a lot !
