### PR TITLE
Fix comment typo in connect example

### DIFF
--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -105,7 +105,7 @@ block content
     // Or using promises
     mongoose.connect(uri, options).then(
       () => { /** ready to use. The `mongoose.connect()` promise resolves to undefined. */ },
-      err => { /** handle initial connection error }
+      err => { /** handle initial connection error */ }
     );
 
   h4#connection-string-options Connection String Options


### PR DESCRIPTION
Simple correction for comment in documentation example