### PR TITLE
fix; validateSync when used with required and maxlength (Fix #3025)

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -717,6 +717,10 @@ SchemaType.prototype.doValidateSync = function (value, scope) {
   }
 
   this.validators.forEach(function (v) {
+    if (err) {
+      return;
+    }
+    
     var validator = v.validator;
     var validatorProperties = utils.clone(v);
     validatorProperties.path = path;

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -846,6 +846,19 @@ describe('schema', function(){
       });
     });
 
+    it('doesnt execute other validators if required fails (gh-3025)', function(done) {
+      var breakfast = new Schema({ description: { type: String, required: true, maxlength: 50 } });
+
+      var Breakfast = mongoose.model('gh3025', breakfast, 'gh3025');
+      var bad = new Breakfast({});
+      var error = bad.validateSync();
+
+      assert.ok(error);
+      var errorMessage = 'ValidationError: Path `description` is required.';
+      assert.equal(errorMessage, error.toString());
+      done();
+    });
+
     it('adds required validators to the front of the list (gh-2843)', function(done) {
       var breakfast = new Schema({ description: { type: String, maxlength: 50, required: true } });
 


### PR DESCRIPTION
Fix for #3025 where validateSync() throws TypeError when used with required and maxlength