### PR TITLE
Upgrade mquery to 0.6.0 on master, take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       , "mpromise": "0.5.0"
       , "mpath": "0.1.1"
       , "regexp-clone": "0.0.1"
-      , "mquery" : "0.4.1"
+      , "mquery" : "0.6.0"
     }
   , "devDependencies": {
         "mocha": "1.12.0"

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -9,6 +9,7 @@ var start = require('./common')
   , Schema = mongoose.Schema
   , assert = require('assert')
   , random = require('../lib/utils').random
+  , mongodb = require('mongodb')
   , Query = require('../lib/query');
 
 var Comment = new Schema({
@@ -1289,7 +1290,7 @@ describe('Query', function(){
     })
 
     describe('read', function(){
-      var P = mongoose.mquery.utils.mongo.ReadPreference;
+      var P = mongodb.ReadPreference;
 
       describe('without tags', function(){
         it('works', function(done){

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -15,7 +15,7 @@ var start = require('./common')
   , Mixed = SchemaTypes.Mixed
   , DocumentObjectId = mongoose.Types.ObjectId
   , MongooseArray = mongoose.Types.Array
-  , ReadPref = require('mquery').utils.mongo.ReadPreference
+  , ReadPref = require('mongodb').ReadPreference
   , vm = require('vm')
 
 /**

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -15,7 +15,7 @@ var start = require('./common')
   , Mixed = SchemaTypes.Mixed
   , DocumentObjectId = mongoose.Types.ObjectId
   , MongooseArray = mongoose.Types.Array
-  , ReadPref = require('mquery').utils.mongo.ReadPreference
+  , ReadPref = require('mongodb').ReadPreference
   , vm = require('vm')
   , random = require('../lib/utils').random
 


### PR DESCRIPTION
Previous pull request was crashing tests because mquery no longer explicitly exposes MongoDB driver.
