### PR TITLE
Feature/gh3034 this error

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -35,7 +35,9 @@ function MongooseArray (values, path, doc) {
 
   // Because doc comes from the context of another function, doc === global
   // can happen if there was a null somewhere up the chain (see #3020)
-  if (doc && doc !== global) {
+  // RB Jun 17, 2015 updated to check for presence of expected paths instead
+  // to make more proof against unusual node environments
+  if (doc && doc instanceof Document) {
     arr._parent = doc;
     arr._schema = doc.schema.path(path);
   }

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -34,7 +34,11 @@ function MongooseDocumentArray (values, path, doc) {
   arr.validators = [];
   arr._path = path;
 
-  if (doc) {
+  // Because doc comes from the context of another function, doc === global
+  // can happen if there was a null somewhere up the chain (see #3020 && #3034)
+  // RB Jun 17, 2015 updated to check for presence of expected paths instead
+  // to make more proof against unusual node environments
+  if (doc && doc instanceof Document) {
     arr._parent = doc;
     arr._schema = doc.schema.path(path);
     arr._handlers = {

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1350,5 +1350,37 @@ describe('model: findByIdAndUpdate:', function(){
           });
       });
     });
+
+    it('should work with array documents (gh-3034)', function(done) {
+      var db = start();
+
+      var testSchema = new mongoose.Schema({
+        id: String,
+        name: String,
+        a: [{
+            foo: String
+        }],
+        _createdAt: {
+          type: Number,
+          default: Date.now
+        },
+      });
+
+      var TestModel = db.model('gh3034', testSchema);
+      TestModel.create({ id: '1' }, function(error) {
+        assert.ifError(error);
+        TestModel.findOneAndUpdate(
+          { id: '1' },
+          { $set: { name: 'Joe' } },
+          {
+            upsert: true,
+            setDefaultsOnInsert: true
+          },
+          function(error, result) {
+            assert.ifError(error);
+            done();
+          });
+      });
+    });
   });
 });


### PR DESCRIPTION
I have made one change that may be controversial, and I'm willing to change it if you like.  I dislike checking if doc === global just because in principle there could be cases where global isn't what is expected; we don't actually care specifically if it is global, we care if it isn't the object we expect.  

Therefore, instead of checking against global I'm checking to see if the features / objects we need are present.

I see this somewhat akin to the difference between checking for features in a web browser vs checking which web browser we're in -- feature checking is much more flexible =]