### PR TITLE
adding toNumber to SchemaNumber cast method (gh-6299)

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -223,6 +223,9 @@ SchemaNumber.prototype.cast = function(value, doc, init) {
     if (typeof val === 'number') {
       return val;
     }
+    if (typeof val.toNumber === 'function') {
+      return val.toNumber();
+    }
     if (val.toString && !Array.isArray(val) && val.toString() == Number(val)) {
       return new Number(val);
     }

--- a/test/types.number.test.js
+++ b/test/types.number.test.js
@@ -4,8 +4,8 @@
  */
 
 var mongoose = require('./common').mongoose,
-    SchemaNumber = mongoose.Schema.Types.Number,
-    assert = require('power-assert');
+  SchemaNumber = mongoose.Schema.Types.Number,
+  assert = require('power-assert');
 
 /**
  * Test.
@@ -91,6 +91,21 @@ describe('types.number', function() {
     var n = new SchemaNumber();
     assert.strictEqual(n.cast(true), 1);
     assert.strictEqual(n.cast(false), 0);
+    done();
+  });
+
+  it('prefers toNumber if one exists (gh-6299)', function(done) {
+    var n = new SchemaNumber();
+    var obj = {
+      str: '10',
+      toNumber: function() {
+        return Number(this.str);
+      },
+      toString: function() {
+        return '11';
+      }
+    };
+    assert.strictEqual(n.cast(obj), 10);
     done();
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

#6299 when casting a decimals.js object with new Number(obj), the return is not a converted to a number as expected. This PR, adds a conditional call to obj.toNumber if it exists and is a function that returns the object's representation of itself as a number. 

This could have also been solved by just returning `Number(obj)` all of the time instead of `new Number(obj)` but this PR seems less backwards breaking on the off chance folks are relying explicitly on instanceof Number vs typeof Number.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The output changes to the expected output in #6299 and the test I added to types.number.test.js passes:
```
  it('prefers toNumber if one exists (gh-6299)', function(done) {
    var n = new SchemaNumber();
    var obj = {
      str: '10',
      toNumber: function() {
        return Number(this.str);
      },
      toString: function() {
        return '11';
      }
    };
    assert.strictEqual(n.cast(obj), 10);
    done();
  });
```
mongoose>: npm test -- -g 'prefers toNumber if one exists'

> mongoose@5.0.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "prefers toNumber if one exists"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (5s)

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
