### PR TITLE
fixes #6738 adding a test to cover $set with positional syntax on nested mixed paths

### DIFF
--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1608,6 +1608,19 @@ describe('document', function() {
           done();
         });
 
+        it('allows positional syntax on mixed nested paths (gh-6738)', function() {
+          var schema = new Schema({ nested: {} });
+          var M = mongoose.model('gh6738', schema);
+          var doc = new M({
+            'nested.x': 'foo',
+            'nested.y': 42,
+            'nested.a.b.c': { d: { e: { f: 'g' } } }
+          });
+          assert.strictEqual(doc.nested.x, 'foo');
+          assert.strictEqual(doc.nested.y, 42);
+          assert.strictEqual(doc.nested.a.b.c.d.e.f, 'g');
+        });
+
         it('gh-1954', function(done) {
           var schema = new Schema({
             schedule: [new Schema({open: Number, close: Number})]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

In 5.1.3 changes were made to `$set` to allow positional syntax for embedded discriminators. As #6738 demonstrates, this also affected nested Mixed schema paths (**in a good way**). This change adds a test for a nested Mixed path to ensure that the behavior remains consistent going forward.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a failing test, made it pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```
mongoose>: npm test -- -g gh-6738

> mongoose@5.2.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6738"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:3620) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (146ms)
  1 failing

  1) document
       setter
         on nested paths
           using set(path, object)
             allows positional syntax on mixed nested paths (gh-6738):

      AssertionError [ERR_ASSERTION]: 'foo' === 'foO'
      + expected - actual

      -foo
      +foO

      at Context.<anonymous> (test/document.test.js:1619:18)



npm ERR! Test failed.  See above for more details.

mongoose>: npm test -- -g gh-6738

> mongoose@5.2.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6738"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:3725) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (141ms)
  1 failing

  1) document
       setter
         on nested paths
           using set(path, object)
             allows positional syntax on mixed nested paths (gh-6738):

      AssertionError [ERR_ASSERTION]: 42 === 43
      + expected - actual

      -42
      +43

      at Context.<anonymous> (test/document.test.js:1620:18)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6738

> mongoose@5.2.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6738"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:3751) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (143ms)
  1 failing

  1) document
       setter
         on nested paths
           using set(path, object)
             allows positional syntax on mixed nested paths (gh-6738):

      AssertionError [ERR_ASSERTION]: 'g' === 'G'
      + expected - actual

      -g
      +G

      at Context.<anonymous> (test/document.test.js:1621:18)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g gh-6738

> mongoose@5.2.5-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6738"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:3771) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․

  1 passing (139ms)

mongoose>:
```