### PR TITLE
fixes #6414 - populates array of objects with space separated paths

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -508,6 +508,24 @@ exports.populate = function populate(path, select, model, match, options, subPop
   // necessary to keep backward compatibility (select could be
   // an array, string, or object literal).
 
+  function makeSingles(arr) {
+    let ret = [];
+    arr.forEach(function(obj) {
+      if (/[\s]/.test(obj.path)) {
+        let paths = obj.path.split(' ');
+        paths.forEach(function(p) {
+          let copy = Object.assign({}, obj);
+          copy.path = p;
+          ret.push(copy);
+        });
+      } else {
+        ret.push(obj);
+      }
+    });
+
+    return ret;
+  }
+
   // might have passed an object specifying all arguments
   if (arguments.length === 1) {
     if (path instanceof PopulateOptions) {
@@ -515,8 +533,20 @@ exports.populate = function populate(path, select, model, match, options, subPop
     }
 
     if (Array.isArray(path)) {
-      return path.map(function(o) {
-        return exports.populate(o)[0];
+      let singles = makeSingles(path);
+      return singles.map(function(o) {
+        if (o.populate) {
+          return exports.populate(
+            o.path,
+            o.select,
+            o.model,
+            o.match,
+            o.options,
+            o.populate)[0];
+        } else {
+          return exports.populate(o)[0];
+        }
+
       });
     }
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -6138,8 +6138,8 @@ describe('model: populate:', function() {
       });
     });
 
-    describe('populates an array of objects (gh6284)', function() {
-      it('with mulitiple space separated paths', function() {
+    describe('populates an array of objects', function() {
+      it('subpopulates array w/ space separated path (gh-6284)', function() {
         return co(function* () {
           var db = start();
           var houseSchema = new Schema({ location: String });
@@ -6211,6 +6211,50 @@ describe('model: populate:', function() {
           assert.equal(doc.userId.houseId.location, '123 abc st.');
           assert.equal(doc.userId.cityId.name, 'Some City');
           assert.equal(doc.userId.districtId.name, 'That District');
+        });
+      });
+      it('populates array of space separated path objs (gh-6414)', function() {
+        return co(function* () {
+          var userSchema = new Schema({
+            name: String
+          });
+
+          var User = db.model('gh6414User', userSchema);
+
+          var officeSchema = new Schema({
+            managerId: { type: Schema.ObjectId, ref: 'gh6414User' },
+            supervisorId: { type: Schema.ObjectId, ref: 'gh6414User' },
+            associatesIds: [{ type: Schema.ObjectId, ref: 'gh6414User' }]
+          });
+
+          var Office = db.model('gh6414Office', officeSchema);
+
+          var manager = new User({ name: 'John' });
+          var billy = new User({ name: 'Billy' });
+          var tom = new User({ name: 'Tom' });
+          var hafez = new User({ name: 'Hafez' });
+          var office = new Office({
+            managerId: manager._id,
+            supervisorId: hafez._id,
+            associatesIds: [billy._id, tom._id]
+          });
+
+          yield manager.save();
+          yield hafez.save();
+          yield billy.save();
+          yield tom.save();
+          yield office.save();
+
+          let doc = yield Office.findOne()
+            .populate([
+              { path: 'managerId supervisorId associatesIds', select: 'name -_id' },
+              //{ path: 'someOtherField' }
+            ]);
+
+          assert.strictEqual(doc.managerId.name, 'John');
+          assert.strictEqual(doc.supervisorId.name, 'Hafez');
+          assert.strictEqual(doc.associatesIds[0].name, 'Billy');
+          assert.strictEqual(doc.associatesIds[1].name, 'Tom');
         });
       });
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

This change allows the `.populate()` method to accept an array of objects with space separated path properties as described by the example in #6414.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

all current tests pass, added a failing test based on the example in #6414 and made it pass:
```
mongoose>: npm test -- -g 'gh-6414'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6414"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (560ms)
  1 failing

  1) model: populate:
       github issues
         populates an array of objects
           populates array of space separated paths (gh-6414):

      AssertionError [ERR_ASSERTION]: 'John' === 'JohnX'
      + expected - actual

      -John
      +JohnX

      at test/model.populate.test.js:6254:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6414'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6414"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (526ms)
  1 failing

  1) model: populate:
       github issues
         populates an array of objects
           populates array of space separated paths (gh-6414):

      AssertionError [ERR_ASSERTION]: 'Hafez' === 'HafezX'
      + expected - actual

      -Hafez
      +HafezX

      at test/model.populate.test.js:6255:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6414'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6414"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (535ms)
  1 failing

  1) model: populate:
       github issues
         populates an array of objects
           populates array of space separated paths (gh-6414):

      AssertionError [ERR_ASSERTION]: 'Billy' === 'BillyX'
      + expected - actual

      -Billy
      +BillyX

      at test/model.populate.test.js:6256:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6414'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6414"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (530ms)
  1 failing

  1) model: populate:
       github issues
         populates an array of objects
           populates array of space separated paths (gh-6414):

      AssertionError [ERR_ASSERTION]: 'Tom' === 'TomX'
      + expected - actual

      -Tom
      +TomX

      at test/model.populate.test.js:6257:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6414'

> mongoose@5.0.18-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6414"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (521ms)

mongoose>:
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
### the output of the example in #6414 before this change:
```
issues: node ./6414.js
{ associatesIds: [ 5aee4014b5155f52f6f925b1, 5aee4014b5155f52f6f925b2 ],
  _id: 5aee4014b5155f52f6f925b4,
  managerId: { name: 'John' },
  supervisorId: 5aee4014b5155f52f6f925b3,
  __v: 0 }
issues:
```
### the output of the example in #6414 after this change:
```
issues: node ./6414.js
{ associatesIds: [ { name: 'Billy' }, { name: 'Tom' } ],
  _id: 5aef1f902cb7a55f3bb1edcb,
  managerId: { name: 'John' },
  supervisorId: { name: 'Hafez' },
  __v: 0 }
issues:
```