### PR TITLE
Added support for GeoJSON to Query#near

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2651,7 +2651,7 @@ Query.prototype.near = function () {
       params.push({ center : arguments[0], spherical : sphere });
     } else if ('string' == typeof arguments[0]) {
       params.push(arguments[0]);
-    } else if (arguments[0].constructor.name == 'Object') {
+    } else if (utils.isObject(arguments[0])) {
       params.push(arguments[0]);
     }
   } else if (arguments.length === 2) {
@@ -2660,7 +2660,7 @@ Query.prototype.near = function () {
     } else if ('string' == typeof arguments[0] && Array.isArray(arguments[1])) {
       params.push(arguments[0]);
       params.push({ center : arguments[1], spherical : sphere });
-    } else if ('string' == typeof arguments[0] && arguments[1].constructor.name == 'Object') {
+    } else if ('string' == typeof arguments[0] && utils.isObject(arguments[1])) {
       params.push(arguments[0]);
       params.push(arguments[1]);
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       , "mpromise": "0.3.0"
       , "mpath": "0.1.1"
       , "regexp-clone": "0.0.1"
-      , "mquery" : "0.2.6"
+      , "mquery" : "0.2.7"
     }
   , "devDependencies": {
         "mocha": "1.12.0"

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1919,6 +1919,37 @@ describe('geo-spatial', function(){
       }
     });
 
+    it('$near works with GeoJSON (gh-1482)', function (done) {
+      var geoJSONSchema = new Schema({ loc : { type : { type : String }, coordinates : [Number] } });
+      geoJSONSchema.index({ loc : '2dsphere' });
+      var name = 'geospatial'+random();
+      var db = start()
+        , Test = db.model('Geo1', geoJSONSchema, name);
+
+      var pending = 2;
+      function complete (err) {
+        if (complete.ran) return;
+        if (err) return done(complete.ran = err);
+        --pending || test();
+      }
+
+      Test.on('index', complete);
+      Test.create({ loc: { type : 'Point', coordinates :[ 10, 20 ]}}, { loc: {
+        type : 'Point', coordinates: [ 40, 90 ]}}, complete);
+
+      function test () {
+        // $maxDistance is in meters... so even though they aren't that far off
+        // in lat/long, need an incredibly high number here
+        Test.where('loc').near({ center : { type : 'Point', coordinates :
+          [11,20]}, maxDistance : 1000000 }).exec(function (err, docs) {
+          db.close();
+          assert.ifError(err);
+          assert.equal(1, docs.length);
+          done();
+        });
+      }
+    });
+
     it('$within arrays (gh-586)', function(done){
       var db = start()
         , Test = db.model('Geo2', geoSchema, collection + 'geospatial');

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -328,6 +328,18 @@ describe('Query', function(){
       assert.deepEqual(query._conditions, {checkin: {$near: [40, -72]}});
       done();
     })
+    it('via where, where GeoJSON param', function(done){
+      var query = new Query({}, {}, null, p1.collection);
+      query.where('loc').near({ center : { type : 'Point', coordinates : [40, -72 ]}});
+      assert.deepEqual(query._conditions, {loc: {$near: { $geometry : { type : 'Point', coordinates : [40, -72] }}}});
+      done();
+    })
+    it('not via where, where GeoJSON param', function(done){
+      var query = new Query({}, {}, null, p1.collection);
+      query.near('loc', { center : { type : 'Point', coordinates : [40, -72 ]}});
+      assert.deepEqual(query._conditions, {loc: {$near: { $geometry : { type : 'Point', coordinates : [40, -72] }}}});
+      done();
+    })
   })
 
   describe('nearSphere', function(){


### PR DESCRIPTION
upgrade mquery version as well. As a side effect of that, I had to make this PR dependent on #1609 since this new version of mquery had stuff that broke tests for `sort` (internal representations of stuff changed) I fixed all this up in #1609 where I first upgraded to mquery 2.6, which is where the sort changes were made.
