### PR TITLE
Minimize docs about $unset update validation

### DIFF
--- a/test/docs/validation.test.js
+++ b/test/docs/validation.test.js
@@ -499,7 +499,7 @@ describe('validation docs', function() {
    * you try to explicitly `$unset` the key.
    */
 
-  it('Update Validator Paths', function(done) {
+  it('Update Validators Only Run On Updated Paths', function(done) {
     // acquit:ignore:start
     var outstanding = 2;
     // acquit:ignore:end
@@ -542,12 +542,14 @@ describe('validation docs', function() {
    * - `$pullAll` (>= 4.12.0)
    *
    * For instance, the below update will succeed, regardless of the value of
-   * `number`, because update validators ignore `$inc`. Also, `$push`,
-   * `$addToSet`, `$pull`, and `$pullAll` validation does **not** run any
-   * validation on the array itself, only individual elements of the array.
+   * `number`, because update validators ignore `$inc`.
+   *
+   * Also, `$push`, `$addToSet`, `$pull`, and `$pullAll` validation does
+   * **not** run any validation on the array itself, only individual elements
+   * of the array.
    */
 
-  it('Update Validators Only Run On Specified Paths', function(done) {
+  it('Update Validators Only Run For Some Operations', function(done) {
     var testSchema = new Schema({
       number: { type: Number, max: 0 },
       arr: [{ message: { type: String, maxlength: 10 } }]


### PR DESCRIPTION
The documentation about the caveats when using update validators (`runValidators`) is excellent.

But I found the section on `required` fields to be overkill, to the point of confusion.

It seems obvious to me that validation will not run on a field which we are not updating. In fact, that is covered by the next section, "Update Validators Only Run On Specified Paths".

So for the sake of brevity, I suggest removing that section. But I have preserved a paragraph that lets developers know that `$unset` does perform validation on required fields.