### PR TITLE
adding hint method to aggregate

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -602,6 +602,22 @@ Aggregate.prototype.allowDiskUse = function(value) {
 };
 
 /**
+ * Sets the hint option for the aggregation query (ignored for < 3.6.0)
+ *
+ * ####Example:
+ *
+ *     Model.aggregate(..).hint({ qty: 1, category: 1 } }).exec(callback)
+ *
+ * @param {Object|String} value a hint object or the index name
+ * @see mongodb http://docs.mongodb.org/manual/reference/command/aggregate/
+ */
+
+Aggregate.prototype.hint = function(value) {
+  this.options.hint = value;
+  return this;
+};
+
+/**
  * Lets you set arbitrary options, for middleware or plugins.
  *
  * ####Example:

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -62,11 +62,11 @@ function onlyTestAtOrAbove(semver, ctx, done) {
       return;
     }
 
-    var [major, minor] = semver.split('.').map(function(s) {
+    var desired = semver.split('.').map(function(s) {
       return parseInt(s);
     });
 
-    var meetsMinimum = version[0] > major || (version[0] === major && version[1] >= minor);
+    var meetsMinimum = version[0] > desired[0] || (version[0] === desired[0] && version[1] >= desired[1]);
 
     if (!meetsMinimum) {
       ctx.skip();

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -48,20 +48,27 @@ function setupData(db, callback) {
 }
 
 /**
- * Helper function to test operators that only work in MongoDB 3.4 and above (such as some aggregation pipeline operators)
+ * Helper function to test operators that only work in a specific versoin of MongoDB and above (such as some aggregation pipeline operators)
  *
+ * @param {String} semver, `3.4`, specify minimum compatible mongod version
  * @param {Object} ctx, `this`, so that mocha tests can be skipped
  * @param {Function} done
  * @return {Void}
  */
-function onlyTestMongo34(ctx, done) {
+function onlyTestAtOrAbove(semver, ctx, done) {
   start.mongodVersion(function(err, version) {
     if (err) {
       done(err);
       return;
     }
-    var mongo34 = version[0] > 3 || (version[0] === 3 && version[1] >= 4);
-    if (!mongo34) {
+
+    var [major, minor] = semver.split('.').map(function(s) {
+      return parseInt(s);
+    });
+
+    var meetsMinimum = version[0] > major || (version[0] === major && version[1] >= minor);
+
+    if (!meetsMinimum) {
       ctx.skip();
     }
     done();
@@ -404,7 +411,7 @@ describe('aggregate: ', function() {
 
   describe('Mongo 3.4 operators', function() {
     before(function(done) {
-      onlyTestMongo34(this, done);
+      onlyTestAtOrAbove('3.4', this, done);
     });
 
     describe('graphLookup', function() {
@@ -923,6 +930,7 @@ describe('aggregate: ', function() {
           aggregate.option({maxTimeMS: 1000});
         }
 
+
         assert.equal(aggregate.options.readPreference.mode, pref);
         if (mongo26_or_greater) {
           assert.equal(aggregate.options.allowDiskUse, true);
@@ -1251,5 +1259,39 @@ describe('aggregate: ', function() {
         });
       });
     });
+  });
+
+  describe('Mongo 3.6 options', function() {
+    before(function(done) {
+      onlyTestAtOrAbove('3.6', this, done);
+    });
+
+    it('adds hint option', function(done) {
+      var mySchema = new Schema({ name: String, qty: Number });
+      mySchema.index({ qty: -1, name: -1 });
+      var M = db.model('gh6251', mySchema);
+      M.on('index', function(error) {
+        assert.ifError(error);
+        var docs = [
+          { name: 'Andrew', qty: 4 },
+          { name: 'Betty', qty: 5 },
+          { name: 'Charlie', qty: 4 }
+        ];
+        M.create(docs, function(error) {
+          assert.ifError(error);
+          var aggregate = M.aggregate();
+          aggregate.match({})
+            .hint({ qty: -1, name: -1 }).exec(function(error, docs) {
+              assert.ifError(error);
+              assert.equal(docs[0].name, 'Betty');
+              assert.equal(docs[1].name, 'Charlie');
+              assert.equal(docs[2].name, 'Andrew');
+              done();
+            });
+        });
+      });
+    });
+
+
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

MongoDB 3.6 added the hint option to aggregations. you can currently add a hint with the .option method, but having a convenience method like the one for allowDiskUse makes sense to me.

I also updated the helper method formerly known as onlyTestMongo34. I made the version it looks for variable and changed the name to reflect the new behavior.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Test expects that the resulting array of docs is sorted according to the hint.

```
mongoose>: npm test
....
  2 failing

  1) Model
       bug fixes
         3.6 features
           watch() (gh-5964):
     Uncaught MongoError: Majority read concern requested, but it is not supported by the storage engine.
      at queryCallback (node_modules/mongodb-core/lib/cursor.js:223:25)
      at node_modules/mongodb-core/lib/connection/pool.js:541:18
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  2) Model
       bug fixes
         3.6 features
           watch() before connecting (gh-5964):
     Uncaught MongoError: Majority read concern requested, but it is not supported by the storage engine.
      at queryCallback (node_modules/mongodb-core/lib/cursor.js:223:25)
      at node_modules/mongodb-core/lib/connection/pool.js:541:18
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)



npm ERR! Test failed.  See above for more details.
```
I'm assuming it's my env that's causing these failures.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
