### PR TITLE
For https://github.com/Automattic/mongoose/issues/2596

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -827,9 +827,12 @@ Model.prototype.model = function model(name) {
  *     var Person = mongoose.model('Person', PersonSchema);
  *     var Boss = Person.discriminator('Boss', BossSchema);
  *
- * @param {String} name   discriminator model name
- * @param {Schema} schema discriminator model schema
- * @param {String} value  discriminator model typeKey value
+ * @param {String}  name   discriminator model name
+ * @param {Schema}  schema discriminator model schema
+ * @param {String}  value  discriminator model typeKey value
+ * @param {Boolean} value  cast discriminator name
+ *                          to be made of baseModelName + '.' + name
+ *                          and value made of name
  * @api public
  */
 
@@ -840,6 +843,18 @@ Model.discriminator = function(name, schema, value) {
     name = utils.getFunctionName(model);
     if (!(model.prototype instanceof Model)) {
       throw new Error('The provided class ' + name + ' must extend Model');
+    }
+  } else {
+    if (typeof value == 'boolean') {
+      if (value) {
+        // cast name change to `${this.modelName}.${name}`
+        value = '' + name;
+        name = this.modelName + '.' + name;
+      } else {
+        value = undefined;
+      }
+    } else if (typeof value !== 'string') {
+      value = undefined;
     }
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -829,10 +829,11 @@ Model.prototype.model = function model(name) {
  *
  * @param {String} name   discriminator model name
  * @param {Schema} schema discriminator model schema
+ * @param {String} value  discriminator model typeKey value
  * @api public
  */
 
-Model.discriminator = function(name, schema) {
+Model.discriminator = function(name, schema, value) {
   var model;
   if (typeof name === 'function') {
     model = name;
@@ -842,7 +843,7 @@ Model.discriminator = function(name, schema) {
     }
   }
 
-  schema = discriminator(this, name, schema);
+  schema = discriminator(this, name, schema, value);
   if (this.db.models[name]) {
     throw new OverwriteModelError(name);
   }

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -65,11 +65,27 @@ exports.createModel = function createModel(model, doc, fields, userProvidedField
     ? discriminatorMapping.key
     : null;
 
-  if (key && doc[key] && model.discriminators && model.discriminators[doc[key]]) {
-    var discriminator = model.discriminators[doc[key]];
-    var _fields = utils.clone(userProvidedFields);
-    exports.applyPaths(_fields, discriminator.schema);
-    return new model.discriminators[doc[key]](undefined, _fields, true);
+  var value = doc[key];
+  if (key && value && model.discriminators) {
+    var discriminator = model.discriminators[value] || null;
+    if (!discriminator) {
+      for (var name in model.discriminators) {
+        var it = model.discriminators[name];
+        if (
+          it.schema &&
+          it.schema.discriminatorMapping &&
+          it.schema.discriminatorMapping.value == value
+        ) {
+          discriminator = it;
+          break;
+        }
+      }
+    }
+    if (discriminator) {
+      var _fields = utils.clone(userProvidedFields);
+      exports.applyPaths(_fields, discriminator.schema);
+      return new discriminator(undefined, _fields, true);
+    }
   }
 
   return new model(undefined, fields, true);

--- a/lib/services/model/discriminator.js
+++ b/lib/services/model/discriminator.js
@@ -14,7 +14,8 @@ var CUSTOMIZABLE_DISCRIMINATOR_OPTIONS = {
  * ignore
  */
 
-module.exports = function discriminator(model, name, schema) {
+module.exports = function discriminator(model, name, schema, tiedValue) {
+  
   if (!(schema && schema.instanceOfSchema)) {
     throw new Error('You must pass a valid discriminator Schema');
   }
@@ -46,6 +47,11 @@ module.exports = function discriminator(model, name, schema) {
         '" cannot have field with name "' + key + '"');
   }
 
+  var value = name;
+  if (typeof tiedValue == 'string' && tiedValue) {
+    value = tiedValue;
+  }
+
   function merge(schema, baseSchema) {
     if (baseSchema.paths._id &&
         baseSchema.paths._id.options &&
@@ -59,11 +65,11 @@ module.exports = function discriminator(model, name, schema) {
 
     var obj = {};
     obj[key] = {
-      default: name,
+      default: value,
       select: true,
       set: function(newName) {
-        if (newName === name) {
-          return name;
+        if (newName === value) {
+          return value;
         }
         throw new Error('Can\'t set discriminator key "' + key + '"');
       },
@@ -71,7 +77,7 @@ module.exports = function discriminator(model, name, schema) {
     };
     obj[key][schema.options.typeKey] = String;
     schema.add(obj);
-    schema.discriminatorMapping = {key: key, value: name, isRoot: false};
+    schema.discriminatorMapping = {key: key, value: value, isRoot: false};
 
     if (baseSchema.options.collection) {
       schema.options.collection = baseSchema.options.collection;

--- a/lib/services/model/discriminator.js
+++ b/lib/services/model/discriminator.js
@@ -15,7 +15,6 @@ var CUSTOMIZABLE_DISCRIMINATOR_OPTIONS = {
  */
 
 module.exports = function discriminator(model, name, schema, tiedValue) {
-  
   if (!(schema && schema.instanceOfSchema)) {
     throw new Error('You must pass a valid discriminator Schema');
   }

--- a/lib/services/model/discriminator.js
+++ b/lib/services/model/discriminator.js
@@ -47,7 +47,7 @@ module.exports = function discriminator(model, name, schema, tiedValue) {
   }
 
   var value = name;
-  if (typeof tiedValue == 'string' && tiedValue) {
+  if (typeof tiedValue == 'string' && tiedValue.length) {
     value = tiedValue;
   }
 

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1952,7 +1952,7 @@ describe('model: querying:', function() {
       Test.find({block: {$lte: 'buffer shtuffs are neat'}}, function(err, tests) {
         cb();
         assert.ifError(err);
-        assert.equal(tests.length, 4);
+        assert.equal(tests.length, 3);
       });
 
       var pending = 9;

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1952,7 +1952,7 @@ describe('model: querying:', function() {
       Test.find({block: {$lte: 'buffer shtuffs are neat'}}, function(err, tests) {
         cb();
         assert.ifError(err);
-        assert.equal(tests.length, 3);
+        assert.equal(tests.length, 4);
       });
 
       var pending = 9;


### PR DESCRIPTION

Allows to make model.discriminator call
using 3rd argument, tied to discriminatorKey Value
Population also works

Changes made from->to using parts of, but no model naming changes!
https://gist.github.com/wentout/2171022fe597e5b2564435d6b44eac49

**Summary**

It probably solves parts of this issue, and I able to add naming composition, check the gist above
https://github.com/Automattic/mongoose/issues/2596

Re Fix 4 CI about previous branch.

**Test plan**

I made no hard changes, only interface addition is **value**, which means what to be tied to the discriminator key. And, as this is a last parameter, I thought of no additional tests. However I'm not very sure. It works in my environment for my current task. If you can give me a way, I will try to understand what I was able to break with this change.
