### PR TITLE
should not cause unhandle reject promise when create fail

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1858,8 +1858,11 @@ Model.create = function create(doc, callback) {
 
     async.parallel(toExecute, function(error, savedDocs) {
       if (error) {
-        cb && cb(error);
-        reject(error);
+        if (cb) {
+          cb(error);
+        } else {
+          reject(error);
+        }
         return;
       }
 

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -7,7 +7,8 @@ var start = require('./common'),
     mongoose = start.mongoose,
     random = require('../lib/utils').random,
     Schema = mongoose.Schema,
-    DocumentObjectId = mongoose.Types.ObjectId;
+    DocumentObjectId = mongoose.Types.ObjectId,
+    PromiseProvider = require('../lib/promise_provider');
 
 /**
  * Setup
@@ -63,6 +64,19 @@ describe('model', function() {
         assert.ifError(err);
         assert.ok(!a);
         done();
+      });
+    });
+
+    it('should not cause unhandled reject promise', function(done) {
+      mongoose.Promise = global.Promise;
+      mongoose.Promise = require('bluebird');
+      B.create({title: 'reject promise'}, function(err, b) {
+        assert.ifError(err);
+        B.create({_id: b._id}, function(err) {
+          assert(err);
+          PromiseProvider.reset();
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
When create a instance with a callback, an unhandled reject promise event will triggered if create failed.

```
var TaskSchema = new Schema({
  name: {
    type: String,
    maxlength: 4
  }
})

var Task = mongoose.model('Task', TaskSchema)

Task.create({
  name: 'too long name'
}, function (err, task) {
  // here will have an err.
  console.log(err)
})

process.on('unhandledRejection', function (reason, promise) {
  // and there will a event.
  console.log(reason)
})
````