### PR TITLE
increase mongodb native client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bson": "~0.4.23",
     "hooks-fixed": "1.1.0",
     "kareem": "1.1.3",
-    "mongodb": "2.1.18",
+    "mongodb": "2.1.21",
     "mpath": "0.2.1",
     "mpromise": "0.5.5",
     "mquery": "1.11.0",


### PR DESCRIPTION
increase mongodb version to be able to use  gridFS bucket openUploadStreamWithId new function.