### PR TITLE
Fix openuri connection props

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -695,6 +695,60 @@ Connection.prototype.onOpen = function(callback) {
   }
 };
 
+/*!
+ * ignore
+ */
+
+Connection.prototype._handleOpenUriArgs = function(uri, options, callback) {
+  if (!rgxProtocol.test(uri)) {
+    uri = 'mongodb://' + uri;
+  }
+
+  var parsed;
+  try {
+    parsed = muri(uri);
+  } catch (err) {
+    this.error(err, callback);
+    throw err;
+  }
+
+  if (!this.name) {
+    this.name = parsed.db;
+  }
+
+  host = parsed.hosts[0].host || parsed.hosts[0].ipc;
+  port = parsed.hosts[0].port || 27017;
+
+  this.host = host;
+  this.port = port;
+  this.hosts = parsed.hosts;
+  this.options = this.parseOptions(options, parsed && parsed.options);
+
+  if (!this.name) {
+    var err = new Error('No database name provided');
+    this.error(err, callback);
+    throw err;
+  }
+
+  // authentication
+  if (this.optionsProvideAuthenticationData(options)) {
+    this.user = options.user;
+    this.pass = options.pass;
+  } else if (parsed && parsed.auth) {
+    this.user = parsed.auth.user;
+    this.pass = parsed.auth.pass;
+  } else {
+    this.user = this.pass = undefined;
+  }
+
+  // global configuration options
+  if (options && options.config) {
+    this.config.autoIndex = options.config.autoIndex !== false;
+  }
+
+  return callback;
+};
+
 /**
  * Opens the connection with a URI using `MongoClient.connect()`.
  *
@@ -708,6 +762,7 @@ Connection.prototype.onOpen = function(callback) {
 Connection.prototype.openUri = function(uri, options, callback) {
   this.readyState = STATES.connecting;
   this._closeCalled = false;
+  var callback;
 
   if (typeof options === 'function') {
     callback = options;
@@ -715,6 +770,15 @@ Connection.prototype.openUri = function(uri, options, callback) {
   }
 
   var Promise = PromiseProvider.get();
+
+  try {
+    callback = this._handleOpenUriArgs.apply(this, arguments);
+  } catch (error) {
+    return new Promise.ES6(function(resolve, reject) {
+      reject(error);
+    });
+  }
+
   var _this = this;
 
   if (options && options.useMongoClient) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -716,8 +716,8 @@ Connection.prototype._handleOpenUriArgs = function(uri, options, callback) {
     this.name = parsed.db;
   }
 
-  host = parsed.hosts[0].host || parsed.hosts[0].ipc;
-  port = parsed.hosts[0].port || 27017;
+  var host = parsed.hosts[0].host || parsed.hosts[0].ipc;
+  var port = parsed.hosts[0].port || 27017;
 
   this.host = host;
   this.port = port;
@@ -762,7 +762,6 @@ Connection.prototype._handleOpenUriArgs = function(uri, options, callback) {
 Connection.prototype.openUri = function(uri, options, callback) {
   this.readyState = STATES.connecting;
   this._closeCalled = false;
-  var callback;
 
   if (typeof options === 'function') {
     callback = options;

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -43,7 +43,7 @@ describe('connections:', function() {
       assert.equal(conn.hosts[0].host, 'localhost');
       assert.equal(conn.hosts[0].port, 27017);
       assert.equal(conn.name, 'mongoosetest');
-      
+
       var Test = conn.model('Test', new Schema({ name: String }));
       assert.equal(Test.modelName, 'Test');
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -21,6 +21,11 @@ describe('connections:', function() {
 
       promise.then(function(conn) {
         assert.equal(conn.constructor.name, 'NativeConnection');
+        assert.equal(conn.host, 'localhost');
+        assert.equal(conn.port, 27017);
+        assert.equal(conn.hosts[0].host, 'localhost');
+        assert.equal(conn.hosts[0].port, 27017);
+        assert.equal(conn.name, 'mongoosetest');
 
         return mongoose.disconnect().then(function() { done(); });
       }).catch(done);
@@ -32,6 +37,11 @@ describe('connections:', function() {
 
       promise.then(function(conn) {
         assert.equal(conn.constructor.name, 'NativeConnection');
+        assert.equal(conn.host, 'localhost');
+        assert.equal(conn.port, 27017);
+        assert.equal(conn.hosts[0].host, 'localhost');
+        assert.equal(conn.hosts[0].port, 27017);
+        assert.equal(conn.name, 'mongoosetest');
 
         return mongoose.disconnect().then(function() { done(); });
       }).catch(done);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

After noticing missing connection information while using `openUri()`, I investigated and discovered it did not handle its arguments consistent with `open()` or `openSet()`. Updating adds back the information from the base connection object to make this information available at connection time. This also adds back the ability to have the user & pass information in the options object when using `openUri()`.

I added `Connection.prototype._handleOpenUriArgs` in a similar fashion as `_handleOpenArgs` & `_handleOpenSetArgs`.

**Test plan**

Updated related tests to add additional assertions based on the availability of the additional connection parameters.
