### PR TITLE
README: compact npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mongoose is a [MongoDB](http://www.mongodb.org/) object modeling tool designed t
 
 [![Build Status](https://api.travis-ci.org/Automattic/mongoose.png?branch=master)](https://travis-ci.org/Automattic/mongoose)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Automattic/mongoose?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![NPM version](https://badge.fury.io/js/mongoose.svg)](http://badge.fury.io/js/mongoose)
 
 ## Documentation
 


### PR DESCRIPTION
Added a compact npm badge. This quickly tells the user what the latest release is, and provides a link to the npm release page without having to do a secondary search.

### Before
![screen shot 2015-05-28 at 3 55 02 pm](https://cloud.githubusercontent.com/assets/4898263/7872045/fd18530e-0551-11e5-8a3e-35dfc32d8567.png)


### After
![screen shot 2015-05-28 at 3 54 50 pm](https://cloud.githubusercontent.com/assets/4898263/7872050/05c6faa0-0552-11e5-91ba-2022c1e1f73b.png)
