### PR TITLE
fix(mongos connection): Allow connecting with {mongos: true} to handle connection query params

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -241,11 +241,16 @@ NativeConnection.prototype.parseOptions = function(passed, connStrOpts) {
   o.replset || (o.replset = o.replSet) || (o.replset = {});
   o.server.socketOptions || (o.server.socketOptions = {});
   o.replset.socketOptions || (o.replset.socketOptions = {});
+  (o.mongos === true) && (o.mongos = {});
 
   var opts = connStrOpts || {};
   Object.keys(opts).forEach(function(name) {
     switch (name) {
       case 'ssl':
+        o.server.ssl = opts.ssl;
+        o.replset.ssl = opts.ssl;
+        o.mongos && (o.mongos.ssl = opts.ssl);
+        break;
       case 'poolSize':
         if (typeof o.server[name] === 'undefined') {
           o.server[name] = o.replset[name] = opts[name];
@@ -321,6 +326,7 @@ NativeConnection.prototype.parseOptions = function(passed, connStrOpts) {
       case 'sslValidate':
         o.server.sslValidate = opts.sslValidate;
         o.replset.sslValidate = opts.sslValidate;
+        o.mongos && (o.mongos.sslValidate = opts.sslValidate);
     }
   });
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -403,6 +403,7 @@ describe('connections:', function() {
         assert.equal('object', typeof db.options.db);
         assert.equal('object', typeof db.options.replset);
         assert.equal('object', typeof db.options.replset.socketOptions);
+        assert.equal(undefined, db.options.mongos);
         assert.equal(false, db.options.server.auto_reconnect);
         assert.equal(2, db.options.server.poolSize);
         assert.equal(false, db.options.server.slave_ok);
@@ -446,6 +447,7 @@ describe('connections:', function() {
         assert.equal('object', typeof db.options.db);
         assert.equal('object', typeof db.options.replset);
         assert.equal('object', typeof db.options.replset.socketOptions);
+        assert.equal(undefined, db.options.mongos);
         assert.equal(false, db.options.server.auto_reconnect);
         assert.equal(3, db.options.server.poolSize);
         assert.equal(false, db.options.server.slave_ok);
@@ -490,6 +492,7 @@ describe('connections:', function() {
         assert.equal('object', typeof db.options.db);
         assert.equal('object', typeof db.options.replset);
         assert.equal('object', typeof db.options.replset.socketOptions);
+        assert.equal(undefined, db.options.mongos);
         assert.equal(false, db.options.server.auto_reconnect);
         assert.equal(2, db.options.server.poolSize);
         assert.equal(false, db.options.server.slave_ok);
@@ -527,6 +530,7 @@ describe('connections:', function() {
         assert.equal('object', typeof db.options.db);
         assert.equal('object', typeof db.options.replset);
         assert.equal('object', typeof db.options.replset.socketOptions);
+        assert.equal(undefined, db.options.mongos);
         assert.equal(false, db.options.server.auto_reconnect);
         assert.equal(80, db.options.db.wtimeoutMS);
         assert.equal(2, db.options.server.poolSize);
@@ -546,6 +550,100 @@ describe('connections:', function() {
         assert.equal(true, db.options.db.fsync);
         assert.equal(true, db.options.db.journal);
         assert.equal(false, db.options.db.forceServerObjectId);
+        done();
+      });
+    });
+    describe('when mongos is passed', function() {
+      it('works when specifying {mongos: true}', function(done) {
+        var conn = 'mongodb://localhost/fake?autoReconnect=false&poolSize=2'
+            + '&slaveOk=false&ssl=true&socketTimeoutMS=10&connectTimeoutMS=12'
+            + '&retries=10&reconnectWait=5&rs_name=replworld&readSecondary=true'
+            + '&nativeParser=false&w=2&safe=true&fsync=true&journal=true'
+            + '&wtimeoutMS=80&readPreference=nearest&readPreferenceTags='
+            + 'dc:ny,rack:1&readPreferenceTags=dc:sf&sslValidate=true';
+
+        var db = mongoose.createConnection(conn, {mongos: true});
+        db.on('error', done);
+        db.close();
+        assert.equal('object', typeof db.options);
+        assert.equal('object', typeof db.options.server);
+        assert.equal('object', typeof db.options.server.socketOptions);
+        assert.equal('object', typeof db.options.db);
+        assert.equal('object', typeof db.options.replset);
+        assert.equal('object', typeof db.options.replset.socketOptions);
+        assert.equal('object', typeof db.options.mongos);
+        assert.equal(false, db.options.server.auto_reconnect);
+        assert.equal(2, db.options.server.poolSize);
+        assert.equal(false, db.options.server.slave_ok);
+        assert.equal(true, db.options.server.ssl);
+        assert.equal(true, db.options.replset.ssl);
+        assert.equal(true, db.options.mongos.ssl);
+        assert.equal(10, db.options.server.socketOptions.socketTimeoutMS);
+        assert.equal(10, db.options.replset.socketOptions.socketTimeoutMS);
+        assert.equal(12, db.options.server.socketOptions.connectTimeoutMS);
+        assert.equal(12, db.options.replset.socketOptions.connectTimeoutMS);
+        assert.equal(10, db.options.replset.retries);
+        assert.equal(5, db.options.replset.reconnectWait);
+        assert.equal('replworld', db.options.replset.rs_name);
+        assert.equal(true, db.options.replset.read_secondary);
+        assert.equal(false, db.options.db.native_parser);
+        assert.equal(2, db.options.db.w);
+        assert.equal(true, db.options.db.safe);
+        assert.equal(true, db.options.db.fsync);
+        assert.equal(true, db.options.db.journal);
+        assert.equal(80, db.options.db.wtimeoutMS);
+        assert.equal('nearest', db.options.db.readPreference);
+        assert.deepEqual([{dc: 'ny', rack: 1}, {dc: 'sf'}], db.options.db.read_preference_tags);
+        assert.equal(false, db.options.db.forceServerObjectId);
+        assert.strictEqual(db.options.server.sslValidate, true);
+        assert.strictEqual(db.options.mongos.sslValidate, true);
+        done();
+      });
+      it('works when specifying mongos opts', function(done) {
+        var conn = 'mongodb://localhost/fake?autoReconnect=false&poolSize=2'
+            + '&slaveOk=false&ssl=true&socketTimeoutMS=10&connectTimeoutMS=12'
+            + '&retries=10&reconnectWait=5&rs_name=replworld&readSecondary=true'
+            + '&nativeParser=false&w=2&safe=true&fsync=true&journal=true'
+            + '&wtimeoutMS=80&readPreference=nearest&readPreferenceTags='
+            + 'dc:ny,rack:1&readPreferenceTags=dc:sf&sslValidate=true';
+
+        var db = mongoose.createConnection(conn, {mongos: {w: 3, wtimeoutMS: 80}});
+        db.on('error', done);
+        db.close();
+        assert.equal('object', typeof db.options);
+        assert.equal('object', typeof db.options.server);
+        assert.equal('object', typeof db.options.server.socketOptions);
+        assert.equal('object', typeof db.options.db);
+        assert.equal('object', typeof db.options.replset);
+        assert.equal('object', typeof db.options.replset.socketOptions);
+        assert.equal('object', typeof db.options.mongos);
+        assert.equal(false, db.options.server.auto_reconnect);
+        assert.equal(2, db.options.server.poolSize);
+        assert.equal(false, db.options.server.slave_ok);
+        assert.equal(true, db.options.server.ssl);
+        assert.equal(true, db.options.replset.ssl);
+        assert.equal(true, db.options.mongos.ssl);
+        assert.equal(10, db.options.server.socketOptions.socketTimeoutMS);
+        assert.equal(10, db.options.replset.socketOptions.socketTimeoutMS);
+        assert.equal(12, db.options.server.socketOptions.connectTimeoutMS);
+        assert.equal(12, db.options.replset.socketOptions.connectTimeoutMS);
+        assert.equal(10, db.options.replset.retries);
+        assert.equal(5, db.options.replset.reconnectWait);
+        assert.equal('replworld', db.options.replset.rs_name);
+        assert.equal(true, db.options.replset.read_secondary);
+        assert.equal(false, db.options.db.native_parser);
+        assert.equal(2, db.options.db.w);
+        assert.equal(true, db.options.db.safe);
+        assert.equal(true, db.options.db.fsync);
+        assert.equal(true, db.options.db.journal);
+        assert.equal(80, db.options.db.wtimeoutMS);
+        assert.equal('nearest', db.options.db.readPreference);
+        assert.deepEqual([{dc: 'ny', rack: 1}, {dc: 'sf'}], db.options.db.read_preference_tags);
+        assert.equal(false, db.options.db.forceServerObjectId);
+        assert.strictEqual(db.options.server.sslValidate, true);
+        assert.strictEqual(db.options.mongos.sslValidate, true);
+        assert.equal(db.options.mongos.w, 3);
+        assert.equal(db.options.mongos.wtimeoutMS, 80);
         done();
       });
     });


### PR DESCRIPTION
Currently, if `ssl` and `sslValidate` are specified in the connect string query, and you pass `{mongos: true}` to the `mongoose.connect`, `ssl` and `sslValidate` are not set on the `mongos` opts. You can manually specify `{mongos: {ssl: true, sslValidate: false}}` and it works, but it is [documented](http://mongoosejs.com/docs/connections.html) that `{mongos: true}` is enough. This adds that capability.