### PR TITLE
utils; fix utils.merge

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -350,18 +350,14 @@ exports.random = function () {
 exports.merge = function merge (to, from) {
   var keys = Object.keys(from)
     , i = keys.length
-    , key
+    , key;
 
   while (i--) {
     key = keys[i];
     if ('undefined' === typeof to[key]) {
       to[key] = from[key];
-    } else {
-      if (exports.isObject(from[key])) {
-        merge(to[key], from[key]);
-      } else {
-        to[key] = from[key];
-      }
+    } else if (exports.isObject(from[key])) {
+      merge(to[key], from[key]);
     }
   }
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -300,5 +300,37 @@ describe('utils', function(){
       done();
     })
   })
+
+  describe('merge', function(){
+    it('merges two objects together without overriding properties & methods', function(done){
+      function To() {
+        this.name = 'to';
+        this.toProperty = true;
+      }
+      To.prototype.getName = function() {};
+      To.prototype.toMethod = function() {};
+
+      function From() {
+        this.name = 'from';
+        this.fromProperty = true;
+      }
+      From.prototype.getName = function() {};
+      From.prototype.fromMethod = function() {};
+
+      var to = new To();
+      var from = new From();
+
+      utils.merge(to, from);
+
+      assert.equal(to.name, 'to');
+      assert.equal(to.toProperty, true);
+      assert.equal(to.fromProperty, true);
+      assert.ok(to.getName === To.prototype.getName);
+      assert.ok(to.toMethod === To.prototype.toMethod);
+      assert.equal(to.fomMethod, From.prototype.fomMethod);
+
+      done();
+    })
+  })
 })
 


### PR DESCRIPTION
DocBloc says: "Merges `from` into `to` without overwriting existing properties." which it wasn't doing (from properties were over-riding to.)
