### PR TITLE
Add autoIndex config example at connection level

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -148,6 +148,10 @@ block content
       While nice for development, it is recommended this behavior be disabled in production since index creation can cause a [significant performance impact](http://docs.mongodb.org/manual/core/indexes/#index-creation-operations). Disable the behavior by setting the `autoIndex` option of your schema to `false`, or globally on the connection by setting the option `config.autoIndex` to `false`.
 
   :js
+    mongoose.connect('mongodb://user:pass@localhost:port/database', { config: { autoIndex: false } });
+    // or  
+    mongoose.createConnection('mongodb://user:pass@localhost:port/database', { config: { autoIndex: false } });
+    // or
     animalSchema.set('autoIndex', false);
     // or
     new Schema({..}, { autoIndex: false });


### PR DESCRIPTION
Adding more visibility to the `autoIndex` option by adding examples at the connection level