### PR TITLE
Fixes type in guide template

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -156,7 +156,7 @@ block content
 
   h3#virtuals Virtuals
   :markdown
-    [Virtuals](./api.html#schema_Schema-virtual) are document properties that you can get and set but that do not get persisted to MongoDB. The getters are useful for formatting or combining fields, while settings are useful for de-composing a single value into multiple values for storage.
+    [Virtuals](./api.html#schema_Schema-virtual) are document properties that you can get and set but that do not get persisted to MongoDB. The getters are useful for formatting or combining fields, while setters are useful for de-composing a single value into multiple values for storage.
 
   :js
     // define a schema


### PR DESCRIPTION
On the subject of virtuals, the documentation incorrectly referred to "setters" as "settings", which is confusing.
