### PR TITLE
fix existing faq for array-defaults 

### DIFF
--- a/docs/faq.jade
+++ b/docs/faq.jade
@@ -297,12 +297,24 @@ block content
     **Q**. How can I change mongoose's default behavior of initializing an array
     path to an empty array so that I can require real data on document creation?
 
-    **A**. You can set the default of the array to a function that returns null.
+    **A**. You can set the default of the array to a function that returns `undefined`.
     ```javascript
     const CollectionSchema = new Schema({
       field1: {
         type: [String],
         default: void 0
+      }
+    });
+    ```
+
+    **Q**. How can I initialize an array path to `null`?
+
+    **A**. You can set the default of the array to a function that returns null.
+    ```javascript
+    const CollectionSchema = new Schema({
+      field1: {
+        type: [String],
+        default: () => { return null; }
       }
     });
     ```

--- a/docs/faq.jade
+++ b/docs/faq.jade
@@ -309,7 +309,7 @@ block content
 
     **Q**. How can I initialize an array path to `null`?
 
-    **A**. You can set the default of the array to a function that returns null.
+    **A**. You can set the default of the array to a function that returns `null`.
     ```javascript
     const CollectionSchema = new Schema({
       field1: {


### PR DESCRIPTION

Currently the FAQ says `You can set the default of the array to a function that returns null` but the example returns undefined. I think it would be useful to have both distinct possibilities in the FAQ.

make docclean && make gendoc && node static

![screen shot 2018-07-08 at 8 21 07 am](https://user-images.githubusercontent.com/6015453/42419688-f05558e0-8287-11e8-8a91-11ec90dd1f7e.png)
