### PR TITLE
Applies toObject to conditions of find and update queries recursively

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -985,9 +985,9 @@ Query.prototype.find = function (conditions, callback) {
   if ('function' == typeof conditions) {
     callback = conditions;
     conditions = {};
-  } else if (conditions instanceof Document) {
-    conditions = conditions.toObject();
   }
+
+  conditions = utils.toObject(conditions);
 
   if (mquery.canMerge(conditions)) {
     this.merge(conditions);
@@ -1131,9 +1131,7 @@ Query.prototype.findOne = function (conditions, projection, options, callback) {
   }
 
   // make sure we don't send in the whole Document to merge()
-  if (conditions instanceof Document) {
-    conditions = conditions.toObject();
-  }
+  conditions = utils.toObject(conditions);
 
   if (options) {
     this.setOptions(options);
@@ -1324,9 +1322,7 @@ Query.prototype.distinct = function (field, conditions, callback) {
     }
   }
 
-  if (conditions instanceof Document) {
-    conditions = conditions.toObject();
-  }
+  conditions = utils.toObject(conditions);
 
   if (mquery.canMerge(conditions)) {
     this.merge(conditions)
@@ -1872,9 +1868,7 @@ Query.prototype.update = function (conditions, doc, options, callback) {
   }
 
   // make sure we don't send in the whole Document to merge()
-  if (conditions instanceof Document) {
-    conditions = conditions.toObject();
-  }
+  conditions = utils.toObject(conditions);
 
   var oldCb = callback;
   if (oldCb) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -372,6 +372,47 @@ exports.merge = function merge (to, from) {
 var toString = Object.prototype.toString;
 
 /*!
+ * Applies toObject recursively.
+ *
+ * @param {Document|Array|Object} obj
+ * @return {Object}
+ * @api private
+ */
+
+exports.toObject = function toObject (obj) {
+  if (exports.isNullOrUndefined(obj)) {
+    return obj;
+  }
+
+  if (obj instanceof Document) {
+    return obj.toObject();
+  }
+
+  if (Array.isArray(obj)) {
+    var ret = [];
+
+    for (var i = 0, len = obj.length; i < len; ++i) {
+      ret.push(toObject(obj[i]));
+    }
+
+    return ret;
+  }
+
+  if ((obj.constructor && exports.getFunctionName(obj.constructor) === 'Object') ||
+      (!obj.constructor && exports.isObject(obj))) {
+    var ret = {};
+
+    for (var k in obj) {
+      ret[k] = toObject(obj[k]);
+    }
+
+    return ret;
+  }
+
+  return obj;
+};
+
+/*!
  * Determines if `arg` is an object.
  *
  * @param {Object|Array|String|Function|RegExp|any} arg

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1120,6 +1120,25 @@ describe('model: querying:', function(){
       });
     })
 
+    it('using $or with array of Document', function (done) {
+      var db = start()
+        , Mod = db.model('Mod', 'mods_' + random());
+
+      Mod.create({num: 1}, function(err, one) {
+        assert.ifError(err);
+        Mod.find({num: 1}, function(err, found) {
+          assert.ifError(err);
+          Mod.find({$or: found}, function(err, found) {
+            assert.ifError(err);
+            assert.equal(1, found.length);
+            assert.equal(found[0]._id.toString(), one._id);
+            db.close();
+            done();
+          });
+        });
+      });
+    });
+
     it('where $ne', function(done){
       var db = start()
         , Mod = db.model('Mod', 'mods_' + random());


### PR DESCRIPTION
Currently, when conditions like `{$or: [Document]}` passed to `find`, `findOne`, `distinct` and `update`, it will cause a core dump.
The following code will reproduce the issue.

```js
var mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test');
var Sku = mongoose.model('Sku', {});

(new Sku()).save(function(err, sku) {
  Sku.find({_id: sku._id}, function(err, skus) {
    Sku.find({$or: skus}, function(err, skus) {
      console.log(skus);
      process.exit(0);
    });
  });
});
```