### PR TITLE
fix url in useMongoClient error message #6217

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -340,7 +340,7 @@ Connection.prototype.open = util.deprecate(function() {
   };
 
   return promise;
-}, '`open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client');
+}, '`open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client');
 
 /*!
  * ignore
@@ -653,7 +653,7 @@ Connection.prototype.openSet = util.deprecate(function(uris, database, options, 
   };
 
   return promise;
-}, '`openSet()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client');
+}, '`openSet()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client');
 
 /**
  * error


### PR DESCRIPTION
fixes documentation link in connection deprecation message. #6217 

the link used to point to the current docs, now it should point to the 4.x docs.