### PR TITLE
updated; driver to 1.3.23

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1701,6 +1701,7 @@ Model.mapReduce = function mapReduce (o, callback) {
   }
 
   if (!o.out) o.out = { inline: 1 };
+  if (false !== o.verbose) o.verbose = true;
 
   o.map = String(o.map);
   o.reduce = String(o.reduce);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
   , "dependencies": {
         "hooks": "0.3.2"
-      , "mongodb": "1.3.19"
+      , "mongodb": "1.3.23"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"
       , "muri": "0.3.1"

--- a/test/model.mapreduce.test.js
+++ b/test/model.mapreduce.test.js
@@ -151,6 +151,22 @@ describe('model: mapreduce:', function(){
     });
   })
 
+  it('withholds stats with false verbosity', function(done){
+    var db = start()
+      , MR = db.model('MapReduce', collection)
+
+    var o = {
+        map: function () {}
+      , reduce: function () { return 'test' }
+      , verbose: false
+    }
+
+    MR.mapReduce(o, function (err, results, stats){
+      assert.equal('undefined', typeof stats);
+      done();
+    });
+  });
+
   describe('promises (gh-1628)', function () {
     it('are returned', function(done){
       var db = start()


### PR DESCRIPTION
As a side-effect, mongodb no longer passes the stats as a third
argument to a mapReduce callback unless the verbose option is set. To
provide backwards-compatibility, we will set it unless it is explicitly
unset.

I am mostly interested in this update for this change which resolves
pending commands with errors on a manual disconnection:

https://github.com/mongodb/node-mongodb-native/commit/2667d13214dc6ef80e68aa5e57dc56739a7fdc79

This passes all tests for me including 2.4, shard, and replica set tests.
