### PR TITLE
Fix support for array pipeline argument when using Aggregate#append

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -83,7 +83,9 @@ Aggregate.prototype.model = function(model) {
  */
 
 Aggregate.prototype.append = function() {
-  var args = utils.args(arguments);
+  var args = (1 === arguments.length && util.isArray(arguments[0]))
+      ? arguments[0]
+      : utils.args(arguments);
 
   if (!args.every(isOperator)) {
     throw new Error("Arguments must be aggregate pipeline operators");

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -67,6 +67,18 @@ describe('aggregate: ', function() {
       done();
     });
 
+    it('supports array as single argument', function (done) {
+      var aggregate = new Aggregate();
+
+      assert.equal(aggregate.append([{$a: 1}, {$b: 2}, {$c: 3}]), aggregate);
+      assert.deepEqual(aggregate._pipeline, [{$a: 1}, {$b: 2}, {$c: 3}]);
+
+      aggregate.append([{$d: 4}, {$c: 5}]);
+      assert.deepEqual(aggregate._pipeline, [{$a: 1}, {$b: 2}, {$c: 3}, {$d: 4}, {$c: 5}]);
+
+      done();
+    });
+
     it('throws if non-operator parameter is passed', function(done) {
       var aggregate = new Aggregate(),
           regexp = /Arguments must be aggregate pipeline operators/;
@@ -83,6 +95,10 @@ describe('aggregate: ', function() {
         aggregate.append({ $a: 1 }, { a: 1 });
       }, regexp);
 
+      assert.throws(function () {
+        aggregate.append([{$a: 1}, {a: 1}]);
+      }, regexp);
+
       done();
     });
 
@@ -91,6 +107,16 @@ describe('aggregate: ', function() {
 
       assert.doesNotThrow(function() {
         aggregate.append();
+      });
+
+      done();
+    });
+
+    it('does not throw when empty array is passed as single argument', function (done) {
+      var aggregate = new Aggregate();
+
+      assert.doesNotThrow(function () {
+        aggregate.append([]);
       });
 
       done();


### PR DESCRIPTION
I have an issue where it's not possible to append an array of pipeline operators to an existing aggregate query object. I searched for a related issue, and couldn't find an explanation as to why this feature is ommited.

The docs state it is possible to use `Aggregate#append` with an array of pipeline operators, but the output is an error: **Error: Arguments must be aggregate pipeline operators**. Support for an array of pipeline operators exists for the `Aggregate` constructor, so I added similar functionality to `Aggregate#append` with the corresponding tests.