### PR TITLE
fixed #1412; Subdocuments use their own transform

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1461,7 +1461,13 @@ Document.prototype.toObject = function (options) {
     applyGetters(this, ret, 'paths', options);
   }
 
-  if (true === options.transform) {
+  // In the case where a subdocument has its own transform function, we need to
+  // check and see if the parent has a transform (options.transform) and if the
+  // child schema has a transform (this.schema.options.toObject) In this case,
+  // we need to adjust options.transform to be the child schema's transform and
+  // not the parent schema's
+  if (true === options.transform ||
+      (this.schema.options.toObject && options.transform)) {
     var opts = options.json
       ? this.schema.options.toJSON
       : this.schema.options.toObject;

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -220,6 +220,45 @@ describe('types.documentarray', function(){
       assert.equal(undefined, delta.$pushAll.docs[0].changed);
       done();
     })
+    it('uses the correct transform (gh-1412)', function(done){
+      var db = start();
+      var FirstSchema = new Schema({
+        second: [SecondSchema],
+      });
+
+      FirstSchema.set('toObject', {
+      transform: function first(doc, ret, options) {
+          ret.firstToObject = true;
+          return ret;
+        },
+      });
+
+      var SecondSchema = new Schema({});
+
+      SecondSchema.set('toObject', {
+        transform: function second(doc, ret, options) {
+          ret.secondToObject = true;
+          return ret;
+        },
+      });
+
+      var First = db.model('first', FirstSchema);
+      var Second = db.model('second', SecondSchema);
+
+      var first = new First({
+      });
+
+      first.second.push(new Second());
+      first.second.push(new Second());
+      var obj = first.toObject();
+
+      assert.ok(obj.firstToObject);
+      assert.ok(obj.second[0].secondToObject);
+      assert.ok(obj.second[1].secondToObject);
+      assert.ok(!obj.second[0].firstToObject);
+      assert.ok(!obj.second[1].firstToObject);
+      done();
+    })
   })
 
   describe('create()', function(){


### PR DESCRIPTION
Made it such that subdocuments will use their own transform function
instead of their parent's when `toObject()` is called
