### PR TITLE
fixes #6726 pass Model instance as context to applyGetters

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3948,7 +3948,7 @@ function getModelsMapForPopulate(model, docs, options) {
     let ret;
 
     if (localFieldGetters.length) {
-      ret = localFieldPath.applyGetters(doc[localField], doc);
+      ret = localFieldPath.applyGetters(doc[localField], model.hydrate(doc));
     } else {
       ret = convertTo_id(utils.getValue(localField, doc));
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3948,7 +3948,8 @@ function getModelsMapForPopulate(model, docs, options) {
     let ret;
 
     if (localFieldGetters.length) {
-      ret = localFieldPath.applyGetters(doc[localField], model.hydrate(doc));
+      let hydratedDoc = (doc.$__ != null) ? doc : model.hydrate(doc);
+      ret = localFieldPath.applyGetters(doc[localField], hydratedDoc);
     } else {
       ret = convertTo_id(utils.getValue(localField, doc));
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

#6726 shows that the value of `this` in the path getter from #6702 isn't a Model instance. I couldn't find precedent for calling `hydrate` in this context, but this was best solution I could come up with. I'll sleep on it and take another look in the morning. If this isn't as off the wall as it feels....

I added a failing test, made it pass, all current tests pass.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

```
mongoose>: npm test -- -g gh-6726

> mongoose@5.2.4-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6726"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:20855) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (593ms)
  1 failing

  1) model: populate:
       lean + deep populate (gh-6498)
         passes scope as Model instance (gh-6726):

      Uncaught AssertionError [ERR_ASSERTION]: 'Object' === 'model'
      + expected - actual

      -Object
      +model

      at Object.get (test/model.populate.test.js:7142:20)
      at ObjectId.SchemaType.applyGetters (lib/schematype.js:747:20)
      at getModelsMapForPopulate (lib/model.js:3951:28)
      at populate (lib/model.js:3473:21)
      at _populate (lib/model.js:3443:5)
      at utils.promiseOrCallback.cb (lib/model.js:3416:5)
      at Object.promiseOrCallback (lib/utils.js:222:14)
      at Function.Model.populate (lib/model.js:3415:16)
      at model.Query.Query._completeOne (lib/query.js:1727:9)
      at Immediate.Query.base.findOne.call (lib/query.js:1764:10)
      at Immediate._onImmediate (node_modules/mquery/lib/utils.js:119:16)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6726

> mongoose@5.2.4-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6726"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:20898) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (552ms)
  1 failing

  1) model: populate:
       lean + deep populate (gh-6498)
         passes scope as Model instance (gh-6726):

      AssertionError [ERR_ASSERTION]: 'Max' === 'Min'
      + expected - actual

      -Max
      +Min

      at test/model.populate.test.js:7154:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6726

> mongoose@5.2.4-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6726"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:20945) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․

  1 passing (550ms)

mongoose>: npm test

> mongoose@5.2.4-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:20973) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․(node:20973) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead
․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․

  1990 passing (33s)
  4 pending

mongoose>: 
```
### 6726.js
```js
#!/usr/bin/env node
'use strict';

const mongoose = require('mongoose');
mongoose.connect('mongodb://localhost:27017/test', { useNewUrlParser: true });
const conn = mongoose.connection;


const BarSchema = new mongoose.Schema({});
const Bar = mongoose.model('Bar', BarSchema);

const FooSchema = new mongoose.Schema({
  bar: {
    type: mongoose.Schema.Types.ObjectId,
    ref: 'Bar',
    get(value) {
      console.log(this.constructor.name); // sometimes it prints `model`, sometimes `Object` 
      return value;
    },
  },
});

const Foo = mongoose.model('Foo', FooSchema);
const bar = new Bar();
const foo = new Foo({ bar: bar });

async function run() {
  await bar.save();
  await foo.save();
  const fooWithPopulate = await Foo.find({ _id: foo._id }).populate('bar');
  fooWithPopulate.bar;
  return conn.close();
}

run();
```
### The output of 6726.js before change:
```
issues: ./6726.js
model
model
Object
issues:
```

### The output of 6726.js after change:
```
issues: ./6726.js
model
model
model
issues:
```