### PR TITLE
reproduction #2502 in v4.0.x

### DIFF
--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -21,6 +21,10 @@ PersonSchema.index({ name: 1 });
 PersonSchema.methods.getFullName = function() {
   return this.name.first + ' ' + this.name.last;
 };
+PersonSchema.methods.toJSonConfig = {
+  include: ['prop1', 'prop2'],
+  exclude: ['prop3', 'prop4']
+}
 PersonSchema.statics.findByGender = function(gender, cb) {};
 PersonSchema.virtual('name.full').get(function () {
   return this.name.first + ' ' + this.name.last;


### PR DESCRIPTION
This reproduces #2502 in v4.0.x

I am still not sure whether this is actually allowed (assigning objects to documents.methods) . We just have been doing this for ages. There is an easy workaround: just define methods that return the objects, so if you @vkarpov15 say, that this is not a valid usage, just close the issue and PR.