### PR TITLE
adding .hint to aggregate for 6251

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -602,6 +602,22 @@ Aggregate.prototype.allowDiskUse = function(value) {
 };
 
 /**
+ * Sets the hint option for the aggregation query (ignored for < 3.6.0)
+ *
+ * ####Example:
+ *
+ *     Model.aggregate(..).hint({ qty: 1, category: 1 } }).exec(callback)
+ *
+ * @param {Object|String} value a hint object or the index name
+ * @see mongodb http://docs.mongodb.org/manual/reference/command/aggregate/
+ */
+
+Aggregate.prototype.hint = function(value) {
+  this.options.hint = value;
+  return this;
+};
+
+/**
  * Lets you set arbitrary options, for middleware or plugins.
  *
  * ####Example:


### PR DESCRIPTION
MongoDB 3.6 added the hint option to aggregations. you can currently add a hint with the .option method, but having a convenience method like the one for allowDiskUse makes sense to me.

I also updated the helper method formerly known as onlyTestMongo34. I made the version it looks for variable and changed the name to reflect the new behavior.

Test expects that the resulting array of docs is sorted according to the hint.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
