### PR TITLE
When calling populate inside a pre save hook a copy of the referenced document is saved inline

### DIFF
--- a/test/model.ref.test.js
+++ b/test/model.ref.test.js
@@ -37,6 +37,12 @@ var Comment = new Schema({
   , content  : String
 });
 
+Comment.pre('save', function(next) {
+  //This will result in having a copy of the User inside the Comment document
+  //instead of just a reference.
+  this.populate('_creator', next);
+});
+
 /**
  * Blog post schema.
  */


### PR DESCRIPTION
This just bite me.

What I usually get when saving

``` js
{
    _id: ObjectId(...),
    _creator: ObjectId(...)
}
```

What I get when calling `populate` inside a pre save hook

``` js
{
    _id: ObjectId(...),
    _creator: {
        /*All properties of the User are now here. No reference.*/
    }
}
```

I didn't actually add failing tests. But adding a `populate` call makes some of the ref tests fail.
