### PR TITLE
Update mongo driver to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bson": "0.4.19",
     "hooks-fixed": "1.1.0",
     "kareem": "1.0.1",
-    "mongodb": "2.1.0",
+    "mongodb": "2.1.2",
     "mpath": "0.1.1",
     "mpromise": "0.5.4",
     "mquery": "1.6.3",


### PR DESCRIPTION
This fixes the "No primary server available" errors that occur under high load.

https://jira.mongodb.org/browse/NODE-622