### PR TITLE
Documentation: display by alphabetical order the methods list #1508

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -212,12 +212,23 @@ function fix (str) {
 }
 
 function order (docs) {
+  var sortByCtxName = function (a, b) {
+    return a.ctx.name.localeCompare(b.ctx.name);
+  };
+
   // want index first
   for (var i = 0; i < docs.length; ++i) {
-    if ('index.js' == docs[i].title) {
+    var doc = docs[i];
+
+    if ('index.js' == doc.title) {
       docs.unshift(docs.splice(i, 1)[0]);
-    } else if ('collection.js' == docs[i].title) {
+    } else if ('collection.js' == doc.title) {
       docs.push(docs.splice(i, 1)[0]);
     }
+
+    // sort methods, statics and properties alphabetically
+    doc.methods.sort(sortByCtxName);
+    doc.statics.sort(sortByCtxName);
+    doc.props.sort(sortByCtxName);
   }
 }


### PR DESCRIPTION
I kept the display order of methods first, statics and then properties without mixing them.
