### PR TITLE
Set timestamps automatically by using updateOne method

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -838,6 +838,15 @@ Schema.prototype.setupTimestamp = function(timestamps) {
       applyTimestampsToChildren(this);
       next();
     });
+
+    this.pre('updateOne', function(next) {
+      var overwrite = this.options.overwrite;
+      this.updateOne({}, genUpdates(this.getUpdate(), overwrite), {
+        overwrite: overwrite
+      });
+      applyTimestampsToChildren(this);
+      next();
+    });
   }
 };
 

--- a/test/schema.timestamps.test.js
+++ b/test/schema.timestamps.test.js
@@ -227,6 +227,18 @@ describe('schema options.timestamps', function() {
       });
     });
 
+    it('should change updatedAt when updateOne', function(done) {
+      Cat.findOne({name: 'newcat'}, function(err, doc) {
+        var old = doc.updatedAt;
+        Cat.updateOne({name: 'newcat'}, {$set: {hobby: 'fish'}}, function() {
+          Cat.findOne({name: 'newcat'}, function(err, doc) {
+            assert.ok(doc.updatedAt.getTime() > old.getTime());
+            done();
+          });
+        });
+      });
+    });
+
     it('nested docs (gh-4049)', function(done) {
       var GroupSchema = new Schema({
         cats: [CatSchema]


### PR DESCRIPTION
**Summary**

`timestamps` were being set for `save`, `update` and `findOneAndUpdate` methods, but not for `updateOne`.