### PR TITLE
fix(schema): replace mistype in setupTimestamp method

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -779,37 +779,20 @@ Schema.prototype.hasMixedParent = function(path) {
  */
 Schema.prototype.setupTimestamp = function(timestamps) {
   if (timestamps) {
-    var createdAt = handleTimestampOption(timestamps, 'createdAt');
-    var updatedAt = handleTimestampOption(timestamps, 'updatedAt');
-    var schemaAdditions = {};
-
-    var parts;
-    var i;
-    var cur;
-
-    if (createdAt != null) {
-      cur = schemaAdditions;
-      parts = createdAt.split('.');
-      if (this.pathType(createdAt) === 'adhocOrUndefined') {
-        for (i = 0; i < parts.length; ++i) {
+    var paths = ['createdAt', 'updatedAt'].map(handleTimestampOption.bind(null, timestamps));
+    var createdAt = paths[0];
+    var updatedAt = paths[1];
+    var schemaAdditions = paths.reduce(function (cur, path) {
+      var parts = path.split('.');
+      if (this.pathType(path) === 'adhocOrUndefined') {
+        for (var i = 0; i < parts.length; ++i) {
           cur[parts[i]] = (i < parts.length - 1 ?
-            cur[parts[i]] || {} :
+          cur[parts[i]] || {} :
             Date);
         }
       }
-    }
-
-    if (updatedAt != null) {
-      parts = updatedAt.split('.');
-      cur = schemaAdditions;
-      if (this.pathType(createdAt) === 'adhocOrUndefined') {
-        for (i = 0; i < parts.length; ++i) {
-          cur[parts[i]] = (i < parts.length - 1 ?
-            cur[parts[i]] || {} :
-            Date);
-        }
-      }
-    }
+      return cur;
+    }, {});
 
     this.add(schemaAdditions);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -782,7 +782,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
     var paths = ['createdAt', 'updatedAt'].map(handleTimestampOption.bind(null, timestamps));
     var createdAt = paths[0];
     var updatedAt = paths[1];
-    var schemaAdditions = paths.reduce(function (cur, path) {
+    var schemaAdditions = paths.reduce(function(cur, path) {
       if (path != null) {
         var parts = path.split('.');
         if (this.pathType(path) === 'adhocOrUndefined') {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -792,7 +792,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
         }
       }
       return cur;
-    }, {});
+    }.bind(this), {});
 
     this.add(schemaAdditions);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -783,12 +783,14 @@ Schema.prototype.setupTimestamp = function(timestamps) {
     var createdAt = paths[0];
     var updatedAt = paths[1];
     var schemaAdditions = paths.reduce(function (cur, path) {
-      var parts = path.split('.');
-      if (this.pathType(path) === 'adhocOrUndefined') {
-        for (var i = 0; i < parts.length; ++i) {
-          cur[parts[i]] = (i < parts.length - 1 ?
-          cur[parts[i]] || {} :
-            Date);
+      if (path != null) {
+        var parts = path.split('.');
+        if (this.pathType(path) === 'adhocOrUndefined') {
+          for (var i = 0; i < parts.length; ++i) {
+            cur[parts[i]] = (i < parts.length - 1 ?
+            cur[parts[i]] || {} :
+              Date);
+          }
         }
       }
       return cur;


### PR DESCRIPTION
setupTimestamp method has a misprint [on line 805](https://github.com/Automattic/mongoose/blob/master/lib/schema.js#L805)
When I've try to create `expireAfterSeconds` index on `updatedAt` field, declaring `expires` option in  `Schema` path: `updatedAt: {
		type: Date,
		expires: '1h'
	}`, if `Shema` has `timestamps: true` option, path options replaces with default values and no index creates.
`> db['<collection name>'].getIndexes()
[
	{
		"v" : 2,
		"key" : {
			"_id" : 1
		},
		"name" : "_id_",
		"ns" : "<collection name>"
	}
]`

**Test plan**

Create model with `Shema`, contains `expires` option on `updatedAt` path:
`
mongoose.model('testCollection', new mongoose.Schema({
	updatedAt: {
		type: Date,
		expires: '1h'
	}
}, {
	timestamps: true
}));`, and check for `expireAfterSeconds` index created:
`> db['tests'].getIndexes()
[
	{
		"v" : 2,
		"key" : {
			"_id" : 1
		},
		"name" : "_id_",
		"ns" : "tests"
	},
	{
		"v" : 2,
		"key" : {
			"updatedAt" : 1
		},
		"name" : "updatedAt_1",
		"ns" : "tests",
		"expireAfterSeconds" : 3600,
		"background" : true
	}
]
`
