### PR TITLE
update mongodb to 1.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   , "license": "MIT"
   , "dependencies": {
         "hooks": "0.3.2"
-      , "mongodb": "1.4.9"
+      , "mongodb": "1.4.12"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"
       , "muri": "0.3.1"


### PR DESCRIPTION
mongodb 1.4.9 cann't building in node version 0.11.13.
but 1.4.12 works.
