### PR TITLE
expose connection states for user-land

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var Schema = require('./schema')
   , SchemaType = require('./schematype')
   , VirtualType = require('./virtualtype')
   , SchemaDefaults = require('./schemadefault')
+  , STATES = require('./connectionstate')
   , Types = require('./types')
   , Query = require('./query')
   , Promise = require('./promise')
@@ -61,6 +62,12 @@ function Mongoose () {
   };
   this.createConnection(); // default connection
 };
+
+/**
+ * Expose connection states for user-land
+ * 
+ */
+Mongoose.prototype.STATES = STATES;
 
 /**
  * Sets mongoose options


### PR DESCRIPTION
The below code just check a connection instance is connected

``` js
var conn = mongoose.connection;
if (conn._readyState === 0) {
  mongoose.connect('mongodb://localhost:27017/test');
}
```

but I prefer do this like:

``` js
var conn = mongoose.connection;
if (conn._readyState === mongoose.STATES.disconnected)
  mongoose.connect('mongodb://localhost:27017/test');
}
```
