### PR TITLE
docs: remove dead link to Strongloop blog post.

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -2136,7 +2136,7 @@ Kitten.find().populate(<span class="hljs-string">'owner'</span>, <span class="hl
 
 <h4>Note</h4>
 
-<p>If <code>obj</code> is present, it is cast instead of this query.</p></div><hr class="separate-api-elements"><h3 id="query_Query-cursor"><a href="#query_Query-cursor">Query.prototype.cursor()</a></h3><h5>Parameters</h5><ul class="params"><li class="param">[options] <span class="method-type">&laquo;Object&raquo;</span> </li></ul><h5>Returns:</h5><ul><li><span class="method-type">&laquo;QueryCursor&raquo;</span> </li></ul><div><p>Returns a wrapper around a <a href="http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html">mongodb driver cursor</a>. A QueryCursor exposes a <a href="https://strongloop.com/strongblog/whats-new-io-js-beta-streams3/">Streams3</a>-compatible interface, as well as a <code>.next()</code> function.</p>
+<p>If <code>obj</code> is present, it is cast instead of this query.</p></div><hr class="separate-api-elements"><h3 id="query_Query-cursor"><a href="#query_Query-cursor">Query.prototype.cursor()</a></h3><h5>Parameters</h5><ul class="params"><li class="param">[options] <span class="method-type">&laquo;Object&raquo;</span> </li></ul><h5>Returns:</h5><ul><li><span class="method-type">&laquo;QueryCursor&raquo;</span> </li></ul><div><p>Returns a wrapper around a <a href="http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html">mongodb driver cursor</a>. A QueryCursor exposes a Streams3-compatible interface, as well as a <code>.next()</code> function.</p>
 
 <p>The <code>.cursor()</code> function triggers pre find hooks, but <strong>not</strong> post find hooks.</p>
 

--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -10,7 +10,7 @@ var utils = require('../utils');
  * An AggregationCursor is a concurrency primitive for processing aggregation
  * results one document at a time. It is analogous to QueryCursor.
  *
- * An AggregationCursor fulfills the [Node.js streams3 API](https://strongloop.com/strongblog/whats-new-io-js-beta-streams3/),
+ * An AggregationCursor fulfills the Node.js streams3 API,
  * in addition to several other mechanisms for loading documents from MongoDB
  * one at a time.
  *

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -10,7 +10,7 @@ var utils = require('../utils');
 
 /**
  * A QueryCursor is a concurrency primitive for processing query results
- * one document at a time. A QueryCursor fulfills the [Node.js streams3 API](https://strongloop.com/strongblog/whats-new-io-js-beta-streams3/),
+ * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
  * in addition to several other mechanisms for loading documents from MongoDB
  * one at a time.
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -3214,8 +3214,7 @@ Query.prototype._applyPaths = function applyPaths() {
 
 /**
  * Returns a wrapper around a [mongodb driver cursor](http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html).
- * A QueryCursor exposes a [Streams3](https://strongloop.com/strongblog/whats-new-io-js-beta-streams3/)-compatible
- * interface, as well as a `.next()` function.
+ * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
  *
  * The `.cursor()` function triggers pre find hooks, but **not** post find hooks.
  *


### PR DESCRIPTION
**Summary**

Removes dead link to Strongloop from docs.

**Test plan**

Maybe we should quit referring to just "Streams 3" and instead say
something like "Streams 3 API, the Node.js streams interface since Node.js 6"