### PR TITLE
Added cast support in Model.aggregate

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -6,6 +6,7 @@ var Promise = require('./promise')
   , util = require('util')
   , utils = require('./utils')
   , Query = require('./query')
+  , cast = require('./cast')
   , read = Query.prototype.read
 
 /**
@@ -44,9 +45,9 @@ function Aggregate () {
   this.options = undefined;
 
   if (1 === arguments.length && util.isArray(arguments[0])) {
-    this.append.apply(this, arguments[0]);
+    this.appendArgs = arguments[0];
   } else {
-    this.append.apply(this, arguments);
+    this.appendArgs = arguments;
   }
 }
 
@@ -60,6 +61,7 @@ function Aggregate () {
 
 Aggregate.prototype.bind = function (model) {
   this._model = model;
+  this.append.apply(this, this.appendArgs);
   return this;
 }
 
@@ -87,7 +89,17 @@ Aggregate.prototype.append = function () {
     throw new Error("Arguments must be aggregate pipeline operators");
   }
 
-  this._pipeline = this._pipeline.concat(args);
+  var self = this;
+
+  var nargs = args.map(function(arg) {
+    if (arg.$match) {
+      arg.$match = cast(self._model.schema, arg.$match);
+    }
+
+    return arg;
+  });
+
+  this._pipeline = this._pipeline.concat(nargs);
 
   return this;
 }


### PR DESCRIPTION
It's painful to manually cast several ids to use in `aggregate`.

Since the cast function is now in a separate module (instead of inside `query.js`), it's simple to integrate it with `aggregate.js`.
