### PR TITLE
Fix for #2879

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -781,7 +781,8 @@ Document.prototype.get = function (path, type) {
  */
 
 Document.prototype.$__path = function (path) {
-  var adhocs = this.$__.adhocPaths
+  var base = this.$__
+    , adhocs = (base) ? base.adhocPaths : undefined
     , adhocType = adhocs && adhocs[path];
 
   if (adhocType) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -781,8 +781,7 @@ Document.prototype.get = function (path, type) {
  */
 
 Document.prototype.$__path = function (path) {
-  var base = this.$__
-    , adhocs = (base) ? base.adhocPaths : undefined
+  var adhocs = this.$__.adhocPaths
     , adhocType = adhocs && adhocs[path];
 
   if (adhocType) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -1351,7 +1351,7 @@ function getOwnPropertyDescriptors(object) {
 
   Object.getOwnPropertyNames(object).forEach(function(key) {
     result[key] = Object.getOwnPropertyDescriptor(object, key);
-    result[key].enumerable = false;
+    result[key].enumerable = true;
   });
 
   return result;


### PR DESCRIPTION
This PR fixes Issue #2879 by allowing self-owned nested properties of virtual objects (or any objects?) to be enumerable. (There is also a minor fix for a case where an undefined property crashes the process.)

Suggest also porting this fix to 3.8.x branch (which we still use in production; will file separate PR if this is approved/etc).