### PR TITLE
Fix broken Connection pools anchor in docs

### DIFF
--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -211,7 +211,7 @@ block content
     Mongoose creates a _default connection_ when you call `mongoose.connect()`.
     You can access the default connection using `mongoose.connection`.
 
-    <h3 id="connection_pools"><a href="connection_pools">Connection pools</a></h3>
+    <h3 id="connection_pools"><a href="#connection_pools">Connection pools</a></h3>
 
     Each `connection`, whether created with `mongoose.connect` or
     `mongoose.createConnection` are all backed by an internal configurable


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The anchor on the title of Connection Pools in the documentation doesn't work as it does not contain a hash. This PR adds in the hash so that it is the correct URL and works like other anchors throughout the docs. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I was browsing the docs and wanted to send a link to the Connection Pool section, however clicking the title took me to a 404 page. 

**Test plan**

Visit the connections doc page and click on the Connection Pool title and ensure that it links correctly. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
