### PR TITLE
Fixed call stack overflow when using recursive embedded discriminators

### DIFF
--- a/lib/services/model/applyHooks.js
+++ b/lib/services/model/applyHooks.js
@@ -28,6 +28,7 @@ function applyHooks(model, schema) {
     if (childModel.$appliedHooks) {
       continue;
     }
+    applyHooks(childModel, schema.childSchemas[i].schema);
     if (childModel.discriminators != null) {
       keys = Object.keys(childModel.discriminators);
       for (j = 0; j < keys.length; ++j) {
@@ -35,7 +36,6 @@ function applyHooks(model, schema) {
           childModel.discriminators[keys[j]].schema);
       }
     }
-    applyHooks(childModel, schema.childSchemas[i].schema);
   }
 
   if (!q.length) {

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -367,9 +367,9 @@ describe('discriminator docs', function () {
     }, { _id: false });
 
     var SubEvent = subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema)
-    eventList.path('events').discriminator('SubEvent', subEventSchema);
+    eventListSchema.path('events').discriminator('SubEvent', subEventSchema);
 
-    var Eventlist = db.model('EventList', eventList);
+    var Eventlist = db.model('EventList', eventListSchema);
 
     // Create a new batch of events with different kinds
     var list = {

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -357,29 +357,29 @@ describe('discriminator docs', function () {
    * Recursive embedded discriminators
    */
   it('Recursive embedded discriminators in arrays', function(done) {
-    var eventSchema = new Schema({ message: String },
+    var singleEventSchema = new Schema({ message: String },
       { discriminatorKey: 'kind', _id: false });
 
-    var batchSchema = new Schema({ events: [eventSchema] });
+    var eventListSchema = new Schema({ events: [singleEventSchema] });
 
     var subEventSchema = new Schema({
-       sub_events: [eventSchema]
+       sub_events: [singleEventSchema]
     }, { _id: false });
 
     var SubEvent = subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema)
-    batchSchema.path('events').discriminator('SubEvent', subEventSchema);
+    eventList.path('events').discriminator('SubEvent', subEventSchema);
 
-    var Batch = db.model('EventBatch', batchSchema);
+    var Eventlist = db.model('EventList', eventList);
 
     // Create a new batch of events with different kinds
-    var batch = {
+    var list = {
       events: [
         { kind: 'SubEvent', sub_events: [{kind:'SubEvent', sub_events:[], message:'test1'}], message: 'hello' },
         { kind: 'SubEvent', sub_events: [{kind:'SubEvent', sub_events:[{kind:'SubEvent', sub_events:[], message:'test3'}], message:'test2'}], message: 'world' }
       ]
     };
 
-    Batch.create(batch).
+    Eventlist.create(list).
       then(function(doc) {
         assert.equal(doc.events.length, 2);
 

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -369,6 +369,7 @@ describe('discriminator docs', function () {
     var SubEvent = subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema)
     batchSchema.path('events').discriminator('SubEvent', subEventSchema);
 
+    var Batch = db.model('EventBatch', batchSchema);
 
     // Create a new batch of events with different kinds
     var batch = {

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -385,11 +385,11 @@ describe('discriminator docs', function () {
 
         assert.equal(doc.events[0].sub_events[0].message, 'test1');
         assert.equal(doc.events[0].message, 'hello');
-        assert.ok(doc.events[0] instanceof SubEvent);
+        assert.ok(doc.events[0].sub_events[0] instanceof SubEvent);
 
         assert.equal(doc.events[1].sub_events[0].sub_events[0].message, 'test3');
         assert.equal(doc.events[1].message, 'world');
-        assert.ok(doc.events[1] instanceof SubEvent);
+        assert.ok(doc.events[1].sub_events[0].sub_events[0] instanceof SubEvent);
 
         doc.events.push({kind:'SubEvent', sub_events:[{kind:'SubEvent', sub_events:[], message:'test4'}], message:'pushed'});
         return doc.save();


### PR DESCRIPTION
After the recent changes to applyHooks() in pursue of  #5706  embedded discriminators recursively referencing themselves led to a call stack overflow. The problem was, that the childModel.discriminators tree is descended into before the hooks are applied on the actual discriminator model. That leads to the $appliedHooks attribute, which is to prevent these circular calls, never being set.

I swapped the order of applying the hooks to model first, discriminators second. To be sure there are no implications (because I am new to mongoose), I adapted the embedded discriminators test and wrote a test for these self-referencing/recursive discriminators.