### PR TITLE
Asterisk should not render as markdown bullet

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1286,7 +1286,7 @@ Model.find = function find(conditions, projection, options, callback) {
  *
  * Note: `findById()` triggers `findOne` hooks.
  *
- * * Except for how it treats `undefined`. If you use `findOne()`, you'll see
+ * \* Except for how it treats `undefined`. If you use `findOne()`, you'll see
  * that `findOne(undefined)` and `findOne({ _id: undefined })` are equivalent
  * to `findOne({})` and return arbitrary documents. However, mongoose
  * translates `findById(undefined)` into `findOne({ _id: null })`.


### PR DESCRIPTION
Minor issue with readability in the docs, there's a follow up clarificaiton to the "almost*" clause on `findOne`, but the leading asterisk was being converted to a dot point. Took my a while to find what that "almost" refered to.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
