### PR TITLE
insertMany() multiple validation errors (#5337)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -13,6 +13,7 @@ var PromiseProvider = require('./promise_provider');
 var Query = require('./query');
 var Schema = require('./schema');
 var VersionError = require('./error').VersionError;
+var ValidationError = require('./error').ValidationError;
 var applyHooks = require('./services/model/applyHooks');
 var applyMethods = require('./services/model/applyMethods');
 var applyStatics = require('./services/model/applyStatics');
@@ -2108,18 +2109,16 @@ Model.insertMany = function(arr, options, callback) {
   }
 
   var toExecute = [];
-  arr.forEach(function(doc) {
+  var validationError = new ValidationError(); // Group all ValidationErrors together
+  arr.forEach(function(doc, index) {
     toExecute.push(function(callback) {
       doc = new _this(doc);
       doc.validate({ __noPromise: true }, function(error) {
         if (error) {
-          // Option `ordered` signals that insert should be continued after reaching
-          // a failing insert. Therefore we delegate "null", meaning the validation
-          // failed. It's up to the next function to filter out all failed models
-          if (options != null && typeof options === 'object' && options['ordered'] === false) {
-            return callback(null, null);
-          }
-          return callback(error);
+          validationError.errors[index] = error;
+          // Never return the error, as it will cause parallelLimit to immediately
+          // abort. Return null doc for `ordered: false` option.
+          return callback(null, null);
         }
         callback(null, doc);
       });
@@ -2127,10 +2126,16 @@ Model.insertMany = function(arr, options, callback) {
   });
 
   parallelLimit(toExecute, limit, function(error, docs) {
-    if (error) {
-      callback && callback(error);
+    // `error` should never be anything but null.
+
+    // Option `ordered: false` signals that insert should be continued after reaching
+    // a failing insert. Return grouped ValidationError if this option doesn't exist
+    // or is true (if there are any).
+    if ((options == null || typeof options !== 'object' || options['ordered'] === true) && Object.keys(validationError.errors).length > 0) {
+      callback && callback(validationError);
       return;
     }
+
     // We filter all failed pre-validations by removing nulls
     var docAttributes = docs.filter(function(doc) {
       return doc != null;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5223,6 +5223,24 @@ describe('Model', function() {
       });
     });
 
+    it('insertMany() multiple errors (gh-5337)', function(done) {
+      var schema = new Schema({
+        name: { type: String, required: true }
+      });
+      var Movie = db.model('gh5337', schema);
+      var arr = [
+        { foo: 'Star Wars' },
+        { name: 'Star Wars'},
+        { name: 'The Empire Strikes Back' },
+        { foo: 'The Empire Strikes Back' }
+      ];
+      Movie.insertMany(arr, function(error, docs) {
+        assert.equal(Object.keys(error.errors).length, 2);
+        assert.equal(docs, null);
+        done();
+      });
+    });
+
     it('insertMany() ordered option for constraint errors (gh-3893)', function(done) {
       start.mongodVersion(function(err, version) {
         if (err) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
See #5337.
````javascript
let Movie = new Schema({name: {type: String, required: true}})
Movie.insertMany([{ foo: 'bar' }, {foo: 'baz'}])
.catch((err) => {
  console.log(Object.keys(err.errors).length) // 2
})
````
**Test plan**

Added test 'insertMany() multiple errors (gh-5337)'.
