### PR TITLE
Add model name to primary validation error message

### DIFF
--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -14,8 +14,12 @@ var MongooseError = require('../error.js')
  */
 
 function ValidationError (instance) {
-  MongooseError.call(this, "Validation failed");
-  Error.captureStackTrace(this, arguments.callee);
+  if (instance && instance.constructor.name === 'model') {
+    MongooseError.call(this, instance.constructor.modelName + " validation failed");
+  } else {
+    MongooseError.call(this, "Validation failed");
+  }
+  Error.captureStackTrace && Error.captureStackTrace(this, arguments.callee);
   this.name = 'ValidationError';
   this.errors = instance.errors = {};
 };

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -1668,7 +1668,7 @@ describe('model: populate:', function(){
       });
 
       comment.save(function (err) {
-        assert.equal('Validation failed', err && err.message);
+        assert.equal('CommentWithRequiredField validation failed', err && err.message);
         assert.ok('num' in err.errors);
         assert.ok('str' in err.errors);
         assert.ok('user' in err.errors);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -970,7 +970,7 @@ describe('Model', function(){
         db.close();
         assert.equal(err.errors.name.message, 'Name cannot be greater than 1 character for path "name" with value `hi`');
         assert.equal(err.name,"ValidationError");
-        assert.equal(err.message,"Validation failed");
+        assert.equal(err.message,"IntrospectionValidation validation failed");
         done();
       });
     });

--- a/test/types.buffer.test.js
+++ b/test/types.buffer.test.js
@@ -66,7 +66,7 @@ describe('types.buffer', function(){
       });
 
       t.validate(function (err) {
-        assert.equal(err.message,'Validation failed');
+        assert.equal(err.message,'UserBuffer validation failed');
         assert.equal(err.errors.required.type,'required');
         t.required = {x:[20]}
         t.save(function (err) {
@@ -79,11 +79,11 @@ describe('types.buffer', function(){
 
           t.sub.push({ name: 'Friday Friday' });
           t.save(function (err) {
-            assert.equal(err.message,'Validation failed');
+            assert.equal(err.message,'UserBuffer validation failed');
             assert.equal(err.errors['sub.0.buf'].type,'required');
             t.sub[0].buf = new Buffer("well well");
             t.save(function (err) {
-              assert.equal(err.message,'Validation failed');
+              assert.equal(err.message,'UserBuffer validation failed');
               assert.equal(err.errors['sub.0.buf'].type,'user defined');
               assert.equal(err.errors['sub.0.buf'].message,'valid failed');
 


### PR DESCRIPTION
Related to #2135 

This gives an indication as to which model triggered the validation error.
