### PR TITLE
Add modified paths to VersionError

### DIFF
--- a/lib/error/version.js
+++ b/lib/error/version.js
@@ -13,11 +13,12 @@ var MongooseError = require('./');
  * @api private
  */
 
-function VersionError(doc, currentVersion) {
+function VersionError(doc, currentVersion, modifiedPaths) {
   MongooseError.call(this, 'No matching document found for id "' + doc._id +
     '" version ' + currentVersion);
   this.name = 'VersionError';
   this.version = currentVersion;
+  this.modifiedPaths = modifiedPaths;
 }
 
 /*!

--- a/lib/model.js
+++ b/lib/model.js
@@ -241,6 +241,9 @@ Model.prototype.$__save = function(options, callback) {
       });
     }
 
+    // store the modified paths before the document is reset
+    const modifiedPaths = this.modifiedPaths();
+
     this.$__reset();
 
     let numAffected = 0;
@@ -269,7 +272,7 @@ Model.prototype.$__save = function(options, callback) {
 
         if (numAffected <= 0) {
           // the update failed. pass an error back
-          let err = new VersionError(this, version);
+          let err = new VersionError(this, version, modifiedPaths);
           return callback(err);
         }
 

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -13,7 +13,7 @@ const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 const VersionError = mongoose.Error.VersionError;
 
-describe.only('versioning', function() {
+describe('versioning', function() {
   var db;
   var Comments;
   var BlogPost;

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -13,7 +13,7 @@ const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 const VersionError = mongoose.Error.VersionError;
 
-describe('versioning', function() {
+describe.only('versioning', function() {
   var db;
   var Comments;
   var BlogPost;
@@ -270,6 +270,7 @@ describe('versioning', function() {
       assert.ok(/No matching document/.test(err), err);
       assert.equal(a._doc.__v, 5);
       assert.equal(err.version, b._doc.__v - 1);
+      assert.deepEqual(err.modifiedPaths, ['numbers', 'numbers.2']);
       a.set('arr.0.0', 'updated');
       var d = a.$__delta();
       assert.equal(a._doc.__v, d[0].__v, 'version should be added to where clause');


### PR DESCRIPTION
Fix #6433

**Summary**

This PR fixes #6433 by adding a `modifiedPaths` property to `VersionError` in order to make debugging easier.

**Test plan**

I've updated an existing test and verified that it passes.