### PR TITLE
Fix `this` scope of default functions for DocumentArray and Array

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -101,7 +101,7 @@ function SchemaArray(key, cast, options, schemaOptions) {
     var defaultFn = function() {
       var arr = [];
       if (fn) {
-        arr = defaultArr();
+        arr = defaultArr.call(this);
       } else if (defaultArr != null) {
         arr = arr.concat(defaultArr);
       }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4852,6 +4852,29 @@ describe('Model', function() {
       });
     });
 
+    it('run default function with correct this scope in DocumentArray (gh-6840)', function() {
+      var schema = new Schema({
+        title: String,
+        actors: {
+          type: [{ name: String, character: String }],
+          default: function() {
+            // `this` should be root document and has initial data
+            if (this.title === 'Passenger') {
+              return [
+                { name: 'Jennifer Lawrence', character: 'Aurora Lane' },
+                { name: 'Chris Pratt', character: 'Jim Preston' }
+              ];
+            }
+            return [];
+          }
+        }
+      });
+
+      var Movie = db.model('gh6840', schema);
+      var movie = new Movie({ title: 'Passenger'});
+      assert.equal(movie.actors.length, 2);
+    });
+
     describe('3.6 features', function() {
       before(function(done) {
         start.mongodVersion((err, version) => {


### PR DESCRIPTION
Fix #6840 

**Summary**

DocumentArray ---(this=doc)---> Array ---(no this bind)---> Custom Default Function

**Test plan**

included in this pull request