### PR TITLE
Path validation is called with the incorrect scope

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1271,7 +1271,7 @@ Document.prototype.validateSync = function(pathsToValidate) {
     }
     var p = _this.schema.path(path);
     if (typeof p.originalRequiredValue === 'function') {
-      return p.originalRequiredValue.call(this);
+      return p.originalRequiredValue.call(_this);
     }
     return true;
   });

--- a/lib/document.js
+++ b/lib/document.js
@@ -1144,7 +1144,7 @@ Document.prototype.$__validate = function(callback) {
     }
     var p = _this.schema.path(path);
     if (typeof p.originalRequiredValue === 'function') {
-      return p.originalRequiredValue.call(this);
+      return p.originalRequiredValue.call(_this);
     }
     return true;
   });


### PR DESCRIPTION
Unless I'm mistaken, calling `p.originalRequiredValue` with `this` instead of `_this` doesn't pass the correct scope to custom validation functions.