### PR TITLE
Fixes #6819 - `Model.syncIndexes()` checks for `expireAfterSeconds` option

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1044,7 +1044,7 @@ Model.syncIndexes = function syncIndexes(options, callback) {
             utils.clone(schemaIndex[1]));
 
           // If these options are different, need to rebuild the index
-          const optionKeys = ['unique', 'partialFilterExpression', 'sparse'];
+          const optionKeys = ['unique', 'partialFilterExpression', 'sparse','expireAfterSeconds'];
           const indexCopy = Object.assign({}, index);
           for (const key of optionKeys) {
             if (!(key in options) && !(key in indexCopy)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1044,7 +1044,7 @@ Model.syncIndexes = function syncIndexes(options, callback) {
             utils.clone(schemaIndex[1]));
 
           // If these options are different, need to rebuild the index
-          const optionKeys = ['unique', 'partialFilterExpression', 'sparse','expireAfterSeconds'];
+          const optionKeys = ['unique', 'partialFilterExpression', 'sparse', 'expireAfterSeconds'];
           const indexCopy = Object.assign({}, index);
           for (const key of optionKeys) {
             if (!(key in options) && !(key in indexCopy)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This should fix #6819 and also recreate index on `expireAfterSeconds` option change. Added this key to the values to check for when syncing indexes.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

