### PR TITLE
TypeError--

### DIFF
--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -96,7 +96,7 @@ Subdocument.prototype.ownerDocument = function() {
 Subdocument.prototype.remove = function(callback) {
   this.$parent.set(this.$basePath, null);
   registerRemoveListener(this);
-  if (callback) {
+  if (typeof callback === 'function') {
     callback(null);
   }
 };


### PR DESCRIPTION
I don't know why yet, but I get this error in my application:

    TypeError: callback is not a function
    at Document.Subdocument.remove (/src/xxx/node_modules/mongoose/lib/types/subdocument.js:100:5)
    at Document._done (/src/xxx/node_modules/hooks-fixed/hooks.js:101:24)
    at _next (/src/xxx/node_modules/hooks-fixed/hooks.js:64:28)
    at fnWrapper (/src/xxx/node_modules/hooks-fixed/hooks.js:186:18)
    at Document.Object.defineProperty.value.fn (/src/xxx/node_modules/mongoose/lib/schema.js:249:11)
    at Document._next (/src/xxx/node_modules/hooks-fixed/hooks.js:62:30)
    at Document.proto.(anonymous function) [as $__original_remove] (/src/xxx/node_modules/hooks-fixed/hooks.js:108:20)
    at /src/xxx/node_modules/mongoose/lib/document.js:1898:24
    at new Promise.ES6 (/src/xxx/node_modules/mongoose/lib/promise.js:45:3)
    at Document.wrappedPointCut [as remove] (/src/xxx/node_modules/mongoose/lib/document.js:1880:14)
    at /src/xxx/node_modules/mongoose/lib/schema.js:262:18
    at /src/xxx/node_modules/async/lib/async.js:181:20
    at Object.async.forEachOf.async.eachOf (/src/xxx/node_modules/async/lib/async.js:233:13)
    at Object.async.forEach.async.each (/src/xxx/node_modules/async/lib/async.js:209:22)
    at model.Object.defineProperty.value.fn (/src/xxx/node_modules/mongoose/lib/schema.js:261:15)

The `callback` was equal to `{noop: true}`, maybe it's related to this line: https://github.com/Automattic/mongoose/blob/1f8e5e0609a29273444a6a9c8193d71fb452939a/lib/schema.js#L262
So I add a simple test `typeof callback === "function"`

Regards,