### PR TITLE
db.collection.ensureIndexes() method does not have "safe" option

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -667,8 +667,7 @@ Model.ensureIndexes = function ensureIndexes (cb) {
   // Indexes are created one-by-one to support how MongoDB < 2.4 deals
   // with background indexes.
 
-  var self = this
-    , safe = self.schema.options.safe
+  var self = this;
 
   function done (err) {
     self.emit('index', err);
@@ -679,9 +678,7 @@ Model.ensureIndexes = function ensureIndexes (cb) {
     var index = indexes.shift();
     if (!index) return done();
 
-    var options = index[1];
-    options.safe = safe;
-    self.collection.ensureIndex(index[0], options, tick(function (err) {
+    self.collection.ensureIndex(index[0], index[1], tick(function (err) {
       if (err) return done(err);
       create();
     }));


### PR DESCRIPTION
Correct me if I'm wrong here, but documentation doesn't state that the "safe" option exists:

http://docs.mongodb.org/manual/reference/method/db.collection.ensureIndex/
http://docs.mongodb.org/v2.2/reference/method/db.collection.ensureIndex/

Was there a reason for this before I go crazy with minor fixes like this?
