### PR TITLE
 add ability to define refPath as a function

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3990,8 +3990,16 @@ function getModelsMapForPopulate(model, docs, options) {
 
     refPath = schema && schema.options && schema.options.refPath;
 
-    if (refPath) {
-      modelNames = utils.getValue(refPath, doc);
+    let normalizedRefPath;
+
+    if (refPath && typeof refPath === 'function') {
+      normalizedRefPath = refPath.call(doc, doc, options.path);
+    } else {
+      normalizedRefPath = refPath;
+    }
+
+    if (normalizedRefPath) {
+      modelNames = utils.getValue(normalizedRefPath, doc);
       isRefPathArray = false;
       if (Array.isArray(modelNames)) {
         isRefPathArray = true;


### PR DESCRIPTION
As demonstrated in #6669, if you want to reuse a subSchema with a refPath in multiple parent schemaPaths, making the refPath variable requires some gymnastics. This change allows refPath to accept a function that receives the current path as it's 2nd parameter which allows us to dynamically generate the dynamic ref. I included the first parameter as doc in anticipation of folks who use arrow functions that need access to the doc. 

added a failing test, made it pass, all current tests pass.
```
mongoose>: npm test -- -g 'gh-6669'

> mongoose@5.2.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6669"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7487) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (617ms)
  1 failing

  1) model: populate:
       github issues
         populate virtuals (gh-2562)
           with function for refPath (gh-6669):

      AssertionError [ERR_ASSERTION]: '192.168.1.15' === '192.168.1.1'
      + expected - actual

      -192.168.1.15
      +192.168.1.1

      at test/model.populate.test.js:4768:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6669'

> mongoose@5.2.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6669"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7527) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (575ms)
  1 failing

  1) model: populate:
       github issues
         populate virtuals (gh-2562)
           with function for refPath (gh-6669):

      AssertionError [ERR_ASSERTION]: 'Kev' === 'Ke'
      + expected - actual

      -Kev
      +Ke

      at test/model.populate.test.js:4769:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6669'

> mongoose@5.2.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6669"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7555) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (587ms)
  1 failing

  1) model: populate:
       github issues
         populate virtuals (gh-2562)
           with function for refPath (gh-6669):

      AssertionError [ERR_ASSERTION]: 'chrome' === 'chrom'
      + expected - actual

      -chrome
      +chrom

      at test/model.populate.test.js:4770:18
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>:
mongoose>: npm test

> mongoose@5.2.2-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7740) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․MongoError: password must be a string
    at passwordDigest (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/auth/scram.js:62:43)
    at ScramSHA1.ScramSHA.auth (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/auth/scram.js:174:25)
    at authenticate (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/connection/pool.js:231:17)
    at authenticateLiveConnections (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/connection/pool.js:818:7)
    at /Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/connection/pool.js:863:5
    at waitForLogout (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/connection/pool.js:854:34)
    at Pool.auth (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/connection/pool.js:861:3)
    at Server.auth (/Users/lineus/dev/opc/mongoose/node_modules/mongodb-core/lib/topologies/server.js:955:20)
    at Server.auth (/Users/lineus/dev/opc/mongoose/node_modules/mongodb/lib/topologies/topology_base.js:379:30)
    at authenticate (/Users/lineus/dev/opc/mongoose/node_modules/mongodb/lib/authenticate.js:72:21)
    at module.exports (/Users/lineus/dev/opc/mongoose/node_modules/mongodb/lib/authenticate.js:118:12)
    at /Users/lineus/dev/opc/mongoose/node_modules/mongodb/lib/operations/mongo_client_ops.js:256:5
    at servers.(anonymous function).connect (/Users/lineus/dev/opc/mongoose/node_modules/mongodb/lib/operations/mongo_client_ops.js:364:5)
    at Server.connectHandler (/Users/lineus/dev/opc/mongoose/node_modules/mongodb/lib/topologies/server.js:298:9)
    at Object.onceWrapper (events.js:315:30)
    at emitOne (events.js:116:13)
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․(node:7740) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  1978 passing (33s)
  2 pending

mongoose>:
```

See the output of the first code sample [in this comment](https://github.com/Automattic/mongoose/issues/6669#issuecomment-403016173) to see that it works as expected.