### PR TITLE
optionsProvideAuthenticationData logic refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ test/triage/*.js
 /inspections
 bin/mongoose.min.js
 coverage
+
+# Visual Studio
+# =========
+*.suo
+*.ntvs*
+*.njsproj
+*.sln

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -727,9 +727,9 @@ Connection.prototype.authMechanismDoesNotRequirePassword = function() {
  *   otherwise false.
  */
 Connection.prototype.optionsProvideAuthenticationData = function(options) {
-  return (options != null) &&
-    (options.user != null) &&
-    ((options.pass != null) || this.authMechanismDoesNotRequirePassword());
+  return (options) &&
+    (options.user) &&
+    ((options.pass) || this.authMechanismDoesNotRequirePassword());
 };
 
 /*!

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1174,6 +1174,27 @@ describe('connections:', function() {
           done();
         });
       });
+      describe('when username and password are empty strings', function() {
+        it('should return false', function(done) {
+          var db = mongoose.createConnection('localhost', 'fake', 27000, { user: '', pass: ''});
+          db.on('error', function() {});
+          assert.equal('object', typeof db.options);
+          assert.equal('object', typeof db.options.server);
+          assert.equal(true, db.options.server.auto_reconnect);
+          assert.equal('object', typeof db.options.db);
+          assert.equal(false, db.options.db.forceServerObjectId);
+          assert.equal('fake', db.name);
+          assert.equal('localhost', db.host);
+          assert.equal(27000, db.port);
+          assert.equal(undefined, db.pass);
+          assert.equal(undefined, db.user);
+
+          assert.equal(false, db.shouldAuthenticate());
+
+          db.close();
+          done();
+        });
+      });
       describe('when only username is defined', function() {
         it('should return false', function(done) {
           var db = mongoose.createConnection('localhost', 'fake', 27000, { user: 'user' });


### PR DESCRIPTION
As described in #3484 

Removes the null check for the user/pass options
in the optionsProvideAuthenticationData method of Connection. This reverts the logic back to it's previous state before https://github.com/Automattic/mongoose/commit/9af0d5fb0c5ffd4f8382715a1837e3c110b4ed3b

Adds a test to verify empty strings provided for the user/pass options
properly bypass authentication.

connections:
  shouldAuthenticate()
    when using standard authentication
      when username and password are empty strings