### PR TITLE
don't crash when discriminators have nested schemas

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -25,7 +25,6 @@ function DocumentArray (key, schema, options) {
 
   // compile an embedded document for this schema
   function EmbeddedDocument () {
-    this.$__setSchema(schema);
     // apply methods
     for (var i in schema.methods) {
       this[i] = schema.methods[i];
@@ -33,7 +32,8 @@ function DocumentArray (key, schema, options) {
     Subdocument.apply(this, arguments);
   }
 
-  EmbeddedDocument.prototype = Subdocument.prototype;
+  EmbeddedDocument.prototype = Object.create(Subdocument.prototype);
+  EmbeddedDocument.prototype.$__setSchema(schema);
   EmbeddedDocument.schema = schema;
 
   // apply statics

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -194,6 +194,39 @@ describe('model', function() {
       done();
     });
 
+    it('works with nested schemas (gh-2821)', function(done) {
+      var MinionSchema = function() {
+        mongoose.Schema.apply(this, arguments);
+
+        this.add({
+          name: String
+        });
+      };
+      util.inherits(MinionSchema, mongoose.Schema);
+
+      var BaseSchema = function() {
+        mongoose.Schema.apply( this, arguments );
+
+        this.add({
+          name: String,
+          created_at: Date,
+          minions: [ new MinionSchema() ]
+        });
+      };
+      util.inherits(BaseSchema, mongoose.Schema);
+
+      var PersonSchema = new BaseSchema();
+      var BossSchema = new BaseSchema({
+        department: String
+      });
+
+      assert.doesNotThrow(function() {
+        var Person = db.model('gh2821', PersonSchema);
+        var Boss = Person.discriminator('Boss', BossSchema);
+      });
+      done();
+    });
+
     describe('options', function() {
       it('allows toObject to be overridden', function(done) {
         assert.notDeepEqual(Employee.schema.get('toObject'), Person.schema.get('toObject'));


### PR DESCRIPTION
Should be a fix for #2821