### PR TITLE
Ensuring properties are casted. This fixes #3435

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -326,7 +326,6 @@ function cast$all(val) {
 }
 
 function cast$elemMatch(val) {
-  var hasDollarKey = false;
   var keys = Object.keys(val);
   var numKeys = keys.length;
   var key;
@@ -336,11 +335,7 @@ function cast$elemMatch(val) {
     value = val[key];
     if (key.indexOf('$') === 0 && value) {
       val[key] = this.castForQuery(key, value);
-      hasDollarKey = true;
     }
-  }
-  if (hasDollarKey) {
-    return val;
   }
 
   return cast(this.casterConstructor.schema, val);


### PR DESCRIPTION
I found that when 'hasDollarSign' is set to true the value is returned [see here](https://github.com/Automattic/mongoose/blob/389c8d01576ced32f5cbe5e3001b008c83946ab1/lib/schema/array.js#L342-L344).

This causes properties to not get cased to ObjectId and other types.