### PR TITLE
Fixes syntax errors in jsdoc; fixes #3073

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -149,41 +149,41 @@ Model.prototype.$__handleSave = function $__handleSave(options) {
 };
 
 /**
- * @description Saves this document.
+ * Saves this document.
  *
- * @example:
+ * ####Example:
  *
  *     product.sold = Date.now();
  *     product.save(function (err, product, numberAffected) {
  *       if (err) ..
  *     })
  *
- * @description The callback will receive three parameters, `err` if an error occurred, `product` which is the saved `product`, and `numberAffected` which will be 1 when the document was found and updated in the database, otherwise 0.
+ * The callback will receive three parameters, `err` if an error occurred, `product` which is the saved `product`, and `numberAffected` which will be 1 when the document was found and updated in the database, otherwise 0.
  *
  * The `fn` callback is optional. If no `fn` is passed and validation fails, the validation error will be emitted on the connection used to create this model.
- * @example:
+ * ####Example:
  *     var db = mongoose.createConnection(..);
  *     var schema = new Schema(..);
  *     var Product = db.model('Product', schema);
  *
  *     db.on('error', handleError);
  *
- * @description However, if you desire more local error handling you can add an `error` listener to the model and handle errors there instead.
- * @example:
+ * However, if you desire more local error handling you can add an `error` listener to the model and handle errors there instead.
+ * ####Example:
  *     Product.on('error', handleError);
  *
- * @description As an extra measure of flow control, save will return a Promise (bound to `fn` if passed) so it could be chained, or hook to recive errors
- * @example:
+ * As an extra measure of flow control, save will return a Promise (bound to `fn` if passed) so it could be chained, or hook to recive errors
+ * ####Example:
  *     product.save().then(function (product, numberAffected) {
  *        ...
  *     }).onRejected(function (err) {
  *        assert.ok(err)
  *     })
  *
- * @description For legacy reasons, mongoose stores object keys in reverse order on initial save. That is, `{ a: 1, b: 2}` will be saved as `{ b: 2, a: 1 }` in MongoDB. To override this behavior, set [the `toObject.retainKeyOrder` option](http://mongoosejs.com/docs/api.html#document_Document-toObject) to true on your schema.
+ * For legacy reasons, mongoose stores object keys in reverse order on initial save. That is, `{ a: 1, b: 2}` will be saved as `{ b: 2, a: 1 }` in MongoDB. To override this behavior, set [the `toObject.retainKeyOrder` option](http://mongoosejs.com/docs/api.html#document_Document-toObject) to true on your schema.
  *
- * @param {Object} [options] options set `options.safe` to override [schema's safe option](/docs/guide.html#safe)
- * @param {function(err, product, Number)} [fn] optional callback
+ * @param {Object} [options] options set `options.safe` to override [schema's safe option](http://mongoosejs.com//docs/guide.html#safe)
+ * @param {function(err,product,Number)} [fn] optional callback
  * @return {Promise} Promise
  * @api public
  * @see middleware http://mongoosejs.com/docs/middleware.html
@@ -604,9 +604,9 @@ Model.prototype.$__where = function _where (where) {
 }
 
 /**
- * @description Removes this document from the db.
+ * Removes this document from the db.
  *
- * @example:
+ * ####Example:
  *     product.remove(function (err, product) {
  *       if (err) return handleError(err);
  *       Product.findById(product._id, function (err, product) {
@@ -615,16 +615,16 @@ Model.prototype.$__where = function _where (where) {
  *     })
  *
  *
- * @description As an extra measure of flow control, remove will return a Promise (bound to `fn` if passed) so it could be chained, or hooked to recive errors
+ * As an extra measure of flow control, remove will return a Promise (bound to `fn` if passed) so it could be chained, or hooked to recive errors
  *
- * @example
+ * ####Example:
  *     product.remove().then(function (product) {
  *        ...
  *     }).onRejected(function (err) {
  *        assert.ok(err)
  *     })
  *
- * @param {function (err, product)} [fn] optional callback
+ * @param {function(err,product)} [fn] optional callback
  * @return {Promise} Promise
  * @api public
  */


### PR DESCRIPTION
The docs for functions model.save() and model.remove():
- used unsupported jsdoc formatting instead of markdown. This made it so that most of the function description was ignored and didn't compile into the html docs.
- the callback function params use unsupported jsdoc and got mangled in the output. I've fixed it so it's supported, but it's still illegal jsdoc. (Can't do "@param {function(err,product,Number)}", it should be "@param {Function}")
- The link to options.safe was relative and didn't render as a link; made it into a proper url but it still doesn't render as a link. (Not sure if the markdown syntax is supported inside a @param element)
