### PR TITLE
Fix for #2879 in 3.8.x branch

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -732,7 +732,8 @@ Document.prototype.get = function (path, type) {
  */
 
 Document.prototype.$__path = function (path) {
-  var adhocs = this.$__.adhocPaths
+  var base = this.$__
+    , adhocs = (base) ? base.adhocPaths : undefined
     , adhocType = adhocs && adhocs[path];
 
   if (adhocType) {


### PR DESCRIPTION
#2880 fixed #2879 in master, but it is still broken in the 3.8.x branch.

The real fix would be to make the properties enumerable, however doing so would cause a breaking change (as mentioned in #2211).