### PR TITLE
Fix justOne test

### DIFF
--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -4106,7 +4106,8 @@ describe('model: populate:', function() {
               populate('author').
               exec(function(error, post) {
                 assert.ifError(error);
-                assert.equal(post.author.name, 'Val');
+                assert.strictEqual(Array.isArray(post.author), false);
+                assert.ok(post.author.name.match(/^(Val|Test)$/));
                 done();
               });
           });


### PR DESCRIPTION
`npm test` will occasionally fail because the justOne test doesn't cover the case where the alternate populated document is returned

Also added in an assertion that `justOne` virtuals should not be returned as an array for good measure