### PR TITLE
Fix webpack build

### DIFF
--- a/lib/document_provider.web.js
+++ b/lib/document_provider.web.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/* eslint-env browser */
+
+/*!
+ * Module dependencies.
+ */
+var BrowserDocument = require('./browserDocument.js');
+
+/**
+ * Returns the Document constructor for the current context
+ *
+ * @api private
+ */
+module.exports = function() {
+  return BrowserDocument;
+};

--- a/lib/drivers/index.web.js
+++ b/lib/drivers/index.web.js
@@ -1,0 +1,1 @@
+module.exports = require('./browser');


### PR DESCRIPTION
With this fix, we can have the browser implementation be compatible with webpack.

Solution derived from @patterncoder's ["hack"](https://github.com/Automattic/mongoose/issues/3578#issuecomment-166437240).

The "solutions" in related issues haven't been satisfactory. The current `lib/drivers/index.js`'s `typeof window === 'undefined'` check doesn't satisfy webpack without extraneous (and irrelevant to mongoose in the browser) loaders. Requiring a separate `<script>` tag also breaks the point of webpack. While webpack isn't a specified case mongoose supports, this one file would handle the problem entirely.

Resolves webpack/webpack#1040
Resolves webpack/webpack#2566
Resolves #3713
Resolves #3578