### PR TITLE
propagate strict option to a child schema

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -619,7 +619,7 @@ Schema.interpretAsType = function(path, obj, options) {
           childSchemaOptions.typeKey = options.typeKey;
         }
         //propagate 'strict' option to child schema
-        if(options.hasOwnProperty('strict')) {
+        if (options.hasOwnProperty('strict')) {
           childSchemaOptions.strict = options.strict;
         }
         var childSchema = new Schema(cast, childSchemaOptions);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -618,6 +618,10 @@ Schema.interpretAsType = function(path, obj, options) {
         if (options.typeKey) {
           childSchemaOptions.typeKey = options.typeKey;
         }
+        //propagate 'strict' option to child schema
+        if(options.hasOwnProperty('strict')) {
+          childSchemaOptions.strict = options.strict;
+        }
         var childSchema = new Schema(cast, childSchemaOptions);
         childSchema.$implicitlyCreated = true;
         return new MongooseTypes.DocumentArray(path, childSchema, obj);


### PR DESCRIPTION
propagate the 'strict' option to a child schema.

solve this issue [#4823](https://github.com/Automattic/mongoose/issues/4823)

