### PR TITLE
updating jade files to fix #6038

### DIFF
--- a/docs/models.jade
+++ b/docs/models.jade
@@ -6,10 +6,11 @@ block content
     [Models](./api.html#model-js) are fancy constructors compiled from our `Schema` definitions. Instances of these models represent [documents](./documents.html) which can be saved and retrieved from our database. All document creation and retrieval from the database is handled by these models.
 
   h3 Compiling your first model
-  :js
+  :markdown
+    ```javascript
     var schema = new mongoose.Schema({ name: 'string', size: 'string' });
     var Tank = mongoose.model('Tank', schema);
-
+    ```
   :markdown
     The first argument is the _singular_ name of the collection your model is for. ** Mongoose automatically looks for the _plural_ version of your model name. **
     Thus, for the example above, the model Tank is for the **tanks** collection in the database.
@@ -18,7 +19,7 @@ block content
   h3 Constructing documents
   :markdown
     [Documents](./documents.html) are instances of our model. Creating them and saving to the database is easy:
-  :js
+    ```javascript
     var Tank = mongoose.model('Tank', yourSchema);
 
     var small = new Tank({ size: 'small' });
@@ -33,35 +34,39 @@ block content
       if (err) return handleError(err);
       // saved!
     })
+    ```
   :markdown
     Note that no tanks will be created/removed until the connection your model
     uses is open. Every model has an associated connection. When you use
     `mongoose.model()`, your model will use the default mongoose connection.
-  :js
+    ```javascript
     mongoose.connect('localhost', 'gettingstarted');
+    ```
   :markdown
     If you create a custom connection, use that connection's `model()` function
     instead.
-  :js
+    ```javascript
     var connection = mongoose.createConnection('mongodb://localhost:27017/test');
     var Tank = connection.model('Tank', yourSchema);
-
+    ```
   h3 Querying
   :markdown
     Finding documents is easy with Mongoose, which supports the [rich](http://www.mongodb.org/display/DOCS/Advanced+Queries) query syntax of MongoDB. Documents can be retreived using each `models` [find](./api.html#model_Model.find), [findById](./api.html#model_Model.findById), [findOne](./api.html#model_Model.findOne), or [where](./api.html#model_Model.where) static methods.
 
-  :js
+    ```javascript
     Tank.find({ size: 'small' }).where('createdDate').gt(oneYearAgo).exec(callback);
+    ```
   :markdown
     See the chapter on [querying](./queries.html) for more details on how to use the [Query](./api.html#query-js) api.
   h3 Removing
   :markdown
     Models have a static `remove` method available for removing all documents matching `conditions`.
-  :js
+    ```javascript
     Tank.remove({ size: 'large' }, function (err) {
       if (err) return handleError(err);
       // removed!
     });
+    ```
   h3 Updating
   :markdown
     Each `model` has its own `update` method for modifying documents in the database without returning them to your application. See the [API](./api.html#model_Model.update) docs for more detail.

--- a/docs/schematypes.jade
+++ b/docs/schematypes.jade
@@ -34,7 +34,8 @@ block content
     - [Objectid](./api.html#schema-objectid-js)
     - Array
   h4 Example
-  :js
+  :markdown
+    ```javaScript
     var schema = new Schema({
       name:    String,
       binary:  Buffer,
@@ -79,12 +80,12 @@ block content
     m.ofMixed = [1, [], 'three', { four: 5 }];
     m.nested.stuff = 'good';
     m.save(callback);
-
+    ```
   h3 SchemaType Options
   :markdown
     You can declare a schema type using the type directly, or an object with
     a `type` property.
-  :js
+    ```javascript
     var schema1 = new Schema({
       test: String // `test` is a path of type String
     });
@@ -92,16 +93,18 @@ block content
     var schema2 = new Schema({
       test: { type: String } // `test` is a path of type string
     });
+    ```
   :markdown
     In addition to the type property, you can specify additional properties
     for a path. For example, if you want to lowercase a string before saving:
-  :js
+    ```javascript
     var schema2 = new Schema({
       test: {
         type: String,
         lowercase: true // Always convert `test` to lowercase
       }
     });
+    ```
   :markdown
     The `lowercase` property only works for strings. There are certain options
     which apply for all schema types, and some that apply for specific schema
@@ -116,7 +119,7 @@ block content
     * `set`: function, defines a custom setter for this property using [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
     * `alias`: string, mongoose >= 4.10.0 only. Defines a [virtual](http://mongoosejs.com/docs/guide.html#virtuals) with the given name that gets/sets this path.
 
-  :js
+    ```javascript
     var numberSchema = new Schema({
       integerOnly: {
         type: Number,
@@ -135,7 +138,7 @@ block content
     doc.i = 3.001;
     doc.integerOnly; // 3
     doc.i; // 3
-
+    ```
   h5 Indexes
   p
   :markdown
@@ -146,7 +149,7 @@ block content
     * `index`: boolean, whether to define an [index](https://docs.mongodb.com/manual/indexes/) on this property.
     * `unique`: boolean, whether to define a [unique index](https://docs.mongodb.com/manual/core/index-unique/) on this property.
     * `sparse`: boolean, whether to define a [sparse index](https://docs.mongodb.com/manual/core/index-sparse/) on this property.
-  :js
+    ```javascript
     var schema2 = new Schema({
       test: {
         type: String,
@@ -155,6 +158,7 @@ block content
         // specifying `index: true` is optional if you do `unique: true`
       }
     });
+    ```
   h5 String
   :markdown
     * `lowercase`: boolean, whether to always call `.toLowerCase()` on the value
@@ -178,7 +182,7 @@ block content
   :markdown
     [Built-in `Date` methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) are [__not__ hooked into](https://github.com/Automattic/mongoose/issues/1598) the mongoose change tracking logic which in English means that if you use a `Date` in your document and modify it with a method like `setMonth()`, mongoose will be unaware of this change and `doc.save()` will not persist this modification. If you must modify `Date` types using built-in methods, tell mongoose about the change with `doc.markModified('pathToYourDate')` before saving.
 
-  :js
+    ```javascript
     var Assignment = mongoose.model('Assignment', { dueDate: Date });
     Assignment.findOne(function (err, doc) {
       doc.dueDate.setMonth(3);
@@ -187,31 +191,37 @@ block content
       doc.markModified('dueDate');
       doc.save(callback); // works
     })
-
+    ```
   h4#mixed Mixed
   p An "anything goes" SchemaType, its flexibility comes at a trade-off of it being harder to maintain. Mixed is available either through Schema.Types.Mixed or by passing an empty object literal. The following are equivalent:
-  :js
+  :markdown
+    ```javascript
     var Any = new Schema({ any: {} });
     var Any = new Schema({ any: Object });
     var Any = new Schema({ any: Schema.Types.Mixed });
+    ```
   p
     | Since it is a schema-less type, you can change the value to anything else you like, but Mongoose loses the ability to auto detect and save those changes. To "tell" Mongoose that the value of a Mixed type has changed, call the
     code .markModified(path)
     |  method of the document passing the path to the Mixed type you just changed.
-  :js
+  :markdown
+    ```javascript
     person.anything = { x: [3, 4, { y: "changed" }] };
     person.markModified('anything');
     person.save(); // anything will now get saved
+    ```
   h4#objectids ObjectIds
   p
     | To specify a type of ObjectId, use
     code Schema.Types.ObjectId
     |  in your declaration.
-  :js
+  :markdown
+    ```javascript
     var mongoose = require('mongoose');
     var ObjectId = mongoose.Schema.Types.ObjectId;
     var Car = new Schema({ driver: ObjectId });
     // or just Schema.ObjectId for backwards compatibility with v2
+    ```
   h4#arrays Arrays
   p
     | Provide creation of arrays of
@@ -219,7 +229,8 @@ block content
     |  or
     a(href="./subdocs.html") Sub-Documents
     |.
-  :js
+  :markdown
+    ```javascript
     var ToySchema = new Schema({ name: String });
     var ToyBox = new Schema({
       toys: [ToySchema],
@@ -228,34 +239,42 @@ block content
       numbers: [Number]
       // ... etc
     });
+    ```
   p
     | Note: specifying an empty array is equivalent to
     code Mixed
     |. The following all create arrays of
     code Mixed
     |:
-  :js
+  :markdown
+    ```javascript
     var Empty1 = new Schema({ any: [] });
     var Empty2 = new Schema({ any: Array });
     var Empty3 = new Schema({ any: [Schema.Types.Mixed] });
     var Empty4 = new Schema({ any: [{}] });
+    ```
   p
     | Arrays implicitly have a default value of `[]` (empty array).
-  :js
+  :markdown
+    ```javascript
     var Toy = mongoose.model('Test', ToySchema);
     console.log((new Toy()).toys); // []
+    ```
   p
     | To overwrite this default, you need to set the default value to `undefined`
-  :js
+  :markdown
+    ```javascript
     var ToySchema = new Schema({
       toys: {
         type: [ToySchema],
         default: undefined
       }
     });
+    ```
   p
     | If an array is marked as `required`, it must have at least one element.
-  :js
+  :markdown
+    ```javascript
     var ToySchema = new Schema({
       toys: {
         type: [ToySchema],
@@ -266,6 +285,7 @@ block content
     Toy.create({ toys: [] }, function(error) {
       console.log(error.errors['toys'].message); // Path "toys" is required.
     });
+    ```
   h3#customtypes Creating Custom Types
   p
     | Mongoose can also be extended with custom SchemaTypes. Search the
@@ -283,7 +303,7 @@ block content
   :markdown
     The `schema.path()` function returns the instantiated schema type for a
     given path.
-  :js
+    ```javascript
     var sampleSchema = new Schema({ name: { type: String, required: true } });
     console.log(sampleSchema.path('name'));
     // Output looks like:
@@ -295,6 +315,7 @@ block content
      *   instance: 'String',
      *   validators: ...
      */
+     ```
   :markdown
     You can use this function to inspect the schema type for a given path,
     including what validators it has and what the type is.

--- a/docs/subdocs.jade
+++ b/docs/subdocs.jade
@@ -7,7 +7,7 @@ block content
     means you can nest schemas in other schemas. Mongoose has two
     distinct notions of subdocuments: arrays of subdocuments and single nested
     subdocuments.
-  :js
+    ```javascript
     var childSchema = new Schema({ name: 'string' });
 
     var parentSchema = new Schema({
@@ -17,7 +17,7 @@ block content
       // in mongoose >= 4.2.0
       child: childSchema
     });
-
+    ```
   :markdown
     Subdocuments are similar to normal documents. Nested schemas can have
     [middleware](http://mongoosejs.com/docs/middleware.html), [custom validation logic](http://mongoosejs.com/docs/middleware.html),
@@ -25,7 +25,7 @@ block content
     difference is that subdocuments are
     not saved individually, they are saved whenever their top-level parent
     document is saved.
-  :js
+    ```javascript
     var Parent = mongoose.model('Parent', parentSchema);
     var parent = new Parent({ children: [{ name: 'Matt' }, { name: 'Sarah' }] })
     parent.children[0].name = 'Matthew';
@@ -34,14 +34,14 @@ block content
     // does **not** actually save the subdocument. You need to save the parent
     // doc.
     parent.save(callback);
-
+    ```
   :markdown
     Subdocuments have `save` and `validate` [middleware](http://mongoosejs.com/docs/middleware.html)
     just like top-level documents. Calling `save()` on the parent document triggers
     the `save()` middleware for all its subdocuments, and the same for `validate()`
     middleware.
 
-  :js
+    ```javascript
     childSchema.pre('save', function (next) {
       if ('invalid' == this.name) {
         return next(new Error('#sadpanda'));
@@ -53,14 +53,14 @@ block content
     parent.save(function (err) {
       console.log(err.message) // #sadpanda
     });
-  
+    ```
   :markdown
     Subdocuments' `pre('save')` and `pre('validate')` middleware execute
     **before** the top-level document's `pre('save')` but **after** the
     top-level document's `pre('validate')` middleware. This is because validating
     before `save()` is actually a piece of built-in middleware.
   
-  :js
+    ```javascript
     // Below code will print out 1-4 in order
     var childSchema = new mongoose.Schema({ name: 'string' });
 
@@ -87,16 +87,16 @@ block content
       console.log('4');
       next();
     });
-
+    ```
 
   h3 Finding a sub-document
   :markdown
     Each subdocument has an `_id` by default. Mongoose document arrays have a
     special [id](./api.html#types_documentarray_MongooseDocumentArray-id) method
     for searching a document array to find a document with a given `_id`.
-  :js
+    ```javascript
     var doc = parent.children.id(_id);
-
+    ```
   h3 Adding sub-docs to arrays
   :markdown
     MongooseArray methods such as
@@ -104,7 +104,7 @@ block content
     [unshift](./api.html#types_array_MongooseArray.unshift),
     [addToSet](./api.html#types_array_MongooseArray.addToSet),
     and others cast arguments to their proper types transparently:
-  :js
+    ```javascript
     var Parent = mongoose.model('Parent');
     var parent = new Parent;
 
@@ -118,13 +118,14 @@ block content
       if (err) return handleError(err)
       console.log('Success!');
     });
+    ```
   :markdown
     Sub-docs may also be created without adding them to the array by using the
     [create](./api.html#types_documentarray_MongooseDocumentArray.create)
     method of MongooseArrays.
-  :js
+    ```javascript
     var newdoc = parent.children.create({ name: 'Aaron' });
-
+    ```
   h3 Removing subdocs
   :markdown
     Each subdocument has it's own
@@ -132,7 +133,7 @@ block content
     an array subdocument, this is equivalent to calling `.pull()` on the
     subdocument. For a single nested subdocument, `remove()` is equivalent
     to setting the subdocument to `null`.
-  :js
+    ```javascript
     // Equivalent to `parent.children.pull(_id)`
     parent.children.id(_id).remove();
     // Equivalent to `parent.child = null`
@@ -141,12 +142,12 @@ block content
       if (err) return handleError(err);
       console.log('the subdocs were removed');
     });
-
+    ```
   h4#altsyntax Alternate declaration syntax for arrays
   :markdown
     If you create a schema with an array of objects, mongoose will automatically
     convert the object to a schema for you:
-  :js
+    ```javascript
     var parentSchema = new Schema({
       children: [{ name: 'string' }]
     });
@@ -154,7 +155,7 @@ block content
     var parentSchema = new Schema({
       children: [new Schema({ name: 'string' })]
     });
-  
+    ```
   h3#next Next Up
   :markdown
     Now that we've covered `Sub-documents`, let's take a look at


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Sorry for doing this more than once. I wanted to get it right as it's my first contribution.
This fixes 3 of the 4 files mentioned in #6038 removing the :js markdown and replacing it
with backticks (adding :markdown where needed).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This was done to restore formatting to the code blocks on these specific pages in the documentation.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

here are screen shoots of the pages in this commit that have been rendered via:
```
make docclean
make gendocs
```
and served via:
```
node static.js
```

![models rendered](https://user-images.githubusercontent.com/6015453/35470749-54df76aa-031d-11e8-8127-2d8160f633f3.png)
![schematypes rendered](https://user-images.githubusercontent.com/6015453/35470750-54efd9f0-031d-11e8-9c25-ba290dbc9517.png)
![subdocs rendered](https://user-images.githubusercontent.com/6015453/35470751-54fd080a-031d-11e8-8b28-40b45d5d8941.png)
