### PR TITLE
ClarifyDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ var mongoose = require('mongoose');
 mongoose.connect('mongodb://localhost/my_database');
 ```
 
-Once connected, the `open` event is fired on the `Connection` instance. If you're using `mongoose.connect`, the `Connection` is `mongoose.connection`. Otherwise, `mongoose.createConnection` return value is a `Connection`.
+Once connected, the `open` event is fired on the `Connection` instance. If you're using `mongoose.connect`, the `Connection` is `mongoose.connection`. Otherwise, `mongoose.createConnection` return value is a `Connection`. 
+
+**Note:** _If the connection fails or if attempting to connect via a Mongoose GUI shows only a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
 
 **Important!** Mongoose buffers all the commands until it's connected to the database. This means that you don't have to wait until it connects to MongoDB in order to define models, run queries, etc.
 
@@ -128,7 +130,15 @@ Or just do it all at once
 var MyModel = mongoose.model('ModelName', mySchema);
 ```
 
-We can then instantiate it, and save it:
+The first argument is the _singular_ name of the collection your model is for. **Mongoose automatically looks for the _plural_ version of your model name.** For example, if you use
+
+```js
+var MyModel = mongoose.model('Ticket', mySchema);
+```
+
+Then Mongoose will create the model for your __tickets__ collection, not your __ticket__ collection.
+
+Once we have our model, we can then instantiate it, and save it:
 
 ```js
 var instance = new MyModel();

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mongoose.connect('mongodb://localhost/my_database');
 
 Once connected, the `open` event is fired on the `Connection` instance. If you're using `mongoose.connect`, the `Connection` is `mongoose.connection`. Otherwise, `mongoose.createConnection` return value is a `Connection`. 
 
-**Note:** _If the connection fails or if attempting to connect via a Mongoose GUI shows only a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
+**Note:** _If the connection fails or if attempting to connect via a Mongo GUI only shows a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
 
 **Important!** Mongoose buffers all the commands until it's connected to the database. This means that you don't have to wait until it connects to MongoDB in order to define models, run queries, etc.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mongoose.connect('mongodb://localhost/my_database');
 
 Once connected, the `open` event is fired on the `Connection` instance. If you're using `mongoose.connect`, the `Connection` is `mongoose.connection`. Otherwise, `mongoose.createConnection` return value is a `Connection`. 
 
-**Note:** _If the connection fails or if attempting to connect via a Mongo GUI only shows a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
+**Note:** _If the connection fails then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
 
 **Important!** Mongoose buffers all the commands until it's connected to the database. This means that you don't have to wait until it connects to MongoDB in order to define models, run queries, etc.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mongoose.connect('mongodb://localhost/my_database');
 
 Once connected, the `open` event is fired on the `Connection` instance. If you're using `mongoose.connect`, the `Connection` is `mongoose.connection`. Otherwise, `mongoose.createConnection` return value is a `Connection`. 
 
-**Note:** _If the connection fails then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
+**Note:** _If the local connection fails then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed._
 
 **Important!** Mongoose buffers all the commands until it's connected to the database. This means that you don't have to wait until it connects to MongoDB in order to define models, run queries, etc.
 

--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -9,7 +9,7 @@ block content
     mongoose.connect('mongodb://localhost/myapp');
 
   :markdown
-    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the connection fails then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
+    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the local connection fails then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
    
     We may also specify several more parameters in the `uri` depending on your environment:
 

--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -9,7 +9,7 @@ block content
     mongoose.connect('mongodb://localhost/myapp');
 
   :markdown
-    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the connection fails or if attempting to connect via a Mongoose GUI shows only a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
+    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the connection fails or if attempting to connect via a Mongo GUI only shows a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
    
     We may also specify several more parameters in the `uri` depending on your environment:
 

--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -9,7 +9,9 @@ block content
     mongoose.connect('mongodb://localhost/myapp');
 
   :markdown
-    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). We may also specify several more parameters in the `uri` depending on your environment:
+    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the connection fails or if attempting to connect via a Mongoose GUI shows only a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
+   
+    We may also specify several more parameters in the `uri` depending on your environment:
 
   :js
     mongoose.connect('mongodb://username:password@host:port/database?options...');

--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -9,7 +9,7 @@ block content
     mongoose.connect('mongodb://localhost/myapp');
 
   :markdown
-    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the connection fails or if attempting to connect via a Mongo GUI only shows a blank screen despite successful connection, then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
+    This is the minimum needed to connect the `myapp` database running locally on the default port (27017). If the connection fails then try using 127.0.0.1 instead of localhost. Sometimes issues may arise when the local hostname has been changed.
    
     We may also specify several more parameters in the `uri` depending on your environment:
 

--- a/docs/models.jade
+++ b/docs/models.jade
@@ -11,6 +11,8 @@ block content
     var Tank = mongoose.model('Tank', schema);
 
   :markdown
+    The first argument is the _singular_ name of the collection your model is for. ** Mongoose automatically looks for the _plural_ version of your model name. **
+    Thus, for the example above, the model Tank is for the **tanks** collection in the database.
     The `.model()` function makes a copy of `schema`. Make sure that you've added everything you want to `schema` before calling `.model()`!
 
   h3 Constructing documents


### PR DESCRIPTION
Clarified that the model name is singular, but the collection it specifies is plural. Also added a note about the mongodb connection, since sometimes if the hostname has been changed, there might be problems connecting to localhost.