### PR TITLE
Add Pokémon to list of uncountables

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,7 +102,8 @@ exports.uncountables = [
   'news',
   'expertise',
   'status',
-  'media'
+  'media',
+  'pokemon'
 ];
 var uncountables = exports.uncountables;
 


### PR DESCRIPTION
This PR adds Pokémon to the list of uncountables.

The plural of Pokémon is [not Pokémons](https://en.wikipedia.org/wiki/Portal:Pok%C3%A9mon). 

I've personally encountered this issue when using Mongoose on private projects, although I am aware of the `pluralize` option, I think Pokémon is used widely enough that it should be added as a default exception.