### PR TITLE
Fix #4947 by ensuring class is created with new keyword

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1823,7 +1823,7 @@ Model.create = function create(doc, callback) {
         var Model = _this.discriminators && doc[discriminatorKey] ?
           _this.discriminators[doc[discriminatorKey]] :
           _this;
-        var toSave = doc instanceof Model ? doc : Model(doc);
+        var toSave = doc instanceof Model ? doc : new Model(doc);
         var callbackWrapper = function(error, doc) {
           if (error) {
             return callback(error);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #4947 - just a missing `new` keyword.

**Test plan**

Tests all run fine locally.