### PR TITLE
Make sure that createdAt does not get overriden

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -753,7 +753,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
       var defaultTimestamp = new Date();
       var auto_id = this._id && this._id.auto;
 
-      if (!this[createdAt]) {
+      if (!this[createdAt] && this.isSelected(createdAt)) {
         this[createdAt] = auto_id ? this._id.getTimestamp() : defaultTimestamp;
       }
 


### PR DESCRIPTION
`createdAt` should always represent the document’s creation date. Whenever
`createdAt` is not selected (so `undefined`) and we update the document – it
should not be set to a new value.

Fix #4340