### PR TITLE
fixed updateValidator object checker

### DIFF
--- a/lib/services/updateValidators.js
+++ b/lib/services/updateValidators.js
@@ -51,8 +51,10 @@ module.exports = function(query, schema, castedDoc, options) {
     paths = Object.keys(query._conditions);
     numPaths = keys.length;
     for (var i = 0; i < numPaths; ++i) {
-      if (typeof query._conditions[paths[i]] === 'object') {
-        var conditionKeys = Object.keys(query._conditions[paths[i]]);
+      var path = paths[i];
+      var condition = query._conditions[path];
+      if (condition && typeof condition === 'object') {
+        var conditionKeys = Object.keys(condition);
         var numConditionKeys = conditionKeys.length;
         var hasDollarKey = false;
         for (var j = 0; j < numConditionKeys; ++j) {
@@ -65,7 +67,7 @@ module.exports = function(query, schema, castedDoc, options) {
           continue;
         }
       }
-      updatedKeys[paths[i]] = true;
+      updatedKeys[path] = true;
     }
 
     if (options.setDefaultsOnInsert) {

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1351,6 +1351,32 @@ describe('model: findByIdAndUpdate:', function(){
       });
     });
 
+    it('should allow null values in query (gh-3135)', function(done) {
+        var db = start();
+
+        var testSchema = new mongoose.Schema({
+          id:      String,
+          blob:    ObjectId,
+          status:  String,
+        });
+
+        var TestModel = db.model('gh3135', testSchema);
+        TestModel.create({ blob: null, status: 'active' }, function(error) {
+          assert.ifError(error);
+          TestModel.findOneAndUpdate(
+            { id: '1', blob: null },
+            { $set: { status: 'inactive' }},
+            {
+              upsert: true,
+              setDefaultsOnInsert: true
+            },
+            function(error, result) {
+              assert.ifError(error);
+              done();
+            });
+        });
+    });
+
     it('should work with array documents (gh-3034)', function(done) {
       var db = start();
 


### PR DESCRIPTION
Fixed up updateValidator object checker on encountering null during upsert.
This is because it attempts a `Object.keys(v)` after checking
that a condition is an `object` but this fails for null which.
is an object.

This PR addresses https://github.com/Automattic/mongoose/issues/3135