### PR TITLE
Allow passing models directly in refs

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1955,7 +1955,13 @@ function populate (model, docs, options, cb) {
                || schema && schema.options.ref // declared in schema
                || model.modelName              // an ad-hoc structure
 
-  var Model = model.db.model(modelName);
+  // We can pass a model directly if it depends on another connection
+  if (typeof modelName == "function") {
+    var Model = modelName;
+  } else {
+    var Model = model.db.model(modelName);
+  }
+  
 
   // expose the model used
   options.model = Model;


### PR DESCRIPTION
It allows using cross-connection references. Would solve this: http://stackoverflow.com/questions/15680210/populate-from-two-different-databases-in-mongoose

Probably not the right way to code it but you get the point.
