### PR TITLE
Introducing mergeSchemas function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -438,6 +438,108 @@ Mongoose.prototype.modelNames = function() {
 Mongoose.prototype.modelNames.$hasSideEffects = true;
 
 /**
+ * Generates a new Schema merged from others
+ *
+ * @param {Schema|Array} schemas
+ * @param {Object} options options like in Schema constructor
+ * @param {Boolean} control says when the generated schema will have control over merged schemas
+ * @api public
+ * @return {Schema}
+ */
+Mongoose.prototype.mergeSchemas = function(schemas, options, control)
+{
+  var schema = {}, dstSchema, dict = {};
+  var _kinds = [], _kind;
+  var ret; // return object
+
+  // control defaults to true
+  control = (control !== false);
+
+  // ensure options has a name
+  if (control && !(options && options.name))
+    throw new Error('Merged schemas must have a name when controlled.');
+  // ensure schemas param is an array
+  if (schemas.constructor !== Array)
+    schemas = [schemas];
+
+  if (control && options && options.name)
+    _kind = options.name;
+
+  schemas.forEach(function(obj) {
+    if (!(obj instanceof Schema))
+      throw new Error('Only Schema objects are allowed.');
+    if (control && !obj.options.name)
+      throw new Error('All SchemaS must have the name option defined.');
+
+    _kinds.push(obj.options.name);
+
+    obj.eachPath(function(p) {
+      // ignored fields
+      if (obj.options._id && p.path === obj.options.typeKey)
+        return;
+
+      p = obj.path(p);
+      dstSchema = schema;
+      let i = 0;
+      let paths = p.path.split(/\./);
+      for (; i < paths.length - 1; i++) {
+        dstSchema[paths[i]] = dstSchema[paths[i]] || {};
+	dstSchema = dstSchema[paths[i]];
+      }
+
+      if (dict[p.path] === undefined) {
+        dict[p.path] = obj;
+        dstSchema[paths[i]] = p.options;
+      } else {
+        let fmtError = 'Schema conflict on path `{{path}}`, use prefixName Schema '
+         + 'option to solve this.';
+        let prefix;
+
+	if (dict[p.path].options.prefixName)
+          prefix = dict[p.path].options.prefixName;
+	else if (dict[p.path].options.name)
+          prefix = dict[p.path].options.name + '_';
+        else
+          prefix = '';
+
+        if (dict[p.path] !== null) {
+	  let _prefix;
+
+	  if (obj.options.prefixName)
+            _prefix = obj.options.prefixName;
+	  else if (obj.options.name)
+            _prefix = obj.options.name + '_';
+          else
+            _prefix = '';
+
+          if (!(prefix || _prefix))
+            throw new Error(fmtError.replace('{{path}}', p.path));
+
+	  if (_prefix) {
+            dstSchema[_prefix + paths[i]] = dstSchema[paths[i]];
+            delete dstSchema[paths[i]];
+          }
+        }
+
+        if (dstSchema[prefix + paths[i]] !== undefined)
+          throw new Error(fmtError.replace('{{path}}', p.path));
+        dstSchema[prefix + paths[i]] = p.options;
+      }
+    });
+  });
+
+  ret = Schema(schema, options);
+  if (control) {
+    ret.mergeControl = {
+      _kind: _kind,
+      _kinds: _kinds,
+    };
+  }
+
+  return ret;
+}
+
+/**
  * Applies global plugins to `schema`.
  *
  * @param {Schema} schema

--- a/lib/index.js
+++ b/lib/index.js
@@ -489,8 +489,8 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
 
       p = obj.path(p);
       dstSchema = schema;
-      let i = 0;
-      let paths = p.path.split(/\./);
+      var i = 0;
+      var paths = p.path.split(/\./);
       for (; i < paths.length - 1; i++) {
         dstSchema[paths[i]] = dstSchema[paths[i]] || {};
 	dstSchema = dstSchema[paths[i]];
@@ -500,9 +500,9 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
         dict[p.path] = obj;
         dstSchema[paths[i]] = p.options;
       } else {
-        let fmtError = 'Schema conflict on path `{{path}}`, use prefixName Schema '
+        var fmtError = 'Schema conflict on path `{{path}}`, use prefixName Schema '
          + 'option to solve this.';
-        let prefix;
+        var prefix;
 
 	if (dict[p.path].options.prefixName)
           prefix = dict[p.path].options.prefixName;
@@ -512,7 +512,7 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
           prefix = '';
 
         if (dict[p.path] !== null) {
-	  let _prefix;
+	  var _prefix;
 
 	  if (obj.options.prefixName)
             _prefix = obj.options.prefixName;

--- a/lib/index.js
+++ b/lib/index.js
@@ -493,7 +493,7 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
       var paths = p.path.split(/\./);
       for (; i < paths.length - 1; i++) {
         dstSchema[paths[i]] = dstSchema[paths[i]] || {};
-	dstSchema = dstSchema[paths[i]];
+        dstSchema = dstSchema[paths[i]];
       }
 
       if (dict[p.path] === undefined) {
@@ -504,19 +504,19 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
          + 'option to solve this.';
         var prefix;
 
-	if (dict[p.path].options.prefixName)
+        if (dict[p.path].options.prefixName)
           prefix = dict[p.path].options.prefixName;
-	else if (dict[p.path].options.name)
+        else if (dict[p.path].options.name)
           prefix = dict[p.path].options.name + '_';
         else
           prefix = '';
 
         if (dict[p.path] !== null) {
-	  var _prefix;
+          var _prefix;
 
-	  if (obj.options.prefixName)
+          if (obj.options.prefixName)
             _prefix = obj.options.prefixName;
-	  else if (obj.options.name)
+          else if (obj.options.name)
             _prefix = obj.options.name + '_';
           else
             _prefix = '';
@@ -524,7 +524,7 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
           if (!(prefix || _prefix))
             throw new Error(fmtError.replace('{{path}}', p.path));
 
-	  if (_prefix) {
+          if (_prefix) {
             dstSchema[_prefix + paths[i]] = dstSchema[paths[i]];
             delete dstSchema[paths[i]];
           }
@@ -541,12 +541,12 @@ Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
   if (control) {
     ret.mergeControl = {
       _kind: _kind,
-      _kinds: _kinds,
+      _kinds: _kinds
     };
   }
 
   return ret;
-}
+};
 
 /**
  * Applies global plugins to `schema`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -440,15 +440,23 @@ Mongoose.prototype.modelNames.$hasSideEffects = true;
 /**
  * Generates a new Schema merged from others
  *
+ * @param {Object} [schema] Object with fields that the merged Schemas does not have
  * @param {Schema|Array} schemas
  * @param {Object} options options like in Schema constructor
- * @param {Boolean} control says when the generated schema will have control over merged schemas
+ * @param {Boolean} [control] says when the generated schema will have control over merged schemas
  * @api public
  * @return {Schema}
  */
-Mongoose.prototype.mergeSchemas = function(schemas, options, control)
-{
-  var schema = {}, dstSchema, dict = {};
+Mongoose.prototype.mergeSchemas = function(schema, schemas, options, control) {
+  if (schema.constructor !== Object) {
+    control = options;
+    options = schemas;
+    schemas = schema;
+    schema = undefined;
+  }
+  schema = schema || {};
+
+  var dstSchema, dict = {};
   var _kinds = [], _kind;
   var ret; // return object
 
@@ -468,14 +476,15 @@ Mongoose.prototype.mergeSchemas = function(schemas, options, control)
   schemas.forEach(function(obj) {
     if (!(obj instanceof Schema))
       throw new Error('Only Schema objects are allowed.');
+
     if (control && !obj.options.name)
       throw new Error('All SchemaS must have the name option defined.');
 
     _kinds.push(obj.options.name);
 
     obj.eachPath(function(p) {
-      // ignored fields
-      if (obj.options._id && p.path === obj.options.typeKey)
+      // ignored fields, for now (_id)
+      if (obj.options._id && p === '_id')
         return;
 
       p = obj.path(p);

--- a/lib/model.js
+++ b/lib/model.js
@@ -680,7 +680,7 @@ Model.prototype.$__mergeControl = function(delta, isDelta) {
     this.setValue('_kind', delta._kind = this.schema.mergeControl._kind);
     this.setValue('_kinds', delta._kinds = this.schema.mergeControl._kinds);
   }
-}
+};
 
 /**
  * Signal that we desire an increment of this documents version.
@@ -904,7 +904,7 @@ Model.prototype.ofKind = function(kind) {
     return false;
 
   return this._kind === kind || this._kinds.indexOf(kind) > -1;
-}
+};
 
 /**
  * Check if model implements a Schema
@@ -926,7 +926,7 @@ Model.ofKind = function(kind) {
 
   return this.schema.mergeControl._kind === kind ||
    this.schema.mergeControl._kinds.indexOf(kind) > -1;
-}
+};
 
 // Model (class) features
 
@@ -3361,7 +3361,7 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   }
 
   if (mergeControlEnabled) {
-    // Forces _kind and _kinds path if merged Schema is controlled  
+    // Forces _kind and _kinds path if merged Schema is controlled
     schema.add({ _kind: String });
     schema.add({ _kinds: [String] });
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -141,6 +141,7 @@ Model.prototype.$__handleSave = function(options, callback) {
     }
 
     this.$__version(true, obj);
+    this.$__mergeControl(obj);
     this.collection.insert(obj, options.safe, function(err, ret) {
       if (err) {
         _this.isNew = true;
@@ -186,6 +187,7 @@ Model.prototype.$__handleSave = function(options, callback) {
         }
       }
 
+      this.$__mergeControl(delta[1]);
       this.collection.update(where, delta[1], options.safe, function(err, ret) {
         if (err) {
           callback(err);
@@ -651,6 +653,21 @@ Model.prototype.$__version = function(where, delta) {
 };
 
 /**
+ * Appends merge control _kind and _kinds value
+ *
+ * @api private
+ * @method $__mergeControl
+ * @memberOf Model
+ */
+
+Model.prototype.$__mergeControl = function(delta) {
+  if (this.schema.mergeControl !== undefined) {
+    this.setValue('_kind', delta._kind = this.schema.mergeControl._kind);
+    this.setValue('_kinds', delta._kinds = this.schema.mergeControl._kinds);
+  }
+}
+
+/**
  * Signal that we desire an increment of this documents version.
  *
  * ####Example:
@@ -845,6 +862,49 @@ Model.discriminator = function(name, schema) {
 
   return d;
 };
+
+/**
+ * Check if document implements a Schema
+ *
+ * @param {String|Schema} kind
+ * @return {Boolean}
+ * @api public
+ */
+
+Model.prototype.ofKind = function(kind) {
+  if (kind instanceof Schema) {
+    if (!kind.options.name)
+      return false;
+    kind = kind.options.name;
+  }
+
+  if (!this._kind && (!this._kinds || !Array.isArray(this._kinds)))
+    return false;
+
+  return this._kind === kind || this._kinds.indexOf(kind) > -1;
+}
+
+/**
+ * Check if model implements a Schema
+ *
+ * @param {String|Schema} kind
+ * @return {Boolean}
+ * @api public
+ */
+
+Model.ofKind = function(kind) {
+  if (kind instanceof Schema) {
+    if (!kind.options.name)
+      return false;
+    kind = kind.options.name;
+  }
+
+  if (!this.schema.mergeControl)
+    return false;
+
+  return this.schema.mergeControl._kind === kind ||
+   this.schema.mergeControl._kinds.indexOf(kind) > -1;
+}
 
 // Model (class) features
 
@@ -3258,12 +3318,19 @@ Model._getSchema = function _getSchema(path) {
 
 Model.compile = function compile(name, schema, collectionName, connection, base) {
   var versioningEnabled = schema.options.versionKey !== false;
+  var mergeControlEnabled = schema.mergeControl !== undefined;
 
   if (versioningEnabled && !schema.paths[schema.options.versionKey]) {
     // add versioning to top level documents only
     var o = {};
     o[schema.options.versionKey] = Number;
     schema.add(o);
+  }
+
+  if (mergeControlEnabled) {
+    // Forces _kind and _kinds path if merged Schema is controlled  
+    schema.add({ _kind: String });
+    schema.add({ _kinds: [String] });
   }
 
   var model;

--- a/lib/model.js
+++ b/lib/model.js
@@ -663,6 +663,18 @@ Model.prototype.$__version = function(where, delta) {
 
 Model.prototype.$__mergeControl = function(delta, isDelta) {
   if (this.schema.mergeControl !== undefined) {
+    delete delta['$unset']['_kind'];
+    delete delta['$unset']['_kinds'];
+    var empty = true;
+    for (var prop in delta['$unset']) {
+      if (delta['$unset'].hasOwnProperty(prop)) {
+        empty = false;
+        break;
+      }
+    }
+    if (empty)
+      delete delta['$unset'];
+
     if (isDelta === true)
       delta = delta['$set'];
     this.setValue('_kind', delta._kind = this.schema.mergeControl._kind);

--- a/lib/model.js
+++ b/lib/model.js
@@ -187,7 +187,7 @@ Model.prototype.$__handleSave = function(options, callback) {
         }
       }
 
-      this.$__mergeControl(delta[1]);
+      this.$__mergeControl(delta[1], true);
       this.collection.update(where, delta[1], options.safe, function(err, ret) {
         if (err) {
           callback(err);
@@ -660,8 +660,10 @@ Model.prototype.$__version = function(where, delta) {
  * @memberOf Model
  */
 
-Model.prototype.$__mergeControl = function(delta) {
+Model.prototype.$__mergeControl = function(delta, isDelta) {
   if (this.schema.mergeControl !== undefined) {
+    if (isDelta === true)
+      delta = delta['$set'];
     this.setValue('_kind', delta._kind = this.schema.mergeControl._kind);
     this.setValue('_kinds', delta._kinds = this.schema.mergeControl._kinds);
   }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -45,6 +45,8 @@ var IS_KAREEM_HOOK = {
  * - [id](/docs/guide.html#id): bool - defaults to true
  * - [_id](/docs/guide.html#_id): bool - defaults to true
  * - `minimize`: bool - controls [document#toObject](#document_Document-toObject) behavior when called manually - defaults to true
+ * - [name]: string - Schema name, used on merge when was not given a prefixName - no default
+ * - [prefixName]: string - Prefix name used for disambiguation when merging schemas - no default
  * - [read](/docs/guide.html#read): string
  * - [safe](/docs/guide.html#safe): bool - defaults to true.
  * - [shardKey](/docs/guide.html#shardKey): bool - defaults to `null`


### PR DESCRIPTION
**Summary**

I am working on a project that is a base for a lot of products and I needed a way to have small SchemaS and know when my document is using one of those schemas. JSON is very flexible and this implementation helps to manage this flexibility and continuing to use the amazing Mongoose Library.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

```js
var mongoose = require('mongoose'),
    Schema = mongoose.Schema;

var tpPerson = Schema({
  name: { type: String, required: true },
  birth: Date,
}, { name: 'tpPerson' });

var tpBlogInfo = Schema({
  blogName: { type: String, required: true },
  blogAddress: { type: String, required: true },
}, { name: 'tpBlogInfo' });

var tpBlogger = mongoose.mergeSchemas({
  otherBlogs: [tpBlogInfo],
}, [tpPerson, tpBlogInfo], { name: 'tpBlogger' });

var Blogger = mongoose.model('Blogger', tpBlogger);
console.log('tpBlogger ? ' + Blogger.ofKind(tpBlogger));
console.log('tpPerson ? ' + Blogger.ofKind(tpPerson));

var myMom = new Blogger({
  name: 'Monica',
  blogName: 'How do I cook?',
  blogAddress: 'www.howdoicook.invented.net',
});

// Not yet, cause here we are looking to document
console.log('tpPerson ? ' + myMom.ofKind('tpPerson'));
myMom.save(function(err) {
  if (err) console.log(err.message);

  // Yes, we generated before persisting to MongoDB
  console.log('tpPerson ? ' + myMom.ofKind('tpPerson'));
});

// In other words: use ofKind on model before write values, and use on documents before
// read values
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->