### PR TITLE
fix wrong link in documentation

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -398,7 +398,7 @@ SchemaType.prototype.get = function(fn) {
  *
  * ####Error message templates:
  *
- * From the examples above, you may have noticed that error messages support basic templating. There are a few other template keywords besides `{PATH}` and `{VALUE}` too. To find out more, details are available [here](#error_messages_MongooseError-messages)
+ * From the examples above, you may have noticed that error messages support basic templating. There are a few other template keywords besides `{PATH}` and `{VALUE}` too. To find out more, details are available [here](#error_messages_MongooseError.messages)
  *
  * ####Asynchronous validation:
  *


### PR DESCRIPTION
Existing link didn't go anywhere.