### PR TITLE
Update mquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mongodb": "2.2.31",
     "mpath": "0.3.0",
     "mpromise": "0.5.5",
-    "mquery": "2.3.1",
+    "mquery": "2.3.2",
     "ms": "2.0.0",
     "muri": "1.2.2",
     "regexp-clone": "0.0.1",


### PR DESCRIPTION
mquery 2.3.1 uses debug 2.6.8 which has the following security advisory: https://nodesecurity.io/advisories/534

mquery 2.3.2 uses debug 2.6.9, which will resolve the security issue.