### PR TITLE
Update mongodb to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   , "license": "MIT"
   , "dependencies": {
         "hooks": "0.3.2"
-      , "mongodb": "1.4.12"
+      , "mongodb": "~1.4"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"
       , "muri": "0.3.1"


### PR DESCRIPTION
It's already `1.4.15`. Let it just be `~1.4`?
