### PR TITLE
fixes #6455 CustomQuery should inherit from model.Query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -167,7 +167,7 @@ Query.prototype.toConstructor = function toConstructor() {
     Query.call(this, criteria, options || null, model, coll);
   };
 
-  util.inherits(CustomQuery, Query);
+  util.inherits(CustomQuery, model.Query);
 
   // set inherited defaults
   var p = CustomQuery.prototype;

--- a/test/query.toconstructor.test.js
+++ b/test/query.toconstructor.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var start = require('./common'),
     mongoose = start.mongoose,
     Schema = mongoose.Schema,


### PR DESCRIPTION
As described in #6455, custom queries don't currently inherit the model's middleware. This change makes CustomQuery inherit from model.Query instead of Query which fixes this.

All current tests pass, made a failing test, then made it pass:
```
mongoose>: npm test -- -g 'gh-6455'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6455"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (463ms)
  1 failing

  1) Query:
       toConstructor
         gets middleware from model (gh-6455):

      AssertionError [ERR_ASSERTION]: 'Romero' === 'romeo'
      + expected - actual

      -Romero
      +romeo

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as strictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/query.toconstructor.test.js:210:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6455'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6455"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (510ms)
  1 failing

  1) Query:
       toConstructor
         gets middleware from model (gh-6455):

      AssertionError [ERR_ASSERTION]: 1 === 0
      + expected - actual

      -1
      +0

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as strictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/query.toconstructor.test.js:211:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1916 passing (25s)
  9 pending

mongoose>: git status
On branch fix-6455
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   lib/query.js
        modified:   test/query.toconstructor.test.js

no changes added to commit (use "git add" and/or "git commit -a")
mongoose>: eslint lib/query.js
mongoose>: eslint test/query.toconstructor.test.js
mongoose>: shirley 'make CustomQuery inherit from model.Query instead of Query to get middleware'
[fix-6455 2f45f7b] make CustomQuery inherit from model.Query instead of Query to get middleware
 2 files changed, 24 insertions(+), 1 deletion(-)
Counting objects: 42, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (42/42), done.
Writing objects: 100% (42/42), 5.61 KiB | 0 bytes/s, done.
Total 42 (delta 32), reused 0 (delta 0)
remote: Resolving deltas: 100% (32/32), completed with 15 local objects.
To https://github.com/lineus/mongoose.git
 * [new branch]      fix-6455 -> fix-6455
Branch fix-6455 set up to track remote branch fix-6455 from origin.
mongoose>:
```
### output of 6455.js before change:
```
issues: ./6455.js
[ { _id: 5afe9d25781027432c34d1e5, name: 'Romero', __v: 0 } ]
issues:
```
### output of 6455.js after change:
```
issues: ./6455.js
Executing hook
[ { _id: 5afe9d393a2916434b78a1d4, name: 'Romero', __v: 0 } ]
issues:
```