### PR TITLE
InsertMany behaves as expected for validation errors while ordered op…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1976,6 +1976,12 @@ Model.insertMany = function(arr, options, callback) {
       doc = new _this(doc);
       doc.validate({ __noPromise: true }, function(error) {
         if (error) {
+          // Option `ordered` signals that insert should be continued after reaching
+          // a failing insert. Therefore we delegate "null", meaning the validation
+          // failed. It's up to the next function to filter out all failed models
+          if (options['ordered'] === false) {
+            return callback(null, null);
+          }
           return callback(error);
         }
         callback(null, doc);
@@ -1988,7 +1994,11 @@ Model.insertMany = function(arr, options, callback) {
       callback && callback(error);
       return;
     }
-    var docObjects = docs.map(function(doc) {
+    // We filter all failed pre-validations by removing nulls
+    var docAttributes = docs.filter(function(doc) {
+      return doc != null;
+    });
+    var docObjects = docAttributes.map(function(doc) {
       if (doc.schema.options.versionKey) {
         doc[doc.schema.options.versionKey] = 0;
       }
@@ -2002,12 +2012,12 @@ Model.insertMany = function(arr, options, callback) {
         callback && callback(error);
         return;
       }
-      for (var i = 0; i < docs.length; ++i) {
-        docs[i].isNew = false;
-        docs[i].emit('isNew', false);
-        docs[i].constructor.emit('isNew', false);
+      for (var i = 0; i < docAttributes.length; ++i) {
+        docAttributes[i].isNew = false;
+        docAttributes[i].emit('isNew', false);
+        docAttributes[i].constructor.emit('isNew', false);
       }
-      callback && callback(null, docs);
+      callback && callback(null, docAttributes);
     });
   });
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -1979,7 +1979,7 @@ Model.insertMany = function(arr, options, callback) {
           // Option `ordered` signals that insert should be continued after reaching
           // a failing insert. Therefore we delegate "null", meaning the validation
           // failed. It's up to the next function to filter out all failed models
-          if (options['ordered'] === false) {
+          if (options != null && typeof options === 'object' && options['ordered'] === false) {
             return callback(null, null);
           }
           return callback(error);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1998,6 +1998,11 @@ Model.insertMany = function(arr, options, callback) {
     var docAttributes = docs.filter(function(doc) {
       return doc != null;
     });
+    // Quickly escape while there aren't any valid docAttributes
+    if (docAttributes.length < 1) {
+      callback && callback(null, []);
+      return;
+    }
     var docObjects = docAttributes.map(function(doc) {
       if (doc.schema.options.versionKey) {
         doc[doc.schema.options.versionKey] = 0;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5303,6 +5303,41 @@ describe('Model', function() {
       }
     });
 
+    it('insertMany() ordered option for single validation error', function(done) {
+      start.mongodVersion(function(err, version) {
+        if (err) {
+          done(err);
+          return;
+        }
+        var mongo34 = version[0] > 3 || (version[0] === 3 && version[1] >= 4);
+        if (!mongo34) {
+          done();
+          return;
+        }
+
+        test();
+      });
+
+      function test() {
+        var schema = new Schema({
+          name: { type: String, required: true }
+        });
+        var Movie = db.model('gh5068-2', schema);
+
+        var arr = [
+          { foo: 'Star Wars' },
+          { foo: 'The Fast and the Furious' },
+        ];
+        Movie.insertMany(arr, { ordered: false }, function(error) {
+          assert.ifError(error);
+          Movie.find({}).sort({ name: 1 }).exec(function(error, docs) {
+            assert.equal(docs.length, 0);
+            done();
+          });
+        });
+      }
+    });
+
     it('insertMany() hooks (gh-3846)', function(done) {
       var schema = new Schema({
         name: String

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5326,7 +5326,7 @@ describe('Model', function() {
 
         var arr = [
           { foo: 'Star Wars' },
-          { foo: 'The Fast and the Furious' },
+          { foo: 'The Fast and the Furious' }
         ];
         Movie.insertMany(arr, { ordered: false }, function(error) {
           assert.ifError(error);


### PR DESCRIPTION
### Summary
The native mongodb driver documents functionality for an option called: 'ordered'. It's documentation is as follows: If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails. I expected this to work with mongoose as well, as it is documented. However this is only true for failing unique constraint errors. I've made little modifications to make it work for all validation errors.

### Test plan
Added an extra unit test for making sure the behavior of validation errors is identical to the one of constraint errors

### Notice
This is one of my very first pull-requests, if I went too far without discussion or if there are other concerns that need taken care of please let me know.