### PR TITLE
migration doc fix: correct syntax is eachAsync

### DIFF
--- a/migrating_to_5.md
+++ b/migrating_to_5.md
@@ -74,7 +74,7 @@ The `useMongooseAggCursor` option from 4.x is now always on. This is the new syn
 // cursor.
 const cursor = MyModel.aggregate([{ $match: { name: 'Val' } }]).cursor().exec();
 // No need to `await` on the cursor or wait for a promise to resolve
-cursor.forEach(doc => console.log(doc));
+cursor.eachAsync(doc => console.log(doc));
 
 // Can also pass options to `cursor()`
 const cursorWithOptions = MyModel.

--- a/migrating_to_5.md
+++ b/migrating_to_5.md
@@ -74,7 +74,7 @@ The `useMongooseAggCursor` option from 4.x is now always on. This is the new syn
 // cursor.
 const cursor = MyModel.aggregate([{ $match: { name: 'Val' } }]).cursor().exec();
 // No need to `await` on the cursor or wait for a promise to resolve
-cursor.each(doc => console.log(doc));
+cursor.forEach(doc => console.log(doc));
 
 // Can also pass options to `cursor()`
 const cursorWithOptions = MyModel.


### PR DESCRIPTION
this is also wrong in the documentation http://mongoosejs.com/docs/api.html#Aggregate (or at least not documentated that in mongoose 5 / useMongooseAggCursor flag you have to use eachAsync instead of each)