### PR TITLE
Added support for simple enums in schemas

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -195,6 +195,14 @@ Schema.prototype.add = function add (obj, prefix) {
       throw new TypeError('Invalid value for schema path `'+ prefix + key +'`');
     }
 
+    // enum shortcut
+    if(Array.isArray(obj[key]) && isEnum(obj[key])){
+      obj[key] = {
+        type: String,
+        enum: obj[key]
+      }
+    }
+
     if (utils.isObject(obj[key]) && (!obj[key].constructor || 'Object' == obj[key].constructor.name) && (!obj[key].type || obj[key].type.type)) {
       if (Object.keys(obj[key]).length) {
         // nested object { last: { name: String }}
@@ -208,6 +216,22 @@ Schema.prototype.add = function add (obj, prefix) {
     }
   }
 };
+
+/*! 
+ * Checks if the array is an enum
+ */
+ function isEnum(arr){
+  if (arr.length > 1) {
+    for (var i = 0; i < arr.length; i++){
+      if (!utils.isNullOrUndefined(arr[i]) && 'string' != typeof arr[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+ }
 
 /**
  * Reserved document keys.

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -267,12 +267,18 @@ describe('schema', function(){
 
     it('string enum', function(done){
       var Test = new Schema({
-          complex: { type: String, enum: ['a', 'b', undefined, 'c', null] }
+          complex: { type: String, enum: ['a', 'b', undefined, 'c', null] },
+          sugar: ['a', undefined,  'b', 'c', null]
       });
 
       assert.ok(Test.path('complex') instanceof SchemaTypes.String);
       assert.deepEqual(Test.path('complex').enumValues,['a', 'b', 'c', null]);
       assert.equal(Test.path('complex').validators.length, 1)
+
+      // syntax sugar
+      assert.ok(Test.path('sugar') instanceof SchemaTypes.String);
+      assert.deepEqual(Test.path('sugar').enumValues,['a', 'b', 'c', null]);
+      assert.equal(Test.path('sugar').validators.length, 1)
 
       Test.path('complex').enum('d', 'e');
 


### PR DESCRIPTION
Adds support for the simple enum syntax: https://github.com/LearnBoost/mongoose/issues/1525
Because mongoose supports specifying types as strings it only applies if the array has more than one item (which is generally the case for enums anyway)

Example:

```
var user = new Schema({
    name: String
    role: ['admin', 'moderator', 'editor', 'user']
})
```

I've added the tests for it as well
