### PR TITLE
fixes #6477 prevent default falses from being skipped by $__dirty

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2003,8 +2003,7 @@ Document.prototype.$__dirty = function() {
   // gh-2558: if we had to set a default and the value is not undefined,
   // we have to save as well
   all = all.concat(this.$__.activePaths.map('default', function(path) {
-    var pType = typeof _this.getValue(path);
-    if (path === '_id' || (!_this.getValue(path) && pType !== 'boolean')) {
+    if (path === '_id' || _this.getValue(path) == null) {
       return;
     }
     return {

--- a/lib/document.js
+++ b/lib/document.js
@@ -2003,7 +2003,8 @@ Document.prototype.$__dirty = function() {
   // gh-2558: if we had to set a default and the value is not undefined,
   // we have to save as well
   all = all.concat(this.$__.activePaths.map('default', function(path) {
-    if (path === '_id' || !_this.getValue(path)) {
+    var pType = typeof _this.getValue(path);
+    if (path === '_id' || (!_this.getValue(path) && pType !== 'boolean')) {
       return;
     }
     return {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -5123,6 +5123,51 @@ describe('document', function() {
       done();
     });
 
+    it('sets a boolean path to the desired default (gh-6477)', function() {
+      var schema = new Schema({
+        name: String,
+        f: {
+          type: Boolean,
+          default: false
+        },
+        t: {
+          type: Boolean,
+          default: true
+        }
+      });
+
+      var Test = db.model('gh6477', schema);
+
+      var test = new Test;
+      assert.strictEqual(test.t, true);
+      assert.strictEqual(test.f, false);
+
+      return co(function* () {
+        yield test.save();
+        let found = yield Test.findOne({});
+        assert.strictEqual(found.t, true);
+        assert.strictEqual(found.f, false);
+
+        // use native driver directly to kill the fields
+        yield Test.collection.update({}, { $unset: { t: true, f: true } });
+
+        // use native driver directly to ensure fields were updated correctly.
+        let updated = yield Test.collection.findOne({});
+        assert.strictEqual(updated.t, undefined);
+        assert.strictEqual(updated.f, undefined);
+
+        // udate the doc with the expectation that default booleans will be saved.
+        let again = yield Test.findOne({});
+        again.name = 'Britney';
+        yield again.save();
+
+        let final = yield Test.collection.findOne({});
+        assert.strictEqual(final.name, 'Britney');
+        assert.strictEqual(final.t, true);
+        assert.strictEqual(final.f, false);
+      });
+    });
+
     it('virtuals with no getters return undefined (gh-6223)', function(done) {
       var personSchema = new mongoose.Schema({
         name: { type: String },

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3952,6 +3952,48 @@ describe('Model', function() {
     });
   });
 
+  it('sets a boolean path to the desired default (gh-6477)', function() {
+    var schema = new Schema({
+      name: String,
+      f: {
+        type: Boolean,
+        default: false
+      },
+      t: {
+        type: Boolean,
+        default: true
+      }
+    });
+
+    var Test = db.model('gh6477', schema);
+
+    var test = new Test;
+    assert.strictEqual(test.t, true);
+    assert.strictEqual(test.f, false);
+
+    return co(function*() {
+      yield test.save();
+      let found = yield Test.findOne({});
+      assert.strictEqual(found.t, true);
+      assert.strictEqual(found.f, false);
+
+      yield Test.collection.update({}, { $unset: { t: true, f: true } });
+
+      let updated = yield Test.collection.findOne({});
+      assert.strictEqual(updated.t, undefined);
+      assert.strictEqual(updated.f, undefined);
+
+      let again = yield Test.findOne({});
+      again.name = 'Britney';
+      yield again.save();
+
+      let final = yield Test.collection.findOne({});
+      assert.strictEqual(final.name, 'Britney');
+      assert.strictEqual(final.t, true);
+      assert.strictEqual(final.f, false);
+    });
+  });
+
   it('setting a path to undefined should retain the value as undefined', function(done) {
     var B = db.model('BlogPost', collection + random());
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3977,8 +3977,10 @@ describe('Model', function() {
       assert.strictEqual(found.t, true);
       assert.strictEqual(found.f, false);
 
+      // use native driver directly to kill the fields
       yield Test.collection.update({}, { $unset: { t: true, f: true } });
 
+      // use native driver directly to ensure fields are saved correctly.
       let updated = yield Test.collection.findOne({});
       assert.strictEqual(updated.t, undefined);
       assert.strictEqual(updated.f, undefined);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3952,51 +3952,6 @@ describe('Model', function() {
     });
   });
 
-  it('sets a boolean path to the desired default (gh-6477)', function() {
-    var schema = new Schema({
-      name: String,
-      f: {
-        type: Boolean,
-        default: false
-      },
-      t: {
-        type: Boolean,
-        default: true
-      }
-    });
-
-    var Test = db.model('gh6477', schema);
-
-    var test = new Test;
-    assert.strictEqual(test.t, true);
-    assert.strictEqual(test.f, false);
-
-    return co(function*() {
-      yield test.save();
-      let found = yield Test.findOne({});
-      assert.strictEqual(found.t, true);
-      assert.strictEqual(found.f, false);
-
-      // use native driver directly to kill the fields
-      yield Test.collection.update({}, { $unset: { t: true, f: true } });
-
-      // use native driver directly to ensure fields are saved correctly.
-      let updated = yield Test.collection.findOne({});
-      assert.strictEqual(updated.t, undefined);
-      assert.strictEqual(updated.f, undefined);
-
-      // udate the doc with the expectation that default booleans will be saved.
-      let again = yield Test.findOne({});
-      again.name = 'Britney';
-      yield again.save();
-
-      let final = yield Test.collection.findOne({});
-      assert.strictEqual(final.name, 'Britney');
-      assert.strictEqual(final.t, true);
-      assert.strictEqual(final.f, false);
-    });
-  });
-
   it('setting a path to undefined should retain the value as undefined', function(done) {
     var B = db.model('BlogPost', collection + random());
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3985,6 +3985,7 @@ describe('Model', function() {
       assert.strictEqual(updated.t, undefined);
       assert.strictEqual(updated.f, undefined);
 
+      // udate the doc with the expectation that default booleans will be saved.
       let again = yield Test.findOne({});
       again.name = 'Britney';
       yield again.save();


### PR DESCRIPTION
As demonstrated in #6477, a document returned from a query, with an unset field that defaults to false, subsequently saved would not add the default to the document. This change aligns the behavior with other path defaults.

all current tests pass, made a failing test, then made it pass.
```
mongoose>: npm test

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1916 passing (25s)
  9 pending

mongoose>:
```

### Output of 6477.js before change:
```
issues: ./6477.js
5.1.1: f: failed to set f = false on save()
issues: 
```
### Output of 6477.js after change:
```
issues: ./6477.js
5.1.2-pre:
issues:
```