### PR TITLE
propagate runSettersOnQuery option to child schema

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -596,7 +596,7 @@ Schema.interpretAsType = function(path, obj, options) {
         }
         //propagate 'runSettersOnQuery' option to child schema
         if (options.hasOwnProperty('runSettersOnQuery')) {
-            childSchemaOptions.runSettersOnQuery = options.runSettersOnQuery;
+          childSchemaOptions.runSettersOnQuery = options.runSettersOnQuery;
         }
         var childSchema = new Schema(cast, childSchemaOptions);
         childSchema.$implicitlyCreated = true;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -594,6 +594,10 @@ Schema.interpretAsType = function(path, obj, options) {
         if (options.hasOwnProperty('strict')) {
           childSchemaOptions.strict = options.strict;
         }
+        //propagate 'runSettersOnQuery' option to child schema
+        if (options.hasOwnProperty('runSettersOnQuery')) {
+            childSchemaOptions.runSettersOnQuery = options.runSettersOnQuery;
+        }
         var childSchema = new Schema(cast, childSchemaOptions);
         childSchema.$implicitlyCreated = true;
         return new MongooseTypes.DocumentArray(path, childSchema, obj);


### PR DESCRIPTION
**Summary**
Currently `runSettersOnQuery` will not run on array with subdocs as this option is not propagated to the child schema, this PR just propagate this option (like it is currently done for the `strict` option)
for example:
```js
var UserSchema = new mongoose.Schema({
	friends: [
		{
			name: {
				type: String,
				set: function(val) {
					var res = '_' + val;
					return res;
				}
			}
		}
	]
}, {collection: 'users', runSettersOnQuery: true});

var UserModel = mongoose.model('User', UserSchema);
// The setter of friends.name will NOT run
UserModel.find({"friends.name": "aaa"}).exec()
```

**Test plan**
Not sure where to add tests, didnt fins something similar