### PR TITLE
Fix schema methods didn't add into properties

### DIFF
--- a/lib/services/document/compile.js
+++ b/lib/services/document/compile.js
@@ -77,7 +77,7 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
         }
 
         if (!this.$__.getters[path]) {
-          var nested = Object.create(Document.prototype, getOwnPropertyDescriptors(this));
+          var nested = Object.create(Object.getPrototypeOf(this), getOwnPropertyDescriptors(this));
 
           // save scope for nested getters/setters
           if (!prefix) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -4931,5 +4931,19 @@ describe('document', function() {
         });
       });
     });
+
+    it('test methods in properties', function(done) {
+      var PropMethodSchema = new Schema({
+        nested: {
+          a: { type: String }
+        }
+      });
+      PropMethodSchema.methods.func = function() {};
+      var PropMethod = db.model('propertiesMethod', PropMethodSchema);
+      var doc = new PropMethod;
+      doc.init({nested: {a: 'test'}});
+      assert.strictEqual(doc.nested.func, doc.func);
+      done();
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Our builds are broken since upgrade to `^4.12.0`, it looks like schema methods didn't add into properties and nested properties.

**Test plan**

In the following test case, it works fine in `<= 4.11.14`:

```js
var PropMethodSchema = new Schema({
  nested: {
    a: { type: String }
  }
});
PropMethodSchema.methods.func = function() {};
var PropMethod = db.model('propertiesMethod', PropMethodSchema);
var doc = new PropMethod;
doc.init({nested: {a: 'test'}});
assert.strictEqual(doc.nested.func, doc.func);
``` 
