### PR TITLE
fixes #6546 ignore populated paths not included in inclusive selection

### DIFF
--- a/lib/services/query/selectPopulatedFields.js
+++ b/lib/services/query/selectPopulatedFields.js
@@ -13,7 +13,8 @@ module.exports = function selectPopulatedFields(query) {
     var userProvidedFields = query._userProvidedFields || {};
     if (query.selectedInclusively()) {
       for (i = 0; i < paths.length; ++i) {
-        if (!isPathInFields(userProvidedFields, paths[i])) {
+        var hasPath = query._fields[paths[i]];
+        if (!isPathInFields(userProvidedFields, paths[i]) && hasPath) {
           query.select(paths[i]);
         }
       }

--- a/test/services.query.test.js
+++ b/test/services.query.test.js
@@ -54,5 +54,26 @@ describe('Query helpers', function() {
 
       done();
     });
+
+    it('ignores populated paths not inclusively selected (gh-6546)', function(done) {
+      var schema = new Schema({
+        one: String,
+        two: String
+      });
+
+      var q = new Query({});
+      q.schema = schema;
+
+      assert.strictEqual(q._fields, void 0);
+
+      q.select('one');
+      q.populate('two');
+      assert.deepEqual(q._fields, { one: 1 });
+
+      selectPopulatedFields(q);
+
+      assert.deepEqual(q._fields, { one: 1 });
+      done();
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As demonstrated in #6546, if you populate a path that isn't a member of the inclusively selected paths, selectPopulatedFields will add that path to the selected fields. This change adds a check for this condition before adding the populate path.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a failing test, made it pass, all current tests pass
```
mongoose>: npm test -- -g 'gh-6546'

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6546"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (119ms)
  1 failing

  1) Query helpers
       selectPopulatedFields
         only adds selected paths when selecting paths inclusively (gh-6546):

      AssertionError [ERR_ASSERTION]: { one: 1, two: 1 } deepEqual { one: 1 }
      + expected - actual

       {
         "one": 1
      -  "two": 1
       }

      at Context.<anonymous> (test/services.query.test.js:76:14)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6546'

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6546"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (118ms)

mongoose>:
mongoose>: npm test

> mongoose@5.1.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․

  1958 passing (33s)
  2 pending

mongoose>:
```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
### output of 6546.js before change:
```
issues: ./6546.js
result { _id: 5b2f7af1677d9f0f3adc0428,
  title: 'test',
  inner: { _id: 5b2f7af1677d9f0f3adc0427, title: 'inner' } }
issues:
```
### output of 6546.js after change:
```
issues: ./6546.js
result { _id: 5b2f93d7c416b419a67e8b07, title: 'test' }
issues:
```