### PR TITLE
Fix documentarray id method when using object _id

### DIFF
--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -121,8 +121,7 @@ MongooseDocumentArray.mixin.id = function (id) {
       sid || (sid = String(id));
       if (sid == _id._id) return this[i];
     } else if (!(_id instanceof ObjectId)) {
-      sid || (sid = String(id));
-      if (sid == _id) return this[i];
+      if (utils.deepEqual(id, _id)) return this[i];
     } else if (casted == _id) {
       return this[i];
     }

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -110,6 +110,26 @@ describe('types.documentarray', function(){
     assert.equal(a.id(id3).title, 'rock-n-roll');
     assert.equal(a.id(sub3._id).title, 'rock-n-roll');
 
+    // test with object as _id
+    var Custom = new Schema({
+        title: { type: String }
+      , _id:   { one: { type: String }, two: { type: String } }
+    });
+
+    var Subdocument = TestDoc(Custom);
+
+    var sub1 = new Subdocument();
+    sub1._id = {one: 'rolling', two: 'rock'};
+    sub1.title = 'to be a rock and not to roll';
+
+    var sub2 = new Subdocument();
+    sub2._id = {one: 'rock', two: 'roll'};
+    sub2.title = 'rock-n-roll';
+
+    var a = new MongooseDocumentArray([sub1,sub2]);
+    assert.notEqual(a.id({one: 'rolling', two: 'rock'}).title, 'rock-n-roll');
+    assert.equal(a.id({one: 'rock', two: 'roll'}).title, 'rock-n-roll');
+
     // test with no _id
     var NoId = new Schema({
         title: { type: String }


### PR DESCRIPTION
When trying to use an object _id field ("compound" or "composite" _id) in documentarray (subschema), I have found that the documentarray id() method is improperly casting the id to string (which effectively turn the object into "[object Object]" string).

I've read object _id fields are [not officially supported in Mongoose](https://groups.google.com/forum/#!msg/mongoose-orm/yp_hHanUruo/ffM3WQPD-i8J). However, in my use case they seems to work rather well, apart from that id() issue.
