### PR TITLE
fix bug: Using options in aggregates doesn't set anything

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -544,7 +544,7 @@ Aggregate.prototype.allowDiskUse = function(value) {
  */
 
 Aggregate.prototype.option = function(value) {
-  for (var key in Object.keys(value)) {
+  for (var key in value) {
     this.options[key] = value[key];
   }
   return this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose",
-  "version": "5.0.0",
+  "version": "5.0.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -852,7 +852,7 @@ describe('aggregate: ', function() {
       });
     });
 
-    it('handles aggregation options', function(done) {
+    it('handles aggregation options allowDiskUse', function(done) {
       start.mongodVersion(function(err, version) {
         if (err) {
           throw err;
@@ -865,11 +865,13 @@ describe('aggregate: ', function() {
         var aggregate = m.aggregate([match]).read(pref);
         if (mongo26_or_greater) {
           aggregate.allowDiskUse(true);
+          aggregate.option({maxTimeMS: 1000});
         }
 
         assert.equal(aggregate.options.readPreference.mode, pref);
         if (mongo26_or_greater) {
           assert.equal(aggregate.options.allowDiskUse, true);
+          assert.equal(aggregate.options.maxTimeMS, 1000);
         }
 
         aggregate.

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -852,7 +852,7 @@ describe('aggregate: ', function() {
       });
     });
 
-    it('handles aggregation options allowDiskUse', function(done) {
+    it('handles aggregation options', function(done) {
       start.mongodVersion(function(err, version) {
         if (err) {
           throw err;


### PR DESCRIPTION
**Summary**

Using options when executing an aggregate doesn't work and they could not be set

Code (from documentation)


```
// Set the `allowDiskUse` option
var agg = Model.aggregate(..).option({ allowDiskUse: true }); 

```

*Current*
`agg.options; // `{ '0': undefined }``

Fix
`agg.options; // `{ 'allowDiskUse': true }``

**Test plan**
Now when an aggregate is running as the following and setting mongoose to debug code, the options are set propertly

![image](https://user-images.githubusercontent.com/1193758/35097843-99030974-fc5a-11e7-837b-b5eac142654d.png)


![image](https://user-images.githubusercontent.com/1193758/35097820-783c6d20-fc5a-11e7-9f87-63c23bbb5650.png)

