### PR TITLE
Dedupe modified paths

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -939,7 +939,9 @@ Document.prototype.modifiedPaths = function() {
     var parts = path.split('.');
     return list.concat(parts.reduce(function(chains, part, i) {
       return chains.concat(parts.slice(0, i).concat(part).join('.'));
-    }, []));
+    }, []).filter(function(chain) {
+      return (list.indexOf(chain) === -1);
+    }));
   }, []);
 };
 


### PR DESCRIPTION
This change filters out modified chains already present in the list before concatenating.

See #4223