### PR TITLE
fixed #1376; subdocuments now use own toJSON opts

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1534,12 +1534,18 @@ Document.prototype.toJSON = function (options) {
   // check for object type since an array of documents
   // being stringified passes array indexes instead
   // of options objects. JSON.stringify([doc, doc])
-  if (!(options && 'Object' == options.constructor.name)) {
+  // 8/5/2013-(3.7)
+  // The second check here is to make sure that populated documents (or
+  // subdocuments) use their own options for `.toJSON()` instead of their
+  // parent's
+  if (!(options && 'Object' == options.constructor.name)
+      || ((!options || options.json) && this.schema.options.toJSON)) {
     options = this.schema.options.toJSON
       ? clone(this.schema.options.toJSON)
       : {};
   }
   options.json = true;
+
   return this.toObject(options);
 };
 


### PR DESCRIPTION
subdocuments and populated paths were using the parent's toJSON options
instead of their own. This fixes that.
