### PR TITLE
refactor(connection): use `client.db()` syntax rather than double-parsing the URI

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,10 +11,9 @@ const Collection = require(driver + '/collection');
 const STATES = require('./connectionstate');
 const MongooseError = require('./error');
 const PromiseProvider = require('./promise_provider');
+const get = require('lodash.get');
 const mongodb = require('mongodb');
 const utils = require('./utils');
-
-const parser = require('mongodb/lib/url_parser');
 
 /*!
  * A list of authentication mechanisms that don't require a password for authentication.
@@ -52,12 +51,6 @@ function Connection(base) {
   this.models = {};
   this.config = {autoIndex: true};
   this.replica = false;
-  this.hosts = null;
-  this.host = null;
-  this.port = null;
-  this.user = null;
-  this.pass = null;
-  this.name = null;
   this.options = null;
   this.otherDbs = []; // FIXME: To be replaced with relatedDbs
   this.relatedDbs = {}; // Hashmap of other dbs that share underlying connection
@@ -132,6 +125,99 @@ Object.defineProperty(Connection.prototype, 'readyState', {
  */
 
 Connection.prototype.collections;
+
+/**
+ * The name of the database this connection points to.
+ *
+ * ####Example
+ *
+ *     mongoose.createConnection('mongodb://localhost:27017/mydb').name; // "mydb"
+ *
+ * @property name
+ * @memberOf Connection
+ * @api public
+ */
+
+Object.defineProperty(Connection.prototype, 'name', {
+  get: function() {
+    return this.$dbName != null ? this.$dbName : get(this, 'client.s.options.dbName');
+  }
+});
+
+/**
+ * The host name portion of the URI. If multiple hosts, such as a replica set,
+ * this will contain the first host name in the URI
+ *
+ * ####Example
+ *
+ *     mongoose.createConnection('mongodb://localhost:27017/mydb').name; // "localhost"
+ *
+ * @property host
+ * @memberOf Connection
+ * @api public
+ */
+
+Object.defineProperty(Connection.prototype, 'host', {
+  get: function() {
+    return get(this, 'client.s.options.servers.0.host', null) ||
+      get(this, 'client.s.options.servers.0.domain_socket', null);
+  }
+});
+
+/**
+ * The port portion of the URI. If multiple hosts, such as a replica set,
+ * this will contain the port from the first host name in the URI.
+ *
+ * ####Example
+ *
+ *     mongoose.createConnection('mongodb://localhost:27017/mydb').port; // 27017
+ *
+ * @property port
+ * @memberOf Connection
+ * @api public
+ */
+
+Object.defineProperty(Connection.prototype, 'port', {
+  get: function() {
+    return get(this, 'client.s.options.servers.0.port', 27017);
+  }
+});
+
+/**
+ * The username specified in the URI
+ *
+ * ####Example
+ *
+ *     mongoose.createConnection('mongodb://val:psw@localhost:27017/mydb').user; // "val"
+ *
+ * @property user
+ * @memberOf Connection
+ * @api public
+ */
+
+Object.defineProperty(Connection.prototype, 'user', {
+  get: function() {
+    return get(this, 'client.s.options.auth.user', null);
+  }
+});
+
+/**
+ * The password specified in the URI
+ *
+ * ####Example
+ *
+ *     mongoose.createConnection('mongodb://val:psw@localhost:27017/mydb').pass; // "psw"
+ *
+ * @property pass
+ * @memberOf Connection
+ * @api public
+ */
+
+Object.defineProperty(Connection.prototype, 'pass', {
+  get: function() {
+    return get(this, 'client.s.options.auth.password', null);
+  }
+});
 
 /**
  * The mongodb.Db instance, set when the connection is opened
@@ -332,81 +418,68 @@ Connection.prototype.openUri = function(uri, options, callback) {
 
   this._connectionOptions = options;
   let dbName = options.dbName;
+  if (dbName != null) {
+    this.$dbName = dbName;
+  }
   delete options.dbName;
 
+  if (!('promiseLibrary' in options)) {
+    options.promiseLibrary = PromiseProvider.get();
+  }
+
   const promise = new Promise((resolve, reject) => {
-    parser(uri, options, (error, parsed) => {
+    let client = new mongodb.MongoClient(uri, options);
+    _this.client = client;
+    client.connect(function(error) {
       if (error) {
-        this.readyState = STATES.disconnected;
+        _this.readyState = STATES.disconnected;
         if (_this.listeners('error').length > 0) {
           _this.emit('error', error);
         }
         return reject(error);
       }
 
-      dbName = dbName || parsed.dbName;
-      this.name = dbName;
-      this.host = parsed.servers[0].host || parsed.servers[0].domain_socket;
-      this.port = parsed.servers[0].port || 27017;
-      if (parsed.auth) {
-        this.user = parsed.auth.user;
-        this.pass = parsed.auth.password;
-      }
-      if (!('promiseLibrary' in options)) {
-        options.promiseLibrary = PromiseProvider.get();
-      }
+      const db = dbName != null ? client.db(dbName) : client.db();
+      _this.db = db;
 
-      mongodb.MongoClient.connect(uri, options, function(error, client) {
-        if (error) {
-          _this.readyState = STATES.disconnected;
-          if (_this.listeners('error').length > 0) {
-            _this.emit('error', error);
-          }
-          return reject(error);
-        }
-        const db = client.db(dbName);
-        _this.db = db;
-        _this.client = client;
-
-        // Backwards compat for mongoose 4.x
-        db.on('reconnect', function() {
-          _this.readyState = STATES.connected;
-          _this.emit('reconnect');
-          _this.emit('reconnected');
-        });
-        db.s.topology.on('reconnectFailed', function() {
-          _this.emit('reconnectFailed');
-        });
-        db.s.topology.on('left', function(data) {
-          _this.emit('left', data);
-        });
-        db.s.topology.on('joined', function(data) {
-          _this.emit('joined', data);
-        });
-        db.s.topology.on('fullsetup', function(data) {
-          _this.emit('fullsetup', data);
-        });
-        db.on('close', function() {
-          // Implicitly emits 'disconnected'
-          _this.readyState = STATES.disconnected;
-        });
-        db.on('timeout', function() {
-          _this.emit('timeout');
-        });
-
-        delete _this.then;
-        delete _this.catch;
+      // Backwards compat for mongoose 4.x
+      db.on('reconnect', function() {
         _this.readyState = STATES.connected;
-
-        for (let i in _this.collections) {
-          if (utils.object.hasOwnProperty(_this.collections, i)) {
-            _this.collections[i].onOpen();
-          }
-        }
-
-        resolve(_this);
-        _this.emit('open');
+        _this.emit('reconnect');
+        _this.emit('reconnected');
       });
+      db.s.topology.on('reconnectFailed', function() {
+        _this.emit('reconnectFailed');
+      });
+      db.s.topology.on('left', function(data) {
+        _this.emit('left', data);
+      });
+      db.s.topology.on('joined', function(data) {
+        _this.emit('joined', data);
+      });
+      db.s.topology.on('fullsetup', function(data) {
+        _this.emit('fullsetup', data);
+      });
+      db.on('close', function() {
+        // Implicitly emits 'disconnected'
+        _this.readyState = STATES.disconnected;
+      });
+      db.on('timeout', function() {
+        _this.emit('timeout');
+      });
+
+      delete _this.then;
+      delete _this.catch;
+      _this.readyState = STATES.connected;
+
+      for (let i in _this.collections) {
+        if (utils.object.hasOwnProperty(_this.collections, i)) {
+          _this.collections[i].onOpen();
+        }
+      }
+
+      resolve(_this);
+      _this.emit('open');
     });
   });
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -138,11 +138,7 @@ Connection.prototype.collections;
  * @api public
  */
 
-Object.defineProperty(Connection.prototype, 'name', {
-  get: function() {
-    return this.$dbName != null ? this.$dbName : get(this, 'client.s.options.dbName');
-  }
-});
+Connection.prototype.name;
 
 /**
  * The host name portion of the URI. If multiple hosts, such as a replica set,
@@ -150,7 +146,7 @@ Object.defineProperty(Connection.prototype, 'name', {
  *
  * ####Example
  *
- *     mongoose.createConnection('mongodb://localhost:27017/mydb').name; // "localhost"
+ *     mongoose.createConnection('mongodb://localhost:27017/mydb').host; // "localhost"
  *
  * @property host
  * @memberOf Connection
@@ -397,8 +393,6 @@ Connection.prototype.openUri = function(uri, options, callback) {
       options.auth = options.auth || {};
       options.auth.user = options.user;
       options.auth.password = options.pass;
-      this.user = options.auth.user;
-      this.pass = options.auth.password;
     }
     delete options.user;
     delete options.pass;
@@ -481,6 +475,10 @@ Connection.prototype.openUri = function(uri, options, callback) {
       resolve(_this);
       _this.emit('open');
     });
+
+    _this.name = dbName != null ?
+      dbName :
+      get(_this, 'client.s.options.dbName', null);
   });
 
   if (callback != null) {

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -51,11 +51,7 @@ NativeConnection.prototype.useDb = function(name, options) {
   newConn.collections = {};
   newConn.models = {};
   newConn.replica = this.replica;
-  newConn.hosts = this.hosts;
-  newConn.host = this.host;
-  newConn.port = this.port;
-  newConn.user = this.user;
-  newConn.pass = this.pass;
+  newConn.name = this.name;
   newConn.options = this.options;
   newConn._readyState = this._readyState;
   newConn._closeCalled = this._closeCalled;
@@ -70,6 +66,8 @@ NativeConnection.prototype.useDb = function(name, options) {
   // the 'connected' event is the first time we'll have access to the db object
 
   var _this = this;
+
+  newConn.client = _this.client;
 
   if (this.db && this._readyState === STATES.connected) {
     wireup();


### PR DESCRIPTION

Fix #6286
Re: https://github.com/mongodb-js/connect-mongodb-session/issues/50#issuecomment-373041196

@mbroadst I'd appreciate some feedback on this one since it digs into driver internals.