### PR TITLE
repro; #3521

### DIFF
--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -757,6 +757,36 @@ describe('schema', function() {
       });
     });
 
+    it('should allow an array of subdocuments with enums (gh-3521)', function(done) {
+      var coolSchema = new Schema({
+        votes: [{
+          vote: { type: String, enum: ['cool', 'not-cool'] }
+        }]
+      });
+      var Cool = mongoose.model('gh-3521', coolSchema, 'gh-3521');
+
+      var cool = new Cool();
+      cool.votes.push(cool.votes.create({
+        vote: 'cool'
+      }));
+      cool.validate(function(error) {
+        assert.ifError(error);
+
+        var terrible = new Cool();
+        terrible.votes.push(terrible.votes.create({
+          vote: 'terrible'
+        }));
+        terrible.validate(function(error) {
+          assert.ok(error);
+          assert.ok(error.errors['votes.0.vote']);
+          assert.equal(error.errors['votes.0.vote'].message,
+            '`terrible` is not a valid enum value for path `vote`.');
+
+          done();
+        });
+      });
+    });
+
     it('doesnt do double validation on document arrays (gh-2618)', function(done) {
       var A = new Schema({str: String});
       var B = new Schema({a: [A]});


### PR DESCRIPTION
@vkarpov15 so here’s a test scenario for #3521.

It happens in very specific cases (the test may need to be rewritten a little to highlight those specificities).

The subdocument has to be created with `subdoc.create()` and pushed into the mongoose array.
If you also add a `required` attribute to the `votes.vote` field, the validation works fine, for some reason.

I am not sure where to fix that in the code, so here’s a test, that may help you pinpoint where it is failing exactly.