### PR TITLE
fixed populate can not use more model

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -624,9 +624,15 @@ exports.populate = function populate(path, select, model, match, options, subPop
 
   var ret = [];
   var paths = path.split(' ');
+  var models = undefined;
+  if (typeof model === 'string') {
+    models = model.split(' ');
+  }
   options = exports.clone(options, { retainKeyOrder: true });
   for (var i = 0; i < paths.length; ++i) {
-    ret.push(new PopulateOptions(paths[i], select, match, options, model, subPopulate));
+    var _model = model;
+    if (models && i < models.length) _model = models[i];
+    ret.push(new PopulateOptions(paths[i], select, match, options, _model, subPopulate));
   }
 
   return ret;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -632,6 +632,7 @@ exports.populate = function populate(path, select, model, match, options, subPop
   for (var i = 0; i < paths.length; ++i) {
     var _model = model;
     if (models && i < models.length) _model = models[i];
+    
     ret.push(new PopulateOptions(paths[i], select, match, options, _model, subPopulate));
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -632,7 +632,6 @@ exports.populate = function populate(path, select, model, match, options, subPop
   for (var i = 0; i < paths.length; ++i) {
     var _model = model;
     if (models && i < models.length) _model = models[i];
-    
     ret.push(new PopulateOptions(paths[i], select, match, options, _model, subPopulate));
   }
 


### PR DESCRIPTION
as before use this code:

populate: {
path: 'data.user data.group',
model: 'User Group',
select: '_id'
}

you will get an err like this:
MissingSchemaError: Schema hasn't been registered for model "User Group".

after fixed this code, all thing is going well, it can use more model at same time

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
