### PR TITLE
Fix `mongoose.models` consistency bug.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,8 @@ function Mongoose () {
   this.options = {
     pluralization: true
   };
-  this.createConnection(); // default connection
+  var conn = this.createConnection(); // default connection
+  conn.models = this.models;
 };
 
 /**

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -873,7 +873,8 @@ describe('connections:', function(){
     it('returns names of all models registered on it', function(done){
       var m = new mongoose.Mongoose;
       m.model('root', { x: String });
-      m.model('another', { x: String });
+      var another = m.model('another', { x: String });
+      another.discriminator('discriminated', new Schema({ x: String }));
 
       var db = m.createConnection();
       db.model('something', { x: String });
@@ -885,9 +886,10 @@ describe('connections:', function(){
 
       names = m.modelNames();
       assert.ok(Array.isArray(names));
-      assert.equal(2, names.length);
+      assert.equal(3, names.length);
       assert.equal('root', names[0]);
       assert.equal('another', names[1]);
+      assert.equal('discriminated', names[2]);
 
       done();
     })


### PR DESCRIPTION
Since `mongoose.models` and `mongoose.connection.models` weren't the
same object, calling `doc.db.modelNames()` didn't return the same output
as calling `mongoose.modelNames()` even if `doc` was an instance of a 
`Model` registered to the default connection.

This caused weird problems when using discriminators, since they are
registered with `parentModel.db.model(...)` (which is equal to
`mongoose.connection`) rather than with `mongoose.model(...)`. Using
discriminators, `mongoose.models` ended up having the parent models'
references, while `mongoose.connection.models` had the discriminators
references.

The fix was to set the default connection's `models` property to
`mongoose.models` so that they share the same object. This makes
`mongoose.models` and `mongoose.connection.models` (or
`document.db.models`, `model.db.models`, `model.base.models` etc.)
deterministically equal.
