### PR TITLE
docs: fix Model.aggregate()

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -1468,7 +1468,7 @@ then(<span class="hljs-function"><span class="hljs-keyword">function</span> (<sp
 <span class="hljs-comment">// Or use the aggregation pipeline builder.</span>
 Users.aggregate()
   .group({ _id: <span class="hljs-literal">null</span>, maxBalance: { $max: <span class="hljs-string">'$balance'</span> } })
-  .select(<span class="hljs-string">'-id maxBalance'</span>)
+  .project(<span class="hljs-string">'-id maxBalance'</span>)
   .exec(<span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">err, res</span>) </span>{
     <span class="hljs-keyword">if</span> (err) <span class="hljs-keyword">return</span> handleError(err);
     <span class="hljs-built_in">console</span>.log(res); <span class="hljs-comment">// [ { maxBalance: 98 } ]</span>


### PR DESCRIPTION
Wrong method was used for projection with the aggregation pipeline builder.

**Summary**

I assume that the documentation was wrongly updated after the new 5.x version and that an old way to do projection with the aggregation pipeline builder by using .select() was changed. I didn't check the changelog.

**Test plan**

It fixes this error : `TypeError: Model.aggregate(...).select is not a function` that you have if you just follow the documentation.