### PR TITLE
remove old schema.methods loop

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1923,7 +1923,7 @@ Model.geoNear = function (near, options, callback) {
 
     this.collection.geoNear(near, options, handler);
   }
-  
+
   return promise;
 };
 
@@ -2667,9 +2667,6 @@ Model.compile = function compile (name, schema, collectionName, connection, base
       })(i);
     }
   }
-
-  for (var i in schema.methods)
-    model.prototype[i] = schema.methods[i];
 
   // apply statics
   for (var i in schema.statics) {


### PR DESCRIPTION
The schema.methods loop was improved (line 2653), but the old loop was left behind.
