### PR TITLE
Prefix mongoose.Schema call with new operator

### DIFF
--- a/docs/index.jade
+++ b/docs/index.jade
@@ -56,7 +56,7 @@ block content
     Let's get a reference to it and define our kittens.
 
     ```javascript
-    var kittySchema = mongoose.Schema({
+    var kittySchema = new mongoose.Schema({
       name: String
     });
     ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Whilst the existing code works, I thought maybe since `Schema` is a constructor, it makes sense to use the `new` operator. It also seems more consistent with other examples in the documentation :)

**Test Plan**
I don't think this requires any tests ?