### PR TITLE
Cache connection in useDb, replace connection.otherDbs array with a hashmap

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -59,7 +59,8 @@ function Connection(base) {
   this.pass = null;
   this.name = null;
   this.options = null;
-  this.otherDbs = [];
+  this.otherDbs = []; // FIXME: To be replaced with relatedDbs
+  this.relatedDbs = {}; // Hashmap of other dbs that share underlying connection
   this.states = STATES;
   this._readyState = STATES.disconnected;
   this._closeCalled = false;
@@ -103,9 +104,14 @@ Object.defineProperty(Connection.prototype, 'readyState', {
 
     if (this._readyState !== val) {
       this._readyState = val;
-      // loop over the otherDbs on this connection and change their state
+      // [legacy] loop over the otherDbs on this connection and change their state
       for (var i = 0; i < this.otherDbs.length; i++) {
         this.otherDbs[i].readyState = val;
+      }
+
+      // loop over relatedDbs on this connection and change their state
+      for (var k in this.relatedDbs) {
+        this.relatedDbs[k].readyState = val;
       }
 
       if (STATES.connected === val) {

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -40,7 +40,10 @@ NativeConnection.prototype.__proto__ = MongooseConnection.prototype;
  * @api public
  */
 
-NativeConnection.prototype.useDb = function(name) {
+NativeConnection.prototype.useDb = function(name, options) {
+  // Return immediately if cached
+  if (options && options.useCache && this.relatedDbs[name]) return this.relatedDbs[name];
+
   // we have to manually copy all of the attributes...
   var newConn = new this.constructor();
   newConn.name = name;
@@ -87,6 +90,12 @@ NativeConnection.prototype.useDb = function(name) {
   // push onto the otherDbs stack, this is used when state changes
   this.otherDbs.push(newConn);
   newConn.otherDbs.push(this);
+
+  // push onto the relatedDbs cache, this is used when state changes
+  if (options && options.useCache) {
+    this.relatedDbs[newConn.name] = newConn;
+    newConn.relatedDbs = this.relatedDbs;
+  }
 
   return newConn;
 };

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -985,6 +985,15 @@ describe('connections:', function() {
       });
       db2.close();
     });
+
+    it('cache connections to the same db', function() {
+      var db = start();
+      var db2 = db.useDb('mongoose-test-2', { useCache: true });
+      var db3 = db.useDb('mongoose-test-2', { useCache: true });
+
+      assert.strictEqual(db2, db3);
+      db.close();
+    });
   });
 
   describe('shouldAuthenticate()', function() {


### PR DESCRIPTION
**Summary**

- Replace ```connection.otherDbs``` array with a hashmap
- Make the ```useDb``` API use it as a cache

See #3302

**Test Plan**

```
it('cache connections to the same db', function() {
    var db = start();
    var db2 = db.useDb('mongoose-test-2');
    var db3 = db.useDb('mongoose-test-2');

    assert.strictEqual(db2, db3);
    db.close();
});
```