### PR TITLE
Removing mention of "numAffected" from document.save example

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1805,7 +1805,7 @@ Document.prototype.$markValid = function(path) {
  * ####Example:
  *
  *     product.sold = Date.now();
- *     product.save(function (err, product, numAffected) {
+ *     product.save(function (err, product) {
  *       if (err) ..
  *     })
  *
@@ -1813,7 +1813,6 @@ Document.prototype.$markValid = function(path) {
  *
  * 1. `err` if an error occurred
  * 2. `product` which is the saved `product`
- * 3. `numAffected` will be 1 when the document was successfully persisted to MongoDB, otherwise 0. Unless you tweak mongoose's internals, you don't need to worry about checking this parameter for errors - checking `err` is sufficient to make sure your document was properly saved.
  *
  * As an extra measure of flow control, save will return a Promise.
  * ####Example:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
According to [migration](https://github.com/Automattic/mongoose/blob/master/migrating_to_5.md) guide: 

> ### `numAffected` and `save()`
>
> `doc.save()` no longer passes `numAffected` as a 3rd param to its callback.

This change fixes incorrect example from generated API documentation here: http://mongoosejs.com/docs/api.html#document_Document-save
