### PR TITLE
fixes #6474 let aggregate.replaceRoot accept objects as well as strings

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -362,7 +362,7 @@ Aggregate.prototype.replaceRoot = function(newRoot) {
   let ret;
 
   if (typeof newRoot === 'string') {
-    ret = (newRoot && newRoot.charAt(0) === '$') ? newRoot : '$' + newRoot;
+    ret = newRoot.startsWith('$') ? newRoot : '$' + newRoot;
   } else {
     ret = newRoot;
   }

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -345,13 +345,13 @@ Aggregate.prototype.unwind = function() {
  * Note that the `$replaceRoot` operator requires field strings to start with '$'.
  * If you are passing in a string Mongoose will prepend '$' if the specified field doesn't start '$'.
  * If you are passing in an object the strings in your expression will not be altered.
- * 
+ *
  * ####Examples:
  *
  *     aggregate.replaceRoot("user");
  *
  *     aggregate.replaceRoot({ x: { $concat: ['$this', '$that'] } });
- * 
+ *
  * @see $replaceRoot https://docs.mongodb.org/manual/reference/operator/aggregation/replaceRoot
  * @param {String|Object} the field or document which will become the new root document
  * @return {Aggregate}

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -359,7 +359,7 @@ Aggregate.prototype.unwind = function() {
  */
 
 Aggregate.prototype.replaceRoot = function(newRoot) {
-  let ret;
+  var ret;
 
   if (typeof newRoot === 'string') {
     ret = newRoot.startsWith('$') ? newRoot : '$' + newRoot;

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -342,23 +342,34 @@ Aggregate.prototype.unwind = function() {
 /**
  * Appends a new $replaceRoot operator to this aggregate pipeline.
  *
- * Note that the `$replaceRoot` operator requires the new root to start with '$'.
- * Mongoose will prepend '$' if the specified field doesn't start '$'.
- *
+ * Note that the `$replaceRoot` operator requires field strings to start with '$'.
+ * If you are passing in a string Mongoose will prepend '$' if the specified field doesn't start '$'.
+ * If you are passing in an object the strings in your expression will not be altered.
+ * 
  * ####Examples:
  *
  *     aggregate.replaceRoot("user");
  *
+ *     aggregate.replaceRoot({ x: { $concat: ['$this', '$that'] } });
+ * 
  * @see $replaceRoot https://docs.mongodb.org/manual/reference/operator/aggregation/replaceRoot
- * @param {String} the field which will become the new root document
+ * @param {String|Object} the field or document which will become the new root document
  * @return {Aggregate}
  * @api public
  */
 
 Aggregate.prototype.replaceRoot = function(newRoot) {
+  let ret;
+
+  if (typeof newRoot === 'string') {
+    ret = (newRoot && newRoot.charAt(0) === '$') ? newRoot : '$' + newRoot;
+  } else {
+    ret = newRoot;
+  }
+
   return this.append({
     $replaceRoot: {
-      newRoot: (newRoot && newRoot.charAt(0) === '$') ? newRoot : '$' + newRoot
+      newRoot: ret
     }
   });
 };

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -528,7 +528,7 @@ describe('aggregate: ', function() {
           [{ $replaceRoot: { newRoot: '$myNewRoot' }}]);
         done();
       });
-      it('works with an object (gh-6474)', function (done) {
+      it('works with an object (gh-6474)', function(done) {
         var aggregate = new Aggregate();
 
         aggregate.replaceRoot({ x: { $concat: ['$this', '$that'] } });

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -519,13 +519,22 @@ describe('aggregate: ', function() {
     });
 
     describe('replaceRoot', function() {
-      it('works', function(done) {
+      it('works with a string', function(done) {
         var aggregate = new Aggregate();
 
         aggregate.replaceRoot('myNewRoot');
 
         assert.deepEqual(aggregate._pipeline,
           [{ $replaceRoot: { newRoot: '$myNewRoot' }}]);
+        done();
+      });
+      it('works with an object (gh-6474)', function (done) {
+        var aggregate = new Aggregate();
+
+        aggregate.replaceRoot({ x: { $concat: ['$this', '$that'] } });
+
+        assert.deepEqual(aggregate._pipeline,
+          [{ $replaceRoot: { newRoot: { x: { $concat: ['$this', '$that'] } } } } ]);
         done();
       });
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As pointed out in #6474, replaceRoot can also take an expression that results in a document. This change retains the current ability to pass a string that refers to a field in the document, but also allows us to pass in an object ( expression ). 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

All current tests pass, added a failing test, made it pass:
```
mongoose>: npm test -- -g gh-6474

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6474"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (131ms)
  1 failing

  1) aggregate:
       Mongo 3.4 operators
         replaceRoot
           works with object (gh-6474):
     TypeError: newRoot.charAt is not a function
      at Aggregate.replaceRoot (lib/aggregate.js:361:36)
      at Context.<anonymous> (test/aggregate.test.js:534:19)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6474

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6474"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (127ms)

mongoose>: npm test -- -g gh-6474

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6474"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (133ms)

mongoose>: npm test

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1913 passing (25s)
  9 pending

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### Output of [6474.js](https://github.com/Automattic/mongoose/issues/6474#issuecomment-389436735) before this change:
```
issues: ./6474.js
TypeError: newRoot.charAt is not a function
    at Aggregate.replaceRoot (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/aggregate.js:361:36)
    at run (/Users/lineus/dev/Help/mongoose5/issues/6474.js:38:6)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
^C
issues: 
```
### Output of [6474.js](https://github.com/Automattic/mongoose/issues/6474#issuecomment-389436735) after this change:
```
issues: ./6474.js
issues:
```