### PR TITLE
Changed Comments to Comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ m.save(); // does not work b/c the default connection object was never connected
 In the first example snippet, we defined a key in the Schema that looks like:
 
 ```
-comments: [Comments]
+comments: [Comment]
 ```
 
-Where `Comments` is a `Schema` we created. This means that creating embedded documents is as simple as:
+Where `Comment` is a `Schema` we created. This means that creating embedded documents is as simple as:
 
 ```js
 // retrieve my model


### PR DESCRIPTION
In the description of Embedded Documents, the **Comments** schema should be **Comment** as it's what has been defined previously, or it will be quite confusing