### PR TITLE
Makes Indexed Paths for Optional Nested Documents Sparse

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1362,14 +1362,14 @@ Schema.prototype.indexes = function() {
         subIndex = 0,
         keyIndex;
 
-    for(subIndex = 0; subIndex < len; ++subIndex) {
+    for (subIndex = 0; subIndex < len; ++subIndex) {
       indexObj = subindexes[subIndex][0];
       keys = Object.keys(indexObj);
       klen = keys.length;
       newindex = {};
 
       // use forward iteration, order matters
-      for(keyIndex = 0; keyIndex < klen; ++keyIndex) {
+      for (keyIndex = 0; keyIndex < klen; ++keyIndex) {
         key = keys[keyIndex];
         newindex[prefix + key] = indexObj[key];
       }
@@ -1400,29 +1400,29 @@ Schema.prototype.indexes = function() {
     prefix = prefix || '';
     keys = Object.keys(schema.paths);
 
-    for(keyIndex = 0; keyIndex < keys.length; ++keyIndex) {
+    for (keyIndex = 0; keyIndex < keys.length; ++keyIndex) {
       key = keys[keyIndex];
       path = schema.paths[key];
 
-      if(path instanceof MongooseTypes.DocumentArray || path.$isSingleNested) {
+      if (path instanceof MongooseTypes.DocumentArray || path.$isSingleNested) {
         collectIndexes(path.schema, prefix + key + '.', !path.isRequired || optional);
       } else {
         index = path._index || (path.caster && path.caster._index);
 
-        if(index !== false && index !== null && index !== undefined) {
+        if (index !== false && index !== null && index !== undefined) {
           field = {};
           isObject = utils.isObject(index);
           options = isObject ? index : {};
 
-          if(typeof index === 'string') {
+          if (typeof index === 'string') {
             type = index;
-          } else if(isObject) {
+          } else if (isObject) {
             type = index.type;
           } else {
             type = false;
           }
 
-          if(type && ~Schema.indexTypes.indexOf(type)) {
+          if (type && ~Schema.indexTypes.indexOf(type)) {
             field[prefix + key] = type;
           } else if(options.text) {
             field[prefix + key] = 'text';
@@ -1432,13 +1432,13 @@ Schema.prototype.indexes = function() {
             field[prefix + key] = 1;
           }
 
-          if(optional) {
+          if (optional) {
             options.sparse = true;
           }
 
           delete options.type;
 
-          if(!('background' in options)) {
+          if (!('background' in options)) {
             options.background = true;
           }
 
@@ -1449,11 +1449,11 @@ Schema.prototype.indexes = function() {
 
     schemaStack.pop();
 
-    if(prefix) {
+    if (prefix) {
       fixSubIndexPaths(schema, prefix);
     } else {
       schema._indexes.forEach(function(index) {
-        if(!('background' in index[1])) {
+        if (!('background' in index[1])) {
           index[1].background = true;
         }
       });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1424,7 +1424,7 @@ Schema.prototype.indexes = function() {
 
           if (type && ~Schema.indexTypes.indexOf(type)) {
             field[prefix + key] = type;
-          } else if(options.text) {
+          } else if (options.text) {
             field[prefix + key] = 'text';
 
             delete options.text;
@@ -1460,7 +1460,7 @@ Schema.prototype.indexes = function() {
 
       indexes = indexes.concat(schema._indexes);
     }
-  };
+  }
 
   collectIndexes(this);
   return indexes;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1345,46 +1345,100 @@ Schema.prototype.indexes = function() {
   var indexes = [];
   var schemaStack = [];
 
-  var collectIndexes = function(schema, prefix) {
+  /*!
+   * Checks for indexes added to subdocs using Schema.index().
+   * These indexes need their paths prefixed properly.
+   *
+   * schema._indexes = [ [indexObj, options], [indexObj, options] ..]
+   */
+  function fixSubIndexPaths(schema, prefix) {
+    var subindexes = schema._indexes,
+        len = subindexes.length,
+        indexObj,
+        newindex,
+        klen,
+        keys,
+        key,
+        subIndex = 0,
+        keyIndex;
+
+    for(subIndex = 0; subIndex < len; ++subIndex) {
+      indexObj = subindexes[subIndex][0];
+      keys = Object.keys(indexObj);
+      klen = keys.length;
+      newindex = {};
+
+      // use forward iteration, order matters
+      for(keyIndex = 0; keyIndex < klen; ++keyIndex) {
+        key = keys[keyIndex];
+        newindex[prefix + key] = indexObj[key];
+      }
+
+      indexes.push([newindex, subindexes[subIndex][1]]);
+    }
+  }
+
+  function collectIndexes(schema, prefix, optional) {
+    var keyIndex,
+        isObject,
+        options,
+        field,
+        index,
+        type,
+        path,
+        keys,
+        key;
+
     // Ignore infinitely nested schemas, if we've already seen this schema
     // along this path there must be a cycle
     if (schemaStack.indexOf(schema) !== -1) {
       return;
     }
+
     schemaStack.push(schema);
 
     prefix = prefix || '';
-    var key, path, index, field, isObject, options, type;
-    var keys = Object.keys(schema.paths);
+    keys = Object.keys(schema.paths);
 
-    for (var i = 0; i < keys.length; ++i) {
-      key = keys[i];
+    for(keyIndex = 0; keyIndex < keys.length; ++keyIndex) {
+      key = keys[keyIndex];
       path = schema.paths[key];
 
-      if ((path instanceof MongooseTypes.DocumentArray) || path.$isSingleNested) {
-        collectIndexes(path.schema, prefix + key + '.');
+      if(path instanceof MongooseTypes.DocumentArray || path.$isSingleNested) {
+        collectIndexes(path.schema, prefix + key + '.', !path.isRequired || optional);
       } else {
         index = path._index || (path.caster && path.caster._index);
 
-        if (index !== false && index !== null && index !== undefined) {
+        if(index !== false && index !== null && index !== undefined) {
           field = {};
           isObject = utils.isObject(index);
           options = isObject ? index : {};
-          type = typeof index === 'string' ? index :
-              isObject ? index.type :
-                  false;
 
-          if (type && ~Schema.indexTypes.indexOf(type)) {
+          if(typeof index === 'string') {
+            type = index;
+          } else if(isObject) {
+            type = index.type;
+          } else {
+            type = false;
+          }
+
+          if(type && ~Schema.indexTypes.indexOf(type)) {
             field[prefix + key] = type;
-          } else if (options.text) {
+          } else if(options.text) {
             field[prefix + key] = 'text';
+
             delete options.text;
           } else {
             field[prefix + key] = 1;
           }
 
+          if(optional) {
+            options.sparse = true;
+          }
+
           delete options.type;
-          if (!('background' in options)) {
+
+          if(!('background' in options)) {
             options.background = true;
           }
 
@@ -1395,54 +1449,21 @@ Schema.prototype.indexes = function() {
 
     schemaStack.pop();
 
-    if (prefix) {
+    if(prefix) {
       fixSubIndexPaths(schema, prefix);
     } else {
       schema._indexes.forEach(function(index) {
-        if (!('background' in index[1])) {
+        if(!('background' in index[1])) {
           index[1].background = true;
         }
       });
+
       indexes = indexes.concat(schema._indexes);
     }
   };
 
   collectIndexes(this);
   return indexes;
-
-  /*!
-   * Checks for indexes added to subdocs using Schema.index().
-   * These indexes need their paths prefixed properly.
-   *
-   * schema._indexes = [ [indexObj, options], [indexObj, options] ..]
-   */
-
-  function fixSubIndexPaths(schema, prefix) {
-    var subindexes = schema._indexes,
-        len = subindexes.length,
-        indexObj,
-        newindex,
-        klen,
-        keys,
-        key,
-        i = 0,
-        j;
-
-    for (i = 0; i < len; ++i) {
-      indexObj = subindexes[i][0];
-      keys = Object.keys(indexObj);
-      klen = keys.length;
-      newindex = {};
-
-      // use forward iteration, order matters
-      for (j = 0; j < klen; ++j) {
-        key = keys[j];
-        newindex[prefix + key] = indexObj[key];
-      }
-
-      indexes.push([newindex, subindexes[i][1]]);
-    }
-  }
 };
 
 /**

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -114,28 +114,14 @@ describe('model', function() {
           assert.ifError(err);
 
           function iter(index) {
-            if (index[0] === 'name') {
-              ++assertions;
-            }
-            if (index[0] === 'blogposts._id') {
-              ++assertions;
-            }
-            if (index[0] === 'blogposts.title') {
-              ++assertions;
-            }
-            if (index[0] === 'featured._id') {
-              ++assertions;
-            }
-            if (index[0] === 'featured.title') {
-              ++assertions;
-            }
+            ++assertions;
           }
 
           for (var i in indexes) {
             indexes[i].forEach(iter);
           }
 
-          assert.equal(assertions, 5);
+          assert.equal(assertions, 6);
           db.close(done);
         });
       });
@@ -208,12 +194,87 @@ describe('model', function() {
       done();
     });
 
+    it('made sparse for optional nested documents', function(done) {
+      var GrandchildSchema,
+          ChildSchema,
+          ParentSchema,
+          indexes;
+
+      GrandchildSchema = new Schema({
+        requiredNested2: {
+          type:           String,
+          required:       true,
+          unique:         true
+        },
+        optionalNested2: String
+      });
+
+      ChildSchema = new Schema({
+        requiredNested1:  {
+          type:             GrandchildSchema,
+          required:         true
+        },
+        optionalNested1:  Number
+      });
+
+      ParentSchema = new Schema({
+        child:  ChildSchema
+      });
+
+      indexes = ParentSchema.indexes();
+
+      assert.equal(indexes.length, 1);
+      assert.ok(indexes[0][1].sparse);
+
+      done();
+    });
+
+    it('not made sparse for required nested documents', function(done) {
+      var GrandchildSchema,
+          ChildSchema,
+          ParentSchema,
+          indexes;
+
+      GrandchildSchema = new Schema({
+        requiredNested2: {
+          type:           String,
+          required:       true,
+          unique:         true
+        },
+        optionalNested2: String
+      });
+
+      ChildSchema = new Schema({
+        requiredNested1:  {
+          type:             GrandchildSchema,
+          required:         true
+        },
+        optionalNested1:  Number
+      });
+
+      ParentSchema = new Schema({
+        child:  {
+          type:     ChildSchema,
+          required: true
+        }
+      });
+
+      indexes = ParentSchema.indexes();
+
+      assert.equal(indexes.length, 1);
+      assert.ok(!indexes[0][1].sparse);
+
+      done();
+    });
+
     it('primitive arrays (gh-3347)', function(done) {
+      var indexes;
       var schema = new Schema({
         arr: [{ type: String, unique: true }]
       });
 
-      var indexes = schema.indexes();
+      indexes = schema.indexes();
+
       assert.equal(indexes.length, 1);
       assert.deepEqual(indexes[0][0], { arr: 1 });
       assert.ok(indexes[0][1].unique);

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -114,14 +114,28 @@ describe('model', function() {
           assert.ifError(err);
 
           function iter(index) {
-            ++assertions;
+            if (index[0] === 'name') {
+              ++assertions;
+            }
+            if (index[0] === 'blogposts._id') {
+              ++assertions;
+            }
+            if (index[0] === 'blogposts.title') {
+              ++assertions;
+            }
+            if (index[0] === 'featured._id') {
+              ++assertions;
+            }
+            if (index[0] === 'featured.title') {
+              ++assertions;
+            }
           }
 
           for (var i in indexes) {
             indexes[i].forEach(iter);
           }
 
-          assert.equal(assertions, 6);
+          assert.equal(assertions, 5);
           db.close(done);
         });
       });
@@ -259,9 +273,9 @@ describe('model', function() {
 
       assert.equal(indexes.length, 2);
 
-      if(indexes[0][0]['child.requiredNested1.requiredNested2']) {
+      if (indexes[0][0]['child.requiredNested1.requiredNested2']) {
         assert.ok(indexes[0][1].sparse);
-      } else if(indexes[1][0]['child.requiredNested1.requiredNested2']) {
+      } else if (indexes[1][0]['child.requiredNested1.requiredNested2']) {
         assert.ok(indexes[1][1].sparse);
       } else {
         done('requiredNested2 not indexed.');

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -229,6 +229,47 @@ describe('model', function() {
       done();
     });
 
+    it('made sparse when the parent schema marks it as optional but the grandparent schema does not mark the parent as optional', function(done) {
+      var GrandchildSchema,
+          ChildSchema,
+          ParentSchema,
+          indexes;
+
+      GrandchildSchema = new Schema({
+        requiredNested2: {
+          type:           String,
+          required:       true,
+          unique:         true
+        },
+        optionalNested2: String
+      });
+
+      ChildSchema = new Schema({
+        requiredNested1:  GrandchildSchema,
+        optionalNested1:  Number
+      });
+
+      ParentSchema = new Schema({
+        child:  ChildSchema
+      });
+
+      ParentSchema.index({child: 1});
+
+      indexes = ParentSchema.indexes();
+
+      assert.equal(indexes.length, 2);
+
+      if(indexes[0][0]['child.requiredNested1.requiredNested2']) {
+        assert.ok(indexes[0][1].sparse);
+      } else if(indexes[1][0]['child.requiredNested1.requiredNested2']) {
+        assert.ok(indexes[1][1].sparse);
+      } else {
+        done('requiredNested2 not indexed.');
+      }
+
+      done();
+    });
+
     it('not made sparse for required nested documents', function(done) {
       var GrandchildSchema,
           ChildSchema,


### PR DESCRIPTION
**Summary**

This PR addresses my comments made on issue #1860.  Specifically, if a document has optional nested documents which themselves have fields that are indexed, an index will be created on the main document for that indexed field.  When 2 documents that omit the optional nested document are saved, an error is thrown for duplicate keys.  This leads to behavior similar to the analogy I made where "I don't have to have a kid, but I better know his birthday."

It is also inappropriate to require the sub-schema that creates the index for this field to declare the index sparse in some situations where the sub-schema may be used in a variety of different situations, each with differing needs.  Some of these situations may not require the sub-schema while others do.  This makes it difficult or impossible to make the sub-schema accurately make an index sparse.

This PR solves that problem by making the indexed fields of nested documents sparse if and only if the nested document (or one of its ancestors) are optional.

**Test plan**

I added 3 new test cases to confirm that indexed fields within subdocuments are made sparse only when expected.  All other tests are passing.
