### PR TITLE
Boolean strict mode #5211

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+4.9.8 / 2017-05-07
+==================
+ * docs(subdocs): rewrite subdocs guide #5217
+ * fix(document): avoid circular JSON if error in doc array under single nested subdoc #5208
+ * fix(document): set intermediate empty objects for deeply nested undefined paths before path itself #5206
+ * fix(schema): throw error if first param to schema.plugin() is not a function #5201
+ * perf(document): major speedup in validating subdocs (50x in some cases) #5191
+
 4.9.7 / 2017-04-30
 ==================
  * docs: fix typo #5204 [phutchins](https://github.com/phutchins)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -143,41 +143,14 @@ Connection.prototype.db;
 
 Connection.prototype.config;
 
-/**
- * Opens the connection to MongoDB.
- *
- * `options` is a hash with the following possible properties:
- *
- *     config  - passed to the connection config instance
- *     db      - passed to the connection db instance
- *     server  - passed to the connection server instance(s)
- *     replset - passed to the connection ReplSet instance
- *     user    - username for authentication
- *     pass    - password for authentication
- *     auth    - options for authentication (see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate)
- *
- * ####Notes:
- *
- * Mongoose forces the db option `forceServerObjectId` false and cannot be overridden.
- * Mongoose defaults the server `auto_reconnect` options to true which can be overridden.
- * See the node-mongodb-native driver instance for options that it understands.
- *
- * _Options passed take precedence over options included in connection strings._
- *
- * @param {String} connection_string mongodb://uri or the host to which you are connecting
- * @param {String} [database] database name
- * @param {Number} [port] database port
- * @param {Object} [options] options
- * @param {Function} [callback]
- * @see node-mongodb-native https://github.com/mongodb/node-mongodb-native
- * @see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate
- * @api public
+/*!
+ * ignore
  */
 
-Connection.prototype.open = function(host, database, port, options, callback) {
-  var parsed;
-  var Promise = PromiseProvider.get();
+Connection.prototype._handleOpenArgs = function(host, database, port, options, callback) {
   var err;
+
+  var parsed;
 
   if (typeof database === 'string') {
     switch (arguments.length) {
@@ -221,11 +194,9 @@ Connection.prototype.open = function(host, database, port, options, callback) {
 
     try {
       parsed = muri(host);
-    } catch (err) {
-      this.error(err, callback);
-      return new Promise.ES6(function(resolve, reject) {
-        reject(err);
-      });
+    } catch (error) {
+      this.error(error, callback);
+      throw error;
     }
 
     database = parsed.db;
@@ -240,25 +211,19 @@ Connection.prototype.open = function(host, database, port, options, callback) {
     err = new Error('Trying to open unclosed connection.');
     err.state = this.readyState;
     this.error(err, callback);
-    return new Promise.ES6(function(resolve, reject) {
-      reject(err);
-    });
+    throw err;
   }
 
   if (!host) {
     err = new Error('Missing hostname.');
     this.error(err, callback);
-    return new Promise.ES6(function(resolve, reject) {
-      reject(err);
-    });
+    throw err;
   }
 
   if (!database) {
     err = new Error('Missing database name.');
     this.error(err, callback);
-    return new Promise.ES6(function(resolve, reject) {
-      reject(err);
-    });
+    throw err;
   }
 
   // authentication
@@ -275,19 +240,13 @@ Connection.prototype.open = function(host, database, port, options, callback) {
     if (host.length > 2) {
       err = new Error('Username and password must be URI encoded if they ' +
         'contain "@", see http://bit.ly/2nRYRyq');
-      this.error(err, callback);
-      return new Promise.ES6(function(resolve, reject) {
-        reject(err);
-      });
+      throw err;
     }
     var auth = host.shift().split(':');
     if (auth.length > 2) {
       err = new Error('Username and password must be URI encoded if they ' +
         'contain ":", see http://bit.ly/2nRYRyq');
-      this.error(err, callback);
-      return new Promise.ES6(function(resolve, reject) {
-        reject(err);
-      });
+      throw err;
     }
     host = host.pop();
     this.user = auth[0];
@@ -304,6 +263,52 @@ Connection.prototype.open = function(host, database, port, options, callback) {
   this.name = database;
   this.host = host;
   this.port = port;
+
+  return callback;
+};
+
+/**
+ * Opens the connection to MongoDB.
+ *
+ * `options` is a hash with the following possible properties:
+ *
+ *     config  - passed to the connection config instance
+ *     db      - passed to the connection db instance
+ *     server  - passed to the connection server instance(s)
+ *     replset - passed to the connection ReplSet instance
+ *     user    - username for authentication
+ *     pass    - password for authentication
+ *     auth    - options for authentication (see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate)
+ *
+ * ####Notes:
+ *
+ * Mongoose forces the db option `forceServerObjectId` false and cannot be overridden.
+ * Mongoose defaults the server `auto_reconnect` options to true which can be overridden.
+ * See the node-mongodb-native driver instance for options that it understands.
+ *
+ * _Options passed take precedence over options included in connection strings._
+ *
+ * @param {String} connection_string mongodb://uri or the host to which you are connecting
+ * @param {String} [database] database name
+ * @param {Number} [port] database port
+ * @param {Object} [options] options
+ * @param {Function} [callback]
+ * @see node-mongodb-native https://github.com/mongodb/node-mongodb-native
+ * @see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate
+ * @api public
+ */
+
+Connection.prototype.open = function() {
+  var Promise = PromiseProvider.get();
+  var callback;
+
+  try {
+    callback = this._handleOpenArgs.apply(this, arguments);
+  } catch (error) {
+    return new Promise.ES6(function(resolve, reject) {
+      reject(error);
+    });
+  }
 
   var _this = this;
   var promise = new Promise.ES6(function(resolve, reject) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -663,6 +663,18 @@ Document.prototype.set = function(path, val, type, options) {
   var schema;
   var parts = path.split('.');
 
+  // gh-4578, if setting a deeply nested path that doesn't exist yet, create it
+  var cur = this._doc;
+  var curPath = '';
+  for (i = 0; i < parts.length - 1; ++i) {
+    cur = cur[parts[i]];
+    curPath += (curPath.length > 0 ? '.' : '') + parts[i];
+    if (!cur) {
+      this.set(curPath, {});
+      cur = this.getValue(curPath);
+    }
+  }
+
   if (pathType === 'adhocOrUndefined' && strict) {
     // check for roots that are Mixed types
     var mixed;
@@ -917,7 +929,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
       } else if (obj[parts[i]] && Array.isArray(obj[parts[i]])) {
         obj = obj[parts[i]];
       } else {
-        this.set(cur, {});
+        obj[parts[i]] = obj[parts[i]] || {};
         obj = obj[parts[i]];
       }
     }
@@ -1360,15 +1372,17 @@ function _getPathsToValidate(doc) {
   paths = paths.concat(Object.keys(doc.$__.activePaths.states.modify));
   paths = paths.concat(Object.keys(doc.$__.activePaths.states.default));
 
-  var subdocs = doc.$__getAllSubdocs();
-  var subdoc;
-  var len = subdocs.length;
-  for (i = 0; i < len; ++i) {
-    subdoc = subdocs[i];
-    if (subdoc.$isSingleNested &&
-        doc.isModified(subdoc.$basePath) &&
-        !doc.isDirectModified(subdoc.$basePath)) {
-      paths.push(subdoc.$basePath);
+  if (!doc.ownerDocument) {
+    var subdocs = doc.$__getAllSubdocs();
+    var subdoc;
+    var len = subdocs.length;
+    for (i = 0; i < len; ++i) {
+      subdoc = subdocs[i];
+      if (subdoc.$isSingleNested &&
+          doc.isModified(subdoc.$basePath) &&
+          !doc.isDirectModified(subdoc.$basePath)) {
+        paths.push(subdoc.$basePath);
+      }
     }
   }
 
@@ -1376,8 +1390,14 @@ function _getPathsToValidate(doc) {
   // the children as well
   for (i = 0; i < paths.length; ++i) {
     var path = paths[i];
+
+    var _pathType = doc.schema.path(path);
+    if (!_pathType || !_pathType.$isMongooseArray || _pathType.$isMongooseDocumentArray) {
+      continue;
+    }
+
     var val = doc.getValue(path);
-    if (val && val.isMongooseArray && !Buffer.isBuffer(val) && !val.isMongooseDocumentArray) {
+    if (val) {
       var numElements = val.length;
       for (var j = 0; j < numElements; ++j) {
         paths.push(path + '.' + j);
@@ -1431,7 +1451,7 @@ Document.prototype.$__validate = function(callback) {
   var paths = _getPathsToValidate(this);
 
   if (paths.length === 0) {
-    process.nextTick(function() {
+    return process.nextTick(function() {
       var error = _complete();
       if (error) {
         return _this.schema.s.hooks.execPost('validate:error', _this, [ _this], { error: error }, function(error) {
@@ -1485,7 +1505,10 @@ Document.prototype.$__validate = function(callback) {
     });
   };
 
-  paths.forEach(validatePath);
+  var numPaths = paths.length;
+  for (var i = 0; i < numPaths; ++i) {
+    validatePath(paths[i]);
+  }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,8 @@ var Schema = require('./schema'),
     pkg = require('../package.json');
 
 var querystring = require('querystring');
+var saveSubdocs = require('./plugins/saveSubdocs');
+var validateBeforeSave = require('./plugins/validateBeforeSave');
 
 var Aggregate = require('./aggregate');
 var PromiseProvider = require('./promise_provider');
@@ -364,6 +366,13 @@ Mongoose.prototype.model = function(name, schema, collection, skipInit) {
   }
 
   if (schema) {
+    // Reverse order because these both unshift()
+    if (!schema._plugins.saveSubdocs) {
+      schema.plugin(saveSubdocs);
+    }
+    if (!schema._plugins.validateBeforeSave) {
+      schema.plugin(validateBeforeSave);
+    }
     this._applyPlugins(schema);
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -637,7 +637,8 @@ Model.prototype.$__version = function(where, delta) {
 
   // $push $addToSet don't need the where clause set
   if (VERSION_WHERE === (VERSION_WHERE & this.$__.version)) {
-    where[key] = this.getValue(key);
+    var value = this.getValue(key);
+    if (value != null) where[key] = value;
   }
 
   if (VERSION_INC === (VERSION_INC & this.$__.version)) {

--- a/lib/plugins/saveSubdocs.js
+++ b/lib/plugins/saveSubdocs.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var each = require('async/each');
+
+/*!
+ * ignore
+ */
+
+module.exports = function(schema) {
+  schema._plugins.saveSubdocs = true;
+
+  schema.callQueue.unshift(['pre', ['save', function(next) {
+    if (this.ownerDocument) {
+      next();
+      return;
+    }
+
+    var _this = this;
+    var subdocs = this.$__getAllSubdocs();
+
+    if (!subdocs.length) {
+      next();
+      return;
+    }
+
+    each(subdocs, function(subdoc, cb) {
+      subdoc.save(function(err) {
+        cb(err);
+      });
+    }, function(error) {
+      if (error) {
+        return _this.schema.s.hooks.execPost('save:error', _this, [_this], { error: error }, function(error) {
+          next(error);
+        });
+      }
+      next();
+    });
+  }]]);
+};

--- a/lib/plugins/validateBeforeSave.js
+++ b/lib/plugins/validateBeforeSave.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/*!
+ * ignore
+ */
+
+module.exports = function(schema) {
+  schema._plugins.validateBeforeSave = true;
+
+  schema.callQueue.unshift(['pre', ['save', function(next, options) {
+    var _this = this;
+    // Nested docs have their own presave
+    if (this.ownerDocument) {
+      return next();
+    }
+
+    var hasValidateBeforeSaveOption = options &&
+        (typeof options === 'object') &&
+        ('validateBeforeSave' in options);
+
+    var shouldValidate;
+    if (hasValidateBeforeSaveOption) {
+      shouldValidate = !!options.validateBeforeSave;
+    } else {
+      shouldValidate = this.schema.options.validateBeforeSave;
+    }
+
+    // Validate
+    if (shouldValidate) {
+      // HACK: use $__original_validate to avoid promises so bluebird doesn't
+      // complain
+      if (this.$__original_validate) {
+        this.$__original_validate({__noPromise: true}, function(error) {
+          return _this.schema.s.hooks.execPost('save:error', _this, [_this], { error: error }, function(error) {
+            next(error);
+          });
+        });
+      } else {
+        this.validate({__noPromise: true}, function(error) {
+          return _this.schema.s.hooks.execPost('save:error', _this, [ _this], { error: error }, function(error) {
+            next(error);
+          });
+        });
+      }
+    } else {
+      next();
+    }
+  }]]);
+};

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -86,6 +86,7 @@ function Schema(obj, options) {
   this.tree = {};
   this.query = {};
   this.childSchemas = [];
+  this._plugins = {};
 
   this.s = {
     hooks: new Kareem(),
@@ -107,9 +108,9 @@ function Schema(obj, options) {
       (!this.options.noId && this.options._id) && !_idSubDoc;
 
   if (auto_id) {
-    obj = {_id: {auto: true}};
-    obj._id[this.options.typeKey] = Schema.ObjectId;
-    this.add(obj);
+    var _obj = {_id: {auto: true}};
+    _obj._id[this.options.typeKey] = Schema.ObjectId;
+    this.add(_obj);
   }
 
   // ensure the documents receive an id getter unless disabled
@@ -166,88 +167,6 @@ Object.defineProperty(Schema.prototype, '_defaultMiddleware', {
   enumerable: false,
   writable: false,
   value: [
-    {
-      kind: 'pre',
-      hook: 'save',
-      fn: function(next, options) {
-        var _this = this;
-        // Nested docs have their own presave
-        if (this.ownerDocument) {
-          return next();
-        }
-
-        var hasValidateBeforeSaveOption = options &&
-            (typeof options === 'object') &&
-            ('validateBeforeSave' in options);
-
-        var shouldValidate;
-        if (hasValidateBeforeSaveOption) {
-          shouldValidate = !!options.validateBeforeSave;
-        } else {
-          shouldValidate = this.schema.options.validateBeforeSave;
-        }
-
-        // Validate
-        if (shouldValidate) {
-          // HACK: use $__original_validate to avoid promises so bluebird doesn't
-          // complain
-          if (this.$__original_validate) {
-            this.$__original_validate({__noPromise: true}, function(error) {
-              return _this.schema.s.hooks.execPost('save:error', _this, [_this], { error: error }, function(error) {
-                next(error);
-              });
-            });
-          } else {
-            this.validate({__noPromise: true}, function(error) {
-              return _this.schema.s.hooks.execPost('save:error', _this, [ _this], { error: error }, function(error) {
-                next(error);
-              });
-            });
-          }
-        } else {
-          next();
-        }
-      }
-    },
-    {
-      kind: 'pre',
-      hook: 'save',
-      isAsync: true,
-      fn: function(next, done) {
-        if (this.$__preSavingFromParent) {
-          done();
-          next();
-          return;
-        }
-
-        var _this = this;
-        var subdocs = this.$__getAllSubdocs();
-
-        if (!subdocs.length) {
-          done();
-          next();
-          return;
-        }
-
-        each(subdocs, function(subdoc, cb) {
-          subdoc.$__preSavingFromParent = true;
-          subdoc.save(function(err) {
-            cb(err);
-          });
-        }, function(error) {
-          for (var i = 0; i < subdocs.length; ++i) {
-            delete subdocs[i].$__preSavingFromParent;
-          }
-          if (error) {
-            return _this.schema.s.hooks.execPost('save:error', _this, [_this], { error: error }, function(error) {
-              done(error);
-            });
-          }
-          next();
-          done();
-        });
-      }
-    },
     {
       kind: 'pre',
       hook: 'validate',
@@ -354,6 +273,7 @@ Schema.prototype.clone = function() {
   s.callQueue = this.callQueue.map(function(f) { return f; });
   s.methods = utils.clone(this.methods);
   s.statics = utils.clone(this.statics);
+  s._plugins = utils.clone(this._plugins);
   s.s.hooks = this.s.hooks.clone();
   return s;
 };
@@ -1187,6 +1107,10 @@ Schema.prototype.post = function(method, fn) {
  */
 
 Schema.prototype.plugin = function(fn, opts) {
+  if (typeof fn !== 'function') {
+    throw new Error('First param to `schema.plugin()` must be a function, ' +
+      'got "' + (typeof fn) + '"');
+  }
   fn(this, opts);
   return this;
 };

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -74,6 +74,8 @@ function SchemaArray(key, cast, options, schemaOptions) {
     }
   }
 
+  this.$isMongooseArray = true;
+
   SchemaType.call(this, key, options, 'Array');
 
   var defaultArr;

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -6,6 +6,8 @@ var utils = require('../utils');
 
 var SchemaType = require('../schematype');
 
+var CastError = SchemaType.CastError;
+
 /**
  * Boolean SchemaType constructor.
  *
@@ -58,16 +60,29 @@ SchemaBoolean.prototype.cast = function(value) {
   if (value === null) {
     return value;
   }
-  if (value === '0') {
-    return false;
+
+  if (!this.options.strict) {
+    // legacy mode
+    if (value === '0') {
+      return false;
+    }
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    return !!value;
+  } else {
+    // strict mode (throws if value is not a boolean, instead of converting)
+    if (value === true || value === 'true' || value === 1 || value === '1') {
+      return true;
+    }
+    if (value === false || value === 'false' || value === 0 || value === '0') {
+      return false;
+    }
+    throw new CastError('boolean', value, this.path);
   }
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  return !!value;
 };
 
 SchemaBoolean.$conditionalHandlers =

--- a/lib/services/model/discriminator.js
+++ b/lib/services/model/discriminator.js
@@ -84,7 +84,8 @@ module.exports = function discriminator(model, name, schema) {
     schema.options.id = id;
     schema.s.hooks = model.schema.s.hooks.merge(schema.s.hooks);
 
-    schema.callQueue = baseSchema.callQueue.concat(schema.callQueue.slice(schema._defaultMiddleware.length));
+    schema.callQueue = baseSchema.callQueue.
+      concat(schema.callQueue.slice(schema._defaultMiddleware.length));
     schema._requiredpaths = undefined; // reset just in case Schema#requiredPaths() was called on either schema
   }
 

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -71,7 +71,13 @@ Subdocument.prototype.$markValid = function(path) {
 };
 
 Subdocument.prototype.invalidate = function(path, err, val) {
-  Document.prototype.invalidate.call(this, path, err, val);
+  // Hack: array subdocuments' validationError is equal to the owner doc's,
+  // so validating an array subdoc gives the top-level doc back. Temporary
+  // workaround for #5208 so we don't have circular errors.
+  if (err !== this.ownerDocument().$__.validationError) {
+    Document.prototype.invalidate.call(this, path, err, val);
+  }
+
   if (this.$parent) {
     this.$parent.invalidate([this.$basePath, path].join('.'), err, val);
   } else if (err.kind === 'cast' || err.name === 'CastError') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose",
   "description": "Mongoose MongoDB ODM",
-  "version": "4.9.8-pre",
+  "version": "4.9.9-pre",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",
   "keywords": [
     "mongodb",

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -45,12 +45,4 @@ describe('schematype', function() {
       return Promise.all(validatePromises);
     });
   });
-  // describe('boolean (strict mode) (gh-5211)', function() {
-  //   it('strict mode*', function(done) {
-  //     var db = start();
-  //     db.close();
-  //     console.log(db);
-  //     done();
-  //   });
-  // });
 });

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -42,7 +42,7 @@ describe('schematype', function() {
         return m1.validate();
       });
 
-      return Promise.all(validatePromises);
+      return global.Promise.all(validatePromises);
     });
   });
 });

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -29,5 +29,28 @@ describe('schematype', function() {
       assert.strictEqual(true, m3.b);
       done();
     });
+    it('strict mode (gh-5211)', function() {
+      var db = start(),
+          s1 = new Schema({b: {type: Boolean, strict: true}}),
+          M1 = db.model('BooleanStrictTrue', s1);
+      db.close();
+
+      var m1 = new M1;
+      var strictValues = [true, false, 'true', 'false', 0, 1, '0', '1'];
+      var validatePromises = strictValues.map(function(value) {
+        m1.b = value;
+        return m1.validate();
+      });
+
+      return Promise.all(validatePromises);
+    });
   });
+  // describe('boolean (strict mode) (gh-5211)', function() {
+  //   it('strict mode*', function(done) {
+  //     var db = start();
+  //     db.close();
+  //     console.log(db);
+  //     done();
+  //   });
+  // });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -772,15 +772,15 @@ describe('schema', function() {
 
       Tobi.pre('save', function() {
       });
-      assert.equal(Tobi.callQueue.length, 5);
+      assert.equal(Tobi.callQueue.length, 3);
 
       Tobi.post('save', function() {
       });
-      assert.equal(Tobi.callQueue.length, 6);
+      assert.equal(Tobi.callQueue.length, 4);
 
       Tobi.pre('save', function() {
       });
-      assert.equal(Tobi.callQueue.length, 7);
+      assert.equal(Tobi.callQueue.length, 5);
       done();
     });
   });


### PR DESCRIPTION
See #5211 and #4245. Strict mode (`strict: true`) throws cast error if input is not a boolean representation. Not backwards breaking as new behavior is opt-in via option. Unit test for accepted values included. Could not add documentation because `make docs` errors (should go into separate issue?).