### PR TITLE
Fix the bulkWrite::updateMany case

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2115,7 +2115,7 @@ Model.bulkWrite = function(ops, options, callback) {
         try {
           op['updateMany']['filter'] = cast(_this.schema,
             op['updateMany']['filter']);
-          op['updateMany']['update'] = castUpdate(_this.schema, op['updateMany']['filter'], {
+          op['updateMany']['update'] = castUpdate(_this.schema, op['updateMany']['update'], {
             strict: _this.schema.options.strict,
             overwrite: false
           });


### PR DESCRIPTION
**Summary**

The `update` option was inadvertently being wrapped by the passed-in `filter` option. Most likely a copy-paste error in the code.

I ran into this issue when trying to do a bulkWrite->writeMany operation.

**Test plan**

No additional tests were added, as it should be easy to eyeball the error.

![Diff](https://cloud.githubusercontent.com/assets/174619/25129808/9f993b76-240d-11e7-826a-69d77e645809.png)
