### PR TITLE
Read Model from this

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -389,7 +389,7 @@ Mongoose.prototype.model = function(name, schema, collection, skipInit) {
   }
 
   var connection = options.connection || this.connection;
-  model = Model.compile(name, schema, collection, connection, this);
+  model = this.Model.compile(name, schema, collection, connection, this);
 
   if (!skipInit) {
     model.init();


### PR DESCRIPTION
Hi,

I'm looking for a workaround on an issue (on compound primary key). I think I have a Quick & Dirty solution, so I want to override Model.

The following PR allow that by using the Mongoose.prototype.Model = Model; (line 674) and not the require (line 13)

Regards,

Gaël - HungryUp