### PR TITLE
feat(model): support options in `deleteMany`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1480,19 +1480,26 @@ Model.deleteOne = function deleteOne(conditions, callback) {
  * Like `Model.remove()`, this function does **not** trigger `pre('remove')` or `post('remove')` hooks.
  *
  * @param {Object} conditions
+ * @param {Object} [options] optional see [`Query.prototype.setOptions()`](http://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback]
  * @return {Query}
  * @api public
  */
 
-Model.deleteMany = function deleteMany(conditions, callback) {
+Model.deleteMany = function deleteMany(conditions, options, callback) {
   if (typeof conditions === 'function') {
     callback = conditions;
     conditions = {};
+    options = null;
+  }
+  else if (typeof options === 'function') {
+    callback = options;
+    options = null;
   }
 
   // get the mongodb collection object
   var mq = new this.Query(conditions, {}, this, this.collection);
+  mq.setOptions(options);
 
   if (callback) {
     callback = this.$wrapCallback(callback);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4823,7 +4823,32 @@ describe('Model', function() {
         assert.equal(postCalled, 0);
         assert.equal(postErrorCalled, 1);
       });
+    });
 
+    it('deleteMany() with options (gh-6805)', function(done) {
+      var schema = new Schema({
+        name: String
+      });
+      var Character = db.model('gh6805', schema);
+
+      var arr = [
+        { name: 'Tyrion Lannister' },
+        { name: 'Cersei Lannister' },
+        { name: 'Jon Snow' },
+        { name: 'Daenerys Targaryen' }
+      ];
+      Character.insertMany(arr, function(err, docs) {
+        assert.ifError(err);
+        assert.equal(docs.length, 4);
+        Character.deleteMany({ name: /Lannister/ }, { w: 1 }, function(err) {
+          assert.ifError(err);
+          Character.find({}, function(err, docs) {
+            assert.ifError(err);
+            assert.equal(docs.length, 2);
+            done();
+          });
+        });
+      });
     });
 
     describe('3.6 features', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

1. `insertMany` and `updateMany` support options parameter, so I think `deleteMany` should support too to avoid confusion
2. This will also fix #6805

**Test plan**

Tests are included in the `test/model.test.js` and `test/docs/transaction.test.js`

```sh
╭─Fonger@Fongers-Macbook  ~/opensource/mongoose  ‹delete-many-options›
╰─$ mocha test/docs/transactions.test.js                                    1 ↵

(node:31830) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․․․․․․․․

  8 passing (1s)
```

Locally passed