### PR TITLE
Allowing callback to be optional

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1232,7 +1232,7 @@ Document.prototype.validate = function(options, callback) {
     options = null;
   }
 
-  this.$__validate(callback);
+  this.$__validate(callback || function() {});
 };
 
 /*!


### PR DESCRIPTION
This allows callback to be optional as `$__validate` assumes callback is defined and not optional.  

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is a small fix to handle the issue with callback not being defined, breaking the validation process.  This is tied to #4841

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
