### PR TITLE
Make array props non-enumerable

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -28,6 +28,12 @@ function MongooseArray (values, path, doc) {
   var arr = [].concat(values);;
   arr.__proto__ = MongooseArray.prototype;
 
+  Object.defineProperty(arr, '_atomics', { enumerable: false, configurable: true, writable: true });
+  Object.defineProperty(arr, 'validators', { enumerable: false, configurable: true, writable: true });
+  Object.defineProperty(arr, '_path', {enumerable: false, configurable: true, writable: true });
+  Object.defineProperty(arr, '_parent', { enumerable: false, configurable: true, writable: true });
+  Object.defineProperty(arr, '_schema', { enumerable: false, configurable: true, writable: true });
+
   arr._atomics = {};
   arr.validators = [];
   arr._path = path;

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -36,6 +36,7 @@ describe('types array', function(){
     assert.ok(a instanceof Array);
     assert.ok(a instanceof MongooseArray);
     assert.equal(true, Array.isArray(a));
+    assert.deepEqual(Object.keys(a), Object.keys(a.toObject()));
     assert.deepEqual(a._atomics.constructor, Object);
     done();
   });


### PR DESCRIPTION
Libraries like `should` and `chai` do an array comparison by checking the length of `Object.keys(array)` (among other things).  Because a `MongooseArray` has a few properties that are enumerable, `Object.keys` will return them, and so the equality test fails.  To get around this, you have to call `toObject` on the `MongooseArray`.  This works, but it prevents you from testing a full object at once, and instead forces you to test each property separately.

This pull marks those `MongooseArray` properties as non-enumerable, so that they are not returned by `Object.keys`.  I added a new test to verify this works, and all existing tests pass.