### PR TITLE
Add Semicolons to Line-Ends for Uniformity

### DIFF
--- a/docs/index.jade
+++ b/docs/index.jade
@@ -48,18 +48,18 @@ html(lang='en')
         :js
           var kittySchema = mongoose.Schema({
               name: String
-          })
+          });
         :markdown
           So far so good. We've got a schema with one property, `name`, which will be a  `String`. The next step is compiling our schema into a [Model](/docs/models.html).
         :js
-          var Kitten = mongoose.model('Kitten', kittySchema)
+          var Kitten = mongoose.model('Kitten', kittySchema);
         :markdown
           A model is a class with which we construct documents.
           In this case, each document will be a kitten with properties and behaviors as declared in our schema.
           Let's create a kitten document representing the little guy we just met on the sidewalk outside:
         :js
-          var silence = new Kitten({ name: 'Silence' })
-          console.log(silence.name) // 'Silence'
+          var silence = new Kitten({ name: 'Silence' });
+          console.log(silence.name); // 'Silence'
         :markdown
           Kittens can meow, so let's take a look at how to add "speak" functionality to our documents:
         :js
@@ -67,16 +67,16 @@ html(lang='en')
           kittySchema.methods.speak = function () {
             var greeting = this.name
               ? "Meow name is " + this.name
-              : "I don't have a name"
+              : "I don't have a name";
             console.log(greeting);
           }
 
-          var Kitten = mongoose.model('Kitten', kittySchema)
+          var Kitten = mongoose.model('Kitten', kittySchema);
         :markdown
           Functions added to the `methods` property of a schema get compiled into the `Model` prototype and exposed on each document instance:
         :js
           var fluffy = new Kitten({ name: 'fluffy' });
-          fluffy.speak() // "Meow name is fluffy"
+          fluffy.speak(); // "Meow name is fluffy"
         :markdown
           We have talking kittens! But we still haven't saved anything to MongoDB.
           Each document can be saved to the database by calling its [save](/docs/api.html#model_Model-save) method. The first argument to the callback will be an error if any occured.
@@ -91,13 +91,13 @@ html(lang='en')
         :js
           Kitten.find(function (err, kittens) {
             if (err) return console.error(err);
-            console.log(kittens)
+            console.log(kittens);
           })
         :markdown
           We just logged all of the kittens in our db to the console.
           If we want to filter our kittens by name, Mongoose supports MongoDBs rich [querying](/docs/queries.html) syntax.
         :js
-          Kitten.find({ name: /^Fluff/ }, callback)
+          Kitten.find({ name: /^Fluff/ }, callback);
         :markdown
           This performs a search for all documents with a name property that begins with "Fluff" and returns the result as an array of kittens to the callback.
         h3 Congratulations


### PR DESCRIPTION
Added semicolons to code lines where they were missing to match the rest of the document. The semicolons create uniformity in the code examples and improve clarity. No source code or markdown tags were edited.