### PR TITLE
fixes #6651 dont use newUrlParser until next driver update

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -433,7 +433,7 @@ Connection.prototype.openUri = function(uri, options, callback) {
   if (!('promiseLibrary' in options)) {
     options.promiseLibrary = PromiseProvider.get();
   }
-  options.useNewUrlParser = true;
+  options.useNewUrlParser = false;
 
   const parsePromise = new Promise((resolve, reject) => {
     parseConnectionString(uri, options, (err, parsed) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

as demonstrated in #6651, #6648, #6649 and addressed in  https://github.com/mongodb/node-mongodb-native/pull/1771 the new url parser is broken for the moment. this PR forces useNewUrlParser to false.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

all current tests pass ( minus deprecation warnings )

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
[update] removed 6647 from above list as I'm not certain the new url parser will *ever* add the default port implicitly. 