### PR TITLE
fixes #6572 make MongooseArray and MongooseDocumentArray properties non-enumerable

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -33,14 +33,41 @@ function MongooseArray(values, path, doc) {
   var keysMA = Object.keys(MongooseArray.mixin);
   var numKeys = keysMA.length;
   for (var i = 0; i < numKeys; ++i) {
-    arr[keysMA[i]] = MongooseArray.mixin[keysMA[i]];
+    Object.defineProperty(arr, keysMA[i], {
+      value: MongooseArray.mixin[keysMA[i]],
+      enumerable: false,
+      writable: true
+    });
   }
 
-  arr._path = path;
-  arr.isMongooseArray = true;
-  arr.validators = [];
-  arr._atomics = {};
-  arr._schema = void 0;
+  Object.defineProperty(arr, '_path', {
+    value: path,
+    enumerable: false,
+    writable: true
+  });
+
+  Object.defineProperty(arr, 'isMongooseArray', {
+    value: true,
+    enumerable: false
+  });
+
+  Object.defineProperty(arr, 'validators', {
+    value: [],
+    enumerable: false,
+    writable: true
+  });
+
+  Object.defineProperty(arr, '_atomics', {
+    value: {},
+    enumerable: false,
+    writable: true
+  });
+
+  Object.defineProperty(arr, '_schema', {
+    value: void 0,
+    enumerable: false,
+    writable: true
+  });
 
   // Because doc comes from the context of another function, doc === global
   // can happen if there was a null somewhere up the chain (see #3020)

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -41,7 +41,11 @@ function MongooseDocumentArray(values, path, doc) {
   // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
   var arr = new CoreMongooseArray();
   if (Array.isArray(values)) values.forEach(v => arr.push(v));
-  arr._path = path;
+  Object.defineProperty(arr, '_path', {
+    value: path,
+    enumerable: false,
+    writable: true
+  });
 
   var props = {
     isMongooseDocumentArray: true,
@@ -55,20 +59,32 @@ function MongooseDocumentArray(values, path, doc) {
   // otherwise MongooseArray#push will mark the array as modified to the parent.
   var keysMA = Object.keys(MongooseArray.mixin);
   var numKeys = keysMA.length;
-  for (var j = 0; j < numKeys; ++j) {
-    arr[keysMA[j]] = MongooseArray.mixin[keysMA[j]];
+  for (var i = 0; i < numKeys; ++i) {
+    Object.defineProperty(arr, keysMA[i], {
+      value: MongooseArray.mixin[keysMA[i]],
+      enumerable: false,
+      writable: true
+    });
   }
 
   var keysMDA = Object.keys(MongooseDocumentArray.mixin);
   numKeys = keysMDA.length;
-  for (var i = 0; i < numKeys; ++i) {
-    arr[keysMDA[i]] = MongooseDocumentArray.mixin[keysMDA[i]];
+  for (let i = 0; i < numKeys; ++i) {
+    Object.defineProperty(arr, keysMDA[i], {
+      value: MongooseDocumentArray.mixin[keysMDA[i]],
+      enumerable: false,
+      writable: true
+    });
   }
 
   var keysP = Object.keys(props);
   numKeys = keysP.length;
   for (var k = 0; k < numKeys; ++k) {
-    arr[keysP[k]] = props[keysP[k]];
+    Object.defineProperty(arr, keysP[k], {
+      value: props[keysP[k]],
+      enumerable: false,
+      writable: true
+    });
   }
 
   // Because doc comes from the context of another function, doc === global

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -40,6 +40,13 @@ describe('types array', function() {
     db.close(done);
   });
 
+  it('only contains non-enumerable properties (gh-6572)', function(done) {
+    var a = new MongooseArray([1, 2, 3]);
+    var keys = Object.keys(a);
+    assert.deepEqual(['0', '1', '2'], keys);
+    done();
+  });
+
   it('behaves and quacks like an Array', function(done) {
     var a = new MongooseArray;
 

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -56,6 +56,13 @@ describe('types.documentarray', function() {
     db.close(done);
   });
 
+  it('only contains non-enumerable properties (gh-6572)', function(done) {
+    var a = new MongooseDocumentArray([1, 2, 3]);
+    var keys = Object.keys(a);
+    assert.deepEqual(['0', '1', '2'], keys);
+    done();
+  });
+
   it('behaves and quacks like an array', function(done) {
     var a = new MongooseDocumentArray();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

as pointed out in #6572, the properties of MongooseArrays and MongooseDocumentArrays are enumerable which means they show up in `for..in` and `Object.keys()`. This change makes all current properties & mixin methods non-enumerable.

all current tests pass and added 2 new failing tests that now also pass. 
Linted, and explicitly tested on npm 4 and 8.

```
mongoose>: npm test -- -g gh-6572

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6572"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (129ms)
  1 failing

  1) types.documentarray
       only contains non-enumerable properties (gh-6572):

      AssertionError: [ '0', '1', '2' ] == [ '0', '1', '2' ]
      + expected - actual


      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as equal] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/types.documentarray.test.js:62:12)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js

^C
mongoose>: npm test -- -g gh-6572

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6572"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (124ms)

mongoose>: npm test -- -g gh-6572

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6572"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !․

  1 passing (131ms)
  1 failing

  1) types array
       only contains non-enumerable properties (gh-6572):

      AssertionError: [ '0', '1', '4' ] deepEqual [ '0',
  '1',
  '2',
  '_path',
  'isMongooseArray',
  'validators',
  '_schema' ]
      + expected - actual

       [
         "0"
         "1"
      -  "4"
      +  "2"
      +  "_path"
      +  "isMongooseArray"
      +  "validators"
      +  "_schema"
       ]

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as deepEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/types.array.test.js:46:12)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6572

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6572"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !․

  1 passing (137ms)
  1 failing

  1) types array
       only contains non-enumerable properties (gh-6572):

      AssertionError: [ '0', '1', '4' ] deepEqual [ '0', '1', '2' ]
      + expected - actual

       [
         "0"
         "1"
      -  "4"
      +  "2"
       ]

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as deepEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/types.array.test.js:46:12)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6572

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6572"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․

  2 passing (131ms)

mongoose>: npm test

> mongoose@5.1.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1954 passing (36s)
  3 pending

mongoose>: lint
lib/types/array.js
lib/types/documentarray.js
test/types.array.test.js
test/types.documentarray.test.js
mongoose>: 
```

### 6572.js
```js
#!/usr/bin/env node
'use strict';

const mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test');
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const albumSchema = new Schema({
  title: String,
  players: [{
    name: String,
    instrument: [{
      kind: String
    }]
  }]
});

const Album = mongoose.model('album', albumSchema);

const test = new Album({
  title: 'At The Blackhawk',
  players: [
    { name: 'Rouse', instrument: [{ kind: 'Sax' }, { kind: 'Tenor Sax' }]},
    { name: 'Monk', instrument: [{ kind: 'Piano' }] }
  ]
});

function go() {
  return Album.find();
}

async function run() {
  await conn.dropDatabase();
  await test.save();
  let found = await go();
  let arInst = found[0].players[0].instrument;
  for (let j in arInst) {
    console.log(arInst[j]);
  }
  return conn.close();
}

run();
```
### Output before change:
```
issues: ./6572.js
{ _id: 5b1c09b38772e8828b6582bb, kind: 'Sax' }
{ _id: 5b1c09b38772e8828b6582ba, kind: 'Tenor Sax' }
instrument
[Function: toBSON]
{}
{ instrument:
   [ { _id: 5b1c09b38772e8828b6582bb, kind: 'Sax' },
     { _id: 5b1c09b38772e8828b6582ba, kind: 'Tenor Sax' } ],
  _id: 5b1c09b38772e8828b6582b9,
  name: 'Rouse' }
[Function: _cast]
[Function: _markModified]
[Function: _registerAtomic]
[Function: $__getAtomics]
[Function: hasAtomics]
[Function: _mapCast]
[Function: push]
[Function: nonAtomicPush]
[Function: $pop]
[Function: pop]
[Function: $shift]
[Function: shift]
[Function: pull]
[Function: splice]
[Function: unshift]
[Function: sort]
[Function: addToSet]
[Function: set]
[Function: toObject]
[Function: inspect]
[Function: indexOf]
[Function: pull]
[Function: id]
[Function: create]
[Function: notify]
true
[]
DocumentArray {
  casterConstructor:
   { [Function: EmbeddedDocument]
     schema:
      Schema {
        obj: [Object],
        paths: [Object],
        aliases: {},
        subpaths: {},
        virtuals: [Object],
        singleNestedPaths: {},
        nested: {},
        inherits: {},
        callQueue: [],
        _indexes: [],
        methods: {},
        methodOptions: {},
        statics: {},
        tree: [Object],
        query: {},
        childSchemas: [],
        plugins: [Array],
        s: [Object],
        _userProvidedOptions: [Object],
        options: [Object],
        '$implicitlyCreated': true,
        '$globalPluginsApplied': true,
        _requiredpaths: [] },
     '$isArraySubdocument': true,
     domain: undefined,
     _events: undefined,
     _maxListeners: undefined,
     setMaxListeners: [Function: setMaxListeners],
     getMaxListeners: [Function: getMaxListeners],
     emit: [Function: emit],
     addListener: [Function: addListener],
     on: [Function: addListener],
     prependListener: [Function: prependListener],
     once: [Function: once],
     prependOnceListener: [Function: prependOnceListener],
     removeListener: [Function: removeListener],
     removeAllListeners: [Function: removeAllListeners],
     listeners: [Function: listeners],
     listenerCount: [Function: listenerCount],
     eventNames: [Function: eventNames],
     options: { type: [Array] },
     path: 'instrument',
     '$appliedMethods': true,
     '$appliedHooks': true },
  caster:
   { [Function: EmbeddedDocument]
     schema:
      Schema {
        obj: [Object],
        paths: [Object],
        aliases: {},
        subpaths: {},
        virtuals: [Object],
        singleNestedPaths: {},
        nested: {},
        inherits: {},
        callQueue: [],
        _indexes: [],
        methods: {},
        methodOptions: {},
        statics: {},
        tree: [Object],
        query: {},
        childSchemas: [],
        plugins: [Array],
        s: [Object],
        _userProvidedOptions: [Object],
        options: [Object],
        '$implicitlyCreated': true,
        '$globalPluginsApplied': true,
        _requiredpaths: [] },
     '$isArraySubdocument': true,
     domain: undefined,
     _events: undefined,
     _maxListeners: undefined,
     setMaxListeners: [Function: setMaxListeners],
     getMaxListeners: [Function: getMaxListeners],
     emit: [Function: emit],
     addListener: [Function: addListener],
     on: [Function: addListener],
     prependListener: [Function: prependListener],
     once: [Function: once],
     prependOnceListener: [Function: prependOnceListener],
     removeListener: [Function: removeListener],
     removeAllListeners: [Function: removeAllListeners],
     listeners: [Function: listeners],
     listenerCount: [Function: listenerCount],
     eventNames: [Function: eventNames],
     options: { type: [Array] },
     path: 'instrument',
     '$appliedMethods': true,
     '$appliedHooks': true },
  '$isMongooseArray': true,
  path: 'instrument',
  instance: 'Array',
  validators: [],
  setters: [],
  getters: [],
  options: { type: [ [Object] ] },
  _index: null,
  defaultValue: [Function],
  schema:
   Schema {
     obj: { kind: [Function: String] },
     paths: { kind: [Object], _id: [Object] },
     aliases: {},
     subpaths: {},
     virtuals: { id: [Object] },
     singleNestedPaths: {},
     nested: {},
     inherits: {},
     callQueue: [],
     _indexes: [],
     methods: {},
     methodOptions: {},
     statics: {},
     tree: { kind: [Function: String], _id: [Object], id: [Object] },
     query: {},
     childSchemas: [],
     plugins: [ [Object], [Object], [Object], [Object], [Object] ],
     s: { hooks: [Object] },
     _userProvidedOptions: { minimize: true, typeKey: 'type', strict: true },
     options:
      { minimize: true,
        typeKey: 'type',
        strict: true,
        id: true,
        noVirtualId: false,
        _id: true,
        noId: false,
        validateBeforeSave: true,
        read: null,
        shardKey: null,
        autoIndex: null,
        discriminatorKey: '__t',
        versionKey: '__v',
        capped: false,
        bufferCommands: true },
     '$implicitlyCreated': true,
     '$globalPluginsApplied': true,
     _requiredpaths: [] },
  schemaOptions: {},
  '$isMongooseDocumentArray': true }
{ isNew: [Function: notify], save: [Function: notify] }
issues:
```
### Output after change:
```
issues: ./6572.js
{ _id: 5b1c01324b7ede7aed2e0cd5, kind: 'Sax' }
{ _id: 5b1c01324b7ede7aed2e0cd4, kind: 'Tenor Sax' }
issues:
```