### PR TITLE
Fix typo in schematypes docs

### DIFF
--- a/docs/schematypes.jade
+++ b/docs/schematypes.jade
@@ -66,7 +66,7 @@ block content
     m.updated = new Date;
     m.binary = new Buffer(0);
     m.living = false;
-    m.mixed = {[ any: { thing: 'i want' } ]};
+    m.mixed = { any: { thing: 'i want' } };
     m.markModified('mixed');
     m._someId = new mongoose.Types.ObjectId;
     m.array.push(1);


### PR DESCRIPTION
Mixed type example improperly embeds array in object...

`m.mixed = { [ any: { thing: 'i want' } ] };`
