### PR TITLE
fix "TypeError: Cannot read property 'options' of undefined" error th…

### DIFF
--- a/lib/services/query/castUpdate.js
+++ b/lib/services/query/castUpdate.js
@@ -247,7 +247,7 @@ function walkUpdatePath(schema, obj, op, strict, context, pref) {
  */
 
 function _handleCastError(error, query, key, aggregatedError) {
-  if (!query.options.multipleCastError) {
+  if (typeof query !== 'object' || !query.options.multipleCastError) {
     throw error;
   }
   aggregatedError.addError(key, error);


### PR DESCRIPTION
…at stops actual error from being thrown

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using model.bulkWrite, I came across the error "TypeError: Cannot read property 'options' of undefined" that was thrown when I passed an array of updates with one of the updates having an object with a property that was the wrong type for the model. This stops that error from being thrown and throws the actual error, which in my case was a CastError.

With my limited knowledge of this project I would say that this doesn't fix the underlying issue, which I assume is incorrect usage of castUpdate.js

**Test plan**

Error before change:
```
TypeError: Cannot read property 'options' of undefined
    at _handleCastError (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/services/query/castUpdate.js:250:13)
    at walkUpdatePath (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/services/query/castUpdate.js:232:11)
    at castUpdate (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/services/query/castUpdate.js:72:18)
    at /Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/model.js:2308:26
    at /Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/internal/parallel.js:27:9
    at eachOfArrayLike (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/eachOf.js:57:9)
    at exports.default (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/eachOf.js:9:5)
    at _parallel (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/internal/parallel.js:26:5)
    at parallelLimit (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/parallel.js:85:26)
    at /Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/model.js:2392:5
    at Promise (<anonymous>)
    at Function.Model.bulkWrite (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/model.js:2391:17)
    at wg.wait (/Users/my-user/Documents/projects/has-offers-server/lib/services/awesome-o.service.js:692:22)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
    at process.wrappedFunction (/Users/my-user/Documents/projects/my-server/node_modules/newrelic/lib/transaction/tracer/index.js:284:51)
```

Correct error after change:
```
{ CastError: Cast to number failed for value "undefined" at path "model_property_name"
    at CastError (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/error/cast.js:27:11)
    at SchemaNumber.cast (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/schema/number.js:231:9)
    at SchemaNumber.SchemaType._castForQuery (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/schematype.js:1088:15)
    at SchemaNumber.castForQuery (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/schema/number.js:282:14)
    at SchemaNumber.SchemaType.castForQueryWrapper (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/schematype.js:1045:15)
    at castUpdateVal (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/services/query/castUpdate.js:346:19)
    at walkUpdatePath (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/services/query/castUpdate.js:229:22)
    at castUpdate (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/services/query/castUpdate.js:72:18)
    at /Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/model.js:2308:26
    at /Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/internal/parallel.js:27:9
    at eachOfArrayLike (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/eachOf.js:57:9)
    at exports.default (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/eachOf.js:9:5)
    at _parallel (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/internal/parallel.js:26:5)
    at parallelLimit (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/node_modules/async/parallel.js:85:26)
    at /Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/model.js:2392:5
    at Promise (<anonymous>)
    at Function.Model.bulkWrite (/Users/my-user/Documents/projects/my-server/node_modules/mongoose/lib/model.js:2391:17)
    at wg.wait (/Users/my-user/Documents/projects/my-server/lib/services/awesome-o.service.js:692:22)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
    at process.wrappedFunction (/Users/my-user/Documents/projects/my-server/node_modules/newrelic/lib/transaction/tracer/index.js:284:51)
  message: 'Cast to number failed for value "undefined" at path "model_property_name"',
  name: 'CastError',
  stringValue: '"undefined"',
  kind: 'number',
  value: undefined,
  path: 'model_property_name',
  reason: undefined }
```
