### PR TITLE
db.open emits error even if it was caught

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -281,15 +281,17 @@ Connection.prototype.open = function(host, database, port, options, callback) {
   var Promise = PromiseProvider.get();
   var promise = new Promise.ES6(function(resolve, reject) {
     _this._open(true, function(error) {
-      callback && callback(error);
       if (error) {
-        reject(error);
-        if (!callback && !promise.$hasHandler) {
+        if (callback) {
+          callback(error);
+        } else if (reject) {
+          reject(error);
+        } else {
           _this.emit('error', error);
         }
-        return;
+      } else {
+        resolve();
       }
-      resolve();
     });
   });
   return promise;


### PR DESCRIPTION
original error on reconnect

```
TypeError: db.close is not a function
    at NativeConnection.db.on.error (/home/travis/build/bucket-list/operator/source/utils/mongoose.js:2:1821)
    at emitOne (events.js:96:13)
    at NativeConnection.emit (events.js:188:7)
    at /home/travis/build/bucket-list/operator/node_modules/mongoose/lib/connection.js:288:17
    at NativeConnection.Connection.error (/home/travis/build/bucket-list/operator/node_modules/mongoose/lib/connection.js:451:12)
    at /home/travis/build/bucket-list/operator/node_modules/mongoose/lib/connection.js:482:15
    at /home/travis/build/bucket-list/operator/node_modules/mongoose/lib/drivers/node-mongodb-native/connection.js:69:21
    at /home/travis/build/bucket-list/operator/node_modules/mongoose/node_modules/mongodb/lib/db.js:229:14
    at Server.<anonymous> (/home/travis/build/bucket-list/operator/node_modules/mongoose/node_modules/mongodb/lib/server.js:259:9)
    at Server.g (events.js:291:16)
    at emitOne (events.js:96:13)
    at Server.emit (events.js:188:7)
    at Pool.<anonymous> (/home/travis/build/bucket-list/operator/node_modules/mongoose/node_modules/mongodb-core/lib/topologies/server.js:313:21)
    at emitOne (events.js:96:13)
    at Pool.emit (events.js:188:7)
    at Connection.<anonymous> (/home/travis/build/bucket-list/operator/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:260:12)
    at Connection.g (events.js:291:16)
    at emitTwo (events.js:106:13)
    at Connection.emit (events.js:191:7)
    at Socket.<anonymous> (/home/travis/build/bucket-list/operator/node_modules/mongoose/node_modules/mongodb-core/lib/connection/connection.js:172:10)
    at Socket.g (events.js:291:16)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:185:7)
    at Socket._onTimeout (net.js:334:8)
    at tryOnTimeout (timers.js:232:11)
    at Timer.listOnTimeout (timers.js:202:5)
```