### PR TITLE
docs #6603 add undefined return to {model,doc}.save

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1931,7 +1931,7 @@ Document.prototype.$markValid = function(path) {
  * @method save
  * @memberOf Document
  * @instance
- * @return {Promise} Promise
+ * @return {Promise|undefined} Returns undefined if used with callback or a Promise otherwise.
  * @api public
  * @see middleware http://mongoosejs.com/docs/middleware.html
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -327,7 +327,7 @@ Model.prototype.$__save = function(options, callback) {
  * @param {Object} [options.safe] overrides [schema's safe option](http://mongoosejs.com//docs/guide.html#safe)
  * @param {Boolean} [options.validateBeforeSave] set to false to save without validating.
  * @param {Function} [fn] optional callback
- * @return {Promise|undefined} Returns undefined with callback or a Promise otherwise.
+ * @return {Promise|undefined} Returns undefined if used with callback or a Promise otherwise.
  * @api public
  * @see middleware http://mongoosejs.com/docs/middleware.html
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -327,7 +327,7 @@ Model.prototype.$__save = function(options, callback) {
  * @param {Object} [options.safe] overrides [schema's safe option](http://mongoosejs.com//docs/guide.html#safe)
  * @param {Boolean} [options.validateBeforeSave] set to false to save without validating.
  * @param {Function} [fn] optional callback
- * @return {Promise} Promise
+ * @return {Promise|undefined} Returns undefined with callback or a Promise otherwise.
  * @api public
  * @see middleware http://mongoosejs.com/docs/middleware.html
  */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Inspired by #6603, this change further codifies the return value of undefined when using `.save()` with a callback.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

make docclean && make gendocs && node static.js

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
