### PR TITLE
Add 2 tests around mongoose.pluralize(..); fix docs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -237,8 +237,8 @@ Mongoose.prototype.disconnect = function(callback) {
 /**
  * Getter/setter around function for pluralizing collection names.
  *
- * @param {Function|null} [fn] overwrites the function used to pluralize connection names
- * @return {Function|null} the current function used to pluralize connection names, `undefined` by default.
+ * @param {Function|null} [fn] overwrites the function used to pluralize collection names
+ * @return {Function|null} the current function used to pluralize collection names, defaults to the legacy function from `mongoose-legacy-pluralize`.
  * @api public
  */
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,7 +57,7 @@ describe('mongoose module:', function() {
     assert.equal(mongoose.model('User').collection.name, 'users');
     done();
   });
-  
+
   it('returns legacy pluralize function by default', function(done) {
     var legacyPluralize = require('mongoose-legacy-pluralize');
     var mongoose = new Mongoose();
@@ -65,6 +65,21 @@ describe('mongoose module:', function() {
     var pluralize = mongoose.pluralize();
 
     assert.equal(pluralize, legacyPluralize);
+    done();
+  });
+
+  it('sets custom pluralize function (gh-5877)', function(done) {
+    var mongoose = new Mongoose();
+
+    // some custom function of type (str: string) => string
+    var customPluralize = (str) => str;
+    mongoose.pluralize(customPluralize);
+
+    var pluralize = mongoose.pluralize();
+    assert.equal(pluralize, customPluralize);
+
+    mongoose.model('User', new Schema({}));
+    assert.equal(mongoose.model('User').collection.name, 'User');
     done();
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,6 +57,16 @@ describe('mongoose module:', function() {
     assert.equal(mongoose.model('User').collection.name, 'users');
     done();
   });
+  
+  it('returns legacy pluralize function by default', function(done) {
+    var legacyPluralize = require('mongoose-legacy-pluralize');
+    var mongoose = new Mongoose();
+    
+    var pluralize = mongoose.pluralize();
+
+    assert.equal(pluralize, legacyPluralize);
+    done();
+  });
 
   it('{g,s}etting options', function(done) {
     var mongoose = new Mongoose();


### PR DESCRIPTION
**Summary**

I've...
- fixed the inline documentation for the ``mongoose.pluralize(..)`` function
- added a test, checking the default pluralize function returned by said function
- added a test for setting a custom pluralization function

**Test plan**

**``$ npm run test``**
```
> mongoose@5.0.18-pre test /home/sk/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database
```
*...*
```
  1867 passing (56s)
  8 pending
```