### PR TITLE
Fix #6785 and propagate readConcern options in populate from parent query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3734,11 +3734,17 @@ Query.prototype.populate = function() {
 
   const res = utils.populate.apply(null, arguments);
 
-  // Propagate readPreference and lean from parent query, unless one already
-  // specified
+  // Propagate readConcern and readPreference and lean from parent query,
+  // unless one already specified
   if (this.options != null) {
+    const readConcern = this.options.readConcern;
     const readPref = this.options.readPreference;
+
     for (let i = 0; i < res.length; ++i) {
+      if (readConcern != null && get(res[i], 'options.readConcern') == null) {
+        res[i].options = res[i].options || {};
+        res[i].options.readConcern = readConcern;
+      }
       if (readPref != null && get(res[i], 'options.readPreference') == null) {
         res[i].options = res[i].options || {};
         res[i].options.readPreference = readPref;

--- a/lib/query.js
+++ b/lib/query.js
@@ -849,8 +849,6 @@ Query.prototype.mod = function() {
  *     query.select({ a: 1, b: 1 });
  *     query.select({ c: 0, d: 0 });
  *
- *     // force inclusion of field excluded at schema level
- *     query.select('+path')
  *
  * @method select
  * @memberOf Query


### PR DESCRIPTION
Fix #6785 select fields starting with `+` is not working as described See #6785 
Also propagate readConcern options from parent query like readPreference does in #5460