### PR TITLE
validate schema arrays when accidentally undefined

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -233,6 +233,10 @@ Schema.prototype.add = function add (obj, prefix) {
       throw new TypeError('Invalid value for schema path `'+ prefix + key +'`');
     }
 
+    if (Array.isArray(obj[key]) && obj[key].length === 1 && null == obj[key][0]) {
+      throw new TypeError('Invalid value for schema Array path `'+ prefix + key +'`');
+    }
+
     if (utils.isObject(obj[key]) && (!obj[key].constructor || 'Object' == utils.getFunctionName(obj[key].constructor)) && (!obj[key].type || obj[key].type.type)) {
       if (Object.keys(obj[key]).length) {
         // nested object { last: { name: String }}


### PR DESCRIPTION
Fixes #2238, Arrays of Sub-documents not validating if schema is accidentally undefined
