### PR TITLE
Clean a GitHub 404 in queries.jade

### DIFF
--- a/docs/queries.jade
+++ b/docs/queries.jade
@@ -27,7 +27,7 @@ block content
     will be null. If the query is successful, the `error` parameter will be null, and the `result` will be populated with the results of the query.
   .important
     :markdown
-      Anywhere a callback is passed to a query in Mongoose, the callback follows the pattern `callback(error, results)`. What `results` is depends on the operation: For `findOne()` it is a [potentially-null single document](./docs/api.html#model_Model.findOne), `find()` a [list of documents](./docs/api.html#model_Model.find), `count()` [the number of documents](./docs/api.html#model_Model.count), `update()` the [number of documents affected](./docs/api.html#model_Model.update), etc. The [API docs for Models](./docs/api.html#model-js) provide more detail on what is passed to the callbacks.
+      Anywhere a callback is passed to a query in Mongoose, the callback follows the pattern `callback(error, results)`. What `results` is depends on the operation: For `findOne()` it is a [potentially-null single document](./api.html#model_Model.findOne), `find()` a [list of documents](./api.html#model_Model.find), `count()` [the number of documents](./api.html#model_Model.count), `update()` the [number of documents affected](./api.html#model_Model.update), etc. The [API docs for Models](./api.html#model-js) provide more detail on what is passed to the callbacks.
   :markdown
     Now let's look at what happens when no `callback` is passed:
   :js


### PR DESCRIPTION
A couple links in the [queries.html](http://mongoosejs.com/docs/queries.html) documentation (in the yellow thingy) redirect to a GitHub 404:

This is due to an unnecessary `docs` item in the urls:

```
http://mongoosejs.com/docs/docs/api.html#model_Model.findOne -> http://mongoosejs.com/docs/api.html#model_Model.findOne
```
