### PR TITLE
fix wrong reference link to $lookup by removing brackets

### DIFF
--- a/docs/populate.jade
+++ b/docs/populate.jade
@@ -3,7 +3,7 @@ extends layout
 block content
   h2 Population
   :markdown
-    MongoDB has the join-like ([$lookup](https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/)) aggregation operator in versions >= 3.2. Mongoose has a more powerful alternative called `populate()`, which lets you reference documents in other collections.
+    MongoDB has the join-like [$lookup](https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/) aggregation operator in versions >= 3.2. Mongoose has a more powerful alternative called `populate()`, which lets you reference documents in other collections.
 
     Population is the process of automatically replacing the specified paths in the document with document(s) from other collection(s). We may populate a single document, multiple documents, plain object, multiple plain objects, or all objects returned from a query. Let's look at some examples.
   :js


### PR DESCRIPTION
![screenshot from 2017-07-29 16-21-14](https://user-images.githubusercontent.com/3785025/28744441-7e29e37e-747a-11e7-996c-399126b6c994.png)

The closing bracket becomes part of the url and takes to "File not found" page. Removed them, as they look unnecessary in the statement anyway. 
