### PR TITLE
Doc save called twice it triggers TypeError: doc.toObject is not a function

### DIFF
--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -202,7 +202,7 @@ MongooseDocumentArray.mixin = {
 
   toObject: function(options) {
     return this.map(function(doc) {
-      return doc && doc.toObject(options) || null;
+      return doc && typeof doc.toObject == 'function' && doc.toObject(options) || null;
     });
   },
 


### PR DESCRIPTION
Can be handled in the code, but When Doc save triggers twice it triggers TypeError: doc.toObject is not a function

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When the save() triggered twice for the same document, throws an error. TypeError: doc.toObject is not a function

**Test plan**
```
'use strict'

let mongoose = require('mongoose'),
  assert = require('assert'),moment = require('moment')

mongoose.connect('mongodb://localhost:27017/test')

var schema = new mongoose.Schema({
  title: String,
  array: [{
    name: String
  }]
})

let Order = mongoose.model('Order', schema, 'Order'),
  doc = {
    title:"test",
    array: []
  }

Order.collection.insertOne(doc, function (err) {
  assert.ifError(err)

  Order.findOne({
    _id: doc._id
  }, function (err, order) {
    assert.ifError(err)
    //first save call 
    console.log("First Save")
     order.save({title:"test here"})

    order.array.push({name:"test1"})
    //second save call after some logic
    order.save(function (err) {
      console.log("Second Save callback")
      assert.ifError(err)
      mongoose.disconnect()
    })
    console.log("Second Save End")
  })
})
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
