### PR TITLE
Best way to mitigate invalid ID query breaking change of 4.0?

### DIFF
--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1501,4 +1501,31 @@ describe('Query', function(){
       });
     });
   });
+
+  describe('Invalid IDs', function () {
+    it('should not throw an error when bogus id using find', function (done) {
+      var db = start();
+      var Product = db.model('Product', 'Product_setOptions_test');
+      Product.find({_id: 'bogus'}).exec(function(error) {
+        assert.ifError(error);
+        db.close(done);
+      });
+    });
+    it('should not throw an error when bogus id using findOne', function (done) {
+      var db = start();
+      var Product = db.model('Product', 'Product_setOptions_test');
+      Product.findOne({_id: 'bogus'}).exec(function(error) {
+        assert.ifError(error);
+        db.close(done);
+      });
+    });
+    it('should not throw an error when bogus id using findById', function (done) {
+      var db = start();
+      var Product = db.model('Product', 'Product_setOptions_test');
+      Product.findById({_id: 'bogus'}).exec(function(error) {
+        assert.ifError(error);
+        db.close(done);
+      });
+    });
+  });
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1522,7 +1522,7 @@ describe('Query', function(){
     it('should not throw an error when bogus id using findById', function (done) {
       var db = start();
       var Product = db.model('Product', 'Product_setOptions_test');
-      Product.findById({_id: 'bogus'}).exec(function(error) {
+      Product.findById('bogus').exec(function(error) {
         assert.ifError(error);
         db.close(done);
       });


### PR DESCRIPTION
The 4.x series brought an unexpected breaking change.

Now when you query based on the record `_id`, the string you are passing has to be a proper Mongo Object Id or look-alike. Anything else will throw a `CastError` vs a null result object that it used to return in the 3.x series.

Needless to say this change breaks an array of tests and existing codebases. What used to return a `null` result now throws an error.

Is there a way to mitigate this issue or are we locked to 3.x until we allocate resources to refactor all the codebase where needed?
