### PR TITLE
asynchronous post hooks

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -554,7 +554,14 @@ Schema.prototype.pre = function(){
  */
 
 Schema.prototype.post = function(method, fn){
-  return this.queue('on', arguments);
+  // assuming that all callbacks with arity < 2 are synchronous post hooks
+  if (fn.length < 2)
+    return this.queue('on', arguments);
+  return this.queue('post', [arguments[0], function(next){
+    // wrap original function so that the callback goes last,
+    // for compatibility with old code that is using synchronous post hooks
+    fn.call(this, this, next);
+  }]);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
   , "dependencies": {
-        "hooks": "0.2.1"
+        "hooks": "0.3.2"
       , "mongodb": "1.3.23"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -38,11 +38,13 @@ describe('model middleware', function(){
       called++;
     });
 
-    schema.post('save', function (obj) {
-      assert.equal(obj.title,'Little Green Running Hood');
-      assert.equal(2, called);
-      db.close();
-      done();
+    schema.post('save', function(obj, next){
+      setTimeout(function(){
+        assert.equal(obj.title,'Little Green Running Hood');
+        assert.equal(2, called);
+        called++;
+        next();
+      }, 0);
     });
 
     var db = start()
@@ -52,8 +54,12 @@ describe('model middleware', function(){
 
     test.save(function(err){
       assert.ifError(err);
+      assert.equal(test.title,'Little Green Running Hood');
+      assert.equal(3, called);
+      db.close();
+      done();
     });
-  })
+  });
 
   it('works', function(done){
     var schema = new Schema({


### PR DESCRIPTION
As discussed in #787 and #986 
The main reason why this is needed is post save hooks in which we can perform async operations like creating another or updating existing models. For example in my project we log operations on some models as events and we use post save hooks to create and save the `Event` model, but because post hooks are synchronous `save` method will always return before we save `Event` model, and if this post hook fails the error will be silently ignored.

This PR introduces async post hooks. For compatibility reasons it checks arity of the callback for the post hook, and adds all functions with arity >= 2 as async hooks, assuming that old sync callbacks have arity 0-1
