### PR TITLE
The performance improvement Model.prototype.$__handleSave() method

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -90,13 +90,9 @@ Model.prototype.$__handleSave = function $__handleSave(options) {
 
   if (this.isNew) {
     // send entire doc
-    var schemaOptions = utils.clone(this.schema.options);
-    schemaOptions.toObject = schemaOptions.toObject || {};
-
     var toObjectOptions = {};
-
-    if (schemaOptions.toObject.retainKeyOrder) {
-      toObjectOptions.retainKeyOrder = schemaOptions.toObject.retainKeyOrder;
+    if ( this.schema.options.toObject && this.schema.options.toObject.retainKeyOrder ) {
+      toObjectOptions.retainKeyOrder = true;
     }
 
     toObjectOptions.depopulate = 1;


### PR DESCRIPTION
By removing unnecessary steps `utils.clone(this.schema.options)` can achieve the best performance for obvious reasons.
