### PR TITLE
Prevented converting of dates to timestamps when respecting valueOf()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -763,7 +763,7 @@ exports.mergeClone = function(to, fromObj) {
       });
     } else {
       var val = fromObj[key];
-      if (val != null && val.valueOf) {
+      if (val != null && val.valueOf && !(val instanceof Date)) {
         val = val.valueOf();
       }
       if (exports.isObject(val)) {


### PR DESCRIPTION
**Summary**

Add check when respecting object's `valueOf` to ignore dates. This prevents dates being cast as timestamps when saved to the database as reported in #6145, where `Date.valueOf` returns a timestamp.

**Test plan**
 The script described in #6145 functions as expected