### PR TITLE
Use MongoDB 3.4 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - "0.10"
   - "iojs"
 before_script:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.11.tgz
-  - tar -zxvf mongodb-linux-x86_64-2.6.11.tgz
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.4.0.tgz
+  - tar -zxvf mongodb-linux-x86_64-3.4.0.tgz
   - mkdir -p ./data/db
-  - ./mongodb-linux-x86_64-2.6.11/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017
+  - ./mongodb-linux-x86_64-3.4.0/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017

--- a/test/collection.capped.test.js
+++ b/test/collection.capped.test.js
@@ -63,7 +63,7 @@ describe('collections: capped:', function() {
   });
   it('attempting to use existing non-capped collection as capped emits error', function(done) {
     db = start();
-    var opts = {safe: true};
+    var opts = {};
     var conn = 'capped_existing_' + random();
 
     db.on('open', function() {


### PR DESCRIPTION
Use latest MongoDB in CI

Also had to amend a test which uses an invalid parameter to build a collection (I'm not able to find a `safe` option documented for `createCollection` in mongodb 2.6 and above)

Helpful for #4799