### PR TITLE
docs(document): clarify the findById and findByIdAndUpdate examples

### DIFF
--- a/docs/documents.jade
+++ b/docs/documents.jade
@@ -27,7 +27,7 @@ block content
   :markdown
     If we do need the document returned in our application there is another, often [better](./api.html#model_Model.findByIdAndUpdate), option:
   :js
-    Tank.findByIdAndUpdate(id, { $set: { size: 'large' }}, function (err, tank) {
+    Tank.findByIdAndUpdate(id, { $set: { size: 'large' }}, { new: true }, function (err, tank) {
       if (err) return handleError(err);
       res.send(tank);
     });

--- a/docs/documents.jade
+++ b/docs/documents.jade
@@ -15,9 +15,9 @@ block content
       if (err) return handleError(err);
 
       tank.size = 'large';
-      tank.save(function (err) {
+      tank.save(function (err, updatedTank) {
         if (err) return handleError(err);
-        res.send(tank);
+        res.send(updatedTank);
       });
     });
   :markdown


### PR DESCRIPTION
The current example given for the 'findById' method places the updated document in the callback function while the 'findByIdAndUpdate' method places the original document in the callback. To keep things consistent they should both return the updated document which is returned from the db.

Wasn't sure which branch to put this on, happy to move it.