### PR TITLE
Add checks for collection presence for `onOpen` and `onClose`.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -505,7 +505,7 @@ Connection.prototype.onOpen = function(callback) {
     // avoid having the collection subscribe to our event emitter
     // to prevent 0.3 warning
     for (var i in _this.collections) {
-      if (_this.collections[i]) {
+      if (utils.object.hasOwnProperty(_this.collections, i)) {
         _this.collections[i].onOpen();
       }
     }
@@ -606,7 +606,7 @@ Connection.prototype.onClose = function() {
   // avoid having the collection subscribe to our event emitter
   // to prevent 0.3 warning
   for (var i in this.collections) {
-    if (this.collections[i]) {
+    if (utils.object.hasOwnProperty(this.collections, i)) {
       this.collections[i].onClose();
     }
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -505,7 +505,9 @@ Connection.prototype.onOpen = function(callback) {
     // avoid having the collection subscribe to our event emitter
     // to prevent 0.3 warning
     for (var i in _this.collections) {
-      _this.collections[i].onOpen();
+      if (_this.collections[i]) {
+        _this.collections[i].onOpen();
+      }
     }
 
     callback && callback();
@@ -604,7 +606,9 @@ Connection.prototype.onClose = function() {
   // avoid having the collection subscribe to our event emitter
   // to prevent 0.3 warning
   for (var i in this.collections) {
-    this.collections[i].onClose();
+    if (this.collections[i]) {
+      this.collections[i].onClose();
+    }
   }
 
   this.emit('close');


### PR DESCRIPTION
Problem in `for (var i in `, which can return prototype keys.

I got this problem in Mocha tests. `for (var i in this.collections)` in addition to collections names, became returns `getClassName` value. And this produced following error:
```
TypeError: _this.collections[i].onOpen is not a function
    at open (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongoose/lib/connection.js:508:28)
    at NativeConnection.Connection.onOpen (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongoose/lib/connection.js:521:5)
    at /Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongoose/lib/connection.js:483:11
    at /Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongoose/lib/drivers/node-mongodb-native/connection.js:60:5
    at /Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb/lib/db.js:234:5
    at connectHandler (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb/lib/server.js:306:7)
    at g (events.js:286:16)
    at emitOne (events.js:96:13)
    at emit (events.js:188:7)
    at /Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:572:23
    at /Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:492:18
    at ScramSHA1.reauthenticate (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/auth/scram.js:312:25)
    at applyAuthentications (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:488:36)
    at /Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:527:7
    at commandCallback (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:1194:9)
    at Callbacks.emit (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:119:3)
    at .messageHandler (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/topologies/server.js:358:23)
    at Socket.<anonymous> (/Users/nod/www/_npm/graphql-compose-mongoose/node_modules/mongodb-core/lib/connection/connection.js:292:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:172:18)
    at Socket.Readable.push (_stream_readable.js:130:10)
    at TCP.onread (net.js:542:20)
```