### PR TITLE
Don't throw on checking if `$exists` in more complex queries

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -879,6 +879,7 @@ SchemaType.prototype.$conditionalHandlers = {
   $in: handleArray,
   $ne: handleSingle,
   $nin: handleArray,
+  $exists: handleSingle,
   $type: function(val) {
     if (typeof val !== 'number' && typeof val !== 'string') {
       throw new Error('$type parameter must be number or string');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When trying to construct a query that uses the `$exists` operator on fields, queries fail with error `Can't use $exists with String`. 

I believe that `$exists` can be applied to ANY kind of field, so I tried to add it in the most generic place.

**Test plan**

test code:
```js
const mongoose = require('mongoose');

const kittenModel = mongoose.model('test', {
  name: String,
  likes: String
}, 'testitems');

const mongodbConnectionString = process.env.MONGO_CONNECTION_STRING || 'mongodb://localhost/test';
mongoose.Promise = Promise;
mongoose.connect(mongodbConnectionString)
  .then(() => {
    let itsy = new kittenModel({ name: 'Itsy', likes: 'mischief' });
    let bitsy = new kittenModel({ name: 'Bitsy', likes: 'sleeping' });
    let teeny = new kittenModel({ name: 'Teeny', likes: 'eating' });
    let weeny = new kittenModel({ name: 'Weeny' });
    return Promise.all([
      itsy.save(), bitsy.save(), teeny.save(), weeny.save()
    ])
  })
  .then(() => {
    console.log('Finding all kittens who don\'t specify what they like, or they like sleeping');
    //  (all except the ones who like anything other than sleeping)
    return kittenModel.find({
      likes: {
        $not: {
          $exists: true,
          $ne: "sleeping"
        }
      }
    }, { _id: 1, name: 1, likes: 1 }, { lean: true }).exec();
  })
  .catch((err) => { console.error(err); process.exit(-1); })
  .then((result) => { console.log(result); process.exit(0); });
```

Fixed/expected result:
```
$ node demo.js
Finding all kittens who don't specify what they like, or they like sleeping
[ { _id: 5889220d0610d65b9b790295,
    name: 'Bitsy',
    likes: 'sleeping' },
  { _id: 5889220d0610d65b9b790297, name: 'Weeny' } ]
```


Actual result:
```
$ node demo.js
Finding all kittens who don't specify what they like, or they like sleeping
Error: Can't use $exists with String.
    at SchemaString.castForQuery (/Users/ikari/src/kittens/node_modules/mongoose/lib/schema/string.js:501:13)
    at cast (/Users/ikari/src/kittens/node_modules/mongoose/lib/cast.js:215:46)
    at Query.cast (/Users/ikari/src/kittens/node_modules/mongoose/lib/query.js:2753:12)
    at Query.find (/Users/ikari/src/kittens/node_modules/mongoose/lib/query.js:1143:10)
    at /Users/ikari/src/kittens/node_modules/mongoose/lib/query.js:2310:21
    at Query.exec (/Users/ikari/src/kittens/node_modules/mongoose/lib/query.js:2304:17)
    at mongoose.connect.then.then (/Users/ikari/src/kittens/demo.js:32:55)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```
