### PR TITLE
Fixing define for global.define in amd scenarios.

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -68,7 +68,7 @@ function Document (obj, fields, skipId) {
 
     keys.forEach(function(key) {
       if (!(key in schema.tree)) {
-        define(key, null, self);
+        defineKey(key, null, self);
       }
     });
   }
@@ -1330,7 +1330,7 @@ function compile (tree, proto, prefix) {
     key = keys[i];
     limb = tree[key];
 
-    define(key
+    defineKey(key
         , (('Object' === utils.getFunctionName(limb.constructor)
                && Object.keys(limb).length)
                && (!limb.type || limb.type.type)
@@ -1359,7 +1359,7 @@ function getOwnPropertyDescriptors(object) {
  * Defines the accessor named prop on the incoming prototype.
  */
 
-function define (prop, subprops, prototype, prefix, keys) {
+function defineKey (prop, subprops, prototype, prefix, keys) {
   var prefix = prefix || ''
     , path = (prefix ? prefix + '.' : '') + prop;
 


### PR DESCRIPTION
Ran into a problem using mongoose with webpack, it really dislikes redifining *define*.  This is a tiny patch that would fix this problem.  I know I could fix webpack, but this is way easier and perhaps solves other issues with javascript compilers.   