### PR TITLE
fixes #6589 add projection option to docs for findOneAnd{Remove,Delete}

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1915,6 +1915,7 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
  * - `select`: sets the document fields to return
+ * - `projection`: like select, it determines which fields to return, ex. `{ projection: { _id: 0 } }`
  * - `rawResult`: if true, returns the [raw result from the MongoDB driver](http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findAndModify)
  * - `strict`: overwrites the schema's [strict mode option](http://mongoosejs.com/docs/guide.html#strict) for this update
  *
@@ -2028,6 +2029,7 @@ Model.findByIdAndDelete = function(id, options, callback) {
  * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
  * - `select`: sets the document fields to return
+ * - `projection`: like select, it determines which fields to return, ex. `{ projection: { _id: 0 } }`
  * - `rawResult`: if true, returns the [raw result from the MongoDB driver](http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findAndModify)
  * - `strict`: overwrites the schema's [strict mode option](http://mongoosejs.com/docs/guide.html#strict) for this update
  *


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
Raised in #6589, projections is a valid option in the native driver. Both `findAndModify()` and `findOneAndDelete()` take the projection option. Adding this to the docs.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

make docclean && make gendocs && node static.js

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
