### PR TITLE
Adding missing word to timestamps section

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -622,7 +622,7 @@ block content
     var thingSchema = new Schema({..}, { timestamps: { createdAt: 'created_at' } });
     var Thing = mongoose.model('Thing', thingSchema);
     var thing = new Thing();
-    thing.save(); // `created_at` & `updatedAt` will included
+    thing.save(); // `created_at` & `updatedAt` will be included
 
   h3#plugins Pluggable
   p


### PR DESCRIPTION
Just needed the word `be` in the code example.