### PR TITLE
docs; clarify param projection in findOne

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1192,10 +1192,11 @@ Query.prototype._findOne = function(callback) {
  *     });
  *
  * @param {Object|Query} [criteria] mongodb selector
- * @param {Object} [projection] optional fields to return (http://bit.ly/1HotzBo)
+ * @param {Object} [projection] optional fields to return
  * @param {Function} [callback]
  * @return {Query} this
  * @see findOne http://docs.mongodb.org/manual/reference/method/db.collection.findOne/
+ * @see Query.select #query_Query-select
  * @api public
  */
 


### PR DESCRIPTION
1. Short link removed because it's a duplicate of `@see findOne`.
2. `@see Query.select` added because of its relation to the `projection` argument.

Thank you!