### PR TITLE
attempt to fix #3728

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -25,20 +25,26 @@ var isMongooseObject = utils.isMongooseObject;
 
 function MongooseArray(values, path, doc) {
   var arr = [].concat(values);
+  var props = {
+    isMongooseArray: true,
+    validators: [],
+    _path: path,
+    _atomics: {},
+    _schema: void 0
+  };
+  var tmp = {};
 
-  utils.decorate( arr, MongooseArray.mixin );
-  arr.isMongooseArray = true;
-
-  var _options = { enumerable: false, configurable: true, writable: true };
-  var keys = Object.keys(MongooseArray.mixin).
-    concat(['isMongooseArray', 'validators', '_path']);
-  for (var i = 0; i < keys.length; ++i) {
-    Object.defineProperty(arr, keys[i], _options);
+  var keysMA = Object.keys(MongooseArray.mixin);
+  for (var i = 0; i < keysMA.length; ++i) {
+    tmp[keysMA[i]] = {enumerable: false, configurable: true, writable: true, value: MongooseArray.mixin[keysMA[i]]};
   }
 
-  arr._atomics = {};
-  arr.validators = [];
-  arr._path = path;
+  var keysP = Object.keys(props);
+  for (var j = 0; j < keysP.length; ++j) {
+    tmp[keysP[j]] = {enumerable: false, configurable: true, writable: true, value: props[keysP[j]]};
+  }
+
+  Object.defineProperties(arr, tmp);
 
   // Because doc comes from the context of another function, doc === global
   // can happen if there was a null somewhere up the chain (see #3020)

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -22,16 +22,35 @@ var MongooseArray = require('./array'),
 
 function MongooseDocumentArray(values, path, doc) {
   var arr = [].concat(values);
+  var props = {
+    isMongooseArray: true,
+    isMongooseDocumentArray: true,
+    validators: [],
+    _path: path,
+    _atomics: {},
+    _schema: void 0,
+    _handlers: void 0
+  };
+  var tmp = {};
 
   // Values always have to be passed to the constructor to initialize, since
   // otherwise MongooseArray#push will mark the array as modified to the parent.
-  utils.decorate( arr, MongooseDocumentArray.mixin );
-  arr.isMongooseArray = true;
-  arr.isMongooseDocumentArray = true;
+  var keysMA = Object.keys(MongooseArray.mixin);
+  for (var j = 0; j < keysMA.length; ++j) {
+    tmp[keysMA[j]] = {enumerable: false, configurable: true, writable: true, value: MongooseArray.mixin[keysMA[j]]};
+  }
 
-  arr._atomics = {};
-  arr.validators = [];
-  arr._path = path;
+  var keysMDA = Object.keys(MongooseDocumentArray.mixin);
+  for (var i = 0; i < keysMDA.length; ++i) {
+    tmp[keysMDA[i]] = {enumerable: false, configurable: true, writable: true, value: MongooseDocumentArray.mixin[keysMDA[i]]};
+  }
+
+  var keysP = Object.keys(props);
+  for (var k = 0; k < keysP.length; ++k) {
+    tmp[keysP[k]] = {enumerable: false, configurable: true, writable: true, value: props[keysP[k]]};
+  }
+
+  Object.defineProperties(arr, tmp);
 
   // Because doc comes from the context of another function, doc === global
   // can happen if there was a null somewhere up the chain (see #3020 && #3034)
@@ -55,157 +74,160 @@ function MongooseDocumentArray(values, path, doc) {
 /*!
  * Inherits from MongooseArray
  */
-MongooseDocumentArray.mixin = Object.create( MongooseArray.mixin );
+//MongooseDocumentArray.mixin = Object.create( MongooseArray.mixin );
+MongooseDocumentArray.mixin = {
 
-/**
- * Overrides MongooseArray#cast
- *
- * @method _cast
- * @api private
- * @receiver MongooseDocumentArray
- */
+  /**
+   * Overrides MongooseArray#cast
+   *
+   * @method _cast
+   * @api private
+   * @receiver MongooseDocumentArray
+   */
 
-MongooseDocumentArray.mixin._cast = function(value, index) {
-  if (value instanceof this._schema.casterConstructor) {
-    if (!(value.__parent && value.__parentArray)) {
-      // value may have been created using array.create()
-      value.__parent = this._parent;
-      value.__parentArray = this;
+  _cast: function(value, index) {
+    if (value instanceof this._schema.casterConstructor) {
+      if (!(value.__parent && value.__parentArray)) {
+        // value may have been created using array.create()
+        value.__parent = this._parent;
+        value.__parentArray = this;
+      }
+      value.__index = index;
+      return value;
     }
-    value.__index = index;
-    return value;
-  }
 
-  // handle cast('string') or cast(ObjectId) etc.
-  // only objects are permitted so we can safely assume that
-  // non-objects are to be interpreted as _id
-  if (Buffer.isBuffer(value) ||
+    // handle cast('string') or cast(ObjectId) etc.
+    // only objects are permitted so we can safely assume that
+    // non-objects are to be interpreted as _id
+    if (Buffer.isBuffer(value) ||
       value instanceof ObjectId || !utils.isObject(value)) {
-    value = { _id: value };
-  }
-  return new this._schema.casterConstructor(value, this, undefined, undefined, index);
-};
+      value = {_id: value};
+    }
+    return new this._schema.casterConstructor(value, this, undefined, undefined, index);
+  },
 
-/**
- * Searches array items for the first document with a matching _id.
- *
- * ####Example:
- *
- *     var embeddedDoc = m.array.id(some_id);
- *
- * @return {EmbeddedDocument|null} the subdocument or null if not found.
- * @param {ObjectId|String|Number|Buffer} id
- * @TODO cast to the _id based on schema for proper comparison
- * @method id
- * @api public
- * @receiver MongooseDocumentArray
- */
+  /**
+   * Searches array items for the first document with a matching _id.
+   *
+   * ####Example:
+   *
+   *     var embeddedDoc = m.array.id(some_id);
+   *
+   * @return {EmbeddedDocument|null} the subdocument or null if not found.
+   * @param {ObjectId|String|Number|Buffer} id
+   * @TODO cast to the _id based on schema for proper comparison
+   * @method id
+   * @api public
+   * @receiver MongooseDocumentArray
+   */
 
-MongooseDocumentArray.mixin.id = function(id) {
-  var casted,
+  id: function(id) {
+    var casted,
       sid,
       _id;
 
-  try {
-    var casted_ = ObjectIdSchema.prototype.cast.call({}, id);
-    if (casted_) casted = String(casted_);
-  } catch (e) {
-    casted = null;
-  }
-
-  for (var i = 0, l = this.length; i < l; i++) {
-    _id = this[i].get('_id');
-
-    if (_id === null || typeof _id === 'undefined') {
-      continue;
-    } else if (_id instanceof Document) {
-      sid || (sid = String(id));
-      if (sid == _id._id) return this[i];
-    } else if (!(_id instanceof ObjectId)) {
-      if (utils.deepEqual(id, _id)) return this[i];
-    } else if (casted == _id) {
-      return this[i];
+    try {
+      var casted_ = ObjectIdSchema.prototype.cast.call({}, id);
+      if (casted_) casted = String(casted_);
+    } catch (e) {
+      casted = null;
     }
-  }
 
-  return null;
-};
+    for (var i = 0, l = this.length; i < l; i++) {
+      _id = this[i].get('_id');
 
-/**
- * Returns a native js Array of plain js objects
- *
- * ####NOTE:
- *
- * _Each sub-document is converted to a plain object by calling its `#toObject` method._
- *
- * @param {Object} [options] optional options to pass to each documents `toObject` method call during conversion
- * @return {Array}
- * @method toObject
- * @api public
- * @receiver MongooseDocumentArray
- */
-
-MongooseDocumentArray.mixin.toObject = function(options) {
-  return this.map(function(doc) {
-    return doc && doc.toObject(options) || null;
-  });
-};
-
-/**
- * Helper for console.log
- *
- * @method inspect
- * @api public
- * @receiver MongooseDocumentArray
- */
-
-MongooseDocumentArray.mixin.inspect = function() {
-  return Array.prototype.slice.call(this);
-};
-
-/**
- * Creates a subdocument casted to this schema.
- *
- * This is the same subdocument constructor used for casting.
- *
- * @param {Object} obj the value to cast to this arrays SubDocument schema
- * @method create
- * @api public
- * @receiver MongooseDocumentArray
- */
-
-MongooseDocumentArray.mixin.create = function(obj) {
-  return new this._schema.casterConstructor(obj);
-};
-
-/**
- * Creates a fn that notifies all child docs of `event`.
- *
- * @param {String} event
- * @return {Function}
- * @method notify
- * @api private
- * @receiver MongooseDocumentArray
- */
-
-MongooseDocumentArray.mixin.notify = function notify(event) {
-  var self = this;
-  return function notify(val) {
-    var i = self.length;
-    while (i--) {
-      if (!self[i]) continue;
-      switch (event) {
-        // only swap for save event for now, we may change this to all event types later
-        case 'save':
-          val = self[i];
-          break;
-        default:
-          // NO-OP
-          break;
+      if (_id === null || typeof _id === 'undefined') {
+        continue;
+      } else if (_id instanceof Document) {
+        sid || (sid = String(id));
+        if (sid == _id._id) return this[i];
+      } else if (!(_id instanceof ObjectId)) {
+        if (utils.deepEqual(id, _id)) return this[i];
+      } else if (casted == _id) {
+        return this[i];
       }
-      self[i].emit(event, val);
     }
-  };
+
+    return null;
+  },
+
+  /**
+   * Returns a native js Array of plain js objects
+   *
+   * ####NOTE:
+   *
+   * _Each sub-document is converted to a plain object by calling its `#toObject` method._
+   *
+   * @param {Object} [options] optional options to pass to each documents `toObject` method call during conversion
+   * @return {Array}
+   * @method toObject
+   * @api public
+   * @receiver MongooseDocumentArray
+   */
+
+  toObject: function(options) {
+    return this.map(function(doc) {
+      return doc && doc.toObject(options) || null;
+    });
+  },
+
+  /**
+   * Helper for console.log
+   *
+   * @method inspect
+   * @api public
+   * @receiver MongooseDocumentArray
+   */
+
+  inspect: function() {
+    return Array.prototype.slice.call(this);
+  },
+
+  /**
+   * Creates a subdocument casted to this schema.
+   *
+   * This is the same subdocument constructor used for casting.
+   *
+   * @param {Object} obj the value to cast to this arrays SubDocument schema
+   * @method create
+   * @api public
+   * @receiver MongooseDocumentArray
+   */
+
+  create: function(obj) {
+    return new this._schema.casterConstructor(obj);
+  },
+
+  /**
+   * Creates a fn that notifies all child docs of `event`.
+   *
+   * @param {String} event
+   * @return {Function}
+   * @method notify
+   * @api private
+   * @receiver MongooseDocumentArray
+   */
+
+  notify: function notify(event) {
+    var self = this;
+    return function notify(val) {
+      var i = self.length;
+      while (i--) {
+        if (!self[i]) continue;
+        switch (event) {
+          // only swap for save event for now, we may change this to all event types later
+          case 'save':
+            val = self[i];
+            break;
+          default:
+            // NO-OP
+            break;
+        }
+        self[i].emit(event, val);
+      }
+    };
+  }
+
 };
 
 /*!

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -35,6 +35,7 @@ describe('types array', function() {
     assert.ok(a instanceof Array);
     assert.ok(a.isMongooseArray);
     assert.equal(true, Array.isArray(a));
+
     assert.deepEqual(Object.keys(a), Object.keys(a.toObject()));
     assert.deepEqual(a._atomics.constructor, Object);
     done();

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -7,7 +7,6 @@ var start = require('./common')
   , mongoose = require('./common').mongoose
   , random = require('../lib/utils').random
   , setValue = require('../lib/utils').setValue
-  , MongooseArray = mongoose.Types.Array
   , MongooseDocumentArray = mongoose.Types.DocumentArray
   , EmbeddedDocument = require('../lib/types/embedded')
   , DocumentArray = require('../lib/types/documentarray')
@@ -55,12 +54,10 @@ describe('types.documentarray', function() {
     assert.ok(a.isMongooseArray);
     assert.ok(a.isMongooseDocumentArray);
     assert.ok(Array.isArray(a));
-    assert.equal('Object', a._atomics.constructor.name);
-    assert.equal('object', typeof a);
 
-    var b = new MongooseArray([1,2,3,4]);
-    assert.equal('object', typeof b);
-    assert.equal(Object.keys(b.toObject()).length,4);
+    assert.deepEqual(Object.keys(a), Object.keys(a.toObject()));
+    assert.deepEqual(a._atomics.constructor, Object);
+
     done();
   });
 


### PR DESCRIPTION
this is attempt to fix performance degradation caused by usage of `Object.defineProperty`

according this [blog post](https://www.nczonline.net/blog/2015/11/performance-implication-object-defineproperty/) we can improve performance by using one call to `Object.defineProperties` instead of several calls to  `Object.defineProperty`

note: there is possible [zero performance impact](http://webreflection.blogspot.co.id/2014/03/what-books-didnt-tell-you-about-es5.html#zero-performance-impact) in case of using `Object.defineProperty` on `object.prototype` but unfortunately it's impossible because JS doesn't allow subclass builtin objects such as `Array`

also this PR makes `MongooseArray` and `MongooseDocumentArray` consistent as well as its 'duck' tests