### PR TITLE
Document transform options for QueryCursor

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2966,6 +2966,9 @@ Query.prototype.stream = util.deprecate(Query.prototype.stream, 'Mongoose: ' +
  *       }
  *     });
  *
+ * ####Valid options
+ *
+ *   - `transform`: optional function which accepts a mongoose document. The return value of the function will be emitted on `data` and returned by `.next()`.
  *
  * @return {QueryCursor}
  * @param {Object} [options]

--- a/lib/querycursor.js
+++ b/lib/querycursor.js
@@ -31,6 +31,7 @@ function QueryCursor(query, options) {
 
   this.cursor = null;
   this.query = query;
+  this._transforms = options.transform ? [options.transform] : [];
   var _this = this;
   var model = query.model;
   model.collection.find(query._conditions, options, function(err, cursor) {
@@ -196,7 +197,17 @@ QueryCursor.prototype.eachAsync = function(fn, callback) {
  * (populate, etc.)
  */
 
-function _next(ctx, callback) {
+function _next(ctx, cb) {
+  var callback = cb;
+  if (ctx._transforms.length) {
+    callback = function(err, doc) {
+      if (err || doc === null) return cb(err, doc);
+      cb(err, ctx._transforms.reduce(function(doc, fn) {
+        return fn(doc);
+      }, doc));
+    };
+  }
+
   if (ctx._error) {
     return process.nextTick(function() {
       callback(ctx._error);

--- a/lib/querycursor.js
+++ b/lib/querycursor.js
@@ -72,6 +72,44 @@ QueryCursor.prototype._read = function() {
   });
 };
 
+/**
+ * Registers a transform function which subsequently maps documents retrieved
+ * via the streams interface or `.next()`
+ *
+ * ####Example
+ *
+ *     // Map documents returned by `data` events
+ *     Thing.
+ *       find({ name: /^hello/ }).
+ *       cursor().
+ *       map(function (doc) {
+ *        doc.foo = "bar";
+ *        return doc;
+ *       })
+ *       on('data', function(doc) { console.log(doc.foo); });
+ *
+ *     // Or map documents returned by `.next()`
+ *     var cursor = Thing.find({ name: /^hello/ }).
+ *       cursor().
+ *       map(function (doc) {
+ *         doc.foo = "bar";
+ *         return doc;
+ *       });
+ *     cursor.next(function(error, doc) {
+ *       console.log(doc.foo);
+ *     });
+ *
+ * @param {Function} fn
+ * @return {QueryCursor}
+ * @api public
+ * @method map
+ */
+
+QueryCursor.prototype.map = function(fn) {
+  this._transforms.push(fn);
+  return this;
+};
+
 /*!
  * Marks this cursor as errored
  */

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -217,6 +217,56 @@ describe('QueryCursor', function() {
     });
   });
 
+  describe('#map', function() {
+    it('maps documents', function(done) {
+      var cursor = Model.find().sort({ name: 1 }).cursor()
+        .map(function(obj) {
+          obj.name += '_mapped';
+          return obj;
+        })
+        .map(function(obj) {
+          obj.name += '_mappedagain';
+          return obj;
+        });
+
+      var expectedNames = ['Axl_mapped_mappedagain', 'Slash_mapped_mappedagain'];
+      var cur = 0;
+      cursor.on('data', function(doc) {
+        assert.equal(doc.name, expectedNames[cur++]);
+        assert.equal(doc.test, 'test');
+      });
+
+      cursor.on('error', function(error) {
+        done(error);
+      });
+
+      cursor.on('end', function() {
+        assert.equal(cur, 2);
+        done();
+      });
+    });
+
+    it('with #next', function(done) {
+      var cursor = Model.find().sort({ name: 1 }).cursor()
+        .map(function(obj) {
+          obj.name += '_next';
+          return obj;
+        });
+
+      cursor.next(function(error, doc) {
+        assert.ifError(error);
+        assert.equal(doc.name, 'Axl_next');
+        assert.equal(doc.test, 'test');
+        cursor.next(function(error, doc) {
+          assert.ifError(error);
+          assert.equal(doc.name, 'Slash_next');
+          assert.equal(doc.test, 'test');
+          done();
+        });
+      });
+    });
+  });
+
   describe('#eachAsync()', function() {
     it('iterates one-by-one, stopping for promises', function(done) {
       var cursor = Model.find().sort({ name: 1 }).cursor();

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -190,6 +190,33 @@ describe('QueryCursor', function() {
     });
   });
 
+  describe('`transform` option', function() {
+    it('transforms document', function(done) {
+      var cursor = Model.find().sort({ name: 1 }).cursor({
+        transform: function(doc) {
+          doc.name += '_transform';
+          return doc;
+        }
+      });
+
+      var expectedNames = ['Axl_transform', 'Slash_transform'];
+      var cur = 0;
+      cursor.on('data', function(doc) {
+        assert.equal(doc.name, expectedNames[cur++]);
+        assert.equal(doc.test, 'test');
+      });
+
+      cursor.on('error', function(error) {
+        done(error);
+      });
+
+      cursor.on('end', function() {
+        assert.equal(cur, 2);
+        done();
+      });
+    });
+  });
+
   describe('#eachAsync()', function() {
     it('iterates one-by-one, stopping for promises', function(done) {
       var cursor = Model.find().sort({ name: 1 }).cursor();


### PR DESCRIPTION
This PR adds 2 (related) features discussed in #4705

- `.cursor(opts)` accepts a `transform` function which is applied when the cursor returns a document

- `QueryCursor#map` which allows additional transform functions to be applied to documents pulled with the cursor (whether by the streams interface or `next()`)

The `transform` option and `.map()` can be combined and happens to be chainable e.g. `.cursor({ transform: function () {} }).map(...).map(...).on('data')`

