### PR TITLE
Updated QueryStream#destroy documentation.

### DIFF
--- a/docs/2.7.x/docs/querystream.html
+++ b/docs/2.7.x/docs/querystream.html
@@ -301,7 +301,7 @@ stream.paused // true
 
 <h2>QueryStream#destroy</h2>
 
-<p>Destroys the stream. No more events will be emitted after<br />calling this method.</p>
+<p>Destroys the stream and emits the close event. No more events will be emitted after<br />the close event.</p>
 
 <pre><code>stream.destroy([err])
 </code></pre>

--- a/docs/2.8.x/docs/querystream.html
+++ b/docs/2.8.x/docs/querystream.html
@@ -301,7 +301,7 @@ stream.paused // true
 
 <h2>QueryStream#destroy</h2>
 
-<p>Destroys the stream. No more events will be emitted after<br />calling this method.</p>
+<p>Destroys the stream and emits the close event. No more events will be emitted after<br />the close event.</p>
 
 <pre><code>stream.destroy([err])
 </code></pre>

--- a/lib/querystream.js
+++ b/lib/querystream.js
@@ -322,7 +322,7 @@ QueryStream.prototype.resume = function() {
 };
 
 /**
- * Destroys the stream, closing the underlying cursor. No more events will be emitted.
+ * Destroys the stream, closing the underlying cursor, which emits the close event. No more events will be emitted after the close event.
  *
  * @param {Error} [err]
  * @api public


### PR DESCRIPTION
Currently the doc explicitly says no events will be emitted after calling the `destory()` method on stream. However, that is not true and misleading because it does emit the close event.