### PR TITLE
Update `parentArray` references when directly assigning document arrays

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -878,6 +878,13 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
     if (val && val.isMongooseArray) {
       val._registerAtomic('$set', val);
 
+      // Update embedded document parent references (gh-5189)
+      if (val.isMongooseDocumentArray) {
+        val.forEach(function(item) {
+          item && item.__parentArray && (item.__parentArray = val);
+        });
+      }
+
       // Small hack for gh-1638: if we're overwriting the entire array, ignore
       // paths that were modified before the array overwrite
       this.$__.activePaths.forEach(function(modifiedPath) {

--- a/test/document.modified.test.js
+++ b/test/document.modified.test.js
@@ -465,6 +465,28 @@ describe('document modified', function() {
 
         done();
       });
+
+      it('updates embedded doc parents upon direct assignment (gh-5189)', function(done) {
+        var db = start();
+        var familySchema = new Schema({
+          children: [{name: {type: String, required: true}}]
+        });
+        var Family = db.model('Family', familySchema);
+        Family.create({
+          children: [
+            {name: 'John'},
+            {name: 'Mary'}
+          ]
+        }, function(err, family) {
+          family.set({children: family.children.slice(1)});
+          family.children.forEach(function(child) {
+            child.set({name: 'Maryanne'});
+          });
+
+          assert.equal(family.validateSync(), undefined);
+          done();
+        });
+      });
     });
 
     it('should support setting mixed paths by string (gh-1418)', function(done) {


### PR DESCRIPTION
**Summary**

This is a proposal to fix the primary issue described in #5189.

**Test plan**

A test has been added that demonstrates the failure case without the included fix. See [`test/document.modified.test.js#468`](https://github.com/Automattic/mongoose/pull/5192/files#diff-2242966c7ef28bf9e498506e1bcff490R468). Steps to manually reproduce can be found in #5189.

**Notes**


I must admit it feels wrong reaching into `val.__parentArray` within `Document.prototype.$__set`. A new method to encapsulate this on `DocumentArray` might be preferable, and I'd be happy to propose one if this direction feels right.

In any case, modifying the value passed to `Document.prototype.set` might itself be quite undesirable, and other more involved solutions may avoid this, for example:
- cloning assigned document arrays and their embedded documents, with consistent internals like `__parentArray` and `__index`.
- override `Array.prototype.filter`, `Array.prototype.slice` etc. on `MongooseArray` to update parent references on returned arrays.
- do not keep a reference to `__parentArray` altogether, and instead store its path to retrieve the actual array when we need to generate element paths.

Feedback very welcome! This issue is raising its head for us quite often so any path forward would be much appreciated.