### PR TITLE
putting 3 lines back to fix #6314

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -74,6 +74,9 @@ function parse() {
               tag.types = tag.types.join('|');
             }
             ctx[tag.type].push(tag);
+            tag.description = tag.description ?
+              md.parse(tag.description).replace(/^<p>/, '').replace(/<\/p>$/, '') :
+              ''; 
             break;
           case 'method':
             ctx.type = 'method';


### PR DESCRIPTION
#6314 shows an example of one of the links on the api docs not being formatted correctly. [This gist](https://gist.github.com/lineus/746d25bdb63b723ca9abc20fe6fa0459) shows that adding these specific lines back into docs/source/api.js causes the markdown to get parsed again, thereby rendering the links correctly.

I verified that the links get rendered correctly with `make gendocs && node static` and compared the effect of these three lines to the intent of the commit in which they were deleted, and they do not appear to effect the create method's api documentation. 

