### PR TITLE
Just found a little bug.

### DIFF
--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -162,6 +162,21 @@ SchemaBuffer.prototype.castForQuery = function ($conditional, val) {
   }
 };
 
+/**
+ * Set the subtype of Buffer.
+ *
+ * ####Example:
+ *
+ *     var s = new Schema({ _id: { type: Buffer, subtype: 0x04 });
+ * 
+ * @param  {Number} value the subtype value
+ * @return {SchemaType} this
+ */
+SchemaType.prototype.subtype = function(value) {
+  this._subtype = 'number' === typeof(value) ? value : 0x00;
+  return this;
+};
+
 /*!
  * Module exports.
  */

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -631,26 +631,6 @@ SchemaType._isRef = function (self, value, doc, init) {
 
   return false;
 }
-/**
- * Set the subtype of Buffer.
- *
- * ####Example:
- *
- *     var s = new Schema({ _id: { type: Buffer, subtype: 0x04 });
- * 
- * @param  {Number} value the subtype value
- * @return {SchemaType} this
- */
-SchemaType.prototype.subtype = function(value) {
-  if ('Buffer' === this.instance) {
-    if ('number' === typeof(value)) {
-      this._subtype = value;
-    } else {
-      this._subtype = 0x00;
-    }
-  }
-  return this;
-}
 
 /*!
  * Module exports.


### PR DESCRIPTION
if schema like this:

``` javascript
    _id: {
        type: Buffer,
        default: function() {
            return (new MongooseBuffer(uuid.v4())).toObject(0x04);
        }
    }
```

the sub_type will be lost.

And I think I really need the spec that Heckmann has mentioned before  >> https://github.com/LearnBoost/mongoose/pull/1000#issuecomment-6912708 
