### PR TITLE
Add Model.hydrate() and test case

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1562,6 +1562,27 @@ Model.create = function create (doc, fn) {
 };
 
 /**
+ * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
+ * The document returned has no paths marked as modified initially.
+ *
+ * ####Example:
+ *
+ *     // hydrate previous data into a Mongoose document
+ *     var mongooseCandy = Candy.hydrate({ _id: '54108337212ffb6d459f854c', type: 'jelly bean' });
+ *
+ * @param {Object} obj
+ * @return {Document}
+ * @api public
+ */
+
+Model.hydrate = function (obj) {
+  var doc = this(obj);
+  doc.$__reset();
+  doc.isNew = false;
+  return doc;
+};
+
+/**
  * Updates documents in the database without returning them.
  *
  * ####Examples:

--- a/test/model.hydrate.test.js
+++ b/test/model.hydrate.test.js
@@ -1,0 +1,48 @@
+/**
+ * Test dependencies.
+ */
+
+var start = require('./common')
+  , assert = require('assert')
+  , mongoose = start.mongoose
+  , random = require('../lib/utils').random
+  , Schema = mongoose.Schema
+  , DocumentObjectId = mongoose.Types.ObjectId
+
+/**
+ * Setup
+ */
+
+var schema = Schema({
+    title: String
+})
+
+
+describe('model', function(){
+  describe('hydrate()', function(){
+    var db;
+    var B;
+
+    before(function(){
+      db = start();
+      B = db.model('model-create', schema, 'model-create-'+random());
+    })
+
+    after(function(done){
+      db.close(done);
+    })
+
+    it('hydrates documents with no modified paths', function(done){
+      var hydrated = B.hydrate({ _id: '541085faedb2f28965d0e8e7', title: 'chair' });
+
+      assert.ok(hydrated.get('_id') instanceof DocumentObjectId);
+      assert.equal(hydrated.title, 'chair');
+
+      assert.equal(hydrated.isNew, false);
+      assert.equal(hydrated.isModified(), false);
+      assert.equal(hydrated.isModified('title'), false);
+
+      done();
+    });
+  });
+})


### PR DESCRIPTION
As mentioned in issue #2290 , there is currently no good way to produce a Mongoose object from data pre-saved to the DB. `new MyObj()` works but sets `isNew` to true and all paths to modified.

This PR introduces a simple `Model.hydrate(obj)` method that turns raw object data (such as that created with `doc.toObject()`) into a Mongoose doc with isNew=false and no paths marked modified. I included a simple test also (I don't think it needs too much since it's pretty simple).

Use-case: we cache users outside of the normal Mongo collection. We need to be able to take users from our cache and use them as if they originated from Mongo in that state.
