### PR TITLE
Add a property to validators from certains SchemaType to help build m…

### DIFF
--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -135,7 +135,8 @@ SchemaDate.prototype.min = function (value, message) {
         return val === null || val.valueOf() >= min.valueOf();
       },
       message: msg,
-      type: 'min'
+      type: 'min',
+      min: value
     });
   }
 
@@ -190,7 +191,8 @@ SchemaDate.prototype.max = function (value, message) {
         return val === null || val.valueOf() <= max.valueOf();
       },
       message: msg,
-      type: 'max'
+      type: 'max',
+      max: value
     });
   }
 

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -95,7 +95,8 @@ SchemaNumber.prototype.min = function (value, message) {
         return v === null || v >= value;
       },
       message: msg,
-      type: 'min'
+      type: 'min',
+      min: value
     });
   }
 
@@ -148,7 +149,8 @@ SchemaNumber.prototype.max = function (value, message) {
         return v === null || v <= value;
       },
       message: msg,
-      type: 'max'
+      type: 'max',
+      max: value
     });
   }
 

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -109,7 +109,8 @@ SchemaString.prototype.enum = function () {
   this.validators.push({
     validator: this.enumValidator,
     message: errorMessage,
-    type: 'enum'
+    type: 'enum',
+    enumValues: vals
   });
 
   return this;
@@ -231,7 +232,8 @@ SchemaString.prototype.minlength = function (value, message) {
         return v === null || v.length >= value;
       },
       message: msg,
-      type: 'minlength'
+      type: 'minlength',
+      minlength: value
     });
   }
 
@@ -284,7 +286,8 @@ SchemaString.prototype.maxlength = function (value, message) {
         return v === null || v.length <= value;
       },
       message: msg,
-      type: 'maxlength'
+      type: 'maxlength',
+      maxlength: value
     });
   }
 
@@ -341,7 +344,12 @@ SchemaString.prototype.match = function match (regExp, message) {
     return ret;
   };
 
-  this.validators.push({ validator: matchValidator, message: msg, type: 'regexp' });
+  this.validators.push({
+    validator: matchValidator,
+    message: msg,
+    type: 'regexp',
+    regexp: regExp
+  });
   return this;
 };
 


### PR DESCRIPTION
Hi!,
I work on a module to do advance localization of the Mongoose's ValidatorErrors. To have the value of the specific validator would really help to build custom error message with all the infos needed without having to dig in the schema.

## Actual ValidationError
Here's an example of an error for the `maxlength` validator. I have everything that I need in the `properties` object to build a localized error message but the actual `maxlength`.

```json
{
  "properties": {
    "type": " maxlength",
    "message": "Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length (3).",
    "path": "description",
    "value": "foobar"
  },
  "message": "Path `description` (`foobar`) is longer than the maximum allowed length (3).",
  "name": "ValidatorError",
  "kind": "maxlength",
  "path": "description",
  "value": "foobar"
}
```

## ValidationError with an additional property
I propose to add a property, keyed with the value of the property `kind` / `properties/type` that contain the value entered in the schema for this validator.

```json
{
  "properties": {
    "type": " maxlength",
    "message": "Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length (3).",
    "path": "description",
    "value": "foobar",
    "maxlength": 3
  },
  "message": "Path `description` (`foobar`) is longer than the maximum allowed length (3).",
  "name": "ValidatorError",
  "kind": "maxlength",
  "path": "description",
  "value": "foobar"
}
```

Thank you!