### PR TITLE
Fixing issue #2120

### DIFF
--- a/docs/2.7.x/index.html
+++ b/docs/2.7.x/index.html
@@ -262,7 +262,7 @@ var Post = mongoose.model('BlogPost', BlogPost);
 
 <h2>Connecting to MongoDB</h2>
 
-<p>First, we need to define a connection. If your app uses only one database, you should use <code>mongose.connect</code>. If you need to create additional connections, use <code>mongoose.createConnection</code>.</p>
+<p>First, we need to define a connection. If your app uses only one database, you should use <code>mongoose.connect</code>. If you need to create additional connections, use <code>mongoose.createConnection</code>.</p>
 
 <p>Both <code>connect</code> and <code>createConnection</code> take a <code>mongodb://</code> URI, or the parameters <code>host, database, port, options</code>.</p>
 


### PR DESCRIPTION
Under the heading **Connecting to MongoDB**, it explains about different connection methods. One of them described as **mongoose.connect**, but first time it spelled wrongly as **mongose.connect**(see missing 'o'). Change it to **mongoose.connect**
