### PR TITLE
Fix comment of Query.setOptions to specify correct read preference option

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -852,11 +852,12 @@ Query.prototype.read = function read(pref, tags) {
  * - [comment](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24comment) *
  * - [snapshot](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bsnapshot%28%29%7D%7D) *
  * - [hint](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24hint) *
- * - [slaveOk](http://docs.mongodb.org/manual/applications/replication/#read-preference) *
+ * - [readPreference](http://docs.mongodb.org/manual/applications/replication/#read-preference) **
  * - [lean](./api.html#query_Query-lean) *
  * - [safe](http://www.mongodb.org/display/DOCS/getLastError+Command)
  *
  * _* denotes a query helper method is also available_
+ * _** query helper method to set `readPreference` is `read()`_
  *
  * @param {Object} options
  * @api public


### PR DESCRIPTION
Reported in https://github.com/Automattic/mongoose/issues/3470. The old comment referred to `slaveOk`, which is deprecated. This pull request updated the comment to use `readPreference` instead.