### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -371,6 +371,7 @@ Mongoose.prototype.disconnect = function(fn) {
  */
 
 Mongoose.prototype.model = function(name, schema, collection, skipInit) {
+  if (this !== mongoose) return Mongoose.prototype.model.apply(mongoose, arguments);
   if (typeof schema === 'string') {
     collection = schema;
     schema = false;


### PR DESCRIPTION
See #3768

To allow invocation of `model` in any context, I do a quick check to see if `this` within the invocation refers to the `mongoose` instance.  If it does not, `Mongoose.prototype.model` is called again with the proper context.