### PR TITLE
reveal subtopics in sidebar on first click

### DIFF
--- a/docs/api.jade
+++ b/docs/api.jade
@@ -279,14 +279,15 @@ html(lang='en')
     script(src="/docs/js/cookies.min.js")
     script.
       $(".toggle-item").click(function() {
-        if ($(this).hasClass('fa-caret-right')) {
-          $(this).removeClass('fa-caret-right');
-          $(this).addClass('fa-caret-down');
-          $(this).parent().addClass('displayed');
+        var $parent = $(this).parent(),
+            $icon   = $(this).find("i");
+
+        if($parent.hasClass('displayed')){
+          $parent.removeClass('displayed');
+          $icon.addClass("fa-caret-right").removeClass("fa-caret-down");
         } else {
-          $(this).addClass('fa-caret-right');
-          $(this).removeClass('fa-caret-down');
-          $(this).parent().removeClass('displayed');
+          $parent.addClass('displayed');
+          $icon.removeClass("fa-caret-right").addClass("fa-caret-down");
         }
       });
       $(".module").on("click", ".showcode", function (e) {


### PR DESCRIPTION
fixes #5291

**Summary**

* Missing font-awesome "fa" class caused incorrect font to be used, leading to unicode □ appearing instead of the desired caret.
* Desired "toggling" behavior on first click was added by modifying/simplifying existing javascript.

**Test plan**

Running `make docs` locally leads to correct toggling behavior.

![screenshot](https://cloud.githubusercontent.com/assets/1489337/26465649/da7cf110-4140-11e7-8716-f05658b831b8.png)
