### PR TITLE
Domain module support

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1676,6 +1676,9 @@ Model.mapReduce = function mapReduce (o, callback) {
     q = undefined;
   }
 
+  if (process.domain)
+    callback = process.domain.bind(callback);
+
   this.collection.mapReduce(null, null, o, function (err, ret, stats) {
     if (err) return callback(err);
 
@@ -1724,7 +1727,14 @@ Model.mapReduce = function mapReduce (o, callback) {
  */
 
 Model.aggregate = function aggregate () {
-  return this.collection.aggregate.apply(this.collection, arguments);
+  var args, cb, _i;
+  args = 2 <= arguments.length ? __slice.call(arguments, 0, _i = arguments.length - 1) : (_i = 0, []), cb = arguments[_i++];
+  if (process.domain && 'function' === typeof cb) {
+    cb = process.domain.bind(cb);
+  }
+  if (cb)
+    args.push(cb);
+  return this.collection.aggregate.apply(this.collection, args);
 }
 
 /*!

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -124,6 +124,8 @@ Promise.prototype.addErrback = function (fn) {
  */
 
 Promise.prototype.addBack = function (fn) {
+  if (process.domain)
+    fn = process.domain.bind(fn);
   this.on('err', function(err){
     fn.call(this, err);
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -387,6 +387,8 @@ exports.args = sliced;
 
 exports.tick = function tick (callback) {
   if ('function' !== typeof callback) return;
+  if (process.domain)
+    callback = process.domain.bind(callback);
   return function () {
     try {
       callback.apply(this, arguments);


### PR DESCRIPTION
Added domain support to mongoose.

Almost every query uses either a Promise or utils.tick so both of those will bind the current process's domain to the callback, if the process has a domain. As far as I could tell, the only other places that needed it were mapReduce and aggregate.
