### PR TITLE
fixes #1280; properly excludes subdocument fields

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -165,11 +165,16 @@ Document.prototype.$__buildDoc = function (obj, fields, skipId) {
       , last = len-1
       , doc_ = doc
       , i = 0
-
+    var curPath = "";
     for (; i < len; ++i) {
       var piece = path[i]
         , def
-
+      // we want to be able to exclude stuff at intermediary levels of documents
+      if (exclude) {
+        curPath += piece;
+        if (curPath in fields) break;
+        curPath += ".";
+      }
       if (i === last) {
         if (fields) {
           if (exclude) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -978,7 +978,6 @@ function completeMany (model, docs, fields, self, pop, promise) {
   var opts = pop ?
     { populated: pop }
     : undefined;
-
   for (var i=0; i < len; ++i) {
     arr[i] = new model(undefined, fields, true);
     arr[i].init(docs[i], opts, function (err) {


### PR DESCRIPTION
Before, you would have to specify the full subdocument path and all
properties to exclude it. Can now just specify the top level
