### PR TITLE
Fix bug with initializing new object with _id

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -107,7 +107,7 @@ function Schema(obj, options) {
 
   if (auto_id) {
     obj = {_id: {auto: true}};
-    obj._id[this.options.typeKey] = Schema.ObjectId;
+    obj._id[this.options.typeKey] = Schema.Types.ObjectId;
     this.add(obj);
   }
 


### PR DESCRIPTION
The bug happened while running tests locally.  The error message was:
```
TypeError: Undefined type `undefined` at `_id.auto`
Did you try nesting Schemas? You can only nest using refs or arrays.
```

It produced the following stack trace:
```
    at Function.Schema.interpretAsType (.../node_modules/mongoose/lib/schema.js:557:11)
    at Schema.path (.../node_modules/mongoose/lib/schema.js:464:29)
    at Schema.add (.../node_modules/mongoose/lib/schema.js:348:12)
    at Schema.add (.../node_modules/mongoose/lib/schema.js:343:14)
    at new Schema (.../node_modules/mongoose/lib/schema.js:107:10)
    at Function.Schema.interpretAsType (.../node_modules/mongoose/lib/schema.js:529:25)
    at Schema.path (.../node_modules/mongoose/lib/schema.js:464:29)
    at Schema.add (.../node_modules/mongoose/lib/schema.js:348:12)
    at Schema.add (.../node_modules/mongoose/lib/schema.js:343:14)
    at new Schema (.../node_modules/mongoose/lib/schema.js:94:10)
```

After stepping through debugger, I saw that `Schema.ObjectId` is undefined,
but `Schema.Types.ObjectId` is not.  This change got my code running successfully.