### PR TITLE
fix model.find returning default array values for excluded fields

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -172,12 +172,28 @@ Document.prototype._buildDoc = function (obj, fields, skipId) {
     for (; i < len; ++i) {
       var piece = path[i]
         , def
+        , chain
+        , termin
+        , j = 0
 
       if (i === last) {
         if (fields) {
           if (exclude) {
             // apply defaults to all non-excluded fields
             if (p in fields) continue;
+            // loop through all excluded subfields and remove from defaults
+            for (; j < path.length; j++) {
+              if (j === 0) {
+                if (path[j] in fields) continue;
+                chain = path[j];
+              } else {
+                chain += '.' + path[j];
+                if (chain in fields) {
+                  termin = true;
+                }
+              }
+            }
+            if (termin === true) continue;
 
             def = type.getDefault(self, true);
             if ('undefined' !== typeof def) {


### PR DESCRIPTION
(Schema.find: Excluding field which contains array still returns a blank field).
Subfields with an array have a default of the array. In an exclude query, if not looped through and removed, the default array is returned incorrectly.
