### PR TITLE
fixes #6554 - add virtual ref function ability to getModelsMapForPopulate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3681,10 +3681,16 @@ function getModelsMapForPopulate(model, docs, options) {
       '_id';
     let justOne = true;
     if (virtual && virtual.options && virtual.options.ref) {
+      let normalizedRef;
+      if (typeof virtual.options.ref === 'function') {
+        normalizedRef = virtual.options.ref.call(doc, doc);
+      } else {
+        normalizedRef = virtual.options.ref;
+      }
       justOne = virtual.options.justOne;
       isVirtual = true;
       if (!modelNames) {
-        modelNames = [virtual.options.ref];
+        modelNames = [normalizedRef];
       }
     } else if (schema) {
       justOne = !schema.$isMongooseArray;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As demonstrated in #6554, the ref: as a function doesn't work. This changes adds the capability.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

made a failing test, made it pass, all current tests pass 
```
mongoose>: npm test -- -g 'gh-6554'

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6554"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (542ms)
  1 failing

  1) model: populate:
       lean + deep populate (gh-6498)
         populates virtual of embedded discriminator with dynamic ref (gh-6554):

      AssertionError [ERR_ASSERTION]: 'Test name' === 'Rachmaninoff'
      + expected - actual

      -Test name
      +Rachmaninoff

      at test/model.populate.test.js:6888:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: g 5 gitter
gitter: workBug cjr
gitter: cd -
/Users/lineus/dev/opc/mongoose
mongoose>: cd -
/Users/lineus/dev/Help/mongoose5/gitter
gitter: cd -
/Users/lineus/dev/opc/mongoose
mongoose>: npm test -- -g 'gh-6554'

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6554"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (551ms)

mongoose>: npm test

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1952 passing (30s)
  2 pending

mongoose>:
```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### Output of 6554.js after change 
```
issues: ./6554.js
[
  {
    "_id": "5b16d5209dc4cb3893569999",
    "events": [
      {
        "users": [
          {
            "ID": 1,
            "refKey": "Users"
          }
        ],
        "_id": "5b16d5209dc4cb389356999b",
        "kind": "Clicked",
        "element": "#hero",
        "message": "hello",
        "users_$": [
          {
            "_id": "5b16d5209dc4cb3893569998",
            "employeeId": 1,
            "name": "Test name"
          }
        ]
      },
      {
        "_id": "5b16d5209dc4cb389356999a",
        "kind": "Purchased",
        "product": "action-figure-1",
        "message": "world",
        "users_$": []
      }
    ],
    "__v": 0
  }
]
^C
issues:
```
**Edited:** The one test that was previously failing is now passing. I had to reinstall due to previous package changes.