### PR TITLE
fix(model): skip redundant clone in insertMany

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2365,7 +2365,9 @@ Model.$__insertMany = function(arr, options, callback) {
   var validationErrors = [];
   arr.forEach(function(doc) {
     toExecute.push(function(callback) {
-      doc = new _this(doc);
+      if(!doc instanceof _this){
+        doc = new _this(doc);        
+      }
       doc.validate({ __noPromise: true }, function(error) {
         if (error) {
           // Option `ordered` signals that insert should be continued after reaching

--- a/lib/model.js
+++ b/lib/model.js
@@ -2366,7 +2366,7 @@ Model.$__insertMany = function(arr, options, callback) {
   arr.forEach(function(doc) {
     toExecute.push(function(callback) {
       if (!(doc instanceof _this)) {
-        doc = new _this(doc);        
+        doc = new _this(doc);
       }
       doc.validate({ __noPromise: true }, function(error) {
         if (error) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -2365,7 +2365,7 @@ Model.$__insertMany = function(arr, options, callback) {
   var validationErrors = [];
   arr.forEach(function(doc) {
     toExecute.push(function(callback) {
-      if(!doc instanceof _this){
+      if (!(doc instanceof _this)) {
         doc = new _this(doc);        
       }
       doc.validate({ __noPromise: true }, function(error) {


### PR DESCRIPTION
**Summary**
As discussed in [issue #6461](https://github.com/Automattic/mongoose/issues/6461#issuecomment-389696817).


