### PR TITLE
Fix documentarray id method when _id is null-ish.

### DIFF
--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -117,7 +117,9 @@ MongooseDocumentArray.mixin.id = function (id) {
   for (var i = 0, l = this.length; i < l; i++) {
     _id = this[i].get('_id');
 
-    if (_id instanceof Document) {
+    if (_id === null || typeof _id === 'undefined') {
+      continue;
+    } else if (_id instanceof Document) {
       sid || (sid = String(id));
       if (sid == _id._id) return this[i];
     } else if (!(_id instanceof ObjectId)) {

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -167,6 +167,9 @@ describe('types.documentarray', function(){
       threw = err;
     }
     assert.equal(false, threw);
+    // undefined and null should not match a nonexistent _id
+    assert.strictEqual(null, a.id(undefined));
+    assert.strictEqual(null, a.id(null));
 
     // test when _id is a populated document
     var Custom = new Schema({


### PR DESCRIPTION
Fixes a bug introduced by a190d41. The tests in this PR pass in 4.0.6 but fail in 4.0.7.

When assigning a new array to a MongooseDocumentArray, with both arrays containing multiple objects/subdocuments (respectively) without _id fields, the resulting array would consist entirely of the first element. This code example explains it better:

    var mongoose = require('mongoose');
    var Foo = mongoose.model('Foo', new mongoose.Schema({
        things: [{
            _id: false,
            name: String
        }]
    }));
    var fooInstance = new Foo();

    var thingsArray = [
        {name: 'qux'},
        {name: 'baz'},
        {name: 'bar'}
    ];

    fooInstance.things = thingsArray;
    console.log(fooInstance.things);
    // Works!
    // => [
    //   {name: 'qux'},
    //   {name: 'baz'},
    //   {name: 'bar'}
    // ]

    fooInstance.things = thingsArray;
    console.log(fooInstance.things);
    // Broken :(
    // => [
    //   {name: 'qux'},
    //   {name: 'qux'},
    //   {name: 'qux'}
    // ]
