### PR TITLE
Add Query prototype `.catch()` method

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2198,6 +2198,20 @@ Query.prototype.then = function(resolve, reject) {
 };
 
 /**
+ * Executes the query returning a `Promise` which will be
+ * resolved with either the doc(s) or rejected with the error.
+ * Like `.then()`, but only takes a rejection handler.
+ *
+ * @param {Function} [reject]
+ * @return {Promise}
+ * @api public
+ */
+
+Query.prototype.catch = function(reject) {
+  return this.exec().then(null, reject);
+};
+
+/**
  * Finds the schema for `path`. This is different than
  * calling `schema.path` as it also resolves paths with
  * positional selectors (something.$.another.$.path).


### PR DESCRIPTION
See #4173

I haven't added a test as I couldn't find one for the `.then()` method either, and it's a pretty trivial implementation. Let me know if anything else needs adding.