### PR TITLE
fix: upgrade mongodb -> 2.2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bson": "~0.5.4",
     "hooks-fixed": "1.2.0",
     "kareem": "1.1.3",
-    "mongodb": "2.2.11",
+    "mongodb": "2.2.12",
     "mpath": "0.2.1",
     "mpromise": "0.5.5",
     "mquery": "2.0.0",


### PR DESCRIPTION
Mostly excited about a memory leak that was fixed, but there are other fixes in there too.