### PR TITLE
handle populating embedded discriminator paths

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3568,101 +3568,21 @@ function getModelsMapForPopulate(model, docs, options) {
     }
 
     if (Array.isArray(schema)) {
-      for (var i = 0; i < schema.length; ++i) {
-        var _modelNames = _getModelNames(schema[i]);
+      for (var j = 0; j < schema.length; ++j) {
+        var _modelNames = _getModelNames(doc, schema[j]);
         if (!_modelNames) {
           continue;
         }
         modelNames = (modelNames || []).concat(_modelNames);
       }
     } else {
-      modelNames = _getModelNames(schema);
+      modelNames = _getModelNames(doc, schema);
       if (!modelNames) {
         continue;
       }
     }
 
-    function _getModelNames(schema) {
-      var modelNames;
-
-      if (schema && schema.caster) {
-        schema = schema.caster;
-      }
-
-      if (!schema && model.discriminators) {
-        discriminatorKey = model.schema.discriminatorMapping.key;
-      }
-
-      refPath = schema && schema.options && schema.options.refPath;
-
-      if (refPath) {
-        modelNames = utils.getValue(refPath, doc);
-        isRefPathArray = Array.isArray(modelNames);
-      } else {
-        if (!modelNameFromQuery) {
-          var modelForCurrentDoc = model;
-          var schemaForCurrentDoc;
-
-          if (!schema && discriminatorKey) {
-            modelForFindSchema = utils.getValue(discriminatorKey, doc);
-
-            if (modelForFindSchema) {
-              try {
-                modelForCurrentDoc = model.db.model(modelForFindSchema);
-              } catch (error) {
-                return error;
-              }
-
-              schemaForCurrentDoc = modelForCurrentDoc.schema._getSchema(options.path);
-
-              if (schemaForCurrentDoc && schemaForCurrentDoc.caster) {
-                schemaForCurrentDoc = schemaForCurrentDoc.caster;
-              }
-            }
-          } else {
-            schemaForCurrentDoc = schema;
-          }
-          var virtual = modelForCurrentDoc.schema._getVirtual(options.path);
-
-          var ref;
-          if ((ref = get(schemaForCurrentDoc, 'options.ref')) != null) {
-            modelNames = [ref];
-          } else if ((ref = get(virtual, 'options.ref')) != null) {
-            if (typeof ref === 'function') {
-              ref = ref.call(doc, doc);
-            }
-
-            // When referencing nested arrays, the ref should be an Array
-            // of modelNames.
-            if (Array.isArray(ref)) {
-              modelNames = ref;
-            } else {
-              modelNames = [ref];
-            }
-
-            isVirtual = true;
-          } else {
-            // We may have a discriminator, in which case we don't want to
-            // populate using the base model by default
-            modelNames = discriminatorKey ? null : [model.modelName];
-          }
-        } else {
-          modelNames = [modelNameFromQuery];  // query options
-        }
-      }
-
-      if (!modelNames) {
-        return;
-      }
-
-      if (!Array.isArray(modelNames)) {
-        modelNames = [modelNames];
-      }
-
-      return modelNames;
-    }
-
-    virtual = model.schema._getVirtual(options.path);
+    var virtual = model.schema._getVirtual(options.path);
     var localField;
     if (virtual && virtual.options) {
       var virtualPrefix = virtual.$nestedSchemaPath ?
@@ -3750,6 +3670,86 @@ function getModelsMapForPopulate(model, docs, options) {
         available[modelName].allIds.push(ret);
       }
     }
+  }
+
+  function _getModelNames(doc, schema) {
+    var modelNames;
+
+    if (schema && schema.caster) {
+      schema = schema.caster;
+    }
+
+    if (!schema && model.discriminators) {
+      discriminatorKey = model.schema.discriminatorMapping.key;
+    }
+
+    refPath = schema && schema.options && schema.options.refPath;
+
+    if (refPath) {
+      modelNames = utils.getValue(refPath, doc);
+      isRefPathArray = Array.isArray(modelNames);
+    } else {
+      if (!modelNameFromQuery) {
+        var modelForCurrentDoc = model;
+        var schemaForCurrentDoc;
+
+        if (!schema && discriminatorKey) {
+          modelForFindSchema = utils.getValue(discriminatorKey, doc);
+
+          if (modelForFindSchema) {
+            try {
+              modelForCurrentDoc = model.db.model(modelForFindSchema);
+            } catch (error) {
+              return error;
+            }
+
+            schemaForCurrentDoc = modelForCurrentDoc.schema._getSchema(options.path);
+
+            if (schemaForCurrentDoc && schemaForCurrentDoc.caster) {
+              schemaForCurrentDoc = schemaForCurrentDoc.caster;
+            }
+          }
+        } else {
+          schemaForCurrentDoc = schema;
+        }
+        var virtual = modelForCurrentDoc.schema._getVirtual(options.path);
+
+        var ref;
+        if ((ref = get(schemaForCurrentDoc, 'options.ref')) != null) {
+          modelNames = [ref];
+        } else if ((ref = get(virtual, 'options.ref')) != null) {
+          if (typeof ref === 'function') {
+            ref = ref.call(doc, doc);
+          }
+
+          // When referencing nested arrays, the ref should be an Array
+          // of modelNames.
+          if (Array.isArray(ref)) {
+            modelNames = ref;
+          } else {
+            modelNames = [ref];
+          }
+
+          isVirtual = true;
+        } else {
+          // We may have a discriminator, in which case we don't want to
+          // populate using the base model by default
+          modelNames = discriminatorKey ? null : [model.modelName];
+        }
+      } else {
+        modelNames = [modelNameFromQuery];  // query options
+      }
+    }
+
+    if (!modelNames) {
+      return;
+    }
+
+    if (!Array.isArray(modelNames)) {
+      modelNames = [modelNames];
+    }
+
+    return modelNames;
   }
 
   return map;

--- a/lib/model.js
+++ b/lib/model.js
@@ -21,6 +21,7 @@ var castUpdate = require('./services/query/castUpdate');
 var discriminator = require('./services/model/discriminator');
 var isPathSelectedInclusive = require('./services/projection/isPathSelectedInclusive');
 var get = require('lodash.get');
+var getSchemaTypes = require('./services/populate/getSchemaTypes');
 var mpath = require('mpath');
 var parallel = require('async/parallel');
 var parallelLimit = require('async/parallelLimit');
@@ -3551,92 +3552,114 @@ function getModelsMapForPopulate(model, docs, options) {
   var originalModel = options.model;
   var isVirtual = false;
   var isRefPathArray = false;
-
-  schema = model._getSchema(options.path);
-  var isUnderneathDocArray = schema && schema.$isUnderneathDocArray;
-  if (isUnderneathDocArray &&
-      options &&
-      options.options &&
-      options.options.sort) {
-    return new Error('Cannot populate with `sort` on path ' + options.path +
-      ' because it is a subproperty of a document array');
-  }
-
-  if (schema && schema.caster) {
-    schema = schema.caster;
-  }
-
-  if (!schema && model.discriminators) {
-    discriminatorKey = model.schema.discriminatorMapping.key;
-  }
-
-  refPath = schema && schema.options && schema.options.refPath;
+  var modelSchema = model.schema;
 
   for (i = 0; i < len; i++) {
     doc = docs[i];
 
-    if (refPath) {
-      modelNames = utils.getValue(refPath, doc);
-      isRefPathArray = Array.isArray(modelNames);
+    schema = getSchemaTypes(modelSchema, doc, options.path);
+    var isUnderneathDocArray = schema && schema.$isUnderneathDocArray;
+    if (isUnderneathDocArray &&
+        options &&
+        options.options &&
+        options.options.sort) {
+      return new Error('Cannot populate with `sort` on path ' + options.path +
+        ' because it is a subproperty of a document array');
+    }
+
+    if (Array.isArray(schema)) {
+      for (var i = 0; i < schema.length; ++i) {
+        var _modelNames = _getModelNames(schema[i]);
+        if (!_modelNames) {
+          continue;
+        }
+        modelNames = (modelNames || []).concat(_modelNames);
+      }
     } else {
-      if (!modelNameFromQuery) {
-        var modelForCurrentDoc = model;
-        var schemaForCurrentDoc;
-
-        if (!schema && discriminatorKey) {
-          modelForFindSchema = utils.getValue(discriminatorKey, doc);
-
-          if (modelForFindSchema) {
-            try {
-              modelForCurrentDoc = model.db.model(modelForFindSchema);
-            } catch (error) {
-              return error;
-            }
-
-            schemaForCurrentDoc = modelForCurrentDoc._getSchema(options.path);
-
-            if (schemaForCurrentDoc && schemaForCurrentDoc.caster) {
-              schemaForCurrentDoc = schemaForCurrentDoc.caster;
-            }
-          }
-        } else {
-          schemaForCurrentDoc = schema;
-        }
-        var virtual = modelForCurrentDoc.schema._getVirtual(options.path);
-
-        var ref;
-        if ((ref = get(schemaForCurrentDoc, 'options.ref')) != null) {
-          modelNames = [ref];
-        } else if ((ref = get(virtual, 'options.ref')) != null) {
-          if (typeof ref === 'function') {
-            ref = ref.call(doc, doc);
-          }
-
-          // When referencing nested arrays, the ref should be an Array
-          // of modelNames.
-          if (Array.isArray(ref)) {
-            modelNames = ref;
-          } else {
-            modelNames = [ref];
-          }
-
-          isVirtual = true;
-        } else {
-          // We may have a discriminator, in which case we don't want to
-          // populate using the base model by default
-          modelNames = discriminatorKey ? null : [model.modelName];
-        }
-      } else {
-        modelNames = [modelNameFromQuery];  // query options
+      modelNames = _getModelNames(schema);
+      if (!modelNames) {
+        continue;
       }
     }
 
-    if (!modelNames) {
-      continue;
-    }
+    function _getModelNames(schema) {
+      var modelNames;
 
-    if (!Array.isArray(modelNames)) {
-      modelNames = [modelNames];
+      if (schema && schema.caster) {
+        schema = schema.caster;
+      }
+
+      if (!schema && model.discriminators) {
+        discriminatorKey = model.schema.discriminatorMapping.key;
+      }
+
+      refPath = schema && schema.options && schema.options.refPath;
+
+      if (refPath) {
+        modelNames = utils.getValue(refPath, doc);
+        isRefPathArray = Array.isArray(modelNames);
+      } else {
+        if (!modelNameFromQuery) {
+          var modelForCurrentDoc = model;
+          var schemaForCurrentDoc;
+
+          if (!schema && discriminatorKey) {
+            modelForFindSchema = utils.getValue(discriminatorKey, doc);
+
+            if (modelForFindSchema) {
+              try {
+                modelForCurrentDoc = model.db.model(modelForFindSchema);
+              } catch (error) {
+                return error;
+              }
+
+              schemaForCurrentDoc = modelForCurrentDoc.schema._getSchema(options.path);
+
+              if (schemaForCurrentDoc && schemaForCurrentDoc.caster) {
+                schemaForCurrentDoc = schemaForCurrentDoc.caster;
+              }
+            }
+          } else {
+            schemaForCurrentDoc = schema;
+          }
+          var virtual = modelForCurrentDoc.schema._getVirtual(options.path);
+
+          var ref;
+          if ((ref = get(schemaForCurrentDoc, 'options.ref')) != null) {
+            modelNames = [ref];
+          } else if ((ref = get(virtual, 'options.ref')) != null) {
+            if (typeof ref === 'function') {
+              ref = ref.call(doc, doc);
+            }
+
+            // When referencing nested arrays, the ref should be an Array
+            // of modelNames.
+            if (Array.isArray(ref)) {
+              modelNames = ref;
+            } else {
+              modelNames = [ref];
+            }
+
+            isVirtual = true;
+          } else {
+            // We may have a discriminator, in which case we don't want to
+            // populate using the base model by default
+            modelNames = discriminatorKey ? null : [model.modelName];
+          }
+        } else {
+          modelNames = [modelNameFromQuery];  // query options
+        }
+      }
+
+      if (!modelNames) {
+        return;
+      }
+
+      if (!Array.isArray(modelNames)) {
+        modelNames = [modelNames];
+      }
+
+      return modelNames;
     }
 
     virtual = model.schema._getVirtual(options.path);
@@ -3856,20 +3879,6 @@ function isDoc(doc) {
   // only docs
   return true;
 }
-
-/**
- * Finds the schema for `path`. This is different than
- * calling `schema.path` as it also resolves paths with
- * positional selectors (something.$.another.$.path).
- *
- * @param {String} path
- * @return {Schema}
- * @api private
- */
-
-Model._getSchema = function _getSchema(path) {
-  return this.schema._getSchema(path);
-};
 
 /*!
  * Compiler utility.

--- a/lib/services/model/discriminator.js
+++ b/lib/services/model/discriminator.js
@@ -128,7 +128,10 @@ module.exports = function discriminator(model, name, schema) {
 
   if (!model.schema.discriminatorMapping) {
     model.schema.discriminatorMapping = {key: key, value: null, isRoot: true};
+    model.schema.discriminators = {};
   }
+
+  model.schema.discriminators[name] = schema;
 
   if (model.discriminators[name]) {
     throw new Error('Discriminator with name "' + name + '" already exists');

--- a/lib/services/populate/getSchemaTypes.js
+++ b/lib/services/populate/getSchemaTypes.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/*!
+ * ignore
+ */
+
+var Mixed = require('../../schema/mixed');
+var get = require('lodash.get');
+var mpath = require('mpath');
+var utils = require('../../utils');
+
+/*!
+ * ignore
+ */
+
+module.exports = function getSchemaTypes(schema, doc, path) {
+  var pathschema = schema.path(path);
+
+  if (pathschema) {
+    return pathschema;
+  }
+
+  function search(parts, schema) {
+    var p = parts.length + 1;
+    var foundschema;
+    var trypath;
+
+    while (p--) {
+      trypath = parts.slice(0, p).join('.');
+      foundschema = schema.path(trypath);
+      if (foundschema) {
+        if (foundschema.caster) {
+          // array of Mixed?
+          if (foundschema.caster instanceof Mixed) {
+            return foundschema.caster;
+          }
+
+          var schemas = null;
+          if (doc != null && foundschema.schema != null && foundschema.schema.discriminators != null) {
+            var discriminators = foundschema.schema.discriminators;
+            var keys = mpath.get(trypath + '.' + foundschema.schema.options.discriminatorKey,
+              doc);
+            schemas = Object.keys(discriminators).
+              reduce(function(cur, discriminator) {
+                if (keys.indexOf(discriminator) !== -1) {
+                  cur.push(discriminators[discriminator]);
+                }
+                return cur;
+              }, []);
+          }
+
+          // Now that we found the array, we need to check if there
+          // are remaining document paths to look up for casting.
+          // Also we need to handle array.$.path since schema.path
+          // doesn't work for that.
+          // If there is no foundschema.schema we are dealing with
+          // a path like array.$
+          if (p !== parts.length && foundschema.schema) {
+            var ret;
+            if (parts[p] === '$') {
+              if (p + 1 === parts.length) {
+                // comments.$
+                return foundschema;
+              }
+              // comments.$.comments.$.title
+              ret = search(parts.slice(p + 1), schema);
+              if (ret) {
+                ret.$isUnderneathDocArray = ret.$isUnderneathDocArray ||
+                  !foundschema.schema.$isSingleNested;
+              }
+              return ret;
+            }
+
+            if (schemas != null && schemas.length > 0) {
+              ret = [];
+              for (var i = 0; i < schemas.length; ++i) {
+                var _ret = search(parts.slice(p), schemas[i]);
+                if (_ret) {
+                  _ret.$isUnderneathDocArray = _ret.$isUnderneathDocArray ||
+                    !foundschema.schema.$isSingleNested;
+                  if (_ret.$isUnderneathDocArray) {
+                    ret.$isUnderneathDocArray = true;
+                  }
+                }
+                ret.push(_ret);
+              }
+              return ret;
+            } else {
+              ret = search(parts.slice(p), foundschema.schema);
+
+              if (ret) {
+                ret.$isUnderneathDocArray = ret.$isUnderneathDocArray ||
+                  !foundschema.schema.$isSingleNested;
+              }
+
+              return ret;
+            }
+          }
+        }
+
+        return foundschema;
+      }
+    }
+  }
+
+  // look for arrays
+  var parts = path.split('.');
+  for (var i = 0; i < parts.length; ++i) {
+    if (parts[i] === '$') {
+      // Re: gh-5628, because `schema.path()` doesn't take $ into account.
+      parts[i] = '0';
+    }
+  }
+  return search(parts, schema);
+}

--- a/lib/services/populate/getSchemaTypes.js
+++ b/lib/services/populate/getSchemaTypes.js
@@ -8,7 +8,9 @@ var Mixed = require('../../schema/mixed');
 var mpath = require('mpath');
 
 /*!
- * ignore
+ * @param {Schema} schema
+ * @param {Object} doc POJO
+ * @param {string} path
  */
 
 module.exports = function getSchemaTypes(schema, doc, path) {
@@ -73,14 +75,14 @@ module.exports = function getSchemaTypes(schema, doc, path) {
               ret = [];
               for (var i = 0; i < schemas.length; ++i) {
                 var _ret = search(parts.slice(p), schemas[i]);
-                if (_ret) {
+                if (_ret != null) {
                   _ret.$isUnderneathDocArray = _ret.$isUnderneathDocArray ||
                     !foundschema.schema.$isSingleNested;
                   if (_ret.$isUnderneathDocArray) {
                     ret.$isUnderneathDocArray = true;
                   }
+                  ret.push(_ret);
                 }
-                ret.push(_ret);
               }
               return ret;
             } else {

--- a/lib/services/populate/getSchemaTypes.js
+++ b/lib/services/populate/getSchemaTypes.js
@@ -5,9 +5,7 @@
  */
 
 var Mixed = require('../../schema/mixed');
-var get = require('lodash.get');
 var mpath = require('mpath');
-var utils = require('../../utils');
 
 /*!
  * ignore
@@ -112,4 +110,4 @@ module.exports = function getSchemaTypes(schema, doc, path) {
     }
   }
   return search(parts, schema);
-}
+};

--- a/test/helpers/populate.getSchemaTypes.test.js
+++ b/test/helpers/populate.getSchemaTypes.test.js
@@ -44,9 +44,10 @@ describe('getSchemaTypes', function() {
       items: [
         { type: 'Book', author: 'test 1' },
         { type: 'EBook', author: 'test 2' },
-        { type: 'Other' },
+        { type: 'Other' }
       ]
-    }
+    };
+
     var schemaTypes = getSchemaTypes(BundleSchema, doc, 'items.author');
 
     assert.ok(Array.isArray(schemaTypes));

--- a/test/helpers/populate.getSchemaTypes.test.js
+++ b/test/helpers/populate.getSchemaTypes.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var Schema = require('../../lib/schema');
+var assert = require('assert');
+var getSchemaTypes = require('../../lib/services/populate/getSchemaTypes');
+
+describe('getSchemaTypes', function() {
+  it('handles embedded discriminators (gh-5970)', function(done) {
+    var ItemSchema = new Schema({
+      title: {
+        type: String,
+        required: true
+      }
+    }, {discriminatorKey: 'type'});
+
+    var ItemBookSchema = new Schema({
+      author: {
+        type: String,
+        ref: 'Ref1'
+      }
+    });
+
+    var ItemEBookSchema = new Schema({
+      author: {
+        type: String,
+        ref: 'Ref2'
+      }
+    });
+
+    var OtherItem = new Schema({ name: String });
+
+    var BundleSchema = new Schema({
+      items: [{
+        type: ItemSchema,
+        required: false
+      }]
+    });
+
+    BundleSchema.path('items').discriminator('Book', ItemBookSchema);
+    BundleSchema.path('items').discriminator('EBook', ItemEBookSchema);
+    BundleSchema.path('items').discriminator('Other', OtherItem);
+
+    var doc = {
+      items: [
+        { type: 'Book', author: 'test 1' },
+        { type: 'EBook', author: 'test 2' },
+        { type: 'Other' },
+      ]
+    }
+    var schemaTypes = getSchemaTypes(BundleSchema, doc, 'items.author');
+
+    assert.ok(Array.isArray(schemaTypes));
+    // Make sure we only got the schema paths for Book and EBook, and none
+    // for the 'Other'
+    assert.equal(schemaTypes.length, 2);
+    assert.equal(schemaTypes[0].options.ref, 'Ref1');
+    assert.equal(schemaTypes[1].options.ref, 'Ref2');
+
+    done();
+  });
+});


### PR DESCRIPTION
Re: #5970 

This is a substantial change, so I want to put in a PR and review the changes more later. In particular, this change makes it so that `populate()` searches schemas on every doc, rather than once before looking through every doc.