### PR TITLE
Fixes #6768 don't use $each when pushing an array into an array

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -257,7 +257,9 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
         }
 
         if (Array.isArray(obj[key]) && (op === '$addToSet' || op === '$push') && key !== '$each') {
-          obj[key] = { $each: obj[key] };
+          if (schematype.caster && !schematype.caster.$isMongooseArray) {
+            obj[key] = { $each: obj[key] };
+          }
         }
 
         if (options.omitUndefined && obj[key] === void 0) {

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -2849,6 +2849,28 @@ describe('model: update:', function() {
         });
     });
 
+    it('doesn\'t add $each when pushing an array into an array (gh-6768)', function() {
+      const schema = new Schema({
+        arr: [[String]]
+      });
+
+      const Test = db.model('gh6768', schema);
+
+      const test = new Test;
+
+      return co(function*() {
+        yield test.save();
+        let cond = { _id: test._id };
+        let data = ['one', 'two'];
+        let update = { $push: { arr: data } };
+        let opts = { new: true };
+        let doc = yield Test.findOneAndUpdate(cond, update, opts);
+        assert.strictEqual(doc.arr.length, 1);
+        assert.strictEqual(doc.arr[0][0], 'one');
+        assert.strictEqual(doc.arr[0][1], 'two');
+      });
+    });
+
     it('casting embedded discriminators if path specified in filter (gh-5841)', function() {
       return co(function*() {
         const sectionSchema = new Schema({ show: Boolean, order: Number },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

as demonstrated in #6768, when $push-ing an array into a multidimensional array, the $each should not be implicitly added. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a failing test, made it pass, all current tests pass:
```
mongoose>: npm test -- -g 'gh-6768'

> mongoose@5.2.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6768"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7202) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (587ms)
  1 failing

  1) model: update:
       bug fixes
         doesn't add $each when pushing an array into an array (gh-6768):

      AssertionError [ERR_ASSERTION]: 2 === 1
      + expected - actual

      -2
      +1

      at test/model.update.test.js:2868:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6768'

> mongoose@5.2.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6768"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7300) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․

  1 passing (582ms)

mongoose>: npm test

> mongoose@5.2.7-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:7481) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. Touse the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․(node:7481) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,․․․․․․․․․
  ․․․․․․․․․․․․

  2004 passing (32s)
  9 pending

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

the following test script fails on 5.2.6
### 6768.js
```js
#!/usr/bin/env node
'use strict';

const assert = require('assert');
const mongoose = require('mongoose');
mongoose.connect('mongodb://localhost:27017/test', { useNewUrlParser: true });
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const schema = new Schema({
  arr: [[String]]
});

const Test = mongoose.model('test', schema);

const test = new Test;

async function run() {
  await conn.dropDatabase();
  await test.save();
  let cond = { _id: test._id };
  let data = ['one', 'two'];
  let update = { $push: { arr: data } };
  await Test.findOneAndUpdate(cond, update);
  let doc = await Test.findOne({});
  assert.strictEqual(doc.arr.length, 1);
  assert.strictEqual(doc.arr[0][0], 'one');
  assert.strictEqual(doc.arr[0][1], 'two');
  return conn.close();
}

run().catch((e) => {
  console.error(e);
  return conn.close();
});
```
### Ouput before change:
```
issues: ./6768.js
{ AssertionError [ERR_ASSERTION]: 2 === 1
    at run (/Users/lineus/dev/Help/mongoose5/issues/6768.js:26:10)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
  generatedMessage: true,
  name: 'AssertionError [ERR_ASSERTION]',
  code: 'ERR_ASSERTION',
  actual: 2,
  expected: 1,
  operator: '===' }
issues:
```
### Output after change:
```
issues: ./6768.js
issues:
```