### PR TITLE
fix: limiting number of async operations per time in insertMany

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -21,6 +21,7 @@ var discriminator = require('./services/model/discriminator');
 var isPathSelectedInclusive = require('./services/projection/isPathSelectedInclusive');
 var mpath = require('mpath');
 var parallel = require('async/parallel');
+var parallelLimit = require('async/parallelLimit')
 var util = require('util');
 var utils = require('./utils');
 
@@ -2056,7 +2057,7 @@ Model.insertMany = function(arr, options, callback) {
     });
   });
 
-  parallel(toExecute, function(error, docs) {
+  parallelLimit(toExecute, 1000, function(error, docs) {
     if (error) {
       callback && callback(error);
       return;

--- a/lib/model.js
+++ b/lib/model.js
@@ -21,7 +21,7 @@ var discriminator = require('./services/model/discriminator');
 var isPathSelectedInclusive = require('./services/projection/isPathSelectedInclusive');
 var mpath = require('mpath');
 var parallel = require('async/parallel');
-var parallelLimit = require('async/parallelLimit')
+var parallelLimit = require('async/parallelLimit');
 var util = require('util');
 var utils = require('./utils');
 


### PR DESCRIPTION
**Summary**
For huge numbers of documents to insert using Model.insertMany produces an ‘CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory’ error.

This PR solves this issue by using parallelLimit() to limit the number of operations per time to 1000. This fits well to the underlying  db.collections.insertMany which itself limit the number of DB operations to 1000 per time.

