### PR TITLE
Added get / set to reserved path list.

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -224,7 +224,7 @@ Schema.prototype.add = function add (obj, prefix) {
  *
  * Keys in this object are names that are rejected in schema declarations b/c they conflict with mongoose functionality. Using these key name will throw an error.
  *
- *      on, emit, _events, db, init, isNew, errors, schema, options, modelName, collection, _pres, _posts, toObject
+ *      on, emit, _events, db, get, set, init, isNew, errors, schema, options, modelName, collection, _pres, _posts, toObject
  *
  * _NOTE:_ Use of these terms as method names is permitted, but play at your own risk, as they may be existing mongoose document methods you are stomping on.
  *
@@ -236,6 +236,8 @@ Schema.reserved = Object.create(null);
 var reserved = Schema.reserved;
 reserved.on =
 reserved.db =
+reserved.set =
+reserved.get =
 reserved.init =
 reserved.isNew =
 reserved.errors =


### PR DESCRIPTION
Using get or set in your schema results in exceptions in ./lib/document.js. 

Example Cases:

```
var Thing = mongoose.model('Thing', { set: String });

var thing = new Thing();
thing.set = "Thing One";

thing.save(function(err) {
  console.log(err);
});
```

```
var Thing = mongoose.model('Thing', { 
  name: String, 
  items: [{ 
    set: String,
    date: Date }] });

var thing = new Thing();
thing.name = "Thing One";
thing.items.push({ set: "one", date: new Date() });

thing.save(function(err) {
  console.log(err);
});
```

```
var Thing = mongoose.model('Thing', { get: String });

var thing = new Thing();
thing.get = "Thing One";

thing.save(function(err) {
  console.log(err);
});
```
