### PR TITLE
Correctly propagate write concern options in save()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -145,20 +145,21 @@ Model.prototype.$__handleSave = function(options, callback) {
   let i;
   let keys;
   let len;
-  if (!options.safe && this.schema.options.safe) {
-    options.safe = this.schema.options.safe;
-  }
-  if (typeof options.safe === 'boolean') {
-    options.safe = null;
-  }
-  let safe = options.safe ? utils.clone(options.safe) : options.safe;
+  let saveOptions = {};
 
+  _handleSafe(options);
   applyWriteConcern(this.schema, options);
+  if ('w' in options) saveOptions.w = options.w;
+  if ('j' in options) saveOptions.j = options.j;
+  if ('wtimeout' in options) saveOptions.wtimeout = options.wtimeout;
 
   const session = 'session' in options ? options.session : this.$session();
   if (session != null) {
-    safe = typeof safe === 'object' && safe != null ? safe : {};
-    safe.session = session;
+    saveOptions.session = session;
+  }
+
+  if (Object.keys(saveOptions).length === 0) {
+    saveOptions = null;
   }
 
   if (this.isNew) {
@@ -178,7 +179,7 @@ Model.prototype.$__handleSave = function(options, callback) {
     }
 
     this.$__version(true, obj);
-    this.collection.insertOne(obj, safe, function(err, ret) {
+    this.collection.insertOne(obj, saveOptions, function(err, ret) {
       if (err) {
         _this.isNew = true;
         _this.emit('isNew', true);
@@ -223,7 +224,7 @@ Model.prototype.$__handleSave = function(options, callback) {
         }
       }
 
-      this.collection.updateOne(where, delta[1], safe, function(err, ret) {
+      this.collection.updateOne(where, delta[1], saveOptions, function(err, ret) {
         if (err) {
           callback(err);
           return;

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -210,7 +210,7 @@ describe('connections:', function() {
           }).
           then(function() {
             return new Promise(function(resolve) {
-              setTimeout(function() { resolve(); }, 4000);
+              setTimeout(function() { resolve(); }, 8000);
             });
           }).
           then(function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3,7 +3,7 @@
 /**
  * Test dependencies.
  */
-
+require('../lib/driver').set(require('../lib/drivers/node-mongodb-native'));
 const assert = require('power-assert');
 const co = require('co');
 const random = require('../lib/utils').random;
@@ -5354,6 +5354,88 @@ describe('Model', function() {
       const doc = new Model();
 
       return doc.save({ safe: { w: 0 } });
+    });
+
+    it('save() with acknowledged writes fail if topology is not replica set (gh-6862)', function(done) {
+      // If there is no replica sets, speicify w > 1 will throw BadValue error
+      // This test use his error to check if w options are correctly passed to mongodb
+
+      // skip this test if the server is a replica set
+      if (db.client.topology.constructor.name === 'ReplSet') {
+        return this.skip();
+      }
+
+      const schemaA = new Schema({
+        name: String
+      }, { writeConcern: { w: 2 }});
+      const schemaB = new Schema({
+        name: String
+      });
+
+      const UserA = db.model('gh6862_1', schemaA);
+      const UserB = db.model('gh6862_2', schemaB);
+
+      const userA = new UserA();
+      const userB = new UserB();
+      userA.save(function(error) {
+        assert.ok(error);
+        assert.equal(error.name, 'MongoError');
+        assert.equal(error.codeName, 'BadValue');
+
+        userB.save({ w: 2 },function(error) {
+          assert.ok(error);
+          assert.equal(error.name, 'MongoError');
+          assert.equal(error.codeName, 'BadValue');
+          done();
+        });
+      });
+    });
+
+    it.skip('save() with wtimeout defined in schema (gh-6862)', function(done) {
+      // If you want to test this, setup replica set with 1 primary up and 1 slave down
+      this.timeout(process.env.TRAVIS ? 9000 : 5500);
+      const schema = new Schema({
+        name: String
+      }, {
+        writeConcern: {
+          w: 2,
+          wtimeout: 1000
+        }
+      });
+      const User = db.model('gh6862_3', schema);
+      const user = new User();
+      user.name = 'Jon Snow';
+      user.save(function(error) {
+        assert.ok(error);
+        assert.equal(error.name, 'MongoWriteConcernError');
+
+        // although timeout, it should have successfully saved the doc
+        User.findOne({}, function(err, user) {
+          if (err) return done(err);
+          assert.equal(user.name, 'Jon Snow');
+          done();
+        });
+      });
+    });
+
+    it.skip('save with wtimeout in options (gh_6862)', function(done) {
+      // If you want to test this, setup replica set with 1 primary up and 1 slave down
+      this.timeout(process.env.TRAVIS ? 9000 : 5500);
+      const schema = new Schema({
+        name: String
+      });
+      const User = db.model('gh6862_4', schema);
+      const user = new User();
+      user.name = 'Jon Snow';
+      user.save({ w: 2, wtimeout: 1000 }, function(error) {
+        assert.ok(error);
+        assert.equal(error.name, 'MongoWriteConcernError');
+        User.findOne({}, function(err, user) {
+          if (err) return done(err);
+          assert.equal(user.name, 'Jon Snow');
+          done();
+        });
+      });
     });
 
     it('bulkWrite casting updateMany, deleteOne, deleteMany (gh-3998)', function(done) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3,7 +3,7 @@
 /**
  * Test dependencies.
  */
-require('../lib/driver').set(require('../lib/drivers/node-mongodb-native'));
+
 const assert = require('power-assert');
 const co = require('co');
 const random = require('../lib/utils').random;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5357,8 +5357,8 @@ describe('Model', function() {
     });
 
     it('save() with acknowledged writes fail if topology is not replica set (gh-6862)', function(done) {
-      // If there is no replica sets, speicify w > 1 will throw BadValue error
-      // This test use his error to check if w options are correctly passed to mongodb
+      // If w > 1 and there is no replica sets, mongodb will throw BadValue error
+      // This test uses this to check if option `w` is correctly propagated to mongodb
 
       // skip this test if the server is a replica set
       if (db.client.topology.constructor.name === 'ReplSet') {


### PR DESCRIPTION
**Summary**

`save()` doesn't work with write concern. Only legacy `safe` options are supported.
(IMO, I think `safe` should be deprecated in the next major release of mongoose) 

**This bug is critical because it makes mongoose lack of durability guarantee.**

Fixes #6862 and now write concern options are correctly propagated to mongodb.

**Test plan**

Add tests for both `writeConcern` defined in schema level and in save(`options`).

1 test to check if `w > 1` trigger error when topology of server is not a replica set
2 tests are skipped by default because they require replica sets and special setup to trigger write concern timeout. These 2 tests passed on my computer.

See the comments in code for details.