### PR TITLE
Normalize bugs.email, so `npm` will shut up

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   , "engines": { "node": ">=0.6.19" }
   , "bugs": {
         "url":"https://github.com/learnboost/mongoose/issues/new"
-      , "email": "https://groups.google.com/group/mongoose-orm"
+      , "email": "mongoose-orm@googlegroups.com"
     }
   , "repository": {
         "type": "git"


### PR DESCRIPTION
Stop `npm` from spitting out: 
`npm WARN package.json mongoose@3.8.1-pre bugs.email field must be a string email. Deleted.`
