### PR TITLE
chore(document): use function reference

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1188,7 +1188,7 @@ Document.prototype.$__validate = function(callback) {
     var pathToCheck = paths[i];
     if (this.schema.nested[pathToCheck]) {
       var _v = this.getValue(pathToCheck);
-      if (utils.isMongooseObject(_v)) {
+      if (isMongooseObject(_v)) {
         _v = _v.toObject({ virtuals: false });
       }
       var _subpaths = Object.keys(flatten(_v)).map(function(p) {


### PR DESCRIPTION
`isMongooseObject` was referenced in the top of the file to use `utils.isMongooseObject`, so no need to use `utils.` here