### PR TITLE
fix: added type boolean to options documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ Mongoose.prototype.STATES = STATES;
  *     mongoose.set('debug', function(collectionName, methodName, arg1, arg2...) {}); // use custom function to log collection methods + arguments
  *
  * @param {String} key
- * @param {String|Function} value
+ * @param {String|Function|Boolean} value
  * @api public
  */
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When setting `mongoose.set('debug', true)`, the IDE indicates wrong argument type.

**Test plan**

Doesn't change any code.
