### PR TITLE
fix for TypeError being thrown when calling save() more than once if the object being saved has atomics

### DIFF
--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -248,7 +248,11 @@ MongooseDocumentArray.mixin = {
 
   toObject: function(options) {
     return this.map(function(doc) {
-      return doc && doc.toObject(options) || null;
+      try {
+        return doc.toObject(options);
+      } catch (e) {
+        return doc || null;
+      }
     });
   },
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3729,6 +3729,38 @@ describe('Model', function() {
         done();
       });
     });
+
+    it('no TypeError when attempting to save more than once after using atomics', function(done) {
+      const M = db.model('M', new Schema({
+        test: {type: 'string', unique: true},
+        elements: [{
+          el: {type: 'string', required: true}
+        }]
+      }));
+      const a = new M({
+        test: 'a',
+        elements: [{el: 'b'}]
+      });
+      const b = new M({
+        test: 'b',
+        elements: [{el: 'c'}]
+      });
+      a.save(function() {
+        b.save(function() {
+          b.elements.push({el: 'd'});
+          b.test = 'a';
+          b.save(function(error,res) {
+            assert.strictEqual(error.message,'E11000 duplicate key error collection: mongoose_test.ms index: test_1 dup key: { : "a" }');
+            assert.strictEqual(res,undefined);
+            b.save(function(error,res) {
+              assert.strictEqual(error.message,'E11000 duplicate key error collection: mongoose_test.ms index: test_1 dup key: { : "a" }');
+              assert.strictEqual(res,undefined);
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3750,10 +3750,10 @@ describe('Model', function() {
           b.elements.push({el: 'd'});
           b.test = 'a';
           b.save(function(error,res) {
-            assert.strictEqual(error.message,'E11000 duplicate key error collection: mongoose_test.ms index: test_1 dup key: { : "a" }');
+            assert.strictEqual(!error,false);
             assert.strictEqual(res,undefined);
             b.save(function(error,res) {
-              assert.strictEqual(error.message,'E11000 duplicate key error collection: mongoose_test.ms index: test_1 dup key: { : "a" }');
+              assert.strictEqual(!error,false);
               assert.strictEqual(res,undefined);
               done();
             });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

fix for issue #6635 , if an object had atomics and calling save() on that object failed for some reason, the atomics array of EmbeddedDocuments would already have been converted to POJOs.  So if you tried to save it again it would try to call .toObject() on the POJO which would throw a TypeError.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Reran @dbellavista gist located here: https://gist.github.com/dbellavista/46df766acc09695f448be339ca96632e

Wrote a new test: 'no TypeError when attempting to save more than once after using atomics':
```
it('no TypeError when attempting to save more than once after using atomics', function(done) {
      const M = db.model('M', new Schema({
        test: {type: 'string', unique: true},
        elements: [{
          el: {type: 'string', required: true}
        }]
      }));
      const a = new M({
        test: 'a',
        elements: [{el: 'b'}]
      });
      const b = new M({
        test: 'b',
        elements: [{el: 'c'}]
      });
      a.save(function() {
        b.save(function() {
          b.elements.push({el: 'd'});
          b.test = 'a';
          b.save(function(error,res) {
            assert.strictEqual(!error,false);
            assert.strictEqual(res,undefined);
            b.save(function(error,res) {
              assert.strictEqual(!error,false);
              assert.strictEqual(res,undefined);
              done();
            });
          });
        });
      });
    });
```
Built it with Travis CI on my fork. Had a couple intermittent failures, mostly for timeouts, but they passed when run locally and on a rebuild. Link to build status: https://travis-ci.org/evanhenke/mongoose/
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
