### PR TITLE
Fix an error on findOneAndUpdate with array of arrays

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -205,7 +205,7 @@ SchemaArray.prototype.castForQuery = function($conditional, value) {
   } else {
     val = $conditional;
     var proto = this.casterConstructor.prototype;
-    var method = proto.castForQuery || proto.cast;
+    var method = proto && (proto.castForQuery || proto.cast);
     var caster = this.caster;
 
     if (Array.isArray(val)) {


### PR DESCRIPTION
I have scema with 'Array of Arrays' field type like

```
let schema = new mongoose.Schema({
    name: String,
    fieldArray: [[Number]]
}, { strict: true, versionKey: false });
```

Creating new document works fine for this

```
let doc = { name: "asdf", fieldArray: [[12, 654, 8], [-54, -45]]};
new model(doc).save()
```

But findOneAndUpdate throws error

> TypeError: Cannot read property 'castForQuery' of undefined at SchemaArray.castForQuery
> (\node_modules\mongoose\lib\schema\array.js:208:37)
>     at Query._castUpdateVal (\node_modules\mongoose\lib\query.js:2575:17)
>     at Query._walkUpdatePath (\node_modules\mongoose\lib\query.js:2519:25)
>     at Query._castUpdate (\node_modules\mongoose\lib\query.js:2391:23)
>     at castDoc (\node_modules\mongoose\lib\query.js:2598:18)
>     at Query._findAndModify (\node_modules\mongoose\lib\query.js:1825:17)
>     at Query._findOneAndUpdate (\node_modules\mongoose\lib\query.js:1692:8)
>     at \node_modules\kareem\index.js:239:8
>     at \node_modules\kareem\index.js:18:7
>     at _combinedTickCallback (internal/process/next_tick.js:67:7)
>     at process._tickCallback (internal/process/next_tick.js:98:9)

Full code to reproduce error
```
'use strict';
var mongoose = require('mongoose');
mongoose.Promise = require('bluebird');

let schema = new mongoose.Schema({
    name: String,
    fieldArray: [[Number]]
}, { strict: true, versionKey: false });

let model = mongoose.model('TestArray', schema);

mongoose.connect('mongodb://localhost/TestArray');

let doc = { name: 'asdf', fieldArray: [[12, 654, 8], [-54, -45]]};
let newDoc = { fieldArray: [[34], [-54], [0, 12]]};

new model(doc).save()
    .then(() => model.findOneAndUpdate({name: doc.name}, newDoc, {new: true}))
    .then(doc => console.log(doc.toObject()))
    .catch(err => console.warn(err))
    .finally(() => mongoose.connection.close());
```


I've looked to [ node_modules\mongoose\lib\schema\array.js:208](https://github.com/Automattic/mongoose/blob/master/lib/schema/array.js#L208)
As I can see if line 208 change to
`var method = proto && (proto.castForQuery || proto.cast);`
the logic will not be broken. After the fix findOneAndUpdate works fine for above example.