### PR TITLE
fixes #6478 make MongooseMap.toJSON return an object

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -91,7 +91,12 @@ class MongooseMap extends Map {
   }
 
   toJSON() {
-    return new Map(this);
+    let ret = {};
+    const keys = this.keys();
+    for (let key of keys) {
+      ret[key] = this.get(key);
+    }
+    return ret;
   }
 
   inspect() {

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -408,4 +408,38 @@ describe('Map', function() {
       assert.ok(fromDb);
     });
   });
+
+  it('toJSON seralizes map paths (gh-6478)', function() {
+    const schema = new mongoose.Schema({
+      str: {
+        type: Map,
+        of: String
+      },
+      num: {
+        type: Map,
+        of: Number
+      }
+    });
+
+    const Test = db.model('gh6478', schema);
+    const test = new Test({
+      str: {
+        testing: '123'
+      },
+      num: {
+        testing: 456
+      }
+    });
+
+    assert.deepEqual(test.str.toJSON(), { testing: '123' });
+    assert.deepEqual(test.num.toJSON(), { testing: 456 });
+
+    return co(function*() {
+      yield test.save();
+
+      let found = yield Test.findOne();
+      assert.deepEqual(found.str.toJSON(), { testing: '123' });
+      assert.deepEqual(found.num.toJSON(), { testing: 456 });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As described in #6478 MongooseMap.toJSON() currently returns a Map. This change results in an object of the map's key value pairs being returned instead.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

all current tests pass, added a failing test, made it pass:
```
mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (130ms)
  1 failing

  1) Map
       toJSON seralizes the map (gh-6478):

      AssertionError: { testing: 123 } deepEqual { testing: 456 }
      + expected - actual

       {
      -  "testing": 123
      +  "testing": 456
       }

      at Context.<anonymous> (test/types.map.test.js:435:12)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (125ms)

mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (445ms)
  1 failing

  1) Map
       toJSON seralizes the map (gh-6478):

      AssertionError: { testing: '123' } deepEqual { testing: '12' }
      + expected - actual

       {
      -  "testing": "123"
      +  "testing": "12"
       }

      at test/types.map.test.js:441:14
      at next (native)
      at onFulfilled (node_modules/co/index.js:65:19)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (377ms)
  1 failing

  1) Map
       toJSON seralizes the map (gh-6478):

      AssertionError: { testing: 456 } deepEqual { testing: 45 }
      + expected - actual

       {
      -  "testing": 456
      +  "testing": 45
       }

      at test/types.map.test.js:442:14
      at next (native)
      at onFulfilled (node_modules/co/index.js:65:19)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (497ms)

mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (396ms)
  1 failing

  1) Map
       toJSON seralizes the map (gh-6478):

      AssertionError: { testing: 456 } deepEqual { testing: 45 }
      + expected - actual

       {
      -  "testing": 456
      +  "testing": 45
       }

      at test/types.map.test.js:444:14
      at next (native)
      at onFulfilled (node_modules/co/index.js:65:19)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6478'

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6478"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (521ms)
  1 failing

  1) Map
       toJSON seralizes the map (gh-6478):

      AssertionError: { testing: '123' } deepEqual { testing: '12' }
      + expected - actual

       {
      -  "testing": "123"
      +  "testing": "12"
       }

      at test/types.map.test.js:443:14
      at next (native)
      at onFulfilled (node_modules/co/index.js:65:19)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test

> mongoose@5.1.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1928 passing (34s)
  2 pending

mongoose>:
```

### 6478.js
```js
#!/usr/bin/env node
'use strict';

const mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test');
const conn = mongoose.connection;
const Schema = mongoose.Schema;
const Map = global.Map;

const schema = new Schema({
  test: {
    type: Map,
    of: String,
    default: new Map()
  }
});

const Test = mongoose.model('test', schema);

const mapTest = new Test({});

mapTest.test.set('key1', 'value1');

async function run() {
  await conn.dropDatabase();
  await mapTest.save();
  let found = await Test.findOne();
  console.log(JSON.stringify(found));
  return conn.close();
}

run();
```
### Output with 5.1.1
```
issues: ./6478.js
{"test":{},"_id":"5b0156d1d3c111222137e0be","__v":0}
issues:
```
### Output with 5.1.2-pre
```
issues: npm install ~/dev/opc/mongoose >/dev/null 2>&1
issues: ./6478.js
{"test":{"key1":"value1"},"_id":"5b0156f9bfa8cb224a0f330b","__v":0}
issues:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
