### PR TITLE
Allow options to be passed to save/remove

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -81,11 +81,10 @@ Model.prototype.collection;
 
 Model.prototype.modelName;
 
-Model.prototype.$__handleSave = function $__handleSave() {
+Model.prototype.$__handleSave = function $__handleSave(options) {
   var self = this;
   var innerPromise = new Promise;
-  var options = {};
-  if (this.schema.options.safe) {
+  if (!options.safe && this.schema.options.safe) {
     options.safe = this.schema.options.safe;
   }
 
@@ -191,7 +190,17 @@ Model.prototype.$__handleSave = function $__handleSave() {
  * @see middleware http://mongoosejs.com/docs/middleware.html
  */
 
-Model.prototype.save = function (fn) {
+Model.prototype.save = function (options, fn) {
+
+  if ('function' == typeof options) {
+    fn = options;
+    options = undefined;
+  }
+
+  if (!options) {
+    options = {};
+  }
+
   var self = this;
   var finalPromise = new Promise(fn);
 
@@ -216,7 +225,7 @@ Model.prototype.save = function (fn) {
 
   // Handle save and resaults
   p1
-    .then(this.$__handleSave.bind(this))
+    .then(this.$__handleSave.bind(this, options))
     .then(function (result) {
       self.$__reset();
       self.$__storeShard();
@@ -616,7 +625,17 @@ Model.prototype.$__where = function _where (where) {
  * @api public
  */
 
-Model.prototype.remove = function remove (fn) {
+Model.prototype.remove = function remove (options, fn) {
+
+  if ('function' == typeof options) {
+    fn = options;
+    options = undefined;
+  }
+
+  if (!options) {
+    options = {};
+  }
+
   if (this.$__.removing) {
     this.$__.removing.onResolve(fn);
     return this;
@@ -625,9 +644,9 @@ Model.prototype.remove = function remove (fn) {
   var promise = this.$__.removing = new Promise(fn)
     , where = this.$__where()
     , self = this
-    , options = {}
+    ;
 
-  if (this.schema.options.safe) {
+  if (!options.safe && this.schema.options.safe) {
     options.safe = this.schema.options.safe;
   }
 


### PR DESCRIPTION
This should fix #2494, and additionally allows options to be passed to both `save()` and `remove()`.

Wasn't real sure how to go about writing an automated test for this or where to put it.
