### PR TITLE
gh-2378 enable getters for properties defined with non-strict schemas; u...

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -61,6 +61,17 @@ function Document (obj, fields, skipId) {
     this.set(obj, undefined, true);
   }
 
+  if (!schema.options.strict && obj) {
+    var self = this
+      , keys = Object.keys(this._doc);
+
+    keys.forEach(function(key) {
+      if (!(key in schema.tree)) {
+        define(key, null, self);
+      }
+    });
+  }
+
   this.$__registerHooksFromSchema();
 }
 
@@ -438,8 +449,7 @@ Document.prototype.set = function (path, val, type, options) {
       var keys = Object.keys(path)
         , i = keys.length
         , pathtype
-        , key
-
+        , key;
 
       while (i--) {
         key = keys[i];
@@ -1245,7 +1255,6 @@ function define (prop, subprops, prototype, prefix, keys) {
     });
 
   } else {
-
     Object.defineProperty(prototype, prop, {
         enumerable: true
       , configurable: true


### PR DESCRIPTION
See #2378 for more details. The tests in `test/document.strict.test.js` have been appropriately updated as well. 
All tests (including new `assert`'s pass.
