### PR TITLE
Run linter in parallel and only on node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: node_js
 sudo: false
-node_js:
-  - "10"
-  - "9"
-  - "8"
-  - "7"
-  - "6"
-  - "5"
-  - "4"
+node_js: [10, 9, 8, 7, 6, 5, 4]
 before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.6.tgz
   - tar -zxvf mongodb-linux-x86_64-3.6.6.tgz
@@ -15,9 +8,12 @@ before_script:
   - mkdir -p ./data/db/27000
   - printf "\n--timeout 8000" >> ./test/mocha.opts
   - ./mongodb-linux-x86_64-3.6.6/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
-  - sleep 3
-script:
-  - npm test
-  - node tools/checkNodeVersion.js "4.x || 5.x" || npm run lint
+  - sleep 2
+matrix:
+  include:
+    - name: "👕Linter"
+      node_js: 10
+      before_script: skip
+      script: npm run lint
 notifications:
   email: false

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -137,7 +137,7 @@ describe('connections:', function() {
           }).
           then(function() {
             return new Promise(function(resolve) {
-              setTimeout(function() { resolve(); }, 50);
+              setTimeout(function() { resolve(); }, 100);
             });
           }).
           then(function() {
@@ -151,7 +151,7 @@ describe('connections:', function() {
           }).
           then(function() {
             return new Promise(function(resolve) {
-              setTimeout(function() { resolve(); }, 2000);
+              setTimeout(function() { resolve(); }, 4000);
             });
           }).
           then(function() {

--- a/tools/checkNodeVersion.js
+++ b/tools/checkNodeVersion.js
@@ -1,7 +1,0 @@
-const version = process.version;
-const semver = require('semver');
-
-// Gnarly but this helps us avoid running eslint on node v4.
-if (!semver.satisfies(version, process.argv[2])) {
-  throw new Error(`${version} does not satisfy "${process.argv[2]}"`);
-}


### PR DESCRIPTION
**Summary**

- Only run eslint on node.js 10 because there's no need to lint on every version
- Run eslint in parallel so it can help us to distinguish lint error from build failure and also speed up CI
- Fix flaky connection test

[Example travis-ci output:
![image](https://user-images.githubusercontent.com/5862369/43941897-734c65f6-9ca8-11e8-86c5-915a4b6e643f.png)](https://travis-ci.org/Automattic/mongoose/builds/414379650?utm_source=github_status&utm_medium=notification)

**Future Work**

Maybe we can run `npm audit` on node.js 10 (because only npm@6+ support it)
However, `npm audit` currently cannot ignore devDependencies