### PR TITLE
Fix `parseOption` mutates user passed option map

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -245,7 +245,7 @@ NativeConnection.prototype.doClose = function(fn) {
  */
 
 NativeConnection.prototype.parseOptions = function(passed, connStrOpts) {
-  var o = passed ? require('clone')(passed) : {};
+  var o = passed ? require('../../utils').clone(passed) : {};
 
   o.db || (o.db = {});
   o.auth || (o.auth = {});

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -245,7 +245,8 @@ NativeConnection.prototype.doClose = function(fn) {
  */
 
 NativeConnection.prototype.parseOptions = function(passed, connStrOpts) {
-  var o = passed || {};
+  var o = passed ? require('clone')(passed) : {};
+
   o.db || (o.db = {});
   o.auth || (o.auth = {});
   o.server || (o.server = {});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "async": "2.1.4",
     "bson": "~1.0.4",
-    "clone": "^2.1.1",
     "hooks-fixed": "2.0.0",
     "kareem": "1.4.1",
     "mongodb": "2.2.27",
@@ -31,6 +30,7 @@
     "ms": "2.0.0",
     "muri": "1.2.1",
     "regexp-clone": "0.0.1",
+    "sinon": "~2.3.4",
     "sliced": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "async": "2.1.4",
     "bson": "~1.0.4",
+    "clone": "^2.1.1",
     "hooks-fixed": "2.0.0",
     "kareem": "1.4.1",
     "mongodb": "2.2.27",

--- a/test/parse.options.test.js
+++ b/test/parse.options.test.js
@@ -1,0 +1,55 @@
+var mongoose = require( '../' );
+var assert = require( 'power-assert' );
+
+describe( 'parseOptions', function () {
+    it( 'should not mutate user passed options map', function () {
+        var db = new mongoose.Connection();
+        var now = Date.now();
+
+        var userPassedOptionsMap = Object.create( null, {
+            auth: {
+                value: {},
+                enumerable: true
+            },
+            prop_num: {
+                value: now,
+                enumerable: true
+            },
+            prop_obj: {
+                value: {},
+                enumerable: true
+            }
+        } );
+        var ultimateOptionsMap = db.parseOptions( userPassedOptionsMap );
+
+        assert.notEqual( ultimateOptionsMap, userPassedOptionsMap );
+        assert.deepStrictEqual( userPassedOptionsMap, Object.create( null, {
+            auth: {
+                value: {},
+                enumerable: true
+            },
+            prop_num: {
+                value: now,
+                enumerable: true
+            },
+            prop_obj: {
+                value: {},
+                enumerable: true
+            }
+        } ) );
+        assert.notDeepStrictEqual( ultimateOptionsMap, Object.create( null, {
+            auth: {
+                value: {},
+                enumerable: true
+            },
+            prop_num: {
+                value: now,
+                enumerable: true
+            },
+            prop_obj: {
+                value: {},
+                enumerable: true
+            }
+        } ) );
+    } );
+} );

--- a/test/parse.options.test.js
+++ b/test/parse.options.test.js
@@ -1,55 +1,55 @@
-var mongoose = require( '../' );
-var assert = require( 'power-assert' );
+var mongoose = require('../');
+var assert = require('power-assert');
 
-describe( 'parseOptions', function () {
-    it( 'should not mutate user passed options map', function () {
-        var db = new mongoose.Connection();
-        var now = Date.now();
+describe('parseOptions', function() {
+  it('should not mutate user passed options map', function() {
+    var db = new mongoose.Connection();
+    var now = Date.now();
 
-        var userPassedOptionsMap = Object.create( null, {
-            auth: {
-                value: {},
-                enumerable: true
-            },
-            prop_num: {
-                value: now,
-                enumerable: true
-            },
-            prop_obj: {
-                value: {},
-                enumerable: true
-            }
-        } );
-        var ultimateOptionsMap = db.parseOptions( userPassedOptionsMap );
+    var userPassedOptionsMap = Object.create(null, {
+      auth: {
+        value: {},
+        enumerable: true
+      },
+      prop_num: {
+        value: now,
+        enumerable: true
+      },
+      prop_obj: {
+        value: {},
+        enumerable: true
+      }
+    });
+    var ultimateOptionsMap = db.parseOptions(userPassedOptionsMap);
 
-        assert.notEqual( ultimateOptionsMap, userPassedOptionsMap );
-        assert.deepStrictEqual( userPassedOptionsMap, Object.create( null, {
-            auth: {
-                value: {},
-                enumerable: true
-            },
-            prop_num: {
-                value: now,
-                enumerable: true
-            },
-            prop_obj: {
-                value: {},
-                enumerable: true
-            }
-        } ) );
-        assert.notDeepStrictEqual( ultimateOptionsMap, Object.create( null, {
-            auth: {
-                value: {},
-                enumerable: true
-            },
-            prop_num: {
-                value: now,
-                enumerable: true
-            },
-            prop_obj: {
-                value: {},
-                enumerable: true
-            }
-        } ) );
-    } );
-} );
+    assert.notEqual(ultimateOptionsMap, userPassedOptionsMap);
+    assert.deepStrictEqual(userPassedOptionsMap, Object.create(null, {
+      auth: {
+        value: {},
+        enumerable: true
+      },
+      prop_num: {
+        value: now,
+        enumerable: true
+      },
+      prop_obj: {
+        value: {},
+        enumerable: true
+      }
+    }));
+    assert.notDeepStrictEqual(ultimateOptionsMap, Object.create(null, {
+      auth: {
+        value: {},
+        enumerable: true
+      },
+      prop_num: {
+        value: now,
+        enumerable: true
+      },
+      prop_obj: {
+        value: {},
+        enumerable: true
+      }
+    }));
+  });
+});

--- a/test/parse.options.test.js
+++ b/test/parse.options.test.js
@@ -1,5 +1,7 @@
 var mongoose = require('../');
 var assert = require('power-assert');
+var sinon = require('sinon');
+var util = require('../lib/utils');
 
 describe('parseOptions', function() {
   it('should not mutate user passed options map', function() {
@@ -20,8 +22,13 @@ describe('parseOptions', function() {
         enumerable: true
       }
     });
-    var ultimateOptionsMap = db.parseOptions(userPassedOptionsMap);
+    var ultimateOptionsMap;
 
+    sinon.spy(util, 'clone');
+
+    ultimateOptionsMap = db.parseOptions(userPassedOptionsMap);
+
+    assert.ok(util.clone.calledWith(userPassedOptionsMap));
     assert.notEqual(ultimateOptionsMap, userPassedOptionsMap);
     assert.deepStrictEqual(userPassedOptionsMap, Object.create(null, {
       auth: {
@@ -51,5 +58,7 @@ describe('parseOptions', function() {
         enumerable: true
       }
     }));
+
+    util.clone.restore();
   });
 });


### PR DESCRIPTION
**Summary**

Consider the following code snippet:

```javascript
var mongoose = require( 'mongoose' );

var options = Object.create( null, {
    auth: { value: {} }
} );

// internally calls `parseOption( options, connStrOpts /* options that were passed in the connection string, if any */ )`
mongoose.connect( 'mongodb://localhost/my_database', options );
```

The issue is that `parseOption( options )` currently mutates the passed `options` parameter. Should that really happen?
- Library users may not expect that their data will possibly get mutated by mongosse
- If a library user passes a secured object composed with `Object.create( ... )`, the connection attempt will fail
- Mutating users references is not playing-nice, imho

The change in this PR resolves the described issue.

**Test plan**

A unit test for this change exists in _test/parse.options.test.js_. Run the unit test specific to this change with

    $ mocha test/parse.options.test.js