### PR TITLE
fixes #6612 - allow dynamic ref to handle >1 model getModelsMapForPopulate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3711,7 +3711,7 @@ function getModelsMapForPopulate(model, docs, options) {
       justOne = virtual.options.justOne;
       isVirtual = true;
       if (!modelNames) {
-        modelNames = [normalizedRef];
+        modelNames = [].concat(normalizedRef);
       }
     } else if (schema) {
       justOne = !schema.$isMongooseArray;

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -6996,8 +6996,8 @@ describe('model: populate:', function() {
 
       clickedSchema.virtual('users_$', {
         ref: function(doc) {
-          const refKeys = doc.events[0].users.map(user => user.refKey)
-          return refKeys
+          const refKeys = doc.events[0].users.map(user => user.refKey);
+          return refKeys;
         },
         localField: 'users.ID',
         foreignField: 'employeeId'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This fixes the issue reported in  https://github.com/Automattic/mongoose/issues/6612.

When a dynamic ref function returned an array containing more than 1 model, the ```getModelsMapForPopulate``` function was unable to find the correct model because the returned array was nested within ```modelNames```. When the tried to look up the model, it was unable to find a model that matches the entire array thus throwing an error.

This pull requests updates the logic so that the ```normalizedRef``` is concatenated instead to prevent nesting.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added a test which failed:

```
npm test -- -g 'gh-6612'

> mongoose@5.1.7-pre test /Users/mac/Documents/code/playground/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6612"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (497ms)
  1 failing

  1) model: populate:
       lean + deep populate (gh-6498)
         populates virtual of embedded discriminator with dynamic ref when more than one model name is returned (gh-6612):
     MissingSchemaError: Schema hasn't been registered for model "gh6612_Users,gh6612_Author".
Use mongoose.model(name, schema)
      at new MissingSchemaError (lib/error/missingSchema.js:20:11)
      at NativeConnection.Connection.model (lib/connection.js:717:11)
      at getModelsMapForPopulate (lib/model.js:3752:20)
      at populate (lib/model.js:3264:21)
      at _populate (lib/model.js:3234:5)
      at utils.promiseOrCallback.cb (lib/model.js:3207:5)
      at Object.promiseOrCallback (lib/utils.js:222:14)
      at Function.Model.populate (lib/model.js:3206:16)
      at model.Query.Query._completeOne (lib/query.js:1532:9)
      at Immediate.Query.base.findOne.call (lib/query.js:1569:10)
      at Immediate._onImmediate (node_modules/mquery/lib/utils.js:119:16)



npm ERR! Test failed.  See above for more details.
```

The test passed after the update
```
npm test -- -g 'gh-6612'

> mongoose@5.1.7-pre test /Users/mac/Documents/code/playground/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6612"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (476ms)
```

The full test suite passed as well:

```
npm test

> mongoose@5.1.7-pre test /Users/mac/Documents/code/playground/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1958 passing (1m)
  2 pending
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
