### PR TITLE
Reject promise on .create() error

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1565,7 +1565,7 @@ Model.create = function create (doc, fn) {
   var promise = new Promise(cb);
   retPromise.then(function (docs) {
     promise.fulfill.apply(promise, docs);
-  }, cb);
+  }, promise.reject.bind(promise));
 
   p1.fulfill();
   return promise;

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -137,6 +137,19 @@ describe('model', function(){
           done();
         }, done).end();
       })
+
+      it('and should reject promise on error', function(done){
+        var p = B.create({ title: 'optional callback 4' });
+        p.then(function (doc) {
+          var p2 = B.create({ _id: doc._id });
+          p2.then(function () {
+            assert(false);
+          }, function (err) {
+            assert(err);
+            done();
+          }).end();
+        }, done).end();
+      })
     })
   });
 })


### PR DESCRIPTION
Promise was not rejected on .create() error.
Example (trying to duplicate "unique" field):

```
var m = Model.create({ _id: 'already_used' });
m.then(funcion(doc) {
  Model.create({ _id: 'already_used' })
    .then(function () {}, function (err) { //never called });
});
```

Thanks!! Mongoose is awesome ;)
