### PR TITLE
Update description said "documents" instead of "one document"

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2197,7 +2197,7 @@ Model.hydrate = function(obj) {
 };
 
 /**
- * Updates documents in the database without returning them.
+ * Updates one document in the database without returning it.
  *
  * ####Examples:
  *


### PR DESCRIPTION
People will notice that they can update several documents at once as soon as they learn about the  `multi` attribute a few lines below.
