### PR TITLE
Fix incorrect examples of some String validators

### DIFF
--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -200,12 +200,12 @@ SchemaString.prototype.trim = function () {
  *     })
  *
  *     // custom error messages
- *     // We can also use the special {MINLENGTH} token which will be replaced with the invalid value
- *     var minlength = [10, 'The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum length ({MINLENGTH}).'];
+ *     // We can also use the special {MINLENGTH} token which will be replaced with the minimum allowed length
+ *     var minlength = [5, 'The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).'];
  *     var schema = new Schema({ postalCode: { type: String, minlength: minlength })
  *     var Address = mongoose.model('Address', schema);
  *     var address = new Address({ postalCode: '9512' });
- *     s.validate(function (err) {
+ *     address.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512`) is shorter than the minimum length (5).
  *     })
  *
@@ -253,13 +253,13 @@ SchemaString.prototype.minlength = function (value, message) {
  *     })
  *
  *     // custom error messages
- *     // We can also use the special {MAXLENGTH} token which will be replaced with the invalid value
- *     var maxlength = [10, 'The value of path `{PATH}` (`{VALUE}`) exceeds the maximum allowed length ({MAXLENGTH}).'];
+ *     // We can also use the special {MAXLENGTH} token which will be replaced with the maximum allowed length
+ *     var maxlength = [9, 'The value of path `{PATH}` (`{VALUE}`) exceeds the maximum allowed length ({MAXLENGTH}).'];
  *     var schema = new Schema({ postalCode: { type: String, maxlength: maxlength })
  *     var Address = mongoose.model('Address', schema);
  *     var address = new Address({ postalCode: '9512512345' });
  *     address.validate(function (err) {
- *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512512345`) exceeds the maximum allowed length (10).
+ *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512512345`) exceeds the maximum allowed length (9).
  *     })
  *
  * @param {Number} value maximum string length


### PR DESCRIPTION
On String validators minlength and maxlength:
- the special tokens {MINLENGTH} and {MAXLENGTH} were said to be replaced by the 'invalid value'. Changed that to 'minimum allowed length' and 'maximum allowed length'.
- validate() was called on variable s instead of address.
- The minlength example validated min 10, but shows error msg for min 5. Changed to validate 5
- The maxlength example validated max 10, but validates a max 10 string. Changed to validate 9 and show error msg for 9.