### PR TITLE
document.js fixes for functions prepended with `$`

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1048,6 +1048,8 @@ Document.prototype.unmarkModified = function(path) {
  *     doc.$ignore('foo');
  *     doc.save() // changes to foo will not be persisted and validators won't be run
  *
+ * @memberOf Document
+ * @method $ignore
  * @param {String} path the path to ignore
  * @api public
  */
@@ -1120,11 +1122,12 @@ Document.prototype.isModified = function(paths) {
  *
  *     MyModel = mongoose.model('test', { name: { type: String, default: 'Val '} });
  *     var m = new MyModel();
- *     m.$isDefault('name');               // true
+ *     m.$isDefault('name'); // true
  *
+ * @memberOf Document
+ * @method $isDefault
  * @param {String} [path]
  * @return {Boolean}
- * @method $isDefault
  * @api public
  */
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Small fix in the documentation for the errors that occur [here](http://mongoosejs.com/docs/api.html#document-js) and [here](http://mongoosejs.com/docs/api.html#document_function%20Object()%20%7B%20%5Bnative%20code%5D%20%7D-%24isDefault)

The issue was that `dox` wasn't correctly generating the function names for functions that start with `$` without explicitly specifying `@method` and `@memberOf`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Current:
`$isDefault()`
<img width="478" alt="screen shot 2017-03-29 at 10 09 45 am" src="https://cloud.githubusercontent.com/assets/6899016/24458752/db631f06-1467-11e7-860a-8c5f7d0d2225.png">

`$ignore()`
<img width="432" alt="screen shot 2017-03-29 at 10 09 06 am" src="https://cloud.githubusercontent.com/assets/6899016/24458722/c4ef65f4-1467-11e7-9e7f-fd61cf23deda.png">


Fixes:
`$isDefault()`
<img width="371" alt="screen shot 2017-03-29 at 10 03 41 am" src="https://cloud.githubusercontent.com/assets/6899016/24458505/1eb8c89c-1467-11e7-90c7-7344d1b9388a.png">

`$ignore()`
<img width="469" alt="screen shot 2017-03-29 at 10 03 34 am" src="https://cloud.githubusercontent.com/assets/6899016/24458685/a266a5ec-1467-11e7-92ad-33ce7ad64ae2.png">

