### PR TITLE
TypeError when updating a document with null properties

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1868,7 +1868,7 @@ Query.prototype._castUpdate = function _castUpdate (obj, overwrite) {
   while (i--) {
     op = ops[i];
     val = ret[op];
-    if ('Object' === val.constructor.name && !overwrite) {
+    if (val && 'Object' === val.constructor.name && !overwrite) {
       hasKeys |= this._walkUpdatePath(val, op);
     } else if (overwrite && 'Object' === ret.constructor.name) {
       // if we are just using overwrite, cast the query and then we will


### PR DESCRIPTION
Updating a document with null properties causes a `TypeError` to be thrown from `Query.prototype._castUpdate`.  In the non-`overwrite` case the `TypeError` is thrown instead of the `Invalid atomic update value [...]` error that is intended while in the `overwrite` case the `TypeError` is thrown when the operation should complete successfully.  An example snippet which demonstrates the issue:

``` JavaScript
"use strict";

var Person,
    mongoose = require("mongoose"),
    personSchema;

personSchema = new mongoose.Schema({_id: String}, {strict: false});
Person = mongoose.model("Person", personSchema);


function runTest(cb) {
  var bob;

  bob = {
    _id: "Bob",
    spouse: null
  };
  Person.update({_id: "Bob"}, bob, {overwrite: true}, function(err, result) {
    if (err) {
      console.log("Error updating document: " + err);
    }
    cb(err);
  });
}
```

Invoking `runTest` will print an error message for the `TypeError` rather than completing successfully.

The fix in this pull request is trivial and simply checks if `val` is truthy before checking the constructor name.

Thanks for considering it,
Kevin
