### PR TITLE
(6223) adding null check before adding virtual to toJSON

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2309,7 +2309,9 @@ function applyGetters(self, json, type, options) {
       path = paths[i];
       parts = path.split('.');
       v = clone(self.get(path), options);
-      if (v === void 0 || v === null) {
+      var svp = schema.virtuals[path];
+      var glen = svp.getters ? svp.getters.length : 0;
+      if ((v === void 0) || (v === null && glen === 0)) {
         continue;
       }
       plen = parts.length;

--- a/lib/document.js
+++ b/lib/document.js
@@ -2309,7 +2309,7 @@ function applyGetters(self, json, type, options) {
       path = paths[i];
       parts = path.split('.');
       v = clone(self.get(path), options);
-      if (v === void 0) {
+      if (v === void 0 || v === null) {
         continue;
       }
       plen = parts.length;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -823,6 +823,35 @@ describe('document', function() {
         });
       });
     });
+
+    it('jsonifying an object\'s virtuals ignores nulls with no getter (gh-6223)', function(done) {
+      const personSchema = new mongoose.Schema({
+        name: { type: String },
+        children: [{
+          name: { type: String }
+        }]
+      }, {
+          toObject: { getters: true, virtuals: true },
+          toJSON: { getters: true, virtuals: true }
+      });
+      personSchema.virtual('favoriteChild').set(function (v) {
+        return this.set('children.0', v);
+      });
+
+      personSchema.virtual('heir').get(function () {
+        return this.get('children.0');
+      });
+
+      const Person = db.model('Person', personSchema);
+
+      const person = new Person({
+        name: 'Anakin'
+      });
+
+      assert.strictEqual(void 0, person.toObject().favoriteChild);
+      
+      done()
+    });
   });
 
   describe('inspect', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

adding a check for null when adding virtuals in toJSON output.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
#6223 has a complete explanation.  tl;dr starting in 4.11.5 toJSON would include null properties on virtuals. this was introduced in 2ede28b1fe4db0895a4dcb19275adc8349dc8e24

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
npm test output:
  1936 passing (28s)
  4 pending

### before change:
```
$ ./6223.js 
{
  "name": "Anakin",
  "_id": "5aa67c80725c1adf174ea890",
  "children": [],
  "id": "5aa67c80725c1adf174ea890",
  "favoriteChild": null
}
```
### after change
```
$ ./6223.js 
{
  "name": "Anakin",
  "_id": "5aa67d34f8aa88df9a028cf4",
  "children": [],
  "id": "5aa67d34f8aa88df9a028cf4"
}
```
