### PR TITLE
verifying if the value.validate() exists as a function

### DIFF
--- a/lib/schema/embedded.js
+++ b/lib/schema/embedded.js
@@ -173,7 +173,7 @@ Embedded.prototype.doValidate = function(value, fn, scope) {
     if (!value) {
       return fn(null);
     }
-    if (typeof(value['validate']) === 'function') {
+    if (typeof value['validate'] === 'function') {
       value.validate(fn, {__noPromise: true});
     } else {
       fn(null);


### PR DESCRIPTION
fix the issue [#4960](https://github.com/Automattic/mongoose/issues/4960)
avoiding the Exception `TypeError: value.validate is not a function` by checking if the typeof value.validate is a function in a embed subdoc. 

