### PR TITLE
Fixed getUpdate() in pre update hooks

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2054,6 +2054,8 @@ Query.prototype.update = function (conditions, doc, options, callback) {
     this.setOptions(options);
   }
 
+  if (!this._update) this._update = castedDoc;
+
   // Hooks
   if (callback) {
     return this._execUpdate(castedQuery, castedDoc, options, callback);


### PR DESCRIPTION
The problem:
````javascript
// whatever schema
schema.pre('update', function(next) {
    console.log('update', this.getUpdate()); // used to be null!
    next();
});

var Model = mongoose.model('model', schema);
Model.update({_id: 1}, {hello: 'world'}, {}, function(err, result) {
    // whatever
});
````