### PR TITLE
Pluralize Mongoose 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mquery": "1.6.3",
     "ms": "0.1.0",
     "muri": "1.0.0",
-    "pluralize-mongoose": "0.1.0",
+    "pluralize-mongoose": "0.2.0",
     "regexp-clone": "0.0.1",
     "sliced": "0.0.5"
   },


### PR DESCRIPTION
Differences in filtering between Mongoose and Pluralize resulted in #3490
This update resolves #3490 by using the old filtering system.