### PR TITLE
Fixed incorrect annotation in SchemaNumber#min

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -39,7 +39,7 @@ SchemaNumber.prototype.checkRequired = function checkRequired (value) {
 };
 
 /**
- * Sets a maximum number validator.
+ * Sets a minimum number validator.
  *
  * ####Example:
  *


### PR DESCRIPTION
This small fix clears up the docs a little bit. It said maximum instead of minimum.
