### PR TITLE
fixes #6390 - prevents casting of populated docs in document.init

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -486,7 +486,9 @@ function init(self, obj, doc, prefix) {
       if (obj[i] === null) {
         doc[i] = null;
       } else if (obj[i] !== undefined) {
-        if (schema) {
+        let intCache = obj[i].$__ || {};
+        let wasPopulated = intCache.wasPopulated || null;
+        if (schema && !wasPopulated) {
           try {
             doc[i] = schema.cast(obj[i], self, true);
           } catch (e) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

populated paths were getting through the document.init _init function to the try/cast block, this change checks if the path is populated and doesn't try to cast if it is.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This doesn't break any existing tests, and I wrote a failing test, then made it pass:
```
mongoose>: npm test -- -g 'gh-6390'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6390"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (550ms)
  1 failing

  1) document
       bug fixes
         doesnt try to cast populated embedded docs (gh-6390):

      AssertionError [ERR_ASSERTION]: 'vodoo' === 'Nicole'
      + expected - actual

      -vodoo
      +Nicole

      at test/document.test.js:5424:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6390'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6390"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (542ms)

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Here is the example code I used to debug this with before and after output. It always worked with lean because that bypassed document.init.
### 6390.js
```js
#!/usr/bin/env node
'use strict';

const mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test');
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const otherSchema = new Schema({
  name: String
});

const subSchema = new Schema({
  my: String,
  other: {
    type: Schema.Types.ObjectId,
    refPath: 'sub.my'
  }
});

const schema = new Schema({
  name: String,
  sub: subSchema
});

const Other = mongoose.model('other', otherSchema);
const Test = mongoose.model('test', schema);

const other = new Other({ name: 'Nicole' });

const test = new Test({
  name: 'abc',
  sub: {
    my: 'other',
    other: other._id
  }
});

async function run() {
  await conn.dropDatabase();
  await other.save();
  await test.save();

  let noLean = await Test.findOne({ name: 'abc' }).populate('sub.other');
  console.log(noLean.sub.other.name);

  let lean = await Test.findOne({ name: 'abc' }).populate('sub.other').lean();
  console.log(lean.sub.other.name);

  return conn.close();
}

run();
```
### Output before change:
```
issues: ./6390.js
undefined
Nicole
issues:
```
### Output after change:
```
issues: ./6390.js
Nicole
Nicole
issues:
```