### PR TITLE
Authentication will now still occur when auth method is MONGODB-X509 and no password is supplied.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -480,7 +480,7 @@ Connection.prototype.onOpen = function(callback) {
   }
 
   // re-authenticate
-  if (self.user && (self.pass || self.authMechanismDoesNotRequirePassword())) {
+  if (this.shouldAuthenticate()) {
     self.db.authenticate(self.user, self.pass, self.options.auth, function(err) {
       open(err, true);
     });
@@ -680,6 +680,25 @@ Connection.prototype.modelNames = function() {
   return Object.keys(this.models);
 };
 
+/**
+ * @brief Returns if the connection requires authentication after it is opened. Generally if a
+ * username and password are both provided than authentication is needed, but in some cases a
+ * password is not required.
+ * @api private
+ * @return {Boolean} true if the connection should be authenticated after it is opened, otherwise false.
+ */
+Connection.prototype.shouldAuthenticate = function() {
+  return self.user && (self.pass || self.authMechanismDoesNotRequirePassword());
+}
+
+/**
+ * @brief Returns if the current authentication mechanism needs a password to authenticate according
+ * to the passed in options object. The options object is the one passed into the open and openSet
+ * methods.
+ * @api private
+ * @return {Boolean} true if the authentication mechanism specified in the options object requires
+ *  a password, otherwise false.
+ */
 Connection.prototype.authMechanismDoesNotRequirePassword = function() {
   if (this.options.auth) {
     return this.options.auth.authMechanism === 'MONGODB-X509';

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -480,7 +480,7 @@ Connection.prototype.onOpen = function(callback) {
   }
 
   // re-authenticate
-  if (self.user && self.pass) {
+  if (self.user && (self.pass || self.authMechanismDoesNotRequirePassword())) {
     self.db.authenticate(self.user, self.pass, self.options.auth, function(err) {
       open(err, true);
     });
@@ -679,6 +679,13 @@ Connection.prototype.model = function(name, schema, collection) {
 Connection.prototype.modelNames = function() {
   return Object.keys(this.models);
 };
+
+Connection.prototype.authMechanismDoesNotRequirePassword = function() {
+  if (this.config.auth) {
+    return this.config.auth.authMechanism === 'MONGODB-X509';
+  }
+  return true;
+}
 
 /*!
  * Module exports.

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -698,7 +698,8 @@ Connection.prototype.modelNames = function() {
  * @return {Boolean} true if the connection should be authenticated after it is opened, otherwise false.
  */
 Connection.prototype.shouldAuthenticate = function() {
-  return this.user && (this.pass || this.authMechanismDoesNotRequirePassword());
+  return (this.user != null) &&
+    ((this.pass != null) || this.authMechanismDoesNotRequirePassword());
 };
 
 /**
@@ -709,7 +710,7 @@ Connection.prototype.shouldAuthenticate = function() {
  *  a password, otherwise false.
  */
 Connection.prototype.authMechanismDoesNotRequirePassword = function() {
-  if (this.options.auth) {
+  if (this.options && this.options.auth) {
     return authMechanismsWhichDontRequirePassword.indexOf(this.options.auth.authMechanism) >= 0;
   }
   return true;
@@ -726,7 +727,9 @@ Connection.prototype.authMechanismDoesNotRequirePassword = function() {
  *   otherwise false.
  */
 Connection.prototype.optionsProvideAuthenticationData = function(options) {
-  return options && options.user && (options.pass || this.authMechanismDoesNotRequirePassword());
+  return (options != null) &&
+    (options.user != null) &&
+    ((options.pass != null) || this.authMechanismDoesNotRequirePassword());
 };
 
 /*!

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -681,8 +681,8 @@ Connection.prototype.modelNames = function() {
 };
 
 Connection.prototype.authMechanismDoesNotRequirePassword = function() {
-  if (this.config.auth) {
-    return this.config.auth.authMechanism === 'MONGODB-X509';
+  if (this.options.auth) {
+    return this.options.auth.authMechanism === 'MONGODB-X509';
   }
   return true;
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -230,7 +230,7 @@ Connection.prototype.open = function(host, database, port, options, callback) {
   }
 
   // authentication
-  if (options && options.user && (options.pass || this.authMechanismDoesNotRequirePassword())) {
+  if (this.optionsProvideAuthenticationData(options)) {
     this.user = options.user;
     this.pass = options.pass;
 
@@ -372,7 +372,7 @@ Connection.prototype.openSet = function(uris, database, options, callback) {
   }
 
   // authentication
-  if (options && options.user && options.pass) {
+  if (this.optionsProvideAuthenticationData(options)) {
     this.user = options.user;
     this.pass = options.pass;
 
@@ -692,9 +692,8 @@ Connection.prototype.shouldAuthenticate = function() {
 }
 
 /**
- * @brief Returns if the current authentication mechanism needs a password to authenticate according
- * to the passed in options object. The options object is the one passed into the open and openSet
- * methods.
+ * @brief Returns a boolean value that specifies if the current authentication mechanism needs a
+ * password to authenticate according to the auth objects passed into the open/openSet methods.
  * @api private
  * @return {Boolean} true if the authentication mechanism specified in the options object requires
  *  a password, otherwise false.
@@ -704,6 +703,20 @@ Connection.prototype.authMechanismDoesNotRequirePassword = function() {
     return this.options.auth.authMechanism === 'MONGODB-X509';
   }
   return true;
+}
+
+/**
+ * @brief Returns a boolean value that specifies if the provided objects object provides enough
+ * data to authenticate with. Generally this is true if the username and password are both specified
+ * but in some authentication methods, a password is not required for authentication so only a username
+ * is required.
+ * @param {Object} [options] the options object passed into the open/openSet methods.
+ * @api private
+ * @return {Boolean} true if the provided options object provides enough data to authenticate with,
+ *   otherwise false.
+ */
+Connection.prototype.optionsProvideAuthenticationData = function(options) {
+  return options && options.user && (options.pass || this.authMechanismDoesNotRequirePassword());
 }
 
 /*!

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -230,7 +230,7 @@ Connection.prototype.open = function(host, database, port, options, callback) {
   }
 
   // authentication
-  if (options && options.user && options.pass) {
+  if (options && options.user && (options.pass || this.authMechanismDoesNotRequirePassword())) {
     this.user = options.user;
     this.pass = options.pass;
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,6 +19,16 @@ var utils = require('./utils')
 
 var rgxProtocol = /^(?:.)+:\/\//;
 
+/*!
+ * A list of authentication mechanisms that don't require a password for authentication.
+ * This is used by the authMechanismDoesNotRequirePassword method.
+ *
+ * @api private
+ */
+var authMechanismsWhichDontRequirePassword = [
+  'MONGODB-X509'
+];
+
 /**
  * Connection constructor
  *
@@ -688,8 +698,8 @@ Connection.prototype.modelNames = function() {
  * @return {Boolean} true if the connection should be authenticated after it is opened, otherwise false.
  */
 Connection.prototype.shouldAuthenticate = function() {
-  return self.user && (self.pass || self.authMechanismDoesNotRequirePassword());
-}
+  return this.user && (this.pass || this.authMechanismDoesNotRequirePassword());
+};
 
 /**
  * @brief Returns a boolean value that specifies if the current authentication mechanism needs a
@@ -700,10 +710,10 @@ Connection.prototype.shouldAuthenticate = function() {
  */
 Connection.prototype.authMechanismDoesNotRequirePassword = function() {
   if (this.options.auth) {
-    return this.options.auth.authMechanism === 'MONGODB-X509';
+    return authMechanismsWhichDontRequirePassword.indexOf(this.options.auth.authMechanism) >= 0;
   }
   return true;
-}
+};
 
 /**
  * @brief Returns a boolean value that specifies if the provided objects object provides enough
@@ -717,7 +727,7 @@ Connection.prototype.authMechanismDoesNotRequirePassword = function() {
  */
 Connection.prototype.optionsProvideAuthenticationData = function(options) {
   return options && options.user && (options.pass || this.authMechanismDoesNotRequirePassword());
-}
+};
 
 /*!
  * Module exports.

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -269,7 +269,7 @@ describe('connections:', function() {
       done();
     });
 
-    it('but fails when passing user and no pass', function(done) {
+    it('but fails when passing user and no pass with standard authentication', function(done) {
       var db = mongoose.createConnection('localhost', 'fake', 27000, {user: 'no_pass'});
       db.on('error', function() {});
       assert.equal('object', typeof db.options);
@@ -282,6 +282,23 @@ describe('connections:', function() {
       assert.equal(27000, db.port);
       assert.equal(undefined, db.pass);
       assert.equal(undefined, db.user);
+      db.close();
+      done();
+    });
+
+    it('but passes when passing user and no pass with the MONGODB-X509 authMechanism', function(done) {
+      var db = mongoose.createConnection('localhost', 'fake', 27000, {user: 'no_pass', auth: {authMechanism: 'MONGODB-X509'}});
+      db.on('error', function() {});
+      assert.equal('object', typeof db.options);
+      assert.equal('object', typeof db.options.server);
+      assert.equal(true, db.options.server.auto_reconnect);
+      assert.equal('object', typeof db.options.db);
+      assert.equal(false, db.options.db.forceServerObjectId);
+      assert.equal('fake', db.name);
+      assert.equal('localhost', db.host);
+      assert.equal(27000, db.port);
+      assert.equal(undefined, db.pass);
+      assert.equal('no_pass', db.user);
       db.close();
       done();
     });
@@ -1131,6 +1148,139 @@ describe('connections:', function() {
       });
       db2.close();
 
+    });
+  });
+
+  describe('shouldAuthenticate()', function() {
+    describe('when using standard authentication', function() {
+      describe('when username and password are undefined', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, {});
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal(undefined, db.pass);
+          assert.equal(undefined, db.user);
+
+          assert.equal(false, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
+      describe('when only username is defined', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, { user: 'user' });
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal(undefined, db.pass);
+          assert.equal(undefined, db.user);
+
+          assert.equal(false, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
+      describe('when both username and password are defined', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, { user: 'user', pass: 'pass' });
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal('pass', db.pass);
+          assert.equal('user', db.user);
+
+          assert.equal(true, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
+    });
+    describe('when using MONGODB-X509 authentication', function() {
+      describe('when username and password are undefined', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, {});
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal(undefined, db.pass);
+          assert.equal(undefined, db.user);
+
+          assert.equal(false, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
+      describe('when only username is defined', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, { user: 'user', auth: { authMechanism: 'MONGODB-X509' } });
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal(undefined, db.pass);
+          assert.equal('user', db.user);
+
+          assert.equal(true, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
+      describe('when both username and password are defined', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, { user: 'user', pass: 'pass', auth: { authMechanism: 'MONGODB-X509' } });
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal('pass', db.pass);
+          assert.equal('user', db.user);
+
+          assert.equal(true, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
I use MONGODB-X509 authentication with my mongo DB and I have found a problem with the logic around whether mongoose should authenticate or not.

MONGODB-X509 authentication uses certificates to authenticate clients instead of a password. This means that you can leave the password field blank. The problem is that currently if you leave the password as blank than authentication doesn't happen at all and you do not have permissions to execute anything on the database.

I have added a method that checks if the current authentication method needs a password and, if it does not, still calls the mongo driver's authenticate method.

Have I missed any other places where authenticate would be called?

Thanks!

