### PR TITLE
fix erroneous change in #3730

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -80,8 +80,9 @@ Aggregate.prototype.bind = function (model) {
  */
 
 Aggregate.prototype.append = function () {
-  var args = utils.args(arguments)
-    , arg;
+  var args = (1 === arguments.length && util.isArray(arguments[0]))
+      ? arguments[0]
+      : utils.args(arguments);
 
   if (!args.every(isOperator)) {
     throw new Error("Arguments must be aggregate pipeline operators");
@@ -265,14 +266,12 @@ Aggregate.prototype.near = function (arg) {
  */
 
 Aggregate.prototype.unwind = function () {
-  var args = (1 === arguments.length && util.isArray(arguments[0]))
-      ? arguments[0]
-      : utils.args(arguments);
+  var args = utils.args(arguments);
 
   return this.append.apply(this, args.map(function (arg) {
     return { $unwind: '$' + arg };
   }));
-}
+};
 
 /**
  * Appends a new $sort operator to this aggregate pipeline.


### PR DESCRIPTION
Fixes changes in #3730, messed up the line for changes. Now correctly placed in `Aggregate#append`.