### PR TITLE
schema; create plugins array to reference registered plugins

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -63,6 +63,7 @@ function Schema (obj, options) {
   this.statics = {};
   this.tree = {};
   this._requiredpaths = undefined;
+  this.plugins = [];
 
   this.options = this.defaultOptions(options);
 
@@ -548,6 +549,7 @@ Schema.prototype.post = function(method, fn){
  */
 
 Schema.prototype.plugin = function (fn, opts) {
+  this.plugins.push(fn);
   fn(this, opts);
   return this;
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1125,6 +1125,15 @@ describe('schema', function(){
 
       assert.equal(true, called);
       done();
+    });
+
+    it('pushes plugin to plugins array', function(done) {
+      var Toby = new Schema(),
+          plugin = function(schema) {};
+
+      Toby.plugin(plugin);
+      assert.strictEqual(plugin, Toby.plugins[0]);
+      done();
     })
   });
 


### PR DESCRIPTION
I enjoy using plugins.. and testing plugins independently.

So, when I use a plugin in the schema, I don't want to have to re-test the functionality.  This PR gives me the ability to just confirm that the plugin is being used.
