### PR TITLE
Add $addFields pipeline operator via a Mongoose Function

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -125,7 +125,7 @@ Aggregate.prototype.append = function() {
  *     aggregate.addFields({ salary_k: { $divide: [ "$salary", 1000 ] } });
  *
  * @param {Object} arg field specification
- * @see projection http://docs.mongodb.org/manual/reference/aggregation/project/
+ * @see $addFields https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/
  * @return {Aggregate}
  * @api public
  */

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -107,6 +107,41 @@ Aggregate.prototype.append = function() {
 };
 
 /**
+ * Appends a new $addFields operator to this aggregate pipeline.
+ * Requires MongoDB v3.4+ to work
+ *
+ * ####Examples:
+  *
+ *     // adding new fields based on existing fields
+ *     aggregate.addFields({
+ *         newField: '$b.nested'
+ *       , plusTen: { $add: ['$val', 10]}
+ *       , sub: {
+ *            name: '$a'
+ *         }
+ *     })
+ *
+ *     // etc
+ *     aggregate.addFields({ salary_k: { $divide: [ "$salary", 1000 ] } });
+ *
+ * @param {Object} arg field specification
+ * @see projection http://docs.mongodb.org/manual/reference/aggregation/project/
+ * @return {Aggregate}
+ * @api public
+ */
+Aggregate.prototype.addFields = function(arg) {
+  var fields = {};
+  if (typeof arg === 'object' && !util.isArray(arg)) {
+    Object.keys(arg).forEach(function(field) {
+      fields[field] = arg[field];
+    });
+  } else {
+    throw new Error('Invalid addFields() argument. Must be an object');
+  }
+  return this.append({$addFields: fields});
+};
+
+/**
  * Appends a new $project operator to this aggregate pipeline.
  *
  * Mongoose query [selection syntax](#query_Query-select) is also supported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose",
-  "version": "4.12.4-pre",
+  "version": "4.12.5-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2866,15 +2866,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.4.1"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2891,6 +2882,15 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.4.1"
       }
     },
     "requirejs": {
@@ -3097,14 +3097,6 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3114,6 +3106,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringifier": {

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -448,7 +448,7 @@ describe('aggregate: ', function() {
       });
     });
 
-    describe('project', function() {
+    describe('addFields', function() {
       it('(object)', function(done) {
         var aggregate = new Aggregate();
   

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -451,13 +451,12 @@ describe('aggregate: ', function() {
     describe('addFields', function() {
       it('(object)', function(done) {
         var aggregate = new Aggregate();
-  
+
         assert.equal(aggregate.addFields({ a: 1, b: 1, c: 0 }), aggregate);
         assert.deepEqual(aggregate._pipeline, [{ $addFields: { a: 1, b: 1, c: 0 } }]);
-  
+
         aggregate.addFields({ d: {$add: ['$a','$b']} });
         assert.deepEqual(aggregate._pipeline, [{ $addFields: { a: 1, b: 1, c: 0 } }, { $addFields: { d: {$add: ['$a','$b']} } }]);
-  
         done();
       });
     });

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -448,6 +448,20 @@ describe('aggregate: ', function() {
       });
     });
 
+    describe('project', function() {
+      it('(object)', function(done) {
+        var aggregate = new Aggregate();
+  
+        assert.equal(aggregate.addFields({ a: 1, b: 1, c: 0 }), aggregate);
+        assert.deepEqual(aggregate._pipeline, [{ $addFields: { a: 1, b: 1, c: 0 } }]);
+  
+        aggregate.addFields({ d: {$add: ['$a','$b']} });
+        assert.deepEqual(aggregate._pipeline, [{ $addFields: { a: 1, b: 1, c: 0 } }, { $addFields: { d: {$add: ['$a','$b']} } }]);
+  
+        done();
+      });
+    });
+
     describe('facet', function() {
       it('works', function(done) {
         var aggregate = new Aggregate();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
MongoDB v3.4 added the $addFields aggregation pipeline operator.
[https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/](https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/)

This PR adds a function `addFields()` to add this stage to the aggregation pipeline.

**Test plan**
Created a `addFields` test in `tests/aggregate.test.js`
