### PR TITLE
Delay stack generation until it's required

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1957,7 +1957,7 @@ Document.prototype.$__registerHooksFromSchema = function() {
       var args = [].slice.call(arguments);
       var lastArg = args.pop();
       var fn;
-      var originalStack = new Error().stack;
+      var originalError = new Error();
       var $results;
       if (lastArg && typeof lastArg !== 'function') {
         args.push(lastArg);
@@ -1972,7 +1972,7 @@ Document.prototype.$__registerHooksFromSchema = function() {
             // stack trace of the original save() function call rather
             // than the async trace
             if (error instanceof VersionError) {
-              error.stack = originalStack;
+              error.stack = originalError.stack;
             }
             _this.$__handleReject(error);
             reject(error);


### PR DESCRIPTION
(continued from #4682)

If some kind of stack beautification library (like with coffeescript) is used, generating the stack for every query is really expensive (in the order of 1,5s per 1000 queries).

This should still give the same stacktrace, but only generate the beautifyed stack if it's actually used, increasing performance for the common non-error case.

Even without stack beautification, accessing Error().stack is [10x slower](https://jsperf.com/error-vs-error-stack) than just storing Error(), making this a generally applicable optimization.