### PR TITLE
getters not working for refs

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -96,23 +96,6 @@ SchemaArray.prototype.checkRequired = function (value) {
 };
 
 /**
- * Overrides the getters application for the population special-case
- *
- * @param {Object} value
- * @param {Object} scope
- * @api private
- */
-
-SchemaArray.prototype.applyGetters = function (value, scope) {
-  if (this.caster.options && this.caster.options.ref) {
-    // means the object id was populated
-    return value;
-  }
-
-  return SchemaType.prototype.applyGetters.call(this, value, scope);
-};
-
-/**
  * Casts values for set().
  *
  * @param {Object} value

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -547,8 +547,6 @@ SchemaType.prototype.applySetters = function (value, scope, init, priorVal) {
  */
 
 SchemaType.prototype.applyGetters = function (value, scope) {
-  if (SchemaType._isRef(this, value, scope, true)) return value;
-
   var v = value
     , getters = this.getters
     , len = getters.length;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -81,6 +81,8 @@ schema.path('nested.setr').set(function (v) {
   return v + ' setter';
 });
 schema.path('pop').get(function (v) {
+  if (!v) return null;
+
   return v.title;
 });
 


### PR DESCRIPTION
I found this issue as I wanted to do:

```
var schema = new Schema({
  payments: [
    {
      ref: 'Payment',
      type: ObjectId
    }
  ]
});

schema.virtual('supportedPayments').get(function() {
  var payments = this.getValue('payments');

  return payments.map(function(payment) {
    return payment.type;
  });
});

schema.path('payments').get(function(articles) {
  return articles.map(function(article) {
    return article.id;
  });
});
```
