### PR TITLE
Integration for ES6 classes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -309,14 +309,23 @@ Mongoose.prototype.disconnect.$hasSideEffects = true;
  *     var collectionName = 'actor'
  *     var M = mongoose.model('Actor', schema, collectionName)
  *
- * @param {String} name model name
+ * @param {String|Function} name model name or class extending Model
  * @param {Schema} [schema]
- * @param {String} [collection] name (optional, induced from model name)
+ * @param {String} [collection] name (optional, inferred from model name)
  * @param {Boolean} [skipInit] whether to skip initialization (defaults to false)
  * @api public
  */
 
 Mongoose.prototype.model = function(name, schema, collection, skipInit) {
+  var model;
+  if (typeof name === 'function') {
+    model = name;
+    name = model.name;
+    if (!(model.prototype instanceof Model)) {
+      throw new mongoose.Error('The provided class ' + name + ' must extend Model');
+    }
+  }
+
   if (typeof schema === 'string') {
     collection = schema;
     schema = false;
@@ -354,7 +363,6 @@ Mongoose.prototype.model = function(name, schema, collection, skipInit) {
     this._applyPlugins(schema);
   }
 
-  var model;
   var sub;
 
   // connection.model() may be passing a different schema for
@@ -393,7 +401,7 @@ Mongoose.prototype.model = function(name, schema, collection, skipInit) {
   }
 
   var connection = options.connection || this.connection;
-  model = this.Model.compile(name, schema, collection, connection, this);
+  model = this.Model.compile(model || name, schema, collection, connection, this);
 
   if (!skipInit) {
     model.init();

--- a/lib/model.js
+++ b/lib/model.js
@@ -3190,7 +3190,7 @@ Model._getSchema = function _getSchema(path) {
 /*!
  * Compiler utility.
  *
- * @param {String} name model name
+ * @param {String|Function} name model name or class extending Model
  * @param {Schema} schema
  * @param {String} collectionName
  * @param {Connection} connection
@@ -3207,19 +3207,28 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
     schema.add(o);
   }
 
-  // generate new class
-  function model(doc, fields, skipId) {
-    if (!(this instanceof model)) {
-      return new model(doc, fields, skipId);
-    }
-    Model.call(this, doc, fields, skipId);
+  var model;
+  if (typeof name === 'function' && name.prototype instanceof Model) {
+    model = name;
+    name = model.name;
+    schema.loadClass(model, true);
+  } else {
+    // generate new class
+    model = function model(doc, fields, skipId) {
+      if (!(this instanceof model)) {
+        return new model(doc, fields, skipId);
+      }
+      Model.call(this, doc, fields, skipId);
+    };
   }
 
   model.hooks = schema.s.hooks.clone();
   model.base = base;
   model.modelName = name;
-  model.__proto__ = Model;
-  model.prototype.__proto__ = Model.prototype;
+  if (!(model.prototype instanceof Model)) {
+    model.__proto__ = Model;
+    model.prototype.__proto__ = Model.prototype;
+  }
   model.model = Model.prototype.model;
   model.db = model.prototype.db = connection;
   model.discriminators = model.prototype.discriminators = undefined;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1504,6 +1504,45 @@ Schema.prototype.remove = function(path) {
   }
 };
 
+/**
+ * Loads an ES6 class into a schema. Maps setters + getters, static methods, and instance methods to schema virtuals, statics, and methods.
+ *
+ * @param {Function} model
+ */
+Schema.prototype.loadClass = function(model) {
+  if (model === Object.prototype || model === Function.prototype) {
+    return this;
+  }
+
+  // Add static methods
+  Object.getOwnPropertyNames(model).forEach(function(name) {
+    if (name.match(/^(length|name|prototype)$/)) {
+      return;
+    }
+    var method = Object.getOwnPropertyDescriptor(model, name);
+    if (typeof method.value === 'function') this.static(name, method.value);
+  }, this);
+
+  // Add methods and virtuals
+  Object.getOwnPropertyNames(model.prototype).forEach(function(name) {
+    if (name.match(/^(constructor)$/)) {
+      return;
+    }
+    var method = Object.getOwnPropertyDescriptor(model.prototype, name);
+    if (typeof method.value === 'function') {
+      this.method(name, method.value);
+    }
+    if (typeof method.get === 'function') {
+      this.virtual(name).get(method.get);
+    }
+    if (typeof method.set === 'function') {
+      this.virtual(name).set(method.set);
+    }
+  }, this);
+
+  return (this.loadClass(Object.getPrototypeOf(model)));
+};
+
 /*!
  * ignore
  */

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1509,19 +1509,21 @@ Schema.prototype.remove = function(path) {
  *
  * @param {Function} model
  */
-Schema.prototype.loadClass = function(model) {
+Schema.prototype.loadClass = function(model, virtualsOnly) {
   if (model === Object.prototype || model === Function.prototype) {
     return this;
   }
 
   // Add static methods
-  Object.getOwnPropertyNames(model).forEach(function(name) {
-    if (name.match(/^(length|name|prototype)$/)) {
-      return;
-    }
-    var method = Object.getOwnPropertyDescriptor(model, name);
-    if (typeof method.value === 'function') this.static(name, method.value);
-  }, this);
+  if (!virtualsOnly) {
+    Object.getOwnPropertyNames(model).forEach(function(name) {
+      if (name.match(/^(length|name|prototype)$/)) {
+        return;
+      }
+      var method = Object.getOwnPropertyDescriptor(model, name);
+      if (typeof method.value === 'function') this.static(name, method.value);
+    }, this);
+  }
 
   // Add methods and virtuals
   Object.getOwnPropertyNames(model.prototype).forEach(function(name) {
@@ -1529,8 +1531,10 @@ Schema.prototype.loadClass = function(model) {
       return;
     }
     var method = Object.getOwnPropertyDescriptor(model.prototype, name);
-    if (typeof method.value === 'function') {
-      this.method(name, method.value);
+    if (!virtualsOnly) {
+      if (typeof method.value === 'function') {
+        this.method(name, method.value);
+      }
     }
     if (typeof method.get === 'function') {
       this.virtual(name).get(method.get);


### PR DESCRIPTION
The reason for this PR is that I noticed that mongoose under the hood is essentially acting as a mixin to a class, and I saw room for improvement with the syntax for defining models. Generally static and instance methods have to be inconveniently defined through helpers on a `Schema` before they are copied onto the model, and `Model.compile` is also being inefficient by manually setting the prototype. So essentially, mongoose is doing work that ES6 already natively supports.

With these changes `mongoose.model` can support taking an ES6 class where `name` is normally provided:

``` javascript
const mongoose = require('mongoose');
const { Model, Schema } = mongoose;

const schema = new Schema({
  _id: Schema.ObjectId,
  field1: Number,
  field2: String
});
class SomeThing extends Model {
  static explode() {
    return SomeThing.explode();
  }

  get numString() {
    return this.field1 + this.field2;
  }

  increment() {
    return SomeThing.update({ _id: this._id }, {
      $inc: { 'field1': 1 }
    }, { new: true }).exec();
  }
}

module.exports = mongoose.model(SomeThing, schema, 'some_things');
```

I've also included a `loadClass` instance method for schemas that accomplishes some of what [`mongoose-class-wrapper`](https://github.com/aksyonov/mongoose-class-wrapper) can do. It allows similar functionality as the above, but it's useful for sub-schema definitions.

This should be fully backward compatible and shouldn't introduce any breaking changes.
