### PR TITLE
greatly improve travis-ci pass rate

### DIFF
--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -1208,7 +1208,7 @@ describe('aggregate: ', function() {
           cursor().
           exec().
           eachAsync(checkDoc, { parallel: 2}).then(function() {
-            assert.ok(Date.now() - startedAt[1] > 100);
+            assert.ok(Date.now() - startedAt[1] >= 100);
             assert.equal(startedAt.length, 2);
             assert.ok(startedAt[1] - startedAt[0] < 50);
             assert.deepEqual(names.sort(), expectedNames);

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1983,7 +1983,7 @@ describe('model: querying:', function() {
         assert.equal(tests.length, 3);
       });
 
-      var pending = 9;
+      var pending = 10;
 
       function cb() {
         if (--pending) {

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -54,7 +54,6 @@ describe('model: querying:', function() {
     });
 
     mongoose.model('BlogPostB', BlogPostB);
-    collection = 'blogposts_' + random();
 
     ModSchema = new Schema({
       num: Number,
@@ -82,6 +81,11 @@ describe('model: querying:', function() {
 
   after(function(done) {
     db.close(done);
+  });
+
+  beforeEach(function() {
+    // use different collection name in every test to avoid conflict (gh-6816)
+    collection = 'blogposts_' + random();
   });
 
   it('find returns a Query', function(done) {

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -329,7 +329,7 @@ describe('QueryCursor', function() {
         };
       };
       cursor.eachAsync(checkDoc, { parallel: 2 }).then(function() {
-        assert.ok(Date.now() - startedAt[1] > 100);
+        assert.ok(Date.now() - startedAt[1] >= 100);
         assert.equal(startedAt.length, 2);
         assert.ok(startedAt[1] - startedAt[0] < 50);
         assert.deepEqual(names.sort(), ['Axl', 'Slash']);


### PR DESCRIPTION
## 1. Fix `model: querying: with previously existing null values in the db`

This test fails *frequently*. You can see it in almost every travis build that fails.
Like this one: https://travis-ci.org/Automattic/mongoose/jobs/412335127

[![travis-fail-1](https://user-images.githubusercontent.com/5862369/43701213-f0424a4a-9987-11e8-9d67-b7137ce3530c.png)](https://travis-ci.org/Automattic/mongoose/jobs/412335127)

```
  1) model: querying:
       with previously existing null values in the db:
      Uncaught AssertionError: 0 == 3
      + expected - actual
      -0
      +3
      
      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as equal] (node_modules/empower-core/lib/decorate.js:51:30)
      at test/model.querying.test.js:1983:16 ......
```

### Explanation

The description of mocha output is misleading. If you inspect the error stacks, you can find that the actual assertion error is at `test/model.querying.test.js:1983:16` so **the actual test case that fails is `model: querying: with conditionals`**

I guess it's because the error is thrown in callback so mocha fail to recognize the correct test case. I think tests need to be refactored to avoid throwing error in async callback. We should use `done(err)` instead to let mocha know where the error is.

There are 10 sub-tests in this test case. So `pending` tests number should be `10` instead of `9`.
The incorrect `pending` value may lead to `Test` collection being removed too early and trigger this error. That's why travis-ci often fail on this test because `pending` value is wrong.

```js
/**
   test/model.querying.test.js Line 1980-1996
*/

      /* ...there are total 10 tests like this, the is is the last test */
      Test.find({block: {$lte: 'buffer shtuffs are neat'}}, function(err, tests) {
        cb();
        assert.ifError(err);

        /** this fail very often because if test collection is cleared
          before all of the tests are finished, tests.length will be 0.
          It leads to `Uncaught AssertionError: 0 == 3`
        */
        assert.equal(tests.length, 3);
      });

      /**
         ⚠️This is incorrect. There are total 10 tests.
      */
      var pending = 9;

      function cb() {
        // When a test is finished, decrement pending number by 1
        if (--pending) {
          return;
        }

        // Clear the Test collection if all pending tests are finished
        Test.remove({}, function(err) {
          assert.ifError(err);
          done();
        });
      }
```

## 2. Fix collection name conflict in `model: querying:` tests

Fix build failure like this: https://travis-ci.org/Automattic/mongoose/jobs/412108300
[![travis-fail-2](https://user-images.githubusercontent.com/5862369/43708647-8490a8a8-999d-11e8-9b2f-2923bbb1bc9e.png)](https://travis-ci.org/Automattic/mongoose/jobs/412108300)

```
 4) model: querying:
       update
         can handle minimize option (gh-3381):
     OverwriteModelError: Cannot overwrite `gh3381` model once compiled.
```

```
  5) model: querying:
       findOne
         querying if an array contains one of multiple members $in a set:
     Uncaught AssertionError: '5b65c248705df70ab9cd50b4' == 5b65c248705df70ab9cd50b5
```

#### Explanation

Simply move the generation of random collection name from `before` to `beforeEach` to guarantee unique collection name is used.

```diff
before(function(done) {
...
-    collection = 'blogposts_' + random();	
...
});

+  beforeEach(function() {
+    collection = 'blogposts_' + random();
+  });

```

## 3. Fix `QueryCursor#eachAsync() parallelization` and `aggregate: cursor() eachAsync with options (parallel)`

```diff
  beforeEach(function() {
    // use different collection name in every test to avoid conflict (gh-6816)
    collection = 'blogposts_' + random();
  });
```

Fix build failure like this: https://travis-ci.org/Automattic/mongoose/jobs/412101075
[![travis-fail-3](https://user-images.githubusercontent.com/5862369/43701256-16c795ee-9988-11e8-8e5d-a6fd0ea70a41.png)](https://travis-ci.org/Automattic/mongoose/jobs/412101075)

```
  1) QueryCursor
       #eachAsync()
         parallelization:
      AssertionError: false == true
      + expected - actual
      -false
      +true
      
      at test/query.cursor.test.js:332:16
```

### Explanation

If `setTimeout` is so accurate that delay exactly 100ms, this test will fail.

```js
    it('parallelization', function(done) {
      var cursor = Model.find().sort({ name: 1 }).cursor();

      var names = [];
      var startedAt = [];
      var checkDoc = function(doc) {
        names.push(doc.name);
        startedAt.push(Date.now());
        return {
          then: function(resolve) {
            setTimeout(function() {
              resolve();
            }, 100); // Fired after 100 ms
          }
        };
      };
      cursor.eachAsync(checkDoc, { parallel: 2 }).then(function() {

        // ⚠️This may fail if setTimeout is accurate and delay exactly 100ms
        assert.ok(Date.now() - startedAt[1] > 100);

        assert.equal(startedAt.length, 2);
        assert.ok(startedAt[1] - startedAt[0] < 50);
        assert.deepEqual(names.sort(), ['Axl', 'Slash']);
        done();
      }).catch(done);
    });
```

