### PR TITLE
re: refactoring tests to start fewer connections

### DIFF
--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -26,7 +26,7 @@ var EmployeeSchema = new Schema({
 
 mongoose.model('Employee', EmployeeSchema);
 
-function setupData(callback) {
+function setupData(db, callback) {
   var saved = 0;
   var emps = [
     { name: 'Alice', sal: 18000, dept: 'sales', customers: ['Eve', 'Fred'] },
@@ -34,7 +34,6 @@ function setupData(callback) {
     { name: 'Carol', sal: 14000, dept: 'r&d', reportsTo: 'Bob' },
     { name: 'Dave', sal: 14500, dept: 'r&d', reportsTo: 'Carol' }
   ];
-  var db = start();
   var Employee = db.model('Employee');
 
   emps.forEach(function(data) {
@@ -42,7 +41,7 @@ function setupData(callback) {
 
     emp.save(function() {
       if (++saved === emps.length) {
-        callback(db);
+        callback();
       }
     });
   });
@@ -74,6 +73,16 @@ function onlyTestMongo34(ctx, done) {
  */
 
 describe('aggregate: ', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   describe('append', function() {
     it('(pipeline)', function(done) {
       var aggregate = new Aggregate();
@@ -504,17 +513,8 @@ describe('aggregate: ', function() {
   });
 
   describe('exec', function() {
-    var db;
-
     before(function(done) {
-      setupData(function(_db) {
-        db = _db;
-        done();
-      });
-    });
-
-    after(function(done) {
-      db.close(done);
+      setupData(db, done);
     });
 
     it('project', function(done) {
@@ -883,16 +883,6 @@ describe('aggregate: ', function() {
     });
 
     describe('middleware (gh-5251)', function() {
-      var db;
-
-      before(function() {
-        db = start();
-      });
-
-      after(function(done) {
-        db.close(done);
-      });
-
       it('pre', function(done) {
         var s = new Schema({ name: String });
 
@@ -1026,8 +1016,6 @@ describe('aggregate: ', function() {
   });
 
   it('cursor (gh-3160)', function() {
-    const db = start();
-
     const MyModel = db.model('gh3160', { name: String });
 
     return co(function * () {
@@ -1059,8 +1047,6 @@ describe('aggregate: ', function() {
   });
 
   it('cursor() with useMongooseAggCursor (gh-5145)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh5145', { name: String });
 
     var cursor = MyModel.
@@ -1073,8 +1059,6 @@ describe('aggregate: ', function() {
   });
 
   it('cursor() with useMongooseAggCursor works (gh-5145) (gh-5394)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh5394', { name: String });
 
     MyModel.create({ name: 'test' }, function(error) {
@@ -1097,8 +1081,6 @@ describe('aggregate: ', function() {
   });
 
   it('cursor() eachAsync (gh-4300)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh4300', { name: String });
 
     var cur = 0;
@@ -1128,8 +1110,6 @@ describe('aggregate: ', function() {
   });
 
   it('ability to add noCursorTimeout option (gh-4241)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh4241', {
       name: String
     });
@@ -1147,8 +1127,6 @@ describe('aggregate: ', function() {
   });
 
   it('query by document (gh-4866)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh4866', {
       name: String
     });
@@ -1162,8 +1140,6 @@ describe('aggregate: ', function() {
   });
 
   it('sort by text score (gh-5258)', function(done) {
-    var db = start();
-
     var mySchema = new Schema({ test: String });
     mySchema.index({ test: 'text' });
     var M = db.model('gh5258', mySchema);

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -449,12 +449,20 @@ describe('connections:', function() {
   });
 
   describe('.model()', function() {
+    var db;
+
+    before(function() {
+      db = start();
+    });
+
+    after(function(done) {
+      db.close(done);
+    });
+
     it('allows passing a schema', function(done) {
-      var db = start();
       var MyModel = db.model('MyModelasdf', new Schema({
         name: String
       }));
-      db.close();
 
       assert.ok(MyModel.schema instanceof Schema);
       assert.ok(MyModel.prototype.schema instanceof Schema);
@@ -473,7 +481,6 @@ describe('connections:', function() {
     });
 
     it('prevents overwriting pre-existing models', function(done) {
-      var db = start();
       var name = 'gh-1209-a';
       db.model(name, new Schema);
 
@@ -481,12 +488,10 @@ describe('connections:', function() {
         db.model(name, new Schema);
       }, /Cannot overwrite `gh-1209-a` model/);
 
-      db.close();
       done();
     });
 
     it('allows passing identical name + schema args', function(done) {
-      var db = start();
       var name = 'gh-1209-b';
       var schema = new Schema;
 
@@ -495,17 +500,14 @@ describe('connections:', function() {
         db.model(name, schema);
       });
 
-      db.close();
       done();
     });
 
     it('throws on unknown model name', function(done) {
-      var db = start();
       assert.throws(function() {
         db.model('iDoNotExist!');
       }, /Schema hasn't been registered/);
 
-      db.close();
       done();
     });
 
@@ -536,11 +538,9 @@ describe('connections:', function() {
     describe('get existing model with not existing collection in db', function() {
       it('must return exiting collection with all collection options', function(done) {
         mongoose.model('some-th-1458', new Schema({test: String}, {capped: {size: 1000, max: 10}}));
-        var db = start();
         var m = db.model('some-th-1458');
         assert.equal(1000, m.collection.opts.capped.size);
         assert.equal(10, m.collection.opts.capped.max);
-        db.close();
         done();
       });
     });
@@ -548,7 +548,6 @@ describe('connections:', function() {
     describe('passing collection name', function() {
       describe('when model name already exists', function() {
         it('returns a new uncached model', function(done) {
-          var db = start();
           var s1 = new Schema({a: []});
           var name = 'non-cached-collection-name';
           var A = db.model(name, s1);
@@ -558,7 +557,6 @@ describe('connections:', function() {
           assert.ok(A.collection.name !== C.collection.name);
           assert.ok(db.models[name].collection.name !== C.collection.name);
           assert.ok(db.models[name].collection.name === A.collection.name);
-          db.close();
           done();
         });
       });
@@ -566,14 +564,12 @@ describe('connections:', function() {
 
     describe('passing object literal schemas', function() {
       it('works', function(done) {
-        var db = start();
         var A = db.model('A', {n: [{age: 'number'}]});
         var a = new A({n: [{age: '47'}]});
         assert.strictEqual(47, a.n[0].age);
         a.save(function(err) {
           assert.ifError(err);
           A.findById(a, function(err) {
-            db.close();
             assert.ifError(err);
             assert.strictEqual(47, a.n[0].age);
             done();

--- a/test/document.modified.test.js
+++ b/test/document.modified.test.js
@@ -74,12 +74,20 @@ mongoose.model(modelName, BlogPost);
 var collection = 'blogposts_' + random();
 
 describe('document modified', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   describe('modified states', function() {
     it('reset after save', function(done) {
-      var db = start(),
-          B = db.model(modelName, collection);
-
-      var b = new B;
+      var B = db.model(modelName, collection),
+          b = new B;
 
       b.numbers.push(3);
       b.save(function(err) {
@@ -93,7 +101,6 @@ describe('document modified', function() {
             assert.strictEqual(null, err2);
             assert.equal(b.numbers.length, 2);
 
-            db.close();
             done();
           });
         });
@@ -101,13 +108,10 @@ describe('document modified', function() {
     });
 
     it('of embedded docs reset after save', function(done) {
-      var db = start(),
-          BlogPost = db.model(modelName, collection);
-
-      var post = new BlogPost({title: 'hocus pocus'});
+      var BlogPost = db.model(modelName, collection),
+          post = new BlogPost({title: 'hocus pocus'});
       post.comments.push({title: 'Humpty Dumpty', comments: [{title: 'nested'}]});
       post.save(function(err) {
-        db.close();
         assert.strictEqual(null, err);
         var mFlag = post.comments[0].isModified('title');
         assert.equal(mFlag, false);
@@ -119,22 +123,18 @@ describe('document modified', function() {
 
   describe('isDefault', function() {
     it('works', function(done) {
-      var db = start();
-
       var MyModel = db.model('test',
         {name: {type: String, default: 'Val '}});
       var m = new MyModel();
       assert.ok(m.$isDefault('name'));
-      db.close(done);
+      done();
     });
   });
 
   describe('isModified', function() {
     it('should not throw with no argument', function(done) {
-      var db = start();
       var BlogPost = db.model(modelName, collection);
       var post = new BlogPost;
-      db.close();
 
       var threw = false;
       try {
@@ -148,11 +148,8 @@ describe('document modified', function() {
     });
 
     it('when modifying keys', function(done) {
-      var db = start(),
-          BlogPost = db.model(modelName, collection);
-
-      db.close();
-      var post = new BlogPost;
+      var BlogPost = db.model(modelName, collection),
+          post = new BlogPost;
       post.init({
         title: 'Test',
         slug: 'test',
@@ -172,10 +169,8 @@ describe('document modified', function() {
     });
 
     it('setting a key identically to its current value should not dirty the key', function(done) {
-      var db = start(),
-          BlogPost = db.model(modelName, collection);
+      var BlogPost = db.model(modelName, collection);
 
-      db.close();
       var post = new BlogPost;
       post.init({
         title: 'Test',
@@ -191,10 +186,8 @@ describe('document modified', function() {
 
     describe('on DocumentArray', function() {
       it('work', function(done) {
-        var db = start(),
-            BlogPost = db.model(modelName, collection);
-
-        var post = new BlogPost();
+        var BlogPost = db.model(modelName, collection),
+            post = new BlogPost();
         post.init({
           title: 'Test',
           slug: 'test',
@@ -208,13 +201,11 @@ describe('document modified', function() {
         assert.equal(post.isModified('comments.0.title'), true);
         assert.equal(post.isDirectModified('comments.0.title'), true);
 
-        db.close(done);
+        done();
       });
       it('with accessors', function(done) {
-        var db = start(),
-            BlogPost = db.model(modelName, collection);
-
-        var post = new BlogPost();
+        var BlogPost = db.model(modelName, collection),
+            post = new BlogPost();
         post.init({
           title: 'Test',
           slug: 'test',
@@ -228,7 +219,6 @@ describe('document modified', function() {
         assert.equal(post.isModified('comments.0.body'), true);
         assert.equal(post.isDirectModified('comments.0.body'), true);
 
-        db.close();
         done();
       });
     });
@@ -236,11 +226,8 @@ describe('document modified', function() {
     describe('on MongooseArray', function() {
       it('atomic methods', function(done) {
         // COMPLETEME
-        var db = start(),
-            BlogPost = db.model(modelName, collection);
-
-        db.close();
-        var post = new BlogPost();
+        var BlogPost = db.model(modelName, collection),
+            post = new BlogPost();
         assert.equal(post.isModified('owners'), false);
         post.get('owners').push(new DocumentObjectId);
         assert.equal(post.isModified('owners'), true);
@@ -248,19 +235,15 @@ describe('document modified', function() {
       });
       it('native methods', function(done) {
         // COMPLETEME
-        var db = start(),
-            BlogPost = db.model(modelName, collection);
-
-        db.close();
-        var post = new BlogPost;
+        var BlogPost = db.model(modelName, collection),
+            post = new BlogPost;
         assert.equal(post.isModified('owners'), false);
         done();
       });
     });
 
     it('on entire document', function(done) {
-      var db = start(),
-          BlogPost = db.model(modelName, collection);
+      var BlogPost = db.model(modelName, collection);
 
       var doc = {
         title: 'Test',
@@ -283,7 +266,6 @@ describe('document modified', function() {
       BlogPost.create(doc, function(err, post) {
         assert.ifError(err);
         BlogPost.findById(post.id, function(err, postRead) {
-          db.close();
           assert.ifError(err);
           // set the same data again back to the document.
           // expected result, nothing should be set to modified
@@ -311,8 +293,6 @@ describe('document modified', function() {
     });
 
     it('should let you set ref paths (gh-1530)', function(done) {
-      var db = start();
-
       var parentSchema = new Schema({
         child: {type: Schema.Types.ObjectId, ref: 'gh-1530-2'}
       });
@@ -358,7 +338,7 @@ describe('document modified', function() {
                 assert.ifError(error);
                 assert.ok(child);
                 assert.equal(p.child.toString(), child._id.toString());
-                db.close(done);
+                done();
               });
             });
           });
@@ -367,8 +347,6 @@ describe('document modified', function() {
     });
 
     it('properly sets populated for gh-1530 (gh-2678)', function(done) {
-      var db = start();
-
       var parentSchema = new Schema({
         name: String,
         child: {type: Schema.Types.ObjectId, ref: 'Child'}
@@ -381,7 +359,7 @@ describe('document modified', function() {
       var p = new Parent({name: 'Alex', child: child});
 
       assert.equal(child._id.toString(), p.populated('child').toString());
-      db.close(done);
+      done();
     });
 
     describe('manually populating arrays', function() {
@@ -467,7 +445,6 @@ describe('document modified', function() {
       });
 
       it('updates embedded doc parents upon direct assignment (gh-5189)', function(done) {
-        var db = start();
         var familySchema = new Schema({
           children: [{name: {type: String, required: true}}]
         });
@@ -490,7 +467,6 @@ describe('document modified', function() {
     });
 
     it('should support setting mixed paths by string (gh-1418)', function(done) {
-      var db = start();
       var BlogPost = db.model('1418', new Schema({mixed: {}}));
       var b = new BlogPost;
       b.init({mixed: {}});
@@ -523,15 +499,13 @@ describe('document modified', function() {
           BlogPost.findById(b, function(err, doc) {
             assert.ifError(err);
             assert.equal(doc.get(path), 8);
-            db.close(done);
+            done();
           });
         });
       });
     });
 
     it('should mark multi-level nested schemas as modified (gh-1754)', function(done) {
-      var db = start();
-
       var grandChildSchema = new Schema({
         name: String
       });
@@ -559,16 +533,14 @@ describe('document modified', function() {
           p.save(function(error1, inDb) {
             assert.ifError(error1);
             assert.equal(inDb.child[0].grandChild[0].name, 'Jason');
-            db.close(done);
+            done();
           });
         });
     });
 
     it('should reset the modified state after calling unmarkModified', function(done) {
-      var db = start();
-      var BlogPost = db.model(modelName, collection);
-
-      var b = new BlogPost();
+      var BlogPost = db.model(modelName, collection),
+          b = new BlogPost();
       assert.equal(b.isModified('author'), false);
       b.author = 'foo';
       assert.equal(b.isModified('author'), true);
@@ -598,7 +570,6 @@ describe('document modified', function() {
               assert.strictEqual(err4, null);
               // was not saved because modified state was unset
               assert.equal(b3.author, 'foo');
-              db.close();
               done();
             });
           });

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -360,8 +360,6 @@ describe('document.populate', function() {
   });
 
   it('String _ids', function(done) {
-    var db = start();
-
     var UserSchema = new Schema({
       _id: String,
       name: String
@@ -382,7 +380,6 @@ describe('document.populate', function() {
 
       var note = new Note({author: 'alice', body: 'Buy Milk'});
       note.populate('author', function(err) {
-        db.close();
         assert.ifError(err);
         assert.ok(note.author);
         assert.equal(note.author._id, 'alice');
@@ -393,8 +390,6 @@ describe('document.populate', function() {
   });
 
   it('Buffer _ids', function(done) {
-    var db = start();
-
     var UserSchema = new Schema({
       _id: Buffer,
       name: String
@@ -421,7 +416,6 @@ describe('document.populate', function() {
           assert.ifError(err);
           assert.equal(note.author, 'alice');
           note.populate('author', function(err, note) {
-            db.close();
             assert.ifError(err);
             assert.equal(note.body, 'Buy Milk');
             assert.ok(note.author);
@@ -434,8 +428,6 @@ describe('document.populate', function() {
   });
 
   it('Number _ids', function(done) {
-    var db = start();
-
     var UserSchema = new Schema({
       _id: Number,
       name: String
@@ -456,7 +448,6 @@ describe('document.populate', function() {
 
       var note = new Note({author: 2359, body: 'Buy Milk'});
       note.populate('author').populate(function(err, note) {
-        db.close();
         assert.ifError(err);
         assert.ok(note.author);
         assert.equal(note.author._id, 2359);
@@ -501,8 +492,6 @@ describe('document.populate', function() {
   });
 
   it('gh-3308', function(done) {
-    var db = start();
-
     var Person = db.model('gh3308', {
       name: String
     });
@@ -522,13 +511,11 @@ describe('document.populate', function() {
     gnr.guitarist = buckethead._id;
     assert.ok(!gnr.populated('guitarist'));
 
-    db.close(done);
+    done();
   });
 
   describe('gh-2214', function() {
     it('should return a real document array when populating', function(done) {
-      var db = start();
-
       var Car = db.model('gh-2214-1', {
         color: String,
         model: String
@@ -570,7 +557,6 @@ describe('document.populate', function() {
               joe.cars.push(car);
               assert.ok(joe.isModified('cars'));
               done();
-              db.close();
             });
           });
         });
@@ -579,8 +565,6 @@ describe('document.populate', function() {
   });
 
   it('can depopulate (gh-2509)', function(done) {
-    var db = start();
-
     var Person = db.model('gh2509_1', {
       name: String
     });
@@ -613,7 +597,7 @@ describe('document.populate', function() {
             band.depopulate('lead');
             assert.ok(!band.lead.name);
             assert.equal(band.lead.toString(), docs[0]._id.toString());
-            db.close(done);
+            done();
           });
         });
       });
@@ -643,7 +627,6 @@ describe('document.populate', function() {
   });
 
   it('handles pulling from populated array (gh-3579)', function(done) {
-    var db = start();
     var barSchema = new Schema({name: String});
 
     var Bar = db.model('gh3579', barSchema);
@@ -667,7 +650,7 @@ describe('document.populate', function() {
           assert.ifError(error);
           assert.equal(foo.bars.length, 1);
           assert.equal(foo.bars[0].toString(), docs[1]._id.toString());
-          db.close(done);
+          done();
         });
       });
     });

--- a/test/document.strict.test.js
+++ b/test/document.strict.test.js
@@ -9,12 +9,20 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('document: strict mode:', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   describe('should work', function() {
-    var db, Lax, Strict;
+    var Lax, Strict;
 
     before(function() {
-      db = start();
-
       var raw = {
         ts: {type: Date, default: Date.now},
         content: String,
@@ -121,8 +129,6 @@ describe('document: strict mode:', function() {
   });
 
   it('nested doc', function(done) {
-    var db = start();
-
     var lax = new Schema({
       name: {last: String}
     }, {strict: false});
@@ -155,12 +161,10 @@ describe('document: strict mode:', function() {
     assert.ok(!('hack' in s.name));
     assert.ok(!s.name.hack);
     assert.ok(!s.shouldnt);
-    db.close(done);
+    done();
   });
 
   it('sub doc', function(done) {
-    var db = start();
-
     var lax = new Schema({
       ts: {type: Date, default: Date.now},
       content: String
@@ -202,13 +206,11 @@ describe('document: strict mode:', function() {
       assert.equal(doc.dox[0].content, 'sample2');
       assert.ok(!('rouge' in doc.dox[0]));
       assert.ok(!doc.dox[0].rouge);
-      db.close(done);
+      done();
     });
   });
 
   it('virtuals', function(done) {
-    var db = start();
-
     var getCount = 0,
         setCount = 0;
 
@@ -247,7 +249,7 @@ describe('document: strict mode:', function() {
     assert.equal(getCount, 1);
     assert.equal(setCount, 2);
 
-    db.close(done);
+    done();
   });
 
   it('can be overridden during set()', function(done) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -118,6 +118,16 @@ var parentSchema = new Schema({
  */
 
 describe('document', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   describe('shortcut getters', function() {
     it('return undefined for properties with a null/undefined parent object (gh-1326)', function(done) {
       var doc = new TestDocument;
@@ -419,8 +429,7 @@ describe('document', function() {
       }
     });
 
-    var db = start(),
-        Test = db.model('toObject-transform', schema),
+    var Test = db.model('toObject-transform', schema),
         Places = db.model('toObject-transform-places', schemaPlaces);
 
     Places.create({identity: 'a'}, {identity: 'b'}, {identity: 'c'}, function(err, a, b, c) {
@@ -431,22 +440,20 @@ describe('document', function() {
 
           docs.toObject({transform: true});
 
-          db.close(done);
+          done();
         });
       });
     });
   });
 
   it('allows you to skip validation on save (gh-2981)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh2981',
       {name: {type: String, required: true}});
 
     var doc = new MyModel();
     doc.save({validateBeforeSave: false}, function(error) {
       assert.ifError(error);
-      db.close(done);
+      done();
     });
   });
 
@@ -467,8 +474,7 @@ describe('document', function() {
         return ret;
       }
     });
-    var db = start(),
-        Test = db.model('TestToObject', schema);
+    var Test = db.model('TestToObject', schema);
 
     Test.create({name: 'chetverikov', iWillNotBeDelete: true, 'nested.iWillNotBeDeleteToo': true}, function(err) {
       assert.ifError(err);
@@ -478,23 +484,12 @@ describe('document', function() {
         assert.equal(doc._doc.iWillNotBeDelete, true);
         assert.equal(doc._doc.nested.iWillNotBeDeleteToo, true);
 
-        db.close(done);
+        done();
       });
     });
   });
 
   describe('toObject', function() {
-    var db;
-    before(function() {
-      return start().then(function(_db) {
-        db = _db;
-      });
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('does not apply toObject functions of subdocuments to root document', function(done) {
       var subdocSchema = new Schema({
         test: String,
@@ -619,15 +614,6 @@ describe('document', function() {
   });
 
   describe('toJSON', function() {
-    var db;
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('toJSON options', function(done) {
       var doc = new TestDocument();
 
@@ -803,15 +789,6 @@ describe('document', function() {
   });
 
   describe('inspect', function() {
-    var db;
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('inspect inherits schema options (gh-4001)', function(done) {
       var opts = {
         toObject: { virtuals: true },
@@ -930,7 +907,6 @@ describe('document', function() {
       done();
     });
     it('calling update on document should relay to its model (gh-794)', function(done) {
-      var db = start();
       var Docs = new Schema({text: String});
       var docs = db.model('docRelayUpdate', Docs);
       var d = new docs({text: 'A doc'});
@@ -950,7 +926,7 @@ describe('document', function() {
         d.update({$set: {text: 'A changed doc'}}, function(err) {
           assert.ifError(err);
           assert.equal(called, true);
-          db.close(done);
+          done();
         });
       });
     });
@@ -981,8 +957,7 @@ describe('document', function() {
   });
 
   it('methods on embedded docs should work', function(done) {
-    var db = start(),
-        ESchema = new Schema({name: String});
+    var ESchema = new Schema({name: String});
 
     ESchema.methods.test = function() {
       return this.name + ' butter';
@@ -994,7 +969,6 @@ describe('document', function() {
     var E = db.model('EmbeddedMethodsAndStaticsE', ESchema);
     var PSchema = new Schema({embed: [ESchema]});
     var P = db.model('EmbeddedMethodsAndStaticsP', PSchema);
-    db.close();
 
     var p = new P({embed: [{name: 'peanut'}]});
     assert.equal(typeof p.embed[0].test, 'function');
@@ -1023,8 +997,6 @@ describe('document', function() {
   });
 
   it('no maxListeners warning should occur', function(done) {
-    var db = start();
-
     var traced = false;
     var trace = console.trace;
 
@@ -1051,14 +1023,12 @@ describe('document', function() {
     var S = db.model('noMaxListeners', schema);
 
     new S({title: 'test'});
-    db.close();
     assert.equal(traced, false);
     done();
   });
 
   it('unselected required fields should pass validation', function(done) {
-    var db = start(),
-        Tschema = new Schema({name: String, req: {type: String, required: true}}),
+    var Tschema = new Schema({name: String, req: {type: String, required: true}}),
         T = db.model('unselectedRequiredFieldValidation', Tschema);
 
     var t = new T({name: 'teeee', req: 'i am required'});
@@ -1086,7 +1056,7 @@ describe('document', function() {
                   assert.ifError(err);
                   t.save(function(err) {
                     assert.ifError(err);
-                    db.close(done);
+                    done();
                   });
                 });
               });
@@ -1101,7 +1071,6 @@ describe('document', function() {
     var collection = 'validateschema_' + random();
 
     it('works (gh-891)', function(done) {
-      var db = start();
       var schema = null;
       var called = false;
 
@@ -1128,14 +1097,13 @@ describe('document', function() {
           m.save(function(err) {
             assert.equal(called, false);
             assert.ifError(err);
-            db.close(done);
+            done();
           });
         });
       });
     });
 
     it('can return a promise', function(done) {
-      var db = start();
       var schema = null;
 
       var validate = [function() {
@@ -1157,7 +1125,7 @@ describe('document', function() {
         promise2.catch(function(err) {
           assert.ok(!!err);
           clearTimeout(timeout);
-          db.close(done);
+          done();
         });
       });
 
@@ -1168,7 +1136,6 @@ describe('document', function() {
     });
 
     it('doesnt have stale cast errors (gh-2766)', function(done) {
-      var db = start();
       var testSchema = new Schema({name: String});
       var M = db.model('gh2766', testSchema);
 
@@ -1181,7 +1148,7 @@ describe('document', function() {
       assert.ifError(m.validateSync());
       m.validate(function(error) {
         assert.ifError(error);
-        db.close(done);
+        done();
       });
     });
 
@@ -1209,7 +1176,6 @@ describe('document', function() {
     });
 
     it('returns a promise when there are no validators', function(done) {
-      var db = start();
       var schema = null;
 
       schema = new Schema({_id: String});
@@ -1220,7 +1186,6 @@ describe('document', function() {
       var promise = m.validate();
       promise.then(function() {
         clearTimeout(timeout);
-        db.close();
         done();
       });
 
@@ -1231,17 +1196,6 @@ describe('document', function() {
     });
 
     describe('works on arrays', function() {
-      var db;
-
-      before(function(done) {
-        db = start();
-        done();
-      });
-
-      after(function(done) {
-        db.close(done);
-      });
-
       it('with required', function(done) {
         var schema = new Schema({
           name: String,
@@ -1324,7 +1278,6 @@ describe('document', function() {
 
     it('validator should run only once gh-1743', function(done) {
       var count = 0;
-      var db = start();
 
       var Control = new Schema({
         test: {
@@ -1349,7 +1302,7 @@ describe('document', function() {
 
       post.save(function() {
         assert.equal(count, 1);
-        db.close(done);
+        done();
       });
     });
 
@@ -1390,7 +1343,6 @@ describe('document', function() {
     it('validator should run in parallel', function(done) {
       // we set the time out to be double that of the validator - 1 (so that running in serial will be greater than that)
       this.timeout(1000);
-      var db = start();
       var count = 0;
 
       var SchemaWithValidator = new Schema({
@@ -1423,13 +1375,12 @@ describe('document', function() {
       m.save(function(err) {
         assert.ifError(err);
         assert.equal(count, 4);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('#invalidate', function(done) {
-    var db = start();
     var InvalidateSchema = null;
     var Post = null;
     var post = null;
@@ -1456,7 +1407,6 @@ describe('document', function() {
       assert.equal(err.errors.baz.kind, 'custom error');
 
       post.save(function(err) {
-        db.close();
         assert.strictEqual(err, null);
         done();
       });
@@ -1465,7 +1415,6 @@ describe('document', function() {
 
   describe('#equals', function() {
     describe('should work', function() {
-      var db;
       var S;
       var N;
       var O;
@@ -1473,16 +1422,11 @@ describe('document', function() {
       var M;
 
       before(function() {
-        db = start();
         S = db.model('equals-S', new Schema({_id: String}));
         N = db.model('equals-N', new Schema({_id: Number}));
         O = db.model('equals-O', new Schema({_id: Schema.ObjectId}));
         B = db.model('equals-B', new Schema({_id: Buffer}));
         M = db.model('equals-I', new Schema({name: String}, {_id: false}));
-      });
-
-      after(function(done) {
-        db.close(done);
       });
 
       it('with string _ids', function(done) {
@@ -1691,9 +1635,7 @@ describe('document', function() {
           val = v;
         });
 
-        var db = start();
         M = db.model('gh-1154', schema);
-        db.close();
         done();
       });
 
@@ -1722,7 +1664,6 @@ describe('document', function() {
 
   describe('gh-2082', function() {
     it('works', function(done) {
-      var db = start();
       var Parent = db.model('gh2082', parentSchema, 'gh2082');
 
       var parent = new Parent({name: 'Hello'});
@@ -1740,7 +1681,7 @@ describe('document', function() {
               Parent.findOne({}, function(error, parent) {
                 assert.ifError(error);
                 assert.equal(parent.children[0].counter, 2);
-                db.close(done);
+                done();
               });
             });
           });
@@ -1751,7 +1692,6 @@ describe('document', function() {
 
   describe('gh-1933', function() {
     it('works', function(done) {
-      var db = start();
       var M = db.model('gh1933', new Schema({id: String, field: Number}), 'gh1933');
 
       M.create({}, function(error) {
@@ -1762,7 +1702,7 @@ describe('document', function() {
           doc.field = 5; // .push({ _id: '123', type: '456' });
           doc.save(function(error) {
             assert.ifError(error);
-            db.close(done);
+            done();
           });
         });
       });
@@ -1779,7 +1719,6 @@ describe('document', function() {
         children: [ItemChildSchema]
       });
 
-      var db = start();
       var ItemParent = db.model('gh-1638-1', ItemParentSchema, 'gh-1638-1');
       var ItemChild = db.model('gh-1638-2', ItemChildSchema, 'gh-1638-2');
 
@@ -1798,7 +1737,7 @@ describe('document', function() {
         p.save(function(error, doc) {
           assert.ifError(error);
           assert.equal(doc.children.length, 1);
-          db.close(done);
+          done();
         });
       });
     });
@@ -1811,7 +1750,6 @@ describe('document', function() {
         s: []
       });
 
-      var db = start();
       var Item = db.model('gh-2434', ItemSchema, 'gh-2434');
 
       var item = new Item({st: 1});
@@ -1826,7 +1764,7 @@ describe('document', function() {
           Item.findById(item._id, function(error, doc) {
             assert.ifError(error);
             assert.equal(doc.st, 3);
-            db.close(done);
+            done();
           });
         });
       });
@@ -1838,7 +1776,6 @@ describe('document', function() {
       name: String
     });
 
-    var db = start();
     var calledName;
     personSchema.methods.fn = function() {
       calledName = this.name;
@@ -1848,20 +1785,10 @@ describe('document', function() {
     var Person = db.model('gh2856', personSchema, 'gh2856');
     new Person({name: 'Val'});
     assert.equal(calledName, 'Val');
-    db.close(done);
+    done();
   });
 
   describe('bug fixes', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('applies toJSON transform correctly for populated docs (gh-2910) (gh-2990)', function(done) {
       var parentSchema = mongoose.Schema({
         c: {type: mongoose.Schema.Types.ObjectId, ref: 'gh-2910-1'}
@@ -2189,16 +2116,6 @@ describe('document', function() {
   });
 
   describe('error processing (gh-2284)', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('save errors', function(done) {
       var schema = new Schema({
         name: { type: String, required: true }
@@ -2325,7 +2242,6 @@ describe('document', function() {
     });
 
     it('single embedded schemas with models (gh-3535)', function(done) {
-      var db = start();
       var personSchema = new Schema({name: String});
       var Person = db.model('gh3535_0', personSchema);
 

--- a/test/es6/all.test.es6.js
+++ b/test/es6/all.test.es6.js
@@ -16,6 +16,10 @@ describe('bug fixes', function() {
     db = start();
   });
 
+  after(function(done) {
+    db.close(done);
+  });
+
   it('discriminators with classes modifies class in place (gh-5175)', function(done) {
     class Vehicle extends mongoose.Model { }
     var V = mongoose.model(Vehicle, new mongoose.Schema());

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -75,8 +75,7 @@ describe('model', function() {
     it('creates in parallel', function(done) {
       // we set the time out to be double that of the validator - 1 (so that running in serial will be greater than that)
       this.timeout(1000);
-      var db = start(),
-          countPre = 0,
+      var countPre = 0,
           countPost = 0;
 
       var SchemaWithPreSaveHook = new Schema({

--- a/test/model.field.selection.test.js
+++ b/test/model.field.selection.test.js
@@ -15,6 +15,7 @@ describe('model field selection', function() {
   var BlogPostB;
   var modelName;
   var collection;
+  var db;
 
   before(function() {
     Comments = new Schema;
@@ -48,11 +49,15 @@ describe('model field selection', function() {
     modelName = 'model.select.blogpost';
     mongoose.model(modelName, BlogPostB);
     collection = 'blogposts_' + random();
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('excluded fields should be undefined', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection),
+    var BlogPostB = db.model(modelName, collection),
         date = new Date;
 
     var doc = {
@@ -67,7 +72,6 @@ describe('model field selection', function() {
 
       var id = created.id;
       BlogPostB.findById(id, {title: 0, 'meta.date': 0, owners: 0, 'comments.user': 0}, function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.equal(found._id.toString(), created._id);
         assert.strictEqual(undefined, found.title);
@@ -88,8 +92,7 @@ describe('model field selection', function() {
   });
 
   it('excluded fields should be undefined and defaults applied to other fields', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection),
+    var BlogPostB = db.model(modelName, collection),
         id = new DocumentObjectId,
         date = new Date;
 
@@ -97,7 +100,6 @@ describe('model field selection', function() {
       assert.ifError(err);
 
       BlogPostB.findById(id, {title: 0}, function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.equal(found._id.toString(), id);
         assert.strictEqual(undefined, found.title);
@@ -112,12 +114,10 @@ describe('model field selection', function() {
   });
 
   it('where subset of fields excludes _id', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
     BlogPostB.create({title: 'subset 1'}, function(err) {
       assert.ifError(err);
       BlogPostB.findOne({title: 'subset 1'}, {title: 1, _id: 0}, function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.strictEqual(undefined, found._id);
         assert.equal(found.title, 'subset 1');
@@ -127,12 +127,10 @@ describe('model field selection', function() {
   });
 
   it('works with subset of fields, excluding _id', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
     BlogPostB.create({title: 'subset 1', author: 'me'}, function(err) {
       assert.ifError(err);
       BlogPostB.find({title: 'subset 1'}, {title: 1, _id: 0}, function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.strictEqual(undefined, found[0]._id);
         assert.equal(found[0].title, 'subset 1');
@@ -145,8 +143,6 @@ describe('model field selection', function() {
   });
 
   it('works with just _id and findOneAndUpdate (gh-3407)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh3407', {test: {type: Number, default: 1}});
 
     MyModel.collection.insert({}, function(error) {
@@ -154,19 +150,17 @@ describe('model field selection', function() {
       MyModel.findOne({}, {_id: 1}, function(error, doc) {
         assert.ifError(error);
         assert.ok(!doc.test);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('works with subset of fields excluding emebedded doc _id (gh-541)', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
 
     BlogPostB.create({title: 'LOTR', comments: [{title: ':)'}]}, function(err, created) {
       assert.ifError(err);
       BlogPostB.find({_id: created}, {_id: 0, 'comments._id': 0}, function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.strictEqual(undefined, found[0]._id);
         assert.equal(found[0].title, 'LOTR');
@@ -184,8 +178,7 @@ describe('model field selection', function() {
   });
 
   it('included fields should have defaults applied when no value exists in db (gh-870)', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection),
+    var BlogPostB = db.model(modelName, collection),
         id = new DocumentObjectId;
 
     BlogPostB.collection.insert(
@@ -193,7 +186,6 @@ describe('model field selection', function() {
         assert.ifError(err);
 
         BlogPostB.findById(id, 'def comments', function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.ok(found);
           assert.equal(found._id.toString(), id);
@@ -208,14 +200,12 @@ describe('model field selection', function() {
   });
 
   it('including subdoc field excludes other subdoc fields (gh-1027)', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
 
     BlogPostB.create({comments: [{title: 'a'}, {title: 'b'}]}, function(err, doc) {
       assert.ifError(err);
 
       BlogPostB.findById(doc._id).select('_id comments.title').exec(function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.ok(found);
         assert.equal(doc._id.toString(), found._id.toString());
@@ -233,14 +223,12 @@ describe('model field selection', function() {
   });
 
   it('excluding nested subdoc fields (gh-1027)', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
 
     BlogPostB.create({title: 'top', comments: [{title: 'a', body: 'body'}, {title: 'b', body: 'body', comments: [{title: 'c'}]}]}, function(err, doc) {
       assert.ifError(err);
 
       BlogPostB.findById(doc._id).select('-_id -comments.title -comments.comments.comments -numbers').exec(function(err, found) {
-        db.close();
         assert.ifError(err);
         assert.ok(found);
         assert.equal(found._id, undefined);
@@ -268,8 +256,6 @@ describe('model field selection', function() {
     // mongodb 2.2 support
 
     it('casts elemMatch args (gh-1091)', function(done) {
-      var db = start();
-
       var postSchema = new Schema({
         ids: [{type: Schema.ObjectId}]
       });
@@ -301,15 +287,13 @@ describe('model field selection', function() {
                 assert.equal(found.id, doc.id);
                 assert.equal(found.ids.length, 1);
                 assert.equal(found.ids[0].toString(), _id2.toString());
-                db.close(done);
+                done();
               });
           });
       });
     });
 
     it('saves modified elemMatch paths (gh-1334)', function(done) {
-      var db = start();
-
       var postSchema = new Schema({
         ids: [{type: Schema.ObjectId}],
         ids2: [{type: Schema.ObjectId}]
@@ -347,7 +331,7 @@ describe('model field selection', function() {
                   found.save(function(err) {
                     assert.ok(err);
 
-                    db.close(done);
+                    done();
                   });
                 });
             });
@@ -356,8 +340,6 @@ describe('model field selection', function() {
     });
 
     it('works with $ positional in select (gh-2031)', function(done) {
-      var db = start();
-
       var postSchema = new Schema({
         tags: [{tag: String, count: 0}]
       });
@@ -370,7 +352,7 @@ describe('model field selection', function() {
           post.tags[0].count = 1;
           post.save(function(error) {
             assert.ok(error);
-            db.close(done);
+            done();
           });
         });
       });
@@ -378,8 +360,7 @@ describe('model field selection', function() {
   });
 
   it('selecting an array of docs applies defaults properly (gh-1108)', function(done) {
-    var db = start(),
-        M = db.model(modelName, collection);
+    var M = db.model(modelName, collection);
 
     var m = new M({title: '1108', comments: [{body: 'yay'}]});
     m.comments[0].comments = undefined;
@@ -390,14 +371,12 @@ describe('model field selection', function() {
         assert.ok(Array.isArray(found.comments));
         assert.equal(found.comments.length, 1);
         assert.ok(Array.isArray(found.comments[0].comments));
-        db.close(done);
+        done();
       });
     });
   });
 
   it('select properties named length (gh-3903)', function(done) {
-    var db = start();
-
     var schema = new mongoose.Schema({
       length: Number,
       name: String
@@ -410,13 +389,12 @@ describe('model field selection', function() {
       MyModel.findOne({}).select({ length: 1 }).exec(function(error, doc) {
         assert.ifError(error);
         assert.ok(!doc.name);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('appropriately filters subdocuments based on properties (gh-1280)', function(done) {
-    var db = start();
     var RouteSchema = new Schema({
       stations: {
         start: {
@@ -464,7 +442,7 @@ describe('model field selection', function() {
           assert.equal(res.stations.start.toString(), 'undefined');
           assert.equal(res.stations.end.toString(), 'undefined');
           assert.ok(Array.isArray(res.stations.points));
-          db.close(done);
+          done();
         });
       });
     });

--- a/test/model.findAndRemoveOne.test.js
+++ b/test/model.findAndRemoveOne.test.js
@@ -17,6 +17,7 @@ describe('model: findOneAndRemove:', function() {
   var modelname;
   var collection;
   var strictSchema;
+  var db;
 
   before(function() {
     Comments = new Schema;
@@ -69,11 +70,16 @@ describe('model: findOneAndRemove:', function() {
 
     strictSchema = new Schema({name: String}, {strict: true});
     mongoose.model('RemoveOneStrictSchema', strictSchema);
+
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('returns the original document', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         title = 'remove muah';
 
     var post = new M({title: title});
@@ -83,7 +89,6 @@ describe('model: findOneAndRemove:', function() {
         assert.ifError(err);
         assert.equal(post.id, doc.id);
         M.findById(post.id, function(err, gone) {
-          db.close();
           assert.ifError(err);
           assert.equal(gone, null);
           done();
@@ -93,10 +98,7 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('options/conditions/doc are merged when no callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection);
-
-    db.close();
+    var M = db.model(modelname, collection);
 
     var now = new Date,
         query;
@@ -132,8 +134,7 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('executes when a callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection + random()),
+    var M = db.model(modelname, collection + random()),
         pending = 5;
 
     M.findOneAndRemove({name: 'aaron1'}, {select: 'name'}, cb);
@@ -146,14 +147,12 @@ describe('model: findOneAndRemove:', function() {
       assert.ifError(err);
       assert.equal(doc, null); // no previously existing doc
       if (--pending) return;
-      db.close();
       done();
     }
   });
 
   it('executed with only a callback throws', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         err;
 
     try {
@@ -162,14 +161,12 @@ describe('model: findOneAndRemove:', function() {
       err = e;
     }
 
-    db.close();
     assert.ok(/First argument must not be a function/.test(err));
     done();
   });
 
   it('executed with only a callback throws', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         err;
 
     try {
@@ -178,14 +175,12 @@ describe('model: findOneAndRemove:', function() {
       err = e;
     }
 
-    db.close();
     assert.ok(/First argument must not be a function/.test(err));
     done();
   });
 
   it('executes when a callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection + random()),
+    var M = db.model(modelname, collection + random()),
         _id = new DocumentObjectId,
         pending = 2;
 
@@ -196,14 +191,12 @@ describe('model: findOneAndRemove:', function() {
       assert.ifError(err);
       assert.equal(doc, null); // no previously existing doc
       if (--pending) return;
-      db.close();
       done();
     }
   });
 
   it('returns the original document', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         title = 'remove muah pleez';
 
     var post = new M({title: title});
@@ -213,7 +206,6 @@ describe('model: findOneAndRemove:', function() {
         assert.ifError(err);
         assert.equal(post.id, doc.id);
         M.findById(post.id, function(err, gone) {
-          db.close();
           assert.ifError(err);
           assert.equal(gone, null);
           done();
@@ -223,11 +215,8 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('options/conditions/doc are merged when no callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
-
-    db.close();
 
     var query;
 
@@ -248,11 +237,8 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('supports v3 select string syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
-
-    db.close();
 
     var query;
 
@@ -267,11 +253,8 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('supports v3 select object syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
-
-    db.close();
 
     var query;
 
@@ -286,11 +269,8 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('supports v3 sort string syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
-
-    db.close();
 
     var query;
 
@@ -307,8 +287,7 @@ describe('model: findOneAndRemove:', function() {
   });
 
   it('supports v3 sort object syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
 
     var query;
@@ -322,11 +301,10 @@ describe('model: findOneAndRemove:', function() {
     assert.equal(Object.keys(query.options.sort).length, 2);
     assert.equal(query.options.sort.author, 1);
     assert.equal(query.options.sort.title, -1);
-    db.close(done);
+    done();
   });
 
   it('supports population (gh-1395)', function(done) {
-    var db = start();
     var M = db.model('A', {name: String});
     var N = db.model('B', {a: {type: Schema.ObjectId, ref: 'A'}, i: Number});
 
@@ -343,23 +321,13 @@ describe('model: findOneAndRemove:', function() {
             assert.equal(doc._id, undefined);
             assert.ok(doc.a);
             assert.equal('i am an A', doc.a.name);
-            db.close(done);
+            done();
           });
       });
     });
   });
 
   describe('middleware', function() {
-    var db;
-
-    beforeEach(function() {
-      db = start();
-    });
-
-    afterEach(function(done) {
-      db.close(done);
-    });
-
     it('works', function(done) {
       var s = new Schema({
         topping: {type: String, default: 'bacon'},
@@ -397,7 +365,7 @@ describe('model: findOneAndRemove:', function() {
       });
     });
 
-    it('works with exec()', function(done) {
+    it('works with exec() (gh-439)', function(done) {
       var s = new Schema({
         topping: {type: String, default: 'bacon'},
         base: String
@@ -413,7 +381,7 @@ describe('model: findOneAndRemove:', function() {
         ++postCount;
       });
 
-      var Breakfast = db.model('gh-439', s);
+      var Breakfast = db.model('Breakfast', s);
       var breakfast = new Breakfast({
         base: 'eggs'
       });

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -21,6 +21,7 @@ describe('model: findOneAndUpdate:', function() {
   var collection;
   var strictSchema;
   var strictThrowSchema;
+  var db;
 
   before(function() {
     Comments = new Schema();
@@ -76,11 +77,16 @@ describe('model: findOneAndUpdate:', function() {
 
     strictThrowSchema = new Schema({name: String}, {strict: 'throw'});
     mongoose.model('UpdateOneStrictThrowSchema', strictThrowSchema);
+
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('WWW returns the edited document', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         title = 'Tobi ' + random(),
         author = 'Brian ' + random(),
         newTitle = 'Woot ' + random(),
@@ -132,7 +138,6 @@ describe('model: findOneAndUpdate:', function() {
         };
 
         M.findOneAndUpdate({title: title}, update, {new: true}, function(err, up) {
-          db.close();
           assert.equal(err && err.stack, err, null);
 
           assert.equal(up.title, newTitle);
@@ -158,10 +163,9 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   describe('will correctly', function() {
-    var db, ItemParentModel, ItemChildModel;
+    var ItemParentModel, ItemChildModel;
 
     before(function() {
-      db = start();
       var itemSpec = new Schema({
         item_id: {
           type: ObjectId, required: true, default: function() {
@@ -179,10 +183,6 @@ describe('model: findOneAndUpdate:', function() {
       });
       ItemParentModel = db.model('ItemParentModel', itemSchema);
       ItemChildModel = db.model('ItemChildModel', itemSpec);
-    });
-
-    after(function() {
-      db.close();
     });
 
     it('update subdocument in array item', function(done) {
@@ -226,8 +226,7 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('returns the original document', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         title = 'Tobi ' + random(),
         author = 'Brian ' + random(),
         newTitle = 'Woot ' + random(),
@@ -262,7 +261,6 @@ describe('model: findOneAndUpdate:', function() {
         };
 
         M.findOneAndUpdate({title: title}, update, {new: false}, function(err, up) {
-          db.close();
           assert.ifError(err);
 
           assert.equal(up.title, post.title);
@@ -288,8 +286,7 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('allows upserting', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         title = 'Tobi ' + random(),
         author = 'Brian ' + random(),
         newTitle = 'Woot ' + random(),
@@ -318,7 +315,6 @@ describe('model: findOneAndUpdate:', function() {
     };
 
     M.findOneAndUpdate({title: title}, update, {upsert: true, new: true}, function(err, up) {
-      db.close();
       assert.ifError(err);
 
       assert.equal(up.title, newTitle);
@@ -336,10 +332,7 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('options/conditions/doc are merged when no callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection);
-
-    db.close();
+    var M = db.model(modelname, collection);
 
     var now = new Date,
         query;
@@ -390,8 +383,7 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('executes when a callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection + random()),
+    var M = db.model(modelname, collection + random()),
         pending = 6;
 
     M.findOneAndUpdate({name: 'aaron'}, {$set: {name: 'Aaron6'}}, {new: false}, cb);
@@ -407,14 +399,12 @@ describe('model: findOneAndUpdate:', function() {
       if (--pending) {
         return;
       }
-      db.close();
       done();
     }
   });
 
   it('executes when a callback is passed to a succeeding function', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection + random()),
+    var M = db.model(modelname, collection + random()),
         pending = 6;
 
     M.findOneAndUpdate({name: 'aaron'}, {$set: {name: 'Aaron'}}, {new: false}).exec(cb);
@@ -430,14 +420,12 @@ describe('model: findOneAndUpdate:', function() {
       if (--pending) {
         return;
       }
-      db.close();
       done();
     }
   });
 
   it('executing with only a callback throws', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         err;
 
     try {
@@ -447,14 +435,12 @@ describe('model: findOneAndUpdate:', function() {
       err = e;
     }
 
-    db.close();
     assert.ok(/First argument must not be a function/.test(err));
     done();
   });
 
   it('updates numbers atomically', function(done) {
-    var db = start(),
-        BlogPost = db.model(modelname, collection),
+    var BlogPost = db.model(modelname, collection),
         totalDocs = 4;
 
     var post = new BlogPost();
@@ -475,7 +461,6 @@ describe('model: findOneAndUpdate:', function() {
 
       function complete() {
         BlogPost.findOne({_id: post.get('_id')}, function(err, doc) {
-          db.close();
           assert.ifError(err);
           assert.equal(doc.get('meta.visitors'), 9);
           done();
@@ -485,7 +470,6 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('honors strict schemas', function(done) {
-    var db = start();
     var S = db.model('UpdateOneStrictSchema');
     var s = new S({name: 'orange crush'});
 
@@ -505,7 +489,6 @@ describe('model: findOneAndUpdate:', function() {
           assert.ok(!doc._doc.ignore);
           assert.equal(doc.name, 'orange crush');
           S.findOneAndUpdate({name: 'orange crush'}, {ignore: true}, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.ok(!doc.ignore);
             assert.ok(!doc._doc.ignore);
@@ -518,7 +501,6 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('returns errors with strict:throw schemas', function(done) {
-    var db = start();
     var S = db.model('UpdateOneStrictThrowSchema');
     var s = new S({name: 'orange crush'});
 
@@ -532,7 +514,6 @@ describe('model: findOneAndUpdate:', function() {
         assert.ok(!doc);
 
         S.findOneAndUpdate({_id: s._id}, {ignore: true}, function(err, doc) {
-          db.close();
           assert.ok(err);
           assert.ok(/not in schema/.test(err));
           assert.ok(!doc);
@@ -543,8 +524,7 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('executing with just a callback throws', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         err;
 
     try {
@@ -554,14 +534,12 @@ describe('model: findOneAndUpdate:', function() {
       err = e;
     }
 
-    db.close();
     assert.ok(/First argument must not be a function/.test(err));
     done();
   });
 
   it('executes when a callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection + random()),
+    var M = db.model(modelname, collection + random()),
         _id = new DocumentObjectId,
         pending = 2;
 
@@ -574,13 +552,12 @@ describe('model: findOneAndUpdate:', function() {
       if (--pending) {
         return;
       }
-      db.close(done);
+      done();
     }
   });
 
   it('executes when a callback is passed to a succeeding function', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection + random()),
+    var M = db.model(modelname, collection + random()),
         _id = new DocumentObjectId,
         pending = 2;
 
@@ -593,13 +570,12 @@ describe('model: findOneAndUpdate:', function() {
       if (--pending) {
         return;
       }
-      db.close(done);
+      done();
     }
   });
 
   it('returns the original document', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         title = 'Tobi ' + random(),
         author = 'Brian ' + random(),
         newTitle = 'Woot ' + random(),
@@ -652,15 +628,14 @@ describe('model: findOneAndUpdate:', function() {
           assert.ok(up.comments[1]._id);
           assert.ok(up.comments[0]._id instanceof DocumentObjectId);
           assert.ok(up.comments[1]._id instanceof DocumentObjectId);
-          db.close(done);
+          done();
         });
       });
     });
   });
 
   it('options/conditions/doc are merged when no callback is passed', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
 
     var now = new Date,
@@ -686,12 +661,11 @@ describe('model: findOneAndUpdate:', function() {
     assert.strictEqual(undefined, query.options.new);
     assert.equal(query._update, undefined);
     assert.strictEqual(undefined, query._conditions._id);
-    db.close(done);
+    done();
   });
 
   it('supports v3 select string syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
 
     var now = new Date,
@@ -704,12 +678,11 @@ describe('model: findOneAndUpdate:', function() {
     query = M.findOneAndUpdate({}, {$set: {date: now}}, {select: 'author -title'});
     assert.strictEqual(1, query._fields.author);
     assert.strictEqual(0, query._fields.title);
-    db.close(done);
+    done();
   });
 
   it('supports v3 select object syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
 
     var now = new Date,
@@ -722,12 +695,11 @@ describe('model: findOneAndUpdate:', function() {
     query = M.findOneAndUpdate({}, {$set: {date: now}}, {select: {author: 1, title: 0}});
     assert.strictEqual(1, query._fields.author);
     assert.strictEqual(0, query._fields.title);
-    db.close(done);
+    done();
   });
 
   it('supports v3 sort string syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection);
+    var M = db.model(modelname, collection);
 
     var now = new Date;
     var _id = new DocumentObjectId;
@@ -760,14 +732,13 @@ describe('model: findOneAndUpdate:', function() {
               return done(err);
             }
             assert.equal(doc.meta.visitors, 10);
-            db.close(done);
+            done();
           });
       });
   });
 
   it('supports v3 sort object syntax', function(done) {
-    var db = start(),
-        M = db.model(modelname, collection),
+    var M = db.model(modelname, collection),
         _id = new DocumentObjectId;
 
     var now = new Date,
@@ -783,12 +754,10 @@ describe('model: findOneAndUpdate:', function() {
     assert.equal(query.options.sort.author, 1);
     assert.equal(query.options.sort.title, -1);
 
-    db.close(done);
+    done();
   });
 
   it('supports $elemMatch with $in (gh-1091 gh-1100)', function(done) {
-    var db = start();
-
     var postSchema = new Schema({
       ids: [{type: Schema.ObjectId}],
       title: String
@@ -811,13 +780,12 @@ describe('model: findOneAndUpdate:', function() {
           assert.equal(found.title, 'woot');
           assert.equal(found.ids.length, 1);
           assert.equal(found.ids[0].toString(), _id2.toString());
-          db.close(done);
+          done();
         });
     });
   });
 
   it('supports population (gh-1395)', function(done) {
-    var db = start();
     var M = db.model('A', {name: String});
     var N = db.model('B', {a: {type: Schema.ObjectId, ref: 'A'}, i: Number});
 
@@ -839,14 +807,12 @@ describe('model: findOneAndUpdate:', function() {
             assert.ok(doc);
             assert.ok(doc.a);
             assert.equal('i am an A', doc.a.name);
-            db.close(done);
+            done();
           });
       });
     });
   });
   it('returns null when doing an upsert & new=false gh-1533', function(done) {
-    var db = start();
-
     var thingSchema = new Schema({
       _id: String,
       flag: {
@@ -865,19 +831,17 @@ describe('model: findOneAndUpdate:', function() {
         assert.ifError(err);
         assert.equal(thing2.id, key);
         assert.equal(thing2.flag, false);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('allows properties to be set to null gh-1643', function(done) {
-    var db = start();
-
     var thingSchema = new Schema({
       name: [String]
     });
 
-    var Thing = db.model('Thing', thingSchema);
+    var Thing = db.model('Thing1', thingSchema);
 
     Thing.create({name: ['Test']}, function(err, thing) {
       if (err) {
@@ -890,13 +854,12 @@ describe('model: findOneAndUpdate:', function() {
           }
           assert.ok(doc);
           assert.equal(null, doc.name);
-          db.close(done);
+          done();
         });
     });
   });
 
   it('honors the overwrite option (gh-1809)', function(done) {
-    var db = start();
     var M = db.model('1809', {name: String, change: Boolean});
     M.create({name: 'first'}, function(err, doc) {
       if (err) {
@@ -908,14 +871,12 @@ describe('model: findOneAndUpdate:', function() {
         }
         assert.ok(doc.change);
         assert.equal(doc.name, undefined);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('can do deep equals on object id after findOneAndUpdate (gh-2070)', function(done) {
-    var db = start();
-
     var accountSchema = new Schema({
       name: String,
       contacts: [{
@@ -955,7 +916,7 @@ describe('model: findOneAndUpdate:', function() {
               if (!/^v0.10.\d+$/.test(process.version)) {
                 assert.ok(_.isEqual(doc.contacts[0].account, a2._id));
               }
-              db.close(done);
+              done();
             });
           });
       });
@@ -969,8 +930,6 @@ describe('model: findOneAndUpdate:', function() {
   });
 
   it('adds __v on upsert (gh-2122) (gh-4505)', function(done) {
-    var db = start();
-
     var accountSchema = new Schema({
       name: String
     });
@@ -989,15 +948,13 @@ describe('model: findOneAndUpdate:', function() {
           Account.findOne({ name: 'test' }, function(error, doc) {
             assert.ifError(error);
             assert.equal(doc.__v, 0);
-            db.close(done);
+            done();
           });
         });
       });
   });
 
   it('works with nested schemas and $pull+$or (gh-1932)', function(done) {
-    var db = start();
-
     var TickSchema = new Schema({name: String});
     var TestSchema = new Schema({a: Number, b: Number, ticks: [TickSchema]});
 
@@ -1012,15 +969,13 @@ describe('model: findOneAndUpdate:', function() {
             assert.ifError(error);
             assert.equal(doc.ticks.length, 1);
             assert.equal(doc.ticks[0].name, 'coffee');
-            db.close(done);
+            done();
           });
         });
     });
   });
 
   it('accepts undefined', function(done) {
-    var db = start();
-
     var s = new Schema({
       time: Date,
       base: String
@@ -1032,13 +987,11 @@ describe('model: findOneAndUpdate:', function() {
       findOneAndUpdate({}, {time: undefined, base: undefined}, {}).
       exec(function(error) {
         assert.ifError(error);
-        db.close(done);
+        done();
       });
   });
 
   it('cast errors for empty objects as object ids (gh-2732)', function(done) {
-    var db = start();
-
     var s = new Schema({
       base: ObjectId
     });
@@ -1049,13 +1002,11 @@ describe('model: findOneAndUpdate:', function() {
       findOneAndUpdate({}, {base: {}}, {}).
       exec(function(error) {
         assert.ok(error);
-        db.close(done);
+        done();
       });
   });
 
   it('strict mode with objects (gh-2947)', function(done) {
-    var db = start();
-
     var s = new Schema({
       test: String
     }, {strict: true});
@@ -1068,21 +1019,11 @@ describe('model: findOneAndUpdate:', function() {
     q.lean();
     q.exec(function(error, doc) {
       assert.ok(!doc.notInSchema);
-      db.close(done);
+      done();
     });
   });
 
   describe('middleware', function() {
-    var db;
-
-    beforeEach(function() {
-      db = start();
-    });
-
-    afterEach(function(done) {
-      db.close(done);
-    });
-
     it('works', function(done) {
       var s = new Schema({
         topping: {type: String, default: 'bacon'},
@@ -1144,8 +1085,6 @@ describe('model: findOneAndUpdate:', function() {
 
   describe('validators (gh-860)', function() {
     it('applies defaults on upsert', function(done) {
-      var db = start();
-
       var s = new Schema({
         topping: {type: String, default: 'bacon'},
         base: String
@@ -1164,14 +1103,12 @@ describe('model: findOneAndUpdate:', function() {
           Breakfast.count({topping: 'bacon'}, function(error, count) {
             assert.ifError(error);
             assert.equal(1, count);
-            db.close(done);
+            done();
           });
         });
     });
 
     it('doesnt set default on upsert if query sets it', function(done) {
-      var db = start();
-
       var s = new Schema({
         topping: {type: String, default: 'bacon'},
         numEggs: {type: Number, default: 3},
@@ -1189,14 +1126,11 @@ describe('model: findOneAndUpdate:', function() {
           assert.equal(breakfast.base, 'eggs');
           assert.equal(breakfast.topping, 'sausage');
           assert.equal(breakfast.numEggs, 4);
-          db.close();
           done();
         });
     });
 
     it('properly sets default on upsert if query wont set it', function(done) {
-      var db = start();
-
       var s = new Schema({
         topping: {type: String, default: 'bacon'},
         base: String
@@ -1215,14 +1149,12 @@ describe('model: findOneAndUpdate:', function() {
           Breakfast.count({topping: 'bacon'}, function(error, count) {
             assert.ifError(error);
             assert.equal(1, count);
-            db.close(done);
+            done();
           });
         });
     });
 
     it('runs validators if theyre set', function(done) {
-      var db = start();
-
       var s = new Schema({
         topping: {
           type: String,
@@ -1257,14 +1189,11 @@ describe('model: findOneAndUpdate:', function() {
           assert.equal(error.errors.topping.message, 'Validator failed for path `topping` with value `bacon`');
 
           assert.ok(!breakfast);
-          db.close();
           done();
         });
     });
 
     it('validators handle $unset and $setOnInsert', function(done) {
-      var db = start();
-
       var s = new Schema({
         steak: {type: String, required: true},
         eggs: {
@@ -1288,14 +1217,11 @@ describe('model: findOneAndUpdate:', function() {
           assert.ok(Object.keys(error.errors).indexOf('steak') !== -1);
           assert.equal(error.errors.eggs.message, 'Validator failed for path `eggs` with value `softboiled`');
           assert.equal(error.errors.steak.message, 'Path `steak` is required.');
-          db.close();
           done();
         });
     });
 
     it('min/max, enum, and regex built-in validators work', function(done) {
-      var db = start();
-
       var s = new Schema({
         steak: {type: String, enum: ['ribeye', 'sirloin']},
         eggs: {type: Number, min: 4, max: 6},
@@ -1334,7 +1260,6 @@ describe('model: findOneAndUpdate:', function() {
                   assert.equal(Object.keys(error.errors)[0], 'bacon');
                   assert.equal(error.errors.bacon.message, 'Path `bacon` is invalid (none).');
 
-                  db.close();
                   done();
                 });
             });
@@ -1342,8 +1267,6 @@ describe('model: findOneAndUpdate:', function() {
     });
 
     it('multiple validation errors', function(done) {
-      var db = start();
-
       var s = new Schema({
         steak: {type: String, enum: ['ribeye', 'sirloin']},
         eggs: {type: Number, min: 4, max: 6},
@@ -1362,14 +1285,11 @@ describe('model: findOneAndUpdate:', function() {
           assert.ok(Object.keys(error.errors).indexOf('steak') !== -1);
           assert.ok(Object.keys(error.errors).indexOf('eggs') !== -1);
           assert.ok(!breakfast);
-          db.close();
           done();
         });
     });
 
     it('validators ignore $inc', function(done) {
-      var db = start();
-
       var s = new Schema({
         steak: {type: String, required: true},
         eggs: {type: Number, min: 4}
@@ -1385,13 +1305,11 @@ describe('model: findOneAndUpdate:', function() {
           assert.ifError(error);
           assert.ok(!!breakfast);
           assert.equal(breakfast.eggs, 1);
-          db.close(done);
+          done();
         });
     });
 
     it('should work with arrays (gh-3035)', function(done) {
-      var db = start();
-
       var testSchema = new mongoose.Schema({
         id: String,
         name: String,
@@ -1408,14 +1326,12 @@ describe('model: findOneAndUpdate:', function() {
         TestModel.findOneAndUpdate({id: '1'}, {$set: {name: 'Joe'}}, {upsert: true, setDefaultsOnInsert: true},
           function(error) {
             assert.ifError(error);
-            db.close(done);
+            done();
           });
       });
     });
 
     it('should allow null values in query (gh-3135)', function(done) {
-      var db = start();
-
       var testSchema = new mongoose.Schema({
         id: String,
         blob: ObjectId,
@@ -1428,14 +1344,12 @@ describe('model: findOneAndUpdate:', function() {
         TestModel.findOneAndUpdate({id: '1', blob: null}, {$set: {status: 'inactive'}}, {upsert: true, setDefaultsOnInsert: true},
           function(error) {
             assert.ifError(error);
-            db.close(done);
+            done();
           });
       });
     });
 
     it('should work with array documents (gh-3034)', function(done) {
-      var db = start();
-
       var testSchema = new mongoose.Schema({
         id: String,
         name: String,
@@ -1454,14 +1368,12 @@ describe('model: findOneAndUpdate:', function() {
         TestModel.findOneAndUpdate({id: '1'}, {$set: {name: 'Joe'}}, {upsert: true, setDefaultsOnInsert: true},
           function(error) {
             assert.ifError(error);
-            db.close(done);
+            done();
           });
       });
     });
 
     it('handles setting array (gh-3107)', function(done) {
-      var db = start();
-
       var testSchema = new mongoose.Schema({
         name: String,
         a: [{
@@ -1481,13 +1393,12 @@ describe('model: findOneAndUpdate:', function() {
             assert.equal(doc.a[0].foo, 'bar');
             assert.equal(doc.b.length, 1);
             assert.equal(doc.b[0], 2);
-            db.close(done);
+            done();
           });
     });
 
 
     it('handles nested cast errors (gh-3468)', function(done) {
-      var db = start();
       var recordSchema = new mongoose.Schema({
         kind: String,
         amount: Number
@@ -1514,14 +1425,12 @@ describe('model: findOneAndUpdate:', function() {
         }, function(error) {
           assert.ok(error);
           assert.ok(error instanceof CastError);
-          db.close(done);
+          done();
         });
       });
     });
 
     it('cast errors with nested schemas (gh-3580)', function(done) {
-      var db = start();
-
       var nested = new Schema({num: Number});
       var s = new Schema({nested: nested});
 
@@ -1530,13 +1439,11 @@ describe('model: findOneAndUpdate:', function() {
       var update = {nested: {num: 'Not a Number'}};
       MyModel.findOneAndUpdate({}, update, function(error) {
         assert.ok(error);
-        db.close(done);
+        done();
       });
     });
 
     it('pull with nested schemas (gh-3616)', function(done) {
-      var db = start();
-
       var nested = new Schema({arr: [{num: Number}]});
       var s = new Schema({nested: nested});
 
@@ -1549,13 +1456,12 @@ describe('model: findOneAndUpdate:', function() {
         MyModel.findOneAndUpdate({}, update, options, function(error, doc) {
           assert.ifError(error);
           assert.equal(doc.nested.arr.length, 0);
-          db.close(done);
+          done();
         });
       });
     });
 
     it('setting nested schema (gh-3889)', function(done) {
-      var db = start();
       var nested = new Schema({ test: String });
       var s = new Schema({ nested: nested });
       var MyModel = db.model('gh3889', s);
@@ -1564,22 +1470,12 @@ describe('model: findOneAndUpdate:', function() {
         { $set: { nested: { test: 'abc' } } },
         function(error) {
           assert.ifError(error);
-          db.close(done);
+          done();
         });
     });
   });
 
   describe('bug fixes', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('passes raw result if rawResult specified (gh-4925)', function(done) {
       var testSchema = new mongoose.Schema({
         test: String

--- a/test/model.geosearch.test.js
+++ b/test/model.geosearch.test.js
@@ -6,7 +6,7 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('model', function() {
-  var schema;
+  var db, schema;
 
   function getModel(db) {
     return db.model('GeoSearch', schema, 'geosearch-' + random());
@@ -19,11 +19,15 @@ describe('model', function() {
       type: String
     });
     schema.index({pos: 'geoHaystack', type: 1}, {bucketSize: 1});
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   describe('geoSearch', function() {
     it('works', function(done) {
-      var db = start();
       var Geo = getModel(db);
       assert.ok(Geo.geoSearch instanceof Function);
 
@@ -59,14 +63,13 @@ describe('model', function() {
             Geo.geoSearch({type: 'place'}, {near: [40, 40], maxDistance: 5}, function(err, results) {
               assert.ifError(err);
               assert.equal(results.length, 0);
-              db.close(done);
+              done();
             });
           });
         }
       });
     });
     it('works with lean', function(done) {
-      var db = start();
       var Geo = getModel(db);
       assert.ok(Geo.geoSearch instanceof Function);
 
@@ -99,13 +102,12 @@ describe('model', function() {
             assert.equal(results[0]._id, geos[0].id);
             assert.strictEqual(results[0].id, undefined);
             assert.ok(!(results[0] instanceof Geo));
-            db.close(done);
+            done();
           });
         }
       });
     });
     it('throws the correct error messages', function(done) {
-      var db = start();
       var Geo = getModel(db);
       assert.ok(Geo.geoSearch instanceof Function);
 
@@ -129,7 +131,7 @@ describe('model', function() {
                 Geo.geoSearch({type: 'test'}, {near: [1, 2]}, function(err) {
                   assert.ok(err);
                   assert.ok(/maxDistance needs a number/.test(err));
-                  db.close(done);
+                  done();
                 });
               });
             });
@@ -148,7 +150,6 @@ describe('model', function() {
     });
 
     it('allows not passing a callback (gh-1614)', function(done) {
-      var db = start();
       var Geo = getModel(db);
       Geo.on('index', function(err) {
         assert.ifError(err);
@@ -167,7 +168,7 @@ describe('model', function() {
           }
 
           function finish() {
-            db.close(done);
+            done();
           }
           promise.then(validate, assert.ifError).then(finish);
         });

--- a/test/model.mapreduce.test.js
+++ b/test/model.mapreduce.test.js
@@ -14,6 +14,7 @@ describe('model: mapreduce:', function() {
   var Comments;
   var BlogPost;
   var collection;
+  var db;
 
   before(function() {
     Comments = new Schema();
@@ -43,11 +44,15 @@ describe('model: mapreduce:', function() {
 
     collection = 'mapreduce_' + random();
     mongoose.model('MapReduce', BlogPost);
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('works', function(done) {
-    var db = start(),
-        MR = db.model('MapReduce', collection);
+    var MR = db.model('MapReduce', collection);
 
     var magicID;
     var id = new mongoose.Types.ObjectId;
@@ -158,7 +163,6 @@ describe('model: mapreduce:', function() {
                 .findOne({_id: 'aaron'})
                 .populate({path: 'value.own', model: 'MapReduce'})
                 .exec(function(err, doc) {
-                  db.close();
                   assert.ifError(err);
                   assert.equal(doc.value.own.author, 'guillermo');
                   done();
@@ -171,8 +175,7 @@ describe('model: mapreduce:', function() {
   });
 
   it('withholds stats with false verbosity', function(done) {
-    var db = start(),
-        MR = db.model('MapReduce', collection);
+    var MR = db.model('MapReduce', collection);
 
     var o = {
       map: function() {
@@ -185,14 +188,13 @@ describe('model: mapreduce:', function() {
 
     MR.mapReduce(o, function(err, results, stats) {
       assert.equal(typeof stats, 'undefined');
-      db.close(done);
+      done();
     });
   });
 
   describe('promises (gh-1628)', function() {
     it('are returned', function(done) {
-      var db = start(),
-          MR = db.model('MapReduce', collection);
+      var MR = db.model('MapReduce', collection);
 
       var o = {
         map: function() {
@@ -205,7 +207,7 @@ describe('model: mapreduce:', function() {
       var promise = MR.mapReduce(o);
       assert.ok(promise instanceof mongoose.Promise);
 
-      db.close(done);
+      done();
     });
   });
 
@@ -303,8 +305,7 @@ describe('model: mapreduce:', function() {
   });
 
   it('withholds stats with false verbosity using then', function(done) {
-    var db = start(),
-        MR = db.model('MapReduce', collection);
+    var MR = db.model('MapReduce', collection);
 
     var o = {
       map: function() {
@@ -317,7 +318,7 @@ describe('model: mapreduce:', function() {
 
     MR.mapReduce(o).then(function(results, stats) {
       assert.equal(typeof stats, 'undefined');
-      db.close(done);
+      done();
     });
   });
 });

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -49,7 +49,6 @@ describe('model middleware', function() {
       next();
     });
 
-    const db = start();
     const TestMiddleware = db.model('TestPostSaveMiddleware', schema);
 
     const test = new TestMiddleware({title: 'Little Green Running Hood'});
@@ -58,7 +57,6 @@ describe('model middleware', function() {
       assert.ifError(err);
       assert.equal(test.title, 'Little Green Running Hood');
       assert.equal(called, 3);
-      db.close();
       done();
     });
   });
@@ -150,12 +148,11 @@ describe('model middleware', function() {
       next();
     });
 
-    var db = start();
     var Book = db.model('gh2462', schema);
 
     Book.create({}, function() {
       assert.equal(count, 2);
-      db.close(done);
+      done();
     });
   });
 
@@ -182,8 +179,7 @@ describe('model middleware', function() {
 
     mongoose.model('TestMiddleware', schema);
 
-    var db = start(),
-        TestMiddleware = db.model('TestMiddleware');
+    var TestMiddleware = db.model('TestMiddleware');
 
     var test = new TestMiddleware();
 
@@ -197,7 +193,6 @@ describe('model middleware', function() {
         assert.equal(called, 2);
 
         test.remove(function(err) {
-          db.close();
           assert.ifError(err);
           assert.equal(called, 3);
           done();
@@ -225,8 +220,7 @@ describe('model middleware', function() {
 
     mongoose.model('TestPostInitMiddleware', schema);
 
-    var db = start(),
-        Test = db.model('TestPostInitMiddleware');
+    var Test = db.model('TestPostInitMiddleware');
 
     var test = new Test({title: 'banana'});
 
@@ -238,7 +232,6 @@ describe('model middleware', function() {
         assert.equal(preinit, 1);
         assert.equal(postinit, 1);
         test.remove(function() {
-          db.close();
           done();
         });
       });
@@ -271,7 +264,6 @@ describe('model middleware', function() {
       next();
     });
 
-    var db = start();
     var Parent = db.model('gh-1829', parentSchema, 'gh-1829');
 
     var parent = new Parent({
@@ -297,7 +289,6 @@ describe('model middleware', function() {
         assert.equal(childPreCallsByName.Jacen, 2);
 
         assert.equal(parentPreCalls, 2);
-        db.close();
         done();
       });
     });
@@ -382,8 +373,7 @@ describe('model middleware', function() {
       ++postRemove;
     });
 
-    var db = start(),
-        Test = db.model('TestPostValidateMiddleware', schema);
+    var Test = db.model('TestPostValidateMiddleware', schema);
 
     var test = new Test({title: 'banana'});
 
@@ -394,7 +384,6 @@ describe('model middleware', function() {
       assert.equal(preRemove, 0);
       assert.equal(postRemove, 0);
       test.remove(function(err) {
-        db.close();
         assert.ifError(err);
         assert.equal(preValidate, 1);
         assert.equal(postValidate, 1);

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -160,8 +160,8 @@ describe('model query casting', function() {
 
   it('casts $nin values of arrays (gh-232)', function(done) {
     var NinSchema = new Schema({
-          num: Number
-        });
+      num: Number
+    });
 
     mongoose.model('Nin', NinSchema);
 

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -22,6 +22,7 @@ describe('model query casting', function() {
   var geoSchemaArray;
   var geoSchemaObject;
   var modelName;
+  var db;
 
   before(function() {
     Comments = new Schema;
@@ -59,11 +60,16 @@ describe('model query casting', function() {
     geoSchemaArray = new Schema({loc: {type: [Number], index: '2d'}});
     geoSchemaObject = new Schema({loc: {long: Number, lat: Number}});
     geoSchemaObject.index({loc: '2d'});
+
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('works', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection),
+    var BlogPostB = db.model(modelName, collection),
         title = 'Loki ' + random();
 
     var post = new BlogPostB(),
@@ -77,25 +83,23 @@ describe('model query casting', function() {
       BlogPostB.findOne({_id: id}, function(err, doc) {
         assert.ifError(err);
         assert.equal(doc.get('title'), title);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('returns cast errors', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
 
     BlogPostB.find({date: 'invalid date'}, function(err) {
       assert.ok(err instanceof Error);
       assert.ok(err instanceof CastError);
-      db.close(done);
+      done();
     });
   });
 
   it('casts $modifiers', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection),
+    var BlogPostB = db.model(modelName, collection),
         post = new BlogPostB({
           meta: {
             visitors: -75
@@ -113,14 +117,13 @@ describe('model query casting', function() {
           assert.equal(found.length, 1);
           assert.equal(found[0].get('_id').toString(), post.get('_id'));
           assert.equal(found[0].get('meta.visitors').valueOf(), post.get('meta.visitors').valueOf());
-          db.close(done);
+          done();
         });
     });
   });
 
   it('casts $in values of arrays (gh-199)', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
 
     var post = new BlogPostB(),
         id = post._id.toString();
@@ -132,14 +135,13 @@ describe('model query casting', function() {
         assert.ifError(err);
 
         assert.equal(doc._id.toString(), id);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('casts $in values of arrays with single item instead of array (jrl-3238)', function(done) {
-    var db = start(),
-        BlogPostB = db.model(modelName, collection);
+    var BlogPostB = db.model(modelName, collection);
 
     var post = new BlogPostB(),
         id = post._id.toString();
@@ -151,15 +153,13 @@ describe('model query casting', function() {
         assert.ifError(err);
 
         assert.equal(doc._id.toString(), id);
-        db.close();
         done();
       });
     });
   });
 
   it('casts $nin values of arrays (gh-232)', function(done) {
-    var db = start(),
-        NinSchema = new Schema({
+    var NinSchema = new Schema({
           num: Number
         });
 
@@ -176,7 +176,7 @@ describe('model query casting', function() {
           Nin.find({num: {$nin: [2]}}, function(err, found) {
             assert.ifError(err);
             assert.equal(found.length, 2);
-            db.close(done);
+            done();
           });
         });
       });
@@ -184,8 +184,7 @@ describe('model query casting', function() {
   });
 
   it('works when finding by Date (gh-204)', function(done) {
-    var db = start(),
-        P = db.model(modelName, collection);
+    var P = db.model(modelName, collection);
 
     var post = new P;
 
@@ -204,7 +203,7 @@ describe('model query casting', function() {
           P.findById(doc._id, function(err, doc) {
             assert.ifError(err);
             assert.strictEqual(doc.meta.date, null);
-            db.close(done);
+            done();
           });
         });
       });
@@ -212,7 +211,6 @@ describe('model query casting', function() {
   });
 
   it('works with $type matching', function(done) {
-    var db = start();
     var B = db.model(modelName, collection);
 
     B.find({title: {$type: {x:1}}}, function(err) {
@@ -221,14 +219,13 @@ describe('model query casting', function() {
       B.find({title: {$type: 2}}, function(err, posts) {
         assert.ifError(err);
         assert.strictEqual(Array.isArray(posts), true);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('works when finding Boolean with $in (gh-998)', function(done) {
-    var db = start(),
-        B = db.model(modelName, collection);
+    var B = db.model(modelName, collection);
 
     var b = new B({published: true});
     b.save(function(err) {
@@ -237,14 +234,13 @@ describe('model query casting', function() {
         assert.ifError(err);
         assert.ok(doc);
         assert.equal(doc[0].id, b.id);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('works when finding Boolean with $ne (gh-1093)', function(done) {
-    var db = start(),
-        B = db.model(modelName, collection + random());
+    var B = db.model(modelName, collection + random());
 
     var b = new B({published: false});
     b.save(function(err) {
@@ -253,26 +249,24 @@ describe('model query casting', function() {
         assert.ifError(err);
         assert.ok(doc);
         assert.equal(doc[0].id, b.id);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('properly casts $and (gh-1180)', function(done) {
-    var db = start(),
-        B = db.model(modelName, collection + random()),
+    var B = db.model(modelName, collection + random()),
         result = B.find({}).cast(B, {$and: [{date: '1987-03-17T20:00:00.000Z'}, {_id: '000000000000000000000000'}]});
     assert.ok(result.$and[0].date instanceof Date);
     assert.ok(result.$and[1]._id instanceof DocumentObjectId);
-    db.close(done);
+    done();
   });
 
   describe('$near', function() {
     this.slow(60);
 
     it('with arrays', function(done) {
-      var db = start(),
-          Test = db.model('Geo4', geoSchemaArray, 'y' + random());
+      var Test = db.model('Geo4', geoSchemaArray, 'y' + random());
 
       Test.once('index', complete);
       Test.create({loc: [10, 20]}, {loc: [40, 90]}, complete);
@@ -284,7 +278,6 @@ describe('model query casting', function() {
           return;
         }
         if (err) {
-          db.close();
           return done(complete.ran = err);
         }
         --pending || test();
@@ -292,7 +285,6 @@ describe('model query casting', function() {
 
       function test() {
         Test.find({loc: {$near: ['30', '40']}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 2);
           done();
@@ -301,8 +293,7 @@ describe('model query casting', function() {
     });
 
     it('with objects', function(done) {
-      var db = start(),
-          Test = db.model('Geo5', geoSchemaObject, 'y' + random());
+      var Test = db.model('Geo5', geoSchemaObject, 'y' + random());
 
       var pending = 2;
 
@@ -311,7 +302,6 @@ describe('model query casting', function() {
           return;
         }
         if (err) {
-          db.close();
           return done(complete.ran = err);
         }
         --pending || test();
@@ -319,7 +309,6 @@ describe('model query casting', function() {
 
       function test() {
         Test.find({loc: {$near: ['30', '40'], $maxDistance: 51}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 2);
           done();
@@ -331,7 +320,6 @@ describe('model query casting', function() {
     });
 
     it('with nested objects', function(done) {
-      var db = start();
       var geoSchemaObject = new Schema({loc: {nested: {long: Number, lat: Number}}});
       geoSchemaObject.index({'loc.nested': '2d'});
 
@@ -344,7 +332,6 @@ describe('model query casting', function() {
           return;
         }
         if (err) {
-          db.close();
           return done(complete.ran = err);
         }
         --pending || test();
@@ -352,7 +339,6 @@ describe('model query casting', function() {
 
       function test() {
         Test.find({'loc.nested': {$near: ['30', '40'], $maxDistance: '50'}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 1);
           done();
@@ -371,8 +357,7 @@ describe('model query casting', function() {
     this.slow(70);
 
     it('with arrays', function(done) {
-      var db = start(),
-          Test = db.model('Geo4', geoSchemaArray, 'y' + random());
+      var Test = db.model('Geo4', geoSchemaArray, 'y' + random());
 
       var pending = 2;
 
@@ -391,7 +376,6 @@ describe('model query casting', function() {
 
       function test() {
         Test.find({loc: {$nearSphere: ['30', '40']}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 2);
           done();
@@ -400,8 +384,7 @@ describe('model query casting', function() {
     });
 
     it('with objects', function(done) {
-      var db = start(),
-          Test = db.model('Geo5', geoSchemaObject, 'y' + random());
+      var Test = db.model('Geo5', geoSchemaObject, 'y' + random());
 
       var pending = 2;
 
@@ -420,7 +403,6 @@ describe('model query casting', function() {
 
       function test() {
         Test.find({loc: {$nearSphere: ['30', '40'], $maxDistance: 1}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 2);
           done();
@@ -429,7 +411,6 @@ describe('model query casting', function() {
     });
 
     it('with nested objects', function(done) {
-      var db = start();
       var geoSchemaObject = new Schema({loc: {nested: {long: Number, lat: Number}}});
       geoSchemaObject.index({'loc.nested': '2d'});
 
@@ -452,7 +433,6 @@ describe('model query casting', function() {
 
       function test() {
         Test.find({'loc.nested': {$nearSphere: ['30', '40'], $maxDistance: 1}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 2);
           done();
@@ -466,8 +446,7 @@ describe('model query casting', function() {
 
     describe('$centerSphere', function() {
       it('with arrays', function(done) {
-        var db = start(),
-            Test = db.model('Geo4', geoSchemaArray, 'y' + random());
+        var Test = db.model('Geo4', geoSchemaArray, 'y' + random());
 
         var pending = 2;
 
@@ -486,7 +465,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$centerSphere: [['11', '20'], '0.4']}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -495,8 +473,7 @@ describe('model query casting', function() {
       });
 
       it('with objects', function(done) {
-        var db = start(),
-            Test = db.model('Geo5', geoSchemaObject, 'y' + random());
+        var Test = db.model('Geo5', geoSchemaObject, 'y' + random());
 
         var pending = 2;
 
@@ -515,7 +492,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$centerSphere: [['11', '20'], '0.4']}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -524,7 +500,6 @@ describe('model query casting', function() {
       });
 
       it('with nested objects', function(done) {
-        var db = start();
         var geoSchemaObject = new Schema({loc: {nested: {long: Number, lat: Number}}});
         geoSchemaObject.index({'loc.nested': '2d'});
 
@@ -547,7 +522,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({'loc.nested': {$within: {$centerSphere: [['11', '20'], '0.4']}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -558,8 +532,7 @@ describe('model query casting', function() {
 
     describe('$center', function() {
       it('with arrays', function(done) {
-        var db = start(),
-            Test = db.model('Geo4', geoSchemaArray, 'y' + random());
+        var Test = db.model('Geo4', geoSchemaArray, 'y' + random());
 
         var pending = 2;
 
@@ -578,7 +551,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$center: [['11', '20'], '1']}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -587,8 +559,7 @@ describe('model query casting', function() {
       });
 
       it('with objects', function(done) {
-        var db = start(),
-            Test = db.model('Geo5', geoSchemaObject, 'y' + random());
+        var Test = db.model('Geo5', geoSchemaObject, 'y' + random());
 
         var pending = 2;
 
@@ -607,7 +578,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$center: [['11', '20'], '1']}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -616,7 +586,6 @@ describe('model query casting', function() {
       });
 
       it('with nested objects', function(done) {
-        var db = start();
         var geoSchemaObject = new Schema({loc: {nested: {long: Number, lat: Number}}});
         geoSchemaObject.index({'loc.nested': '2d'});
 
@@ -639,7 +608,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({'loc.nested': {$within: {$center: [['11', '20'], '1']}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -650,8 +618,7 @@ describe('model query casting', function() {
 
     describe('$polygon', function() {
       it('with arrays', function(done) {
-        var db = start(),
-            Test = db.model('Geo4', geoSchemaArray, 'y' + random());
+        var Test = db.model('Geo4', geoSchemaArray, 'y' + random());
 
         var pending = 2;
 
@@ -670,7 +637,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$polygon: [['8', '1'], ['8', '100'], ['50', '100'], ['50', '1']]}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 2);
             done();
@@ -679,8 +645,7 @@ describe('model query casting', function() {
       });
 
       it('with objects', function(done) {
-        var db = start(),
-            Test = db.model('Geo5', geoSchemaObject, 'y' + random());
+        var Test = db.model('Geo5', geoSchemaObject, 'y' + random());
 
         var pending = 2;
 
@@ -699,7 +664,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$polygon: [['8', '1'], ['8', '100'], ['50', '100'], ['50', '1']]}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 2);
             done();
@@ -708,7 +672,6 @@ describe('model query casting', function() {
       });
 
       it('with nested objects', function(done) {
-        var db = start();
         var geoSchemaObject = new Schema({loc: {nested: {long: Number, lat: Number}}});
         geoSchemaObject.index({'loc.nested': '2d'});
 
@@ -731,7 +694,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({'loc.nested': {$within: {$polygon: [['8', '1'], ['8', '100'], ['50', '100'], ['50', '1']]}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 2);
             done();
@@ -742,8 +704,7 @@ describe('model query casting', function() {
 
     describe('$box', function() {
       it('with arrays', function(done) {
-        var db = start(),
-            Test = db.model('Geo4', geoSchemaArray, 'y' + random());
+        var Test = db.model('Geo4', geoSchemaArray, 'y' + random());
 
         var pending = 2;
 
@@ -762,7 +723,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$box: [['8', '1'], ['50', '100']]}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 2);
             done();
@@ -771,8 +731,7 @@ describe('model query casting', function() {
       });
 
       it('with objects', function(done) {
-        var db = start(),
-            Test = db.model('Geo5', geoSchemaObject, 'y' + random());
+        var Test = db.model('Geo5', geoSchemaObject, 'y' + random());
 
         var pending = 2;
 
@@ -791,7 +750,6 @@ describe('model query casting', function() {
 
         function test() {
           Test.find({loc: {$within: {$box: [['8', '1'], ['50', '100']]}}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 2);
             done();
@@ -800,7 +758,6 @@ describe('model query casting', function() {
       });
 
       it('with nested objects', function(done) {
-        var db = start();
         var geoSchemaObject = new Schema({loc: {nested: {long: Number, lat: Number}}});
         geoSchemaObject.index({'loc.nested': '2d'});
 
@@ -825,7 +782,7 @@ describe('model query casting', function() {
           Test.find({'loc.nested': {$within: {$box: [['8', '1'], ['50', '100']]}}}, function(err, docs) {
             assert.ifError(err);
             assert.equal(docs.length, 2);
-            db.close(done);
+            done();
           });
         }
       });
@@ -839,19 +796,17 @@ describe('model query casting', function() {
         return 'img';
       };
 
-      var db = start(),
-          B = db.model(modelName, collection + random()),
+      var B = db.model(modelName, collection + random()),
           result = B.find({}).cast(B, {tags: {$regex: /a/, $options: opts}});
 
       assert.equal(result.tags.$options, 'img');
-      db.close(done);
+      done();
     });
   });
 
   describe('$elemMatch', function() {
     it('should cast String to ObjectId in $elemMatch', function(done) {
-      var db = start(),
-          BlogPostB = db.model(modelName, collection);
+      var BlogPostB = db.model(modelName, collection);
 
       var commentId = mongoose.Types.ObjectId(111);
 
@@ -864,14 +819,13 @@ describe('model query casting', function() {
           assert.ifError(err);
 
           assert.equal(doc._id.toString(), id);
-          db.close(done);
+          done();
         });
       });
     });
 
     it('should cast String to ObjectId in $elemMatch inside $not', function(done) {
-      var db = start(),
-          BlogPostB = db.model(modelName, collection);
+      var BlogPostB = db.model(modelName, collection);
 
       var commentId = mongoose.Types.ObjectId(111);
 
@@ -884,14 +838,12 @@ describe('model query casting', function() {
           assert.ifError(err);
 
           assert.equal(doc, null);
-          db.close(done);
+          done();
         });
       });
     });
 
     it('should cast subdoc _id typed as String to String in $elemMatch gh3719', function(done) {
-      var db = start();
-
       var child = new Schema({
         _id: {type: String}
       }, {_id: false});
@@ -914,14 +866,12 @@ describe('model query casting', function() {
           assert.ifError(error);
 
           assert.equal(docs.length, 1);
-          db.close(done);
+          done();
         });
       }
     });
 
     it('should cast subdoc _id typed as String to String in $elemMatch inside $not gh3719', function(done) {
-      var db = start();
-
       var child = new Schema({
         _id: {type: String}
       }, {_id: false});
@@ -944,15 +894,13 @@ describe('model query casting', function() {
           assert.ifError(error);
 
           assert.equal(docs.length, 0);
-          db.close(done);
+          done();
         });
       }
     });
   });
 
   it('works with $all (gh-3394)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh3394', {tags: [ObjectId]});
 
     var doc = {
@@ -965,14 +913,12 @@ describe('model query casting', function() {
       MyModel.findOne({tags: {$all: doc.tags}}, function(error, doc) {
         assert.ifError(error);
         assert.ok(doc);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('date with $not + $type (gh-4632)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh4632', { test: Date });
 
     MyModel.find({ test: { $not: { $type: 9 } } }, function(error) {
@@ -982,8 +928,6 @@ describe('model query casting', function() {
   });
 
   it('setOnInsert with custom type (gh-5126)', function(done) {
-    var db = start();
-
     function Point(key, options) {
       mongoose.SchemaType.call(this, key, options, 'Point');
     }
@@ -1021,8 +965,6 @@ describe('model query casting', function() {
   });
 
   it('lowercase in query (gh-4569)', function(done) {
-    var db = start();
-
     var contexts = [];
 
     var testSchema = new Schema({
@@ -1063,8 +1005,6 @@ describe('model query casting', function() {
   });
 
   it('runSettersOnQuery only once on find (gh-5434)', function(done) {
-    var db = start();
-
     var vs = [];
     var UserSchema = new mongoose.Schema({
       name: String,
@@ -1098,8 +1038,6 @@ describe('model query casting', function() {
   });
 
   it('runSettersOnQuery as query option (gh-5350)', function(done) {
-    var db = start();
-
     var contexts = [];
 
     var testSchema = new Schema({
@@ -1132,8 +1070,6 @@ describe('model query casting', function() {
   });
 
   it('_id = 0 (gh-4610)', function(done) {
-    var db = start();
-
     var MyModel = db.model('gh4610', { _id: Number });
 
     MyModel.create({ _id: 0 }, function(error) {
@@ -1148,8 +1084,6 @@ describe('model query casting', function() {
   });
 
   it('minDistance (gh-4197)', function(done) {
-    var db = start();
-
     var schema = new Schema({
       name: String,
       loc: {

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -18,6 +18,7 @@ describe('model: querying:', function() {
   var collection;
   var ModSchema;
   var geoSchema;
+  var db;
 
   before(function() {
     Comments = new Schema;
@@ -56,6 +57,7 @@ describe('model: querying:', function() {
       str: String
     });
     mongoose.model('Mod', ModSchema);
+    db = start();
 
     geoSchema = new Schema({loc: {type: [Number], index: '2d'}});
   });
@@ -74,9 +76,12 @@ describe('model: querying:', function() {
     });
   });
 
+  after(function(done) {
+    db.close(done);
+  });
+
   it('find returns a Query', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection);
+    var BlogPostB = db.model('BlogPostB', collection);
 
     // query
     assert.ok(BlogPostB.find({}) instanceof Query);
@@ -93,12 +98,11 @@ describe('model: querying:', function() {
     // query, fields (null), options
     assert.ok(BlogPostB.find({}, null, {}) instanceof Query);
 
-    db.close(done);
+    done();
   });
 
   it('findOne returns a Query', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection);
+    var BlogPostB = db.model('BlogPostB', collection);
 
     // query
     assert.ok(BlogPostB.findOne({}) instanceof Query);
@@ -115,23 +119,21 @@ describe('model: querying:', function() {
     // query, fields (null), options
     assert.ok(BlogPostB.findOne({}, null, {}) instanceof Query);
 
-    db.close(done);
+    done();
   });
 
   it('an empty find does not hang', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection);
+    var BlogPostB = db.model('BlogPostB', collection);
 
     function fn() {
-      db.close(done);
+      done();
     }
 
     BlogPostB.find({}, fn);
   });
 
   it('a query is executed when a callback is passed', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection),
+    var BlogPostB = db.model('BlogPostB', collection),
         count = 5,
         q = {_id: new DocumentObjectId}; // make sure the query is fast
 
@@ -139,7 +141,7 @@ describe('model: querying:', function() {
       if (--count) {
         return;
       }
-      db.close(done);
+      done();
     }
 
     // query
@@ -159,8 +161,7 @@ describe('model: querying:', function() {
   });
 
   it('query is executed where a callback for findOne', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection),
+    var BlogPostB = db.model('BlogPostB', collection),
         count = 5,
         q = {_id: new DocumentObjectId}; // make sure the query is fast
 
@@ -168,7 +169,6 @@ describe('model: querying:', function() {
       if (--count) {
         return;
       }
-      db.close();
       done();
     }
 
@@ -190,23 +190,19 @@ describe('model: querying:', function() {
 
   describe('count', function() {
     it('returns a Query', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
       assert.ok(BlogPostB.count({}) instanceof Query);
-      db.close();
       done();
     });
 
     it('Query executes when you pass a callback', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           pending = 2;
 
       function fn() {
         if (--pending) {
           return;
         }
-        db.close();
         done();
       }
 
@@ -215,8 +211,7 @@ describe('model: querying:', function() {
     });
 
     it('counts documents', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Wooooot ' + random();
 
       var post = new BlogPostB();
@@ -237,7 +232,6 @@ describe('model: querying:', function() {
             assert.equal(typeof count, 'number');
             assert.equal(count, 2);
 
-            db.close();
             done();
           });
         });
@@ -247,16 +241,13 @@ describe('model: querying:', function() {
 
   describe('distinct', function() {
     it('returns a Query', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       assert.ok(BlogPostB.distinct('title', {}) instanceof Query);
-      db.close();
       done();
     });
 
     it('executes when you pass a callback', function(done) {
-      var db = start();
       var Address = new Schema({zip: String});
       Address = db.model('Address', Address, 'addresses_' + random());
 
@@ -267,14 +258,13 @@ describe('model: querying:', function() {
           assert.equal(results.length, 2);
           assert.ok(results.indexOf('10010') > -1);
           assert.ok(results.indexOf('99701') > -1);
-          db.close(done);
+          done();
         });
         assert.ok(query instanceof Query);
       });
     });
 
     it('permits excluding conditions gh-1541', function(done) {
-      var db = start();
       var Address = new Schema({zip: String});
       Address = db.model('Address', Address, 'addresses_' + random());
       Address.create({zip: '10010'}, {zip: '10010'}, {zip: '99701'}, function(err) {
@@ -284,7 +274,7 @@ describe('model: querying:', function() {
           assert.equal(results.length, 2);
           assert.ok(results.indexOf('10010') > -1);
           assert.ok(results.indexOf('99701') > -1);
-          db.close(done);
+          done();
         });
       });
     });
@@ -292,25 +282,21 @@ describe('model: querying:', function() {
 
   describe('update', function() {
     it('returns a Query', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       assert.ok(BlogPostB.update({}, {}) instanceof Query);
       assert.ok(BlogPostB.update({}, {}, {}) instanceof Query);
-      db.close();
       done();
     });
 
     it('Query executes when you pass a callback', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           count = 2;
 
       function fn() {
         if (--count) {
           return;
         }
-        db.close();
         done();
       }
 
@@ -319,7 +305,6 @@ describe('model: querying:', function() {
     });
 
     it('can handle minimize option (gh-3381)', function() {
-      var db = start();
       var Model = db.model('gh3381', {
         name: String,
         mixed: Schema.Types.Mixed
@@ -330,10 +315,8 @@ describe('model: querying:', function() {
         then(() => Model.collection.findOne()).
         then(doc => {
           assert.ok(doc.mixed == null);
-          db.close();
         }).
         catch(err => {
-          db.close();
           throw err;
         });
     });
@@ -341,8 +324,7 @@ describe('model: querying:', function() {
 
   describe('findOne', function() {
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Wooooot ' + random();
 
       var post = new BlogPostB();
@@ -356,15 +338,13 @@ describe('model: querying:', function() {
           assert.equal(title, doc.get('title'));
           assert.equal(doc.isNew, false);
 
-          db.close();
           done();
         });
       });
     });
 
     it('casts $modifiers', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           post = new BlogPostB({
             meta: {
               visitors: -10
@@ -381,15 +361,13 @@ describe('model: querying:', function() {
           assert.equal(found.get('meta.visitors').valueOf(), post.get('meta.visitors').valueOf());
           found.id; // trigger caching
           assert.equal(found.get('_id').toString(), post.get('_id'));
-          db.close();
           done();
         });
       });
     });
 
     it('querying if an array contains one of multiple members $in a set', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       var post = new BlogPostB();
 
@@ -405,7 +383,6 @@ describe('model: querying:', function() {
           BlogPostB.findOne({_id: post._id, tags: /otba/i}, function(err, doc) {
             assert.ifError(err);
             assert.equal(doc._id.toString(), post._id);
-            db.close();
             done();
           });
         });
@@ -413,8 +390,7 @@ describe('model: querying:', function() {
     });
 
     it('querying if an array contains one of multiple members $in a set 2', function(done) {
-      var db = start(),
-          BlogPostA = db.model('BlogPostB', collection);
+      var BlogPostA = db.model('BlogPostB', collection);
 
       var post = new BlogPostA({tags: ['gooberOne']});
 
@@ -447,14 +423,12 @@ describe('model: querying:', function() {
         if (--pending) {
           return;
         }
-        db.close();
         done();
       }
     });
 
     it('querying via $where a string', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({title: 'Steve Jobs', author: 'Steve Jobs'}, function(err, created) {
         assert.ifError(err);
@@ -463,15 +437,13 @@ describe('model: querying:', function() {
           assert.ifError(err);
 
           assert.equal(found._id.toString(), created._id);
-          db.close();
           done();
         });
       });
     });
 
     it('querying via $where a function', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({author: 'Atari', slug: 'Atari'}, function(err, created) {
         assert.ifError(err);
@@ -484,15 +456,13 @@ describe('model: querying:', function() {
           assert.ifError(err);
 
           assert.equal(found._id.toString(), created._id);
-          db.close();
           done();
         });
       });
     });
 
     it('based on nested fields', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           post = new BlogPostB({
             meta: {
               visitors: 5678
@@ -507,15 +477,13 @@ describe('model: querying:', function() {
           assert.equal(found.get('meta.visitors')
             .valueOf(), post.get('meta.visitors').valueOf());
           assert.equal(found.get('_id').toString(), post.get('_id'));
-          db.close();
           done();
         });
       });
     });
 
     it('based on embedded doc fields (gh-242, gh-463)', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({comments: [{title: 'i should be queryable'}], numbers: [1, 2, 33333], tags: ['yes', 'no']}, function(err, created) {
         assert.ifError(err);
@@ -535,7 +503,6 @@ describe('model: querying:', function() {
               BlogPostB.findOne({'tags.1': 'no'}, function(err, found) {
                 assert.ifError(err);
                 assert.equal(found._id.toString(), created._id);
-                db.close();
                 done();
               });
             });
@@ -545,14 +512,12 @@ describe('model: querying:', function() {
     });
 
     it('works with nested docs and string ids (gh-389)', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({comments: [{title: 'i should be queryable by _id'}, {title: 'me too me too!'}]}, function(err, created) {
         assert.ifError(err);
         var id = created.comments[1]._id.toString();
         BlogPostB.findOne({'comments._id': id}, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.strictEqual(!!found, true, 'Find by nested doc id hex string fails');
           assert.equal(found._id.toString(), created._id);
@@ -562,8 +527,7 @@ describe('model: querying:', function() {
     });
 
     it('using #all with nested #elemMatch', function(done) {
-      var db = start(),
-          P = db.model('BlogPostB', collection + '_nestedElemMatch');
+      var P = db.model('BlogPostB', collection + '_nestedElemMatch');
 
       var post = new P({title: 'nested elemMatch'});
       post.comments.push({title: 'comment A'}, {title: 'comment B'}, {title: 'comment C'});
@@ -578,7 +542,6 @@ describe('model: querying:', function() {
         var query1 = {$elemMatch: {_id: id2.toString(), title: 'comment C'}};
 
         P.findOne({comments: {$all: [query0, query1]}}, function(err, p) {
-          db.close();
           assert.ifError(err);
           assert.equal(p.id, post.id);
           done();
@@ -587,8 +550,7 @@ describe('model: querying:', function() {
     });
 
     it('using #or with nested #elemMatch', function(done) {
-      var db = start(),
-          P = db.model('BlogPostB', collection);
+      var P = db.model('BlogPostB', collection);
 
       var post = new P({title: 'nested elemMatch'});
       post.comments.push({title: 'comment D'}, {title: 'comment E'}, {title: 'comment F'});
@@ -602,7 +564,6 @@ describe('model: querying:', function() {
         var query1 = {comments: {$elemMatch: {_id: id1.toString(), title: 'comment E'}}};
 
         P.findOne({$or: [query0, query1]}, function(err, p) {
-          db.close();
           assert.ifError(err);
           assert.equal(p.id, post.id);
           done();
@@ -611,8 +572,7 @@ describe('model: querying:', function() {
     });
 
     it('buffer $in array', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({
         sigs: [new Buffer([1, 2, 3]),
@@ -627,7 +587,6 @@ describe('model: querying:', function() {
           var query = {sigs: {'$in': [new Buffer([3, 3, 3]), new Buffer([4, 5, 6])]}};
           BlogPostB.findOne(query, function(err) {
             assert.ifError(err);
-            db.close();
             done();
           });
         });
@@ -635,8 +594,7 @@ describe('model: querying:', function() {
     });
 
     it('regex with Array (gh-599)', function(done) {
-      var db = start(),
-          B = db.model('BlogPostB', random());
+      var B = db.model('BlogPostB', random());
 
       B.create({tags: 'wooof baaaark meeeeow'.split(' ')}, function(err) {
         assert.ifError(err);
@@ -646,7 +604,6 @@ describe('model: querying:', function() {
           assert.ok(!!~doc.tags.indexOf('meeeeow'));
 
           B.findOne({tags: {$regex: 'eow$'}}, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.strictEqual(true, !!doc);
             assert.strictEqual(true, !!~doc.tags.indexOf('meeeeow'));
@@ -657,14 +614,12 @@ describe('model: querying:', function() {
     });
 
     it('regex with options', function(done) {
-      var db = start(),
-          B = db.model('BlogPostB', collection);
+      var B = db.model('BlogPostB', collection);
 
       var post = new B({title: '$option queries'});
       post.save(function(err) {
         assert.ifError(err);
         B.findOne({title: {$regex: ' QUERIES$', $options: 'i'}}, function(err, doc) {
-          db.close();
           assert.strictEqual(null, err, err && err.stack);
           assert.equal(doc.id, post.id);
           done();
@@ -673,15 +628,13 @@ describe('model: querying:', function() {
     });
 
     it('works with $elemMatch and $in combo (gh-1100)', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           id1 = new DocumentObjectId,
           id2 = new DocumentObjectId;
 
       BlogPostB.create({owners: [id1, id2]}, function(err, created) {
         assert.ifError(err);
         BlogPostB.findOne({owners: {'$elemMatch': {$in: [id2.toString()]}}}, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.ok(found);
           assert.equal(created.id, found.id);
@@ -693,8 +646,7 @@ describe('model: querying:', function() {
 
   describe('findById', function() {
     it('handles undefined', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Edwald ' + random();
 
       var post = new BlogPostB();
@@ -706,14 +658,13 @@ describe('model: querying:', function() {
         BlogPostB.findById(undefined, function(err, doc) {
           assert.ifError(err);
           assert.equal(doc, null);
-          db.close(done);
+          done();
         });
       });
     });
 
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Edwald ' + random();
 
       var post = new BlogPostB();
@@ -731,7 +682,6 @@ describe('model: querying:', function() {
           if (--pending) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -742,15 +692,13 @@ describe('model: querying:', function() {
           if (--pending) {
             return;
           }
-          db.close();
           done();
         });
       });
     });
 
     it('works with partial initialization', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           queries = 5;
 
       var post = new BlogPostB();
@@ -775,7 +723,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -790,7 +737,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -805,7 +751,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -820,7 +765,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -835,15 +779,13 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
       });
     });
 
     it('querying if an array contains at least a certain single member (gh-220)', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       var post = new BlogPostB();
 
@@ -855,7 +797,6 @@ describe('model: querying:', function() {
         BlogPostB.findOne({tags: 'cat'}, function(err, doc) {
           assert.ifError(err);
           assert.equal(doc._id.toString(), post._id);
-          db.close();
           done();
         });
       });
@@ -863,8 +804,7 @@ describe('model: querying:', function() {
 
 
     it('where an array where the $slice operator', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({numbers: [500, 600, 700, 800]}, function(err, created) {
         assert.ifError(err);
@@ -886,7 +826,6 @@ describe('model: querying:', function() {
               assert.equal(found.numbers.length, 2);
               assert.equal(found.numbers[0], 600);
               assert.equal(found.numbers[1], 700);
-              db.close();
               done();
             });
           });
@@ -897,8 +836,7 @@ describe('model: querying:', function() {
 
   describe('find', function() {
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Wooooot ' + random();
 
       var post = new BlogPostB();
@@ -923,7 +861,6 @@ describe('model: querying:', function() {
             assert.equal(title, docs[1].get('title'));
             assert.equal(docs[1].isNew, false);
 
-            db.close();
             done();
           });
         });
@@ -931,22 +868,19 @@ describe('model: querying:', function() {
     });
 
     it('returns docs where an array that contains one specific member', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
       BlogPostB.create({numbers: [100, 101, 102]}, function(err, created) {
         assert.ifError(err);
         BlogPostB.find({numbers: 100}, function(err, found) {
           assert.ifError(err);
           assert.equal(found.length, 1);
           assert.equal(found[0]._id.toString(), created._id);
-          db.close();
           done();
         });
       });
     });
 
     it('works when comparing $ne with single value against an array', function(done) {
-      var db = start();
       var schema = new Schema({
         ids: [Schema.ObjectId],
         b: Schema.ObjectId
@@ -976,7 +910,6 @@ describe('model: querying:', function() {
                 assert.equal(err.message, 'Cast to ObjectId failed for value "4" at path "b" for model "NE_Test"');
 
                 NE.find({b: id3, ids: {$ne: id4}}, function(err, nes4) {
-                  db.close();
                   assert.ifError(err);
                   assert.equal(nes4.length, 0);
                   done();
@@ -989,8 +922,7 @@ describe('model: querying:', function() {
     });
 
     it('with partial initialization', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           queries = 4;
 
       var post = new BlogPostB();
@@ -1010,7 +942,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -1023,7 +954,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -1036,7 +966,6 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
 
@@ -1049,15 +978,13 @@ describe('model: querying:', function() {
           if (--queries) {
             return;
           }
-          db.close();
           done();
         });
       });
     });
 
     it('where $exists', function(done) {
-      var db = start(),
-          ExistsSchema = new Schema({
+      var ExistsSchema = new Schema({
             a: Number,
             b: String
           });
@@ -1069,7 +996,6 @@ describe('model: querying:', function() {
           assert.ifError(err);
           Exists.find({b: {$exists: true}}, function(err, docs) {
             assert.ifError(err);
-            db.close();
             assert.equal(docs.length, 1);
             done();
           });
@@ -1078,15 +1004,13 @@ describe('model: querying:', function() {
     });
 
     it('works with $elemMatch (gh-1100)', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           id1 = new DocumentObjectId,
           id2 = new DocumentObjectId;
 
       BlogPostB.create({owners: [id1, id2]}, function(err) {
         assert.ifError(err);
         BlogPostB.find({owners: {'$elemMatch': {$in: [id2.toString()]}}}, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.length, 1);
           done();
@@ -1095,8 +1019,7 @@ describe('model: querying:', function() {
     });
 
     it('where $mod', function(done) {
-      var db = start(),
-          Mod = db.model('Mod', 'mods_' + random());
+      var Mod = db.model('Mod', 'mods_' + random());
       Mod.create({num: 1}, function(err, one) {
         assert.ifError(err);
         Mod.create({num: 2}, function(err) {
@@ -1105,7 +1028,6 @@ describe('model: querying:', function() {
             assert.ifError(err);
             assert.equal(found.length, 1);
             assert.equal(found[0]._id.toString(), one._id);
-            db.close();
             done();
           });
         });
@@ -1113,8 +1035,7 @@ describe('model: querying:', function() {
     });
 
     it('where $not', function(done) {
-      var db = start(),
-          Mod = db.model('Mod', 'mods_' + random());
+      var Mod = db.model('Mod', 'mods_' + random());
       Mod.create({num: 1}, function(err) {
         assert.ifError(err);
         Mod.create({num: 2}, function(err, two) {
@@ -1123,7 +1044,6 @@ describe('model: querying:', function() {
             assert.ifError(err);
             assert.equal(found.length, 1);
             assert.equal(found[0]._id.toString(), two._id);
-            db.close();
             done();
           });
         });
@@ -1131,8 +1051,7 @@ describe('model: querying:', function() {
     });
 
     it('where or()', function(done) {
-      var db = start(),
-          Mod = db.model('Mod', 'mods_' + random());
+      var Mod = db.model('Mod', 'mods_' + random());
 
       Mod.create({num: 1}, {num: 2, str: 'two'}, function(err, one, two) {
         assert.ifError(err);
@@ -1199,15 +1118,13 @@ describe('model: querying:', function() {
           if (--pending) {
             return;
           }
-          db.close();
           done();
         }
       });
     });
 
     it('using $or with array of Document', function(done) {
-      var db = start(),
-          Mod = db.model('Mod', 'mods_' + random());
+      var Mod = db.model('Mod', 'mods_' + random());
 
       Mod.create({num: 1}, function(err, one) {
         assert.ifError(err);
@@ -1217,7 +1134,6 @@ describe('model: querying:', function() {
             assert.ifError(err);
             assert.equal(found.length, 1);
             assert.equal(found[0]._id.toString(), one._id);
-            db.close();
             done();
           });
         });
@@ -1225,8 +1141,7 @@ describe('model: querying:', function() {
     });
 
     it('where $ne', function(done) {
-      var db = start(),
-          Mod = db.model('Mod', 'mods_' + random());
+      var Mod = db.model('Mod', 'mods_' + random());
       Mod.create({num: 1}, function(err) {
         assert.ifError(err);
         Mod.create({num: 2}, function(err, two) {
@@ -1239,7 +1154,6 @@ describe('model: querying:', function() {
               assert.equal(found.length, 2);
               assert.equal(found[0]._id.toString(), two._id);
               assert.equal(found[1]._id.toString(), three._id);
-              db.close();
               done();
             });
           });
@@ -1248,8 +1162,7 @@ describe('model: querying:', function() {
     });
 
     it('where $nor', function(done) {
-      var db = start(),
-          Mod = db.model('Mod', 'nor_' + random());
+      var Mod = db.model('Mod', 'nor_' + random());
 
       Mod.create({num: 1}, {num: 2, str: 'two'}, function(err, one, two) {
         assert.ifError(err);
@@ -1290,14 +1203,12 @@ describe('model: querying:', function() {
           if (--pending) {
             return;
           }
-          db.close();
           done();
         }
       });
     });
 
     it('STRICT null matches', function(done) {
-      var db = start();
       var BlogPostB = db.model('BlogPostB', collection + random());
 
       var a = {title: 'A', author: null};
@@ -1305,7 +1216,6 @@ describe('model: querying:', function() {
       BlogPostB.create(a, b, function(err, createdA) {
         assert.ifError(err);
         BlogPostB.find({author: {$in: [null], $exists: true}}, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.length, 1);
           assert.equal(found[0]._id.toString(), createdA._id);
@@ -1315,15 +1225,13 @@ describe('model: querying:', function() {
     });
 
     it('null matches null and undefined', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection + random());
+      var BlogPostB = db.model('BlogPostB', collection + random());
 
       BlogPostB.create(
         {title: 'A', author: null},
         {title: 'B'}, function(err) {
           assert.ifError(err);
           BlogPostB.find({author: null}, function(err, found) {
-            db.close();
             assert.ifError(err);
             assert.equal(found.length, 2);
             done();
@@ -1332,8 +1240,7 @@ describe('model: querying:', function() {
     });
 
     it('a document whose arrays contain at least $all string values', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       var post = new BlogPostB({title: 'Aristocats'});
 
@@ -1364,7 +1271,6 @@ describe('model: querying:', function() {
                   assert.equal(docs.length, 1);
 
                   BlogPostB.findOne({tags: {'$all': /^two/}}, function(err, doc) {
-                    db.close();
                     assert.ifError(err);
                     assert.equal(post.id, doc.id);
                     done();
@@ -1378,8 +1284,7 @@ describe('model: querying:', function() {
     });
 
     it('using #nor with nested #elemMatch', function(done) {
-      var db = start(),
-          P = db.model('BlogPostB', collection + '_norWithNestedElemMatch');
+      var P = db.model('BlogPostB', collection + '_norWithNestedElemMatch');
 
       var p0 = {title: 'nested $nor elemMatch1', comments: []};
 
@@ -1395,7 +1300,6 @@ describe('model: querying:', function() {
         var query1 = {comments: {$elemMatch: {_id: id.toString(), title: 'comment Y'}}};
 
         P.find({$nor: [query0, query1]}, function(err, posts) {
-          db.close();
           assert.ifError(err);
           assert.equal(posts.length, 1);
           assert.equal(posts[0].id, post0.id);
@@ -1405,8 +1309,7 @@ describe('model: querying:', function() {
     });
 
     it('strings via regexp', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({title: 'Next to Normal'}, function(err, created) {
         assert.ifError(err);
@@ -1430,7 +1333,6 @@ describe('model: querying:', function() {
                 assert.equal(found._id.toString(), created._id);
 
                 BlogPostB.where('title').regex(/^Next/).findOne(function(err, found) {
-                  db.close();
                   assert.ifError(err);
                   assert.equal(found._id.toString(), created._id);
                   done();
@@ -1443,8 +1345,7 @@ describe('model: querying:', function() {
     });
 
     it('a document whose arrays contain at least $all values', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
       var a1 = {numbers: [-1, -2, -3, -4], meta: {visitors: 4}};
       var a2 = {numbers: [0, -1, -2, -3, -4]};
       BlogPostB.create(a1, a2, function(err, whereoutZero, whereZero) {
@@ -1458,7 +1359,6 @@ describe('model: querying:', function() {
             assert.equal(found.length, 1);
             assert.equal(found[0]._id.toString(), whereoutZero._id);
             BlogPostB.find({numbers: {$all: [0, -1]}}, function(err, found) {
-              db.close();
               assert.ifError(err);
               assert.equal(found.length, 1);
               assert.equal(found[0]._id.toString(), whereZero._id);
@@ -1470,8 +1370,7 @@ describe('model: querying:', function() {
     });
 
     it('where $size', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}, function(err) {
         assert.ifError(err);
@@ -1485,7 +1384,6 @@ describe('model: querying:', function() {
               BlogPostB.find({numbers: {$size: 11}}, function(err, found) {
                 assert.ifError(err);
                 assert.equal(found.length, 1);
-                db.close();
                 done();
               });
             });
@@ -1495,7 +1393,6 @@ describe('model: querying:', function() {
     });
 
     it('$gt, $lt, $lte, $gte work on strings', function(done) {
-      var db = start();
       var D = db.model('D', new Schema({dt: String}), collection);
 
       D.create({dt: '2011-03-30'}, cb);
@@ -1506,9 +1403,6 @@ describe('model: querying:', function() {
       var pending = 4;
 
       function cb(err) {
-        if (err) {
-          db.close();
-        }
         assert.ifError(err);
 
         if (--pending) {
@@ -1519,7 +1413,6 @@ describe('model: querying:', function() {
 
         D.find({'dt': {$gte: '2011-03-30', $lte: '2011-04-01'}}).sort('dt').exec(function(err, docs) {
           if (!--pending) {
-            db.close();
             done();
           }
           assert.ifError(err);
@@ -1534,7 +1427,6 @@ describe('model: querying:', function() {
 
         D.find({'dt': {$gt: '2011-03-30', $lt: '2011-04-02'}}).sort('dt').exec(function(err, docs) {
           if (!--pending) {
-            db.close();
             done();
           }
           assert.ifError(err);
@@ -1557,8 +1449,7 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start(),
-            blogPost = db.model('BlogPostB', collection);
+        var blogPost = db.model('BlogPostB', collection);
 
         blogPost.collection.ensureIndex({title: 'text'}, function(error) {
           assert.ifError(error);
@@ -1579,7 +1470,7 @@ describe('model: querying:', function() {
                     assert.ifError(error);
                     b.remove(function(error) {
                       assert.ifError(error);
-                      db.close(done);
+                      done();
                     });
                   });
                 });
@@ -1593,8 +1484,6 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start();
-
         var exampleSchema = new Schema({
           title: String,
           name: { type: String, text: true },
@@ -1607,7 +1496,7 @@ describe('model: querying:', function() {
           assert.ifError(error);
           Example.findOne({ $text: { $search: 'text search' } }, function(error) {
             assert.ifError(error);
-            db.close(done);
+            done();
           });
         });
       });
@@ -1616,8 +1505,7 @@ describe('model: querying:', function() {
 
   describe('limit', function() {
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({title: 'first limit'}, function(err, first) {
         assert.ifError(err);
@@ -1626,7 +1514,6 @@ describe('model: querying:', function() {
           BlogPostB.create({title: 'third limit'}, function(err) {
             assert.ifError(err);
             BlogPostB.find({title: /limit$/}).limit(2).find(function(err, found) {
-              db.close();
               assert.ifError(err);
               assert.equal(found.length, 2);
               assert.equal(found[0].id, first.id);
@@ -1641,8 +1528,7 @@ describe('model: querying:', function() {
 
   describe('skip', function() {
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({title: '1 skip'}, function(err) {
         assert.ifError(err);
@@ -1655,7 +1541,6 @@ describe('model: querying:', function() {
               assert.equal(found.length, 2);
               assert.equal(found[0].id, second._id);
               assert.equal(found[1].id, third._id);
-              db.close();
               done();
             });
           });
@@ -1666,8 +1551,7 @@ describe('model: querying:', function() {
 
   describe('sort', function() {
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.create({meta: {visitors: 100}}, function(err, least) {
         assert.ifError(err);
@@ -1684,7 +1568,6 @@ describe('model: querying:', function() {
                 assert.equal(found[0].id, largest._id);
                 assert.equal(found[1].id, middle._id);
                 assert.equal(found[2].id, least._id);
-                db.close();
                 done();
               });
           });
@@ -1696,8 +1579,7 @@ describe('model: querying:', function() {
         return done();
       }
 
-      var db = start(),
-          blogPost = db.model('BlogPostB', collection);
+      var blogPost = db.model('BlogPostB', collection);
 
       blogPost.collection.ensureIndex({title: 'text'}, function(error) {
         assert.ifError(error);
@@ -1716,7 +1598,6 @@ describe('model: querying:', function() {
                 assert.equal(documents.length, 2);
                 assert.equal(documents[0].title, 'text search in mongoose');
                 assert.equal(documents[1].title, 'searching in mongoose');
-                db.close();
                 done();
               });
           });
@@ -1727,11 +1608,9 @@ describe('model: querying:', function() {
 
   describe('nested mixed "x.y.z"', function() {
     it('works', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection);
+      var BlogPostB = db.model('BlogPostB', collection);
 
       BlogPostB.find({'mixed.nested.stuff': 'skynet'}, function(err) {
-        db.close();
         assert.ifError(err);
         done();
       });
@@ -1740,14 +1619,12 @@ describe('model: querying:', function() {
 
   it('by Date (gh-336)', function(done) {
     // GH-336
-    var db = start(),
-        Test = db.model('TestDateQuery', new Schema({date: Date}), 'datetest_' + random()),
+    var Test = db.model('TestDateQuery', new Schema({date: Date}), 'datetest_' + random()),
         now = new Date;
 
     Test.create({date: now}, {date: new Date(now - 10000)}, function(err) {
       assert.ifError(err);
       Test.find({date: now}, function(err, docs) {
-        db.close();
         assert.ifError(err);
         assert.equal(docs.length, 1);
         done();
@@ -1756,8 +1633,7 @@ describe('model: querying:', function() {
   });
 
   it('mixed types with $elemMatch (gh-591)', function(done) {
-    var db = start(),
-        S = new Schema({a: [{}], b: Number}),
+    var S = new Schema({a: [{}], b: Number}),
         M = db.model('QueryingMixedArrays', S, random());
 
     var m = new M;
@@ -1779,7 +1655,6 @@ describe('model: querying:', function() {
         };
 
         M.find(query, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs[0].a.length, 5);
           done();
@@ -1790,8 +1665,6 @@ describe('model: querying:', function() {
 
   describe('$all', function() {
     it('with ObjectIds (gh-690)', function(done) {
-      var db = start();
-
       var SSchema = new Schema({name: String});
       var PSchema = new Schema({sub: [SSchema]});
 
@@ -1814,7 +1687,6 @@ describe('model: querying:', function() {
             assert.equal(!!doc, false);
 
             P.findOne({'sub._id': {$all: [o2]}}, function(err, doc) {
-              db.close();
               assert.ifError(err);
               assert.equal(doc.id, p.id);
               done();
@@ -1826,8 +1698,6 @@ describe('model: querying:', function() {
 
     it('with Dates', function(done) {
       this.timeout(3000);
-      var db = start();
-
       var SSchema = new Schema({d: Date});
       var PSchema = new Schema({sub: [SSchema]});
 
@@ -1856,7 +1726,7 @@ describe('model: querying:', function() {
             P.findOne({'sub.d': {$all: [o2]}}, function(err, doc) {
               assert.ifError(err);
               assert.equal(doc.id, p.id);
-              db.close(done);
+              done();
             });
           });
         });
@@ -1864,8 +1734,6 @@ describe('model: querying:', function() {
     });
 
     it('with $elemMatch (gh-3163)', function(done) {
-      var db = start();
-
       start.mongodVersion(function(err, version) {
         if (err) {
           throw err;
@@ -1888,7 +1756,7 @@ describe('model: querying:', function() {
           MyModel.find(query, function(error, docs) {
             assert.ifError(error);
             assert.equal(docs.length, 1);
-            db.close(done);
+            done();
           });
         });
       };
@@ -1897,7 +1765,6 @@ describe('model: querying:', function() {
 
   describe('and', function() {
     it('works with queries gh-1188', function(done) {
-      var db = start();
       var B = db.model('BlogPostB');
 
       B.create({title: 'and operator', published: false, author: 'Me'}, function(err) {
@@ -1932,7 +1799,7 @@ describe('model: querying:', function() {
                 query.exec(function(err, docs) {
                   assert.ifError(err);
                   assert.equal(docs.length, 0);
-                  db.close(done);
+                  done();
                 });
               });
             });
@@ -1942,19 +1809,17 @@ describe('model: querying:', function() {
     });
 
     it('works with nested query selectors gh-1884', function(done) {
-      var db = start();
       var B = db.model('gh1884', {a: String, b: String}, 'gh1884');
 
       B.remove({$and: [{a: 'coffee'}, {b: {$in: ['bacon', 'eggs']}}]}, function(error) {
         assert.ifError(error);
-        db.close(done);
+        done();
       });
     });
   });
 
   it('works with different methods and query types', function(done) {
-    var db = start(),
-        BufSchema = new Schema({name: String, block: Buffer}),
+    var BufSchema = new Schema({name: String, block: Buffer}),
         Test = db.model('BufferTest', BufSchema, 'buffers');
 
     var docA = {name: 'A', block: new Buffer('über')};
@@ -1995,7 +1860,6 @@ describe('model: querying:', function() {
                     assert.equal(rb.block.toString('utf8'), 'hello world');
 
                     Test.remove({}, function(err) {
-                      db.close();
                       assert.ifError(err);
                       done();
                     });
@@ -2011,8 +1875,7 @@ describe('model: querying:', function() {
 
   it('with conditionals', function(done) {
     // $in $nin etc
-    var db = start(),
-        BufSchema = new Schema({name: String, block: Buffer}),
+    var BufSchema = new Schema({name: String, block: Buffer}),
         Test = db.model('Buffer2', BufSchema, 'buffer_' + random());
 
     var docA = {name: 'A', block: new MongooseBuffer([195, 188, 98, 101, 114])}; // über
@@ -2099,7 +1962,6 @@ describe('model: querying:', function() {
           return;
         }
         Test.remove({}, function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -2108,8 +1970,7 @@ describe('model: querying:', function() {
   });
 
   it('with previously existing null values in the db', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection),
+    var BlogPostB = db.model('BlogPostB', collection),
         post = new BlogPostB();
 
     post.collection.insert({meta: {visitors: 9898, a: null}}, {}, function(err, b) {
@@ -2118,15 +1979,13 @@ describe('model: querying:', function() {
       BlogPostB.findOne({_id: b.ops[0]._id}, function(err, found) {
         assert.ifError(err);
         assert.equal(found.get('meta.visitors').valueOf(), 9898);
-        db.close();
         done();
       });
     });
   });
 
   it('with unused values in the db', function(done) {
-    var db = start(),
-        BlogPostB = db.model('BlogPostB', collection),
+    var BlogPostB = db.model('BlogPostB', collection),
         post = new BlogPostB();
 
     post.collection.insert({meta: {visitors: 9898, color: 'blue'}}, {}, function(err, b) {
@@ -2137,7 +1996,6 @@ describe('model: querying:', function() {
         assert.equal(found.get('meta.visitors').valueOf(), 9898);
         found.save(function(err) {
           assert.ifError(err);
-          db.close();
           done();
         });
       });
@@ -2146,8 +2004,7 @@ describe('model: querying:', function() {
 
   describe('2d', function() {
     it('$near (gh-309)', function(done) {
-      var db = start(),
-          Test = db.model('Geo1', geoSchema, 'geospatial' + random());
+      var Test = db.model('Geo1', geoSchema, 'geospatial' + random());
 
       var pending = 2;
 
@@ -2166,7 +2023,6 @@ describe('model: querying:', function() {
 
       function test() {
         Test.find({loc: {$near: [30, 40]}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 2);
           done();
@@ -2175,8 +2031,7 @@ describe('model: querying:', function() {
     });
 
     it('$within arrays (gh-586)', function(done) {
-      var db = start(),
-          Test = db.model('Geo2', geoSchema, collection + 'geospatial');
+      var Test = db.model('Geo2', geoSchema, collection + 'geospatial');
 
       var pending = 2;
 
@@ -2195,7 +2050,6 @@ describe('model: querying:', function() {
 
       function test() {
         Test.find({loc: {'$within': {'$box': [[30, 40], [40, 60]]}}}, function(err, docs) {
-          db.close();
           assert.ifError(err);
           assert.equal(docs.length, 1);
           done();
@@ -2204,8 +2058,7 @@ describe('model: querying:', function() {
     });
 
     it('$nearSphere with arrays (gh-610)', function(done) {
-      var db = start(),
-          Test = db.model('Geo3', geoSchema, 'y' + random());
+      var Test = db.model('Geo3', geoSchema, 'y' + random());
 
       var pending = 2;
 
@@ -2226,7 +2079,7 @@ describe('model: querying:', function() {
         Test.find({loc: {$nearSphere: [30, 40]}}, function(err, docs) {
           assert.ifError(err);
           assert.equal(docs.length, 2);
-          db.close(done);
+          done();
         });
       }
     });
@@ -2238,8 +2091,7 @@ describe('model: querying:', function() {
           coordinates: {type: [Number], index: '2dsphere'}
         }
       });
-      var db = start(),
-          Test = db.model('gh1874', geoSchema, 'gh1874');
+      var Test = db.model('gh1874', geoSchema, 'gh1874');
 
       var pending = 2;
       var complete = function(err) {
@@ -2274,13 +2126,12 @@ describe('model: querying:', function() {
           q.cast(Test);
         });
 
-        db.close(done);
+        done();
       };
     });
 
     it('$maxDistance with arrays', function(done) {
-      var db = start(),
-          Test = db.model('Geo4', geoSchema, 'geo4');
+      var Test = db.model('Geo4', geoSchema, 'geo4');
 
       var pending = 2;
 
@@ -2303,7 +2154,6 @@ describe('model: querying:', function() {
           assert.ifError(err);
           assert.equal(docs.length, 1);
           Test.find({loc: {$near: [25, 32], $maxDistance: 1}}, function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 0);
             done();
@@ -2363,8 +2213,7 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start(),
-            Test = db.model('2dsphere-polygon', schema2dsphere, 'geospatial' + random());
+        var Test = db.model('2dsphere-polygon', schema2dsphere, 'geospatial' + random());
 
         Test.on('index', function(err) {
           assert.ifError(err);
@@ -2383,7 +2232,7 @@ describe('model: querying:', function() {
                 assert.ifError(err);
                 assert.equal(docs.length, 1);
                 assert.equal(created.id, docs[0].id);
-                db.close(done);
+                done();
               });
             });
           });
@@ -2397,8 +2246,7 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start(),
-            Test = db.model('2dsphere-geo', geoSchema, 'geospatial' + random());
+        var Test = db.model('2dsphere-geo', geoSchema, 'geospatial' + random());
 
         Test.on('index', function(err) {
           assert.ifError(err);
@@ -2416,7 +2264,7 @@ describe('model: querying:', function() {
               Test.where('line').intersects().geometry(geojsonLine).findOne(function(err, doc) {
                 assert.ifError(err);
                 assert.equal(created.id, doc.id);
-                db.close(done);
+                done();
               });
             });
           });
@@ -2428,8 +2276,7 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start(),
-            Test = db.model('2dsphere-geo-multi1', geoMultiSchema, 'geospatial' + random());
+        var Test = db.model('2dsphere-geo-multi1', geoMultiSchema, 'geospatial' + random());
 
         Test.create({
           geom: [{type: 'LineString', coordinates: [[-178.0, 10.0], [178.0, 10.0]]},
@@ -2447,7 +2294,7 @@ describe('model: querying:', function() {
             Test.where('geom').intersects().geometry(geojsonLine).findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(created.id, doc.id);
-              db.close(done);
+              done();
             });
           });
         });
@@ -2458,8 +2305,7 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start(),
-            Test = db.model('2dsphere-geo-multi2', geoMultiSchema, 'geospatial' + random());
+        var Test = db.model('2dsphere-geo-multi2', geoMultiSchema, 'geospatial' + random());
 
         Test.create({
           geom: [{type: 'Polygon', coordinates: [[[28.7, 41], [29.2, 40.9], [29.1, 41.3], [28.7, 41]]]},
@@ -2477,7 +2323,7 @@ describe('model: querying:', function() {
             Test.where('geom').intersects().geometry(geojsonPolygon).findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(created.id, doc.id);
-              db.close(done);
+              done();
             });
           });
         });
@@ -2490,8 +2336,7 @@ describe('model: querying:', function() {
           return done();
         }
 
-        var db = start(),
-            Test = db.model('2dsphere-geo', geoSchema, 'geospatial' + random());
+        var Test = db.model('2dsphere-geo', geoSchema, 'geospatial' + random());
 
         Test.on('index', function(err) {
           assert.ifError(err);
@@ -2510,7 +2355,7 @@ describe('model: querying:', function() {
                 assert.ifError(err);
                 assert.equal(docs.length, 1);
                 assert.equal(created.id, docs[0].id);
-                db.close(done);
+                done();
               });
             });
           });
@@ -2525,8 +2370,7 @@ describe('model: querying:', function() {
         var geoJSONSchema = new Schema({loc: {type: {type: String}, coordinates: [Number]}});
         geoJSONSchema.index({loc: '2dsphere'});
         var name = 'geospatial' + random();
-        var db = start(),
-            Test = db.model('Geo1', geoJSONSchema, name);
+        var Test = db.model('Geo1', geoJSONSchema, name);
 
         var pending = 2;
 
@@ -2555,7 +2399,6 @@ describe('model: querying:', function() {
               type: 'Point', coordinates: [11, 20]
             }, maxDistance: 1000000
           }).exec(function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             done();
@@ -2585,7 +2428,6 @@ describe('model: querying:', function() {
       if (!mongo24_or_greater) {
         return done();
       }
-      var db = start();
       var schemas = [];
       schemas[0] = new Schema({t: {type: String, index: 'hashed'}});
       schemas[1] = new Schema({t: {type: String, index: 'hashed', sparse: true}});
@@ -2617,7 +2459,7 @@ describe('model: querying:', function() {
 
       function complete() {
         if (--pending === 0) {
-          db.close(done);
+          done();
         }
       }
     });
@@ -2625,8 +2467,7 @@ describe('model: querying:', function() {
 
   describe('lean', function() {
     it('find', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Wooooot ' + random();
 
       var post = new BlogPostB();
@@ -2642,7 +2483,6 @@ describe('model: querying:', function() {
             assert.ifError(err);
             assert.equal(docs.length, 1);
             assert.strictEqual(docs[0] instanceof mongoose.Document, false);
-            db.close();
             done();
           });
         });
@@ -2650,8 +2490,7 @@ describe('model: querying:', function() {
     });
 
     it('findOne', function(done) {
-      var db = start(),
-          BlogPostB = db.model('BlogPostB', collection),
+      var BlogPostB = db.model('BlogPostB', collection),
           title = 'Wooooot ' + random();
 
       var post = new BlogPostB();
@@ -2660,7 +2499,6 @@ describe('model: querying:', function() {
       post.save(function(err) {
         assert.ifError(err);
         BlogPostB.findOne({title: title}, null, {lean: true}, function(err, doc) {
-          db.close();
           assert.ifError(err);
           assert.ok(doc);
           assert.strictEqual(false, doc instanceof mongoose.Document);
@@ -2709,7 +2547,6 @@ describe('model: querying:', function() {
     });
 
     it('casts $elemMatch (gh-2199)', function(done) {
-      var db = start();
       var schema = new Schema({dates: [Date]});
       var Dates = db.model('Date', schema, 'dates');
 
@@ -2722,7 +2559,7 @@ describe('model: querying:', function() {
           assert.equal(doc.dates.length, 1);
           assert.equal(doc.dates[0].getTime(),
             new Date('2014-07-01T04:00:00.000Z').getTime());
-          db.close(done);
+          done();
         });
       });
     });
@@ -2741,7 +2578,6 @@ describe('model: querying:', function() {
       });
 
       it('casts $eq (gh-2752)', function(done) {
-        var db = start();
         var BlogPostB = db.model('BlogPostB', collection);
 
         BlogPostB.findOne(
@@ -2754,7 +2590,7 @@ describe('model: querying:', function() {
             }
 
             assert.ok(!doc);
-            db.close(done);
+            done();
           });
       });
     });

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -985,9 +985,9 @@ describe('model: querying:', function() {
 
     it('where $exists', function(done) {
       var ExistsSchema = new Schema({
-            a: Number,
-            b: String
-          });
+          a: Number,
+          b: String
+      });
       mongoose.model('Exists', ExistsSchema);
       var Exists = db.model('Exists', 'exists_' + random());
       Exists.create({a: 1}, function(err) {

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -985,8 +985,8 @@ describe('model: querying:', function() {
 
     it('where $exists', function(done) {
       var ExistsSchema = new Schema({
-          a: Number,
-          b: String
+        a: Number,
+        b: String
       });
       mongoose.model('Exists', ExistsSchema);
       var Exists = db.model('Exists', 'exists_' + random());

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -135,9 +135,7 @@ describe('Model', function() {
       var B = mongoose.model('BlogPost');
       var b = B();
       assert.ok(b instanceof B);
-      var db = start();
       B = db.model('BlogPost');
-      db.close();
       b = B();
       assert.ok(b instanceof B);
       done();
@@ -146,9 +144,7 @@ describe('Model', function() {
       var B = mongoose.model('BlogPost');
       var b = new B();
       assert.ok(b instanceof B);
-      var db = start();
       B = db.model('BlogPost');
-      db.close();
       b = new B();
       assert.ok(b instanceof B);
       done();
@@ -156,18 +152,13 @@ describe('Model', function() {
   });
   describe('isNew', function() {
     it('is true on instantiation', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
-
-      db.close();
-      var post = new BlogPost;
+      var BlogPost = db.model('BlogPost', collection),
+        post = new BlogPost;
       assert.equal(post.isNew, true);
       done();
     });
 
     it('on parent and subdocs on failed inserts', function(done) {
-      var db = start();
-
       var schema = new Schema({
         name: {type: String, unique: true},
         em: [new Schema({x: Number})]
@@ -183,7 +174,6 @@ describe('Model', function() {
           assert.equal(a.em[0].isNew, false);
           var b = new A({name: 'i am new', em: [{x: 2}]});
           b.save(function(err) {
-            db.close();
             assert.ok(err);
             assert.equal(b.isNew, true);
             assert.equal(b.em[0].isNew, true);
@@ -195,7 +185,6 @@ describe('Model', function() {
   });
 
   it('gh-2140', function(done) {
-    var db = start();
     var S = new Schema({
       field: [{text: String}]
     });
@@ -206,22 +195,19 @@ describe('Model', function() {
     s.field = [{text: 'text'}];
 
     assert.ok(s.field[0]);
-    db.close(done);
+    done();
   });
 
   describe('schema', function() {
     it('should exist', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
-      db.close();
       assert.ok(BlogPost.schema instanceof Schema);
       assert.ok(BlogPost.prototype.schema instanceof Schema);
       done();
     });
     it('emits init event', function(done) {
-      var db = start(),
-          schema = new Schema({name: String}),
+      var schema = new Schema({name: String}),
           model;
 
       schema.on('init', function(model_) {
@@ -229,7 +215,6 @@ describe('Model', function() {
       });
 
       var Named = db.model('EmitInitOnSchema', schema);
-      db.close();
       assert.equal(model, Named);
       done();
     });
@@ -237,10 +222,8 @@ describe('Model', function() {
 
   describe('structure', function() {
     it('default when instantiated', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
-      db.close();
       var post = new BlogPost;
       assert.equal(post.db.model('BlogPost').modelName, 'BlogPost');
       assert.equal(post.constructor.modelName, 'BlogPost');
@@ -269,15 +252,13 @@ describe('Model', function() {
     describe('array', function() {
       describe('defaults', function() {
         it('to a non-empty array', function(done) {
-          var db = start(),
-              DefaultArraySchema = new Schema({
+          var DefaultArraySchema = new Schema({
                 arr: {type: Array, cast: String, default: ['a', 'b', 'c']},
                 single: {type: Array, cast: String, default: ['a']}
               });
           mongoose.model('DefaultArray', DefaultArraySchema);
           var DefaultArray = db.model('DefaultArray', collection);
           var arr = new DefaultArray;
-          db.close();
           assert.equal(arr.get('arr').length, 3);
           assert.equal(arr.get('arr')[0], 'a');
           assert.equal(arr.get('arr')[1], 'b');
@@ -288,14 +269,12 @@ describe('Model', function() {
         });
 
         it('empty', function(done) {
-          var db = start(),
-              DefaultZeroCardArraySchema = new Schema({
+          var DefaultZeroCardArraySchema = new Schema({
                 arr: {type: Array, cast: String, default: []},
                 auto: [Number]
               });
           mongoose.model('DefaultZeroCardArray', DefaultZeroCardArraySchema);
           var DefaultZeroCardArray = db.model('DefaultZeroCardArray', collection);
-          db.close();
           var arr = new DefaultZeroCardArray();
           assert.equal(arr.get('arr').length, 0);
           assert.equal(arr.arr.length, 0);
@@ -306,27 +285,23 @@ describe('Model', function() {
     });
 
     it('a hash with one null value', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost({
         title: null
       });
-      db.close();
       assert.strictEqual(null, post.title);
       done();
     });
 
     it('when saved', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           pending = 2;
 
       function cb() {
         if (--pending) {
           return;
         }
-        db.close();
         done();
       }
 
@@ -371,11 +346,9 @@ describe('Model', function() {
 
     describe('init', function() {
       it('works', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost', collection);
+        var BlogPost = db.model('BlogPost', collection);
 
         var post = new BlogPost();
-        db.close();
 
         post.init({
           title: 'Test',
@@ -428,10 +401,8 @@ describe('Model', function() {
       });
 
       it('partially', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost', collection);
+        var BlogPost = db.model('BlogPost', collection);
 
-        db.close();
         var post = new BlogPost;
         post.init({
           title: 'Test',
@@ -455,10 +426,8 @@ describe('Model', function() {
       });
 
       it('with partial hash', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost', collection);
+        var BlogPost = db.model('BlogPost', collection);
 
-        db.close();
         var post = new BlogPost({
           meta: {
             date: new Date,
@@ -471,10 +440,8 @@ describe('Model', function() {
       });
 
       it('isNew on embedded documents', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost', collection);
+        var BlogPost = db.model('BlogPost', collection);
 
-        db.close();
         var post = new BlogPost();
         post.init({
           title: 'Test',
@@ -487,8 +454,7 @@ describe('Model', function() {
       });
 
       it('isNew on embedded documents after saving', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost', collection);
+        var BlogPost = db.model('BlogPost', collection);
 
         var post = new BlogPost({title: 'hocus pocus'});
         post.comments.push({title: 'Humpty Dumpty', comments: [{title: 'nested'}]});
@@ -500,7 +466,6 @@ describe('Model', function() {
           assert.equal(post.get('comments')[0].isNew, true);
           assert.equal(post.get('comments')[0].comments[0].isNew, true);
           post.save(function(err) {
-            db.close();
             assert.strictEqual(null, err);
             assert.equal(post.isNew, false);
             assert.equal(post.get('comments')[0].isNew, false);
@@ -517,17 +482,14 @@ describe('Model', function() {
     var Named = mongoose.model('CollectionNamedInSchema1', schema);
     assert.equal(Named.prototype.collection.name, 'users1');
 
-    var db = start();
     var users2schema = new Schema({name: String}, {collection: 'users2'});
     var Named2 = db.model('CollectionNamedInSchema2', users2schema);
-    db.close();
     assert.equal(Named2.prototype.collection.name, 'users2');
     done();
   });
 
   it('saving a model with a null value should perpetuate that null value to the db', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost({
       title: null
@@ -536,7 +498,6 @@ describe('Model', function() {
     post.save(function(err) {
       assert.strictEqual(err, null);
       BlogPost.findById(post.id, function(err, found) {
-        db.close();
         assert.strictEqual(err, null);
         assert.strictEqual(found.title, null);
         done();
@@ -545,8 +506,6 @@ describe('Model', function() {
   });
 
   it('saves subdocuments middleware correctly', function(done) {
-    var db = start();
-
     var child_hook;
     var parent_hook;
     var childSchema = new Schema({
@@ -591,8 +550,7 @@ describe('Model', function() {
   });
 
   it('instantiating a model with a hash that maps to at least 1 undefined value', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost({
       title: undefined
@@ -601,7 +559,6 @@ describe('Model', function() {
     post.save(function(err) {
       assert.strictEqual(null, err);
       BlogPost.findById(post.id, function(err, found) {
-        db.close();
         assert.strictEqual(err, null);
         assert.strictEqual(found.title, undefined);
         done();
@@ -610,8 +567,6 @@ describe('Model', function() {
   });
 
   it('modified nested objects which contain MongoseNumbers should not cause a RangeError on save (gh-714)', function(done) {
-    var db = start();
-
     var schema = new Schema({
       nested: {
         num: Number
@@ -628,7 +583,6 @@ describe('Model', function() {
         assert.ifError(err);
         m.nested.num = 5;
         m.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -637,8 +591,6 @@ describe('Model', function() {
   });
 
   it('no RangeError on remove() of a doc with Number _id (gh-714)', function(done) {
-    var db = start();
-
     var MySchema = new Schema({
       _id: {type: Number},
       name: String
@@ -657,7 +609,6 @@ describe('Model', function() {
         assert.ifError(err);
 
         doc.remove(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -666,8 +617,7 @@ describe('Model', function() {
   });
 
   it('over-writing a number should persist to the db (gh-342)', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost({
       meta: {
@@ -684,7 +634,6 @@ describe('Model', function() {
         BlogPost.findById(post.id, function(err, found) {
           assert.ifError(err);
           assert.equal(found.get('meta.visitors').valueOf(), 20);
-          db.close();
           done();
         });
       });
@@ -693,17 +642,14 @@ describe('Model', function() {
 
   describe('methods', function() {
     it('can be defined', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
-      db.close();
       var post = new BlogPost();
       assert.equal(post.cool(), post);
       done();
     });
 
     it('can be defined on embedded documents', function(done) {
-      var db = start();
       var ChildSchema = new Schema({name: String});
       ChildSchema.method('talk', function() {
         return 'gaga';
@@ -715,7 +661,6 @@ describe('Model', function() {
 
       var ChildA = db.model('ChildA', ChildSchema, 'children_' + random());
       var ParentA = db.model('ParentA', ParentSchema, 'parents_' + random());
-      db.close();
 
       var c = new ChildA;
       assert.equal(typeof c.talk, 'function');
@@ -727,7 +672,6 @@ describe('Model', function() {
     });
 
     it('can be defined with nested key', function(done) {
-      var db = start();
       var NestedKeySchema = new Schema({});
       NestedKeySchema.method('foo', {
         bar: function() {
@@ -743,10 +687,8 @@ describe('Model', function() {
 
   describe('statics', function() {
     it('can be defined', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
-      db.close();
       assert.equal(BlogPost.woot(), BlogPost);
       done();
     });
@@ -754,8 +696,7 @@ describe('Model', function() {
 
   describe('casting as validation errors', function() {
     it('error', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           threw = false;
 
       var post;
@@ -782,15 +723,13 @@ describe('Model', function() {
         post.date = new Date;
         post.meta.date = new Date;
         post.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
       });
     });
     it('nested error', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           threw = false;
 
       var post = new BlogPost;
@@ -816,7 +755,6 @@ describe('Model', function() {
       assert.equal(threw, false);
 
       post.save(function(err) {
-        db.close();
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);
         done();
@@ -825,8 +763,7 @@ describe('Model', function() {
 
 
     it('subdocument cast error', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost({
         title: 'Test',
@@ -837,7 +774,6 @@ describe('Model', function() {
       post.get('comments')[0].set('date', 'invalid');
 
       post.save(function(err) {
-        db.close();
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);
         done();
@@ -872,8 +808,7 @@ describe('Model', function() {
 
 
     it('subdocument error when adding a subdoc', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           threw = false;
 
       var post = new BlogPost();
@@ -889,7 +824,6 @@ describe('Model', function() {
       assert.equal(threw, false);
 
       post.save(function(err) {
-        db.close();
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);
         done();
@@ -898,8 +832,7 @@ describe('Model', function() {
 
 
     it('updates', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost();
       post.set('title', '1');
@@ -913,7 +846,6 @@ describe('Model', function() {
           assert.ifError(err);
 
           BlogPost.findOne({_id: post.get('_id')}, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(doc.get('title'), '2');
             done();
@@ -923,19 +855,16 @@ describe('Model', function() {
     });
 
     it('$pull', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           post = new BlogPost();
 
-      db.close();
       post.get('numbers').push('3');
       assert.equal(post.get('numbers')[0], 3);
       done();
     });
 
     it('$push', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           post = new BlogPost();
 
       post.get('numbers').push(1, 2, 3, 4);
@@ -945,7 +874,6 @@ describe('Model', function() {
           found.get('numbers').pull('3');
           found.save(function() {
             BlogPost.findById(found.get('_id'), function(err, found2) {
-              db.close();
               assert.ifError(err);
               assert.equal(found2.get('numbers').length, 3);
               done();
@@ -956,8 +884,7 @@ describe('Model', function() {
     });
 
     it('Number arrays', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost();
       post.numbers.push(1, '2', 3);
@@ -972,15 +899,12 @@ describe('Model', function() {
           assert.ok(~doc.numbers.indexOf(2));
           assert.ok(~doc.numbers.indexOf(3));
 
-          db.close();
           done();
         });
       });
     });
 
     it('date casting compat with datejs (gh-502)', function(done) {
-      var db = start();
-
       Date.prototype.toObject = function() {
         return {
           millisecond: 86,
@@ -1018,7 +942,6 @@ describe('Model', function() {
           m.save(function(err) {
             assert.ifError(err);
             M.remove(function(err) {
-              db.close();
               delete Date.prototype.toObject;
               assert.ifError(err);
               done();
@@ -1047,8 +970,7 @@ describe('Model', function() {
         asyncScope: {type: String, validate: [dovalidateAsync, 'async scope failed'], required: true}
       }));
 
-      var db = start(),
-          TestValidation = db.model('TestValidation');
+      var TestValidation = db.model('TestValidation');
 
       var post = new TestValidation();
       post.set('simple', '');
@@ -1061,7 +983,6 @@ describe('Model', function() {
 
         post.set('simple', 'here');
         post.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -1077,8 +998,7 @@ describe('Model', function() {
         simple: {type: String, validate: [validate, 'must be abc']}
       }));
 
-      var db = start(),
-          TestValidationMessage = db.model('TestValidationMessage');
+      var TestValidationMessage = db.model('TestValidationMessage');
 
       var post = new TestValidationMessage();
       post.set('simple', '');
@@ -1092,7 +1012,6 @@ describe('Model', function() {
 
         post.set('simple', 'abc');
         post.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -1100,7 +1019,6 @@ describe('Model', function() {
     });
 
     it('with Model.schema.path introspection (gh-272)', function(done) {
-      var db = start();
       var IntrospectionValidationSchema = new Schema({
         name: String
       });
@@ -1110,7 +1028,6 @@ describe('Model', function() {
       }, 'Name cannot be greater than 1 character for path "{PATH}" with value `{VALUE}`');
       var doc = new IntrospectionValidation({name: 'hi'});
       doc.save(function(err) {
-        db.close();
         assert.equal(err.errors.name.message, 'Name cannot be greater than 1 character for path "name" with value `hi`');
         assert.equal(err.name, 'ValidationError');
         assert.ok(err.message.indexOf('IntrospectionValidation validation failed') !== -1, err.message);
@@ -1123,8 +1040,7 @@ describe('Model', function() {
         simple: {type: String, required: true}
       }));
 
-      var db = start(),
-          TestUndefinedValidation = db.model('TestUndefinedValidation');
+      var TestUndefinedValidation = db.model('TestUndefinedValidation');
 
       var post = new TestUndefinedValidation;
 
@@ -1134,7 +1050,6 @@ describe('Model', function() {
 
         post.set('simple', 'here');
         post.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -1142,8 +1057,6 @@ describe('Model', function() {
     });
 
     it('save callback should only execute once (gh-319)', function(done) {
-      var db = start();
-
       var D = db.model('CallbackFiresOnceValidation', new Schema({
         username: {type: String, validate: /^[a-z]{6}$/i},
         email: {type: String, validate: /^[a-z]{6}$/i},
@@ -1159,7 +1072,6 @@ describe('Model', function() {
       var timesCalled = 0;
 
       post.save(function(err) {
-        db.close();
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);
 
@@ -1189,8 +1101,7 @@ describe('Model', function() {
         resultv: {type: String, required: true}
       }));
 
-      var db = start(),
-          TestV = db.model('TestValidationOnResult');
+      var TestV = db.model('TestValidationOnResult');
 
       var post = new TestV;
 
@@ -1205,7 +1116,6 @@ describe('Model', function() {
             assert.ifError(err);
             assert.equal(found.resultv, 'yeah');
             found.save(function(err) {
-              db.close();
               assert.ifError(err);
               done();
             });
@@ -1220,8 +1130,7 @@ describe('Model', function() {
         a: String
       }));
 
-      var db = start(),
-          TestP = db.model('TestPreviousNullValidation');
+      var TestP = db.model('TestPreviousNullValidation');
 
       TestP.collection.insert({a: null, previous: null}, {}, function(err, f) {
         assert.ifError(err);
@@ -1237,7 +1146,6 @@ describe('Model', function() {
             found.set('previous', 'yoyo');
             found.save(function(err) {
               assert.strictEqual(err, null);
-              db.close();
               done();
             });
           });
@@ -1252,8 +1160,7 @@ describe('Model', function() {
         }
       }));
 
-      var db = start(),
-          TestNestedValidation = db.model('TestNestedValidation');
+      var TestNestedValidation = db.model('TestNestedValidation');
 
       var post = new TestNestedValidation();
       post.set('nested.required', null);
@@ -1264,7 +1171,6 @@ describe('Model', function() {
 
         post.set('nested.required', 'here');
         post.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -1283,8 +1189,7 @@ describe('Model', function() {
         items: [Subdocs]
       }));
 
-      var db = start(),
-          TestSubdocumentsValidation = db.model('TestSubdocumentsValidation');
+      var TestSubdocumentsValidation = db.model('TestSubdocumentsValidation');
 
       var post = new TestSubdocumentsValidation();
 
@@ -1317,7 +1222,6 @@ describe('Model', function() {
 
           post.get('items')[0].set('required', true);
           post.save(function(err) {
-            db.close();
             assert.ok(!post.errors);
             assert.ifError(err);
             done();
@@ -1331,8 +1235,7 @@ describe('Model', function() {
         item: {type: String, required: true}
       }));
 
-      var db = start(),
-          TestCallingValidation = db.model('TestCallingValidation');
+      var TestCallingValidation = db.model('TestCallingValidation');
 
       var post = new TestCallingValidation;
 
@@ -1346,7 +1249,6 @@ describe('Model', function() {
 
         post.item = 'yo';
         post.validate(function(err) {
-          db.close();
           assert.equal(err, null);
           assert.strictEqual(post.isNew, true);
           done();
@@ -1363,20 +1265,17 @@ describe('Model', function() {
         result: {type: String, validate: [validator, 'chump validator'], required: false}
       }));
 
-      var db = start(),
-          TestV = db.model('TestRequiredFalse');
+      var TestV = db.model('TestRequiredFalse');
 
       var post = new TestV;
 
-      db.close();
       assert.equal(post.schema.path('result').isRequired, false);
       done();
     });
 
     describe('middleware', function() {
       it('works', function(done) {
-        var db = start(),
-            ValidationMiddlewareSchema = null,
+        var ValidationMiddlewareSchema = null,
             Post = null,
             post = null;
 
@@ -1406,15 +1305,13 @@ describe('Model', function() {
           post.set('baz', 'good');
           post.save(function(err) {
             assert.ifError(err);
-            db.close();
             done();
           });
         });
       });
 
       it('async', function(done) {
-        var db = start(),
-            AsyncValidationMiddlewareSchema = null,
+        var AsyncValidationMiddlewareSchema = null,
             Post = null,
             post = null;
 
@@ -1448,15 +1345,13 @@ describe('Model', function() {
           post.set('prop', 'good');
           post.save(function(err) {
             assert.ifError(err);
-            db.close();
             done();
           });
         });
       });
 
       it('complex', function(done) {
-        var db = start(),
-            ComplexValidationMiddlewareSchema = null,
+        var ComplexValidationMiddlewareSchema = null,
             Post = null,
             post = null,
             abc = function(v) {
@@ -1519,7 +1414,6 @@ describe('Model', function() {
 
           post.save(function(err) {
             assert.ifError(err);
-            db.close();
             done();
           });
         });
@@ -1535,10 +1429,8 @@ describe('Model', function() {
         date: {type: Date, default: now}
       }));
 
-      var db = start(),
-          TestDefaults = db.model('TestDefaults');
+      var TestDefaults = db.model('TestDefaults');
 
-      db.close();
       var post = new TestDefaults;
       assert.ok(post.get('date') instanceof Date);
       assert.equal(+post.get('date'), now);
@@ -1554,11 +1446,9 @@ describe('Model', function() {
         }
       }));
 
-      var db = start(),
-          TestDefaults = db.model('TestNestedDefaults');
+      var TestDefaults = db.model('TestNestedDefaults');
 
       var post = new TestDefaults();
-      db.close();
       assert.ok(post.get('nested.date') instanceof Date);
       assert.equal(+post.get('nested.date'), now);
       done();
@@ -1575,10 +1465,8 @@ describe('Model', function() {
         items: [Items]
       }));
 
-      var db = start(),
-          TestSubdocumentsDefaults = db.model('TestSubdocumentsDefaults');
+      var TestSubdocumentsDefaults = db.model('TestSubdocumentsDefaults');
 
-      db.close();
       var post = new TestSubdocumentsDefaults();
       post.get('items').push({});
       assert.ok(post.get('items')[0].get('date') instanceof Date);
@@ -1587,7 +1475,6 @@ describe('Model', function() {
     });
 
     it('allows nulls', function(done) {
-      var db = start();
       var T = db.model('NullDefault', new Schema({name: {type: String, default: null}}), collection);
       var t = new T();
 
@@ -1597,7 +1484,6 @@ describe('Model', function() {
         assert.ifError(err);
 
         T.findById(t._id, function(err, t) {
-          db.close();
           assert.ifError(err);
           assert.strictEqual(null, t.name);
           done();
@@ -1608,25 +1494,21 @@ describe('Model', function() {
 
   describe('virtuals', function() {
     it('getters', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           post = new BlogPost({
             title: 'Letters from Earth',
             author: 'Mark Twain'
           });
 
-      db.close();
       assert.equal(post.get('titleWithAuthor'), 'Letters from Earth by Mark Twain');
       assert.equal(post.titleWithAuthor, 'Letters from Earth by Mark Twain');
       done();
     });
 
     it('set()', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           post = new BlogPost();
 
-      db.close();
       post.set('titleWithAuthor', 'Huckleberry Finn by Mark Twain');
       assert.equal(post.get('title'), 'Huckleberry Finn');
       assert.equal(post.get('author'), 'Mark Twain');
@@ -1634,8 +1516,7 @@ describe('Model', function() {
     });
 
     it('should not be saved to the db AZZ', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           post = new BlogPost();
 
       post.set('titleWithAuthor', 'Huckleberry Finn by Mark Twain');
@@ -1649,15 +1530,13 @@ describe('Model', function() {
           assert.equal(found.get('title'), 'Huckleberry Finn');
           assert.equal(found.get('author'), 'Mark Twain');
           assert.ok(!('titleWithAuthor' in found.toObject()));
-          db.close();
           done();
         });
       });
     });
 
     it('nested', function(done) {
-      var db = start(),
-          PersonSchema = new Schema({
+      var PersonSchema = new Schema({
             name: {
               first: String,
               last: String
@@ -1685,8 +1564,6 @@ describe('Model', function() {
             }
           });
 
-      db.close();
-
       assert.equal(person.get('name.full'), 'Michael Sorrentino');
       person.set('name.full', 'The Situation');
       assert.equal(person.get('name.first'), 'The');
@@ -1702,8 +1579,7 @@ describe('Model', function() {
 
   describe('.remove()', function() {
     it('works', function(done) {
-      var db = start(),
-          collection = 'blogposts_' + random(),
+      var collection = 'blogposts_' + random(),
           BlogPost = db.model('BlogPost', collection);
 
       BlogPost.create({title: 1}, {title: 2}, function(err) {
@@ -1713,7 +1589,6 @@ describe('Model', function() {
           assert.ifError(err);
 
           BlogPost.find({}, function(err, found) {
-            db.close();
             assert.ifError(err);
             assert.equal(found.length, 1);
             assert.equal(found[0].title, '2');
@@ -1724,8 +1599,7 @@ describe('Model', function() {
     });
 
     it('errors when id deselected (gh-3118)', function(done) {
-      var db = start(),
-          collection = 'blogposts_' + random(),
+      var collection = 'blogposts_' + random(),
           BlogPost = db.model('BlogPost', collection);
 
       BlogPost.create({title: 1}, {title: 2}, function(err) {
@@ -1735,14 +1609,13 @@ describe('Model', function() {
           doc.remove(function(err) {
             assert.ok(err);
             assert.equal(err.message, 'No _id found on document!');
-            db.close(done);
+            done();
           });
         });
       });
     });
 
     it('should not remove any records when deleting by id undefined', function(done) {
-      var db = start();
       var collection = 'blogposts_' + random();
       var BlogPost = db.model('BlogPost', collection);
       BlogPost.create({title: 1}, {title: 2}, function(err) {
@@ -1759,8 +1632,7 @@ describe('Model', function() {
     });
 
     it('should not remove all documents in the collection (gh-3326)', function(done) {
-      var db = start(),
-          collection = 'blogposts_' + random(),
+      var collection = 'blogposts_' + random(),
           BlogPost = db.model('BlogPost', collection);
 
       BlogPost.create({title: 1}, {title: 2}, function(err) {
@@ -1770,7 +1642,6 @@ describe('Model', function() {
           doc.remove(function(err) {
             assert.ifError(err);
             BlogPost.find(function(err, found) {
-              db.close();
               assert.ifError(err);
               assert.equal(found.length, 1);
               assert.equal(found[0].title, '2');
@@ -1783,15 +1654,10 @@ describe('Model', function() {
   });
 
   describe('#remove()', function() {
-    var db, B;
+    var B;
 
     before(function() {
-      db = start();
       B = db.model('BlogPost', 'blogposts_' + random());
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     it('passes the removed document (gh-1419)', function(done) {
@@ -1857,8 +1723,7 @@ describe('Model', function() {
 
     describe('when called multiple times', function() {
       it('always executes the passed callback gh-1210', function(done) {
-        var db = start(),
-            collection = 'blogposts_' + random(),
+        var collection = 'blogposts_' + random(),
             BlogPost = db.model('BlogPost', collection),
             post = new BlogPost();
 
@@ -1894,8 +1759,7 @@ describe('Model', function() {
 
       mongoose.model('PostWithClashGetters', Post);
 
-      var db = start(),
-          PostModel = db.model('PostWithClashGetters', 'postwithclash' + random());
+      var PostModel = db.model('PostWithClashGetters', 'postwithclash' + random());
 
       var post = new PostModel({
         title: 'Test',
@@ -1903,7 +1767,6 @@ describe('Model', function() {
         subject: {name: 'B'}
       });
 
-      db.close();
       assert.equal(post.author.name, 'A');
       assert.equal(post.subject.name, 'B');
       assert.equal(post.author.name, 'A');
@@ -1911,10 +1774,7 @@ describe('Model', function() {
     });
 
     it('should not be triggered at construction (gh-685)', function(done) {
-      var db = start(),
-          called = false;
-
-      db.close();
+      var called = false;
 
       var schema = new mongoose.Schema({
         number: {
@@ -1956,11 +1816,9 @@ describe('Model', function() {
 
       mongoose.model('ShortcutGetterObject', schema);
 
-      var db = start(),
-          ShortcutGetter = db.model('ShortcutGetterObject', 'shortcut' + random()),
+      var ShortcutGetter = db.model('ShortcutGetterObject', 'shortcut' + random()),
           post = new ShortcutGetter();
 
-      db.close();
       post.set('date', Date.now());
       assert.ok(post.date instanceof Date);
       done();
@@ -1975,21 +1833,17 @@ describe('Model', function() {
         });
         mongoose.model('ShortcutGetterNested', schema);
 
-        var db = start(),
-            ShortcutGetterNested = db.model('ShortcutGetterNested', collection),
+        var ShortcutGetterNested = db.model('ShortcutGetterNested', collection),
             doc = new ShortcutGetterNested();
 
-        db.close();
         assert.equal(typeof doc.first, 'object');
         assert.ok(doc.first.second.isMongooseArray);
         done();
       });
 
       it('works with object literals', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost', collection);
+        var BlogPost = db.model('BlogPost', collection);
 
-        db.close();
         var date = new Date;
 
         var meta = {
@@ -2065,8 +1919,6 @@ describe('Model', function() {
       });
 
       it('object property access works when root initd with null', function(done) {
-        var db = start();
-
         var schema = new Schema({
           nest: {
             st: String
@@ -2084,15 +1936,12 @@ describe('Model', function() {
         assert.equal(t.nest.st, 'jsconf rules');
 
         t.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
       });
 
       it('object property access works when root initd with undefined', function(done) {
-        var db = start();
-
         var schema = new Schema({
           nest: {
             st: String
@@ -2110,15 +1959,12 @@ describe('Model', function() {
         assert.equal(t.nest.st, 'jsconf rules');
 
         t.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
       });
 
       it('pre-existing null object re-save', function(done) {
-        var db = start();
-
         var schema = new Schema({
           nest: {
             st: String,
@@ -2154,7 +2000,6 @@ describe('Model', function() {
 
               t.nest = null;
               t.save(function(err) {
-                db.close();
                 assert.ifError(err);
                 assert.strictEqual(t._doc.nest, null);
                 done();
@@ -2165,8 +2010,6 @@ describe('Model', function() {
       });
 
       it('array of Mixed on existing doc can be pushed to', function(done) {
-        var db = start();
-
         mongoose.model('MySchema', new Schema({
           nested: {
             arrays: []
@@ -2193,7 +2036,6 @@ describe('Model', function() {
               assert.ifError(err);
 
               DooDad.findById(doodad._id, function(err, doodad) {
-                db.close();
                 assert.ifError(err);
                 assert.deepEqual(doodad.nested.arrays.toObject(), [['+10', 'yup', date], ['another', 1]]);
                 done();
@@ -2204,8 +2046,6 @@ describe('Model', function() {
       });
 
       it('props can be set directly when property was named "type"', function(done) {
-        var db = start();
-
         function def() {
           return [{x: 1}, {x: 2}, {x: 3}];
         }
@@ -2238,7 +2078,6 @@ describe('Model', function() {
               assert.ifError(err);
 
               DooDad.findById(doodad._id, function(err, doodad) {
-                db.close();
                 assert.ifError(err);
                 assert.equal(doodad.nested.type, 'nope');
                 assert.deepEqual(doodad.nested.array.toObject(), ['some', 'new', 'stuff']);
@@ -2253,8 +2092,6 @@ describe('Model', function() {
 
   describe('setters', function() {
     it('are used on embedded docs (gh-365 gh-390 gh-422)', function(done) {
-      var db = start();
-
       function setLat(val) {
         return parseInt(val, 10);
       }
@@ -2289,7 +2126,6 @@ describe('Model', function() {
       deal.save(function(err) {
         assert.ifError(err);
         Deal.findById(deal._id, function(err, deal) {
-          db.close();
           assert.ifError(err);
           assert.equal(deal.locations[0].lat.valueOf(), 1);
           // GH-422
@@ -2301,8 +2137,7 @@ describe('Model', function() {
   });
 
   it('changing a number non-atomically (gh-203)', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost();
 
@@ -2320,7 +2155,6 @@ describe('Model', function() {
           assert.ifError(err);
 
           BlogPost.findById(post._id, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(+doc.meta.visitors, 3);
             done();
@@ -2332,8 +2166,7 @@ describe('Model', function() {
 
   describe('atomic subdocument', function() {
     it('saving', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection),
+      var BlogPost = db.model('BlogPost', collection),
           totalDocs = 4,
           saveQueue = [];
 
@@ -2341,7 +2174,6 @@ describe('Model', function() {
 
       function complete() {
         BlogPost.findOne({_id: post.get('_id')}, function(err, doc) {
-          db.close();
 
           assert.ifError(err);
           assert.equal(doc.get('comments').length, 5);
@@ -2421,8 +2253,7 @@ describe('Model', function() {
     });
 
     it('setting (gh-310)', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       BlogPost.create({
         comments: [{title: 'first-title', body: 'first-body'}]
@@ -2440,7 +2271,6 @@ describe('Model', function() {
                 assert.ifError(err);
                 BlogPost.findById(blog.id, function(err, foundBlog) {
                   assert.ifError(err);
-                  db.close();
                   var comment = foundBlog.get('comments')[0];
                   assert.equal(comment.title, 'second-title');
                   assert.equal(comment.body, 'second-body');
@@ -2464,7 +2294,6 @@ describe('Model', function() {
     });
     mongoose.model('Outer', Outer);
 
-    var db = start();
     Outer = db.model('Outer', 'arr_test_' + random());
 
     var outer = new Outer();
@@ -2481,7 +2310,6 @@ describe('Model', function() {
           assert.ifError(err);
           assert.ok(found.get('_id') instanceof DocumentObjectId);
           Outer.findById(found.get('_id'), function(err, found2) {
-            db.close();
             assert.ifError(err);
             assert.equal(found2.inner.length, 1);
             assert.equal(found2.inner[0].arr.length, 1);
@@ -2494,8 +2322,7 @@ describe('Model', function() {
   });
 
   it('multiple number push() calls', function(done) {
-    var db = start(),
-        schema = new Schema({
+    var schema = new Schema({
           nested: {
             nums: [Number]
           }
@@ -2515,7 +2342,6 @@ describe('Model', function() {
         assert.ifError(err);
         assert.equal(t.nested.nums.length, 2);
         Temp.findById(t._id, function(err) {
-          db.close();
           assert.ifError(err);
           assert.equal(t.nested.nums.length, 2);
           done();
@@ -2525,8 +2351,7 @@ describe('Model', function() {
   });
 
   it('multiple push() calls', function(done) {
-    var db = start(),
-        schema = new Schema({
+    var schema = new Schema({
           nested: {
             nums: [Number]
           }
@@ -2544,7 +2369,6 @@ describe('Model', function() {
         assert.ifError(err);
         assert.equal(t.nested.nums.length, 3);
         Temp.findById(t._id, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.nested.nums.length, 3);
           done();
@@ -2554,8 +2378,7 @@ describe('Model', function() {
   });
 
   it('activePaths should be updated for nested modifieds', function(done) {
-    var db = start(),
-        schema = new Schema({
+    var schema = new Schema({
           nested: {
             nums: [Number]
           }
@@ -2568,15 +2391,13 @@ describe('Model', function() {
       t.nested.nums.pull(1);
       t.nested.nums.pull(2);
       assert.equal(t.$__.activePaths.paths['nested.nums'], 'modify');
-      db.close();
       done();
     });
   });
 
 
   it('activePaths should be updated for nested modifieds as promise', function(done) {
-    var db = start(),
-        schema = new Schema({
+    var schema = new Schema({
           nested: {
             nums: [Number]
           }
@@ -2589,14 +2410,12 @@ describe('Model', function() {
       t.nested.nums.pull(1);
       t.nested.nums.pull(2);
       assert.equal(t.$__.activePaths.paths['nested.nums'], 'modify');
-      db.close();
       done();
     }).catch(done);
   });
 
   it('$pull should affect what you see in an array before a save', function(done) {
-    var db = start(),
-        schema = new Schema({
+    var schema = new Schema({
           nested: {
             nums: [Number]
           }
@@ -2608,14 +2427,12 @@ describe('Model', function() {
       assert.ifError(err);
       t.nested.nums.pull(1);
       assert.equal(t.nested.nums.length, 4);
-      db.close();
       done();
     });
   });
 
   it('$shift', function(done) {
-    var db = start(),
-        schema = new Schema({
+    var schema = new Schema({
           nested: {
             nums: [Number]
           }
@@ -2649,7 +2466,6 @@ describe('Model', function() {
             found.save(function(err) {
               assert.ifError(err);
               Temp.findById(t._id, function(err, found) {
-                db.close();
                 assert.ifError(err);
                 assert.equal(found.nested.nums.length, 1);
                 assert.equal(found.nested.nums[0], 2);
@@ -2664,8 +2480,7 @@ describe('Model', function() {
 
   describe('saving embedded arrays', function() {
     it('of Numbers atomically', function(done) {
-      var db = start(),
-          TempSchema = new Schema({
+      var TempSchema = new Schema({
             nums: [Number]
           }),
           totalDocs = 2,
@@ -2695,7 +2510,7 @@ describe('Model', function() {
             return num.valueOf() === 3;
           });
           assert.ok(v);
-          db.close(done);
+          done();
         });
       }
 
@@ -2729,8 +2544,7 @@ describe('Model', function() {
     });
 
     it('of Strings atomically', function(done) {
-      var db = start(),
-          StrListSchema = new Schema({
+      var StrListSchema = new Schema({
             strings: [String]
           }),
           totalDocs = 2,
@@ -2743,7 +2557,6 @@ describe('Model', function() {
 
       function complete() {
         StrList.findOne({_id: t.get('_id')}, function(err, doc) {
-          db.close();
           assert.ifError(err);
 
           assert.equal(doc.get('strings').length, 3);
@@ -2796,8 +2609,7 @@ describe('Model', function() {
     });
 
     it('of Buffers atomically', function(done) {
-      var db = start(),
-          BufListSchema = new Schema({
+      var BufListSchema = new Schema({
             buffers: [Buffer]
           }),
           totalDocs = 2,
@@ -2810,7 +2622,6 @@ describe('Model', function() {
 
       function complete() {
         BufList.findOne({_id: t.get('_id')}, function(err, doc) {
-          db.close();
           assert.ifError(err);
 
           assert.equal(doc.get('buffers').length, 3);
@@ -2864,8 +2675,7 @@ describe('Model', function() {
     });
 
     it('works with modified element properties + doc removal (gh-975)', function(done) {
-      var db = start(),
-          B = db.model('BlogPost', collection),
+      var B = db.model('BlogPost', collection),
           b = new B({comments: [{title: 'gh-975'}]});
 
       b.save(function(err) {
@@ -2886,7 +2696,6 @@ describe('Model', function() {
               doc.save(function(err) {
                 assert.ifError(err);
                 B.findById(doc._id, function(err, doc) {
-                  db.close();
                   assert.ifError(err);
                   assert.equal(doc.comments.length, 0);
                   done();
@@ -2899,8 +2708,7 @@ describe('Model', function() {
     });
 
     it('updating an embedded document in an embedded array with set call', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       BlogPost.create({
         comments: [{
@@ -2920,7 +2728,6 @@ describe('Model', function() {
           found.save(function(err) {
             assert.ifError(err);
             BlogPost.findById(found._id, function(err, updated) {
-              db.close();
               assert.ifError(err);
               assert.equal(updated.comments[0].title, 'after-change');
               done();
@@ -2932,8 +2739,7 @@ describe('Model', function() {
   });
 
   it('updating an embedded document in an embedded array (gh-255)', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     BlogPost.create({comments: [{title: 'woot'}]}, function(err, post) {
       assert.ifError(err);
@@ -2944,7 +2750,6 @@ describe('Model', function() {
         found.save(function(err) {
           assert.ifError(err);
           BlogPost.findById(found._id, function(err, updated) {
-            db.close();
             assert.ifError(err);
             assert.equal(updated.comments[0].title, 'notwoot');
             done();
@@ -2955,8 +2760,7 @@ describe('Model', function() {
   });
 
   it('updating an embedded array document to an Object value (gh-334)', function(done) {
-    var db = start(),
-        SubSchema = new Schema({
+    var SubSchema = new Schema({
           name: String,
           subObj: {subName: String}
         });
@@ -2975,7 +2779,6 @@ describe('Model', function() {
         doc.save(function(err) {
           assert.ifError(err);
           AModel.findById(instance.id, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(doc.arrData[0].subObj.subName, 'modified subName');
             done();
@@ -2986,8 +2789,7 @@ describe('Model', function() {
   });
 
   it('saving an embedded document twice should not push that doc onto the parent doc twice (gh-267)', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection),
+    var BlogPost = db.model('BlogPost', collection),
         post = new BlogPost();
 
     post.comments.push({title: 'woot'});
@@ -3001,7 +2803,6 @@ describe('Model', function() {
           assert.ifError(err);
           assert.equal(post.comments.length, 1);
           BlogPost.findById(post.id, function(err, found) {
-            db.close();
             assert.ifError(err);
             assert.equal(found.comments.length, 1);
             done();
@@ -3013,8 +2814,7 @@ describe('Model', function() {
 
   describe('embedded array filtering', function() {
     it('by the id shortcut function', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost();
 
@@ -3028,7 +2828,6 @@ describe('Model', function() {
         assert.ifError(err);
 
         BlogPost.findById(post.get('_id'), function(err, doc) {
-          db.close();
           assert.ifError(err);
 
           // test with an objectid
@@ -3043,8 +2842,7 @@ describe('Model', function() {
     });
 
     it('by the id with cast error', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost();
 
@@ -3052,7 +2850,6 @@ describe('Model', function() {
         assert.ifError(err);
 
         BlogPost.findById(post.get('_id'), function(err, doc) {
-          db.close();
           assert.ifError(err);
           assert.strictEqual(doc.comments.id(null), null);
           done();
@@ -3061,8 +2858,7 @@ describe('Model', function() {
     });
 
     it('by the id shortcut with no match', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var post = new BlogPost();
 
@@ -3070,7 +2866,6 @@ describe('Model', function() {
         assert.ifError(err);
 
         BlogPost.findById(post.get('_id'), function(err, doc) {
-          db.close();
           assert.ifError(err);
           assert.strictEqual(doc.comments.id(new DocumentObjectId), null);
           done();
@@ -3080,8 +2875,7 @@ describe('Model', function() {
   });
 
   it('removing a subdocument atomically', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost();
     post.title = 'hahaha';
@@ -3099,7 +2893,6 @@ describe('Model', function() {
           assert.ifError(err);
 
           BlogPost.findById(post.get('_id'), function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(doc.comments.length, 1);
             assert.equal(doc.comments[0].title, 'aaaa');
@@ -3111,8 +2904,7 @@ describe('Model', function() {
   });
 
   it('single pull embedded doc', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost();
     post.title = 'hahaha';
@@ -3131,7 +2923,6 @@ describe('Model', function() {
           assert.ifError(err);
 
           BlogPost.findById(post.get('_id'), function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(doc.comments.length, 0);
             done();
@@ -3142,8 +2933,7 @@ describe('Model', function() {
   });
 
   it('saving mixed data', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection),
+    var BlogPost = db.model('BlogPost', collection),
         count = 3;
 
     // string
@@ -3157,7 +2947,6 @@ describe('Model', function() {
         if (--count) {
           return;
         }
-        db.close();
         done();
       });
     });
@@ -3197,7 +2986,6 @@ describe('Model', function() {
                 if (--count) {
                   return;
                 }
-                db.close();
                 done();
               });
             });
@@ -3215,7 +3003,6 @@ describe('Model', function() {
               if (--count) {
                 return;
               }
-              db.close();
               done();
             });
           });
@@ -3225,8 +3012,7 @@ describe('Model', function() {
   });
 
   it('populating mixed data from the constructor (gh-200)', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost');
+    var BlogPost = db.model('BlogPost');
 
     var post = new BlogPost({
       mixed: {
@@ -3238,7 +3024,6 @@ describe('Model', function() {
       }
     });
 
-    db.close();
     assert.equal(post.mixed.type, 'test');
     assert.equal(post.mixed.github, 'rules');
     assert.equal(post.mixed.nested.number, 3);
@@ -3250,8 +3035,7 @@ describe('Model', function() {
       type: {type: String, default: 'YES!'}
     }));
 
-    var db = start(),
-        TestDefaults = db.model('TestTypeDefaults');
+    var TestDefaults = db.model('TestTypeDefaults');
 
     var post = new TestDefaults();
     assert.equal(typeof post.get('type'), 'string');
@@ -3266,15 +3050,13 @@ describe('Model', function() {
     post.x.y.type = '#402';
     post.x.y.owner = 'me';
     post.save(function(err) {
-      db.close();
       assert.ifError(err);
       done();
     });
   });
 
   it('unaltered model does not clear the doc (gh-195)', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost();
     post.title = 'woot';
@@ -3289,7 +3071,6 @@ describe('Model', function() {
           assert.ifError(err);
 
           BlogPost.findById(doc._id, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(doc.title, 'woot');
             done();
@@ -3302,7 +3083,6 @@ describe('Model', function() {
   describe('hooks', function() {
     describe('pre', function() {
       it('with undefined and null', function(done) {
-        var db = start();
         var schema = new Schema({name: String});
         var called = 0;
 
@@ -3320,7 +3100,6 @@ describe('Model', function() {
         var s = new S({name: 'zupa'});
 
         s.save(function(err) {
-          db.close();
           assert.ifError(err);
           assert.equal(called, 2);
           done();
@@ -3329,7 +3108,6 @@ describe('Model', function() {
 
 
       it('with an async waterfall', function(done) {
-        var db = start();
         var schema = new Schema({name: String});
         var called = 0;
 
@@ -3351,7 +3129,6 @@ describe('Model', function() {
 
         var p = s.save();
         p.then(function() {
-          db.close();
           assert.equal(called, 2);
           done();
         }).catch(done);
@@ -3359,8 +3136,6 @@ describe('Model', function() {
 
 
       it('called on all sub levels', function(done) {
-        var db = start();
-
         var grandSchema = new Schema({name: String});
         grandSchema.pre('save', function(next) {
           this.name = 'grand';
@@ -3384,7 +3159,6 @@ describe('Model', function() {
         var s = new S({name: 'a', child: [{name: 'b', grand: [{name: 'c'}]}]});
 
         s.save(function(err, doc) {
-          db.close();
           assert.ifError(err);
           assert.equal(doc.name, 'parent');
           assert.equal(doc.child[0].name, 'child');
@@ -3395,8 +3169,6 @@ describe('Model', function() {
 
 
       it('error on any sub level', function(done) {
-        var db = start();
-
         var grandSchema = new Schema({name: String});
         grandSchema.pre('save', function(next) {
           next(new Error('Error 101'));
@@ -3418,7 +3190,6 @@ describe('Model', function() {
         var s = new S({name: 'a', child: [{name: 'b', grand: [{name: 'c'}]}]});
 
         s.save(function(err) {
-          db.close();
           assert.ok(err instanceof Error);
           assert.equal(err.message, 'Error 101');
           done();
@@ -3427,8 +3198,7 @@ describe('Model', function() {
 
       describe('init', function() {
         it('has access to the true ObjectId when used with querying (gh-289)', function(done) {
-          var db = start(),
-              PreInitSchema = new Schema({}),
+          var PreInitSchema = new Schema({}),
               preId = null;
 
           PreInitSchema.pre('init', function() {
@@ -3441,7 +3211,6 @@ describe('Model', function() {
           doc.save(function(err) {
             assert.ifError(err);
             PreInit.findById(doc._id, function(err) {
-              db.close();
               assert.ifError(err);
               assert.strictEqual(undefined, preId);
               done();
@@ -3477,8 +3246,7 @@ describe('Model', function() {
 
         mongoose.model('PostHookTest', schema);
 
-        var db = start(),
-            BlogPost = db.model('PostHookTest');
+        var BlogPost = db.model('PostHookTest');
 
         post = new BlogPost();
 
@@ -3493,7 +3261,6 @@ describe('Model', function() {
 
                 doc.remove(function(err) {
                   process.nextTick(function() {
-                    db.close();
                     assert.ifError(err);
                     assert.ok(remove);
                     done();
@@ -3522,7 +3289,6 @@ describe('Model', function() {
 
         mongoose.model('Parent', ParentSchema);
 
-        var db = start();
         var Parent = db.model('Parent');
 
         var parent = new Parent();
@@ -3530,7 +3296,6 @@ describe('Model', function() {
         parent.embeds.push({title: 'Testing post hooks for embedded docs'});
 
         parent.save(function(err) {
-          db.close();
           assert.ifError(err);
           assert.ok(save);
           done();
@@ -3541,14 +3306,12 @@ describe('Model', function() {
 
   describe('#exec()', function() {
     it('count()', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost' + random(), bpSchema);
+      var BlogPost = db.model('BlogPost' + random(), bpSchema);
 
       BlogPost.create({title: 'interoperable count as promise'}, function(err) {
         assert.ifError(err);
         var query = BlogPost.count({title: 'interoperable count as promise'});
         query.exec(function(err, count) {
-          db.close();
           assert.ifError(err);
           assert.equal(count, 1);
           done();
@@ -3558,8 +3321,7 @@ describe('Model', function() {
 
     it('update()', function(done) {
       var col = 'BlogPost' + random();
-      var db = start(),
-          BlogPost = db.model(col, bpSchema);
+      var BlogPost = db.model(col, bpSchema);
 
       BlogPost.create({title: 'interoperable update as promise'}, function(err) {
         assert.ifError(err);
@@ -3567,7 +3329,6 @@ describe('Model', function() {
         query.exec(function(err) {
           assert.ifError(err);
           BlogPost.count({title: 'interoperable update as promise delta'}, function(err, count) {
-            db.close();
             assert.ifError(err);
             assert.equal(count, 1);
             done();
@@ -3577,14 +3338,12 @@ describe('Model', function() {
     });
 
     it('findOne()', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost' + random(), bpSchema);
+      var BlogPost = db.model('BlogPost' + random(), bpSchema);
 
       BlogPost.create({title: 'interoperable findOne as promise'}, function(err, created) {
         assert.ifError(err);
         var query = BlogPost.findOne({title: 'interoperable findOne as promise'});
         query.exec(function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.id, created.id);
           done();
@@ -3593,8 +3352,7 @@ describe('Model', function() {
     });
 
     it('find()', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost' + random(), bpSchema);
+      var BlogPost = db.model('BlogPost' + random(), bpSchema);
 
       BlogPost.create(
         {title: 'interoperable find as promise'},
@@ -3603,7 +3361,6 @@ describe('Model', function() {
           assert.ifError(err);
           var query = BlogPost.find({title: 'interoperable find as promise'}).sort('_id');
           query.exec(function(err, found) {
-            db.close();
             assert.ifError(err);
             assert.equal(found.length, 2);
             var ids = {};
@@ -3617,8 +3374,7 @@ describe('Model', function() {
     });
 
     it('remove()', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost' + random(), bpSchema);
+      var BlogPost = db.model('BlogPost' + random(), bpSchema);
 
       BlogPost.create(
         {title: 'interoperable remove as promise'},
@@ -3628,7 +3384,6 @@ describe('Model', function() {
           query.exec(function(err) {
             assert.ifError(err);
             BlogPost.count({title: 'interoperable remove as promise'}, function(err, count) {
-              db.close();
               assert.equal(count, 0);
               done();
             });
@@ -3637,15 +3392,13 @@ describe('Model', function() {
     });
 
     it('op can be changed', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost' + random(), bpSchema),
+      var BlogPost = db.model('BlogPost' + random(), bpSchema),
           title = 'interop ad-hoc as promise';
 
       BlogPost.create({title: title}, function(err, created) {
         assert.ifError(err);
         var query = BlogPost.count({title: title});
         query.exec('findOne', function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.id, created.id);
           done();
@@ -3655,15 +3408,13 @@ describe('Model', function() {
 
     describe('promises', function() {
       it('count()', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost' + random(), bpSchema);
+        var BlogPost = db.model('BlogPost' + random(), bpSchema);
 
         BlogPost.create({title: 'interoperable count as promise 2'}, function(err) {
           assert.ifError(err);
           var query = BlogPost.count({title: 'interoperable count as promise 2'});
           var promise = query.exec();
           promise.then(function(count) {
-            db.close();
             assert.equal(count, 1);
             done();
           }).catch(done);
@@ -3672,8 +3423,7 @@ describe('Model', function() {
 
       it('update()', function(done) {
         var col = 'BlogPost' + random();
-        var db = start(),
-            BlogPost = db.model(col, bpSchema);
+        var BlogPost = db.model(col, bpSchema);
 
         BlogPost.create({title: 'interoperable update as promise 2'}, function(err) {
           assert.ifError(err);
@@ -3681,7 +3431,6 @@ describe('Model', function() {
           var promise = query.exec();
           promise.then(function() {
             BlogPost.count({title: 'interoperable update as promise delta 2'}, function(err, count) {
-              db.close();
               assert.ifError(err);
               assert.equal(count, 1);
               done();
@@ -3691,7 +3440,6 @@ describe('Model', function() {
       });
 
       it('findOne()', function() {
-        const db = start();
         const BlogPost = db.model('BlogPost' + random(), bpSchema);
 
         let created;
@@ -3708,8 +3456,7 @@ describe('Model', function() {
       });
 
       it('find()', function(done) {
-        var db = start(),
-            BlogPost = db.model('BlogPost' + random(), bpSchema);
+        var BlogPost = db.model('BlogPost' + random(), bpSchema);
 
         BlogPost.create(
           {title: 'interoperable find as promise 2'},
@@ -3719,7 +3466,6 @@ describe('Model', function() {
             var query = BlogPost.find({title: 'interoperable find as promise 2'}).sort('_id');
             var promise = query.exec();
             promise.then(function(found) {
-              db.close();
               assert.ifError(err);
               assert.equal(found.length, 2);
               assert.equal(found[0].id, createdOne.id);
@@ -3730,7 +3476,6 @@ describe('Model', function() {
       });
 
       it('remove()', function() {
-        const db = start();
         const BlogPost = db.model('BlogPost' + random(), bpSchema);
 
         return BlogPost.create({title: 'interoperable remove as promise 2'}).
@@ -3746,8 +3491,7 @@ describe('Model', function() {
       });
 
       it('are thenable', function(done) {
-        var db = start(),
-            B = db.model('BlogPost' + random(), bpSchema);
+        var B = db.model('BlogPost' + random(), bpSchema);
 
         var peopleSchema = new Schema({name: String, likes: ['ObjectId']});
         var P = db.model('promise-BP-people', peopleSchema, random());
@@ -3775,10 +3519,8 @@ describe('Model', function() {
                   assert.equal(people.length, 3);
                   return people;
                 }).then(function() {
-                  db.close();
                   done();
                 }, function(err) {
-                  db.close();
                   done(new Error(err));
                 });
               });
@@ -3789,8 +3531,7 @@ describe('Model', function() {
 
   describe('console.log', function() {
     it('hides private props', function(done) {
-      var db = start(),
-          BlogPost = db.model('BlogPost', collection);
+      var BlogPost = db.model('BlogPost', collection);
 
       var date = new Date(1305730951086);
       var id0 = new DocumentObjectId('4dd3e169dbfb13b4570000b9');
@@ -3810,8 +3551,6 @@ describe('Model', function() {
           {_id: id3, title: 'the next thang', date: date, body: 'this is a comment too!'}]
       });
 
-      db.close();
-
       var out = post.inspect();
       assert.equal(out.meta.visitors, post.meta.visitors);
       assert.deepEqual(out.numbers, Array.prototype.slice.call(post.numbers));
@@ -3824,9 +3563,7 @@ describe('Model', function() {
 
   describe('pathnames', function() {
     it('named path can be used', function(done) {
-      var db = start(),
-          P = db.model('pathnametest', new Schema({path: String}));
-      db.close();
+      var P = db.model('pathnametest', new Schema({path: String}));
 
       var threw = false;
       try {
@@ -3841,7 +3578,6 @@ describe('Model', function() {
   });
 
   it('subdocuments with changed values should persist the values', function(done) {
-    var db = start();
     var Subdoc = new Schema({name: String, mixed: Schema.Types.Mixed});
     var T = db.model('SubDocMixed', new Schema({subs: [Subdoc]}));
 
@@ -3885,7 +3621,6 @@ describe('Model', function() {
               assert.ifError(err);
 
               T.findById(t._id, function(err, t) {
-                db.close();
                 assert.ifError(err);
                 assert.strictEqual(t.subs[0].mixed.w, 5);
                 done();
@@ -3920,8 +3655,7 @@ describe('Model', function() {
 
   // Demonstration showing why GH-261 is a misunderstanding
   it('a single instantiated document should be able to update its embedded documents more than once', function(done) {
-    var db = start(),
-        BlogPost = db.model('BlogPost', collection);
+    var BlogPost = db.model('BlogPost', collection);
 
     var post = new BlogPost();
     post.comments.push({title: 'one'});
@@ -3933,7 +3667,6 @@ describe('Model', function() {
       post.save(function(err) {
         assert.ifError(err);
         BlogPost.findById(post._id, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.comments[0].title, 'two');
           done();
@@ -3945,8 +3678,6 @@ describe('Model', function() {
   describe('save()', function() {
     describe('when no callback is passed', function() {
       it('should emit error on its Model when there are listeners', function(done) {
-        const db = start();
-
         const DefaultErrSchema = new Schema({});
         DefaultErrSchema.pre('save', function(next) {
           next(new Error);
@@ -3955,7 +3686,6 @@ describe('Model', function() {
         var DefaultErr = db.model('DefaultErr3', DefaultErrSchema, 'default_err_' + random());
 
         DefaultErr.on('error', function(err) {
-          db.close();
           assert.ok(err instanceof Error);
           done();
         });
@@ -3965,8 +3695,7 @@ describe('Model', function() {
     });
 
     it('saved changes made within callback of a previous no-op save gh-1139', function(done) {
-      var db = start(),
-          B = db.model('BlogPost', collection);
+      var B = db.model('BlogPost', collection);
 
       var post = new B({title: 'first'});
       post.save(function(err) {
@@ -3983,7 +3712,7 @@ describe('Model', function() {
             B.findById(post, function(err, doc) {
               assert.ifError(err);
               assert.equal(doc.title, 'changed');
-              db.close(done);
+              done();
             });
           });
         });
@@ -3991,12 +3720,10 @@ describe('Model', function() {
     });
 
     it('rejects new documents that have no _id set (1595)', function(done) {
-      var db = start();
       var s = new Schema({_id: {type: String}});
       var B = db.model('1595', s);
       var b = new B;
       b.save(function(err) {
-        db.close();
         assert.ok(err);
         assert.ok(/must have an _id/.test(err));
         done();
@@ -4007,8 +3734,7 @@ describe('Model', function() {
 
   describe('_delta()', function() {
     it('should overwrite arrays when directly set (gh-1126)', function(done) {
-      var db = start(),
-          B = db.model('BlogPost', collection);
+      var B = db.model('BlogPost', collection);
 
       B.create({title: 'gh-1126', numbers: [1, 2]}, function(err, b) {
         assert.ifError(err);
@@ -4048,7 +3774,7 @@ describe('Model', function() {
                   assert.equal(b.numbers.length, 2);
                   assert.equal(b.numbers[0], 4);
                   assert.equal(b.numbers[1], 5);
-                  db.close(done);
+                  done();
                 });
               });
             });
@@ -4058,8 +3784,7 @@ describe('Model', function() {
     });
 
     it('should use $set when subdoc changed before pulling (gh-1303)', function(done) {
-      var db = start(),
-          B = db.model('BlogPost', 'gh-1303-' + random());
+      var B = db.model('BlogPost', 'gh-1303-' + random());
 
       B.create(
         {title: 'gh-1303', comments: [{body: 'a'}, {body: 'b'}, {body: 'c'}]},
@@ -4084,7 +3809,6 @@ describe('Model', function() {
               assert.ifError(err);
 
               B.findById(b._id, function(err, b) {
-                db.close();
                 assert.ifError(err);
                 assert.ok(Array.isArray(b.comments));
                 assert.equal(b.comments.length, 2);
@@ -4100,12 +3824,10 @@ describe('Model', function() {
 
   describe('backward compatibility', function() {
     it('with conflicted data in db', function(done) {
-      var db = start();
       var M = db.model('backwardDataConflict', new Schema({namey: {first: String, last: String}}));
       var m = new M({namey: '[object Object]'});
       m.namey = {first: 'GI', last: 'Joe'};// <-- should overwrite the string
       m.save(function(err) {
-        db.close();
         assert.strictEqual(err, null);
         assert.strictEqual('GI', m.namey.first);
         assert.strictEqual('Joe', m.namey.last);
@@ -4146,15 +3868,13 @@ describe('Model', function() {
 
   describe('non-schema adhoc property assignments', function() {
     it('are not saved', function(done) {
-      var db = start(),
-          B = db.model('BlogPost', collection);
+      var B = db.model('BlogPost', collection);
 
       var b = new B;
       b.whateveriwant = 10;
       b.save(function(err) {
         assert.ifError(err);
         B.collection.findOne({_id: b._id}, function(err, doc) {
-          db.close();
           assert.ifError(err);
           assert.ok(!('whateveriwant' in doc));
           done();
@@ -4164,7 +3884,6 @@ describe('Model', function() {
   });
 
   it('should not throw range error when using Number _id and saving existing doc (gh-691)', function(done) {
-    var db = start();
     var T = new Schema({_id: Number, a: String});
     var D = db.model('Testing691', T, 'asdf' + random());
     var d = new D({_id: 1});
@@ -4176,7 +3895,6 @@ describe('Model', function() {
 
         d.a = 'yo';
         d.save(function(err) {
-          db.close();
           assert.ifError(err);
           done();
         });
@@ -4186,8 +3904,6 @@ describe('Model', function() {
 
   describe('setting an unset value', function() {
     it('is saved (gh-742)', function(done) {
-      var db = start();
-
       var DefaultTestObject = db.model('defaultTestObject',
         new Schema({
           score: {type: Number, default: 55}
@@ -4212,7 +3928,6 @@ describe('Model', function() {
 
               doc.score = 55;
               doc.save(function(err, doc) {
-                db.close();
                 assert.ifError(err);
                 assert.equal(doc.score, 55);
                 done();
@@ -4225,13 +3940,11 @@ describe('Model', function() {
   });
 
   it('path is cast to correct value when retreived from db', function(done) {
-    var db = start();
     var schema = new Schema({title: {type: 'string', index: true}});
     var T = db.model('T', schema);
     T.collection.insert({title: 234}, {safe: true}, function(err) {
       assert.ifError(err);
       T.findOne(function(err, doc) {
-        db.close();
         assert.ifError(err);
         assert.equal(doc.title, '234');
         done();
@@ -4240,8 +3953,7 @@ describe('Model', function() {
   });
 
   it('setting a path to undefined should retain the value as undefined', function(done) {
-    var db = start(),
-        B = db.model('BlogPost', collection + random());
+    var B = db.model('BlogPost', collection + random());
 
     var doc = new B;
     doc.title = 'css3';
@@ -4296,7 +4008,6 @@ describe('Model', function() {
             b.save(function(err) {
               assert.ifError(err);
               B.collection.findOne({_id: b._id}, function(err, b) {
-                db.close();
                 assert.ifError(err);
                 assert.strictEqual(undefined, b.meta);
                 assert.strictEqual(undefined, b.comments);
@@ -4311,7 +4022,6 @@ describe('Model', function() {
 
   describe('unsetting a default value', function() {
     it('should be ignored (gh-758)', function(done) {
-      var db = start();
       var M = db.model('758', new Schema({s: String, n: Number, a: Array}));
       M.collection.insert({}, {safe: true}, function(err) {
         assert.ifError(err);
@@ -4319,14 +4029,13 @@ describe('Model', function() {
           assert.ifError(err);
           m.s = m.n = m.a = undefined;
           assert.equal(m.$__delta(), undefined);
-          db.close(done);
+          done();
         });
       });
     });
   });
 
   it('allow for object passing to ref paths (gh-1606)', function(done) {
-    var db = start();
     var schA = new Schema({title: String});
     var schma = new Schema({
       thing: {type: Schema.Types.ObjectId, ref: 'A'},
@@ -4350,13 +4059,10 @@ describe('Model', function() {
     assert.equal(thing.thing, a._id);
     assert.equal(thing.subdoc.thing[0], a._id);
 
-    db.close(done);
+    done();
   });
 
   it('setters trigger on null values (gh-1445)', function(done) {
-    var db = start();
-    db.close();
-
     var OrderSchema = new Schema({
       total: {
         type: Number,

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -152,8 +152,8 @@ describe('Model', function() {
   });
   describe('isNew', function() {
     it('is true on instantiation', function(done) {
-      var BlogPost = db.model('BlogPost', collection),
-        post = new BlogPost;
+      var BlogPost = db.model('BlogPost', collection);
+      var post = new BlogPost;
       assert.equal(post.isNew, true);
       done();
     });
@@ -253,9 +253,9 @@ describe('Model', function() {
       describe('defaults', function() {
         it('to a non-empty array', function(done) {
           var DefaultArraySchema = new Schema({
-                arr: {type: Array, cast: String, default: ['a', 'b', 'c']},
-                single: {type: Array, cast: String, default: ['a']}
-              });
+            arr: {type: Array, cast: String, default: ['a', 'b', 'c']},
+            single: {type: Array, cast: String, default: ['a']}
+          });
           mongoose.model('DefaultArray', DefaultArraySchema);
           var DefaultArray = db.model('DefaultArray', collection);
           var arr = new DefaultArray;
@@ -270,9 +270,9 @@ describe('Model', function() {
 
         it('empty', function(done) {
           var DefaultZeroCardArraySchema = new Schema({
-                arr: {type: Array, cast: String, default: []},
-                auto: [Number]
-              });
+            arr: {type: Array, cast: String, default: []},
+            auto: [Number]
+          });
           mongoose.model('DefaultZeroCardArray', DefaultZeroCardArraySchema);
           var DefaultZeroCardArray = db.model('DefaultZeroCardArray', collection);
           var arr = new DefaultZeroCardArray();
@@ -1537,11 +1537,11 @@ describe('Model', function() {
 
     it('nested', function(done) {
       var PersonSchema = new Schema({
-            name: {
-              first: String,
-              last: String
-            }
-          });
+        name: {
+          first: String,
+          last: String
+        }
+      });
 
       PersonSchema
         .virtual('name.full')
@@ -2323,10 +2323,10 @@ describe('Model', function() {
 
   it('multiple number push() calls', function(done) {
     var schema = new Schema({
-          nested: {
-            nums: [Number]
-          }
-        });
+      nested: {
+        nums: [Number]
+      }
+    });
 
     mongoose.model('NestedPushes', schema);
     var Temp = db.model('NestedPushes', collection);
@@ -2352,10 +2352,10 @@ describe('Model', function() {
 
   it('multiple push() calls', function(done) {
     var schema = new Schema({
-          nested: {
-            nums: [Number]
-          }
-        });
+      nested: {
+        nums: [Number]
+      }
+    });
 
     var Temp = db.model('NestedPushes', schema, collection);
 
@@ -2379,10 +2379,10 @@ describe('Model', function() {
 
   it('activePaths should be updated for nested modifieds', function(done) {
     var schema = new Schema({
-          nested: {
-            nums: [Number]
-          }
-        });
+      nested: {
+        nums: [Number]
+      }
+    });
 
     var Temp = db.model('NestedPushes', schema, collection);
 
@@ -2398,10 +2398,10 @@ describe('Model', function() {
 
   it('activePaths should be updated for nested modifieds as promise', function(done) {
     var schema = new Schema({
-          nested: {
-            nums: [Number]
-          }
-        });
+      nested: {
+        nums: [Number]
+      }
+    });
 
     var Temp = db.model('NestedPushes', schema, collection);
 
@@ -2416,10 +2416,10 @@ describe('Model', function() {
 
   it('$pull should affect what you see in an array before a save', function(done) {
     var schema = new Schema({
-          nested: {
-            nums: [Number]
-          }
-        });
+      nested: {
+        nums: [Number]
+      }
+    });
 
     var Temp = db.model('NestedPushes', schema, collection);
 
@@ -2433,10 +2433,10 @@ describe('Model', function() {
 
   it('$shift', function(done) {
     var schema = new Schema({
-          nested: {
-            nums: [Number]
-          }
-        });
+      nested: {
+        nums: [Number]
+      }
+    });
 
     mongoose.model('TestingShift', schema);
     var Temp = db.model('TestingShift', collection);
@@ -2761,9 +2761,9 @@ describe('Model', function() {
 
   it('updating an embedded array document to an Object value (gh-334)', function(done) {
     var SubSchema = new Schema({
-          name: String,
-          subObj: {subName: String}
-        });
+      name: String,
+      subObj: {subName: String}
+    });
     var GH334Schema = new Schema({name: String, arrData: [SubSchema]});
 
     mongoose.model('GH334', GH334Schema);

--- a/test/plugin.idGetter.test.js
+++ b/test/plugin.idGetter.test.js
@@ -9,9 +9,17 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('id virtual getter', function() {
-  it('should work as expected with an ObjectId', function(done) {
-    var db = start();
+  var db;
 
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
+  it('should work as expected with an ObjectId', function(done) {
     var schema = new Schema({});
 
     var S = db.model('Basic', schema);
@@ -25,8 +33,6 @@ describe('id virtual getter', function() {
   });
 
   it('should be turned off when `id` option is set to false', function(done) {
-    var db = start();
-
     var schema = new Schema({}, {id: false});
 
     var S = db.model('NoIdGetter', schema);
@@ -41,13 +47,11 @@ describe('id virtual getter', function() {
 
 
   it('should be turned off when the schema has a set `id` path', function(done) {
-    var db = start();
-
     var schema = new Schema({
       id: String
     });
 
-    var S = db.model('NoIdGetter', schema);
+    var S = db.model('SchemaHasId', schema);
     S.create({ id: 'test'}, function(err, s) {
       assert.ifError(err);
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -21,6 +21,7 @@ describe('Query', function() {
   var Comment;
   var Product;
   var p1;
+  var db;
 
   before(function() {
     Comment = new Schema({
@@ -43,6 +44,14 @@ describe('Query', function() {
   before(function() {
     var Prod = mongoose.model('Product');
     p1 = new Prod();
+  });
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   describe('constructor', function() {
@@ -858,16 +867,6 @@ describe('Query', function() {
   });
 
   describe('casting', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('to an array of mixed', function(done) {
       var query = new Query({}, {}, null, p1.collection);
       var Product = db.model('Product');
@@ -1018,19 +1017,17 @@ describe('Query', function() {
 
   describe('distinct', function() {
     it('op', function(done) {
-      var db = start();
       var Product = db.model('Product');
       var prod = new Product({});
       var q = new Query({}, {}, Product, prod.collection).distinct('blah', function() {
         assert.equal(q.op, 'distinct');
-        db.close(done);
+        done();
       });
     });
   });
 
   describe('without a callback', function() {
     it('count, update, remove works', function(done) {
-      var db = start();
       var Product = db.model('Product', 'update_products_' + random());
       new Query(p1.collection, {}, Product).count();
       Product.create({tags: 12345}, function(err) {
@@ -1048,7 +1045,6 @@ describe('Query', function() {
               Product.find({tags: 123456}, function(err, p) {
                 assert.ifError(err);
                 assert.equal(p.length, 0);
-                db.close();
                 done();
               });
             }, time);
@@ -1060,7 +1056,6 @@ describe('Query', function() {
 
   describe('findOne', function() {
     it('sets the op', function(done) {
-      var db = start();
       var Product = db.model('Product');
       var prod = new Product({});
       var q = new Query(prod.collection, {}, Product).distinct();
@@ -1070,18 +1065,16 @@ describe('Query', function() {
         assert.equal(q.op, 'distinct');
         q.findOne();
         assert.equal(q.op, 'findOne');
-        db.close();
         done();
       }, 50);
     });
 
     it('works as a promise', function(done) {
-      var db = start();
       var Product = db.model('Product');
       var promise = Product.findOne();
 
       promise.then(function() {
-        db.close(done);
+        done();
       }, function(err) {
         assert.ifError(err);
       });
@@ -1089,16 +1082,6 @@ describe('Query', function() {
   });
 
   describe('deleteOne/deleteMany', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('handles deleteOne', function(done) {
       var M = db.model('deleteOne', new Schema({ name: 'String' }));
       M.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
@@ -1132,12 +1115,10 @@ describe('Query', function() {
 
   describe('remove', function() {
     it('handles cast errors async', function(done) {
-      var db = start();
       var Product = db.model('Product');
 
       assert.doesNotThrow(function() {
         Product.where({numbers: [[[]]]}).remove(function(err) {
-          db.close();
           assert.ok(err);
           done();
         });
@@ -1145,11 +1126,9 @@ describe('Query', function() {
     });
 
     it('supports a single conditions arg', function(done) {
-      var db = start();
       var Product = db.model('Product');
 
       Product.create({strings: ['remove-single-condition']}).then(function() {
-        db.close();
         var q = Product.where().remove({strings: 'remove-single-condition'});
         assert.ok(q instanceof mongoose.Query);
         done();
@@ -1157,7 +1136,6 @@ describe('Query', function() {
     });
 
     it('supports a single callback arg', function(done) {
-      var db = start();
       var Product = db.model('Product');
       var val = 'remove-single-callback';
 
@@ -1165,7 +1143,6 @@ describe('Query', function() {
         Product.where({strings: val}).remove(function(err) {
           assert.ifError(err);
           Product.findOne({strings: val}, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.ok(!doc);
             done();
@@ -1175,7 +1152,6 @@ describe('Query', function() {
     });
 
     it('supports conditions and callback args', function(done) {
-      var db = start();
       var Product = db.model('Product');
       var val = 'remove-cond-and-callback';
 
@@ -1183,7 +1159,6 @@ describe('Query', function() {
         Product.where().remove({strings: val}, function(err) {
           assert.ifError(err);
           Product.findOne({strings: val}, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.ok(!doc);
             done();
@@ -1193,7 +1168,6 @@ describe('Query', function() {
     });
 
     it('single option, default', function(done) {
-      var db = start();
       var Test = db.model('Test_single', new Schema({ name: String }));
 
       Test.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
@@ -1211,8 +1185,7 @@ describe('Query', function() {
     });
 
     it('single option, false', function(done) {
-      var db = start();
-      var Test = db.model('Test_single', new Schema({ name: String }));
+      var Test = db.model('Test_single_false', new Schema({ name: String }));
 
       Test.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
         assert.ifError(error);
@@ -1229,8 +1202,7 @@ describe('Query', function() {
     });
 
     it('single option, true', function(done) {
-      var db = start();
-      var Test = db.model('Test_single', new Schema({ name: String }));
+      var Test = db.model('Test_single_true', new Schema({ name: String }));
 
       Test.create([{ name: 'Eddard Stark' }, { name: 'Robb Stark' }], function(error) {
         assert.ifError(error);
@@ -1249,7 +1221,6 @@ describe('Query', function() {
 
   describe('querying/updating with model instance containing embedded docs should work (#454)', function() {
     it('works', function(done) {
-      var db = start();
       var Product = db.model('Product');
 
       var proddoc = {comments: [{text: 'hello'}]};
@@ -1273,7 +1244,7 @@ describe('Query', function() {
               // ensure hidden private props were not saved to db
               assert.ok(!doc.comments[0].hasOwnProperty('parentArry'));
               assert.equal(doc.comments[0].text, 'goodbye');
-              db.close(done);
+              done();
             });
           });
         });
@@ -1491,7 +1462,6 @@ describe('Query', function() {
         });
 
         it('and sends it though the driver', function(done) {
-          var db = start();
           var options = {read: 'secondary', safe: {w: 'majority'}};
           var schema = new Schema({name: String}, options);
           var M = db.model(random(), schema);
@@ -1517,7 +1487,7 @@ describe('Query', function() {
               return done(err);
             }
             assert.ok(called);
-            db.close(done);
+            done();
           });
         });
       });
@@ -1550,14 +1520,12 @@ describe('Query', function() {
       assert.equal(q.options.readPreference.mode, 'secondary');
       assert.equal(q.options.readPreference.tags[0].dc, 'eu');
 
-      var db = start();
       var Product = db.model('Product', 'Product_setOptions_test');
       Product.create(
         {numbers: [3, 4, 5]},
         {strings: 'hi there'.split(' ')}, function(err, doc1, doc2) {
           assert.ifError(err);
           Product.find().setOptions({limit: 1, sort: {_id: -1}, read: 'n'}).exec(function(err, docs) {
-            db.close();
             assert.ifError(err);
             assert.equal(docs.length, 1);
             assert.equal(docs[0].id, doc2.id);
@@ -1584,16 +1552,6 @@ describe('Query', function() {
   });
 
   describe('bug fixes', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     describe('collations', function() {
       before(function(done) {
         var _this = this;
@@ -2383,12 +2341,9 @@ describe('Query', function() {
   });
 
   describe('handles falsy and object projections with defaults (gh-3256)', function() {
-    var db;
     var MyModel;
 
     before(function(done) {
-      db = start();
-
       var PersonSchema = new Schema({
         name: String,
         lastName: String,
@@ -2416,10 +2371,6 @@ describe('Query', function() {
 
         done();
       });
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     it('falsy projection', function(done) {

--- a/test/schema.alias.test.js
+++ b/test/schema.alias.test.js
@@ -9,9 +9,17 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('schema alias option', function() {
-  it('works with all basic schema types', function(done) {
-    var db = start();
+  var db;
 
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
+  it('works with all basic schema types', function(done) {
     var schema = new Schema({
       string:   { type: String, alias: 'StringAlias' },
       number:   { type: Number, alias: 'NumberAlias' },
@@ -50,8 +58,6 @@ describe('schema alias option', function() {
   });
 
   it('works with nested schema types', function(done) {
-    var db = start();
-
     var schema = new Schema({
       nested: {
         string:   { type: String, alias: 'StringAlias' },

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -9,17 +9,24 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('schematype', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   describe('boolean', function() {
     it('null default is permitted (gh-523)', function(done) {
-      var db = start(),
-          s1 = new Schema({b: {type: Boolean, default: null}}),
+      var s1 = new Schema({b: {type: Boolean, default: null}}),
           M1 = db.model('NullDateDefaultIsAllowed1', s1),
           s2 = new Schema({b: {type: Boolean, default: false}}),
           M2 = db.model('NullDateDefaultIsAllowed2', s2),
           s3 = new Schema({b: {type: Boolean, default: true}}),
           M3 = db.model('NullDateDefaultIsAllowed3', s3);
-
-      db.close();
 
       var m1 = new M1;
       assert.strictEqual(null, m1.b);
@@ -31,10 +38,8 @@ describe('schematype', function() {
     });
 
     it('strictBool option (gh-5211)', function(done) {
-      var db = start(),
-          s1 = new Schema({b: {type: Boolean}}),
-          M1 = db.model('StrictBoolTrue', s1);
-      db.close();
+      var s1 = new Schema({b: {type: Boolean}}),
+          M1 = db.model('StrictBoolOption', s1);
 
       var strictValues = [true, false, 'true', 'false', 0, 1, '0', '1', 'no', 'yes'];
 
@@ -55,10 +60,8 @@ describe('schematype', function() {
     });
 
     it('strictBool schema option', function(done) {
-      var db = start(),
-          s1 = new Schema({b: {type: Boolean}}, {strictBool: true}),
+      var s1 = new Schema({b: {type: Boolean}}, {strictBool: true}),
           M1 = db.model('StrictBoolTrue', s1);
-      db.close();
 
       var strictValues = [true, false, 'true', 'false', 0, 1, '0', '1'];
 

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -9,9 +9,17 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('schema select option', function() {
-  it('excluding paths through schematype', function(done) {
-    var db = start();
+  var db;
 
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
+  it('excluding paths through schematype', function(done) {
     var schema = new Schema({
       thin: Boolean,
       name: {type: String, select: false},
@@ -28,9 +36,7 @@ describe('schema select option', function() {
       var item = s;
 
       function cb(err, s) {
-        if (!--pending) {
-          db.close();
-        }
+        pending--;
 
         if (Array.isArray(s)) {
           s = s[0];
@@ -56,8 +62,6 @@ describe('schema select option', function() {
   });
 
   it('including paths through schematype', function(done) {
-    var db = start();
-
     var schema = new Schema({
       thin: Boolean,
       name: {type: String, select: true},
@@ -73,9 +77,8 @@ describe('schema select option', function() {
       var pending = 4;
 
       function cb(err, s) {
-        if (!--pending) {
-          db.close();
-        }
+        pending--;
+
         if (Array.isArray(s)) {
           s = s[0];
         }
@@ -103,11 +106,9 @@ describe('schema select option', function() {
   });
 
   describe('overriding schematype select options', function() {
-    var db, selected, excluded, S, E;
+    var selected, excluded, S, E;
 
     before(function() {
-      db = start();
-
       selected = new Schema({
         thin: Boolean,
         name: {type: String, select: true},
@@ -121,10 +122,6 @@ describe('schema select option', function() {
 
       S = db.model('OverriddingSelectedBySchemaType', selected);
       E = db.model('OverriddingExcludedBySchemaType', excluded);
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     describe('works', function() {
@@ -296,7 +293,6 @@ describe('schema select option', function() {
 
   describe('forcing inclusion of a deselected schema path', function() {
     it('works', function(done) {
-      var db = start();
       var excluded = new Schema({
         thin: Boolean,
         name: {type: String, select: false},
@@ -340,7 +336,6 @@ describe('schema select option', function() {
                     M.findById(d)
                       .select('-thin -docs.bool')
                       .exec(function(err, doc) {
-                        db.close();
                         assert.ifError(err);
                         assert.equal(doc.thin, undefined);
                         assert.equal(doc.name, undefined);
@@ -356,7 +351,6 @@ describe('schema select option', function() {
     });
 
     it('works with query.slice (gh-1370)', function(done) {
-      var db = start();
       var M = db.model('1370', new Schema({many: {type: [String], select: false}}));
 
       M.create({many: ['1', '2', '3', '4', '5']}, function(err) {
@@ -371,15 +365,13 @@ describe('schema select option', function() {
             return done(err);
           }
           assert.equal(doc.many.length, 2);
-          db.close(done);
+          done();
         });
       });
     });
   });
 
   it('conflicting schematype path selection should not error', function(done) {
-    var db = start();
-
     var schema = new Schema({
       thin: Boolean,
       name: {type: String, select: true},
@@ -396,7 +388,7 @@ describe('schema select option', function() {
 
       function cb(err, s) {
         if (!--pending) {
-          db.close(done);
+          done();
         }
         if (Array.isArray(s)) {
           s = s[0];
@@ -412,8 +404,6 @@ describe('schema select option', function() {
   });
 
   it('selecting _id works with excluded schematype path', function(done) {
-    var db = start();
-
     var schema = new Schema({
       name: {type: String, select: false}
     });
@@ -423,7 +413,6 @@ describe('schema select option', function() {
       assert.ok(err instanceof Error, 'conflicting path selection error should be instance of Error');
 
       M.find().select('_id').exec(function(err) {
-        db.close();
         assert.ifError(err, err && err.stack);
         done();
       });
@@ -431,18 +420,15 @@ describe('schema select option', function() {
   });
 
   it('selecting _id works with excluded schematype path on sub doc', function(done) {
-    var db = start();
-
     var schema = new Schema({
       docs: [new Schema({name: {type: String, select: false}})]
     });
 
-    var M = db.model('SelectingOnly_idWithExcludedSchemaType', schema);
+    var M = db.model('SelectingOnly_idWithExcludedSchemaTypeSubDoc', schema);
     M.find().select('_id -docs.name').exec(function(err) {
       assert.ok(err instanceof Error, 'conflicting path selection error should be instance of Error');
 
       M.find().select('_id').exec(function(err) {
-        db.close();
         assert.ifError(err, err && err.stack);
         done();
       });
@@ -450,7 +436,6 @@ describe('schema select option', function() {
   });
 
   it('all inclusive/exclusive combos work', function(done) {
-    var db = start();
     var coll = 'inclusiveexclusivecomboswork_' + random();
 
     var schema = new Schema({
@@ -531,7 +516,6 @@ describe('schema select option', function() {
             nonId(S, id, function() {
               useId(T, id, function() {
                 nonId(T, id, function() {
-                  db.close();
                   done();
                 });
               });
@@ -543,7 +527,6 @@ describe('schema select option', function() {
   });
 
   it('does not set defaults for nested objects (gh-4707)', function(done) {
-    var db = start();
     var userSchema = new Schema({
       name: String,
       age: Number,
@@ -567,13 +550,12 @@ describe('schema select option', function() {
       }).
       then(function(user) {
         assert.ok(!user.profile.flags);
-        db.close(done);
+        done();
       }).
       catch(done);
   });
 
   it('does not create nested objects if not included (gh-4669)', function(done) {
-    var db = start();
     var schema = new Schema({
       field1: String,
       field2: String,
@@ -601,7 +583,7 @@ describe('schema select option', function() {
         assert.ifError(error);
         assert.ok(!doc.toObject({ minimize: false }).field3);
         assert.ok(!doc.toObject({ minimize: false }).field4);
-        db.close(done);
+        done();
       });
     });
   });
@@ -613,7 +595,6 @@ describe('schema select option', function() {
       }
     });
 
-    var db = start();
     var Model = db.model('nested', NestedSchema);
 
     var doc = new Model();
@@ -623,7 +604,7 @@ describe('schema select option', function() {
       Model.findOne({}, {nested: 1}, function(error, doc) {
         assert.ifError(error);
         assert.equal(doc.nested.name, 'val');
-        db.close(done);
+        done();
       });
     });
   });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -36,6 +36,16 @@ TestDocument.prototype.__proto__ = Document.prototype;
  */
 
 describe('schema', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   before(function() {
     TestDocument.prototype.$__setSchema(new Schema({
       test: String
@@ -43,10 +53,9 @@ describe('schema', function() {
   });
 
   describe('nested fields with same name', function() {
-    var db, NestedModel;
+    var NestedModel;
 
     before(function() {
-      db = start();
       var NestedSchema = new Schema({
         a: {
           b: {
@@ -57,10 +66,6 @@ describe('schema', function() {
         b: { $type: String }
       }, { typeKey: '$type' });
       NestedModel = db.model('Nested', NestedSchema);
-    });
-
-    after(function() {
-      db.close();
     });
 
     it('don\'t disappear', function(done) {
@@ -1155,8 +1160,6 @@ describe('schema', function() {
     });
 
     it('merging nested objects (gh-662)', function(done) {
-      var db = start();
-
       var MergedSchema = new Schema({
         a: {
           foo: String
@@ -1187,7 +1190,6 @@ describe('schema', function() {
       merged.save(function(err) {
         assert.ifError(err);
         Merged.findById(merged.id, function(err, found) {
-          db.close();
           assert.ifError(err);
           assert.equal(found.a.foo, 'baz');
           assert.equal(found.a.b.bar, 'qux');
@@ -1278,7 +1280,6 @@ describe('schema', function() {
     });
 
     it('properly gets value of plain objects when dealing with refs (gh-1606)', function(done) {
-      var db = start();
       var el = new Schema({ title: String });
       var so = new Schema({
         title: String,
@@ -1298,7 +1299,7 @@ describe('schema', function() {
           Some.findOne({ _id: s.id }, function(err, ss) {
             assert.ifError(err);
             assert.equal(ss.obj, ele.id);
-            db.close(done);
+            done();
           });
         });
       });
@@ -1392,7 +1393,6 @@ describe('schema', function() {
     });
 
     it('permit _scope to be used (gh-1184)', function(done) {
-      var db = start();
       var child = new Schema({ _scope: Schema.ObjectId });
       var C = db.model('scope', child);
       var c = new C;
@@ -1405,7 +1405,7 @@ describe('schema', function() {
           err = e;
         }
         assert.ifError(err);
-        db.close(done);
+        done();
       });
     });
   });

--- a/test/schema.timestamps.test.js
+++ b/test/schema.timestamps.test.js
@@ -9,6 +9,16 @@ var start = require('./common'),
     Schema = mongoose.Schema;
 
 describe('schema options.timestamps', function() {
+  var conn;
+
+  before(function() {
+    conn = start();
+  });
+
+  after(function(done) {
+    conn.close(done);
+  });
+
   describe('create schema with options.timestamps', function() {
     it('should have createdAt and updatedAt fields', function(done) {
       var TestSchema = new Schema({
@@ -99,7 +109,6 @@ describe('schema options.timestamps', function() {
         timestamps: true
       });
 
-      var conn = start();
       var Test = conn.model('Test', TestSchema);
 
       Test.create({
@@ -142,7 +151,6 @@ describe('schema options.timestamps', function() {
 
   describe('auto update createdAt and updatedAt when create/save/update document', function() {
     var CatSchema;
-    var conn;
     var Cat;
 
     before(function(done) {
@@ -150,7 +158,6 @@ describe('schema options.timestamps', function() {
         name: String,
         hobby: String
       }, {timestamps: true});
-      conn = start();
       Cat = conn.model('Cat', CatSchema);
       Cat.remove({}, done);
     });
@@ -258,9 +265,7 @@ describe('schema options.timestamps', function() {
     });
 
     after(function(done) {
-      Cat.remove({}, function() {
-        conn.close(done);
-      });
+      Cat.remove({}, done);
     });
   });
 });

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -18,6 +18,7 @@ var collection = 'avengers_' + random();
 describe('types array', function() {
   var User;
   var Pet;
+  var db;
 
   before(function() {
     User = new Schema({
@@ -32,6 +33,11 @@ describe('types array', function() {
     });
 
     mongoose.model('Pet', Pet);
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('behaves and quacks like an Array', function(done) {
@@ -73,8 +79,7 @@ describe('types array', function() {
 
   describe('indexOf()', function() {
     it('works', function(done) {
-      var db = start(),
-          User = db.model('User', 'users_' + random()),
+      var User = db.model('User', 'users_' + random()),
           Pet = db.model('Pet', 'pets' + random());
 
       var tj = new User({name: 'tj'}),
@@ -102,7 +107,7 @@ describe('types array', function() {
               assert.equal(user.pets.indexOf(tobi._id), 0);
               assert.equal(user.pets.indexOf(loki._id), 1);
               assert.equal(user.pets.indexOf(jane._id), 2);
-              db.close(done);
+              done();
             });
           });
         });
@@ -117,7 +122,7 @@ describe('types array', function() {
   });
 
   describe('push()', function() {
-    var db, N, S, B, M, D, ST;
+    var N, S, B, M, D, ST;
 
     function save(doc, cb) {
       doc.save(function(err) {
@@ -130,7 +135,6 @@ describe('types array', function() {
     }
 
     before(function(done) {
-      db = start();
       N = db.model('arraySet', Schema({arr: [Number]}));
       S = db.model('arraySetString', Schema({arr: [String]}));
       B = db.model('arraySetBuffer', Schema({arr: [Buffer]}));
@@ -143,10 +147,6 @@ describe('types array', function() {
         }]
       }));
       done();
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     it('works with numbers', function(done) {
@@ -314,16 +314,6 @@ describe('types array', function() {
   });
 
   describe('splice()', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('works', function(done) {
       var collection = 'splicetest-number' + random();
       var schema = new Schema({numbers: [Number]}),
@@ -392,16 +382,6 @@ describe('types array', function() {
   });
 
   describe('unshift()', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('works', function(done) {
       var schema = new Schema({
             types: [new Schema({type: String})],
@@ -482,7 +462,7 @@ describe('types array', function() {
     });
 
     it('applies setters (gh-3032)', function(done) {
-      var ST = db.model('setterArray', Schema({
+      var ST = db.model('setterArrayUnshift', Schema({
         arr: [{
           type: String,
           lowercase: true
@@ -511,15 +491,6 @@ describe('types array', function() {
   });
 
   describe('shift()', function() {
-    var db;
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('works', function(done) {
       var schema = new Schema({
         types: [new Schema({type: String})],
@@ -566,7 +537,6 @@ describe('types array', function() {
           doc.save(function(err) {
             assert.ifError(err);
             A.findById(a._id, function(err, doc) {
-              db.close();
               assert.ifError(err);
 
               var obj = doc.types.toObject();
@@ -593,9 +563,8 @@ describe('types array', function() {
   describe('$shift', function() {
     it('works', function(done) {
       // atomic shift uses $pop -1
-      var db = start();
       var painting = new Schema({colors: []});
-      var Painting = db.model('Painting', painting);
+      var Painting = db.model('PaintingShift', painting);
       var p = new Painting({colors: ['blue', 'green', 'yellow']});
       p.save(function(err) {
         assert.ifError(err);
@@ -619,7 +588,6 @@ describe('types array', function() {
             doc.save(function(err) {
               assert.equal(err, null);
               Painting.findById(doc, function(err, doc) {
-                db.close();
                 assert.ifError(err);
                 assert.equal(doc.colors.length, 1);
                 assert.equal(doc.colors[0], 'yellow');
@@ -634,8 +602,7 @@ describe('types array', function() {
 
   describe('pop()', function() {
     it('works', function(done) {
-      var db = start(),
-          schema = new Schema({
+      var schema = new Schema({
             types: [new Schema({type: String})],
             nums: [Number],
             strs: [String]
@@ -680,7 +647,6 @@ describe('types array', function() {
           doc.save(function(err) {
             assert.ifError(err);
             A.findById(a._id, function(err, doc) {
-              db.close();
               assert.ifError(err);
 
               var obj = doc.types.toObject();
@@ -706,7 +672,6 @@ describe('types array', function() {
 
   describe('pull()', function() {
     it('works', function(done) {
-      var db = start();
       var catschema = new Schema({name: String});
       var Cat = db.model('Cat', catschema);
       var schema = new Schema({
@@ -722,7 +687,6 @@ describe('types array', function() {
           assert.ifError(err);
 
           A.findById(a, function(err, doc) {
-            db.close();
             assert.ifError(err);
             assert.equal(doc.a.length, 1);
             doc.a.pull(cat.id);
@@ -734,7 +698,6 @@ describe('types array', function() {
     });
 
     it('handles pulling with no _id (gh-3341)', function(done) {
-      var db = start();
       var personSchema = new Schema({
         name: String,
         role: String
@@ -774,16 +737,15 @@ describe('types array', function() {
             assert.equal(gnr.members[1].name, 'Izzy');
             assert.equal(gnr.members[2].name, 'Duff');
             assert.equal(gnr.members[3].name, 'Adler');
-            db.close(done);
+            done();
           });
         });
       });
     });
 
     it('properly works with undefined', function(done) {
-      var db = start();
       var catschema = new Schema({ name: String, colors: [{hex: String}] });
-      var Cat = db.model('Cat', catschema);
+      var Cat = db.model('ColoredCat', catschema);
 
       var cat = new Cat({name: 'peanut', colors: [
         {hex: '#FFF'}, {hex: '#000'}, null
@@ -805,7 +767,7 @@ describe('types array', function() {
             assert.equal(doc.colors.length, 2);
             assert.equal(doc.colors[0].hex, '#FFF');
             assert.equal(doc.colors[1].hex, '#000');
-            db.close(done);
+            done();
           });
         });
       });
@@ -814,7 +776,6 @@ describe('types array', function() {
 
   describe('$pop()', function() {
     it('works', function(done) {
-      var db = start();
       var painting = new Schema({colors: []});
       var Painting = db.model('Painting', painting);
       var p = new Painting({colors: ['blue', 'green', 'yellow']});
@@ -841,7 +802,6 @@ describe('types array', function() {
             doc.save(function(err) {
               assert.equal(err, null);
               Painting.findById(doc, function(err, doc) {
-                db.close();
                 assert.strictEqual(null, err);
                 assert.equal(doc.colors.length, 1);
                 assert.equal(doc.colors[0], 'blue');
@@ -856,8 +816,7 @@ describe('types array', function() {
 
   describe('addToSet()', function() {
     it('works', function(done) {
-      var db = start(),
-          e = new Schema({name: String, arr: []}),
+      var e = new Schema({name: String, arr: []}),
           schema = new Schema({
             num: [Number],
             str: [String],
@@ -1026,7 +985,6 @@ describe('types array', function() {
                 assert.ifError(err);
 
                 M.findById(m, function(err, m) {
-                  db.close();
                   assert.ifError(err);
 
                   assert.equal(m.num.length, 8);
@@ -1094,8 +1052,7 @@ describe('types array', function() {
     });
 
     it('handles sub-documents that do not have an _id gh-1973', function(done) {
-      var db = start(),
-          e = new Schema({name: String, arr: []}, {_id: false}),
+      var e = new Schema({name: String, arr: []}, {_id: false}),
           schema = new Schema({
             doc: [e]
           });
@@ -1119,13 +1076,12 @@ describe('types array', function() {
           assert.ok(m.doc.some(function(v) {
             return v.name === 'House';
           }));
-          db.close(done);
+          done();
         });
       });
     });
 
     it('applies setters (gh-3032)', function(done) {
-      var db = start();
       var ST = db.model('setterArray', Schema({
         arr: [{
           type: String,
@@ -1148,7 +1104,7 @@ describe('types array', function() {
           assert.strictEqual('two', doc.arr[1]);
           assert.strictEqual('three', doc.arr[2]);
 
-          db.close(done);
+          done();
         });
       });
     });
@@ -1156,7 +1112,6 @@ describe('types array', function() {
 
   describe('nonAtomicPush()', function() {
     it('works', function(done) {
-      var db = start();
       var U = db.model('User');
       var ID = mongoose.Types.ObjectId;
 
@@ -1180,7 +1135,6 @@ describe('types array', function() {
           u.save(function(err) {
             assert.ifError(err);
             U.findById(u._id, function(err) {
-              db.close();
               assert.ifError(err);
               assert.equal(u.pets.length, 2);
               assert.equal(u.pets[0].toString(), id1.toString());
@@ -1195,7 +1149,6 @@ describe('types array', function() {
 
   describe('sort()', function() {
     it('order should be saved', function(done) {
-      var db = start();
       var M = db.model('ArraySortOrder', new Schema({x: [Number]}));
       var m = new M({x: [1, 4, 3, 2]});
       m.save(function(err) {
@@ -1233,7 +1186,7 @@ describe('types array', function() {
                   assert.equal(m.x[1], 3);
                   assert.equal(m.x[2], 2);
                   assert.equal(m.x[3], 1);
-                  db.close(done);
+                  done();
                 });
               });
             });
@@ -1244,7 +1197,7 @@ describe('types array', function() {
   });
 
   describe('set()', function() {
-    var db, N, S, B, M, D, ST;
+    var N, S, B, M, D, ST;
 
     function save(doc, cb) {
       doc.save(function(err) {
@@ -1257,23 +1210,18 @@ describe('types array', function() {
     }
 
     before(function(done) {
-      db = start();
-      N = db.model('arraySet', Schema({arr: [Number]}));
-      S = db.model('arraySetString', Schema({arr: [String]}));
-      B = db.model('arraySetBuffer', Schema({arr: [Buffer]}));
-      M = db.model('arraySetMixed', Schema({arr: []}));
-      D = db.model('arraySetSubDocs', Schema({arr: [{name: String}]}));
-      ST = db.model('arrayWithSetters', Schema({
+      N = db.model('arraySet2', Schema({arr: [Number]}));
+      S = db.model('arraySetString2', Schema({arr: [String]}));
+      B = db.model('arraySetBuffer2', Schema({arr: [Buffer]}));
+      M = db.model('arraySetMixed2', Schema({arr: []}));
+      D = db.model('arraySetSubDocs2', Schema({arr: [{name: String}]}));
+      ST = db.model('arrayWithSetters2', Schema({
         arr: [{
           type: String,
           lowercase: true
         }]
       }));
       done();
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     it('works combined with other ops', function(done) {
@@ -1590,8 +1538,6 @@ describe('types array', function() {
 
   describe('setting a doc array', function() {
     it('should adjust path positions', function(done) {
-      var db = start();
-
       var D = db.model('subDocPositions', new Schema({
         em1: [new Schema({name: String})]
       }));
@@ -1620,7 +1566,6 @@ describe('types array', function() {
           d.save(function(err) {
             assert.ifError(err);
             D.findById(d, function(err, d) {
-              db.close();
               assert.ifError(err);
               assert.equal(d.em1[0].name, 'position two');
               assert.equal(d.em1[1].name, 'pos1');
@@ -1634,8 +1579,6 @@ describe('types array', function() {
 
   describe('paths with similar names', function() {
     it('should be saved', function(done) {
-      var db = start();
-
       var D = db.model('similarPathNames', new Schema({
         account: {
           role: String,
@@ -1662,7 +1605,6 @@ describe('types array', function() {
           d.save(function(err) {
             assert.ifError(err);
             D.findById(d, function(err, d) {
-              db.close();
               assert.ifError(err);
               assert.equal(d.account.role, 'president');
               assert.equal(d.account.roles.length, 2);
@@ -1680,7 +1622,6 @@ describe('types array', function() {
 
   describe('of number', function() {
     it('allows nulls', function(done) {
-      var db = start();
       var schema = new Schema({x: [Number]}, {collection: 'nullsareallowed' + random()});
       var M = db.model('nullsareallowed', schema);
       var m;
@@ -1692,7 +1633,6 @@ describe('types array', function() {
         // undefined is not allowed
         m = new M({x: [1, undefined, 3]});
         m.save(function(err) {
-          db.close();
           assert.ok(err);
           done();
         });
@@ -1701,16 +1641,6 @@ describe('types array', function() {
   });
 
   describe('bug fixes', function() {
-    var db;
-
-    before(function() {
-      db = start();
-    });
-
-    after(function(done) {
-      db.close(done);
-    });
-
     it('modifying subdoc props and manipulating the array works (gh-842)', function(done) {
       var schema = new Schema({em: [new Schema({username: String})]});
       var M = db.model('modifyingSubDocAndPushing', schema);
@@ -1802,8 +1732,7 @@ describe('types array', function() {
 
   describe('default type', function() {
     it('casts to Mixed', function(done) {
-      var db = start(),
-          DefaultArraySchema = new Schema({
+      var DefaultArraySchema = new Schema({
             num1: Array,
             num2: []
           });
@@ -1811,7 +1740,6 @@ describe('types array', function() {
       mongoose.model('DefaultArraySchema', DefaultArraySchema);
       var DefaultArray = db.model('DefaultArraySchema', collection);
       var arr = new DefaultArray();
-      db.close();
 
       assert.equal(arr.get('num1').length, 0);
       assert.equal(arr.get('num2').length, 0);
@@ -1843,7 +1771,6 @@ describe('types array', function() {
   });
 
   describe('removing from an array atomically using MongooseArray#remove', function() {
-    var db;
     var B;
 
     before(function(done) {
@@ -1855,13 +1782,8 @@ describe('types array', function() {
         oidIds: [{name: 'string'}]
       });
 
-      db = start();
       B = db.model('BlogPost', schema);
       done();
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     it('works', function(done) {

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -603,10 +603,10 @@ describe('types array', function() {
   describe('pop()', function() {
     it('works', function(done) {
       var schema = new Schema({
-            types: [new Schema({type: String})],
-            nums: [Number],
-            strs: [String]
-          });
+        types: [new Schema({type: String})],
+        nums: [Number],
+        strs: [String]
+      });
 
       var A = db.model('pop', schema, 'pop' + random());
 
@@ -1733,9 +1733,9 @@ describe('types array', function() {
   describe('default type', function() {
     it('casts to Mixed', function(done) {
       var DefaultArraySchema = new Schema({
-            num1: Array,
-            num2: []
-          });
+        num1: Array,
+        num2: []
+      });
 
       mongoose.model('DefaultArraySchema', DefaultArraySchema);
       var DefaultArray = db.model('DefaultArraySchema', collection);

--- a/test/types.buffer.test.js
+++ b/test/types.buffer.test.js
@@ -24,8 +24,11 @@ function valid(v) {
 describe('types.buffer', function() {
   var subBuf;
   var UserBuffer;
+  var db;
 
   before(function() {
+    db = start();
+
     subBuf = new Schema({
       name: String,
       buf: {type: Buffer, validate: [valid, 'valid failed'], required: true}
@@ -38,6 +41,10 @@ describe('types.buffer', function() {
       required: {type: Buffer, required: true, index: true},
       sub: [subBuf]
     });
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('test that a mongoose buffer behaves and quacks like a buffer', function(done) {
@@ -60,8 +67,7 @@ describe('types.buffer', function() {
   });
 
   it('buffer validation', function(done) {
-    var db = start(),
-        User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
+    var User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
 
     User.on('index', function() {
       var t = new User({
@@ -93,7 +99,6 @@ describe('types.buffer', function() {
 
               t.sub[0].buf = new Buffer('well well well');
               t.validate(function(err) {
-                db.close();
                 assert.ifError(err);
                 done();
               });
@@ -105,8 +110,7 @@ describe('types.buffer', function() {
   });
 
   it('buffer storage', function(done) {
-    var db = start(),
-        User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
+    var User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
 
     User.on('index', function() {
       var sampleBuffer = new Buffer([123, 223, 23, 42, 11]);
@@ -120,7 +124,6 @@ describe('types.buffer', function() {
       tj.save(function(err) {
         assert.ifError(err);
         User.find({}, function(err, users) {
-          db.close();
           assert.ifError(err);
           assert.equal(users.length, 1);
           var user = users[0];
@@ -136,8 +139,7 @@ describe('types.buffer', function() {
   });
 
   it('test write markModified', function(done) {
-    var db = start(),
-        User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
+    var User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
 
     User.on('index', function() {
       var sampleBuffer = new Buffer([123, 223, 23, 42, 11]);
@@ -158,7 +160,6 @@ describe('types.buffer', function() {
           assert.ifError(err);
 
           User.findById(tj._id, function(err, user) {
-            db.close();
             assert.ifError(err);
 
             var expectedBuffer = new Buffer([123, 97, 97, 42, 11]);
@@ -368,13 +369,11 @@ describe('types.buffer', function() {
   });
 
   it('can be set to null', function(done) {
-    var db = start(),
-        User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
-    var user = new User({array: [null], required: new Buffer(1)});
+    var User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random()),
+        user = new User({array: [null], required: new Buffer(1)});
     user.save(function(err, doc) {
       assert.ifError(err);
       User.findById(doc, function(err, doc) {
-        db.close();
         assert.ifError(err);
         assert.equal(doc.array.length, 1);
         assert.equal(doc.array[0], null);
@@ -384,13 +383,11 @@ describe('types.buffer', function() {
   });
 
   it('can be updated to null', function(done) {
-    var db = start(),
-        User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random());
-    var user = new User({array: [null], required: new Buffer(1), serial: new Buffer(1)});
+    var User = db.model('UserBuffer', UserBuffer, 'usersbuffer_' + random()),
+        user = new User({array: [null], required: new Buffer(1), serial: new Buffer(1)});
     user.save(function(err, doc) {
       assert.ifError(err);
       User.findOneAndUpdate({_id: doc.id}, {serial: null}, {new: true}, function(err, doc) {
-        db.close();
         assert.ifError(err);
         assert.equal(doc.serial, null);
         done();
@@ -409,17 +406,12 @@ describe('types.buffer', function() {
   });
 
   describe('subtype', function() {
-    var db, bufferSchema, B;
+    var bufferSchema, B;
 
     before(function(done) {
-      db = start();
       bufferSchema = new Schema({buf: Buffer});
       B = db.model('1571', bufferSchema);
       done();
-    });
-
-    after(function(done) {
-      db.close(done);
     });
 
     it('default value', function(done) {

--- a/test/types.document.test.js
+++ b/test/types.document.test.js
@@ -21,6 +21,7 @@ describe('types.document', function() {
   var Subdocument;
   var RatingSchema;
   var MovieSchema;
+  var db;
 
   before(function() {
     function _Dummy() {
@@ -61,6 +62,11 @@ describe('types.document', function() {
     });
 
     mongoose.model('Movie', MovieSchema);
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('test that validate sets errors', function(done) {
@@ -97,7 +103,6 @@ describe('types.document', function() {
   });
 
   it('cached _ids', function(done) {
-    var db = start();
     var Movie = db.model('Movie');
     var m = new Movie;
 
@@ -114,11 +119,10 @@ describe('types.document', function() {
     assert.strictEqual(true, m.$__._id !== m2.$__._id);
     assert.strictEqual(true, m.id !== m2.id);
     assert.strictEqual(true, m.$__._id !== m2.$__._id);
-    db.close(done);
+    done();
   });
 
   it('Subdocument#remove (gh-531)', function(done) {
-    var db = start();
     var Movie = db.model('Movie');
 
     var super8 = new Movie({title: 'Super 8'});
@@ -179,7 +183,7 @@ describe('types.document', function() {
                 Movie.findById(super8._id, function(err, movie) {
                   assert.ifError(err);
                   assert.equal(movie.ratings.length, 0);
-                  db.close(done);
+                  done();
                 });
               });
             });
@@ -191,7 +195,6 @@ describe('types.document', function() {
 
   describe('setting nested objects', function() {
     it('works (gh-1394)', function(done) {
-      var db = start();
       var Movie = db.model('Movie');
 
       Movie.create({
@@ -234,7 +237,7 @@ describe('types.document', function() {
                   assert.equal(String(newDate), movie.ratings[0].description.source.time);
                   // url not overwritten using merge
                   assert.equal('http://www.lifeofpimovie.com/', movie.ratings[0].description.source.url);
-                  db.close(done);
+                  done();
                 });
               });
             });

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -46,6 +46,16 @@ function TestDoc(schema) {
  */
 
 describe('types.documentarray', function() {
+  var db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
+  });
+
   it('behaves and quacks like an array', function(done) {
     var a = new MongooseDocumentArray();
 
@@ -247,7 +257,6 @@ describe('types.documentarray', function() {
       done();
     });
     it('uses the correct transform (gh-1412)', function(done) {
-      var db = start();
       var SecondSchema = new Schema({});
 
       SecondSchema.set('toObject', {
@@ -282,7 +291,7 @@ describe('types.documentarray', function() {
       assert.ok(obj.second[1].secondToObject);
       assert.ok(!obj.second[0].firstToObject);
       assert.ok(!obj.second[1].firstToObject);
-      db.close(done);
+      done();
     });
   });
 
@@ -305,8 +314,6 @@ describe('types.documentarray', function() {
 
   describe('push()', function() {
     it('does not re-cast instances of its embedded doc', function(done) {
-      var db = start();
-
       var child = new Schema({name: String, date: Date});
       child.pre('save', function(next) {
         this.date = new Date;
@@ -339,7 +346,7 @@ describe('types.documentarray', function() {
                 doc.children.forEach(function(child) {
                   assert.equal(doc.children[0].id, child.id);
                 });
-                db.close(done);
+                done();
               });
             });
           });
@@ -369,8 +376,7 @@ describe('types.documentarray', function() {
       comments: [Comments]
     });
 
-    var db = start(),
-        Post = db.model('docarray-BlogPost', BlogPost, collection);
+    var Post = db.model('docarray-BlogPost', BlogPost, collection);
 
     var p = new Post({title: 'comment nesting'});
     var c1 = p.comments.create({title: 'c1'});
@@ -394,7 +400,7 @@ describe('types.documentarray', function() {
           Post.findById(p._id, function(err, p) {
             assert.ifError(err);
             assert.equal(p.comments[0].comments[0].comments[0].comments[0].title, 'c4');
-            db.close(done);
+            done();
           });
         });
       });
@@ -430,7 +436,6 @@ describe('types.documentarray', function() {
     });
 
     it('handles validation failures', function(done) {
-      var db = start();
       var nested = new Schema({v: {type: Number, max: 30}});
       var schema = new Schema({
         docs: [nested]
@@ -439,12 +444,11 @@ describe('types.documentarray', function() {
       var m = new M({docs: [{v: 900}]});
       m.save(function(err) {
         assert.equal(err.errors['docs.0.v'].value, 900);
-        db.close(done);
+        done();
       });
     });
 
     it('removes attached event listeners when creating new doc array', function(done) {
-      var db = start();
       var nested = new Schema({v: {type: Number}});
       var schema = new Schema({
         docs: [nested]
@@ -459,7 +463,7 @@ describe('types.documentarray', function() {
         m.save(function(error, m) {
           assert.ifError(error);
           assert.equal(numListeners, m.listeners('save').length);
-          db.close(done);
+          done();
         });
       });
     });

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -16,6 +16,7 @@ describe('types.subdocument', function() {
   var GrandChildSchema;
   var ChildSchema;
   var ParentSchema;
+  var db;
 
   before(function() {
     GrandChildSchema = new Schema({
@@ -33,6 +34,11 @@ describe('types.subdocument', function() {
     });
 
     mongoose.model('Parent-3589-Sub', ParentSchema);
+    db = start();
+  });
+
+  after(function(done) {
+    db.close(done);
   });
 
   it('returns a proper ownerDocument (gh-3589)', function(done) {
@@ -53,7 +59,6 @@ describe('types.subdocument', function() {
     done();
   });
   it('not setting timestamps in subdocuments', function() {
-    var db = start();
     var Thing = db.model('Thing', new Schema({
       subArray: [{
         testString: String


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The main change was in reducing the number of `db.start()` calls on tests to start fewer connections. It was considered that each test file is a high-level test suite and one connection can be opened and shared through each test case that makes part of it. There are exceptions, depending on the semantics of each test case. But with this change the number of calls to `db.start()` dropped from 668 to 96.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Executing `npm test` should open fewer connections.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
