### PR TITLE
Array's `required` validation no longer requires a positive length.

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -125,7 +125,7 @@ SchemaArray.prototype.constructor = SchemaArray;
  */
 
 SchemaArray.prototype.checkRequired = function(value) {
-  return !!(value && value.length);
+  return Array.isArray(value);
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2876,15 +2876,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.4.1"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2901,6 +2892,15 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.4.1"
       }
     },
     "requirejs": {
@@ -3108,15 +3108,6 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3126,6 +3117,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringifier": {

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -386,9 +386,9 @@ describe('schema', function() {
         });
 
         Loki.path('likes').doValidate([], function(err) {
-          assert.ok(err instanceof ValidatorError);
+          assert.ifError(err);
+          done();
         });
-        done();
       });
 
       it('boolean required', function(done) {


### PR DESCRIPTION
Fixed issues https://github.com/Automattic/mongoose/issues/5139. Fixes one test case related to 5139, but issue https://github.com/Automattic/mongoose/issues/5891 remains.

NOTE: this is technically a breaking change as the validation function now just uses `Array.isArray` versus previously it was checking for the existence of array & array.length. This will break for "array-like" objects which previously would've passed. e.g:

```
{
  '0': 'test',
  'length': 1
}
```