### PR TITLE
rawResult option

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1307,7 +1307,7 @@ Query.prototype._findOne = function(callback) {
     if (!options.populate) {
       return options.lean === true
           ? callback(null, doc)
-          : completeOne(_this.model, doc, null, projection, null, callback);
+          : completeOne(_this.model, doc, null, {}, projection, null, callback);
     }
 
     var pop = helpers.preparePopulationOptionsMQ(_this, options);
@@ -1318,7 +1318,7 @@ Query.prototype._findOne = function(callback) {
       }
       return options.lean === true
           ? callback(null, doc)
-          : completeOne(_this.model, doc, null, projection, pop, callback);
+          : completeOne(_this.model, doc, null, {}, projection, pop, callback);
     });
   });
 };
@@ -1628,7 +1628,7 @@ Query.prototype.remove = function(cond, callback) {
  * @param {Function} callback
  */
 
-function completeOne(model, doc, res, fields, pop, callback) {
+function completeOne(model, doc, res, options, fields, pop, callback) {
   var opts = pop ?
   {populated: pop}
       : undefined;
@@ -1638,7 +1638,12 @@ function completeOne(model, doc, res, fields, pop, callback) {
     if (err) {
       return callback(err);
     }
-    if (res) {
+
+    if (options.rawResult) {
+      res.value = casted;
+      return callback(null, res);
+    }
+    if (options.passRawResult) {
       return callback(null, casted, decorateResult(res));
     }
     callback(null, casted);
@@ -1963,20 +1968,21 @@ Query.prototype._findAndModify = function(type, callback) {
     }
 
     if (!doc || (utils.isObject(doc) && Object.keys(doc).length === 0)) {
+      if (opts.rawResult) {
+        return callback(null, res);
+      }
+      // opts.passRawResult will be deprecated soon
       if (opts.passRawResult) {
         return callback(null, null, decorateResult(res));
       }
       return callback(null, null);
     }
 
-    if (!opts.passRawResult) {
-      res = null;
-    }
-
     if (!options.populate) {
-      return options.lean === true
-          ? (opts.passRawResult ? callback(null, doc, decorateResult(res)) : callback(null, doc))
-          : completeOne(_this.model, doc, res, fields, null, callback);
+      if (options.lean === true) {
+        return _completeOneLean(doc, res, opts, callback);
+      }
+      return completeOne(_this.model, doc, res, opts, fields, null, callback);
     }
 
     var pop = helpers.preparePopulationOptionsMQ(_this, options);
@@ -1986,9 +1992,10 @@ Query.prototype._findAndModify = function(type, callback) {
         return callback(err);
       }
 
-      return options.lean === true
-          ? (opts.passRawResult ? callback(null, doc, decorateResult(res)) : callback(null, doc))
-          : completeOne(_this.model, doc, res, fields, pop, callback);
+      if (options.lean === true) {
+        return _completeOneLean(doc, res, opts, callback);
+      }
+      return completeOne(_this.model, doc, res, opts, fields, pop, callback);
     });
   };
 
@@ -2015,6 +2022,20 @@ Query.prototype._findAndModify = function(type, callback) {
 
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+function _completeOneLean(doc, res, opts, callback) {
+  if (opts.rawResult) {
+    return callback(null, res);
+  }
+  if (opts.passRawResult) {
+    return callback(null, doc, decorateResult(res));
+  }
+  return callback(null, doc);
+}
 
 /*!
  * Override mquery.prototype._mergeUpdate to handle mongoose objects in

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1592,6 +1592,27 @@ describe('model: findByIdAndUpdate:', function() {
         });
     });
 
+    it('passes raw result if rawResult specified (gh-4925)', function(done) {
+      var testSchema = new mongoose.Schema({
+        test: String
+      });
+
+      var TestModel = db.model('gh4925', testSchema);
+      var options = { upsert: true, new: true, rawResult: true };
+      var update = { $set: { test: 'abc' } };
+
+      TestModel.findOneAndUpdate({}, update, options).
+        exec(function(error, res) {
+          assert.ifError(error);
+          assert.ok(res);
+          assert.ok(res.ok);
+          assert.equal(res.value.test, 'abc');
+          assert.ok(res.value.id);
+          assert.equal(res.lastErrorObject.n, 1);
+          done();
+        });
+    });
+
     it('raw result as 3rd param w/ no result (gh-4023)', function(done) {
       var testSchema = new mongoose.Schema({
         test: String


### PR DESCRIPTION
Fix #4925

The `passRawResult` option has proven to be exceptionally cumbersome for 2 reasons:

1. We had to hack around it to make it not break error handler middleware. Because an error handler middleware is defined by the number of arguments it takes, conditionally adding a third param makes it impossible to write error handler middleware that can handle both `passRawResult: true` and `passRawResult: false`. The current hack makes it so that raw result is _never_ passed to error handler middleware.
2. You need to use the callback API or mpromise (deprecated). With ES6 promises, you can never get the raw result.

This PR introduces the `rawResult` option, meant as a replacement for `passRawResult`, which makes the 2nd param to the callback the raw result (as opposed to the 3rd). This works better with promises and error handler middleware. @bdentino @evilive3000 @varunjayaraman y'all have reported related issues, do you have any thoughts on this approach?