### PR TITLE
Clear error after document initialization

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -295,6 +295,7 @@ function init (self, obj, doc, prefix) {
       self.$__.activePaths.init(path);
     }
   }
+  self.$__error(null);
 };
 
 /**


### PR DESCRIPTION
An error may be set when doing the following (lines 287 - 289)
```
self.$__try(function(){
    doc[i] = schema.cast(obj[i], self, true);
});
```
The error lingers as `this.$__.saveError` and can cause an error if the document is updated with valid members and saved via `.save()`.