### PR TITLE
Fix the issue that Array values to be overwritten

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -564,9 +564,11 @@ SchemaType.prototype.applySetters = function (value, scope, init, priorVal) {
   }
   
   if (Array.isArray(v) && caster && caster.setters) {
+    var newVal = [];
     for (var i = 0; i < v.length; i++) {
-      v[i] = caster.applySetters(v[i], scope, init, priorVal);
+      newVal.push(caster.applySetters(v[i], scope, init, priorVal));
     }
+    v = newVal;
   }
 
   if (null === v || undefined === v) return v;


### PR DESCRIPTION
Environment:

```
NodeJS 0.10.26
MongoDB 3.0.2
Mongoose 4.0.1
```

The following code will reproduce the issue.

```javascript
var mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test');
var Sku = mongoose.model('Sku', {});
var Item = mongoose.model('Item', {
  skus: [{ref: 'Sku', type: mongoose.Schema.Types.ObjectId}]
});

(new Sku()).save(function(err, sku1) {
  (new Sku()).save(function(err, sku2) {
    var skus = [sku1, sku2];
    var item = new Item();
    console.log(skus); // Output: [ { __v: 0, _id: 553a026e768910b02f6b4a12 }, { __v: 0, _id: 553a026e768910b02f6b4a13 } ]
    item.skus = skus;
    console.log(skus); // Output: [ 553a026e768910b02f6b4a12, 553a026e768910b02f6b4a13 ]
    process.exit(0);
  });
});
```

This pull-request will fix the above issue.

However, Mongoose 3.8.x doesn't have this issue.