### PR TITLE
fix #4434 subdocuments causing error with parent timestamp on update

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -856,18 +856,22 @@ function applyTimestampsToChildren(query) {
             schema.path(key).$isMongooseDocumentArray) {
           len = update.$set[key].length;
           timestamps = schema.path(key).schema.options.timestamps;
-          createdAt = timestamps.createdAt || 'createdAt';
-          updatedAt = timestamps.updatedAt || 'updatedAt';
-          for (var i = 0; i < len; ++i) {
-            update.$set[key][i][updatedAt] = now;
-            update.$set[key][i][createdAt] = now;
+          if (timestamps) {
+            createdAt = timestamps.createdAt || 'createdAt';
+            updatedAt = timestamps.updatedAt || 'updatedAt';
+            for (var i = 0; i < len; ++i) {
+              update.$set[key][i][updatedAt] = now;
+              update.$set[key][i][createdAt] = now;
+            }
           }
         } else if (update.$set[key] && schema.path(key).$isSingleNested) {
           timestamps = schema.path(key).schema.options.timestamps;
-          createdAt = timestamps.createdAt || 'createdAt';
-          updatedAt = timestamps.updatedAt || 'updatedAt';
-          update.$set[key][updatedAt] = now;
-          update.$set[key][createdAt] = now;
+          if (timestamps) {
+            createdAt = timestamps.createdAt || 'createdAt';
+            updatedAt = timestamps.updatedAt || 'updatedAt';
+            update.$set[key][updatedAt] = now;
+            update.$set[key][createdAt] = now;
+          }
         }
       }
     }

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -50,4 +50,39 @@ describe('types.subdocument', function() {
     assert.equal(p._id, p.children[0].child.ownerDocument()._id);
     done();
   });
+  it('not setting timestamps in subdocuments', function() {
+    var Thing = mongoose.model('Thing', new Schema({
+      subArray: [{
+        testString: String
+      }]
+    }, {
+      timestamps: true
+    }));
+
+    var thingy = new Thing({
+      subArray: [{
+        testString: 'Test 1'
+      }]
+    });
+    var id;
+    thingy.save(function(err, item) {
+      assert(!err);
+      id = item._id;
+    })
+    .then(function() {
+      var thingy2 = {
+        subArray: [{
+          testString: 'Test 2'
+        }]
+      };
+      return Thing.update({
+        _id: id
+      }, {$set: thingy2});
+    })
+    .then(function() {
+      mongoose.connection.close();
+    }, function(reason) {
+      assert(!reason);
+    });
+  });
 });


### PR DESCRIPTION
mongoose@4.5.9, mongodb@2.1.18
When updating a saved document with timestamps, the subdocuments without options create an error, since the 'timestamps' option does not exist on the subdocument:
```
var mongoose = require('mongoose')
mongoose.connect('mongodb://localhost/test')
var Schema = mongoose.Schema

var Thing = mongoose.model('Thing', new Schema({
  subArray: [{
    testString: String
  }]
}, {
  timestamps: true
}))

var thingy = new Thing({
  subArray: [{
    testString: 'not updated'
  }]
})

var id
thingy.save(function (err, item) {
  if (err) {
    console.log(err)
  } else {
    id = item._id
  }
})
.then(function () {
  var thingy2 = {
    subArray: [{
      testString: 'updated'
    }]
  }
  return Thing.update({
    _id: id
  }, {$set: thingy2})
})
.then(function () {
  mongoose.connection.close()
})
.catch(function (err) {
  console.log(err)
})
```
the above script gives the following error:
```
TypeError: Cannot read property 'createdAt' of undefined
    at applyTimestampsToChildren (/Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/schema.js:859:33)
    at Query.<anonymous> (/Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/schema.js:816:7)
    at next (/Users/dyang/Documents/mongooseTest/node_modules/kareem/index.js:82:14)
    at Kareem.execPre (/Users/dyang/Documents/mongooseTest/node_modules/kareem/index.js:99:3)
    at Kareem.wrap (/Users/dyang/Documents/mongooseTest/node_modules/kareem/index.js:231:8)
    at Query._execUpdate (/Users/dyang/Documents/mongooseTest/node_modules/kareem/index.js:271:11)
    at Query.update (/Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/query.js:2189:17)
    at /Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/query.js:2230:21
    at new Promise.ES6 (/Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/promise.js:45:3)
    at Query.exec (/Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/query.js:2223:10)
    at Query.then (/Users/dyang/Documents/mongooseTest/node_modules/mongoose/lib/query.js:2253:15)
    at resolve (/Users/dyang/Documents/mongooseTest/node_modules/mpromise/lib/promise.js:284:23)
    at newTickHandler (/Users/dyang/Documents/mongooseTest/node_modules/mpromise/lib/promise.js:239:5)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
I believe this was introduced in 4.5.9, and is related to the solution for #4049.
This PR fixes the issue