### PR TITLE
adding hr tags for parallel save error and add something

### DIFF
--- a/docs/faq.jade
+++ b/docs/faq.jade
@@ -340,7 +340,9 @@ block content
     doc.createdAt = new Date(2011, 5, 1).setHours(4);
     doc.save(); // Works
     ```
-
+    
+    <hr id="parallel_saves" />
+    
     **Q**. Why does calling `save()` multiple times on the same document in parallel only let 
     the first save call succeed and return ParallelSaveErrors for the rest?
 
@@ -348,6 +350,8 @@ block content
     `save()` multiple times in parallel on the same doc could result in conflicts. For example,
     validating, and then subsequently invalidating the same path.
 
+    <hr id="add_something" />
+    
     **Something to add?**
 
     If you'd like to contribute to this page, please


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Whoops. I forgot to add the hr tag in the faq for parallel saves. 

I also added one for something to add. I'm not sure if you want one there, but I liked the look of it. I'm happy to remove it if you don't think it's necessary or looks weird.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

make docclean && make gendocs && node static.js

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
