### PR TITLE
Methods can be in nested key

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2563,6 +2563,24 @@ Model.compile = function compile (name, schema, collectionName, connection, base
   );
 
   // apply methods
+  for (var i in schema.methods) {
+    if (typeof schema.methods[i] === 'function') {
+      model.prototype[i] = schema.methods[i];
+    } else {
+      (function(_i) {
+        Object.defineProperty(model.prototype, _i, {
+          get: function() {
+            var h = {};
+            for (var k in schema.methods[_i]) {
+              h[k] = schema.methods[_i][k].bind(this);
+            }
+            return h;
+          }
+        });
+      })(i);
+    }
+  }
+
   for (var i in schema.methods)
     model.prototype[i] = schema.methods[i];
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -651,7 +651,21 @@ describe('Model', function(){
       p.children.push({});
       assert.equal('function', typeof p.children[0].talk);
       done();
-    })
+    });
+
+    it('can be defined with nested key', function(done) {
+      var db = start();
+      var NestedKeySchema = new Schema({});
+      NestedKeySchema.method('foo', {
+        bar: function(){
+          return this;
+        }
+      });
+      var NestedKey = db.model('NestedKey', NestedKeySchema);
+      var n = new NestedKey();
+      assert.equal(n, n.foo.bar())
+      done();
+    });
   })
 
   describe('statics', function(){


### PR DESCRIPTION
Problem: I want to group `methods` in nested keys.

eg:

``` coffeescript
Schema.method 'method1, ->
  keyA: -> @attribute
  keyB: -> @otherAttribute
```

I forked the repo and quickly patch it, writing tiny test.
