### PR TITLE
Tweak updateOne and replaceOne documentation notes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2346,9 +2346,6 @@ Model.updateMany = function updateMany(conditions, doc, options, callback) {
  * Same as `update()`, except MongoDB will update _only_ the first document that
  * matches `criteria` regardless of the value of the `multi` option.
  *
- * **Note** updateMany will _not_ fire update middleware. Use `pre('updateMany')`
- * and `post('updateMany')` instead.
- *
  * @param {Object} conditions
  * @param {Object} doc
  * @param {Object} [options]
@@ -2364,9 +2361,6 @@ Model.updateOne = function updateOne(conditions, doc, options, callback) {
 /**
  * Same as `update()`, except MongoDB replace the existing document with the
  * given document (no atomic operators like `$set`).
- *
- * **Note** updateMany will _not_ fire update middleware. Use `pre('updateMany')`
- * and `post('updateMany')` instead.
  *
  * @param {Object} conditions
  * @param {Object} doc


### PR DESCRIPTION
It seems that the note about the hooks that are called after `updateMany` was copy+pasted into the `updateOne` and `replaceOne` documentation.

It either does not apply, or the reference to `updateMany` needs to be updated to say `updateOne`/`replaceOne`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
