### PR TITLE
fixes DateSchema behavior for strings

### DIFF
--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -232,12 +232,12 @@ SchemaDate.prototype.cast = function(value) {
 
   if (value instanceof Number || typeof value === 'number') {
     date = new Date(value);
-  } else if (value.valueOf && typeof value.valueOf === 'function') {
-    // support for moment.js
+  } else if (typeof value.valueOf === 'function') {
+    // support for moment.js. This is also the path strings will take because strings
+    // have a `valueOf()`
     date = new Date(value.valueOf());
   } else {
-    // if an invalid string is passed in, it will create an invalid date and
-    // the !isNaN check below will not be true, triggering the CastError
+    // fallback
     date = new Date(value);
   }
 

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -230,13 +230,15 @@ SchemaDate.prototype.cast = function(value) {
     throw new CastError('date', value, this.path);
   }
 
-  if (value instanceof Number || typeof value === 'number'
-      || String(value) == Number(value)) {
-    // support for timestamps
-    date = new Date(Number(value));
+  if (value instanceof Number || typeof value === 'number') {
+    date = new Date(value);
   } else if (value.valueOf) {
     // support for moment.js
     date = new Date(value.valueOf());
+  } else {
+    // if an invalid string is passed in, it will create an invalid date and
+    // the !isNaN check below will not be true, triggering the CastError
+    date = new Date(value);
   }
 
   if (!isNaN(date.valueOf())) {

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -232,7 +232,7 @@ SchemaDate.prototype.cast = function(value) {
 
   if (value instanceof Number || typeof value === 'number') {
     date = new Date(value);
-  } else if (value.valueOf) {
+  } else if (value.valueOf && typeof value.valueOf === 'function') {
     // support for moment.js
     date = new Date(value.valueOf());
   } else {

--- a/test/schema.date.test.js
+++ b/test/schema.date.test.js
@@ -1,0 +1,46 @@
+var start = require('./common'),
+    mongoose = start.mongoose,
+    assert = require('power-assert'),
+    Schema = mongoose.Schema,
+    CastError = require('../lib/schematype').CastError;
+
+/**
+ * Test.
+ */
+
+describe('SchemaDate', function() {
+  var M;
+
+  before(function() {
+    var schema = new Schema({ x: Date });
+    M = mongoose.model('Model', schema);
+  });
+
+  it('accepts a Date', function() {
+    var doc = new M({ x: new Date('2017-01-01') });
+    assert.ok(doc.x instanceof Date);
+    assert.equal(doc.x.getUTCFullYear(), 2017);
+  });
+
+  it('casts a date string to a string', function() {
+    var doc = new M({ x: '2017-10-01' });
+    assert.ok(doc.x instanceof Date);
+  });
+
+  it('interprets a number as a unix timestamp', function() {
+    var doc = new M({ x: 2017 });
+    assert.equal(doc.x.getUTCFullYear(), 1970);
+  });
+
+  it('attempts to interpret a string as a Date, not a timestamo (gh-5395)', function() {
+    var doc = new M({ x: '2017' });
+    assert.equal(doc.x.getUTCFullYear(), 2017);
+  });
+
+  it('casts any object with a `.valueOf` function to a date', function() {
+    var mockDate = Date.now();
+    var doc = new M({ x: { valueOf: function() { return mockDate; } } });
+    assert.ok(doc.x instanceof Date);
+    assert.equal(doc.x.valueOf(), mockDate);
+  });
+});

--- a/test/schema.date.test.js
+++ b/test/schema.date.test.js
@@ -1,8 +1,7 @@
 var start = require('./common'),
     mongoose = start.mongoose,
     assert = require('power-assert'),
-    Schema = mongoose.Schema,
-    CastError = require('../lib/schematype').CastError;
+    Schema = mongoose.Schema;
 
 /**
  * Test.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes casting error for Strings, interpreting them as JavaScript natively does instead of accidentally as a unix timestamp.

See: https://github.com/Automattic/mongoose/issues/5395

