### PR TITLE
Fix #2306: Aggregate cursor usage

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -405,6 +405,11 @@ Aggregate.prototype.exec = function (callback) {
 
   prepareDiscriminatorPipeline(this);
 
+  if (this.options.cursor)
+    return this._model
+      .collection
+      .aggregate(this._pipeline, this.options || {});
+
   this._model
     .collection
     .aggregate(this._pipeline, this.options || {}, promise.resolve.bind(promise));


### PR DESCRIPTION
Aggregate cursor usage.

e.g.:

https://github.com/changyy/mongoose-aggregate-cursor-usage/blob/master/basic.js#L118
