### PR TITLE
consider lean option in populate

### DIFF
--- a/lib/querycursor.js
+++ b/lib/querycursor.js
@@ -209,7 +209,9 @@ function _next(ctx, callback) {
         if (err) {
           return callback(err);
         }
-        _create(ctx, doc, pop, callback);
+        return opts.lean === true ?
+          callback(null, doc) :
+          _create(ctx, doc, pop, callback);
       });
     });
   } else {


### PR DESCRIPTION
It looks #4255 missed a case where populate() was invoked.
Added the missing code.

Please, review.

Thank you,
Grigoriy.