### PR TITLE
Fixes the bson dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.1.4",
-    "bson": "~1.0.1",
+    "bson": "1.0.1",
     "hooks-fixed": "1.2.0",
     "kareem": "1.2.0",
     "mongodb": "2.2.16",


### PR DESCRIPTION
**Summary**
Recently we found an issue related with mongoose in our production application. After some investigation that @jvrbaena summarized [here](https://github.com/Automattic/mongoose/issues/4860#issuecomment-270089296) we saw that the problem is an update to the bson dependency. With this change we fix the dependency version to avoid this kind of unforeseen problems.

**Test plan**
I tried to run the tests in local and I got 123 errors with the current version.
With this change I get 26 errors but they all are related with my local enviroment (sharding, hostnames, etc...). I'm pretty sure they'll pass in the CI.