### PR TITLE
Added a clearer error message

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -57,7 +57,7 @@ NativeCollection.prototype.onOpen = function () {
         if (exists.capped) {
           callback(null, c);
         } else {
-          var msg = 'A non-capped collection exists with this name.\n\n'
+          var msg = 'A non-capped collection exists with the name: '+ self.name +'\n\n'
                   + ' To use this collection as a capped collection, please '
                   + 'first convert it.\n'
                   + ' http://www.mongodb.org/display/DOCS/Capped+Collections#CappedCollections-Convertingacollectiontocapped'


### PR DESCRIPTION
The previous error message stated "A non-capped collection exists with that name."

The driver has the name available in this context, so there's reason not to report it.  It makes troubleshooting easier.

Also, for anyone that's interested, I traced the problem I was having down to a conflict with Sugar.  This code:

``` javascript
if (!self.opts.capped.size) {
```

Will incorrectly detect all your collections as capped if you have included the library Sugar and performed Object.extend().  Not mongoose's problem of course, but keep an eye out for it if you're an application developer doing this.  See this thread for a solution:

https://github.com/andrewplummer/Sugar/issues/248#issuecomment-16199570
