### PR TITLE
Support for "Extended JSON" dates

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -442,6 +442,15 @@ Document.prototype.set = function (path, val, type, options) {
         key = keys[i];
         value = path[key];
         pathtype = this.schema.pathType(prefix + key);
+
+        // Handle strict JSON dates (http://docs.mongodb.org/manual/reference/mongodb-extended-json/#date)
+        if (utils.isObject(value)
+            && Object.keys(value).length == 1
+            && Object.keys(value)[0] == '$date'
+          ) {
+          value = new Date(value.$date);
+        }
+
         if (null != value
             // need to know if plain object - no Buffer, ObjectId, ref, etc
             && utils.isObject(value)


### PR DESCRIPTION
When importing JSON, there needs to be some way to specify Date-type data.  The MongoDB team decided to allow dates to be represented in the form:

```
"myDateField": { "$date": <date data> }
```

http://docs.mongodb.org/manual/reference/mongodb-extended-json/#date

This PR looks for the above form in Document.prototype.set() which allows data imported via Model.create() to include date data.

Note: I haven't added any tests for this functionality.  In fact, I didn't even run the tests.  I don't feel like trying to get make to run on my Windows box right now.  It might be an idea someday to switch to a test framework that could be entirely installed via npm.
