### PR TITLE
Added Notes on findAndUpdate()

### DIFF
--- a/docs/middleware.jade
+++ b/docs/middleware.jade
@@ -76,7 +76,12 @@ block content
     schema.post('remove', function (doc) {
       console.log('%s has been removed', doc._id);
     })
-
+  
+  h3#notes Notes on findAndUpdate()
+  `pre` and `post` are not called for update operations executed directly on the database, including `Model.update`,`.findByIdAndUpdate`,`.findOneAndUpdate`, `.findOneAndRemove`,and `.findByIdAndRemove`.  
+  
+  In order to utilize `pre` or `post` middleware, you should `find()` the document, and call the `init`, `validate`, `save`, or `remove` functions on the document.  See [explanation](http://github.com/LearnBoost/mongoose/issues/964).
+  
   h3#next Next Up
   :markdown
     Now that we've covered `middleware`, let's take a look at Mongooses approach to faking JOINs with its query [population](/docs/populate.html) helper.


### PR DESCRIPTION
Added note to clarify that pre and post middleware is not fired for findOneAndUpdate() class of methods--and this is by design.
