### PR TITLE
adding aggregation/query cursor to api docs #6344

### DIFF
--- a/docs/layout.jade
+++ b/docs/layout.jade
@@ -85,6 +85,8 @@ html(lang='en')
             li.pure-menu-item
               a.pure-menu-link(href="/docs/api.html") API
             li.pure-menu-item.sub-item
+              a.pure-menu-link(href="/docs/api.html#mongoose_Mongoose") Mongoose
+            li.pure-menu-item.sub-item
               a.pure-menu-link(href="/docs/api.html#Schema") Schema
             li.pure-menu-item.sub-item
               a.pure-menu-link(href="/docs/api.html#Connection") Connection

--- a/docs/layout.jade
+++ b/docs/layout.jade
@@ -95,7 +95,11 @@ html(lang='en')
             li.pure-menu-item.sub-item
               a.pure-menu-link(href="/docs/api.html#Query") Query
             li.pure-menu-item.sub-item
+              a.pure-menu-link(href="/docs/api.html#Cursor/querycursor") QueryCursor
+            li.pure-menu-item.sub-item
               a.pure-menu-link(href="/docs/api.html#Aggregate") Aggregate
+            li.pure-menu-item.sub-item
+              a.pure-menu-link(href="/docs/api.html#Cursor/aggregationcursor") AggregationCursor
             li.pure-menu-item.sub-item
               a.pure-menu-link(href="/docs/api.html#Schematype") SchemaType
             li.pure-menu-item.sub-item

--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -18,7 +18,9 @@ const files = [
   'lib/document.js',
   'lib/model.js',
   'lib/query.js',
+  'lib/cursor/QueryCursor.js',
   'lib/aggregate.js',
+  'lib/cursor/AggregationCursor.js',
   'lib/schematype.js',
   'lib/virtualtype.js',
   'lib/error/index.js'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The Aggregation and Query Cursor docs aren't included in the API docs. This change adds them in the docs, and the links in the sidebar.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

make docclean && make gendocs && node static ( verified visually )

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
