### PR TITLE
fix(model): allow virtual ref function to return arrays

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3581,7 +3581,7 @@ function getModelsMapForPopulate(model, docs, options) {
             ref = ref.call(doc, doc);
           }
 
-          // When referencing nested arrays, the ref should be an Array 
+          // When referencing nested arrays, the ref should be an Array
           // of modelNames.
           if (Array.isArray(ref)) {
             modelNames = ref;

--- a/lib/model.js
+++ b/lib/model.js
@@ -3580,7 +3580,7 @@ function getModelsMapForPopulate(model, docs, options) {
           if (typeof ref === 'function') {
             ref = ref.call(doc, doc);
           }
-          
+
           // When referencing nested arrays, the ref should be an Array 
           // of modelNames.
           if (Array.isArray(ref)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3580,7 +3580,15 @@ function getModelsMapForPopulate(model, docs, options) {
           if (typeof ref === 'function') {
             ref = ref.call(doc, doc);
           }
-          modelNames = [ref];
+          
+          // When referencing nested arrays, the ref should be an Array 
+          // of modelNames.
+          if (Array.isArray(ref)) {
+            modelNames = ref;
+          } else {
+            modelNames = [ref];
+          }
+
           isVirtual = true;
         } else {
           // We may have a discriminator, in which case we don't want to


### PR DESCRIPTION
Allow the virtual ref function to return an array of model names.

When referencing fields inside an array of subdocuments, the ref function was expecting a single string as the model name. This was very limiting when using dynamic references on an array of subdocuments.

To solve this I just did a simple type check. If the return value of the ref function is already an array, there's no need to change it. If the result is anything else the code resume with the previous behaviour. This enabled me to use something as:

```Javascript
const appointmentServiceSchema = new Schema({
  serviceId:    Schema.Types.ObjectId,
  serviceType:  String,
  providerId:   Schema.Types.ObjectId,
  providerType: String,
  notes:        String,
  cost:         Number
}, { toJSON: { virtuals: true } });

const appointmentSchema = new Schema({
  services:         [appointmentServiceSchema]
}, { toJSON: { virtuals: true } });

appointmentServiceSchema.virtual('service', {
  ref() {
    return this.services.map((item) => item.serviceType);
  },
  localField:   'serviceId',
  foreignField: '_id',
  justOne:      true
});

appointmentServiceSchema.virtual('provider', {
  ref() {
    return this.services.map((item) => item.providerType);
  },
  localField:   'providerId',
  foreignField: '_id',
  justOne:      true
});
```

Sorry but I didn't have time to write the tests yet. Just did the quick fix and used right away.