### PR TITLE
Fix wrong isSelected() behavior.

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -879,7 +879,7 @@ Document.prototype.isSelected = function isSelected (path) {
         return inclusive;
       }
 
-      if (0 === pathDot.indexOf(cur)) {
+      if (0 === pathDot.indexOf(cur + '.')) {
         return inclusive;
       }
     }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -889,6 +889,30 @@ describe('document:', function(){
     assert.ok(doc.isSelected('em.title'));
     assert.ok(doc.isSelected('em.body'));
     assert.ok(doc.isSelected('em.nonpath'));
+
+    var selection = {
+        '_id': 1,
+        'n': 1
+    }
+
+    doc = new TestDocument(undefined, selection);
+    doc.init({
+        test    : 'test'
+      , numbers : [4,5,6,7]
+      , nested  : {
+            age   : 5
+          , cool  : DocumentObjectId.createFromHexString('4c6c2d6240ced95d0e00003c')
+          , path  : 'my path'
+          , deep  : { x: 'a string' }
+        }
+      , notapath: 'i am not in the schema'
+    });
+
+    assert.ok(doc.isSelected('_id'));
+    assert.ok(doc.isSelected('n'));
+    assert.ok(!doc.isSelected('nested'));
+    assert.ok(!doc.isSelected('nested.age'));
+    assert.ok(!doc.isSelected('numbers'));
     done();
   })
 


### PR DESCRIPTION
When fetching a document with some fields selected, isSelected() always
returns true with any fields starting with that selected-on-fetching fields'
name but which is not really selected on fetching.
