### PR TITLE
Fix aggregation on discriminator models

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -403,12 +403,14 @@ Aggregate.prototype.exec = function (callback) {
     return promise;
   }
 
+  prepareDiscriminatorPipeline(this);
+
   this._model
     .collection
     .aggregate(this._pipeline, this.options || {}, promise.resolve.bind(promise));
 
   return promise;
-}
+};
 
 /*!
  * Helpers
@@ -435,6 +437,40 @@ function isOperator (obj) {
     return '$' === key[0];
   });
 }
+
+/*!
+ * Adds the appropriate `$match` pipeline step to the top of an aggregate's
+ * pipeline, should it's model is a non-root discriminator type. This is
+ * analogous to the `prepareDiscriminatorCriteria` function in `lib/query.js`.
+ *
+ * @param {Aggregate} aggregate Aggregate to prepare
+ */
+
+function prepareDiscriminatorPipeline (aggregate) {
+  var schema = aggregate._model.schema,
+      discriminatorMapping = schema && schema.discriminatorMapping;
+
+  if (discriminatorMapping && !discriminatorMapping.isRoot) {
+    var originalPipeline = aggregate._pipeline,
+        discriminatorKey = discriminatorMapping.key,
+        discriminatorValue = discriminatorMapping.value;
+
+    // If the first pipeline stage is a match and it doesn't specify a `__t`
+    // key, add the discriminator key to it. This allows for potential
+    // aggregation query optimizations not to be disturbed by this feature.
+    if (originalPipeline[0] && originalPipeline[0].$match &&
+        !originalPipeline[0].$match[discriminatorKey]) {
+      originalPipeline[0].$match[discriminatorKey] = discriminatorValue;
+      // `originalPipeline` is a ref, so there's no need for
+      // aggregate._pipeline = originalPipeline
+    } else {
+      var match = {};
+      match[discriminatorKey] = discriminatorValue;
+      aggregate._pipeline = [{ $match: match }].concat(originalPipeline);
+    }
+  }
+}
+
 
 /*!
  * Exports


### PR DESCRIPTION
When performing aggregations over discriminator models, one would expect
the same semantics of performing queries over discriminator models would
apply. That's not the case, however, and no extra query limiting the
aggregation pipeline to a discriminator's type is added to the pipeline.

This adds tests for that feature to the
`test/model.discriminator.querying.test.js`, which test for those
semantics in the `Query` logic (it didn't seem appropriate to add
another test file).

It also adds an implementation of the feature, which borrows from the
`lib/query.js` module's `prepareDiscriminatorCriteria` helper function,
adding a `$match` stage to the top of the pipeline, when there's a
non-root discriminator model.

The filtering is only added to the pipeline just before calling `exec`
over `model.collection.aggregate`, so empty pipelines will still look
empty even if this is added (`Model.aggregate().exec()` still throws
instead of executing an empty pipeline).

It also merges the added stage onto the first pipeline stage if it's a
`$match` group and has no discriminator key in it. This allows (I think)
for query optimization to happen on the `match` stage.

It should be noted that if a discriminator key does exist on the first
`$match`, the discriminator filter will be added before the existing
pipeline, rather than overwriting the existing one - which will yes,
lead to two queries which will never yield any value. This is better
than overwriting the existing one or simply not adding anything because
it's more consistent with the idea of a discriminator.

I'll be glad to provide examples if this isn't clear enough or make
whatever changes you think will make the code cleaner.
