### PR TITLE
gh-3368 adding maxlength and minlength string validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(DOCFILE): $(DOCS)
 	node website.js
 
 %.json: %.js
-	@echo "\n### $(patsubst lib//%,lib/%, $^)" >> $(DOCFILE)
+	@echo -e "\n### $(patsubst lib//%,lib/%, $^)" >> $(DOCFILE)
 	./node_modules/dox/bin/dox < $^ >> $(DOCFILE)
 
 site:

--- a/docs/validation.jade
+++ b/docs/validation.jade
@@ -18,7 +18,7 @@ block content
 
     - All [SchemaTypes](./schematypes.html) have the built in [required](./api.html#schematype_SchemaType-required) validator.
     - [Numbers](./api.html#schema-number-js) have [min](./api.html#schema_number_SchemaNumber-min) and [max](./api.html#schema_number_SchemaNumber-max) validators.
-    - [Strings](./api.html#schema-string-js) have [enum](./api.html#schema_string_SchemaString-enum) and [match](./api.html#schema_string_SchemaString-match) validators.
+    - [Strings](./api.html#schema-string-js) have [enum](./api.html#schema_string_SchemaString-enum), [match](./api.html#schema_string_SchemaString-match), [maxlength](./api.html#schema_string_SchemaString-maxlength) and [minlength](./api.html#schema_string_SchemaString-minlength) validators.
 
     Each of the validator links above provide more information about how to enable them as well as customize their associated error messages.
   h3#customized Custom validators


### PR DESCRIPTION
This pull request fixes #3368 which adds maxlength and minlength validation to validation docs

This also has a minor Makefile fix. I have added -e flag to the echo command on the docs build.