### PR TITLE
colorized output

### DIFF
--- a/examples/population/population-across-three-collections.js
+++ b/examples/population/population-across-three-collections.js
@@ -118,7 +118,7 @@ mongoose.connection.on('open', function() {
         BlogPost.populate(docs, opts, function(err, docs) {
           assert.ifError(err);
           console.log('populated');
-          var s = require('util').inspect(docs, { depth: null });
+          var s = require('util').inspect(docs, { depth: null, colors: true });
           console.log(s);
           done();
         });

--- a/lib/document.js
+++ b/lib/document.js
@@ -14,7 +14,6 @@ var EventEmitter = require('events').EventEmitter,
     utils = require('./utils'),
     clone = utils.clone,
     isMongooseObject = utils.isMongooseObject,
-    inspect = require('util').inspect,
     ValidationError = MongooseError.ValidationError,
     InternalCache = require('./internal'),
     deepEqual = utils.deepEqual,
@@ -2109,7 +2108,7 @@ Document.prototype.inspect = function(options) {
   var opts = options && 'Object' == utils.getFunctionName(options.constructor) ? options : {};
   opts.minimize = false;
   opts.retainKeyOrder = true;
-  return inspect(this.toObject(opts));
+  return this.toObject(opts);
 };
 
 /**

--- a/lib/document.js
+++ b/lib/document.js
@@ -14,6 +14,7 @@ var EventEmitter = require('events').EventEmitter,
     utils = require('./utils'),
     clone = utils.clone,
     isMongooseObject = utils.isMongooseObject,
+    inspect = require('util').inspect,
     ValidationError = MongooseError.ValidationError,
     InternalCache = require('./internal'),
     deepEqual = utils.deepEqual,
@@ -2118,7 +2119,9 @@ Document.prototype.inspect = function(options) {
  * @method toString
  */
 
-Document.prototype.toString = Document.prototype.inspect;
+Document.prototype.toString = function () {
+  return inspect(this.inspect());
+};
 
 /**
  * Returns true if the Document stores the same data as doc.

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -161,14 +161,7 @@ MongooseDocumentArray.mixin.toObject = function(options) {
  */
 
 MongooseDocumentArray.mixin.inspect = function() {
-  return '[' + Array.prototype.map.call(this, function(doc) {
-    if (doc) {
-      return doc.inspect
-        ? doc.inspect()
-        : util.inspect(doc);
-    }
-    return 'null';
-  }).join('\n') + ']';
+  return Array.prototype.slice.call(this);
 };
 
 /**

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -156,7 +156,7 @@ EmbeddedDocument.prototype.update = function() {
  */
 
 EmbeddedDocument.prototype.inspect = function() {
-  return inspect(this.toObject());
+  return this.toObject();
 };
 
 /**

--- a/test/colors.js
+++ b/test/colors.js
@@ -1,0 +1,133 @@
+/**
+ * Module dependencies.
+ */
+
+var start = require('./common'),
+	mongoose = start.mongoose,
+	assert = require('assert'),
+	Schema = mongoose.Schema,
+	MongooseDocumentArray = mongoose.Types.DocumentArray,
+	EmbeddedDocument = require('../lib/types/embedded'),
+	DocumentArray = require('../lib/types/documentarray');
+
+/**
+ * setup
+ */
+
+var test = Schema({
+	string: String,
+	number: Number,
+	date: {
+		type: Date,
+		default: Date.now
+	}
+});
+
+function TestDoc(schema) {
+	var Subdocument = function() {
+		EmbeddedDocument.call(this, {}, new DocumentArray);
+	};
+
+	/**
+	 * Inherits from EmbeddedDocument.
+	 */
+
+	Subdocument.prototype.__proto__ = EmbeddedDocument.prototype;
+
+	/**
+	 * Set schema.
+	 */
+
+	Subdocument.prototype.$__setSchema(schema || test);
+
+	return Subdocument;
+}
+
+/**
+ * Test.
+ */
+
+describe('debug: colors', function () {
+	var db;
+	var Test;
+
+	before(function () {
+		db = start();
+		Test = db.model('Test', test, 'TEST');
+	});
+
+	after(function (done) {
+		db.close(done);
+	});
+
+	it('Document', function (done) {
+
+		var date = new Date();
+
+		Test.create([{
+			string: 'qwerty',
+			number: 123,
+			date: date
+		}, {
+			string: 'asdfgh',
+			number: 456,
+			date: date
+		}, {
+			string: 'zxcvbn',
+			number: 789,
+			date: date
+		}], function (err) {
+			assert.ifError(err);
+			Test
+				.find()
+				.lean(false)
+				.exec(function (err, docs) {
+					assert.ifError(err);
+
+					var colorfull = require('util').inspect(docs, {
+						depth: null,
+						colors: true
+					});
+
+					var colorless = require('util').inspect(docs, {
+						depth: null,
+						colors: false
+					});
+
+					// console.log(colorfull, colorless);
+
+					assert.notEqual(colorfull, colorless);
+
+					done();
+				});
+		});
+	});
+
+	it('MongooseDocumentArray', function () {
+
+		var Subdocument = TestDoc();
+
+		var sub1 = new Subdocument();
+		sub1.string = 'string';
+		sub1.number = 12345;
+		sub1.date = new Date();
+
+		var docs = new MongooseDocumentArray([sub1]);
+
+		var colorfull = require('util').inspect(docs, {
+			depth: null,
+			colors: true
+		});
+
+		var colorless = require('util').inspect(docs, {
+			depth: null,
+			colors: false
+		});
+
+		// console.log(colorfull, colorless);
+
+		assert.notEqual(colorfull, colorless);
+
+	})
+
+});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4180,11 +4180,11 @@ describe('Model', function() {
       db.close();
 
       var out = post.inspect();
-      assert.ok(/meta: { visitors: 45 }/.test(out));
-      assert.ok(/numbers: \[ 5, 6, 7 \]/.test(out));
-      assert.ok(/Wed.+ 2011 \d\d:02:31 GMT/.test(out));
-      assert.ok(!/activePaths:/.test(out));
-      assert.ok(!/_atomics:/.test(out));
+      assert.equal(out.meta.visitors, post.meta.visitors);
+      assert.deepEqual(out.numbers, Array.prototype.slice.call(post.numbers));
+      assert.equal(out.date.valueOf(), post.date.valueOf());
+      assert.equal(out.activePaths, undefined);
+      assert.equal(out._atomics, undefined);
       done();
     });
   });


### PR DESCRIPTION
this PR fixes colorized output

have no idea why you did like so but `Document.inspect` same as `MongooseDocumentArray.mixin.inspect` returns a string instead of object so util.inspect can't colorize it properly

you can check this by running 
```bash
node examples/population/population-across-three-collections.js
```

this fix makes 
`Document.inspect` return `Document.toObject()` with filtered private props
`Document.toString` return string representation of `Document.inspect()`
`MongooseDocumentArray.mixin.inspect` returns array of `Document`
