### PR TITLE
fixes #6854 add Query.prototype.setQuery()

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1333,7 +1333,7 @@ Query.prototype.getQuery = function() {
 };
 
 /**
- * Returns the current query conditions as a JSON object.
+ * Sets the query conditions to the provided JSON object.
  *
  * ####Example:
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -1333,6 +1333,25 @@ Query.prototype.getQuery = function() {
 };
 
 /**
+ * Returns the current query conditions as a JSON object.
+ *
+ * ####Example:
+ *
+ *     var query = new Query();
+ *     query.find({ a: 1 })
+ *     query.setQuery({ a: 2 });
+ *     query.getQuery(); // { a: 2 }
+ *
+ * @param {Object} new query conditions
+ * @return {undefined}
+ * @api public
+ */
+
+Query.prototype.setQuery = function(val) {
+  this._conditions = val;
+};
+
+/**
  * Returns the current update operations as a JSON object.
  *
  * ####Example:

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2739,4 +2739,13 @@ describe('Query', function() {
       });
     });
   });
+
+  describe('setQuery', function() {
+    it('replaces existing query with new value (gh-6854)', function() {
+      var q = new Query({}, {}, null, p1.collection);
+      q.where('userName').exists();
+      q.setQuery({ a: 1 });
+      assert.deepStrictEqual(q._conditions, { a: 1 });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
as described in #6854, it would be nice to have a method to easily change the current query condition ( example in issue ). 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a failing test, made it pass, all current tests pass:
```
mongoose>: npm test -- -g 'gh-6854'

> mongoose@5.2.8 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6854"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:2675) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  !

  0 passing (151ms)
  1 failing

  1) Query
       setQuery
         replaces existing query with new value (gh-6854):

      AssertionError [ERR_ASSERTION]: { a: 1 } deepStrictEqual { b: 1 }
      + expected - actual

       {
      -  "a": 1
      +  "b": 1
       }

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as deepStrictEqual] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/query.test.js:2748:14)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6854'

> mongoose@5.2.8 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6854"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:2701) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․

  1 passing (142ms)

mongoose>:
mongoose>: npm test

> mongoose@5.2.8 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

(node:2890) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․(node:2890) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․

  2011 passing (48s)
  10 pending

mongoose>:
```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### 6854.js after this change could be written as:
```js
#!/usr/bin/env node
'use strict';

const mongoose = require('mongoose');
const removeDiacritics = require('diacritics').remove;
mongoose.connect('mongodb://localhost:27017/test', { useNewUrlParser: true });
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const schema = new Schema({
  x: String
});

schema.pre('findOne', function() {
  let query = this.getQuery();
  let cleanQuery = {};
  Object.keys(query).forEach(k => {
    cleanQuery[k] = removeDiacritics(query[k]);
  });
  this.setQuery(cleanQuery);
});

const Test = mongoose.model('test', schema);

const test = new Test({ x: 'aaa'});

async function run() {
  await conn.dropDatabase();
  await test.save();
  let doc = await Test.findOne({ x: 'ååå'});
  console.log(doc);
  return conn.close();
}

run();
```
### Output:
```
issues: ./6854.js
{ _id: 5b723a7a3d9ed10bfcb1ea03, x: 'aaa', __v: 0 }
issues:
```
