### PR TITLE
Session support for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ node_js:
   - "5"
   - "4"
 before_script:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.15.tgz
-  - tar -zxvf mongodb-linux-x86_64-3.0.15.tgz
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.4.tgz
+  - tar -zxvf mongodb-linux-x86_64-3.6.4.tgz
   - mkdir -p ./data/db/27017
   - mkdir -p ./data/db/27000
-  - ./mongodb-linux-x86_64-3.0.15/bin/mongod --storageEngine mmapv1 --fork --nopreallocj --dbpath ./data/db/27017 --syslog --port 27017
+  - ./mongodb-linux-x86_64-3.6.4/bin/mongod --storageEngine mmapv1 --fork --nopreallocj --dbpath ./data/db/27017 --syslog --port 27017
 script:
   - npm test
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - tar -zxvf mongodb-linux-x86_64-3.6.4.tgz
   - mkdir -p ./data/db/27017
   - mkdir -p ./data/db/27000
-  - ./mongodb-linux-x86_64-3.6.4/bin/mongod --storageEngine mmapv1 --fork --nopreallocj --dbpath ./data/db/27017 --syslog --port 27017
+  - ./mongodb-linux-x86_64-3.6.4/bin/mongod --fork --nopreallocj --dbpath ./data/db/27017 --syslog --port 27017
 script:
   - npm test
   - npm run lint

--- a/lib/document.js
+++ b/lib/document.js
@@ -533,6 +533,26 @@ Document.prototype.update = function update() {
 };
 
 /**
+ * Getter/setter around the session associated with this document. Used to
+ * automatically set `session` if you `save()` a doc that you got from a
+ * query with an associated session.
+ *
+ * @param {ClientSession} [session] overwrite the current session
+ * @return {ClientSession}
+ * @method $session
+ * @api public
+ * @memberOf Document
+ */
+
+Document.prototype.$session = function $session(session) {
+  if (arguments.length === 0) {
+    return this.$__.session;
+  }
+  this.$__.session = session;
+  return session;
+};
+
+/**
  * Alias for `set()`, used internally to avoid conflicts
  *
  * @param {String|Object} path path or object of key/vals to set

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -1,10 +1,13 @@
+'use strict';
+
 /*!
  * Module dependencies.
  */
 
-var MongooseCollection = require('../../collection');
-var Collection = require('mongodb').Collection;
-var utils = require('../../utils');
+const MongooseCollection = require('../../collection');
+const Collection = require('mongodb').Collection;
+const get = require('lodash.get');
+const utils = require('../../utils');
 
 /**
  * A [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) collection implementation.
@@ -248,6 +251,10 @@ function format(obj, sub) {
             formatObjectId(x, key);
           } else if (x[key].constructor.name === 'Date') {
             formatDate(x, key);
+          } else if (x[key].constructor.name === 'ClientSession') {
+            representation = 'ClientSession("' +
+              get(x[key], 'id.id.buffer', '').toString('hex') + '")';
+            x[key] = {inspect: function() { return representation; }};
           } else if (Array.isArray(x[key])) {
             x[key] = x[key].map(map);
           }

--- a/lib/internal.js
+++ b/lib/internal.js
@@ -25,6 +25,7 @@ function InternalCache() {
   this.scope = undefined;
   this.activePaths = new ActiveRoster;
   this.pathsToScopes = {};
+  this.session = null;
 
   // embedded docs
   this.ownerDocument = undefined;

--- a/lib/model.js
+++ b/lib/model.js
@@ -141,7 +141,8 @@ Model.prototype.$__handleSave = function(options, callback) {
     options.safe = null;
   }
   let safe = options.safe ? utils.clone(options.safe) : options.safe;
-  const session = this.$session();
+
+  const session = 'session' in options ? options.session : this.$session();
   if (session != null) {
     safe = safe || {};
     safe.session = session;

--- a/lib/model.js
+++ b/lib/model.js
@@ -130,17 +130,22 @@ Model.prototype.baseModelName;
  */
 
 Model.prototype.$__handleSave = function(options, callback) {
-  var _this = this;
-  var i;
-  var keys;
-  var len;
+  const _this = this;
+  let i;
+  let keys;
+  let len;
   if (!options.safe && this.schema.options.safe) {
     options.safe = this.schema.options.safe;
   }
   if (typeof options.safe === 'boolean') {
     options.safe = null;
   }
-  var safe = options.safe ? utils.clone(options.safe) : options.safe;
+  let safe = options.safe ? utils.clone(options.safe) : options.safe;
+  const session = this.$session();
+  if (session != null) {
+    safe = safe || {};
+    safe.session = session;
+  }
 
   if (this.isNew) {
     // send entire doc
@@ -2140,7 +2145,7 @@ Model.watch = function(pipeline, options) {
  *     doc = await Person.findOne({ name: 'Ned Stark' }, { readPreference: 'secondary' });
  *
  * @param {Object} [options] see the [mongodb driver options](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#startSession)
- * @param {Boolean} [options.causalConsistency=false] set to true to enable causal consistency
+ * @param {Boolean} [options.causalConsistency=true] set to false to disable causal consistency
  * @param {Function} [callback]
  * @return {Promise<ClientSession>} promise that resolves to a MongoDB driver `ClientSession`
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -2130,19 +2130,19 @@ Model.watch = function(pipeline, options) {
 
 /**
  * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
- * for causal consistency in reads.
+ * for benefits like causal consistency and [retryable writes](https://docs.mongodb.com/manual/core/retryable-writes/).
  *
  * This function does not trigger any middleware.
  *
  * ####Example:
  *
- *     // Need to set `causalConsistency: true` to turn on causal consistency
- *     const session = await Person.startSession({ causalConsistency: true });
+ *     const session = await Person.startSession();
  *     let doc = await Person.findOne({ name: 'Ned Stark' }, { session });
  *     await doc.remove();
  *     // `doc` will always be null, even if reading from a replica set
- *     // secondary. Without causal consistency, you might still get a doc
- *     // back below if the secondary is behind.
+ *     // secondary. Without causal consistency, it is possible to
+ *     // get a doc back from the below query if the query reads from a
+ *     // secondary that is experiencing replication lag.
  *     doc = await Person.findOne({ name: 'Ned Stark' }, { readPreference: 'secondary' });
  *
  * @param {Object} [options] see the [mongodb driver options](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#startSession)

--- a/lib/model.js
+++ b/lib/model.js
@@ -144,7 +144,7 @@ Model.prototype.$__handleSave = function(options, callback) {
 
   const session = 'session' in options ? options.session : this.$session();
   if (session != null) {
-    safe = safe || {};
+    safe = Object.assign({}, safe) || {};
     safe.session = session;
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -330,7 +330,7 @@ Model.prototype.save = function(options, fn) {
 
   if (options != null) {
     options = utils.clone(options);
-  } else
+  } else {
     options = {};
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -328,7 +328,9 @@ Model.prototype.save = function(options, fn) {
     options = undefined;
   }
 
-  if (!options) {
+  if (options != null) {
+    options = utils.clone(options);
+  } else
     options = {};
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1068,14 +1068,13 @@ function _ensureIndexes(model, options, callback) {
           (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
         return done();
       }
-      delete options.session;
     }
 
     var index = indexes.shift();
     if (!index) return done();
 
-    var indexFields = index[0];
-    var indexOptions = index[1];
+    var indexFields = utils.clone(index[0]);
+    var indexOptions = utils.clone(index[1]);
     _handleSafe(options);
 
     indexSingleStart(indexFields, options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2812,10 +2812,10 @@ Model.mapReduce = function mapReduce(o, callback) {
  *     });
  *
  *     // Or use the aggregation pipeline builder.
- *     Users.aggregate()
- *       .group({ _id: null, maxBalance: { $max: '$balance' } })
- *       .select('-id maxBalance')
- *       .exec(function (err, res) {
+ *     Users.aggregate().
+ *       group({ _id: null, maxBalance: { $max: '$balance' } }).
+ *       project('-id maxBalance').
+ *       exec(function (err, res) {
  *         if (err) return handleError(err);
  *         console.log(res); // [ { maxBalance: 98 } ]
  *       });

--- a/lib/model.js
+++ b/lib/model.js
@@ -144,7 +144,7 @@ Model.prototype.$__handleSave = function(options, callback) {
 
   const session = 'session' in options ? options.session : this.$session();
   if (session != null) {
-    safe = safe || {};
+    safe = typeof safe === 'object' && safe != null ? safe : {};
     safe.session = session;
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2119,6 +2119,41 @@ Model.watch = function(pipeline, options) {
 };
 
 /**
+ * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
+ * for causal consistency in reads.
+ *
+ * This function does not trigger any middleware.
+ *
+ * ####Example:
+ *
+ *     // Need to set `causalConsistency: true` to turn on causal consistency
+ *     const session = await Person.startSession({ causalConsistency: true });
+ *     let doc = await Person.findOne({ name: 'Ned Stark' }, { session });
+ *     await doc.remove();
+ *     // `doc` will always be null, even if reading from a replica set
+ *     // secondary. Without causal consistency, you might still get a doc
+ *     // back below if the secondary is behind.
+ *     doc = await Person.findOne({ name: 'Ned Stark' }, { readPreference: 'secondary' });
+ *
+ * @param {Object} [options] see the [mongodb driver options](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#startSession)
+ * @param {Boolean} [options.causalConsistency=false] set to true to enable causal consistency
+ * @param {Function} [callback]
+ * @return {Promise<ClientSession>} promise that resolves to a MongoDB driver `ClientSession`
+ * @api public
+ */
+
+Model.startSession = function(options, callback) {
+  return utils.promiseOrCallback(callback, cb => {
+    if (this.collection.buffer) {
+      return this.collection.addQueue(() => {
+        cb(null, this.db.client.startSession(options))
+      });
+    }
+    return cb(null, this.db.client.startSession(options));
+  });
+};
+
+/**
  * Shortcut for validating an array of documents and inserting them into
  * MongoDB if they're all valid. This function is faster than `.create()`
  * because it only sends one operation to the server, rather than one for each

--- a/lib/model.js
+++ b/lib/model.js
@@ -1066,6 +1066,7 @@ function _ensureIndexes(model, options, callback) {
           (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
         return done();
       }
+      delete options.session;
     }
 
     var index = indexes.shift();

--- a/lib/model.js
+++ b/lib/model.js
@@ -2155,7 +2155,7 @@ Model.startSession = function(options, callback) {
   return utils.promiseOrCallback(callback, cb => {
     if (this.collection.buffer) {
       return this.collection.addQueue(() => {
-        cb(null, this.db.client.startSession(options))
+        cb(null, this.db.client.startSession(options));
       });
     }
     return cb(null, this.db.client.startSession(options));

--- a/lib/model.js
+++ b/lib/model.js
@@ -144,13 +144,13 @@ Model.prototype.$__handleSave = function(options, callback) {
 
   const session = 'session' in options ? options.session : this.$session();
   if (session != null) {
-    safe = Object.assign({}, safe) || {};
+    safe = safe || {};
     safe.session = session;
   }
 
   if (this.isNew) {
     // send entire doc
-    var obj = this.toObject(internalToObjectOptions);
+    const obj = this.toObject(internalToObjectOptions);
 
     if ((obj || {})._id === void 0) {
       // documents must have an _id else mongoose won't know
@@ -165,7 +165,7 @@ Model.prototype.$__handleSave = function(options, callback) {
     }
 
     this.$__version(true, obj);
-    this.collection.insert(obj, safe, function(err, ret) {
+    this.collection.insertOne(obj, safe, function(err, ret) {
       if (err) {
         _this.isNew = true;
         _this.emit('isNew', true);
@@ -188,7 +188,7 @@ Model.prototype.$__handleSave = function(options, callback) {
     // since it already exists
     this.$__.inserting = false;
 
-    var delta = this.$__delta();
+    const delta = this.$__delta();
 
     if (delta) {
       if (delta instanceof Error) {
@@ -196,7 +196,7 @@ Model.prototype.$__handleSave = function(options, callback) {
         return;
       }
 
-      var where = this.$__where(delta[0]);
+      const where = this.$__where(delta[0]);
       if (where instanceof Error) {
         callback(where);
         return;

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,23 +1,26 @@
+'use strict';
+
 /*!
  * Module dependencies.
  */
 
-var CastError = require('./error/cast');
-var ObjectParameterError = require('./error/objectParameter');
-var QueryCursor = require('./cursor/QueryCursor');
-var ReadPreference = require('./drivers').ReadPreference;
-var cast = require('./cast');
-var castUpdate = require('./services/query/castUpdate');
-var hasDollarKeys = require('./services/query/hasDollarKeys');
-var helpers = require('./queryhelpers');
-var isInclusive = require('./services/projection/isInclusive');
-var mquery = require('mquery');
-var selectPopulatedFields = require('./services/query/selectPopulatedFields');
-var setDefaultsOnInsert = require('./services/setDefaultsOnInsert');
-var slice = require('sliced');
-var updateValidators = require('./services/updateValidators');
-var util = require('util');
-var utils = require('./utils');
+const CastError = require('./error/cast');
+const ObjectParameterError = require('./error/objectParameter');
+const QueryCursor = require('./cursor/QueryCursor');
+const ReadPreference = require('./drivers').ReadPreference;
+const cast = require('./cast');
+const castUpdate = require('./services/query/castUpdate');
+const get = require('lodash.get');
+const hasDollarKeys = require('./services/query/hasDollarKeys');
+const helpers = require('./queryhelpers');
+const isInclusive = require('./services/projection/isInclusive');
+const mquery = require('mquery');
+const selectPopulatedFields = require('./services/query/selectPopulatedFields');
+const setDefaultsOnInsert = require('./services/setDefaultsOnInsert');
+const slice = require('sliced');
+const updateValidators = require('./services/updateValidators');
+const util = require('util');
+const utils = require('./utils');
 
 /**
  * Query constructor used for building queries. You do not need
@@ -992,6 +995,7 @@ Query.prototype.read = function read(pref, tags) {
  *
  * The following options are for all operations:
  * - [collation](https://docs.mongodb.com/manual/reference/collation/)
+ * - [session](https://docs.mongodb.com/manual/reference/server-sessions/)
  *
  * @param {Object} options
  * @api public
@@ -1077,6 +1081,11 @@ Query.prototype.getUpdate = function() {
  * @api private
  * @receiver Query
  */
+
+Query.prototype._fieldsForExec = function () {
+  return utils.clone(this._fields);
+};
+
 
 /**
  * Return an update document with corrected $set operations.
@@ -1502,10 +1511,16 @@ Query.prototype._findOne = function(callback) {
   this._applyPaths();
   this._fields = this._castFields(this._fields);
 
-  var options = this._mongooseOptions;
-  var projection = this._fieldsForExec();
-  var userProvidedFields = this._userProvidedFields || {};
-  var _this = this;
+  const options = this._mongooseOptions;
+  const projection = this._fieldsForExec();
+  const userProvidedFields = this._userProvidedFields || {};
+  const _this = this;
+
+  // Separate options to pass down to `completeOne()` in case we need to
+  // set a session on the document
+  const completeOneOptions = Object.assign({}, {
+    session: get(this, 'options.session', null)
+  });
 
   // don't pass in the conditions because we already merged them in
   Query.base.findOne.call(_this, {}, function(err, doc) {
@@ -1519,7 +1534,7 @@ Query.prototype._findOne = function(callback) {
     if (!options.populate) {
       return !!options.lean === true
         ? callback(null, doc)
-        : completeOne(_this.model, doc, null, {}, projection, userProvidedFields, null, callback);
+        : completeOne(_this.model, doc, null, completeOneOptions, projection, userProvidedFields, null, callback);
     }
 
     var pop = helpers.preparePopulationOptionsMQ(_this, options);
@@ -1530,7 +1545,7 @@ Query.prototype._findOne = function(callback) {
       }
       return !!options.lean === true
         ? callback(null, doc)
-        : completeOne(_this.model, doc, null, {}, projection, userProvidedFields, pop, callback);
+        : completeOne(_this.model, doc, null, completeOneOptions, projection, userProvidedFields, pop, callback);
     });
   });
 };
@@ -2008,6 +2023,8 @@ function completeOne(model, doc, res, options, fields, userProvidedFields, pop, 
     if (err) {
       return process.nextTick(() => callback(err));
     }
+
+    casted.$session(options.session);
 
     if (options.rawResult) {
       res.value = casted;

--- a/lib/query.js
+++ b/lib/query.js
@@ -10,6 +10,7 @@ const QueryCursor = require('./cursor/QueryCursor');
 const ReadPreference = require('./drivers').ReadPreference;
 const cast = require('./cast');
 const castUpdate = require('./services/query/castUpdate');
+const completeMany = require('./services/query/completeMany');
 const get = require('lodash.get');
 const hasDollarKeys = require('./services/query/hasDollarKeys');
 const helpers = require('./queryhelpers');
@@ -1311,10 +1312,16 @@ Query.prototype._find = function(callback) {
   this._applyPaths();
   this._fields = this._castFields(this._fields);
 
-  var fields = this._fieldsForExec();
-  var mongooseOptions = this._mongooseOptions;
-  var _this = this;
-  var userProvidedFields = _this._userProvidedFields || {};
+  const fields = this._fieldsForExec();
+  const mongooseOptions = this._mongooseOptions;
+  const _this = this;
+  const userProvidedFields = _this._userProvidedFields || {};
+
+  // Separate options to pass down to `completeMany()` in case we need to
+  // set a session on the document
+  const completeManyOptions = Object.assign({}, {
+    session: get(this, 'options.session', null)
+  });
 
   var cb = function(err, docs) {
     if (err) {
@@ -1328,16 +1335,17 @@ Query.prototype._find = function(callback) {
     if (!mongooseOptions.populate) {
       return !!mongooseOptions.lean === true
         ? callback(null, docs)
-        : completeMany(_this.model, docs, fields, userProvidedFields, null, callback);
+        : completeMany(_this.model, docs, fields, userProvidedFields, completeManyOptions, callback);
     }
 
-    var pop = helpers.preparePopulationOptionsMQ(_this, mongooseOptions);
+    const pop = helpers.preparePopulationOptionsMQ(_this, mongooseOptions);
     pop.__noPromise = true;
+    completeManyOptions.populated = pop;
     _this.model.populate(docs, pop, function(err, docs) {
       if (err) return callback(err);
       return !!mongooseOptions.lean === true
         ? callback(null, docs)
-        : completeMany(_this.model, docs, fields, userProvidedFields, pop, callback);
+        : completeMany(_this.model, docs, fields, userProvidedFields, completeManyOptions, callback);
     });
   };
 
@@ -1438,43 +1446,6 @@ Query.prototype.merge = function(source) {
 
   return this;
 };
-
-/*!
- * hydrates many documents
- *
- * @param {Model} model
- * @param {Array} docs
- * @param {Object} fields
- * @param {Query} self
- * @param {Array} [pop] array of paths used in population
- * @param {Function} callback
- */
-
-function completeMany(model, docs, fields, userProvidedFields, pop, callback) {
-  var arr = [];
-  var count = docs.length;
-  var len = count;
-  var opts = pop ? { populated: pop } : undefined;
-  var error = null;
-  function init(_error) {
-    if (_error != null) {
-      error = error || _error;
-    }
-    if (error != null) {
-      --count || process.nextTick(() => callback(error));
-      return;
-    }
-    --count || process.nextTick(() => callback(error, arr));
-  }
-  for (var i = 0; i < len; ++i) {
-    arr[i] = helpers.createModel(model, docs[i], fields, userProvidedFields);
-    try {
-      arr[i].init(docs[i], opts, init);
-    } catch (error) {
-      init(error);
-    }
-  }
-}
 
 /**
  * Adds a collation to this op (MongoDB 3.4 and up)

--- a/lib/query.js
+++ b/lib/query.js
@@ -1082,7 +1082,7 @@ Query.prototype.getUpdate = function() {
  * @receiver Query
  */
 
-Query.prototype._fieldsForExec = function () {
+Query.prototype._fieldsForExec = function() {
   return utils.clone(this._fields);
 };
 

--- a/lib/services/query/completeMany.js
+++ b/lib/services/query/completeMany.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const helpers = require('../../queryhelpers');
+
+module.exports = completeMany;
+
+/*!
+ * Given a model and an array of docs, hydrates all the docs to be instances
+ * of the model. Used to initialize docs returned from the db from `find()`
+ *
+ * @param {Model} model
+ * @param {Array} docs
+ * @param {Object} fields the projection used, including `select` from schemas
+ * @param {Object} userProvidedFields the user-specified projection
+ * @param {Object} opts
+ * @param {Array} [opts.populated]
+ * @param {ClientSession} [opts.session]
+ * @param {Function} callback
+ */
+
+function completeMany(model, docs, fields, userProvidedFields, opts, callback) {
+  const arr = [];
+  let count = docs.length;
+  const len = count;
+  let error = null;
+
+  function init(_error) {
+    if (_error != null) {
+      error = error || _error;
+    }
+    if (error != null) {
+      --count || process.nextTick(() => callback(error));
+      return;
+    }
+    --count || process.nextTick(() => callback(error, arr));
+  }
+
+  for (let i = 0; i < len; ++i) {
+    arr[i] = helpers.createModel(model, docs[i], fields, userProvidedFields);
+    try {
+      arr[i].init(docs[i], opts, init);
+    } catch (error) {
+      init(error);
+    }
+    arr[i].$session(opts.session);
+  }
+}

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4371,8 +4371,7 @@ describe('Model', function() {
 
     test.save(function(error) {
       assert.ok(error);
-      assert.equal(error.toString(),
-        'MongoError: document is larger than the maximum size 16777216');
+      assert.equal(error.name, 'MongoError');
       db.close(done);
     });
   });
@@ -4391,8 +4390,7 @@ describe('Model', function() {
     db.on('connected', function() {
       test.save(function(error) {
         assert.ok(error);
-        assert.equal(error.toString(),
-          'MongoError: document is larger than the maximum size 16777216');
+        assert.equal(error.name, 'MongoError');
         db.close(done);
       });
     });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4084,7 +4084,7 @@ describe('Model', function() {
     var db;
 
     before(function() {
-      db = start();
+      db = start({ noErrorListener: true });
     });
 
     after(function(done) {
@@ -4400,7 +4400,7 @@ describe('Model', function() {
     var db;
 
     before(function() {
-      db = start();
+      db = start({ noErrorListener: true });
     });
 
     after(function(done) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4873,6 +4873,8 @@ describe('Model', function() {
             const session = yield MyModel.startSession({ causalConsistency: true });
 
             assert.equal(session.supports.causalConsistency, true);
+
+            session.endSession();
           });
         });
 
@@ -4890,6 +4892,8 @@ describe('Model', function() {
             const session = yield sessionPromise;
 
             assert.equal(session.supports.causalConsistency, true);
+
+            session.endSession();
           });
         });
 
@@ -4920,6 +4924,8 @@ describe('Model', function() {
             yield doc.save();
 
             assert.ok(session.serverSession.lastUse > lastUse);
+
+            session.endSession();
           });
         });
       });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4901,14 +4901,21 @@ describe('Model', function() {
 
             let lastUse = session.serverSession.lastUse;
 
-            const doc = yield MyModel.findOne({}, null, { session });
+            let doc = yield MyModel.findOne({}, null, { session });
             assert.strictEqual(doc.$__.session, session);
             assert.strictEqual(doc.$session(), session);
 
             assert.ok(session.serverSession.lastUse > lastUse);
             lastUse = session.serverSession.lastUse;
 
-            doc.name = 'test2';
+            doc = yield MyModel.findOneAndUpdate({}, { name: 'test2' }, { session });
+            assert.strictEqual(doc.$__.session, session);
+            assert.strictEqual(doc.$session(), session);
+
+            assert.ok(session.serverSession.lastUse > lastUse);
+            lastUse = session.serverSession.lastUse;
+
+            doc.name = 'test3';
 
             yield doc.save();
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4928,6 +4928,32 @@ describe('Model', function() {
             session.endSession();
           });
         });
+
+        it('sets session when pulling multiple docs from db', function() {
+          return co(function*() {
+            yield MyModel.create({ name: 'test' });
+
+            const session = yield MyModel.startSession();
+
+            let lastUse = session.serverSession.lastUse;
+
+            let docs = yield MyModel.find({}, null, { session });
+            assert.equal(docs.length, 1);
+            assert.strictEqual(docs[0].$__.session, session);
+            assert.strictEqual(docs[0].$session(), session);
+
+            assert.ok(session.serverSession.lastUse > lastUse);
+            lastUse = session.serverSession.lastUse;
+
+            docs[0].name = 'test3';
+
+            yield docs[0].save();
+
+            assert.ok(session.serverSession.lastUse > lastUse);
+
+            session.endSession();
+          });
+        });
       });
     });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4084,7 +4084,7 @@ describe('Model', function() {
     var db;
 
     before(function() {
-      db = start({ noErrorListener: true });
+      db = start();
     });
 
     after(function(done) {
@@ -4400,7 +4400,7 @@ describe('Model', function() {
     var db;
 
     before(function() {
-      db = start({ noErrorListener: true });
+      db = start();
     });
 
     after(function(done) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4860,6 +4860,33 @@ describe('Model', function() {
           assert.equal(changeData.fullDocument.name, 'Ned Stark');
         });
       });
+
+      it('startSession() (gh-6362)', function() {
+        return co(function*() {
+          const MyModel = db.model('gh6362', new Schema({ name: String }));
+
+          const session = yield MyModel.startSession({ causalConsistency: true });
+
+          assert.equal(session.supports.causalConsistency, true);
+        });
+      });
+
+      it('startSession() before connecting (gh-6362)', function() {
+        return co(function*() {
+          const db = start();
+
+          const MyModel = db.model('gh6362_2', new Schema({ name: String }));
+
+          // Don't wait for promise
+          const sessionPromise = MyModel.startSession({ causalConsistency: true });
+
+          yield db;
+
+          const session = yield sessionPromise;
+
+          assert.equal(session.supports.causalConsistency, true);
+        });
+      });
     });
 
     it('method with same name as prop should throw (gh-4475)', function(done) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4229,7 +4229,7 @@ describe('Model', function() {
         yield Person.init();
 
         let err;
-        yield p.save().catch(_err => { err = _err });
+        yield p.save().catch(_err => { err = _err; });
 
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4821,7 +4821,7 @@ describe('Model', function() {
         });
       });
 
-      it('watch() (gh-5964)', function() {
+      it.skip('watch() (gh-5964)', function() {
         return co(function*() {
           const MyModel = db.model('gh5964', new Schema({ name: String }));
 
@@ -4840,7 +4840,7 @@ describe('Model', function() {
         });
       });
 
-      it('watch() before connecting (gh-5964)', function() {
+      it.skip('watch() before connecting (gh-5964)', function() {
         return co(function*() {
           const db = start();
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4091,8 +4091,8 @@ describe('Model', function() {
       db.close(done);
     });
 
-    it('2dsphere indexed field with value is saved', function(done) {
-      var PersonSchema = new Schema({
+    it('2dsphere indexed field with value is saved', function() {
+      const PersonSchema = new Schema({
         name: String,
         loc: {
           type: [Number],
@@ -4100,28 +4100,27 @@ describe('Model', function() {
         }
       });
 
-      var Person = db.model('Person_1', PersonSchema);
-      var loc = [0.3, 51.4];
-      var p = new Person({
+      const Person = db.model('Person_1', PersonSchema);
+      const loc = [0.3, 51.4];
+      const p = new Person({
         name: 'Jimmy Page',
         loc: loc
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(personDoc.loc[0], loc[0]);
-          assert.equal(personDoc.loc[1], loc[1]);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(personDoc.loc[0], loc[0]);
+        assert.equal(personDoc.loc[1], loc[1]);
       });
     });
 
-    it('2dsphere indexed field without value is saved (gh-1668)', function(done) {
-      var PersonSchema = new Schema({
+    it('2dsphere indexed field without value is saved (gh-1668)', function() {
+      const PersonSchema = new Schema({
         name: String,
         loc: {
           type: [Number],
@@ -4129,26 +4128,25 @@ describe('Model', function() {
         }
       });
 
-      var Person = db.model('Person_2', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_2', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page'
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(personDoc.name, 'Jimmy Page');
-          assert.equal(personDoc.loc, undefined);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(personDoc.name, 'Jimmy Page');
+        assert.equal(personDoc.loc, undefined);
       });
     });
 
-    it('2dsphere indexed field in subdoc without value is saved', function(done) {
-      var PersonSchema = new Schema({
+    it('2dsphere indexed field in subdoc without value is saved', function() {
+      const PersonSchema = new Schema({
         name: {type: String, required: true},
         nested: {
           tag: String,
@@ -4160,29 +4158,28 @@ describe('Model', function() {
 
       PersonSchema.index({'nested.loc': '2dsphere'});
 
-      var Person = db.model('Person_3', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_3', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page'
       });
 
       p.nested.tag = 'guitarist';
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(personDoc.name, 'Jimmy Page');
-          assert.equal(personDoc.nested.tag, 'guitarist');
-          assert.equal(personDoc.nested.loc, undefined);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(personDoc.name, 'Jimmy Page');
+        assert.equal(personDoc.nested.tag, 'guitarist');
+        assert.equal(personDoc.nested.loc, undefined);
       });
     });
 
-    it('Doc with 2dsphere indexed field without initial value can be updated', function(done) {
-      var PersonSchema = new Schema({
+    it('Doc with 2dsphere indexed field without initial value can be updated', function() {
+      const PersonSchema = new Schema({
         name: String,
         loc: {
           type: [Number],
@@ -4190,32 +4187,31 @@ describe('Model', function() {
         }
       });
 
-      var Person = db.model('Person_4', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_4', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page'
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        var updates = {
+        yield p.save();
+
+        const updates = {
           $set: {
             loc: [0.3, 51.4]
           }
         };
 
-        Person.findByIdAndUpdate(p._id, updates, {new: true}, function(err, personDoc) {
-          assert.ifError(err);
+        const personDoc = yield Person.findByIdAndUpdate(p._id, updates, {new: true});
 
-          assert.equal(personDoc.loc[0], updates.$set.loc[0]);
-          assert.equal(personDoc.loc[1], updates.$set.loc[1]);
-          done();
-        });
+        assert.equal(personDoc.loc[0], updates.$set.loc[0]);
+        assert.equal(personDoc.loc[1], updates.$set.loc[1]);
       });
     });
 
-    it('2dsphere indexed required field without value is rejected', function(done) {
-      var PersonSchema = new Schema({
+    it('2dsphere indexed required field without value is rejected', function() {
+      const PersonSchema = new Schema({
         name: String,
         loc: {
           type: [Number],
@@ -4224,21 +4220,25 @@ describe('Model', function() {
         }
       });
 
-      var Person = db.model('Person_5', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_5', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page'
       });
 
-      p.save(function(err) {
+      return co(function*() {
+        yield Person.init();
+
+        let err;
+        yield p.save().catch(_err => { err = _err });
+
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);
-        done();
       });
     });
 
-    it('2dsphere field without value but with schema default is saved', function(done) {
-      var loc = [0, 1];
-      var PersonSchema = new Schema({
+    it('2dsphere field without value but with schema default is saved', function() {
+      const loc = [0, 1];
+      const PersonSchema = new Schema({
         name: String,
         loc: {
           type: [Number],
@@ -4247,26 +4247,25 @@ describe('Model', function() {
         }
       });
 
-      var Person = db.model('Person_6', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_6', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page'
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(loc[0], personDoc.loc[0]);
-          assert.equal(loc[1], personDoc.loc[1]);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(loc[0], personDoc.loc[0]);
+        assert.equal(loc[1], personDoc.loc[1]);
       });
     });
 
-    it('2d indexed field without value is saved', function(done) {
-      var PersonSchema = new Schema({
+    it('2d indexed field without value is saved', function() {
+      const PersonSchema = new Schema({
         name: String,
         loc: {
           type: [Number],
@@ -4274,25 +4273,24 @@ describe('Model', function() {
         }
       });
 
-      var Person = db.model('Person_7', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_7', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page'
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(personDoc.loc, undefined);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(personDoc.loc, undefined);
       });
     });
 
-    it('Compound index with 2dsphere field without value is saved', function(done) {
-      var PersonSchema = new Schema({
+    it('Compound index with 2dsphere field without value is saved', function() {
+      const PersonSchema = new Schema({
         name: String,
         type: String,
         slug: {type: String, index: {unique: true}},
@@ -4302,30 +4300,28 @@ describe('Model', function() {
 
       PersonSchema.index({name: 1, loc: '2dsphere'});
 
-      var Person = db.model('Person_8', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_8', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page',
         type: 'musician',
         slug: 'ledzep-1',
         tags: ['guitarist']
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(personDoc.name, 'Jimmy Page');
-          assert.equal(personDoc.loc, undefined);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(personDoc.name, 'Jimmy Page');
+        assert.equal(personDoc.loc, undefined);
       });
     });
 
-
-    it('Compound index on field earlier declared with 2dsphere index is saved', function(done) {
-      var PersonSchema = new Schema({
+    it('Compound index on field earlier declared with 2dsphere index is saved', function() {
+      const PersonSchema = new Schema({
         name: String,
         type: String,
         slug: {type: String, index: {unique: true}},
@@ -4336,24 +4332,23 @@ describe('Model', function() {
       PersonSchema.index({loc: '2dsphere'});
       PersonSchema.index({name: 1, loc: -1});
 
-      var Person = db.model('Person_9', PersonSchema);
-      var p = new Person({
+      const Person = db.model('Person_9', PersonSchema);
+      const p = new Person({
         name: 'Jimmy Page',
         type: 'musician',
         slug: 'ledzep-1',
         tags: ['guitarist']
       });
 
-      p.save(function(err) {
-        assert.ifError(err);
+      return co(function*() {
+        yield Person.init();
 
-        Person.findById(p._id, function(err, personDoc) {
-          assert.ifError(err);
+        yield p.save();
 
-          assert.equal(personDoc.name, 'Jimmy Page');
-          assert.equal(personDoc.loc, undefined);
-          done();
-        });
+        const personDoc = yield Person.findById(p._id);
+
+        assert.equal(personDoc.name, 'Jimmy Page');
+        assert.equal(personDoc.loc, undefined);
       });
     });
   });


### PR DESCRIPTION
Re: #6362 

There's two primary changes here:

1) Models now have a `startSession()` function that returns a promise that resolves to the underlying `ClientSession`. You can pass the `session` option to `Model.find()`, `Model.updateOne()`, etc.

2) Mongoose documents now have a `$session()` function that tracks the session associated with the document. If you load a document using `Model.findOne({}, null, { session })`, that document will track `session` and use that same session when you `save()` the document by default.

@mbroadst @daprahamian any thoughts you have would be much appreciated.