### PR TITLE
Do not overwrite default values in schema when nested timestamps are provided.

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -730,22 +730,18 @@ Schema.prototype.hasMixedParent = function(path) {
  */
 Schema.prototype.setupTimestamp = function(timestamps) {
   if (timestamps) {
-    var paths = ['createdAt', 'updatedAt'].map(handleTimestampOption.bind(null, timestamps));
-    var createdAt = paths[0];
-    var updatedAt = paths[1];
-    var schemaAdditions = paths.reduce(function(cur, path) {
-      if (path != null) {
-        var parts = path.split('.');
-        if (this.pathType(path) === 'adhocOrUndefined') {
-          for (var i = 0; i < parts.length; ++i) {
-            cur[parts[i]] = (i < parts.length - 1 ?
-              cur[parts[i]] || {} :
-              Date);
-          }
-        }
-      }
-      return cur;
-    }.bind(this), {});
+
+    var createdAt = handleTimestampOption(timestamps, 'createdAt');
+    var updatedAt = handleTimestampOption(timestamps, 'updatedAt');
+    var schemaAdditions = {};
+
+    if (updatedAt && !this.paths[updatedAt]) {
+      schemaAdditions[updatedAt] = Date;
+    }
+
+    if (createdAt && !this.paths[createdAt]) {
+      schemaAdditions[createdAt] = Date;
+    }
 
     this.add(schemaAdditions);
 

--- a/test/docs/defaults.test.js
+++ b/test/docs/defaults.test.js
@@ -47,6 +47,24 @@ describe('defaults docs', function () {
     });
   });
 
+  it('Declaring defaults in your schema with timestamps defined', function(done) {
+
+    var schemaDefinition = {
+      name: String,
+      misc: {
+          hometown: String,
+          isAlive: { type: Boolean, default: true }
+      }
+    };
+
+    var schemaWithTimestamps = new Schema(schemaDefinition, {timestamps: {createdAt: 'misc.createdAt'}});
+    var PersonWithTimestamps = db.model('Person_timestamps', schemaWithTimestamps);
+    var dude = new PersonWithTimestamps({ name: 'Keanu', misc: {hometown: 'Beirut'} });
+    assert.equal(dude.misc.isAlive, true);
+
+    done();
+  });
+
   /**
    * You can also set the `default` schema option to a function. Mongoose will
    * execute that function and use the return value as the default.

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -3691,7 +3691,7 @@ describe('document', function() {
     });
 
     it('timestamps with nested paths (gh-5051)', function(done) {
-      var schema = new Schema({ props: Object }, {
+      var schema = new Schema({ props: {} }, {
         timestamps: {
           createdAt: 'props.createdAt',
           updatedAt: 'props.updatedAt'


### PR DESCRIPTION
**Summary**

Sometime after mongoose ~4.6, schemas created with the `timestamps` began overwriting schema defaults in nested properties. For example, schema `{ name: String, misc: { isHappy: { type: Boolean, default: true } }` defined with timestamp `misc.updatedAt` would not instantiate new models with `misc.isHappy` defined.

**Test plan**

Unit test "Declaring defaults in your schema with timestamps defined" defined in `defaults.test.js` captures the logic executing successfully.

Other unit tests pass with this change in place (at least locally for me).
