### PR TITLE
fix blue bird "a promise was created in a handler but was not returne…

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2740,13 +2740,14 @@ Query.prototype.exec = function exec(op, callback) {
   });
 
   if (callback) {
-    promise.then(
+    return promise.then(
       function() {
         callback.apply(null, _results);
-        return null;
+        return Promise.ES6.resolve(_results);
       },
       function(error) {
         callback(error);
+        return Promise.ES6.reject(error);
       }).
       catch(function(error) {
         // If we made it here, we must have an error in the callback re:

--- a/lib/query.js
+++ b/lib/query.js
@@ -2742,19 +2742,30 @@ Query.prototype.exec = function exec(op, callback) {
   if (callback) {
     return promise.then(
       function() {
-        callback.apply(null, _results);
-        return Promise.ES6.resolve(_results);
+        var err;
+        try {
+          callback.apply(null, _results);
+        } catch(err) {
+          // If we made it here, we must have an error in the callback re:
+          // gh-4500, so we need to emit.
+          setImmediate(function() {
+            _this.model.emit('error', err);
+          });
+        }
+        return _results;
       },
       function(error) {
-        callback(error);
-        return Promise.ES6.reject(error);
-      }).
-      catch(function(error) {
-        // If we made it here, we must have an error in the callback re:
-        // gh-4500, so we need to emit.
-        setImmediate(function() {
-          _this.model.emit('error', error);
-        });
+        var err;
+        try {
+          callback(error);
+        } catch(err) {
+          // If we made it here, we must have an error in the callback re:
+          // gh-4500, so we need to emit.
+          setImmediate(function() {
+            _this.model.emit('error', err);
+          });
+        }
+        throw error;
       });
   }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -2742,10 +2742,9 @@ Query.prototype.exec = function exec(op, callback) {
   if (callback) {
     return promise.then(
       function() {
-        var err;
         try {
           callback.apply(null, _results);
-        } catch(err) {
+        } catch (err) {
           // If we made it here, we must have an error in the callback re:
           // gh-4500, so we need to emit.
           setImmediate(function() {
@@ -2755,10 +2754,9 @@ Query.prototype.exec = function exec(op, callback) {
         return _results;
       },
       function(error) {
-        var err;
         try {
           callback(error);
-        } catch(err) {
+        } catch (err) {
           // If we made it here, we must have an error in the callback re:
           // gh-4500, so we need to emit.
           setImmediate(function() {


### PR DESCRIPTION
…d from it"

if u use the default promise library it wont show. if u use bluebird it is smart enough to catch this warning namely: "Warning: a promise was created in a handler but was not returned from it, see http://goo.gl/rRqMUw" this will resolve this issue here.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

if u use bluebird promise library with mongoose. using simple queries will emit a warning:
    (node:8148) Warning: a promise was created in a handler but was not returned from it, see http://goo.gl/rRqMUw
        at Promise.then (xxx\bluebird\js\release\promise.js:124:17)

bluebird is intelligent and it looks for such discrepancies. this is also mentioned in bluebird issue https://github.com/petkaantonov/bluebird/issues/508 but the source i guess is mongoose not bluebird

**Test plan**

first set promise to bluebird:
mongoose.Promise = require('bluebird');

then try running any get query like:
User.findOne({'username':'maa'}).exec(function(err,user){...});

this is because at line 2743 when u do "promise.then" this will create a new promise. this new promise you are not returning. I see why u dont want to return it and instead u return the old promise (which is to keep the original state of the promise i.e. the resolved status of the promise). what I did is return this new promise and in its then and catch functions returned the original values/rejections to maintain its state.
