### PR TITLE
reconnectFailed error from driver not being caught

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -60,7 +60,7 @@ NativeConnection.prototype.doOpen = function(fn) {
 
     if (!mongos) {
       server.s.server.on('error', function(error) {
-        if (/after \d+ retries/.test(error.message)) {
+        if (/after \d+ attempts/.test(error.message)) {
           _this.emit('error', new DisconnectedError(server.s.server.name));
         }
       });


### PR DESCRIPTION
It looks like the error message emitted by the mongo driver when auto reconnect mechanism fails has been changed recently (https://github.com/christkv/mongodb-core/blob/319f26dcbdf71a13f234ca33aac2a49642984b5b/lib/connection/pool.js#L307) from `...after x retries...` to `...after x attempts...`, thus the regex used to caught the error and emit a mongoose `error` is not matching anymore