### PR TITLE
Add return type in mongose.model docs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -285,6 +285,7 @@ Mongoose.prototype.pluralize = function(fn) {
  * @param {Schema} [schema]
  * @param {String} [collection] name (optional, inferred from model name)
  * @param {Boolean} [skipInit] whether to skip initialization (defaults to false)
+ * @return {Model}
  * @api public
  */
 


### PR DESCRIPTION
**Summary**

This will allow lint tools to know the type of `mongoose.model`.

**Test plan**

I should just work :smile: 
