### PR TITLE
Fix for array field false default values

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -77,14 +77,14 @@ function SchemaArray(key, cast, options, schemaOptions) {
   var defaultArr;
   var fn;
 
-  if (this.defaultValue) {
+  if (this.defaultValue !== void 0) {
     defaultArr = this.defaultValue;
     fn = typeof defaultArr === 'function';
   }
 
   if (!('defaultValue' in this) || this.defaultValue !== void 0) {
     this.default(function() {
-      var arr = fn ? defaultArr() : defaultArr || [];
+      var arr = fn ? defaultArr() : defaultArr;
       // Leave it up to `cast()` to convert the array
       return arr;
     });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -233,6 +233,9 @@ describe('schema', function() {
       simple: {$type: String, default: 'a'},
       array: {$type: Array, default: [1, 2, 3, 4, 5]},
       arrayX: {$type: Array, default: 9},
+      arrayZero: {$type: Array, default: 0},
+      arrayFalse: {$type: Array, default: false},
+      arrayString: {$type: Array, default: ""},
       arrayFn: {
         $type: Array, default: function() {
           return [8];
@@ -254,6 +257,9 @@ describe('schema', function() {
     assert.equal(typeof Test.path('array').defaultValue, 'function');
     assert.equal(Test.path('array').getDefault(new TestDocument)[3], 4);
     assert.equal(Test.path('arrayX').getDefault(new TestDocument)[0], 9);
+    assert.equal(Test.path('arrayZero').getDefault(new TestDocument)[0], 0);
+    assert.equal(Test.path('arrayFalse').getDefault(new TestDocument)[0], false);
+    assert.equal(Test.path('arrayString').getDefault(new TestDocument)[0], "");
     assert.equal(typeof Test.path('arrayFn').defaultValue, 'function');
     assert.ok(Test.path('arrayFn').getDefault(new TestDocument).isMongooseArray);
     assert.ok(Test.path('arrayX').getDefault(new TestDocument).isMongooseArray);


### PR DESCRIPTION
When you set default value any false value like 0, false or empty string, it was return empty array. And you need to give that default value in function to hack that. It was because weird undefined check. I hope this PR won’t break anything. It passes tests.