### PR TITLE
ci: add AppVeyor as Windows continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+  matrix:
+    - nodejs_version: "9"
+    - nodejs_version: "8"
+    - nodejs_version: "7"
+    - nodejs_version: "6"
+    - nodejs_version: "5"
+    - nodejs_version: "4"
+
+services:
+  - mongodb
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - npm test
+  - npm run lint
+  - npm run nsp
+
+build: off


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Automatically test changes on Windows (AppVeyor) as well as Linux (Travis CI).

https://www.appveyor.com

This may or may not be worth while for Mongoose. :man_shrugging: 

:notebook: AppVeyor would need to be enabled in the Automatic organization and for Mongoose.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

example build, testing this branch https://ci.appveyor.com/project/ChristianMurphy/mongoose/build/1.0.1

**Caveats**

* Only one AppVeyor build can run at a time on the free plan, so having a large matrix will be slow.
* AppVeyor can be a bit flaky at times, sometimes build will fail for no reason.
* Currently many of the tests are timing out of AppVeyor, and individual builds are taking 15 minutes each.