### PR TITLE
Fix error in SchemaNumber#min()

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -65,7 +65,7 @@ SchemaNumber.prototype.min = function (value, message) {
       return v[1] != 'min';
     });
   if (value != null)
-    this.validators.push([function(v){
+    this.validators.push([this.minValidator = function(v){
       return v === null || v >= value;
     }, 'min']);
   return this;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -363,6 +363,11 @@ describe('schema', function(){
       Tobi.path('friends').doValidate(null, function(err){
         assert.ifError(err);
       });
+
+      Tobi.path('friends').min();
+      Tobi.path('friends').max();
+
+      assert.equal(Tobi.path('friends').validators.length, 0);
       done();
     });
 


### PR DESCRIPTION
`minValidator` property wasn't set which could lead to muliple min validator if `min(...)` is called  at multiple occasion.
