### PR TITLE
Correct URL for plugins search site

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import mongoose from 'mongoose';
 
 ## Plugins
 
-Check out the [plugins search site](http://plugins.mongoosejs.io/) to see hundreds of related modules from the community. Next, learn how to write your own plugin from the [docs](http://mongoosejs.com/docs/plugins.html) or [this blog post](http://thecodebarbarian.com/2015/03/06/guide-to-mongoose-plugins).
+Check out the [plugins search site](http://plugins.mongoosejs.com/) to see hundreds of related modules from the community. Next, learn how to write your own plugin from the [docs](http://mongoosejs.com/docs/plugins.html) or [this blog post](http://thecodebarbarian.com/2015/03/06/guide-to-mongoose-plugins).
 
 ## Contributors
 


### PR DESCRIPTION
Hi! Tiny little PR here. I just clicked on the link to the plugins search site from the README, and noticed that it points to what appears to be the old domain. This fixes that.