### PR TITLE
added handling of value._id (String) being cast to ObjectId

### DIFF
--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -105,8 +105,17 @@ ObjectId.prototype.cast = function (value, doc, init) {
   if (value instanceof oid)
     return value;
 
-  if (value._id && value._id instanceof oid)
-    return value._id;
+  if (value._id) {
+    if (value._id instanceof oid) {
+      return value._id;
+    } else {
+      try {
+        return oid.createFromHexString(value._id);
+      } catch (e) {
+        throw new CastError('ObjectId', value._id, this.path);
+      }
+    }
+  }
 
   if (value.toString) {
     try {


### PR DESCRIPTION
Useful for the case where a document may have populated subdocuments. On update of the parent document the _id of the subdocument will be cast from a string to an ObjectId. 
