### PR TITLE
Update mpromise dependency so Promise.all can be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       , "ms": "0.1.0"
       , "sliced": "0.0.5"
       , "muri": "0.3.1"
-      , "mpromise": "0.3.0"
+      , "mpromise": "0.4.1"
       , "mpath": "0.1.1"
       , "regexp-clone": "0.0.1"
       , "mquery" : "0.3.2"


### PR DESCRIPTION
I am aware of [#1699 use Q.js](https://github.com/LearnBoost/mongoose/issues/1699), however it's scheduled for v4. Until then, it'd be nice to bring Aaron's work on mpromise to fruition in here :)

tl;dr;
With [mpromise](https://github.com/aheckmann/mpromise) we can now use .all([Array of Promises]) which is incredibly useful esp. for plugin creation. 

With updated dependency in mongoose one does not have to resort to redundant modules in code (additionally include latest mpromise or use Q) only to enable p.all
