### PR TITLE
refactor validator error constructor

### DIFF
--- a/lib/errors/validator.js
+++ b/lib/errors/validator.js
@@ -19,24 +19,35 @@ function ValidatorError (path, type, val) {
     ? '"' + type + '" '
     : '';
 
-  var message = 'Validator ' + msg + 'failed for path ' + path
-  if (2 < arguments.length) message += ' with value `' + String(val) + '`';
-
-  MongooseError.call(this, message);
+  MongooseError.call(this, msg);
   Error.captureStackTrace(this, arguments.callee);
   this.name = 'ValidatorError';
   this.path = path;
   this.type = type;
   this.value = val;
-};
+  this.message = this.toString(msg, path, val);
+}
 
 /*!
  * toString helper
+ *
+ * @param {String=} optMsg optionally define the message to format
+ * @param {String=} optPath
+ * @param {String=} optVal
+ * @return {String}
  */
 
-ValidatorError.prototype.toString = function () {
-  return this.message;
-}
+ValidatorError.prototype.toString = function (optMsg, optPath, optVal) {
+  var message;
+  if ('string' === typeof optMsg) {
+    message = 'Validator ' + optMsg + 'failed for path ' + optPath;
+    if ('undefined' !== typeof optVal) message += ' with value `' + String(optVal) + '`';
+  } else {
+    message = this.message;
+  }
+
+  return message;
+};
 
 /*!
  * Inherits from MongooseError


### PR DESCRIPTION
A refactor of the `ValidatorError` constructor and the `toString()` method so it can be overwritten and achieve a custom error message for the `required` built-in validator.

An interim solution until #747 ships, but a good practice nonetheless. Not sure about the docblock, how would you declare an optional argument? I use `=` coming from the GClosure camp.
