### PR TITLE
fix; updateValidators should not flatten dates (Fix #3194)

### DIFF
--- a/lib/services/updateValidators.js
+++ b/lib/services/updateValidators.js
@@ -7,7 +7,7 @@ var ValidationError = require('../error/validation.js');
 var ObjectId = require('../types/objectid');
 
 /**
- * Applies validators and defaults to update and fineOneAndUpdate operations,
+ * Applies validators and defaults to update and findOneAndUpdate operations,
  * specifically passing a null doc as `this` to validators and defaults
  *
  * @param {Query} query
@@ -171,5 +171,6 @@ function flatten(update, path) {
 function shouldFlatten(val) {
   return val &&
     typeof val === 'object' &&
+    !(val instanceof Date) &&
     !(val instanceof ObjectId);
 }

--- a/test/model.aggregate.test.js
+++ b/test/model.aggregate.test.js
@@ -120,7 +120,6 @@ describe('model aggregate', function(){
         .exec();
 
       promise.then(function(res){
-        console.log(res)
           assert.ok(promise instanceof mongoose.Promise);
           assert.ok(res);
           assert.equal(1, res.length);

--- a/test/updateValidators.unit.test.js
+++ b/test/updateValidators.unit.test.js
@@ -39,5 +39,22 @@ describe('updateValidators', function() {
         done();
       });
     });
+
+    it('doesnt flatten dates (gh-3194)', function(done) {
+      var dt = new Date();
+      var fn = updateValidators({}, schema, { test: dt }, {});
+      schema.doValidate.emitter.on('called', function(args) {
+        args.cb();
+      });
+      fn(function(err) {
+        assert.ifError(err);
+        assert.equal(schema.path.calls.length, 2);
+        assert.equal(schema.doValidate.calls.length, 1);
+        assert.equal('test', schema.path.calls[0]);
+        assert.equal('test', schema.path.calls[1]);
+        assert.equal(dt, schema.doValidate.calls[0].v);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This fixes updateValidators for Date fields. It was trying to flatten the Date object and thus not validating the value properly.