### PR TITLE
Fix TypeError: this.get is not a function

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1453,6 +1453,7 @@ function defineKey(prop, subprops, prototype, prefix, keys) {
       enumerable: true
       , configurable: true
       , get: function() {
+          var _self = this;
           if (!this.$__.getters)
             this.$__.getters = {};
 
@@ -1478,7 +1479,7 @@ function defineKey(prop, subprops, prototype, prefix, keys) {
             }
 
             nested.toObject = function() {
-              return this.get(path);
+              return _self.get(path);
             };
 
             nested.toJSON = nested.toObject;


### PR DESCRIPTION
Fix a reference error after a valid `find()` 

      TypeError: this.get is not a function
        at Object.nested.toObject (/home/workspace/programming/code/mongoose/lib/document.js:1481:27)