### PR TITLE
toObject() with custom transform function and subdocuments

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1606,6 +1606,10 @@ Document.prototype.toObject = function (options) {
     options._useSchemaOptions = true;
   }
 
+  // remember the root transform function
+  // to save it from being overwritten by sub-transform functions
+  var originalTransform = options.transform;
+
   var ret = clone(this._doc, options);
 
   if (options.virtuals || options.getters && false !== options.virtuals) {
@@ -1634,6 +1638,8 @@ Document.prototype.toObject = function (options) {
     if (opts) {
       options.transform = opts.transform;
     }
+  } else {
+    options.transform = originalTransform;
   }
 
   if ('function' == typeof options.transform) {


### PR DESCRIPTION
There is an issue regarding a very special edge-case.

The following perquisites have to be met:

1) Using toObject() on the root document with a custom transform function:

```
doc.toObject({
    transform: function(doc, red) {} // can be any function
});
```

2) The root document does not have a transform function set in the schema. `doc.schema.toObject.transform === undefined`

3) A subdocument inside the root document has a transform function set in the schema.

In this case the subdocuments transform function is overwriting the transform function specified when called doc.toObject(). As I do not think this is intended behaviour I created this PR. It adds a test for this case and comes with a possible solution.

To see it failing check out this branch: https://github.com/chmanie/mongoose/tree/toObject-fail
