### PR TITLE
Apply plugins to schemas only once

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -81,6 +81,7 @@ function Schema(obj, options) {
   this._requiredpaths = undefined;
   this.discriminatorMapping = undefined;
   this._indexedpaths = undefined;
+  this._appliedPlugins = [];
 
   this.s = {
     hooks: new Kareem(),
@@ -905,6 +906,8 @@ Schema.prototype.post = function(method, fn) {
  */
 
 Schema.prototype.plugin = function(fn, opts) {
+  if (this._appliedPlugins.indexOf(fn) > -1) { return this; }
+  this._appliedPlugins.push(fn);
   fn(this, opts);
   return this;
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -861,6 +861,22 @@ describe('schema', function() {
       assert.equal(true, called);
       done();
     });
+
+    it('does not apply more than once', function(done) {
+      var Tobi = new Schema,
+          called = 0;
+
+      var plugin = function(schema) {
+        assert.equal(schema, Tobi);
+        called += 1;
+      };
+
+      Tobi.plugin(plugin);
+      Tobi.plugin(plugin);
+
+      assert.equal(1, called);
+      done();
+    });
   });
 
   describe('options', function() {


### PR DESCRIPTION
Prevents the same plugin from being applied to the same schema more than once. See issue #4106 for details.