### PR TITLE
added a schema.construct(fn) method to create a 'constructor' function ...

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2724,6 +2724,9 @@ Model.compile = function compile (name, schema, collectionName, connection, base
     if (!(this instanceof model))
       return new model(doc, fields, skipId);
     Model.call(this, doc, fields, skipId);
+    if (schema.construct && (typeof schema.construct === "function")){
+      schema.construct.call(this);
+    }
   };
 
   model.hooks = schema.s.hooks.clone();

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -305,6 +305,7 @@ Schema.prototype.add = function add (obj, prefix) {
 
 Schema.reserved = Object.create(null);
 var reserved = Schema.reserved;
+reserved.construct =
 reserved.emit =
 reserved.on =
 reserved.once = // EventEmitter
@@ -670,6 +671,31 @@ Schema.prototype.post = function(method, fn) {
 
 Schema.prototype.plugin = function (fn, opts) {
   fn(this, opts);
+  return this;
+};
+
+/**
+ * Adds a function that is called immediately after constructing a model from this schema. There can be only one 'construct' per schema definition.
+ *
+ * ####Example
+ *
+ *     var schema = kittySchema = new Schema(..);
+ *
+ *     schema.construct(function () {
+ *       console.log('meeeeeoooooooooooow');
+ *     })
+ *
+ *     var Kitty = mongoose.model('Kitty', schema);
+ *
+ *     var fizz = new Kitty(); // meeeeeooooooooooooow
+ *
+ *
+ * @param {Function} [fn]
+ * @api public
+ */
+
+Schema.prototype.construct = function (fn) {
+  this.construct = fn;
   return this;
 };
 

--- a/test/model.construct.test.js
+++ b/test/model.construct.test.js
@@ -18,7 +18,7 @@ var schemaB = Schema({
 });
 
 describe('model', function(){
-  describe.only('construct', function(){
+  describe('construct', function(){
     var db;
     var B;
     var calledConstruct, constructCtx;

--- a/test/model.construct.test.js
+++ b/test/model.construct.test.js
@@ -1,0 +1,54 @@
+/**
+ * Test dependencies.
+ */
+
+var start = require('./common')
+  , assert = require('assert')
+  , mongoose = start.mongoose
+  , random = require('../lib/utils').random
+  , Schema = mongoose.Schema
+  , DocumentObjectId = mongoose.Types.ObjectId
+
+/**
+ * Setup
+ */
+
+var schemaB = Schema({
+    title: String
+});
+
+describe('model', function(){
+  describe.only('construct', function(){
+    var db;
+    var B;
+    var calledConstruct, constructCtx;
+
+    before(function(){
+      db = start();
+
+      schemaB.construct(function(){
+        calledConstruct = true;
+        constructCtx = this;
+      });
+
+      B = db.model('model-create', schemaB, 'gh-2637-1');
+    })
+
+    after(function(done){
+      db.close(done);
+    })
+
+    it('calls the schema construct method', function(done) {
+      var b = new B();
+      assert.equal(calledConstruct, true);
+      done();
+    });
+
+    it('calls the schema construct with the model instance as the context', function(done) {
+      var b = new B();
+      assert.equal(constructCtx, b);
+      done();
+    });
+  });
+})
+


### PR DESCRIPTION
In version 3.8.x of Mongoose, I used the https://github.com/ilsken/mongoose-construct plugin to create a "construct" method on my models. I need this functionality due to some complexities in my models that require code to run after creating a my model instance, but prior to any other code running. This plugin worked great to solve my problem.

With v4 of mongoose, however, this plugin no longer works.

I wanted to open a dialog around creating this functionality inside of mongoose directly, and I thought it would be easier to express my thoughts and intent via a pull request with code changes (and tests) rather than just describing the API.

The changes I'm making here are to replace that plugin with functionality built in to Mongoose, directly. 

The general design of the API is:

```js
var MySchema = mongoose.Schema({
  foo: { type: String }
 // ...
});

MySchema.construct(function(){
  // "this" is the model instance
  console.log(this.foo);
});

var MyModel = mongoose.Model("my-model", MySchema);

var m = new MyModel({
  foo: "this is the foo"
});

// output of new MyModel is to log this.foo
// => this is the foo
```

There can be only one (insert Highlander gif here :D) construct function per schema, since this is intended to be a 'constructor' function for the model.

I'm open to any / all feedback and questions about this API design. I made some very specific design decisions in this, to avoid clobbering any existing code and ensure that this worked as smoothly as possible. I recognize that my design ideals may not be the same as the Mongoose team, though, and I'm certainly open to changing this further, to make sure the changes fit.

In the end, though, I need this functionality to be able to complete my upgrade to mongoose v4. I intend to back-port these changes in to the stable release of v4.x, in my own branch, so I can use this immediately.