### PR TITLE
Treat undefined as null when casting numbers

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -211,7 +211,7 @@ SchemaNumber.prototype.cast = function(value, doc, init) {
     if (val === null) {
       return val;
     }
-    if (val === '') {
+    if (val === '' || val === undefined) {
       return null;
     }
     if (typeof val === 'string' || typeof val === 'boolean') {


### PR DESCRIPTION
Currently, a value of undefined will throw an error. 
Added a condition to line 214 so this now treats
undefined as null.
Fix #2901

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Currently, someone using this code needs to filter all values to handle the case of undefined.  By making this change, the code now handles an undefined value as if it was a null value, making it easier for programmers to use.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
