### PR TITLE
For https://github.com/Automattic/mongoose/issues/2596

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -22,6 +22,7 @@ var applyStatics = require('./services/model/applyStatics');
 var cast = require('./cast');
 var castUpdate = require('./services/query/castUpdate');
 var discriminator = require('./services/model/discriminator');
+var getDiscriminatorByValue = require('./queryhelpers').getDiscriminatorByValue;
 var internalToObjectOptions = require('./options').internalToObjectOptions;
 var isPathSelectedInclusive = require('./services/projection/isPathSelectedInclusive');
 var get = require('lodash.get');
@@ -829,10 +830,11 @@ Model.prototype.model = function model(name) {
  *
  * @param {String} name   discriminator model name
  * @param {Schema} schema discriminator model schema
+ * @param {String} value  discriminator model typeKey value
  * @api public
  */
 
-Model.discriminator = function(name, schema) {
+Model.discriminator = function(name, schema, value) {
   var model;
   if (typeof name === 'function') {
     model = name;
@@ -842,7 +844,7 @@ Model.discriminator = function(name, schema) {
     }
   }
 
-  schema = discriminator(this, name, schema);
+  schema = discriminator(this, name, schema, value);
   if (this.db.models[name]) {
     throw new OverwriteModelError(name);
   }
@@ -2034,7 +2036,7 @@ Model.create = function create(doc, callback) {
     args.forEach(doc => {
       toExecute.push(callback => {
         var Model = this.discriminators && doc[discriminatorKey] ?
-          this.discriminators[doc[discriminatorKey]] :
+          this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this, doc[discriminatorKey]) :
           this;
         var toSave = doc;
         var callbackWrapper = (error, doc) => {

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -46,6 +46,34 @@ exports.preparePopulationOptionsMQ = function preparePopulationOptionsMQ(query, 
   return pop;
 };
 
+
+/*!
+ * returns discriminator by discriminatorMapping.value
+ *
+ * @param {Model} model
+ * @param {string} value
+ */
+function getDiscriminatorByValue(model, value) {
+  var discriminator = null;
+  if (!model.discriminators) {
+    return discriminator;
+  }
+  for (var name in model.discriminators) {
+    var it = model.discriminators[name];
+    if (
+      it.schema &&
+      it.schema.discriminatorMapping &&
+      it.schema.discriminatorMapping.value == value
+    ) {
+      discriminator = it;
+      break;
+    }
+  }
+  return discriminator;
+}
+
+exports.getDiscriminatorByValue = getDiscriminatorByValue;
+
 /*!
  * If the document is a mapped discriminator type, it returns a model instance for that type, otherwise,
  * it returns an instance of the given model.
@@ -65,11 +93,14 @@ exports.createModel = function createModel(model, doc, fields, userProvidedField
     ? discriminatorMapping.key
     : null;
 
-  if (key && doc[key] && model.discriminators && model.discriminators[doc[key]]) {
-    var discriminator = model.discriminators[doc[key]];
-    var _fields = utils.clone(userProvidedFields);
-    exports.applyPaths(_fields, discriminator.schema);
-    return new model.discriminators[doc[key]](undefined, _fields, true);
+  var value = doc[key];
+  if (key && value && model.discriminators) {
+    var discriminator = model.discriminators[value] || getDiscriminatorByValue(model, value);
+    if (discriminator) {
+      var _fields = utils.clone(userProvidedFields);
+      exports.applyPaths(_fields, discriminator.schema);
+      return new discriminator(undefined, _fields, true);
+    }
   }
 
   return new model(undefined, fields, true);

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -22,6 +22,7 @@ var util = require('util');
 var utils = require('../utils');
 var castToNumber = require('./operators/helpers').castToNumber;
 var geospatial = require('./operators/geospatial');
+var getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
 
 var MongooseArray;
 var EmbeddedDoc;
@@ -247,10 +248,18 @@ SchemaArray.prototype.castForQuery = function($conditional, value) {
 
     if (val &&
         Constructor.discriminators &&
-        Constructor.schema.options.discriminatorKey &&
-        typeof val[Constructor.schema.options.discriminatorKey] === 'string' &&
-        Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]]) {
-      Constructor = Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]];
+        Constructor.schema &&
+        Constructor.schema.options &&
+        Constructor.schema.options.discriminatorKey) {
+      if (typeof val[Constructor.schema.options.discriminatorKey] === 'string' &&
+          Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]]) {
+        Constructor = Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]];
+      } else {
+        var constructorByValue = getDiscriminatorByValue(Constructor, val[Constructor.schema.options.discriminatorKey]);
+        if (constructorByValue) {
+          Constructor = constructorByValue;
+        }
+      }
     }
 
     var proto = this.casterConstructor.prototype;

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -12,6 +12,7 @@ var SchemaType = require('../schematype');
 var discriminator = require('../services/model/discriminator');
 var util = require('util');
 var utils = require('../utils');
+var getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
 
 var MongooseDocumentArray;
 var Subdocument;
@@ -297,9 +298,17 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
 
     var Constructor = this.casterConstructor;
     if (Constructor.discriminators &&
-        typeof value[i][Constructor.schema.options.discriminatorKey] === 'string' &&
-        Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]]) {
-      Constructor = Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]];
+        Constructor.schema &&
+        Constructor.schema.options &&
+        typeof value[i][Constructor.schema.options.discriminatorKey] === 'string') {
+      if (Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]]) {
+        Constructor = Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]];
+      } else {
+        var constructorByValue = getDiscriminatorByValue(Constructor, value[i][Constructor.schema.options.discriminatorKey]);
+        if (constructorByValue) {
+          Constructor = constructorByValue;
+        }
+      }
     }
 
     // Check if the document has a different schema (re gh-3701)

--- a/lib/schema/embedded.js
+++ b/lib/schema/embedded.js
@@ -11,6 +11,7 @@ const castToNumber = require('./operators/helpers').castToNumber;
 const discriminator = require('../services/model/discriminator');
 const geospatial = require('./operators/geospatial');
 const internalToObjectOptions = require('../options').internalToObjectOptions;
+var getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
 
 let Subdocument;
 
@@ -140,10 +141,17 @@ Embedded.prototype.cast = function(val, doc, init, priorVal) {
   var discriminatorKey = Constructor.schema.options.discriminatorKey;
   if (val != null &&
       Constructor.discriminators &&
-      typeof val[discriminatorKey] === 'string' &&
-      Constructor.discriminators[val[discriminatorKey]]) {
-    Constructor = Constructor.discriminators[val[discriminatorKey]];
+      typeof val[discriminatorKey] === 'string') {
+    if (Constructor.discriminators[val[discriminatorKey]]) {
+      Constructor = Constructor.discriminators[val[discriminatorKey]];
+    } else {
+      var constructorByValue = getDiscriminatorByValue(Constructor, val[discriminatorKey]);
+      if (constructorByValue) {
+        Constructor = constructorByValue;
+      }
+    }
   }
+
 
   var subdoc;
   if (init) {
@@ -202,10 +210,17 @@ Embedded.prototype.doValidate = function(value, fn, scope) {
   var discriminatorKey = Constructor.schema.options.discriminatorKey;
   if (value != null &&
       Constructor.discriminators &&
-      typeof value[discriminatorKey] === 'string' &&
-      Constructor.discriminators[value[discriminatorKey]]) {
-    Constructor = Constructor.discriminators[value[discriminatorKey]];
+      typeof value[discriminatorKey] === 'string') {
+    if (Constructor.discriminators[value[discriminatorKey]]) {
+      Constructor = Constructor.discriminators[value[discriminatorKey]];
+    } else {
+      var constructorByValue = getDiscriminatorByValue(Constructor, value[discriminatorKey]);
+      if (constructorByValue) {
+        Constructor = constructorByValue;
+      }
+    }
   }
+
 
   SchemaType.prototype.doValidate.call(this, value, function(error) {
     if (error) {

--- a/lib/services/model/discriminator.js
+++ b/lib/services/model/discriminator.js
@@ -14,7 +14,7 @@ var CUSTOMIZABLE_DISCRIMINATOR_OPTIONS = {
  * ignore
  */
 
-module.exports = function discriminator(model, name, schema) {
+module.exports = function discriminator(model, name, schema, tiedValue) {
   if (!(schema && schema.instanceOfSchema)) {
     throw new Error('You must pass a valid discriminator Schema');
   }
@@ -46,6 +46,11 @@ module.exports = function discriminator(model, name, schema) {
         '" cannot have field with name "' + key + '"');
   }
 
+  var value = name;
+  if (typeof tiedValue == 'string' && tiedValue.length) {
+    value = tiedValue;
+  }
+
   function merge(schema, baseSchema) {
     if (baseSchema.paths._id &&
         baseSchema.paths._id.options &&
@@ -59,11 +64,11 @@ module.exports = function discriminator(model, name, schema) {
 
     var obj = {};
     obj[key] = {
-      default: name,
+      default: value,
       select: true,
       set: function(newName) {
-        if (newName === name) {
-          return name;
+        if (newName === value) {
+          return value;
         }
         throw new Error('Can\'t set discriminator key "' + key + '"');
       },
@@ -71,7 +76,7 @@ module.exports = function discriminator(model, name, schema) {
     };
     obj[key][schema.options.typeKey] = String;
     schema.add(obj);
-    schema.discriminatorMapping = {key: key, value: name, isRoot: false};
+    schema.discriminatorMapping = {key: key, value: value, isRoot: false};
 
     if (baseSchema.options.collection) {
       schema.options.collection = baseSchema.options.collection;

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -10,6 +10,7 @@ const ObjectIdSchema = require('../schema/objectid');
 const internalToObjectOptions = require('../options').internalToObjectOptions;
 const utils = require('../utils');
 const Document = require('../document');
+const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
 
 /**
  * DocumentArray constructor
@@ -123,10 +124,18 @@ MongooseDocumentArray.mixin = {
 
     if (value &&
         Constructor.discriminators &&
-        Constructor.schema.options.discriminatorKey &&
-        typeof value[Constructor.schema.options.discriminatorKey] === 'string' &&
-        Constructor.discriminators[value[Constructor.schema.options.discriminatorKey]]) {
-      Constructor = Constructor.discriminators[value[Constructor.schema.options.discriminatorKey]];
+        Constructor.schema &&
+        Constructor.schema.options &&
+        Constructor.schema.options.discriminatorKey) {
+      if (typeof value[Constructor.schema.options.discriminatorKey] === 'string' &&
+          Constructor.discriminators[value[Constructor.schema.options.discriminatorKey]]) {
+        Constructor = Constructor.discriminators[value[Constructor.schema.options.discriminatorKey]];
+      } else {
+        var constructorByValue = getDiscriminatorByValue(Constructor, value[Constructor.schema.options.discriminatorKey]);
+        if (constructorByValue) {
+          Constructor = constructorByValue;
+        }
+      }
     }
 
     return new Constructor(value, this, undefined, undefined, index);
@@ -233,10 +242,18 @@ MongooseDocumentArray.mixin = {
     var Constructor = this._schema.casterConstructor;
     if (obj &&
         Constructor.discriminators &&
-        Constructor.schema.options.discriminatorKey &&
-        typeof obj[Constructor.schema.options.discriminatorKey] === 'string' &&
-        Constructor.discriminators[obj[Constructor.schema.options.discriminatorKey]]) {
-      Constructor = Constructor.discriminators[obj[Constructor.schema.options.discriminatorKey]];
+        Constructor.schema &&
+        Constructor.schema.options &&
+        Constructor.schema.options.discriminatorKey) {
+      if (typeof obj[Constructor.schema.options.discriminatorKey] === 'string' &&
+          Constructor.discriminators[obj[Constructor.schema.options.discriminatorKey]]) {
+        Constructor = Constructor.discriminators[obj[Constructor.schema.options.discriminatorKey]];
+      } else {
+        var constructorByValue = getDiscriminatorByValue(Constructor, obj[Constructor.schema.options.discriminatorKey]);
+        if (constructorByValue) {
+          Constructor = constructorByValue;
+        }
+      }
     }
 
     return new Constructor(obj);


### PR DESCRIPTION
Initial commit.

Allows to make model.discriminator call
using 3rd argument, tied to discriminatorKey Value
Population also works

Changes made from->to using parts of, but no model naming changes!
https://gist.github.com/wentout/2171022fe597e5b2564435d6b44eac49

**Summary**

It probably solves parts of this issue, and I able to add naming composition, check the gist above
https://github.com/Automattic/mongoose/issues/2596

**Test plan**

I made no hard changes, only interface addition is **value**, which means what to be tied to the discriminator key. And, as this is a last parameter, I thought of no additional tests. However I'm not very sure. It works in my environment for my current task. If you can give me a way, I will try to understand what I was able to break with this change.
