### PR TITLE
Closes #6181, reflecting changes in the emitIndexError flag

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -307,7 +307,6 @@ block content
     - [bufferCommands](#bufferCommands)
     - [capped](#capped)
     - [collection](#collection)
-    - [emitIndexErrors](#emitIndexErrors)
     - [id](#id)
     - [_id](#_id)
     - [minimize](#minimize)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -29,7 +29,6 @@ var mpath = require('mpath');
  * - [bufferCommands](/docs/guide.html#bufferCommands): bool - defaults to true
  * - [capped](/docs/guide.html#capped): bool - defaults to false
  * - [collection](/docs/guide.html#collection): string - no default
- * - [emitIndexErrors](/docs/guide.html#emitIndexErrors): bool - defaults to false.
  * - [id](/docs/guide.html#id): bool - defaults to true
  * - [_id](/docs/guide.html#_id): bool - defaults to true
  * - `minimize`: bool - controls [document#toObject](#document_Document-toObject) behavior when called manually - defaults to true


### PR DESCRIPTION
From #5910 on `emitIndexErrors` option is no longer used.

However on [the reference for Schema](http://mongoosejs.com/docs/api.html#model_Model.ensureIndexes) and [guide](http://mongoosejs.com/docs/guide.html#options) still both mentions `emitIndexErrors` although the anchor links are still there, causing confusion...

This PR changes the JSDoc and the Jade file for the guide. Generated documents are not checked in.

Closes #6181