### PR TITLE
Query and construct document with aliases with Model.translateAliases

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1084,20 +1084,7 @@ Model.translateAliases = function translateAliases(fields) {
     // Fields is an object (query conditions or document fields)
     for (var key in fields) {
       if (aliases[key]) {
-        var value = fields[key];
-        var propPath = aliases[key]; // 'pure' property path
-        var segments = propPath.split('.');
-
-        if (segments.length < 2) {
-          fields[propPath] = value;
-        } else {
-          var obj = fields[segments[0]] = {};
-          for (var i = 1; i < segments.length - 1; ++i) {
-            obj = obj[segments[i]] = {};
-          }
-          obj[segments[segments.length - 1]] = value;
-        }
-
+        fields[aliases[key]] = fields[key];
         delete fields[key];
       }
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1061,6 +1061,55 @@ Model.base;
 Model.discriminators;
 
 /**
+  * Translate any aliases fields/conditions so the final query or document object is pure
+  *
+  * ####Example:
+  *
+  *     Character
+  *       .find(Character.translateAliases({
+  *         '名': 'Eddard Stark' // Alias for 'name'
+  *       })
+  *       .exec(function(err, characters) {})
+  *
+  * ####Note:
+  * Only translate arguments of object type anything else is returned raw
+  *
+  * @param {Object} raw fields/conditions that may contain aliased keys
+  * @return {Object} the translated 'pure' fields/conditions
+  */
+Model.translateAliases = function translateAliases(fields) {
+  var aliases = this.schema.aliases;
+
+  if (typeof fields === 'object') {
+    // Fields is an object (query conditions or document fields)
+    for (var key in fields) {
+      if (aliases[key]) {
+        var value = fields[key];
+        var propPath = aliases[key]; // 'pure' property path
+        var segments = propPath.split('.');
+
+        if (segments.length < 2) {
+          fields[propPath] = value;
+        } else {
+          var obj = fields[segments[0]] = {};
+          for (var i = 1; i < segments.length - 1; ++i) {
+            obj = obj[segments[i]] = {};
+          }
+          obj[segments[segments.length - 1]] = value;
+        }
+
+        delete fields[key];
+      }
+    }
+
+    return fields;
+  } else {
+    // Don't know typeof fields
+    return fields;
+  }
+};
+
+/**
  * Removes the first document that matches `conditions` from the collection.
  * To remove all documents that match `conditions`, set the `justOne` option
  * to false.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -74,6 +74,7 @@ function Schema(obj, options) {
 
   this.obj = obj;
   this.paths = {};
+  this.aliases = {};
   this.subpaths = {};
   this.virtuals = {};
   this.singleNestedPaths = {};
@@ -136,7 +137,6 @@ function Schema(obj, options) {
  * Create virtual properties with alias field
  */
 function aliasFields(schema) {
-  // console.log(schema.paths);
   for (var path in schema.paths) {
     if (!schema.paths[path].options) continue;
 
@@ -145,6 +145,11 @@ function aliasFields(schema) {
 
     if (alias) {
       if ('string' === typeof alias && alias.length > 0) {
+        if (schema.aliases[alias])
+          throw new Error('Duplicate alias, alias ' + alias + ' is used more than once');
+        else
+          schema.aliases[alias] = prop;
+
         schema
           .virtual(alias)
           .get((function(p) {

--- a/test/model.translateAliases.test.js
+++ b/test/model.translateAliases.test.js
@@ -24,9 +24,7 @@ describe('model translate aliases', function() {
       // How translated aliases suppose to look like
       {
         name: 'Stark',
-        bio: {
-          age: 30
-        }
+        'bio.age': 30
       }
     );
   });

--- a/test/model.translateAliases.test.js
+++ b/test/model.translateAliases.test.js
@@ -1,0 +1,33 @@
+/**
+ * Test dependencies.
+ */
+
+var start = require('./common'),
+    assert = require('power-assert'),
+    mongoose = start.mongoose;
+
+describe('model translate aliases', function() {
+  it('should translate correctly', function() {
+    var Character = mongoose.model('Character', new mongoose.Schema({
+      name: { type: String, alias: '名' },
+      bio: {
+        age: { type: Number, alias: '年齢' }
+      }
+    }));
+
+    assert.deepEqual(
+      // Translate aliases
+      Character.translateAliases({
+        '名': 'Stark',
+        '年齢': 30
+      }),
+      // How translated aliases suppose to look like
+      {
+        name: 'Stark',
+        bio: {
+          age: 30
+        }
+      }
+    );
+  });
+});


### PR DESCRIPTION
Follow up from #5321   
Usage:
```
var Character = mongoose.model('Character', new mongoose.Schema({
  name: { type: String, alias: '名' },
  bio: {
    age: { type: Number, alias: '年齢' }
  }
}));

// The condition for the 'find' query will become { name: 'Stark', bio: { age: 40 } }
Character
  .find(Charater.translateAliases({
    '名': 'Stark',
    '年齢': 40
  })
  .exec((err, characters) => {})

// Can be use similarily when constructing new document
var char = new Character(Character.translateAliases({
  '名': 'Stark',
  '年齢': 40
});
```
