### PR TITLE
mongoose 4.8.3 broke $pullAll: null on subdocs

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -241,7 +241,7 @@ SchemaArray.prototype.castForQuery = function($conditional, value) {
           v = method.call(caster, v);
           return v;
         }
-        if (val != null) {
+        if (v != null) {
           v = new Constructor(v);
           return v;
         }


### PR DESCRIPTION
<!-- *Before creating an issue please make sure you are using the latest version of mongoose -->

**Do you want to request a *feature* or report a *bug*?**

bug

**If the current behavior is a bug, please provide the steps to reproduce.**

```js
var mongoose = require('.');
var Promise = require('bluebird');

mongoose.connect('mongodb://localhost/test');

var Cat = mongoose.model('Cat', { name: String, props: [{
  name: String
}]});

(async function () {
  var kitty = new Cat({ name: 'Zildjian', props: [null, {name: 'abc'}] });
  await kitty.save();

  kitty = await Cat.findById(kitty._id);
  console.log(kitty.props)

  await Cat.update({ _id: kitty._id }, { $pullAll: { props: [null] }})

  kitty = await Cat.findById(kitty._id);
  console.log(kitty.props)
}());
```

**What is the current behavior?**

Returns `[ null, { _id: 58efc1d703b69d6d1f1d2e72, name: 'abc' } ]`.

**What is the expected behavior?**

Should return `[ { _id: 58efc1d703b69d6d1f1d2e72, name: 'abc' } ]`.

**Please mention your node.js, mongoose and MongoDB version.**
node v7.8.0
mongoose 4.8.3, 4.9.4
mongodb 3.2