### PR TITLE
fixes #6418

### DIFF
--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -128,6 +128,10 @@ Decimal128.prototype.cast = function(value, doc, init) {
     return Decimal128Type.fromString(String(value));
   }
 
+  if (typeof value.valueOf === 'function' && typeof value.valueOf() === 'string') {
+    return Decimal128Type.fromString(value.valueOf());
+  }
+
   throw new CastError('Decimal128', value, this.path);
 };
 

--- a/test/types.decimal128.test.js
+++ b/test/types.decimal128.test.js
@@ -25,4 +25,23 @@ describe('types.decimal128', function() {
 
     assert.strictEqual(big.value.toString(), '10000');
   });
+
+  it('uses valueOf method if one exists (gh-6418)', function() {
+    var dec128 = new Schema({
+      value: Schema.Types.Decimal128
+    });
+
+    var BigNum = mongoose.model('gh6418', dec128);
+
+    var obj = {
+      str: '10.123',
+      valueOf: function() {
+        return this.str;
+      }
+    };
+
+    var big = new BigNum({ value: obj });
+
+    assert.strictEqual(big.value.toString(), '10.123');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

This change makes Decimal128 casting honor the valueOf method like Number casting does after #6299.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

After adding change, no current tests broke. Added a failing test to types.decimal128.test.js and made it pass:
```
mongoose>: npm test -- -g 'gh-6418'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6418"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (215ms)
  1 failing

  1) types.decimal128
       uses valueOf method if one exists (gh-6418):

      AssertionError [ERR_ASSERTION]: '10.123' === 'xyz'
      + expected - actual

      -10.123
      +xyz

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as strictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/types.decimal128.test.js:45:12)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6418'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6418"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (135ms)
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
