### PR TITLE
Fixed bug in query streaming result.

### DIFF
--- a/lib/querystream.js
+++ b/lib/querystream.js
@@ -211,7 +211,7 @@ QueryStream.prototype._onNextObject = function _onNextObject (err, doc) {
   var self = this;
   instance.init(doc, this.query, function (err) {
     if (err) return self.destroy(err);
-    self.emit('data', instance);
+    self.emit('data', JSON.stringify(instance));
 
     // trampoline management
     if (T_IDLE === self._inline) {


### PR DESCRIPTION
Steps to reproduce:
1) Create a collection Things.
2) Perform a query to list Things.
3) Redirect output to http.ServerResponse.

Expected result:
Query results are streamed to the response.

Actual results:
A type error is thrown by http.ServerResponse.

```
TypeError: first argument must be a string or Buffer
    at ServerResponse.OutgoingMessage.write (http.js:715:11)
```

Fix details:
It seems that ServerResponse is expecting either a Buffer or a String, and
QueryStream is sending an object instead. Changed QueryStream to transform
the model instance to String via JSON.stringify.

Code to reproduce:

```
  /*
     ... Create a collection and save some kitties ...
  */
  var server = require("http").createServer();
  server.on("request", function (req, res) {
    Kitten.find({}).stream().pipe(res);
  });
```
