### PR TITLE
adding ability for casting from number to decimal128

### DIFF
--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -124,6 +124,10 @@ Decimal128.prototype.cast = function(value, doc, init) {
     return new Decimal128Type(value);
   }
 
+  if (typeof value === 'number') {
+    return Decimal128Type.fromString(String(value));
+  }
+
   throw new CastError('Decimal128', value, this.path);
 };
 

--- a/test/types.decimal128.test.js
+++ b/test/types.decimal128.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var assert = require('power-assert'),
+    start = require('./common'),
+    mongoose = start.mongoose,
+    Schema = mongoose.Schema;
+
+/**
+ * Test.
+ */
+
+describe('types.decimal128', function() {
+  it('casts from type number (gh-6331)', function() {
+    var dec128 = new Schema({
+      value: Schema.Types.Decimal128
+    });
+
+    var BigNum = mongoose.model('gh6331', dec128);
+
+    var big = new BigNum({ value: 10000 });
+
+    assert.strictEqual(big.value.toString(), '10000');
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

details demonstrated in #6331 . **TL;DR decimal128 can only natively convert from a string. This adds a check for typeof 'number', and if so, converts number -> string -> decimal128.**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There was no test/types.decimal128.test.js, and all of the existing tests involving decimal128 are really testing other feature's compatibility with decimal128. I didn't add a specific test for this, but I'm happy to create a types test file if you like. This PR did not cause any existing tests to fail.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### The failing output in #6331 was:
```
issues: ./6331Populate.js
added 1 documents.
issues: ./6331.js
{ _id: 5acf892f4577ef7d036d099b,
  __v: 0,
  amount: NaN,
  id: '5acf892f4577ef7d036d099b' }
issues:
```

### with this change the output becomes:
```
issues: ./6331.js
{ _id: 5acf892f4577ef7d036d099b,
  amount: 10000,
  __v: 0,
  id: '5acf892f4577ef7d036d099b' }
issues:
```