### PR TITLE
fixes #6439 - stop clobbering $in when casting doc in query

### DIFF
--- a/lib/services/query/castUpdate.js
+++ b/lib/services/query/castUpdate.js
@@ -205,7 +205,7 @@ function walkUpdatePath(schema, obj, op, options, context, pref) {
           (utils.isObject(val) && Object.keys(val).length === 0);
       }
     } else {
-      var checkPath = (key === '$each' || key === '$or' || key === '$and') ?
+      var checkPath = (key === '$each' || key === '$or' || key === '$and' || key === '$in') ?
         pref : prefix + key;
       schematype = schema._getSchema(checkPath);
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -878,6 +878,45 @@ describe('Query', function() {
       done();
     });
 
+    it('doesn\'t wipe out $in (gh-6439)', function() {
+      var embeddedSchema = new Schema({
+        name: String
+      }, { _id: false });
+
+      var catSchema = new Schema({
+        name: String,
+        props: [embeddedSchema]
+      });
+
+      var Cat = db.model('gh6439', catSchema);
+      var kitty = new Cat({
+        name: 'Zildjian',
+        props: [
+          { name: 'invalid' },
+          { name: 'abc' },
+          { name: 'def' }
+        ]
+      });
+
+      return co(function*() {
+        yield kitty.save();
+        var cond = { _id: kitty._id };
+        var update = {
+          $pull: {
+            props: {
+              $in: [
+                { name: 'invalid' },
+                { name: 'def' }
+              ]
+            }
+          }
+        };
+        yield Cat.update(cond, update);
+        let found = yield Cat.findOne(cond);
+        assert.strictEqual(found.props[0].name, 'abc');
+      });
+    });
+
     it('find $ne should not cast single value to array for schematype of Array', function(done) {
       var query = new Query({}, {}, null, p1.collection);
       var Product = db.model('Product');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

#6439 demonstrates that $in gets clobbered during update query casting. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

all current tests pass, added a failing test then made it pass:
```
mongoose>: npm test -- -g 'gh-6439'

> mongoose@5.0.18 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6439"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

  !

  0 passing (524ms)
  1 failing

  1) Query
       casting
         doesn't wipe out $in (gh-6439):

      AssertionError [ERR_ASSERTION]: 'abc' === 'xyz'
      + expected - actual

      -abc
      +xyz

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as strictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/query.test.js:917:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6439'

> mongoose@5.0.18 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6439"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (520ms)

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### Output of 6439 example before change:
```
issues: node ./6439.js
result: []
^C
issues:
```
### Output of 6439 example after change:
```
issues: node ./6439.js
result: [ { name: 'abc' } ]
^C
issues:
```