### PR TITLE
Accept multiple paths or array of paths to depopulate

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2595,13 +2595,13 @@ Document.prototype.depopulate = function(path) {
   if (typeof path === 'string') {
     path = path.split(' ');
   }
-  for (const p of path) {
-    var populatedIds = this.populated(p);
+  for (var i = 0; i < path.length; i++) {
+    var populatedIds = this.populated(path[i]);
     if (!populatedIds) {
       continue;
     }
-    delete this.$__.populated[p];
-    this.$set(p, populatedIds);
+    delete this.$__.populated[path[i]];
+    this.$set(path[i], populatedIds);
   }
   return this;
 };

--- a/lib/document.js
+++ b/lib/document.js
@@ -2592,12 +2592,17 @@ Document.prototype.populated = function(path, val, options) {
  */
 
 Document.prototype.depopulate = function(path) {
-  var populatedIds = this.populated(path);
-  if (!populatedIds) {
-    return;
+  if (typeof path === 'string') {
+    path = path.split(' ');
   }
-  delete this.$__.populated[path];
-  this.$set(path, populatedIds);
+  for (const p of path) {
+    var populatedIds = this.populated(p);
+    if (!populatedIds) {
+      continue;
+    }
+    delete this.$__.populated[p];
+    this.$set(p, populatedIds);
+  }
   return this;
 };
 


### PR DESCRIPTION
- `Document.depopulate()` now accepts an array of paths, e.g. `['some', 'path', 'other.path']`
- `Document.depopulate()` now accepts space separated paths, e.g. `'some path other.path'`
- Fixes #5797

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The `populate()` methods in Mongoose accept arrays of paths, or a string with space separated paths. The `depopulate()` method on a document did not support that.

**Test plan**
Minor code change, not tested yet
