### PR TITLE
fix(info_message): It fixes error message. Since nothing bad happened…

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -182,7 +182,7 @@ NativeCollection.prototype.$print = function(name, i, args) {
   }
   var params = '(' + _args.join(', ') + ')';
 
-  console.error(moduleName + functionCall + params);
+  console.info(moduleName + functionCall + params);
 };
 
 /**


### PR DESCRIPTION
…, level of the message should be info instead of error

**Summary**

We use Kibana/Logstash for browsing logs on our project. We have 2 environments dev, uat. On dev env we use mongoose.set('debug', true), so that our queries present in logs. Of course we use debug false on uat.

Please see based on PR, that we would like to change level from error to info for console logging. The reason is that we monkey patch original console, to make it json like, so we can visualize errors and infos with elastic queries. For our dev environment we see level error, but nothing bad happened. Would you like to accept our PR? Since now we see only one option for our project to switch off mongoose debugging, which is not good idea for development environment.

**Test plan**

Code change is really small and can be merged with no impact on functional stuff.
