### PR TITLE
docs: Add `objectIdGetter` option to migrating_to_5.md

### DIFF
--- a/migrating_to_5.md
+++ b/migrating_to_5.md
@@ -96,6 +96,8 @@ console.log(blogPost.author._id); '5b207f84e8061d1d2711b421'
 
 As a consequence, checking whether `blogPost.author._id` is [no longer viable as a way to check whether `author` is populated](https://github.com/Automattic/mongoose/issues/6415#issuecomment-388579185). Use `blogPost.populated('author') != null` or `blogPost.author instanceof mongoose.Types.ObjectId` to check whether `author` is populated instead.
 
+Note that you can call `mongoose.set('objectIdGetter', false)` to change this behavior.
+
 ### Return Values for `remove()` and `deleteX()`
 
 `deleteOne()`, `deleteMany()`, and `remove()` now resolve to the result object


### PR DESCRIPTION
**Summary**

This adds the `objectIdGetter` option to the migration docs.

We have functions like this sprinkled throughout our code:

```js
async doThingWithUser(userOrId) {
    let user;
    if(userOrId._id) {
        user = userOrId;
    } else {
        user = await User.findById(userOrId);
    }
    ...
}
```

So when I read this migration guide I was in a bit of a panic until I found this option.  -_-

**Test plan**

None required.