### PR TITLE
Update index.jade, fixed namespace error

### DIFF
--- a/docs/index.jade
+++ b/docs/index.jade
@@ -52,7 +52,7 @@ html(lang='en')
         :markdown
           So far so good. We've got a schema with one property, `name`, which will be a  `String`. The next step is compiling our schema into a [Model](/docs/models.html).
         :js
-          var Kitten = mongoose.model('Kitten', kittySchema)
+          var Kitten = db.model('Kitten', kittySchema)
         :markdown
           A model is a class with which we construct documents.
           In this case, each document will be a kitten with properties and behaviors as declared in our schema.


### PR DESCRIPTION
I was just beginning to learn using MongoDB via Mongoose, using your tutorial at http://mongoosejs.com/docs/index.html
Unfortunately the "getting started" tutorial has a severe flaw which prevents any commits from succeeding and almost drove me off to mongojs. You write:
`var Kitten = mongoose.model('Kitten', kittySchema)`
whereas according to http://stackoverflow.com/questions/10156623/mongoose-js-instance-save-callback-not-firing you should be writing:
`var Kitten = db.model('Kitten', kittySchema)`
lest the  model will be saved to the wrong namespace. I tested both versions in a coffeescript adaption of the code.
