### PR TITLE
The populate example has an incorrect field.

### DIFF
--- a/docs/populate.jade
+++ b/docs/populate.jade
@@ -90,7 +90,7 @@ block content
   :js
     Story
     .find(...)
-    .populate('fans author') // space delimited path names
+    .populate('fans _creator') // space delimited path names
     .exec()
   .important
     :markdown
@@ -99,7 +99,7 @@ block content
     Story
     .find(...)
     .populate('fans')
-    .populate('author')
+    .populate('_creator')
     .exec()
   h3 Query conditions and other options
   :markdown


### PR DESCRIPTION
The document refers to populating the `author` field on the `storySchema`, but that field does not exist. I assume it meant `_creator`. If not, the `author` property would need to be created.