### PR TITLE
Update uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "open": "0.0.3",
     "q": "1.4.1",
     "tbd": "0.6.4",
-    "uglify-js": "2.4.24",
+    "uglify-js": "2.6.1",
     "underscore": "1.5.2"
   },
   "browserDependencies": {


### PR DESCRIPTION
Resolves https://nodesecurity.io/advisories/uglify-js_regular-expression-denial-of-service

This should have no affect on production Mongoose.
The unpatched flaw could *theoretically* slow the build down.