### PR TITLE
Document new behavior of required validator for arrays

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -141,8 +141,9 @@ SchemaArray.prototype.enum = function() {
 };
 
 /**
- * Check if the given value satisfies a required validator. The given value
- * must be not null nor undefined, and have a positive length.
+ * Check if the given value satisfies a `required` validator. The given value
+ * must be an array (that is, not `null` or `undefined`).
+ * Empty arrays will **not** make `required` validator fail.
  *
  * @param {Any} value
  * @return {Boolean}

--- a/migrating_to_5.md
+++ b/migrating_to_5.md
@@ -261,3 +261,7 @@ was always synchronous, just had a callback for legacy reasons.
 
 You cannot pass parameters to the next pre middleware in the chain using `next()` in mongoose 5.x. In mongoose 4, `next('Test')` in pre middleware would call the
 next middleware with 'Test' as a parameter. Mongoose 5.x has removed support for this.
+
+### `required` validator for arrays
+
+In mongoose 5 the `required` validator only verifies if the value is an array. That is, it will **not** fail for _empty_ arrays as it would in mongoose 4.


### PR DESCRIPTION
Last week I was migrating my project to mongoose 5. The migration guide was very helpful!

But unfortunately I knew the new `required` behavior for arrays after it reached production. :disappointed:

Later I saw that it is in fact in the change log. But I think this must be in the migration guide because of its relevance.

Also fixing the outdated method documentation. 