### PR TITLE
Fix: Values of virtuals are deployed and saved to MongoDB.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -178,6 +178,7 @@ Model.prototype.save = function save (fn) {
     var objectOptions = utils.clone(this.schema.options);
     objectOptions.toObject = objectOptions.toObject || {};
     objectOptions.toObject.depopulate = 1;
+    objectOptions.toObject.virtuals = false;
     var obj = this.toObject(objectOptions.toObject);
 
     if (!utils.object.hasOwnProperty(obj || {}, '_id')) {


### PR DESCRIPTION
1. Set options `toObject: { virtuals: true }` in Schema.
2. Save document.
3. Execute find command with mongo shell, we can see values of virtuals.
