### PR TITLE
I believe it fixes #1245

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -46,7 +46,9 @@ function SchemaArray (key, cast, options) {
     var caster = cast.name in Types ? Types[cast.name] : cast;
     this.casterConstructor = caster;
     this.caster = new caster(null, castOptions);
-    this.caster.path = key;
+    if ('EmbeddedDocument' !== this.caster.constructor.name) {
+      this.caster.path = key;
+    }
   }
 
   SchemaType.call(this, key, options);


### PR DESCRIPTION
If there is EmbeddedDocument inside array, it's not wise to set property `path` ot it. At least because it may already have defined property with such name.
