### PR TITLE
increasing timeout on connection events test cases.

### DIFF
--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -74,18 +74,20 @@ describe('connections:', function() {
 
     describe('connection events', function() {
       beforeEach(function() {
-        this.timeout(25000);
-        return server.start().
-          then(function() { return server.purge(); });
+        this.timeout(60000);
+        return server.start();
       });
 
       afterEach(function() {
-        this.timeout(25000);
-        return server.stop();
+        this.timeout(60000);
+        return server.stop().
+          then(function() {
+            return server.purge();
+          });
       });
 
       it('disconnected (gh-5498) (gh-5524)', function(done) {
-        this.timeout(25000);
+        this.timeout(60000);
 
         var conn;
         var numConnected = 0;
@@ -151,7 +153,7 @@ describe('connections:', function() {
       });
 
       it('reconnectFailed (gh-4027)', function(done) {
-        this.timeout(25000);
+        this.timeout(60000);
 
         var conn;
         var numReconnectFailed = 0;
@@ -221,7 +223,7 @@ describe('connections:', function() {
       });
 
       it('timeout (gh-4513)', function(done) {
-        this.timeout(25000);
+        this.timeout(60000);
 
         var conn;
         var numTimeout = 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The 'connection events' test cases were failing on my computer, because of the 25 seconds timeout. So I increased their timeout to 60s to avoid this problem on slower computers like mine. I also moved the `server.purge()` command to execute after `server.stop()` because it was causing a test failure when executed right after `server.start()`

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
The 'connection events' test cases should pass now even on slower computers.