### PR TITLE
Fix hang encountered with custom id type that contains a buffer

### DIFF
--- a/lib/services/updateValidators.js
+++ b/lib/services/updateValidators.js
@@ -174,5 +174,6 @@ function shouldFlatten(val) {
   return val &&
     typeof val === 'object' &&
     !(val instanceof Date) &&
-    !(val instanceof ObjectId);
+    !(val instanceof ObjectId) &&
+    !(val instanceof Buffer);
 }


### PR DESCRIPTION
modifiedPaths() walks the object structure, encounters the Buffer, then
encounters the parent of the buffer, which hangs the server for up to 30
seconds.