### PR TITLE
Only use first failed validator error per path

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1107,6 +1107,8 @@ Document.prototype.invalidate = function (path, err, val) {
     this.$__.validationError = new ValidationError(this);
   }
 
+  if (this.$__.validationError.errors[path]) return;
+
   if (!err || 'string' === typeof err) {
     err = new ValidatorError({
       path: path,

--- a/test/types.buffer.test.js
+++ b/test/types.buffer.test.js
@@ -68,13 +68,13 @@ describe('types.buffer', function(){
       t.validate(function (err) {
         assert.equal(err.message,'Validation failed');
         assert.equal(err.errors.required.kind,'required');
-        t.required = {x:[20]}
+        t.required = {x:[20]};
         t.save(function (err) {
           assert.ok(err);
-          assert.equal(err.name, 'CastError');
-          assert.equal(err.kind, 'buffer');
-          assert.equal(err.message, 'Cast to buffer failed for value "[object Object]" at path "required"');
-          assert.deepEqual(err.value, {x:[20]});
+          assert.equal(err.name, 'ValidationError');
+          assert.equal(err.errors.required.kind, 'cast');
+          assert.equal(err.errors.required.message, 'Cast to buffer failed for value "[object Object]" at path "required"');
+          assert.deepEqual(err.errors.required.value, {x:[20]});
           t.required = new Buffer("hello");
 
           t.sub.push({ name: 'Friday Friday' });


### PR DESCRIPTION
Fixes #2506 

This will use the first validation error triggered per path.
