### PR TITLE
Adding return to promise callback to suppress bluebird promise warnings

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2747,7 +2747,7 @@ Query.prototype.exec = function exec(op, callback) {
       },
       function(error) {
         callback(error);
-	return Promise.ES6.resolve(error);
+	return null;
       }).
       catch(function(error) {
         // If we made it here, we must have an error in the callback re:

--- a/lib/query.js
+++ b/lib/query.js
@@ -2747,7 +2747,7 @@ Query.prototype.exec = function exec(op, callback) {
       },
       function(error) {
         callback(error);
-	return null;
+	return Promise.ES6.resolve(error);
       }).
       catch(function(error) {
         // If we made it here, we must have an error in the callback re:

--- a/lib/query.js
+++ b/lib/query.js
@@ -2747,6 +2747,7 @@ Query.prototype.exec = function exec(op, callback) {
       },
       function(error) {
         callback(error);
+	return null;
       }).
       catch(function(error) {
         // If we made it here, we must have an error in the callback re:

--- a/lib/query.js
+++ b/lib/query.js
@@ -2747,7 +2747,7 @@ Query.prototype.exec = function exec(op, callback) {
       },
       function(error) {
         callback(error);
-	return null;
+        return null;
       }).
       catch(function(error) {
         // If we made it here, we must have an error in the callback re:


### PR DESCRIPTION
**Summary**

When using .exec() callbacks, bluebird outputs the following error:

`(node:16) Warning: a promise was created in a handler at lib/query.js:2557:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (node_modules/bluebird/js/release/promise.js:79:10)
`

Looks like bluebird wants to see the promise handler return _something_, I just added a standard promise resolve object and the warnings are now gone. 

**Note**: If you don't want to return a promise ([#3931](https://github.com/Automattic/mongoose/issues/3931)) , I was able to use `return null` just as currently is done on line 2554 in that same function, and bluebird warnings will still not appear anymore.

**Edit:** The travis build failed (`Promise.ES6.resolve is not a function`), so I reverted to returning null, which still works. The build still failed for an unrelated issue though:
 ```
1) Model bug fixes insertMany with Decimal (gh-5190):
     Uncaught MongoError: connection 863 to localhost:27017 closed)
```

**Test plan**

Here's an example of normal code that causes this issue:
`User.findOne({'_id': req.params.id}).populate('role','_id').exec(aCallback);`

After adding the return statement to the error callback, bluebird is happy and the warnings stop appearing.

Same issue as [d869ea5d1...](https://github.com/Automattic/mongoose/commit/d869ea5d1a173ba2a679703adb2995fd8cb912c5), but this solution is fairly simple, doesn't change any logic, and cleans up the test output files (which are currently cluttered with bluebird warnings)