### PR TITLE
chore: update acquit to version 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,21 +50,21 @@
       }
     },
     "acquit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/acquit/-/acquit-0.4.1.tgz",
-      "integrity": "sha1-hGur7RTm5JpkqgiFuYpbqaJHd70=",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/acquit/-/acquit-0.5.1.tgz",
+      "integrity": "sha512-UwiB2Cbb3FCvF/9CGrmTZxYHcScLjyYT0RHYMtTgyhxl/PpaDaBhpBb2O1cqOh/9j24Q9rfT7BxhnVtM2USvAw==",
       "dev": true,
       "requires": {
         "commander": "2.5.0",
-        "esprima": "https://github.com/ariya/esprima/archive/85fc2f4b6ad109a86d80d9821f52b5b38d0105c0.tar.gz",
-        "marked": "0.3.5",
-        "underscore": "1.5.2"
+        "esprima": "4.0.0",
+        "lodash": "4.17.4",
+        "marked": "0.3.9"
       },
       "dependencies": {
-        "marked": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
-          "integrity": "sha1-QROhWsXXvKFYpargciRYe5+hW5Q=",
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
@@ -1011,8 +1011,9 @@
       }
     },
     "esprima": {
-      "version": "https://github.com/ariya/esprima/archive/85fc2f4b6ad109a86d80d9821f52b5b38d0105c0.tar.gz",
-      "integrity": "sha512-GyWe6YkK295gEHgCUfRdjb9BWkxWrf3zAB6AvUGhSmW4HLCOw0Zq6cY3eSKCQQk6kaimdNQFssPUY5t8cz2SdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "espurify": {
@@ -1686,7 +1687,7 @@
         "jasmine-reporters": "1.0.2",
         "mkdirp": "0.3.5",
         "requirejs": "2.3.5",
-        "underscore": "1.5.2",
+        "underscore": "1.8.3",
         "walkdir": "0.0.12"
       },
       "dependencies": {
@@ -1729,14 +1730,6 @@
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        }
       }
     },
     "jsesc": {
@@ -3213,9 +3206,9 @@
       "optional": true
     },
     "underscore": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
-      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg=",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
     "universal-deep-strict-equal": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sliced": "1.0.1"
   },
   "devDependencies": {
-    "acquit": "0.4.1",
+    "acquit": "0.5.1",
     "acquit-ignore": "0.0.3",
     "benchmark": "2.1.2",
     "bluebird": "3.5.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

resolves https://snyk.io/vuln/npm:marked:20170112
shouldn't have any impact on mongoose, still it's good to get the latest patches.

**Test plan**

`make docs`

View `docs/api.html`

![selection_003](https://user-images.githubusercontent.com/3107513/34498365-932944bc-efbe-11e7-8461-4d00c9cc72fa.png)
