### PR TITLE
Fix(ensureIndexes) manual call with !schema.options.autoIndex

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -956,11 +956,6 @@ function _ensureIndexes(model, options, callback) {
   };
 
   var create = function() {
-    if (model.schema.options.autoIndex === false ||
-        (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
-      return done();
-    }
-
     var index = indexes.shift();
     if (!index) return done();
 

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -671,11 +671,13 @@ describe('aggregate: ', function() {
             connectToField: 'name',
             as: 'employeeHierarchy'
           }).
+          sort({name: 1}).
           exec(function(err, docs) {
             if (err) {
               return done(err);
             }
             var lowest = docs[3];
+            assert.equal(lowest.name, 'Dave');
             assert.equal(lowest.employeeHierarchy.length, 3);
 
             // First result in array is max depth result
@@ -683,6 +685,7 @@ describe('aggregate: ', function() {
               return doc.name;
             }).sort();
             assert.equal(names[0], 'Alice');
+            assert.equal(names[1], 'Bob');
             assert.equal(names[2], 'Carol');
             done();
           });


### PR DESCRIPTION
Sometimes the test would fail (based on the order the database would return the results)