### PR TITLE
Fix for #3843

### DIFF
--- a/docs/includes/nav.jade
+++ b/docs/includes/nav.jade
@@ -20,8 +20,10 @@ ul
           ul
             li.schematypes
               a(href="./schematypes.html")
-                span schema
                 | types
+            li.customschematypes
+              a(href="./customschematypes.html")
+                | custom
         li
           a(href="./models.html")
             | models

--- a/docs/schematypes.jade
+++ b/docs/schematypes.jade
@@ -154,6 +154,9 @@ block content
     | 
     a(href="https://github.com/OpenifyIt/mongoose-types") types
     |.
+    | To create your own custom schema take a look at
+    a(href="/docs/customschematypes.html") Creating a Basic Custom Schema Type
+    |.
 
   h3#next Next Up
   :markdown

--- a/docs/source/acquit.js
+++ b/docs/source/acquit.js
@@ -21,8 +21,8 @@ var files = [
     title: 'Promises'
   },
   {
-    input: 'test/docs/schematypes.test.js',
-    output: 'schematypes.html',
+    input: 'test/docs/customschematypes.test.js',
+    output: 'customschematypes.html',
     title: 'Custom Schema Types'
   }
 ];

--- a/test/docs/customschematypes.test.js
+++ b/test/docs/customschematypes.test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var mongoose = require('../../');
 
-describe('schemaTypes', function () {
+describe('customSchemaTypes', function () {
   var db;
   var Schema = mongoose.Schema;
 


### PR DESCRIPTION
The /docs/schematypes.html was the only page being generated from both a .jade file and acquit.  Moved acquit output into new page and added reference in appropriate area on schematypes.jade.