### PR TITLE
fixes #6456, fixes #4064 - Throw error when saving the same doc instance more than once in parallel

### DIFF
--- a/docs/faq.jade
+++ b/docs/faq.jade
@@ -341,6 +341,13 @@ block content
     doc.save(); // Works
     ```
 
+    **Q**. Why does calling `save()` multiple times on the same document in parallel only let 
+    the first save call succeed and return ParallelSaveErrors for the rest?
+
+    **A**. Due to the asynchronous nature of validation and middleware in general, calling
+    `save()` multiple times in parallel on the same doc could result in conflicts. For example,
+    validating, and then subsequently invalidating the same path.
+
     **Something to add?**
 
     If you'd like to contribute to this page, please

--- a/lib/error/duplicateSave.js
+++ b/lib/error/duplicateSave.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/*!
+ * Module dependencies.
+ */
+
+var MongooseError = require('./');
+
+/**
+ * DuplicateSave Error constructor.
+ *
+ * @inherits MongooseError
+ * @api private
+ */
+
+function DuplicateSaveError(doc) {
+  let msg = 'Can\'t save() the same doc multiple times in parallel. Document:';
+  MongooseError.call(this, msg + doc.id);
+  this.name = 'DuplicateSaveError';
+}
+
+/*!
+ * Inherits from MongooseError.
+ */
+
+DuplicateSaveError.prototype = Object.create(MongooseError.prototype);
+DuplicateSaveError.prototype.constructor = MongooseError;
+
+/*!
+ * exports
+ */
+
+module.exports = DuplicateSaveError;

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -90,6 +90,16 @@ MongooseError.ValidatorError = require('./validator');
 MongooseError.VersionError = require('./version');
 
 /**
+ * An instance of this error class will be returned when you call `save()` multiple
+ * times on the same document in parallel. See the [FAQ](/docs/faq.html) for more
+ * information.
+ *
+ * @api public
+ */
+
+MongooseError.ParallelSaveError = require('./parallelSave');
+
+/**
  * Thrown when a model with the given name was already registered on the connection.
  * See [the FAQ about `OverwriteModelError`](/docs/faq.html#overwrite-model-error).
  *

--- a/lib/error/parallelSave.js
+++ b/lib/error/parallelSave.js
@@ -13,21 +13,21 @@ var MongooseError = require('./');
  * @api private
  */
 
-function DuplicateSaveError(doc) {
+function ParallelSaveError(doc) {
   let msg = 'Can\'t save() the same doc multiple times in parallel. Document:';
   MongooseError.call(this, msg + doc.id);
-  this.name = 'DuplicateSaveError';
+  this.name = 'ParallelSaveError';
 }
 
 /*!
  * Inherits from MongooseError.
  */
 
-DuplicateSaveError.prototype = Object.create(MongooseError.prototype);
-DuplicateSaveError.prototype.constructor = MongooseError;
+ParallelSaveError.prototype = Object.create(MongooseError.prototype);
+ParallelSaveError.prototype.constructor = MongooseError;
 
 /*!
  * exports
  */
 
-module.exports = DuplicateSaveError;
+module.exports = ParallelSaveError;

--- a/lib/error/parallelSave.js
+++ b/lib/error/parallelSave.js
@@ -7,7 +7,7 @@
 var MongooseError = require('./');
 
 /**
- * DuplicateSave Error constructor.
+ * ParallelSave Error constructor.
  *
  * @inherits MongooseError
  * @api private

--- a/lib/error/parallelSave.js
+++ b/lib/error/parallelSave.js
@@ -14,7 +14,7 @@ var MongooseError = require('./');
  */
 
 function ParallelSaveError(doc) {
-  let msg = 'Can\'t save() the same doc multiple times in parallel. Document:';
+  let msg = 'Can\'t save() the same doc multiple times in parallel. Document: ';
   MongooseError.call(this, msg + doc.id);
   this.name = 'ParallelSaveError';
 }

--- a/lib/internal.js
+++ b/lib/internal.js
@@ -16,6 +16,7 @@ function InternalCache() {
   this.adhocPaths = undefined;
   this.removing = undefined;
   this.inserting = undefined;
+  this.saving = undefined;
   this.version = undefined;
   this.getters = {};
   this._id = undefined;

--- a/lib/model.js
+++ b/lib/model.js
@@ -355,15 +355,15 @@ Model.prototype.save = function(options, fn) {
   const originalStack = new Error().stack;
 
   return utils.promiseOrCallback(fn, cb => {
-    this.$__save(options, error => {
-      if (!parallelSave) {
-        this.$__.saving = undefined;
-      }
+    if (parallelSave) {
+      this.$__handleReject(parallelSave);
+      return cb(parallelSave);
+    }
 
-      if (parallelSave) {
-        this.$__handleReject(parallelSave);
-        return cb(parallelSave);
-      } else if (error) {
+    this.$__save(options, error => {
+      this.$__.saving = undefined;
+
+      if (error) {
         // gh-2633: since VersionError is very generic, take the
         // stack trace of the original save() function call rather
         // than the async trace

--- a/lib/model.js
+++ b/lib/model.js
@@ -352,6 +352,7 @@ Model.prototype.save = function(options, fn) {
 
   return utils.promiseOrCallback(fn, cb => {
     this.$__save(options, error => {
+      this.$__.saving = undefined;
       if (error) {
         // gh-2633: since VersionError is very generic, take the
         // stack trace of the original save() function call rather
@@ -362,7 +363,6 @@ Model.prototype.save = function(options, fn) {
         this.$__handleReject(error);
         return cb(error);
       }
-      this.$__.saving = undefined;
       cb(null, this);
     });
   });

--- a/lib/model.js
+++ b/lib/model.js
@@ -17,6 +17,7 @@ var PromiseProvider = require('./promise_provider');
 var Query = require('./query');
 var Schema = require('./schema');
 var VersionError = require('./error').VersionError;
+var ParallelSaveError = require('./error').ParallelSaveError;
 var applyHooks = require('./services/model/applyHooks');
 var applyMethods = require('./services/model/applyMethods');
 var applyStatics = require('./services/model/applyStatics');
@@ -327,11 +328,14 @@ Model.prototype.$__save = function(options, callback) {
  */
 
 Model.prototype.save = function(options, fn) {
-  if (this.$__.saving) {
-    throw new Error('Do Not Save in parallel');
-  }
+  let parallelSave;
 
-  this.$__.saving = true;
+  if (this.$__.saving) {
+    parallelSave = new ParallelSaveError(this);
+    parallelSave.stack = this.$__.saving;
+  } else {
+    this.$__.saving = new ParallelSaveError(this).stack;
+  }
 
   if (typeof options === 'function') {
     fn = options;
@@ -352,8 +356,14 @@ Model.prototype.save = function(options, fn) {
 
   return utils.promiseOrCallback(fn, cb => {
     this.$__save(options, error => {
-      this.$__.saving = undefined;
-      if (error) {
+      if (!parallelSave) {
+        this.$__.saving = undefined;
+      }
+
+      if (parallelSave) {
+        this.$__handleReject(parallelSave);
+        return cb(parallelSave);
+      } else if (error) {
         // gh-2633: since VersionError is very generic, take the
         // stack trace of the original save() function call rather
         // than the async trace

--- a/lib/model.js
+++ b/lib/model.js
@@ -327,6 +327,12 @@ Model.prototype.$__save = function(options, callback) {
  */
 
 Model.prototype.save = function(options, fn) {
+  if (this.$__.saving) {
+    throw new Error('Do Not Save in parallel');
+  }
+
+  this.$__.saving = true;
+
   if (typeof options === 'function') {
     fn = options;
     options = undefined;
@@ -356,6 +362,7 @@ Model.prototype.save = function(options, fn) {
         this.$__handleReject(error);
         return cb(error);
       }
+      this.$__.saving = undefined;
       cb(null, this);
     });
   });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5398,5 +5398,29 @@ describe('Model', function() {
         });
       });
     });
+    it('Throws when saving same doc in parallel (gh-6456)', function() {
+      const schema = new Schema({
+        name: String
+      });
+
+      const Test = db.model('gh6456', schema);
+
+      const test = new Test({
+        name: 'Billy'
+      });
+
+      function handler() {
+      }
+
+      assert.throws(function() {
+        test.save(handler);
+        test.save(handler);
+      }, /Do Not Save in parallel/);
+
+      assert.throws(function() {
+        test.save().then(handler);
+        test.save().then(handler);
+      }, /Do Not Save in parallel/);
+    });
   });
 });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5400,6 +5400,18 @@ describe('Model', function() {
     });
 
     it('Throws when saving same doc in parallel w/ callback (gh-6456)', function(done) {
+      let called = 0;
+
+      function counter() {
+        if (++called === 2) {
+          Test.count(function(err, cnt) {
+            assert.ifError(err);
+            assert.strictEqual(cnt, 1);
+            done();
+          });
+        }
+      }
+
       const schema = new Schema({
         name: String
       });
@@ -5413,17 +5425,30 @@ describe('Model', function() {
       test.save(function cb(err, doc) {
         assert.ifError(err);
         assert.strictEqual(doc.name, 'Billy');
-        done();
+        counter();
       });
 
       test.save(function cb(err) {
         assert.strictEqual(err.name, 'ParallelSaveError');
         let regex = new RegExp(test.id);
         assert.ok(regex.test(err.message));
+        counter();
       });
     });
 
-    it('Throws when saving same doc in parallel w/ promises (gh-6456)', function() {
+    it('Throws when saving same doc in parallel w/ promises (gh-6456)', function(done) {
+      let called = 0;
+
+      function counter() {
+        if (++called === 2) {
+          Test.count(function(err, cnt) {
+            assert.ifError(err);
+            assert.strictEqual(cnt, 1);
+            done();
+          });
+        }
+      }
+
       const schema = new Schema({
         name: String
       });
@@ -5436,12 +5461,14 @@ describe('Model', function() {
 
       function handler(doc) {
         assert.strictEqual(doc.id, test.id);
+        counter();
       }
 
       function error(err) {
         assert.strictEqual(err.name, 'ParallelSaveError');
         let regex = new RegExp(test.id);
         assert.ok(regex.test(err.message));
+        counter();
       }
 
       test.save().then(handler);


### PR DESCRIPTION
This is to address throwing an Error when saving in parallel as discussed in #6456 and #4064 . It's not ready to merge but I wanted to get a sanity check on the logic of the first draft and open the discussion sooner rather than later. All existing/new tests pass with this change ( now ).