### PR TITLE
Docs: Update schematypes.jade

### DIFF
--- a/docs/schematypes.jade
+++ b/docs/schematypes.jade
@@ -164,6 +164,8 @@ block content
     * `trim`: boolean, whether to always call `.trim()` on the value
     * `match`: RegExp, creates a [validator](./validation.html) that checks if the value matches the given regular expression
     * `enum`: Array, creates a [validator](./validation.html) that checks if the value is in the given array.
+    * `minlength`: Number, creates a [validator](./validation.html) that checks if the value length is not less then the given number
+    * `maxlength`: Number, creates a [validator](./validation.html) that checks if the value length is not greater then the given number
 
     <h5>Number</h5>
 


### PR DESCRIPTION
**Summary**

There is mention of `minlength` and `maxlength` built-in validators for String type on the [Validation page](http://mongoosejs.com/docs/validation.html#built-in-validators).
But at the same time, these are absent in the list of validators for String on the [SchemaTypes page](http://mongoosejs.com/docs/schematypes.html).
Seemed like a good idea to add them to the list.

**Test plan**

```
make docclean
make gendocs
node static.js
```

Looks like: [screenshot](https://monosnap.com/file/pt75oeV957OIR8ySiwPYUvOY9UEVeu.png)