### PR TITLE
findByIdAndUpdate will now respect the overwrite option

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1499,7 +1499,7 @@ Query.prototype._findAndModify = function (type, callback) {
     if (!('new' in opts)) opts.new = true;
     if (!('upsert' in opts)) opts.upsert = false;
 
-    castedDoc = castDoc(this);
+    castedDoc = castDoc(this, opts.overwrite);
     if (!castedDoc) {
       if (opts.upsert) {
         // still need to do the upsert to empty doc
@@ -1995,9 +1995,9 @@ function castQuery (query) {
  * @api private
  */
 
-function castDoc (query) {
+function castDoc (query, overwrite) {
   try {
-    return query._castUpdate(query._update);
+    return query._castUpdate(query._update, overwrite);
   } catch (err) {
     return err;
   }


### PR DESCRIPTION
Previously findByIdAndUpdate would not respect the `overwrite : true` option if passed due to a call to `castDoc` which did not pass along overwrite. 
