### PR TITLE
Model.update with decimal 128 bug

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2521,6 +2521,10 @@ Query.prototype.update = function(conditions, doc, options, callback) {
     callback = undefined;
   }
 
+  if (doc) {
+    this._mergeUpdate(doc);
+  }
+
   return _update(this, 'update', conditions, doc, options, callback);
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -186,7 +186,10 @@ Query.prototype.toConstructor = function toConstructor() {
   p.op = this.op;
   p._conditions = utils.clone(this._conditions, { retainKeyOrder: true });
   p._fields = utils.clone(this._fields);
-  p._update = utils.clone(this._update);
+  p._update = utils.clone(this._update, {
+    flattenDecimals: false,
+    retainKeyOrder: true
+  });
   p._path = this._path;
   p._distinct = this._distinct;
   p._collection = this._collection;
@@ -2519,10 +2522,6 @@ Query.prototype.update = function(conditions, doc, options, callback) {
     conditions = undefined;
     options = undefined;
     callback = undefined;
-  }
-
-  if (doc) {
-    this._mergeUpdate(doc);
   }
 
   return _update(this, 'update', conditions, doc, options, callback);

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -104,8 +104,12 @@ Decimal128.prototype.cast = function(value, doc, init) {
     return ret;
   }
 
-  if (value === null || value === undefined) {
+  if (value == null) {
     return value;
+  }
+
+  if (typeof value === 'object' && typeof value.$numberDecimal === 'string') {
+    return Decimal128Type.fromString(value.$numberDecimal);
   }
 
   if (value instanceof Decimal128Type) {

--- a/lib/services/query/castUpdate.js
+++ b/lib/services/query/castUpdate.js
@@ -286,6 +286,5 @@ function castUpdateVal(schema, val, op, $conditional) {
   if (/^\$/.test($conditional)) {
     return schema.castForQuery($conditional, val);
   }
-
   return schema.castForQuery(val);
 }

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -196,7 +196,12 @@ EmbeddedDocument.prototype.update = function() {
  */
 
 EmbeddedDocument.prototype.inspect = function() {
-  return this.toObject({ transform: false, retainKeyOrder: true, virtuals: false });
+  return this.toObject({
+    transform: false,
+    retainKeyOrder: true,
+    virtuals: false,
+    flattenDecimals: false
+  });
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -861,7 +861,10 @@ exports.mergeClone = function(to, fromObj) {
     if (typeof to[key] === 'undefined') {
       // make sure to retain key order here because of a bug handling the $each
       // operator in mongodb 2.4.4
-      to[key] = exports.clone(fromObj[key], {retainKeyOrder: 1});
+      to[key] = exports.clone(fromObj[key], {
+        retainKeyOrder: 1,
+        flattenDecimals: false
+      });
     } else {
       if (exports.isObject(fromObj[key])) {
         var obj = fromObj[key];
@@ -875,7 +878,10 @@ exports.mergeClone = function(to, fromObj) {
       } else {
         // make sure to retain key order here because of a bug handling the
         // $each operator in mongodb 2.4.4
-        to[key] = exports.clone(fromObj[key], {retainKeyOrder: 1});
+        to[key] = exports.clone(fromObj[key], {
+          retainKeyOrder: 1,
+          flattenDecimals: false
+        });
       }
     }
   }

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -2585,6 +2585,40 @@ describe('model: update:', function() {
       });
     });
 
+    it('update with Decimal type (gh-5361)', function(done) {
+      var schema = new mongoose.Schema({
+        name: String,
+        pricing: [{
+            _id: false,
+            program: String,
+            money: mongoose.Schema.Types.Decimal
+        }]
+      });
+
+      var Person = db.model('Person', schema);
+
+      var data = {
+        name: 'Jack',
+        pricing: [
+            { program: 'A', money: mongoose.Types.Decimal128.fromString('1.2') },
+            { program: 'B', money: mongoose.Types.Decimal128.fromString('3.4') }
+        ]
+      };
+
+      Person.create(data).
+        then(function(data) {
+          var newData = {
+            name: 'Jack',
+            pricing: [
+              { program: 'A', money: mongoose.Types.Decimal128.fromString('5.6') },
+              { program: 'B', money: mongoose.Types.Decimal128.fromString('7.8') }
+            ]
+          };
+          return Person.update({ name: 'Jack' }, newData);
+        }).
+        then(() => done(), done);
+    });
+
     it('single embedded schema under document array (gh-4519)', function(done) {
       var PermissionSchema = new mongoose.Schema({
         read: { type: Boolean, required: true },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
https://github.com/Automattic/mongoose/issues/5361

**Test plan**

the following script should not error with the changes:

```javascript
const mongoose = require('mongoose');
const co = require('co');
mongoose.Promise = global.Promise;
mongoose.set('debug', true);

exec()
  .catch(error => {
    console.error(`Error: ${error}\n${error.stack}`);
    process.exit(2);
  });

function exec() {
  return co(function* () {
    const db = mongoose.createConnection('mongodb://localhost:27017/gh-5361');

    var schema = new mongoose.Schema({
      name: String,
      pricing: [{
        _id: false,
        program: String,
        money: mongoose.Schema.Types.Decimal
      }]
    });

    var Person = db.model('Person', schema);
    yield Person.remove({});

    var data = {
      name: 'Jack',
      pricing: [
        { program: 'A', money: mongoose.Types.Decimal128.fromString('1.2') },
        { program: 'B', money: mongoose.Types.Decimal128.fromString('3.4') }
      ]
    };

    const p = yield Person.create(data) // create works fine

    const newData = {
      name: 'Jack',
      pricing: [
        { program: 'A', money: mongoose.Types.Decimal128.fromString('5.6') },
        { program: 'B', money: mongoose.Types.Decimal128.fromString('7.8') }
      ]
    };


    const update = yield Person.update({ _id: p._id }, newData, { new: true }); // update doesn't work
});
}
```

The problem seems to arise only when `Model.update` is use with `mongoose.Schema.Types.Decimal` as a type in an embedded subdoc array. `Model.findByIdAndUpdate` works fine.

After following the error, it seems that the source of the problem is `Query.findOneAndUpdate` vs `Query.update` in `query.js`. The fix breaks a bunch of tests, and it might be because I'm misusing the `Query._mergeUpdate` function, as seen here in the working `Query.findOneAndUpdate` method:

```javascript
  if (mquery.canMerge(criteria)) {
    this.merge(criteria);
  }

  // apply doc
  if (doc) {
    this._mergeUpdate(doc);
  }
```

