### PR TITLE
Adding nsp check to the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ before_script:
   - mkdir -p ./data/db/27000
   - ./mongodb-linux-x86_64-2.6.11/bin/mongod --fork --nopreallocj --dbpath ./data/db/27017 --syslog --port 27017
 script:
+  - npm run nsp 
   - npm test
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mongoose-long": "0.1.1",
     "mongodb-topology-manager": "1.0.11",
     "node-static": "0.7.7",
-    "nsp": "^2.8.1",
+    "nsp": "~2.8.1",
     "power-assert": "1.4.1",
     "q": "1.4.1",
     "tbd": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "mongoose-long": "0.1.1",
     "mongodb-topology-manager": "1.0.11",
     "node-static": "0.7.7",
+    "nsp": "^2.8.1",
     "power-assert": "1.4.1",
     "q": "1.4.1",
     "tbd": "0.6.4",
@@ -74,6 +75,7 @@
     "fix-lint": "eslint . --fix",
     "install-browser": "npm install `node format_deps.js`",
     "lint": "eslint . --quiet",
+    "nsp": "nsp check",
     "test": "mocha test/*.test.js test/**/*.test.js",
     "test-cov": "istanbul cover --report text --report html _mocha test/*.test.js"
   },


### PR DESCRIPTION
**Summary**

Currently there are no checks being done during CI to ensure dependencies are patched for known vulnerabilities. Since mongoose is such a widely-used project, it'd be useful for known vulnerabilities (as reported by tools like nsp or Snyk) to be highlighted quickly.

See #5675 and #5677 for one example of where it would have been useful to have a check like this. 

_An alternative_ (perhaps a better one) would be to integrate nsp's service (see https://nodesecurity.io/#pricing) as well as Snyk - https://snyk.io/

**Test plan**

The CI should pass (though currently it does not due to #5675 / #5677)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>