### PR TITLE
bug(query): justOne is actually single, and it defaults to false

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1058,22 +1058,22 @@ Model.base;
 Model.discriminators;
 
 /**
-  * Translate any aliases fields/conditions so the final query or document object is pure
-  *
-  * ####Example:
-  *
-  *     Character
-  *       .find(Character.translateAliases({
-  *         '名': 'Eddard Stark' // Alias for 'name'
-  *       })
-  *       .exec(function(err, characters) {})
-  *
-  * ####Note:
-  * Only translate arguments of object type anything else is returned raw
-  *
-  * @param {Object} raw fields/conditions that may contain aliased keys
-  * @return {Object} the translated 'pure' fields/conditions
-  */
+ * Translate any aliases fields/conditions so the final query or document object is pure
+ *
+ * ####Example:
+ *
+ *     Character
+ *       .find(Character.translateAliases({
+ *         '名': 'Eddard Stark' // Alias for 'name'
+ *       })
+ *       .exec(function(err, characters) {})
+ *
+ * ####Note:
+ * Only translate arguments of object type anything else is returned raw
+ *
+ * @param {Object} raw fields/conditions that may contain aliased keys
+ * @return {Object} the translated 'pure' fields/conditions
+ */
 Model.translateAliases = function translateAliases(fields) {
   var aliases = this.schema.aliases;
 
@@ -1094,9 +1094,9 @@ Model.translateAliases = function translateAliases(fields) {
 };
 
 /**
- * Removes the first document that matches `conditions` from the collection.
- * To remove all documents that match `conditions`, set the `justOne` option
- * to false.
+ * Removes all documents that match `conditions` from the collection.
+ * To remove just the first document that matches `conditions`, set the `single`
+ * option to true.
  *
  * ####Example:
  *
@@ -1104,7 +1104,9 @@ Model.translateAliases = function translateAliases(fields) {
  *
  * ####Note:
  *
- * This method sends a remove command directly to MongoDB, no Mongoose documents are involved. Because no Mongoose documents are involved, _no middleware (hooks) are executed_.
+ * This method sends a remove command directly to MongoDB, no Mongoose documents
+ * are involved. Because no Mongoose documents are involved, _no middleware
+ * (hooks) are executed_.
  *
  * @param {Object} conditions
  * @param {Function} [callback]
@@ -1131,7 +1133,7 @@ Model.remove = function remove(conditions, callback) {
 /**
  * Deletes the first document that matches `conditions` from the collection.
  * Behaves like `remove()`, but deletes at most one document regardless of the
- * `justOne` option.
+ * `single` option.
  *
  * ####Example:
  *
@@ -1166,7 +1168,7 @@ Model.deleteOne = function deleteOne(conditions, callback) {
 /**
  * Deletes all of the documents that match `conditions` from the collection.
  * Behaves like `remove()`, but deletes all documents that match `conditions`
- * regardless of the `justOne` option.
+ * regardless of the `single` option.
  *
  * ####Example:
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -1641,7 +1641,7 @@ Query.prototype._remove = function(callback) {
 
 /**
  * Declare and/or execute this query as a `deleteOne()` operation. Works like
- * remove, except it deletes at most one document regardless of the `justOne`
+ * remove, except it deletes at most one document regardless of the `single`
  * option.
  *
  * ####Example
@@ -1697,7 +1697,7 @@ Query.prototype._deleteOne = function(callback) {
 /**
  * Declare and/or execute this query as a `deleteMany()` operation. Works like
  * remove, except it deletes _every_ document that matches `criteria` in the
- * collection, regardless of the value of `justOne`.
+ * collection, regardless of the value of `single`.
  *
  * ####Example
  *

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1188,18 +1188,54 @@ describe('Query', function() {
       }, done).end();
     });
 
-    it('justOne option', function(done) {
+    it('single option, default', function(done) {
       var db = start();
-      var Test = db.model('Test_justOne', new Schema({ name: String }));
+      var Test = db.model('Test_single', new Schema({ name: String }));
 
       Test.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
         assert.ifError(error);
-        Test.remove({ name: /Stark/ }).setOptions({ justOne: false }).exec(function(error, res) {
+        Test.remove({ name: /Stark/ }).exec(function(error, res) {
           assert.ifError(error);
           assert.equal(res.result.n, 2);
           Test.count({}, function(error, count) {
             assert.ifError(error);
             assert.equal(count, 0);
+            done();
+          });
+        });
+      });
+    });
+
+    it('single option, false', function(done) {
+      var db = start();
+      var Test = db.model('Test_single', new Schema({ name: String }));
+
+      Test.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
+        assert.ifError(error);
+        Test.remove({ name: /Stark/ }).setOptions({ single: false }).exec(function(error, res) {
+          assert.ifError(error);
+          assert.equal(res.result.n, 2);
+          Test.count({}, function(error, count) {
+            assert.ifError(error);
+            assert.equal(count, 0);
+            done();
+          });
+        });
+      });
+    });
+
+    it('single option, true', function(done) {
+      var db = start();
+      var Test = db.model('Test_single', new Schema({ name: String }));
+
+      Test.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
+        assert.ifError(error);
+        Test.remove({ name: /Stark/ }).setOptions({ single: true }).exec(function(error, res) {
+          assert.ifError(error);
+          assert.equal(res.result.n, 1);
+          Test.count({}, function(error, count) {
+            assert.ifError(error);
+            assert.equal(count, 1);
             done();
           });
         });


### PR DESCRIPTION
**Summary**

Fixes #5396

Renames the `justOne` option to `single`, and correct the docs. `justOne` doesn't work.

**Test plan**

All three cases (default, true, false) are covered.

(Replaces PR #5397, which is caught in some sort of github limbo.)