### PR TITLE
[documentation] Changes oldEnough to canVote in example

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1566,7 +1566,7 @@ Model.create = function create (doc, fn) {
  *
  * ####Examples:
  *
- *     MyModel.update({ age: { $gt: 18 } }, { oldEnough: true }, fn);
+ *     MyModel.update({ age: { $gt: 18 } }, { canVote: true }, fn);
  *     MyModel.update({ name: 'Tobi' }, { ferret: true }, { multi: true }, function (err, numberAffected, raw) {
  *       if (err) return handleError(err);
  *       console.log('The number of updated documents was %d', numberAffected);


### PR DESCRIPTION
Changes `oldEnough` to `canVote` in example where models with age greater than 18 are updated.
