### PR TITLE
Load bundled driver first to avoid packaging problem

### DIFF
--- a/lib/drivers/index.js
+++ b/lib/drivers/index.js
@@ -5,7 +5,10 @@
 var driver;
 
 if (typeof window === 'undefined') {
-  driver = require(global.MONGOOSE_DRIVER_PATH || './node-mongodb-native');
+  driver = require('./node-mongodb-native');
+  if (global.MONGOOSE_DRIVER_PATH) {
+    driver = require(global.MONGOOSE_DRIVER_PATH || './node-mongodb-native');
+  }
 } else {
   driver = require('./browser');
 }

--- a/lib/drivers/index.js
+++ b/lib/drivers/index.js
@@ -7,7 +7,7 @@ var driver;
 if (typeof window === 'undefined') {
   driver = require('./node-mongodb-native');
   if (global.MONGOOSE_DRIVER_PATH) {
-    driver = require(global.MONGOOSE_DRIVER_PATH || './node-mongodb-native');
+    driver = require(global.MONGOOSE_DRIVER_PATH);
   }
 } else {
   driver = require('./browser');


### PR DESCRIPTION
**Summary**
See [5365](https://github.com/Automattic/mongoose/issues/5365)
Using expression in require doesn't work while packaging using Webpack. For those who doesn't intend to override the 'node-mongodb-native' that is included with mogoose, need not have to solve this problem of packaging if the default native driver is loaded first and then override a mongodb driver using the path provided in global.MONGOOSE_DRIVER_PATH

**Test plan**
Ran the full test, below is the result. I don't think the failure are related to the change in this PR.

  1814 passing (3m)
  5 failing

  1) connections: useMongoClient/openUri (gh-5304) with mongoose.connect():
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.


  2) connections: errors .catch() means error does not get thrown (gh-5229):
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.


  3) model create() creates in parallel:
     Error: Timeout of 1000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.


  4) model indexes do not trigger "MongoError: cannot add index with a background operation in progress" (gh-1365) LONG:
     Uncaught MongoError: connection 331 to localhost:27017 timed out
      at Function.MongoError.create (node_modules\mongodb-core\lib\error.js:29:11)
      at Socket.<anonymous> (node_modules\mongodb-core\lib\connection\connection.js:188:20)
      at Socket._onTimeout (net.js:342:8)

  5) model indexes auto creation can be disabled:
     Uncaught MongoError: connection 331 to localhost:27017 timed out
      at Function.MongoError.create (node_modules\mongodb-core\lib\error.js:29:11)
      at Socket.<anonymous> (node_modules\mongodb-core\lib\connection\connection.js:188:20)
      at Socket._onTimeout (net.js:342:8)
