### PR TITLE
(fixed) error when passed a callback in updata, and that is not a function

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2019,9 +2019,14 @@ Query.prototype.update = function(conditions, doc, options, callback) {
 
   var oldCb = callback;
   if (oldCb) {
-    callback = function(error, result) {
-      oldCb(error, result ? result.result : { ok: 0, n: 0, nModified: 0 });
-    };
+	if('function' === typeof oldCb){
+	  callback = function(error, result) {
+		oldCb(error, result ? result.result : { ok: 0, n: 0, nModified: 0 });
+	  };  
+	}else{		
+	  throw new Error('Invalid callback() argument.');
+	}	  
+    
   }
 
   // strict is an option used in the update checking, make sure it gets set


### PR DESCRIPTION
When you make a update like this:
```javascript
TwitterAccountModel.update(
      {account: account},
      {
        $set: {account: account}
      },
      {upsert: true, new: true},
      {type:'object or other type, like number, string. Onlu function is valid as a callback'});
```
as you see you can pass at fourth parameter any, but it cashed if that is not a function
so i made a previous validation of the fourth parameter, and throw an error it that not a function.
I'll be pleased if you take a moment. Tks