### PR TITLE
Bug fix: Model#save should pass numberAffected as 0 when nothing changed

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -161,7 +161,7 @@ Model.prototype.$__handleSave = function $__handleSave(options) {
         });
       } else {
         _this.$__reset();
-        resolve(_this);
+        resolve();
         return;
       }
 
@@ -2222,7 +2222,7 @@ function subPopulate (docs, options, cb) {
   if (!pop) {
     return cb;
   }
-  
+
   // normalize as array
   if (!Array.isArray(pop)) {
     pop = [pop];

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4309,6 +4309,7 @@ describe('Model', function(){
         new DefaultErr().save();
       })
     });
+
     it('returns number of affected docs', function(done){
       var db = start()
       var schema = new Schema({ name: String });
@@ -4325,7 +4326,29 @@ describe('Model', function(){
           done();
         });
       });
-    })
+    });
+
+    it('returns 0 as the number of affected docs if doc was not modified', function(done){
+      var db = start(),
+          schema = new Schema({ name: String }),
+          Model = db.model('AffectedDocsAreReturned', schema),
+          doc = new Model({ name: 'aaron' });
+
+      doc.save(function (err, doc, affected) {
+        assert.ifError(err);
+        assert.equal(1, affected);
+
+        Model.findById(doc.id).then(function(doc) {
+          doc.save(function (err, doc, affected) {
+            db.close();
+            assert.ifError(err);
+            assert.equal(0, affected);
+            done();
+          });
+        });
+      });
+    });
+
     it('saved changes made within callback of a previous no-op save gh-1139', function(done){
       var db = start()
         , B = db.model('BlogPost', collection);
@@ -4351,7 +4374,6 @@ describe('Model', function(){
         })
       })
     })
-
 
     it('rejects new documents that have no _id set (1595)', function(done){
       var db = start();


### PR DESCRIPTION
Currently, calling `Model#save` on an unchanged document results in `numberAffected` in the callback being set to the document itself. According to the docs, `numberAffected` should always be `0` or `1` (never a document):
> ... `numberAffected` which will be 1 when the document was found and updated in the database, otherwise 0.

In mongoose v3.x this used to work as expected, it was only after upgrading to v4 that we noticed this.