### PR TITLE
Modified Model.geoNear to support passing either a geoJSON point, or a legacy coordinate pair, to the native driver

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1765,7 +1765,7 @@ Model.geoNear = function (near, options, callback) {
     return promise;
   }
 
-  var x,y;
+  var x,y,point;
 
   if (Array.isArray(near)) {
     if (near.length != 2) {
@@ -1780,12 +1780,10 @@ Model.geoNear = function (near, options, callback) {
       return promise;
     }
 
-    x = near.coordinates[0];
-    y = near.coordinates[1];
+    point = near;
   }
 
-  var self = this;
-  this.collection.geoNear(x, y, options, function (err, res) {
+  function cb(err, res) {
     if (err) return promise.error(err);
     if (options.lean) return promise.fulfill(res.results, res.stats);
 
@@ -1807,7 +1805,15 @@ Model.geoNear = function (near, options, callback) {
         --count || promise.fulfill(res.results, res.stats);
       });
     }
-  });
+  }
+
+  var self = this
+    , args = [options, cb];
+
+  //call the driver with either the geoJSON point, or the legacy coordinates pair
+  args.unshift.apply(args, point ? [point] : [x, y]);
+  this.collection.geoNear.apply(this.collection, args);
+
   return promise;
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
   , "dependencies": {
-        "mongodb": "1.4.7"
+        "mongodb": "1.4.8"
       , "hooks": "0.2.1"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"


### PR DESCRIPTION
Since support was recently added to the mongodb native driver for passing a geoJSON point as is to the geoNear command, this commit modifies Model.geoNear to support sending a legacy coordinate pair OR a geoJSON point to the driver, and bumps the version of the driver in package.json.
