### PR TITLE
Emit events when each individual index starts and completes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -866,15 +866,30 @@ Model.ensureIndexes = function ensureIndexes(cb) {
     promise.resolve(err);
   };
 
+  var indexSingleDone = function(err, fields, options, name) {
+    self.emit('index-single-done', err, fields, options, name);
+  };
+  var indexSingleStart = function(fields, options) {
+    self.emit('index-single-start', fields, options);
+  };
+
   var create = function() {
     var index = indexes.shift();
     if (!index) return done();
 
+    var indexFields = index[0];
     var options = index[1];
     options.safe = safe;
-    self.collection.ensureIndex(index[0], options, tick(function(err) {
-      if (err) return done(err);
-      create();
+    
+    indexSingleStart(indexFields, options);
+
+    self.collection.ensureIndex(indexFields, options, tick(function(err,name) {
+      indexSingleDone(err,indexFields, options, name);
+      if (err) {
+      	return done(err);
+      } else {
+        create();
+      }
     }));
   };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -36,6 +36,8 @@ var VERSION_WHERE = 1
  * @inherits Document
  * @event `error`: If listening to this event, it is emitted when a document was saved without passing a callback and an `error` occurred. If not listening, the event bubbles to the connection used to create this Model.
  * @event `index`: Emitted after `Model#ensureIndexes` completes. If an error occurred it is passed with the event.
+ * @event `index-single-start`: Emitted when an individual index starts within `Model#ensureIndexes`. The fields and options being used to build the index are also passed with the event.
+ * @event `index-single-done`: Emitted when an individual index finishes within `Model#ensureIndexes`. If an error occurred it is passed with the event. The fields, options, and index name are also passed.
  * @api public
  */
 


### PR DESCRIPTION
Currently Mongoose will emit an `index` event when all indexes have finished building. This would happen for example when `ensureIndexes()` is finished. Since some indexes can be quite large and take a long time, it would be nice to know when each individual index is finished competing. 

This pull request adds two new emit events to Mongoose schema objects:

`index-single-start` : when an individual index build begins.
`index-single-done` : when an individual index build finishes.

For example:

```js
Model.on('index-single-done', function(err, fields, options, name)
{
	if ( err ) {
		Logger.error('[INDEXER] Model:'+Model.modelName+' failed to build index: '+name+'. Options='+JSON.stringify(options)+
			'. Err='+err);			
	} else {
		Logger.info('[INDEXER] Model:'+Model.modelName+' built index: '+name+'. Options='+JSON.stringify(options));
	}
});
Model.on('index-single-start', function(fields, options)
{
		Logger.info('[INDEXER] Model:'+Model.modelName+' starting index on '+JSON.stringify(fields));	
});
```