### PR TITLE
don't mark path as dirty when using custom getter

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -532,7 +532,7 @@ Document.prototype.set = function (path, val, type, options) {
   // if this doc is being constructed we should not trigger getters
   var priorVal = constructing
     ? undefined
-    : this.get(path);
+    : this.getValue(path);
 
   if (!schema || undefined === val) {
     this.$__set(pathToMark, path, constructing, parts, schema, val, priorVal);

--- a/test/document.modified.test.js
+++ b/test/document.modified.test.js
@@ -51,6 +51,12 @@ var BlogPost = new Schema({
 });
 
 BlogPost
+.path('title')
+.get(function(v) {
+  if (v) return v.toUpperCase();
+});
+
+BlogPost
 .virtual('titleWithAuthor')
 .get(function () {
   return this.get('title') + ' by ' + this.get('author');


### PR DESCRIPTION
Just a quick update to prevent mongoose to mark a path as dirty when using a custom getter 

right now when you do something like that mongoose mark the path as modified 
this PR fix that by using  `getValue`  instead of `get` to compare the new value with the priorValue

``` js
var mongoose = require('mongoose');
var Schema = mongoose.Schema;

var schema = new Schema({ title: String });
schema.path('title').get(function(v) { return v.toUpperCase(); })

var BlogPost = mongoose.model('BlogPost', schema);

var blogPost = new BlogPost()
blogPost.init({ title: 'Foo' })
blogPost.set({ title: 'Foo' })

// should be false 
console.log(blogPost.isModified('title'));
```
