### PR TITLE
Broken link for 'plugin-search'. Changed .io -> .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Mongoose is a [MongoDB](https://www.mongodb.org/) object modeling tool designed 
 
 ## Plugins
 
-Check out the [plugins search site](http://plugins.mongoosejs.io/) to see hundreds of related modules from the community. Next, learn how to write your own plugin from the [docs](http://mongoosejs.com/docs/plugins.html) or [this blog post](http://thecodebarbarian.com/2015/03/06/guide-to-mongoose-plugins).
+Check out the [plugins search site](http://plugins.mongoosejs.com/) to see hundreds of related modules from the community. Next, learn how to write your own plugin from the [docs](http://mongoosejs.com/docs/plugins.html) or [this blog post](http://thecodebarbarian.com/2015/03/06/guide-to-mongoose-plugins).
 
 ## Contributors
 


### PR DESCRIPTION
Changed http://plugins.mongoosejs.io/ to http://plugins.mongoosejs.com/

The link with the **.io** is unreachable while the **.com** link works as intended