### PR TITLE
Potential fix for issue retrieving documents containing arrays within arrays

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -185,7 +185,8 @@ SchemaArray.prototype.cast = function(value, doc, init) {
     if (this.caster) {
       try {
         for (i = 0, l = value.length; i < l; i++) {
-          value[i] = this.caster.cast(value[i], doc, init);
+          value[i] = Array.isArray(value[i]) ?
+            this.cast(value[i], doc, init) : this.caster.cast(value[i], doc, init);
         }
       } catch (e) {
         // rethrow


### PR DESCRIPTION
Potential fix for #6086 

**Summary**
It looked like mongoose was not updating a document correctly based on whether the $addToSet modifier was adding an array of numbers vs an array of strings.  Turns out the update was working fine and the document was being saved as intended, but there were issues with its retrieval.

The reason that an array of strings "worked" was because casting an array to string would cast to a literal string in the shape of the array, e.g. "['foo','bar']" the problem here was it would be of type string instead of truly being an array within another array.

In the case of an array of numbers, it would try to cast the array to a number and fail and throw a CastError and eventually send back an empty array.

The fix was to recursively call SchemaArray.cast until the value to be cast was no longer an array.

**Test plan**

Reran scripts given with issue statement as well as existing unit tests
