### PR TITLE
fix a regression with MONGOOSE_DRIVER_PATH

### DIFF
--- a/lib/drivers/index.js
+++ b/lib/drivers/index.js
@@ -5,8 +5,7 @@
 var driver;
 
 if (typeof window === 'undefined') {
-  driver = require('./' +
-    (global.MONGOOSE_DRIVER_PATH || 'node-mongodb-native'));
+  driver = require(global.MONGOOSE_DRIVER_PATH || './node-mongodb-native');
 } else {
   driver = require('./browser');
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -453,19 +453,19 @@ Mongoose.prototype.__defineGetter__('connection', function(){
  * Driver depentend APIs
  */
 
-var driver = global.MONGOOSE_DRIVER_PATH || 'node-mongodb-native';
+var driver = global.MONGOOSE_DRIVER_PATH || './drivers/node-mongodb-native';
 
 /*!
  * Connection
  */
 
-var Connection = require('./drivers/' + driver + '/connection');
+var Connection = require(driver + '/connection');
 
 /*!
  * Collection
  */
 
-var Collection = require('./drivers/' + driver + '/collection');
+var Collection = require(driver + '/collection');
 
 /**
  * The Mongoose Aggregate constructor


### PR DESCRIPTION
`MONGOOSE_DRIVER_PATH` should not be relative to the mongoose driver folder but must expect a valid absolute path, since it was changed it broke the compatibility of some modules that use it to load there custom drivers, ex: [sergeyksv/tungus](/sergeyksv/tungus).