### PR TITLE
add subdocs of single nested first for proper hook order

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1631,8 +1631,8 @@ Document.prototype.$__getAllSubdocs = function() {
 
     if (val instanceof Embedded) seed.push(val);
     if (val && val.$isSingleNested) {
-      seed.push(val);
       seed = Object.keys(val._doc).reduce(docReducer.bind(val._doc), seed);
+      seed.push(val);
     }
     if (val && val.isMongooseDocumentArray) {
       val.forEach(function _docReduce(doc) {


### PR DESCRIPTION
This is in reference to my last comment on https://github.com/Automattic/mongoose/issues/3680
By adding the sub-docs of the single nested first, pre-save can be bottom-up (e.g. embedded > single nested > parent) and post-save can be top-down (e.g. parent > single nested > embedded).

This is a critical flow for encryption tools like https://github.com/joegoldbeck/mongoose-encryption