### PR TITLE
Deleting with _id undefined will remove all records

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1915,6 +1915,24 @@ describe('Model', function(){
         });
       });
     });
+
+    it('should not remove any records when deleting by id undefined', function(done) {
+      var db = start();
+      var collection = 'blogposts_' + random();
+      var BlogPost = db.model('BlogPost', collection);
+
+      BlogPost.create({ title: 1 }, { title: 2 }, function (err) {
+        assert.ifError(err);
+
+        BlogPost.remove({_id: undefined}, function(err) {
+          assert.ifError(err);
+          BlogPost.find({}, function (err, found) {
+            assert.equal(found.length, 1, 'Should not remove any records');
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('#remove()', function(){


### PR DESCRIPTION
Using `Model.remove({_id: undefined}, cb);` will remove all records from the collection.

I noticed this issue by chance from one of our [broken] tests when i upgraded from 4.1.0 to 4.1.2, my test was fixed and works ok now (no longer sending `undefined`) but this should be addressed here...