### PR TITLE
createConnection should take an extended model too

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -637,7 +637,7 @@ Connection.prototype.collection = function(name, options) {
  *     var collectionName = 'actor'
  *     var M = conn.model('Actor', schema, collectionName)
  *
- * @param {String} name the model name
+ * @param {String|Function} name the model name or class extending Model
  * @param {Schema} [schema] a schema. necessary when defining a model
  * @param {String} [collection] name of mongodb collection (optional) if not given it will be induced from model name
  * @see Mongoose#model #index_Mongoose-model
@@ -646,6 +646,12 @@ Connection.prototype.collection = function(name, options) {
  */
 
 Connection.prototype.model = function(name, schema, collection) {
+  let fn;
+  if (typeof name === 'function') {
+    fn = name;
+    name = fn.name;
+  }
+
   // collection name discovery
   if (typeof schema === 'string') {
     collection = schema;
@@ -673,7 +679,7 @@ Connection.prototype.model = function(name, schema, collection) {
 
   if (schema && schema.instanceOfSchema) {
     // compile a model
-    model = this.base.model(name, schema, collection, opts);
+    model = this.base.model(fn || name, schema, collection, opts);
 
     // only the first model with this name is cached to allow
     // for one-offs with custom collection names etc.

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1110,4 +1110,14 @@ describe('connections:', function() {
       });
     });
   });
+  describe('passing a function into createConnection', function() {
+    it('should store the name of the function (gh-6517)', function(done) {
+      var conn = mongoose.createConnection('mongodb://localhost:27017/gh6517');
+      var schema = new Schema({ name: String });
+      class Person extends mongoose.Model {}
+      conn.model(Person, schema);
+      assert.strictEqual(conn.modelNames()[0], 'Person');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As demonstrated in #6517 createConnection should accept extended Models.

<!-- Explain the **motivation** for making this change. What existing problem does the pull requestsolve? -->

made a failing test, made it pass, all existing tests pass:
```
mongoose>: npm test -- -g 'gh-6517'

> mongoose@5.1.3-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6517"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (181ms)
  1 failing

  1) connections:
       passing a function into createConnection
         should store the name of the function (gh-6517):

      AssertionError: 'Person' === 'yippie'
      + expected - actual

      -Person
      +yippie

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as strictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/connection.test.js:1119:14)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6517'

> mongoose@5.1.3-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6517"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (121ms)

mongoose>: npm test

> mongoose@5.1.3-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1935 passing (35s)
  2 pending

mongoose>:
```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### Output of 6517.js before change:
```
issues: ./6517.js
connection model names: [ 'class Person extends Model { }' ]
{ _id: 5b094defc048d300e5f1e7c7, name: 'Wyatt', __v: 0 }
issues:
```
### Output of 6517.js after change:
```
issues: ./6517.js
connection model names: [ 'Person' ]
{ _id: 5b0950de878f5801b21bcfdf, name: 'Wyatt', __v: 0 }
issues:
```