### PR TITLE
Fix so that compound types can be used for _id and id properties

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -74,13 +74,13 @@ function Schema (obj, options) {
   }
 
   // ensure the documents get an auto _id unless disabled
-  var auto_id = !this.paths['_id'] && (!this.options.noId && this.options._id);
+  var auto_id = !this.tree['_id'] && (!this.options.noId && this.options._id);
   if (auto_id) {
     this.add({ _id: {type: Schema.ObjectId, auto: true} });
   }
 
   // ensure the documents receive an id getter unless disabled
-  var autoid = !this.paths['id'] && (!this.options.noVirtualId && this.options.id);
+  var autoid = !this.tree['id'] && (!this.options.noVirtualId && this.options.id);
   if (autoid) {
     this.virtual('id').get(idGetter);
   }


### PR DESCRIPTION
`Schema` inadvertently overwrites definitions of `_id` and `id` upon creation when using compound types. It tests for the existence of definitions `_id`/`id` using the full property path instead of existing definitions instead of just checking the tree root.

This change allows a model's `_id` property to load correctly from database documents when using a compound type.
