### PR TITLE
Fix toJSON() when apply to a virtual populate -- missing a clone() call.

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2395,7 +2395,7 @@ function applyGetters(self, json, type, options) {
     for (i = 0; i < numPaths; ++i) {
       path = paths[i];
       parts = path.split('.');
-      v = self.get(path);
+      v = clone(self.get(path), options);
       if (v === void 0) {
         continue;
       }


### PR DESCRIPTION

**Summary**

Fixes #5542 

Missing a clone() call to get virtual fields when we're applying getters.

**Test plan**

See #5542 -- with that test case, we're now seeing the correct output (the result is a pure JSON object).
