### PR TITLE
Bug Fix: Pre-init hooks on subdocs should be syncronous

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1600,6 +1600,21 @@ Document.prototype.$__registerHooksFromSchema = function () {
   });
   delete toWrap.post;
 
+  // 'init' should be synchronous on subdocuments
+  if (toWrap.init && self instanceof Embedded) {
+    if (toWrap.init.pre) {
+      toWrap.init.pre.forEach(function (args) {
+        self.pre.apply(self, args);
+      });
+    }
+    if (toWrap.init.post) {
+      toWrap.init.post.forEach(function (args) {
+        self.post.apply(self, args);
+      });
+    }
+    delete toWrap.init;
+  }
+
   Object.keys(toWrap).forEach(function (pointCut) {
     // this is so we can wrap everything into a promise;
     var newName = ('$__original_' + pointCut);


### PR DESCRIPTION
Currently, any subdocument with a pre-init hook is hydrated as a promise. For instance, take this schema:
```javascript
var childSchema = Schema({ age: Number }),
    parentSchema;
childSchema.pre('init', function() {});
parentSchema = Schema({ name: String, children: [childSchema] })
```
When you issue a query for a `Parent` document, its `children` will be promises as opposed to their actual values:
```javascript
{
  __v: 0,
  _id: 55b6c665a2f7a9670204c5cf,
  name: 'Bob',
  children: 
   [ { emitter: [Object], emitted: [Object], ended: false },
     { emitter: [Object], emitted: [Object], ended: false } ]
}
```

I'm not sure my solution is the best fix for this problem, please feel free to offer other ideas. The test I added does check this condition. My fix makes the test pass and I *believe* it doesn't break anything else.