### PR TITLE
Fix typos.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -477,13 +477,13 @@ exports.readPref = function readPref (pref, tags) {
       pref = 'primary';
       break;
     case 'pp':
-      pref = 'primaryPrefered';
+      pref = 'primaryPreferred';
       break;
     case 's':
       pref = 'secondary';
       break;
     case 'sp':
-      pref = 'secondaryPrefered';
+      pref = 'secondaryPreferred';
       break;
     case 'n':
       pref = 'nearest';


### PR DESCRIPTION
Correct typos, `(primary|secondary)Prefered` with `(primary|secondary)Preferred`.
