### PR TITLE
Bug fix: default fields should not dirty a document across saves

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1303,8 +1303,9 @@ Document.prototype.$__reset = function reset () {
     }
   });
 
-  // Clear 'modify'('dirty') cache
+  // Clear 'dirty' cache
   this.$__.activePaths.clear('modify');
+  this.$__.activePaths.clear('default');
   this.$__.validationError = undefined;
   this.errors = undefined;
   var self = this;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1765,6 +1765,25 @@ describe('Model', function(){
         });
       });
     });
+
+    it('do not cause the document to stay dirty after save', function(done){
+      var db = start(),
+          Model = db.model('SavingDefault', new Schema({ name: { type: String, default: 'saving' }}), collection),
+          doc = new Model();
+
+      doc.save(function (err, doc, numberAffected) {
+        assert.ifError(err);
+        assert.strictEqual(1, numberAffected);
+
+        doc.save(function (err, doc, numberAffected) {
+          db.close();
+          assert.ifError(err);
+          // should not have saved a second time
+          assert.strictEqual(0, numberAffected);
+          done();
+        });
+      });
+    });
   });
 
   describe('virtuals', function(){


### PR DESCRIPTION
Currently, `document#save` does not clear the 'default' dirty cache. This means when you have a schema field with a `default` specified, sequential `document#save` calls will each execute a query even if no document changes occurred. This PR clears the 'default' dirty cache when a model is saved so the dirty check works appropriately across saves.