### PR TITLE
if a getter is defined on the localField, use it when populating

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3944,7 +3944,7 @@ function getModelsMapForPopulate(model, docs, options) {
     let ret;
 
     if (localFieldGetters.length) {
-      ret = localFieldGetters[0].call(doc, doc[localField]);
+      ret = localFieldPath.applyGetters(doc[localField], doc);
     } else {
       ret = convertTo_id(utils.getValue(localField, doc));
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3939,7 +3939,16 @@ function getModelsMapForPopulate(model, docs, options) {
       foreignField = foreignField.call(doc);
     }
 
-    const ret = convertTo_id(utils.getValue(localField, doc));
+    const localFieldPath = modelSchema.paths[localField];
+    const localFieldGetters = localFieldPath ? localFieldPath.getters : [];
+    let ret;
+
+    if (localFieldGetters.length) {
+      ret = localFieldGetters[0].call(doc, doc[localField]);
+    } else {
+      ret = convertTo_id(utils.getValue(localField, doc));
+    }
+
     const id = String(utils.getValue(foreignField, doc));
     options._docs[id] = Array.isArray(ret) ? ret.slice() : ret;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

As demonstrated in #6618, if a getter is defined on the path used in a population, that getter isn't called during population. This change calls the getter, thereby using the potentially mutated value in the subsequent find query to retrieve the foreign doc.

@vkarpov15 This part of the change feels wrong to me:
```
    ret = localFieldGetters[0].call(doc, doc[localField]);
```
I've never seen a situation where a path had multiple getters defined, is it safe to always call the first getter in this case?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Made a failing test, made it pass, all existing tests pass:
```
mongoose>: npm test -- -g 'gh-6618'

> mongoose@5.2.2 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6618"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7307) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (590ms)
  1 failing

  1) model: populate:
       lean + deep populate (gh-6498)
         uses getter if one is defined on the localField (gh-6618):
     CastError: Cast to ObjectId failed for value "Model$5b43679362a93d1c8bd8e316" at path "_id" for model "gh6618_user"
      at new CastError (lib/error/cast.js:29:11)
      at ObjectId.cast (lib/schema/objectid.js:158:13)
      at ObjectId.SchemaType.applySetters (lib/schematype.js:724:12)
      at ObjectId.SchemaType._castForQuery (lib/schematype.js:1113:15)
      at ObjectId.SchemaType.castForQuery (lib/schematype.js:1103:15)
      at lib/schematype.js:1052:18
      at Array.map (<anonymous>)
      at ObjectId.handle$in (lib/schematype.js:1048:14)
      at ObjectId.SchemaType.castForQuery (lib/schematype.js:1100:20)
      at ObjectId.SchemaType.castForQueryWrapper (lib/schematype.js:1077:17)
      at cast (lib/cast.js:284:39)
      at model.Query.Query.cast (lib/query.js:3586:12)
      at model.Query.Query._castConditions (lib/query.js:1392:10)
      at model.Query.Query._find (lib/query.js:1407:8)
      at process.nextTick (node_modules/kareem/index.js:333:33)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6618'

> mongoose@5.2.2 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6618"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7342) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․

  1 passing (550ms)

mongoose>: npm test

> mongoose@5.2.2 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7363) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․(node:7363) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead
․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․

  1984 passing (33s)
  4 pending

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### The Output of the repro script in 6618.js becomes
```
issues: ./6618.js
{ _id: 5b436561d05f351b4726e4c3,
  referrer: 'Model$5b436561d05f351b4726e4c2',
  __v: 0,
  referrerUser: [ { _id: 5b436561d05f351b4726e4c2, name: 'billy', __v: 0 } ],
  id: '5b436561d05f351b4726e4c3' }
issues:
```