### PR TITLE
createdAt and updatedAt date attributes

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -83,6 +83,34 @@ function Schema (obj, options) {
   if (autoid) {
     this.virtual('id').get(idGetter);
   }
+
+  // adds updatedAt and createdAt timestamps to documents if enabled
+  var timestamps = this.options.timestamps;
+  if (timestamps) {
+    var createdAt = timestamps.createdAt || 'createdAt'
+      , updatedAt = timestamps.updatedAt || 'updatedAt'
+      , schemaAdditions = {};
+
+    schemaAdditions[updatedAt] = Date;
+
+    if (!this.paths[createdAt]) {
+      schemaAdditions[createdAt] = Date;
+    }
+
+    this.add(schemaAdditions);
+
+    this.pre('save', function (next) {
+      var defaultTimestamp = new Date();
+
+      if (!this[createdAt]){
+        this[createdAt] = auto_id ? this._id.getTimestamp() : defaultTimestamp;
+      }
+
+      this[updatedAt] = this.isNew ? this[createdAt] : defaultTimestamp;
+
+      next();
+    });
+  }
 }
 
 /*!
@@ -902,4 +930,3 @@ Schema.Types = require('./schema/index');
 
 Types = Schema.Types;
 var ObjectId = exports.ObjectId = Types.ObjectId;
-


### PR DESCRIPTION
Hi!

I would like to propose this little feature to have the option to add createdAt and updatedAt timestamps to schemas. I have seen hundreds of plugins that solve this in different ways and I thought it might be great to have it available, at least disabled by default.

I hope it's good enough, thanks!
