### PR TITLE
fixed #475; save hook only emitted when doc saved

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -129,7 +129,10 @@ function handleSave (promise, self) {
       }
     }
 
-    self.emit('save', self, numAffected);
+    // only emit the event when we actually change something
+    if (numAffected !== 0) {
+      self.emit('save', self, numAffected);
+    }
     promise.complete(self, numAffected);
     promise = self = null;
   });

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -196,4 +196,35 @@ describe('model middleware', function(){
       })
     });
   })
+  it('doesn\'t emit save events when a document is not sent to the db (gh-475)', function(done){
+    var db = start();
+    var ts = new Schema({
+      title : String,
+      num : Number
+    });
+    var count = 0;
+    ts.post('save', function () {
+      count++;
+    });
+
+    var Test = db.model('Test' + random(), ts);
+
+    var t = new Test({ title : 'testing'});
+    t.save(function (err) {
+      assert.ifError(err);
+      assert.equal(count, 1);
+
+      t.num = 1;
+      t.save(function (err) {
+        assert.ifError(err);
+        assert.equal(count, 2);
+
+        t.save(function (err) {
+          assert.ifError(err);
+          assert.equal(count, 2);
+          done();
+        });
+      });
+    });
+  })
 });


### PR DESCRIPTION
before, it emitted even if no document was saved, now only emits if the
document is saved and sent to the db
