### PR TITLE
Proper support for asynchronous document post hooks

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1526,14 +1526,14 @@ Document.prototype.$__registerHooksFromSchema = function () {
     }
     var args = [].slice.call(pair[1]);
     var pointCut = pair[0] === 'on' ? 'post' : args[0];
-	if (!(pointCut in seed)) seed[pointCut] = { post: [], pre: [] };
-	if (pair[0] === 'post') {
-		seed[pointCut].post.push(args);
-	} else if (pair[0] === 'on') {
-		seed[pointCut].push(args);
-	} else {
-		seed[pointCut].pre.push(args);
-	}
+    if (!(pointCut in seed)) seed[pointCut] = { post: [], pre: [] };
+    if (pair[0] === 'post') {
+        seed[pointCut].post.push(args);
+    } else if (pair[0] === 'on') {
+        seed[pointCut].push(args);
+    } else {
+        seed[pointCut].pre.push(args);
+    }
     return seed;
   }, {post: []});
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -1526,8 +1526,14 @@ Document.prototype.$__registerHooksFromSchema = function () {
     }
     var args = [].slice.call(pair[1]);
     var pointCut = pair[0] === 'on' ? 'post' : args[0];
-    if (!(pointCut in seed)) seed[pointCut] = [];
-    seed[pointCut].push(args);
+	if (!(pointCut in seed)) seed[pointCut] = { post: [], pre: [] };
+	if (pair[0] === 'post') {
+		seed[pointCut].post.push(args);
+	} else if (pair[0] === 'on') {
+		seed[pointCut].push(args);
+	} else {
+		seed[pointCut].pre.push(args);
+	}
     return seed;
   }, {post: []});
 
@@ -1541,8 +1547,11 @@ Document.prototype.$__registerHooksFromSchema = function () {
 
     // skip weird handlers
     if (~"set ".indexOf(pointCut)) {
-      toWrap[pointCut].forEach(function (args) {
+      toWrap[pointCut].pre.forEach(function (args) {
         self.pre.apply(self, args);
+      });
+      toWrap[pointCut].post.forEach(function (args) {
+        self.post.apply(self, args);
       });
       return;
     }
@@ -1574,9 +1583,13 @@ Document.prototype.$__registerHooksFromSchema = function () {
       return wrapingPromise;
     };
 
-    toWrap[pointCut].forEach(function (args) {
+    toWrap[pointCut].pre.forEach(function (args) {
       args[0] = newName;
       self.pre.apply(self, args);
+    });
+    toWrap[pointCut].post.forEach(function (args) {
+      args[0] = newName;
+      self.post.apply(self, args);
     });
   })
   return self;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -694,7 +694,10 @@ Schema.prototype.post = function(method, fn) {
   return this.queue('post', [arguments[0], function(next){
     // wrap original function so that the callback goes last,
     // for compatibility with old code that is using synchronous post hooks
-    fn.call(this, this, next);
+    var self = this;
+    fn.call(this, this, function(err, result) {
+        return next(err, result || self);
+    });
   }]);
 };
 

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -28,24 +28,22 @@ describe('model middleware', function(){
     schema.post('save', function (obj) {
       assert.equal(obj.title, 'Little Green Running Hood');
       assert.equal(this.title, 'Little Green Running Hood');
-      assert.equal(1, called);
+      assert.equal(0, called);
       called++;
     });
 
     schema.post('save', function (obj) {
       assert.equal(obj.title, 'Little Green Running Hood');
       assert.equal(this.title, 'Little Green Running Hood');
-      assert.equal(2, called);
+      assert.equal(1, called);
       called++;
     });
 
     schema.post('save', function(obj, next){
-      setTimeout(function(){
-        assert.equal(obj.title, 'Little Green Running Hood');
-        assert.equal(0, called);
-        called++;
-        next();
-      }, 0);
+      assert.equal(obj.title, 'Little Green Running Hood');
+      assert.equal(2, called);
+      called++;
+      next();
     });
 
     var db = start()


### PR DESCRIPTION
Asynchronous document post hooks were actually being treated as asynchronous document pre hooks and were being registered as such. This fixes mongoose so it can properly handle these asynchronous post hooks. See issue #3062.