### PR TITLE
fixes #6611 set saving to undefined before emitting save

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -295,7 +295,7 @@ Model.prototype.$__save = function(options, callback) {
         });
       }
     }
-
+    this.$__.saving = undefined;
     this.emit('save', this, numAffected);
     this.constructor.emit('save', this, numAffected);
     callback(null, this);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5474,5 +5474,27 @@ describe('Model', function() {
       test.save().then(handler);
       test.save().catch(error);
     });
+    it('allows calling save in a post save hook (gh-6611)', function() {
+      let called = 0;
+      const noteSchema = new Schema({
+        body: String
+      });
+
+      noteSchema.post('save', function(note) {
+        if (!called) {
+          called++;
+          note.body = 'a note, part deux.';
+          return note.save();
+        }
+      });
+
+
+      const Note = db.model('gh6611', noteSchema);
+      return co(function*() {
+        yield Note.create({ body: 'a note.' });
+        let doc = yield Note.findOne({});
+        assert.strictEqual(doc.body, 'a note, part deux.');
+      });
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As demonstrated in #6611, calling save in a post save hook currently throws a parallel save error. This change allows calling save from within a post save hook.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

made a failing test, made it pass, verified all current tests pass:
```
mongoose>: npm test -- -g 'gh-6611'

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6611"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (505ms)
  1 failing

  1) Model
       bug fixes
         allows calling save in a post save hook (gh-6611):
     Uncaught ParallelSaveError: Can't save() the same doc multiple times in parallel. Document: 5b2e26c6a4d63813a90483b7
      at ParallelSaveError.MongooseError [as constructor] (lib/error/mongooseError.js:11:11)
      at new ParallelSaveError (lib/error/parallelSave.js:18:17)
      at model.Model.save (lib/model.js:342:23)
      at toExecute.push.callback (lib/model.js:2244:16)
      at node_modules/async/internal/parallel.js:31:39
      at eachOfArrayLike (node_modules/async/eachOf.js:65:9)
      at exports.default (node_modules/async/eachOf.js:9:5)
      at _parallel (node_modules/async/internal/parallel.js:30:5)
      at parallelLimit (node_modules/async/parallel.js:88:26)
      at utils.promiseOrCallback.cb (lib/model.js:2248:5)
      at Promise (lib/utils.js:233:5)
      at new Promise (<anonymous>)
      at Object.promiseOrCallback (lib/utils.js:232:10)
      at Function.create (lib/model.js:2209:16)
      at Context.<anonymous> (test/model.test.js:5492:12)



npm ERR! Test failed.  See above for more details.
mongoose>:
mongoose>: npm test -- -g 'gh-6611'

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6611"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (533ms)
  1 failing

  1) Model
       bug fixes
         allows calling save in a post save hook (gh-6611):

      AssertionError [ERR_ASSERTION]: 'a note, part deux.' === 'a note, part 2.'
      + expected - actual

      -a note, part deux.
      +a note, part 2.

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as strictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/model.test.js:5496:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6611'

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6611"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (538ms)

mongoose>: npm test

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․

  1958 passing (33s)
  2 pending

mongoose>: lint
lib/model.js
test/model.test.js
mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
### Output of 6611.js before change:
```
issues: ./6611.js
{ ParallelSaveError: Can't save() the same doc multiple times in parallel. Document: 5b2e11ae369d8b0b10b7be91
    at ParallelSaveError.MongooseError [as constructor] (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/error/mongooseError.js:11:11)
    at new ParallelSaveError (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/error/parallelSave.js:18:17)
    at model.Model.save (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/model.js:342:23)
    at toExecute.push.callback (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/model.js:2244:16)
    at /Users/lineus/dev/Help/mongoose5/node_modules/async/internal/parallel.js:31:39
    at eachOfArrayLike (/Users/lineus/dev/Help/mongoose5/node_modules/async/eachOf.js:65:9)
    at exports.default (/Users/lineus/dev/Help/mongoose5/node_modules/async/eachOf.js:9:5)
    at _parallel (/Users/lineus/dev/Help/mongoose5/node_modules/async/internal/parallel.js:30:5)
    at parallelLimit (/Users/lineus/dev/Help/mongoose5/node_modules/async/parallel.js:88:26)
    at utils.promiseOrCallback.cb (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/model.js:2248:5)
    at Object.promiseOrCallback (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/utils.js:222:14)
    at Function.create (/Users/lineus/dev/Help/mongoose5/node_modules/mongoose/lib/model.js:2209:16)
    at Object.<anonymous> (/Users/lineus/dev/Help/mongoose5/issues/6611.js:31:6)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
  message: 'Can\'t save() the same doc multiple times in parallel. Document: 5b2e11ae369d8b0b10b7be91',
  name: 'ParallelSaveError' }
[]
^C
issues:
```
### Output of 6611.js after change:
```
issues: ./6611.js
^C
issues:
```