### PR TITLE
Include the nested error when throwing CastError from arrays

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -152,7 +152,7 @@ SchemaArray.prototype.cast = function(value, doc, init) {
         }
       } catch (e) {
         // rethrow
-        throw new CastError(e.type, value, this.path);
+        throw new CastError(e.type, value, this.path, e);
       }
     }
 

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -241,7 +241,7 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
             // see gh-746
             value[i] = subdoc;
           } catch (error) {
-            throw new CastError('embedded', value[i], value._path);
+            throw new CastError('embedded', value[i], value._path, error);
           }
         }
       }


### PR DESCRIPTION
Helps pinpoint what caused the problem, rather than a generic-ish error from the array

Not sure of how to appropriately add tests for this