### PR TITLE
Passing undefined to MongooseArray#pull pulls all values

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2259,6 +2259,10 @@ Document.prototype.toString = function() {
  */
 
 Document.prototype.equals = function(doc) {
+  if (!doc) {
+    return false;
+  }
+
   var tid = this.get('_id');
   var docid = doc.get ? doc.get('_id') : doc;
   if (!tid && !docid) {

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -525,7 +525,7 @@ MongooseArray.mixin = {
       mem = cur[i];
       if (mem instanceof Document) {
         var some = values.some(function(v) {
-          return v.equals(mem);
+          return mem.equals(v);
         });
         if (some) {
           [].splice.call(cur, i, 1);

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -96,6 +96,10 @@ MongooseDocumentArray.mixin = {
       return value;
     }
 
+    if (value === undefined || value === null) {
+      return null;
+    }
+
     // handle cast('string') or cast(ObjectId) etc.
     // only objects are permitted so we can safely assume that
     // non-objects are to be interpreted as _id

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -775,6 +775,37 @@ describe('types array', function() {
         });
       });
     });
+
+    it('properly works with undefined', function(done) {
+      var db = start();
+      var catschema = new Schema({ name: String, colors: [{hex: String}] });
+      var Cat = db.model('Cat', catschema);
+
+      var cat = new Cat({name: 'peanut', colors: [
+        {hex: '#FFF'}, {hex: '#000'}, null
+      ]});
+
+      cat.save(function(err) {
+        assert.ifError(err);
+
+        cat.colors.pull(undefined); // converted to null (as mongodb does)
+        assert.equal(cat.colors.length, 2);
+        assert.equal(cat.colors[0].hex, '#FFF');
+        assert.equal(cat.colors[1].hex, '#000');
+
+        cat.save(function(err) {
+          assert.ifError(err);
+
+          Cat.findById(cat._id, function(err, doc) {
+            assert.ifError(err);
+            assert.equal(doc.colors.length, 2);
+            assert.equal(doc.colors[0].hex, '#FFF');
+            assert.equal(doc.colors[1].hex, '#000');
+            db.close(done);
+          });
+        });
+      });
+    });
   });
 
   describe('$pop()', function() {


### PR DESCRIPTION
Passing undefined (and only undefined; doesn't occur with either no args, nor other args + undefined, but does crash with undefined + other args) results in an empty MongooseArray on the mongo side (but not locally until a refresh).

See this example:
```js
var mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test');

var Cat = mongoose.model('Cat', {
    name: String,
    colors: [
        { hex: String }
    ]
});

var kitty = new Cat({ name: 'Zildjian', colors: [{hex:'#FFF'}, {hex:'#FFF'}] });
kitty.save(function (err) {
  kitty.colors.pull(undefined);
  console.log(kitty) // all fine here
  kitty.save(() => {

    Cat.find({ _id: kitty.id }).then((res) => {
        console.log(res[0]) // array empty
    })
  })
});
```

Output:
```
{ colors: 
   [ { _id: 575b3e792d0799125dea917c, hex: '#FFF' },
     { _id: 575b3e792d0799125dea917b, hex: '#FFF' } ],
  _id: 575b3e792d0799125dea917a,
  name: 'Zildjian',
  __v: 0 }
{ colors: [],
  __v: 1,
  name: 'Zildjian',
  _id: 575b3e792d0799125dea917a }
```

This is not the case in mongoose 3.8.x, not sure when that regressed.