### PR TITLE
Fix typo in docs

### DIFF
--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -57,7 +57,7 @@ SchemaString.prototype.constructor = SchemaString;
  *       values: ['opening', 'open', 'closing', 'closed'],
  *       message: 'enum validator failed for path `{PATH}` with value `{VALUE}`'
  *     }
- *     var s = new Schema({ state: { type: String, enum: enu })
+ *     var s = new Schema({ state: { type: String, enum: enum })
  *     var M = db.model('M', s)
  *     var m = new M({ state: 'invalid' })
  *     m.save(function (err) {


### PR DESCRIPTION
Fix `enu` to `enum` in example for `SchemaString#enum([args...])`