### PR TITLE
fix(schema): more duck-typing (fixes #3690)

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -541,7 +541,7 @@ Schema.interpretAsType = function(path, obj, options) {
       ? obj.cast
       : type[0];
 
-    if (cast instanceof Schema) {
+    if (cast && cast.instanceOfSchema) {
       return new MongooseTypes.DocumentArray(path, cast, obj);
     }
 
@@ -565,7 +565,7 @@ Schema.interpretAsType = function(path, obj, options) {
     return new MongooseTypes.Array(path, cast || MongooseTypes.Mixed, obj);
   }
 
-  if (type instanceof Schema) {
+  if (type && type.instanceOfSchema) {
     return new MongooseTypes.Embedded(type, path, obj);
   }
 


### PR DESCRIPTION
I encountered other issues along the way that led me to duck-type a couple of extra `instanceof` calls in `schema.js`. Did thought that it was not necessary at first sight.