### PR TITLE
test(model): add delay to session tests to improve pass rate

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4908,6 +4908,7 @@ describe('Model', function() {
 
       describe('sessions (gh-6362)', function() {
         let MyModel;
+        let delay = ms => done => setTimeout(done, ms);
 
         before(function(done) {
           MyModel = db.model('gh6362', new Schema({ name: String }));
@@ -4963,12 +4964,16 @@ describe('Model', function() {
 
             let lastUse = session.serverSession.lastUse;
 
+            yield delay(1);
+
             let doc = yield MyModel.findOne({}, null, { session });
             assert.strictEqual(doc.$__.session, session);
             assert.strictEqual(doc.$session(), session);
 
             assert.ok(session.serverSession.lastUse > lastUse);
             lastUse = session.serverSession.lastUse;
+
+            yield delay(1);
 
             doc = yield MyModel.findOneAndUpdate({}, { name: 'test2' },
               { session: session });
@@ -4977,6 +4982,8 @@ describe('Model', function() {
 
             assert.ok(session.serverSession.lastUse > lastUse);
             lastUse = session.serverSession.lastUse;
+
+            yield delay(1);
 
             doc.name = 'test3';
 
@@ -4996,6 +5003,8 @@ describe('Model', function() {
 
             let lastUse = session.serverSession.lastUse;
 
+            yield delay(1);
+
             let docs = yield MyModel.find({ _id: doc._id }, null,
               { session: session });
             assert.equal(docs.length, 1);
@@ -5004,6 +5013,8 @@ describe('Model', function() {
 
             assert.ok(session.serverSession.lastUse > lastUse);
             lastUse = session.serverSession.lastUse;
+
+            yield delay(1);
 
             docs[0].name = 'test3';
 
@@ -5023,10 +5034,14 @@ describe('Model', function() {
 
             let lastUse = session.serverSession.lastUse;
 
+            yield delay(1);
+
             let doc = yield MyModel.findOne({}, null, { session });
 
             assert.ok(session.serverSession.lastUse > lastUse);
             lastUse = session.serverSession.lastUse;
+
+            yield delay(1);
 
             doc.name = 'test3';
 


### PR DESCRIPTION

**Summary**

Session tests currently use `session.serverSession.lastUse` time to verify that the session are used in a query.

```js
assert.ok(session.serverSession.lastUse > lastUse);
```

However, Date in JavaScript only support millisecond precision.
If it run too fast, the date may be the same.

I notice that many tests fail on CI because of this

This pull request add delay between requests with 1 millisecond to prevent this

```
  1) Model
       bug fixes
         3.6 features
           sessions (gh-6362)
             sets session when pulling a document from db:
      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
  func.apply(thisObj, args)
      + expected - actual
      -false
      +true
      
      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as ok] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/model.test.js:4985:20
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at process._tickCallback (internal/process/next_tick.js:68:7)

  1) Model
       bug fixes
         3.6 features
           sessions (gh-6362)
             supports overwriting `session` in save():
      AssertionError [ERR_ASSERTION]: false == true
      + expected - actual
      -false
      +true
      
      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as ok] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/model.test.js:5028:20


  1) Model
       bug fixes
         3.6 features
           sessions (gh-6362)
             sets session when pulling a document from db:
      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
  func.apply(thisObj, args)
      + expected - actual
      -false
      +true
      
      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as ok] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/model.test.js:5003:20


```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Test on travis CI