### PR TITLE
Failing test for using update() to set a buffer.

### DIFF
--- a/test/types.buffer.test.js
+++ b/test/types.buffer.test.js
@@ -380,6 +380,25 @@ describe('types.buffer', function() {
 
   });
 
+  it('can be directly updated', function(done) {
+    var db = start()
+      , User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
+    var user = new User({ array: [null], required: new Buffer(1) });
+    user.save(function(err, doc) {
+      assert.ifError(err);
+      assert(doc);
+
+      var conditions = { _id: doc._id }
+        , updateStatement = { $set: {required: new Buffer([123, 456, 789])} };
+
+      User.update(conditions, updateStatement, function(err) {
+        db.close();
+        assert.ifError(err);
+        done();
+      });
+    });
+  });
+
   describe('#toObject', function() {
     it('retains custom subtypes', function(done) {
       var buf = new MongooseBuffer(0);


### PR DESCRIPTION
Failing test only. This test passes in Node 0.12 but fails in Node 4.1.2.

As I mentioned in #3496, I think this is because `utils.mergeClone` treats a buffer as an object in Node 0.12 but not in Node 4. The determination is made by `utils.isObject`.

In node 0.12:

    Object.prototype.toString.call(new Buffer([])) // [object Object]

In node 4.1.2

    Object.prototype.toString.call(new Buffer([])) // [object Uint8Array]