### PR TITLE
Fix errors is not defined

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -93,7 +93,7 @@ DocumentArray.prototype.doValidate = function (array, fn, scope) {
       // sidestep sparse entries
       var doc = array[i];
       if (!doc) {
-        --count || fn(errors);
+        --count || fn(error);
         continue;
       }
 


### PR DESCRIPTION
mongoose/lib/schema/documentarray.js:96
 --count || fn(errors);
 ^
ReferenceError: errors is not defined