### PR TITLE
Make sure Document Exists, After we check to see is obj is an Object. 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -416,10 +416,6 @@ exports.toObject = function toObject(obj) {
     return obj;
   }
 
-  if (obj instanceof Document) {
-    return obj.toObject();
-  }
-
   if (Array.isArray(obj)) {
     ret = [];
 
@@ -439,6 +435,10 @@ exports.toObject = function toObject(obj) {
     }
 
     return ret;
+  }
+
+  if (Document && obj instanceof Document) {
+    return obj.toObject();
   }
 
   return obj;


### PR DESCRIPTION
If `obj` is an Object , let it first check that. Check to see if its a Document later, but only if `Document` is defined.

This is because in some instances `Document` may not be defined. 