### PR TITLE
add index.js to api docs

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -12,6 +12,7 @@ const hl = require('highlight.js');
 const md = require('markdown');
 
 const files = [
+  'lib/index.js',
   'lib/schema.js',
   'lib/connection.js',
   'lib/document.js',


### PR DESCRIPTION
While looking at createConnection for #6217, I noticed that createConnection is missing from the 5.x api docs. I added index.js to the files array in docs/source/api.js at the top to mimic it's previous placement in the 4.x docs. 

tested with make docclean && make gendocs && node static.js