### PR TITLE
Added pre-save validation for unique indexes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2372,12 +2372,47 @@ Model.compile = function compile (name, schema, collectionName, connection, base
   // apply named scopes
   if (schema.namedScopes) schema.namedScopes.compile(model);
 
+  // apply validation for paths with a unique index
+  for(var path in schema.paths) {
+    applyUniqueIndexValidation(model, schema, path);
+  };
+
   model.schema = model.prototype.schema;
   model.options = model.prototype.options;
   model.collection = model.prototype.collection;
 
   return model;
 };
+
+/**
+ * Adds validation for the path if its SchemaType indicates that it has a unique index.
+ *
+ * The validator checks to see if the collection already contains a document with the path’s value and throws an error
+ * if it does
+ *
+ * @param {Model} model
+ * @param {Schema} schema
+ * @param {String} path
+ * @api private
+ */
+function applyUniqueIndexValidation (model, schema, path) {
+  var schemaType = schema.paths[path];
+  if (schemaType._index && schemaType._index.unique) {
+    schemaType.validate(__checkUnique, 'duplicate');
+  }
+
+  function __checkUnique (value, respond) {
+    var conditions = {};
+    conditions[path] = value;
+    model.findOne(conditions, function (err, document) {
+      if (!document) {
+        respond(true);
+      } else {
+        respond(false);
+      }
+    });
+  }
+}
 
 /*!
  * Subclass this model with `conn`, `schema`, and `collection` settings.

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1499,6 +1499,27 @@ describe('Model', function(){
         });
       })
     })
+
+    describe('unique fields', function () {
+      it ('are validated before save', function (done) {
+        var db = start();
+        var uniqueSchema = new Schema({ uniqueField: { type: String, unique: true }, normalField: {type: String }});
+        var UniqueObject = db.model('UniqueObject', uniqueSchema);
+
+        new UniqueObject({ uniqueField: 'foo', normalField: 'bar' }).save(function (err) {
+          assert.strictEqual(null, err);
+          new UniqueObject({ uniqueField: 'foo', normalField: 'bar' }).save(function (err) {
+            assert.strictEqual('duplicate', err.errors.uniqueField.type);
+            assert.strictEqual('uniqueField', err.errors.uniqueField.path);
+            assert.strictEqual('foo', err.errors.uniqueField.value);
+            assert.strictEqual('undefined', typeof err.errors.normalField);
+
+            db.close();
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('defaults application', function(){


### PR DESCRIPTION
Currently unique fields are not validated by Mongoose pre save, rather the save is simply attempted and it is left up to MongoDB to throw an E11000 error.

That behaviour makes elegant error handling difficult (as noted in Issue #1225).

This patch fixes that by adding a pre-save validator which queries the DB for duplicate records and throws a validation error if it finds any. You can now handle these errors as you would with any other validation error:

```
if (err.errors.email.type === 'duplicate') {
    doSomething();
}
```

As a note, this patch will slow down write performance, but I feel that for most cases the more consistant error handling is worth the performance hit. Possibly we could add a configuration flag to allow people to turn this pre-save check off for applications where write performance is critical.
