### PR TITLE
handleArray should ensure val is an Array.

### DIFF
--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -63,6 +63,9 @@ SchemaBoolean.prototype.cast = function (value) {
 
 function handleArray (val) {
   var self = this;
+  if (!Array.isArray(val)) {
+    return [self.cast(val)];
+  }
   return val.map(function (m) {
     return self.cast(m);
   });

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -136,6 +136,9 @@ function handleSingle (val) {
 
 function handleArray (val) {
   var self = this;
+  if (!Array.isArray(val)) {
+    return [this.castForQuery(val)];
+  }
   return val.map( function (m) {
     return self.castForQuery(m);
   });

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -127,6 +127,9 @@ function handleSingle (val) {
 
 function handleArray (val) {
   var self = this;
+  if (!Array.isArray(val)) {
+    return [this.cast(val)];
+  }
   return val.map( function (m) {
     return self.cast(m);
   });

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -227,6 +227,9 @@ function handleSingle (val) {
 
 function handleArray (val) {
   var self = this;
+  if (!Array.isArray(val)) {
+    return [this.cast(val)];
+  }
   return val.map(function (m) {
     return self.cast(m)
   });

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -137,6 +137,9 @@ function handleSingle (val) {
 
 function handleArray (val) {
   var self = this;
+  if (!Array.isArray(val)) {
+    return [self.cast(val)];
+  }
   return val.map(function (m) {
     return self.cast(m);
   });

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -318,6 +318,9 @@ function handleSingle (val) {
 
 function handleArray (val) {
   var self = this;
+  if (!Array.isArray(val)) {
+    return [this.castForQuery(val)];
+  }
   return val.map(function (m) {
     return self.castForQuery(m);
   });

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -1,3 +1,4 @@
+/* vim: set softtabstop=2 ts=2 sw=2 expandtab tw=120: */
 
 /**
  * Test dependencies.
@@ -135,6 +136,26 @@ describe('model query casting', function(){
       });
     });
   })
+
+  it('casts $in values of arrays with single item instead of array (jrl-3238)', function(done) {
+    var db = start()
+      , BlogPostB = db.model(modelName, collection);
+
+    var post = new BlogPostB()
+      , id = post._id.toString()
+
+    post.save(function (err) {
+      assert.ifError(err);
+
+      BlogPostB.findOne({ _id: { $in: id } }, function (err, doc) {
+        assert.ifError(err);
+
+        assert.equal(doc._id.toString(), id);
+        db.close();
+        done();
+      });
+    });
+  });
 
   it('casts $nin values of arrays (gh-232)', function(done){
     var db = start()


### PR DESCRIPTION
It seems reasonable that the `handleArray` helper method should validate that the passed value is in fact an array or coerce it into such rather than try and call `map` on a non-array object. The lack of this protection caused me some grief recently when a single value was accidentally passed in for an `$in` condition.