### PR TITLE
Update code example in Populate

### DIFF
--- a/docs/populate.jade
+++ b/docs/populate.jade
@@ -456,7 +456,7 @@ block content
     // `populate()` after saving. Useful for sending populated data back to the client in an
     // update API endpoint
     MySchema.post('save', function(doc, next) {
-      doc.populate('user').execPopulate(function() {
+      doc.populate('user').execPopulate().then(function() {
         next();
       });
     });


### PR DESCRIPTION
Update example of calling '.execPopulate' method with a working example. 

The method doesn't take in any arguments, whereas the example shows that it does, leading to a never-called 'next' method. Use of 'then' works as expected and is the example provided in other parts of the documentation.

Pull request corrects the example code.