### PR TITLE
Add data dirs in tools/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ index.jade
 bin/
 karma.*.js
 format_deps.js
+tools/31*


### PR DESCRIPTION
**Summary**

75052328bf5f5544194f15137f1bf749e8125eae added the data directories in tools/ to `.gitignore` but not `.npmignore` resulting in the latest npm release to be 900MiB large. This PR will add these data directories to .npmignore.