### PR TITLE
Fix plugin search site links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,4 +59,4 @@ Visit `http://localhost:8088` and you should see the docs with your local change
 
 ### Plugins website
 
-The [plugins](http://plugins.mongoosejs.io/) site is also an [open source project](https://github.com/vkarpov15/mongooseplugins) that you can get involved with. Feel free to fork and improve it as well!
+The [plugins](http://plugins.mongoosejs.com/) site is also an [open source project](https://github.com/vkarpov15/mongooseplugins) that you can get involved with. Feel free to fork and improve it as well!

--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -750,7 +750,7 @@ block content
     | Schemas are also 
     a(href="./plugins.html") pluggable
     |  which allows us to package up reusable features into 
-    a(href="http://plugins.mongoosejs.io") plugins
+    a(href="http://plugins.mongoosejs.com") plugins
     |  that can be shared with the community or just between your projects.
 
   h3#next Next Up

--- a/index.jade
+++ b/index.jade
@@ -25,7 +25,7 @@ html(lang='en')
           li
             a(href="docs/guide.html") Read the Docs
           li
-            a(href="http://plugins.mongoosejs.io") Discover Plugins
+            a(href="http://plugins.mongoosejs.com") Discover Plugins
       #follow
         ul
           li


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The plugin search site currently links to http://plugins.mongoosejs.io, however the site is down. Changed links to http://plugins.mongoosejs.com.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->