### PR TITLE
Fix override of pre-set options when passing custom opts

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1880,6 +1880,15 @@ Document.prototype.$__handleReject = function handleReject(err) {
 
 Document.prototype.$toObject = function(options, json) {
   var defaultOptions = {transform: true, json: json};
+  var inheritedMethodOptions = json ?
+      clone(this.schema.options.toJSON) :
+      clone(this.schema.options.toObject);
+
+  if(!(inheritedMethodOptions && utils.getFunctionName(inheritedMethodOptions.constructor) === 'Object')) {
+    inheritedMethodOptions = {};
+  }
+
+  defaultOptions = Object.assign(defaultOptions, inheritedMethodOptions);
 
   if (options && options.depopulate && !options._skipDepopulateTopLevel && this.$__.wasPopulated) {
     // populated paths that we set to a document

--- a/lib/document.js
+++ b/lib/document.js
@@ -1888,8 +1888,10 @@ Document.prototype.$toObject = function(options, json) {
     inheritedMethodOptions = {};
   }
 
-  defaultOptions = Object.assign(defaultOptions, inheritedMethodOptions);
-
+  for (var opt in inheritedMethodOptions) {
+    defaultOptions[opt] = inheritedMethodOptions[opt];
+  }
+  
   if (options && options.depopulate && !options._skipDepopulateTopLevel && this.$__.wasPopulated) {
     // populated paths that we set to a document
     return clone(this._id, options);


### PR DESCRIPTION
when passing custom opts object to toJSON() or toObject(), the default/pre-set (or as you may to call it) schema options are mistakenly (?) overriden.

**meaning**, that if i have a transformed toJSON/toObject (using the `transform` option), and i want to pass my own custom opts, i'll accidentally override the schema options object which i pre-set to act as defaults, and ignore it -- causing inconvenience and discrepancy.

this commit fixes it. nothing too fancy or complicated.


## code demonstration of the issue:

### '/schemas/animal.schema.js':
```
AnimalSchema.set('toJSON', { virtuals: true, getters: true });

AnimalSchema.options.toJSON.transform = function(animal, animalJSON, opts)
{
    console.log(opts);
    return animalJSON;
}
```

### 'controllers/animal.controller.js'
```
animalDoc.toJSON(); // outputs "{ transform: [Function], getters: true,virtuals: true, json: true,_useSchemaOptions: true, minimize: false }"

animalDoc.toJSON({ customOpt: true }); // outputs "{ customOpt: true, transform: true, json: true, minimize: false }"
```

==

this PR will **correct** toJSON opts object, extending it with the custom passed custom opts param:
(after merge)
```
animalDoc.toJSON({ customOpt: true }); // outputs "{ customOpts: true, transform: [Function], getters: true,virtuals: true, json: true,_useSchemaOptions: true, minimize: false }"
```