### PR TITLE
fix replaceOne with validators

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2499,7 +2499,7 @@ Query.prototype._replaceOne = function(callback) {
         return callback(err);
       }
 
-      Query.base.updateMany.call(_this, castedQuery, castedDoc, options, callback);
+      Query.base.replaceOne.call(_this, castedQuery, castedDoc, options, callback);
     };
     try {
       doValidate(_callback);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
calling model.replaceOne() with the option runValidator = true generates an error ("multi update only works with $ operators"), as when the validation is successful query.updateMany()  is called instead of query.replaceOne().