### PR TITLE
fix getting started guide callbacks

### DIFF
--- a/docs/index.jade
+++ b/docs/index.jade
@@ -82,7 +82,7 @@ html(lang='en')
           Each document can be saved to the database by calling its [save](/docs/api.html#model_Model-save) method. The first argument to the callback will be an error if any occured.
         :js
           fluffy.save(function (err, fluffy) {
-            if (err) // TODO handle the error
+            if (err) {console.log(err)} // TODO handle the error
             fluffy.speak();
           });
         :markdown
@@ -90,8 +90,8 @@ html(lang='en')
           We can access all of the kitten documents through our Kitten [model](/docs/models.html).
         :js
           Kitten.find(function (err, kittens) {
-            if (err) // TODO handle err
-            console.log(kittens)
+            if (err) {console.log(err)} // TODO handle the error
+            console.log(kittens);
           })
         :markdown
           We just logged all of the kittens in our db to the console.


### PR DESCRIPTION
the find and save callbacks were in fact logging to console only if there was an error, rather than the other way around as described in the text.
