### PR TITLE
Fix recursive `readPref`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -472,6 +472,10 @@ exports.readPref = function readPref (pref, tags) {
     pref = pref[0];
   }
 
+  if (pref instanceof ReadPref) {
+    return pref;
+  }
+
   switch (pref) {
     case 'p':
       pref = 'primary';


### PR DESCRIPTION
When using discriminators, `readPref` is called for each schema which causes an incorrectly nested read preference (e.g., `{"_type":"ReadPreference","mode":{"_type":"ReadPreference","mode":{"_type":"ReadPreference","mode":{"_type":"ReadPreference","mode":"secondaryPreferred"}}}}`).

This will ensure that if the `read` key is already a `ReadPref` object that we do not wrap it again.
