### PR TITLE
Apply identifying `type` to validator casting errors

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -299,7 +299,12 @@ function init (self, obj, doc, prefix) {
           try {
             doc[i] = schema.cast(obj[i], self, true);
           } catch (e) {
-            self.invalidate(e.path, e.message, e.value);
+            self.invalidate(e.path, new ValidatorError({
+              path: e.path,
+              message: e.message,
+              type: 'cast',
+              value: e.value
+            }));
           }
         } else {
           doc[i] = obj[i];
@@ -568,7 +573,12 @@ Document.prototype.set = function (path, val, type, options) {
     }
     val = schema.applySetters(val, this, false, priorVal);
   } catch (e) {
-    this.invalidate(e.path, e.message, e.value);
+    this.invalidate(e.path, new ValidatorError({
+      path: e.path,
+      message: e.message,
+      type: 'cast',
+      value: e.value
+    }));
     shouldSet = false;
   }
 


### PR DESCRIPTION
@vkarpov15 

Related to #2499 

This applies appropriate `err.errors.path.type` to signify casting errors as type `cast`.
