### PR TITLE
Update MongoDB dependency to 1.3.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
   , "dependencies": {
         "hooks": "0.2.1"
-      , "mongodb": "1.3.15"
+      , "mongodb": "1.3.17"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"
       , "muri": "0.3.1"


### PR DESCRIPTION
This fixes various bugs. One of them causes crashes when using replica sets. Maybe 1.3.x should be used?
