### PR TITLE
Fix warning from Bluebird about promises created but not returned.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2321,6 +2321,7 @@ Query.prototype.exec = function exec(op, callback) {
     promise.then(
       function() {
         callback.apply(null, _results);
+        return null;
       },
       function(error) {
         callback(error);


### PR DESCRIPTION
I was getting the following while using Bluebird Promises with mongoose 4.7.5:

```
(node:56) Warning: a promise was created in a handler at app/node_modules/mongoose/lib/query.js:2313:18 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (/app/node_modules/bluebird/js/release/promise.js:77:14)
```

The code seems innocuous enough:

```js
  const point = await Point.findOne({src, dst})
        .populate([{path: 'post'},
                   {path: 'src_profile', populate: {path: 'user'}},
                   {path: 'dst_profile', populate: {path: 'user'}}])
        .exec();
```

All of the paths ``post``, ``src_profile``, ``dst_profile``, and ``user`` are virtual population fields.

Strangely enough, if I remove the two deep populates no errors occur. I did check my own code for runaway promises and I don't think I see any.

I made this fix which seems to work in getting these warnings suppressed.
