### PR TITLE
Fix for Documentation typo #2881

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -130,7 +130,7 @@ SchemaType.prototype.index = function (options) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, unique: true })
+ *     var s = new Schema({ name: { type: String, unique: true }});
  *     Schema.path('name').index({ unique: true });
  *
  * _NOTE: violating the constraint returns an `E11000` error from MongoDB when saving, not a Mongoose validation error._


### PR DESCRIPTION
Ending curly brace and semi-colon missing