### PR TITLE
Fill in some gaps in the virtuals docs

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -223,6 +223,7 @@ block content
   :markdown
     Virtual property setters are applied before other validation. So the example above would still work even if the `first` and `last` name fields were required.
 
+    Only non-virtual properties work as part of queries and for field selection.
 
   h3#options Options
   :markdown


### PR DESCRIPTION
Commit messages have more details, but in summary;
- Note that virtual setters get applied before other validation
- Note toObject({ virtuals : true } ) behavior
- Note that you can use a virtual as a 'select' field. 

This request just updates the .jade file. If it's accepted, the corresponding html file will need to be re-generated as well. 
