### PR TITLE
Return null if casting an empty string to a date. Fixes #3134.

### DIFF
--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -209,7 +209,7 @@ SchemaDate.prototype.max = function(value, message) {
 SchemaDate.prototype.cast = function(value) {
   // If null or undefined
   if (value == null || value === '')
-    return value;
+    return null;
 
   if (value instanceof Date)
     return value;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -306,6 +306,8 @@ describe('schema', function() {
       assert.ok(Loki.path('birth_date').cast(1294525628301) instanceof Date);
       assert.ok(Loki.path('birth_date').cast('8/24/2000') instanceof Date);
       assert.ok(Loki.path('birth_date').cast(new Date) instanceof Date);
+      assert.ok(Loki.path('birth_date').cast('') === null);
+      assert.ok(Loki.path('birth_date').cast(null) === null);
       done();
     });
 


### PR DESCRIPTION
This fixes #3134: Empty strings are being saved for date types. Casting an empty string to a date should return null not `''`.

It looks like this was accidentally changed in the fix for #2272 commit 0ac0596368394edec115a47fb78d148f67ea29af