### PR TITLE
Avoid exception on constructor check

### DIFF
--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -102,7 +102,7 @@ MongooseDocumentArray.mixin = {
     var Constructor = this._schema.casterConstructor;
     if (value instanceof Constructor ||
         // Hack re: #5001, see #5005
-        (value && value.constructor.baseCasterConstructor === Constructor)) {
+        (value && value.constructor && value.constructor.baseCasterConstructor === Constructor)) {
       if (!(value.__parent && value.__parentArray)) {
         // value may have been created using array.create()
         value.__parent = this._parent;


### PR DESCRIPTION
I was pushing object created by `Object.create(null);` into an array schema type. Since the prototype is `undefined` is causes `Cannot read property 'baseCasterConstructor' of undefined`.

This PR checks that the prototype is defined first.