### PR TITLE
Change MongoDB Node driver version from 2.1.21 to 2.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bson": "~0.4.23",
     "hooks-fixed": "1.1.0",
     "kareem": "1.1.3",
-    "mongodb": "2.1.21",
+    "mongodb": "2.1.18",
     "mpath": "0.2.1",
     "mpromise": "0.5.5",
     "mquery": "1.11.0",


### PR DESCRIPTION
version 2.1.21 is broken per https://jira.mongodb.org/browse/NODE-722?focusedCommentId=1287950&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1287950. revert to 2.1.18