### PR TITLE
fixes #6440 add notes in api and guide about schema.methods object

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -99,6 +99,7 @@ block content
     ```
 
     * Overwriting a default mongoose document method may lead to unpredictable results. See [this](./api.html#schema_Schema.reserved) for more details.
+    * The example above uses the `Schema.methods` object directly to save an instance method. You can also use the `Schema.method()` helper as described [here](./api.html#schema_Schema-method).
     * Do **not** declare methods using ES6 arrow functions (`=>`). Arrow functions [explicitly prevent binding `this`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_binding_of_this), so your method will **not** have access to the document and the above examples will not work.
 
     <h3 id="statics"><a href="#statics">Statics</a></h3>

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1214,6 +1214,8 @@ Schema.prototype.plugin = function(fn, opts) {
  *     fizz.purr();
  *     fizz.scratch();
  *
+ * NOTE: `Schema.method()` adds instance methods to the `Schema.methods` object. You can also add instance methods directly to the `Schema.methods` object as seen in the [guide](./guide.html#methods)
+ * 
  * @param {String|Object} method name
  * @param {Function} [fn]
  * @api public

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1215,7 +1215,7 @@ Schema.prototype.plugin = function(fn, opts) {
  *     fizz.scratch();
  *
  * NOTE: `Schema.method()` adds instance methods to the `Schema.methods` object. You can also add instance methods directly to the `Schema.methods` object as seen in the [guide](./guide.html#methods)
- * 
+ *
  * @param {String|Object} method name
  * @param {Function} [fn]
  * @api public

--- a/lib/types/buffer.js
+++ b/lib/types/buffer.js
@@ -167,7 +167,7 @@ MongooseBuffer.mixin = {
     'writeFloat writeDouble fill ' +
     'utf8Write binaryWrite asciiWrite set ' +
 
-// node >= 0.5
+  // node >= 0.5
     'writeUInt16LE writeUInt16BE writeUInt32LE writeUInt32BE ' +
     'writeInt16LE writeInt16BE writeInt32LE writeInt32BE ' +
     'writeFloatLE writeFloatBE writeDoubleLE writeDoubleBE'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

docs change for #6440 
This change adds notes to the schema and api docs that attempt to make clear the distinction between `Schema.methods` and `Schema.method()`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

make docclean && make gendocs && node static.js

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
