### PR TITLE
`strictBool` option for schema type boolean (clean)

### DIFF
--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -58,16 +58,29 @@ SchemaBoolean.prototype.cast = function(value) {
   if (value === null) {
     return value;
   }
-  if (value === '0') {
-    return false;
+
+  if (!this.options.strictBool) {
+    // legacy mode
+    if (value === '0') {
+      return false;
+    }
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    return !!value;
+  } else {
+    // strict mode (throws if value is not a boolean, instead of converting)
+    if (value === true || value === 'true' || value === 1 || value === '1') {
+      return true;
+    }
+    if (value === false || value === 'false' || value === 0 || value === '0') {
+      return false;
+    }
+    throw new CastError('boolean', value, this.path);
   }
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  return !!value;
 };
 
 SchemaBoolean.$conditionalHandlers =

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -29,5 +29,21 @@ describe('schematype', function() {
       assert.strictEqual(true, m3.b);
       done();
     });
+    it('strictBool option (gh-5211)', function() {
+      console.log('chekc');
+      var db = start(),
+          s1 = new Schema({b: {type: Boolean, strictBool: true}}),
+          M1 = db.model('StrictBoolTrue', s1);
+      db.close();
+
+      var m1 = new M1;
+      var strictValues = [true, false, 'true', 'false', 0, 1, '0', '1'];
+      var validatePromises = strictValues.map(function(value) {
+        m1.b = value;
+        return m1.validate();
+      });
+
+      return global.Promise.all(validatePromises);
+    });
   });
 });

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -29,21 +29,29 @@ describe('schematype', function() {
       assert.strictEqual(true, m3.b);
       done();
     });
-    it('strictBool option (gh-5211)', function() {
-      console.log('chekc');
+    it('strictBool option (gh-5211)', function(done) {
       var db = start(),
           s1 = new Schema({b: {type: Boolean, strictBool: true}}),
           M1 = db.model('StrictBoolTrue', s1);
       db.close();
 
-      var m1 = new M1;
       var strictValues = [true, false, 'true', 'false', 0, 1, '0', '1'];
-      var validatePromises = strictValues.map(function(value) {
-        m1.b = value;
-        return m1.validate();
+
+      var testsRemaining = strictValues.length;
+      strictValues.forEach(function (value) {
+        var doc = new M1;
+        doc.b = value;
+        doc.validate(function (error) {
+          if (error) {
+            // test fails as soon as one value fails
+            return done(error)
+          }
+          if (!--testsRemaining) {
+            return done()
+          }
+        });
       });
 
-      return global.Promise.all(validatePromises);
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
See #5288, #5211 and #4245. Adds an option for schema type Boolean, called `strictBool` (disabled by default to ensure compatibility). When `strictBool:true` is passed, path input is restricted to `true`, `false`, `'true'`, `'false'`, `1`, `0`, `'1'` and `'0'`. Other values throw a `castError`. `null` is also accepted (as before) so the field can be marked as unspecified.

**Test plan**
0fb09d9 (second one) includes a test which verifies that the values we expect to be accepted are indeed accepted. (Need to test that other values are rejected?)

`npm test -- -g 'strictBool'`: test passed

**TODO**
- Document new option.
