### PR TITLE
Fix documentation error for Aggregate

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -33,7 +33,7 @@ var read = Query.prototype.read;
  *
  * - The documents returned are plain javascript objects, not mongoose documents (since any shape of document can be returned).
  * - Requires MongoDB >= 2.1
- * - Mongoose does **not** cast pipeline stages. `new Aggregate({ $match: { _id: '00000000000000000000000a' } });` will not work unless `_id` is a string in the database. Use `new Aggregate({ $match: { _id: mongoose.Schema.Types.ObjectId('00000000000000000000000a') } });` instead.
+ * - Mongoose does **not** cast pipeline stages. `new Aggregate({ $match: { _id: '00000000000000000000000a' } });` will not work unless `_id` is a string in the database. Use `new Aggregate({ $match: { _id: mongoose.Types.ObjectId('00000000000000000000000a') } });` instead.
  *
  * @see MongoDB http://docs.mongodb.org/manual/applications/aggregation/
  * @see driver http://mongodb.github.com/node-mongodb-native/api-generated/collection.html#aggregate


### PR DESCRIPTION
In the current api docs, is said to use `mongoose.Schema.Types.ObjectId(String)` to convert a string to an ObjectId, but the correct is `mongoose.Types.ObjectId(String)`

Regards