### PR TITLE
Fix model version not being checked properly on queries with push operands.  Issue #1898

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -260,7 +260,7 @@ function operand (self, where, delta, data, val, op) {
   // modifying elements of an array is ok if position does not change.
 
   if ('$push' == op || '$pushAll' == op || '$addToSet' == op) {
-    self.$__.version = VERSION_INC;
+    self.$__.version = self.$__.version | VERSION_INC;
   }
   else if (/^\$p/.test(op)) {
     // potentially changing array positions
@@ -273,7 +273,7 @@ function operand (self, where, delta, data, val, op) {
   // now handling $set, $unset
   else if (/\.\d+\.|\.\d+$/.test(data.path)) {
     // subpath of array
-    self.$__.version = VERSION_WHERE;
+    self.$__.version = self.$__.version | VERSION_WHERE;
   }
 }
 


### PR DESCRIPTION
This bug affects anyone who is depending on mongoose for optimistic locking and has arrays in their documents.