### PR TITLE
Allow saving of array fields selected via $elemMatch

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -482,17 +482,14 @@ Model.prototype.$__delta = function() {
       var pathSplit = data.path.split('.');
       var top = pathSplit[0];
       if (this.$__.selected[top] && this.$__.selected[top].$elemMatch) {
-        //If the selected array entry was modified
-        if (pathSplit.length > 1 && pathSplit[1] == 0) {
-          where[top] = this.$__.selected[top]; //FIXME: will we overwrite anything?
+        // If the selected array entry was modified
+        if (pathSplit.length > 1 && pathSplit[1] == 0 && typeof where[top] === 'undefined') {
+          where[top] = this.$__.selected[top];
           pathSplit[1] = '$';
           data.path = pathSplit.join('.');
         }
-        //if the selected array was entirely reassigned or uses an incompatible operation
-        else if (pathSplit.length == 1 && (
-                   typeof value.hasAtomics === 'undefined' ||
-                   '$set' in value._atomics ||
-                   '$pop' in value._atomics)) {
+        // if the selected array was modified in any other way throw an error
+        else {
           divergent.push(data.path);
           continue;
         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -482,9 +482,20 @@ Model.prototype.$__delta = function() {
       var pathSplit = data.path.split('.');
       var top = pathSplit[0];
       if (this.$__.selected[top] && this.$__.selected[top].$elemMatch) {
-        where[top] = this.$__.selected[top]; //FIXME: will we overwrite anything?
-        pathSplit[1] = '$'; //FIXME: check if the path is really top.0.something
-        data.path = pathSplit.join('.');
+        //If the selected array entry was modified
+        if (pathSplit.length > 1 && pathSplit[1] == 0) {
+          where[top] = this.$__.selected[top]; //FIXME: will we overwrite anything?
+          pathSplit[1] = '$';
+          data.path = pathSplit.join('.');
+        }
+        //if the selected array was entirely reassigned or uses an incompatible operation
+        else if (pathSplit.length == 1 && (
+                   typeof value.hasAtomics === 'undefined' ||
+                   '$set' in value._atomics ||
+                   '$pop' in value._atomics)) {
+          divergent.push(data.path);
+          continue;
+        }
       }
     }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -475,6 +475,19 @@ Model.prototype.$__delta = function() {
       continue;
     }
 
+    var pop = this.populated(data.path, true);
+    if (!pop && this.$__.selected) {
+      // If any array was selected using an $elemMatch projection, we alter the path and where clause
+      // NOTE: MongoDB only supports projected $elemMatch on top level array.
+      var pathSplit = data.path.split('.');
+      var top = pathSplit[0];
+      if (this.$__.selected[top] && this.$__.selected[top].$elemMatch) {
+        where[top] = this.$__.selected[top]; //FIXME: will we overwrite anything?
+        pathSplit[1] = '$'; //FIXME: check if the path is really top.0.something
+        data.path = pathSplit.join('.');
+      }
+    }
+
     if (divergent.length) continue;
 
     if (undefined === value) {
@@ -523,8 +536,7 @@ function checkDivergentArray(doc, path, array) {
     // If any array was selected using an $elemMatch projection, we deny the update.
     // NOTE: MongoDB only supports projected $elemMatch on top level array.
     var top = path.split('.')[0];
-    if ((doc.$__.selected[top] && doc.$__.selected[top].$elemMatch) ||
-        doc.$__.selected[top + '.$']) {
+    if (doc.$__.selected[top + '.$']) {
       return top;
     }
   }

--- a/test/model.field.selection.test.js
+++ b/test/model.field.selection.test.js
@@ -321,26 +321,31 @@ describe('model field selection', function() {
 
         B
         .findById(doc._id)
-        .select({ids: {$elemMatch: {$in: [_id2.toString()]}}})
         .select({ids2: {$elemMatch: {$in: [_id1.toString()]}}})
         .exec(function(err, found) {
           assert.ifError(err);
-          assert.equal(1, found.ids.length);
           assert.equal(1, found.ids2.length);
-          found.ids.pull(_id2);
           found.ids2.set(0, _id2);
+
           found.save(function(err) {
             assert.ifError(err);
 
-            B.findById(doc._id).exec(function(err, found) {
-              assert.equal(1, found.ids.length);
-              assert.equal(_id1.toHexString(), found.ids[0].toHexString());
-
+            B
+            .findById(doc._id)
+            .select({ids: {$elemMatch: {$in: [_id2.toString()]}}})
+            .select('ids2')
+            .exec(function(err, found) {
               assert.equal(2, found.ids2.length);
               assert.equal(_id2.toHexString(), found.ids2[0].toHexString());
               assert.equal(_id2.toHexString(), found.ids2[1].toHexString());
 
-              done();
+              found.ids.pull(_id2);
+
+              found.save(function(err) {
+                assert.ok(err);
+
+                db.close(done);
+              });
             });
           });
         });

--- a/test/model.field.selection.test.js
+++ b/test/model.field.selection.test.js
@@ -327,13 +327,14 @@ describe('model field selection', function() {
           assert.ifError(err);
           assert.equal(1, found.ids.length);
           assert.equal(1, found.ids2.length);
-          found.ids = [];
+          found.ids.pull(_id2);
           found.ids2.set(0, _id2);
           found.save(function(err) {
             assert.ifError(err);
 
             B.findById(doc._id).exec(function(err, found) {
-              assert.equal(0, found.ids.length); //FIXME is this the intended behaviour?
+              assert.equal(1, found.ids.length);
+              assert.equal(_id1.toHexString(), found.ids[0].toHexString());
 
               assert.equal(2, found.ids2.length);
               assert.equal(_id2.toHexString(), found.ids2[0].toHexString());

--- a/test/model.field.selection.test.js
+++ b/test/model.field.selection.test.js
@@ -304,7 +304,7 @@ describe('model field selection', function() {
       });
     });
 
-    it('disallows saving modified elemMatch paths (gh-1334)', function(done) {
+    it('saves modified elemMatch paths (gh-1334)', function(done) {
       var db = start();
 
       var postSchema = new Schema({
@@ -330,11 +330,17 @@ describe('model field selection', function() {
           found.ids = [];
           found.ids2.set(0, _id2);
           found.save(function(err) {
-            db.close();
-            assert.ok(/\$elemMatch projection/.test(err));
-            assert.ok(/ ids/.test(err));
-            assert.ok(/ ids2/.test(err));
-            done();
+            assert.ifError(err);
+
+            B.findById(doc._id).exec(function(err, found) {
+              assert.equal(0, found.ids.length); //FIXME is this the intended behaviour?
+
+              assert.equal(2, found.ids2.length);
+              assert.equal(_id2.toHexString(), found.ids2[0].toHexString());
+              assert.equal(_id2.toHexString(), found.ids2[1].toHexString());
+
+              done();
+            });
           });
         });
       });


### PR DESCRIPTION
See #1334 for discussion.
Test "model field selection with $elemMatch projection disallows saving modified elemMatch paths (gh-1334)" will fail, because saving now succeeds.
I do not know exactly, which additional checks are necessary. For example, what does Mongoose do, when an array field is removed or overwritten with a completely new array? Do I have to check for that?