### PR TITLE
Dont use custom toObject options on save!!!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/source/_docs
 docs/*.html
 tags
 test/triage/*.js
+.idea/

--- a/lib/model.js
+++ b/lib/model.js
@@ -167,7 +167,7 @@ function handleSave (promise, self) {
 Model.prototype.save = function save (fn) {
   var promise = new Promise(fn)
     , complete = handleSave(promise, this)
-    , options = {}
+    , options = {};
 
   if (this.schema.options.safe) {
     options.safe = this.schema.options.safe;
@@ -175,10 +175,17 @@ Model.prototype.save = function save (fn) {
 
   if (this.isNew) {
     // send entire doc
-    var objectOptions = utils.clone(this.schema.options);
-    objectOptions.toObject = objectOptions.toObject || {};
-    objectOptions.toObject.depopulate = 1;
-    var obj = this.toObject(objectOptions.toObject);
+    var schemaOptions = utils.clone(this.schema.options);
+    schemaOptions.toObject = schemaOptions.toObject || {};
+
+    var toObjectOptions = {};
+
+    if(utils.object.hasOwnProperty(schemaOptions, 'retainKeyOrder'))
+      toObjectOptions.retainKeyOrder = schemaOptions.toObject.retainKeyOrder;
+
+    toObjectOptions.depopulate = 1;
+
+    var obj = this.toObject(toObjectOptions);
 
     if (!utils.object.hasOwnProperty(obj || {}, '_id')) {
       // documents must have an _id else mongoose won't know

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -257,7 +257,7 @@ describe('document', function(){
     done();
   });
 
-  it('toObject options', function(done){
+  it('toObject options', function( done ){
     var doc = new TestDocument();
 
     doc.init({
@@ -411,6 +411,39 @@ describe('document', function(){
     // all done
     delete doc.schema.options.toObject;
     done();
+  });
+
+  it('doesnt use custom toObject options on save', function( done ){
+    var schema = new Schema({
+      name: String,
+      iWillNotBeDelete: Boolean,
+      nested: {
+        iWillNotBeDeleteToo: Boolean
+      }
+    });
+
+    schema.set('toObject', {
+      transform: function (doc, ret) {
+        delete ret.iWillNotBeDelete;
+        delete ret.nested.iWillNotBeDeleteToo;
+
+        return ret;
+      }
+    });
+    var db = start()
+      , Test = db.model('TestToObject', schema);
+
+    Test.create({ name: 'chetverikov', iWillNotBeDelete: true, 'nested.iWillNotBeDeleteToo': true}, function( err ){
+      assert.ifError(err);
+      Test.findOne({}, function( err, doc ){
+        assert.ifError(err);
+
+        assert.equal( doc._doc.iWillNotBeDelete, true );
+        assert.equal( doc._doc.nested.iWillNotBeDeleteToo, true );
+
+        done();
+      });
+    });
   });
 
   it('doesnt clobber child schema options when called with no params (gh-2035)', function(done) {
@@ -1255,7 +1288,7 @@ describe('document', function(){
   describe('gh-1638', function() {
     it('works', function(done) {
       var ItemChildSchema = new mongoose.Schema({
-        name: { type: String, required: true, default: "hello" },
+        name: { type: String, required: true, default: "hello" }
       });
 
       var ItemParentSchema = new mongoose.Schema({


### PR DESCRIPTION
Found very critical bug in 3.8.17 after d098ad3820dca4f69691b2f3b62d9fc9cdec924a commit.

Don't use custom toObject options on save (http://mongoosejs.com/docs/api.html#document_Document-toObject --> During save, no custom options are applied to the document before being sent to the database.)
