### PR TITLE
Document.prototype.set is not correctly checking for nested keys

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -446,7 +446,7 @@ Document.prototype.set = function (path, val, type, options) {
             && (!path[key].constructor || 'Object' == path[key].constructor.name)
             && 'virtual' != pathtype
             && !(this.$__path(prefix + key) instanceof MixedSchema)
-            && !(this.schema.paths[key] && this.schema.paths[key].options.ref)
+            && !(this.schema.paths[prefix + key] && this.schema.paths[prefix + key].options.ref)
           ) {
           this.set(path[key], prefix + key, constructing);
         } else if (strict) {


### PR DESCRIPTION
This function should be checking for external references using the prefix, please check the following case:

```javascript
var mongoose = require('mongoose'),
    Schema = mongoose.Schema;

var Group = new Schema({
    name: String,
});

var Role = new Schema({
    group: { type: Schema.Types.ObjectId, ref: 'Group' },
    permissions: {
        group: {
            read: String,
            write: String
        }
    } 
});

var Group = mongoose.model('Group', Group),
    group = new Group({ name: 'user' });

group.save();

var Role = mongoose.model('Role', Role),
    role = new Role({ 
        group: group.id,
        permissions: {
            group: {
                read: "global",
                write: "global"
            }
        }
    });

console.log(role); 

/* Role document should be: 
{
   _id: 52e6314ed724aa0000000002,
  group: 52e6314ed724aa0000000001, 
  permissions: { group: { write: 'global', read: 'global' } }
}

But it is instead:

{
   _id: 52e6314ed724aa0000000002,
  group: 52e6314ed724aa0000000001, 
  permissions: { group: { } }
}

*/
```

```
