### PR TITLE
The feature for simply use of discriminators.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4024,7 +4024,7 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   } else {
     // generate new class
     model = function model(doc, fields, skipId) {
-      model.hooks.execPreSync('createModel', doc)
+      model.hooks.execPreSync('createModel', doc);
       if (!(this instanceof model)) {
         return new model(doc, fields, skipId);
       }

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -90,7 +90,7 @@ exports.getDiscriminatorByValue = getDiscriminatorByValue;
  * @return {Model}
  */
 exports.createModel = function createModel(model, doc, fields, userProvidedFields) {
-  model.hooks.execPreSync('createModel', doc)
+  model.hooks.execPreSync('createModel', doc);
   const discriminatorMapping = model.schema ?
     model.schema.discriminatorMapping :
     null;


### PR DESCRIPTION
The feature for simply use of discriminators.

Sample of use:
```javascript 
UserSchema.pre('createModel', function () {
  if (this && typeof this.role !== 'undefined' && this.role) {
    this.kind = this.role.charAt(0).toUpperCase() + this.role.slice(1) + 'User'
  }
})
```