### PR TITLE
repro; #3478

### DIFF
--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -4,6 +4,7 @@
 
 var start = require('./common')
   , assert = require('assert')
+  , domain = require('domain')
   , mongoose = start.mongoose
   , random = require('../lib/utils').random
   , Schema = mongoose.Schema
@@ -121,6 +122,20 @@ describe('model', function() {
       });
     });
 
+    it('does not swallow exceptions (gh-3222) (gh-3478)', function(done) {
+      var d = domain.create();
+      B.create({title: 'hi'}, function (err) {
+        assert.ifError(err);
+        d.run(function () {
+          throw new Error('This exception should be caught by the domain');
+        });
+      });
+
+      d.once('error', function (err) {
+        assert.equal(err.message, 'This exception should be caught by the domain');
+        done();
+      });
+    });
 
     describe('callback is optional', function() {
       it('with one doc', function(done) {


### PR DESCRIPTION
A test that reproduces #3478 and #3222 and confirms the fix introduced by 6b24976a and 5e78a568 actually works.

A related discussion about how to test these kind of behaviors came up in https://github.com/Automattic/mongoose/issues/3399#issuecomment-142713133:
> And testing this is really hard, unless you're willing to go the process.on('unchaughtException'); route. I'm open to alternative suggestions though :)

This PR uses [domain](https://nodejs.org/api/domain.html) to route exceptions through the test, instead of messing with `process.on('unchaughtException')`. Do you think this is a valid approach?