### PR TITLE
WIP: fix: findAndModify and options [fields] deprecation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,7 @@ Mongoose.prototype.STATES = STATES;
  * Currently supported options are:
  * - 'debug': prints the operations mongoose sends to MongoDB to the console
  * - 'bufferCommands': enable/disable mongoose's buffering mechanism for all connections and models
- * - 'useFindAndModify': false by default. Set to `true` to make `findOneAndUpdate()` and `findOneAndRemove()` use legacy `findAndModify()` rather than native methods`.
+ * - 'useFindAndModify': true by default. Set to `false` to make `findOneAndUpdate()` and `findOneAndRemove()` use native `findOneAndUpdate()` rather than `findAndModify()`.
  * - 'cloneSchemas': false by default. Set to `true` to `clone()` all schemas before compiling into a model.
  * - 'applyPluginsToDiscriminators': false by default. Set to true to apply global plugins to discriminator schemas. This typically isn't necessary because plugins are applied to the base schema and discriminators copy all middleware, methods, statics, and properties from the base schema.
  * - 'objectIdGetter': true by default. Mongoose adds a getter to MongoDB ObjectId's called `_id` that returns `this` for convenience with populate. Set this to false to remove the getter.

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,7 @@ Mongoose.prototype.STATES = STATES;
  * Currently supported options are:
  * - 'debug': prints the operations mongoose sends to MongoDB to the console
  * - 'bufferCommands': enable/disable mongoose's buffering mechanism for all connections and models
- * - 'useFindAndModify': true by default. Set to `false` to make `findOneAndUpdate()` and `findOneAndRemove()` use native `findOneAndUpdate()` rather than `findAndModify()`.
+ * - 'useFindAndModify': false by default. Set to `true` to make `findOneAndUpdate()` and `findOneAndRemove()` use legacy `findAndModify()` rather than native methods`.
  * - 'cloneSchemas': false by default. Set to `true` to `clone()` all schemas before compiling into a model.
  * - 'applyPluginsToDiscriminators': false by default. Set to true to apply global plugins to discriminator schemas. This typically isn't necessary because plugins are applied to the base schema and discriminators copy all middleware, methods, statics, and properties from the base schema.
  * - 'objectIdGetter': true by default. Mongoose adds a getter to MongoDB ObjectId's called `_id` that returns `this` for convenience with populate. Set this to false to remove the getter.

--- a/lib/model.js
+++ b/lib/model.js
@@ -836,7 +836,7 @@ Model.prototype.$__remove = function $__remove(options, cb) {
     return cb(where);
   }
 
-  this.collection.remove(where, options, err => {
+  this.collection.deleteOne(where, options, err => {
     if (!err) {
       this.$__.isDeleted = true;
       this.emit('remove', this);
@@ -1996,8 +1996,8 @@ Model.findOneAndUpdate = function(conditions, update, options, callback) {
   }
 
   var fields;
-  if (options && options.fields) {
-    fields = options.fields;
+  if (options) {
+    fields = options.fields || options.projection;
   }
 
   var retainKeyOrder = get(options, 'retainKeyOrder') ||

--- a/lib/query.js
+++ b/lib/query.js
@@ -1684,7 +1684,7 @@ Query.prototype._find = function(callback) {
   };
 
   var options = this._optionsForExec();
-  options.fields = this._fieldsForExec();
+  options.projection = this._fieldsForExec();
   var filter = this._conditions;
   this._collection.find(filter, options, cb);
   return null;
@@ -2971,9 +2971,9 @@ Query.prototype._findAndModify = function(type, callback) {
 
   if (this._fields) {
     fields = utils.clone(this._fields);
-    opts.fields = this._castFields(fields);
-    if (opts.fields instanceof Error) {
-      return callback(opts.fields);
+    opts.projection = this._castFields(fields);
+    if (opts.projection instanceof Error) {
+      return callback(opts.projection);
     }
   }
 
@@ -2989,7 +2989,7 @@ Query.prototype._findAndModify = function(type, callback) {
 
   var _callback;
 
-  var useFindAndModify = true;
+  var useFindAndModify = false; // default to false now
   var runValidators = _getOption(this, 'runValidators', false);
   var base = _this.model && _this.model.base;
   if ('useFindAndModify' in base.options) {
@@ -3005,10 +3005,6 @@ Query.prototype._findAndModify = function(type, callback) {
       opts.returnOriginal = !opts['new'];
       delete opts['new'];
     }
-    if ('fields' in opts) {
-      opts.projection = opts.fields;
-      delete opts.fields;
-    }
 
     if (type === 'remove') {
       collection.findOneAndDelete(castedQuery, opts, utils.tick(function(error, res) {
@@ -3018,6 +3014,9 @@ Query.prototype._findAndModify = function(type, callback) {
       return this;
     }
 
+    // honors legacy overwrite option for backward compatibility
+    const updateMethod = isOverwriting ? 'findOneAndReplace' : 'findOneAndUpdate';
+
     if (runValidators && doValidate) {
       _callback = function(error) {
         if (error) {
@@ -3026,7 +3025,8 @@ Query.prototype._findAndModify = function(type, callback) {
         if (castedDoc && castedDoc.toBSON) {
           castedDoc = castedDoc.toBSON();
         }
-        collection.findOneAndUpdate(castedQuery, castedDoc, opts, utils.tick(function(error, res) {
+
+        collection[updateMethod](castedQuery, castedDoc, opts, utils.tick(function(error, res) {
           return cb(error, res ? res.value : res, res);
         }));
       };
@@ -3040,7 +3040,7 @@ Query.prototype._findAndModify = function(type, callback) {
       if (castedDoc && castedDoc.toBSON) {
         castedDoc = castedDoc.toBSON();
       }
-      collection.findOneAndUpdate(castedQuery, castedDoc, opts, utils.tick(function(error, res) {
+      collection[updateMethod](castedQuery, castedDoc, opts, utils.tick(function(error, res) {
         return cb(error, res ? res.value : res, res);
       }));
     }
@@ -3953,7 +3953,7 @@ Query.prototype._applyPaths = function applyPaths() {
 Query.prototype.cursor = function cursor(opts) {
   this._applyPaths();
   this._fields = this._castFields(this._fields);
-  this.setOptions({ fields: this._fieldsForExec() });
+  this.setOptions({ projection: this._fieldsForExec() });
   if (opts) {
     this.setOptions(opts);
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -2989,7 +2989,7 @@ Query.prototype._findAndModify = function(type, callback) {
 
   var _callback;
 
-  var useFindAndModify = false; // default to false now
+  var useFindAndModify = true;
   var runValidators = _getOption(this, 'runValidators', false);
   var base = _this.model && _this.model.base;
   if ('useFindAndModify' in base.options) {


### PR DESCRIPTION
**Summary**

Only change internal call and options.
If a user calls the deprecated API or use deprecated options on purpose, mongoose should still show the deprecation message. That's why CI tests have so many deprecation warning.

IMO, `useFindAndModify` and `overwrite` options should be deprecated in the next major release

- [ ] ~~`useFindAndModify` default to be `false`~~ (
EDIT after review from vkarpov15:
For your own good, please set to false explicitly to suppress deprecation warning because we can't guarantee if this is a breaking change at this moment. Please test if everything still works

- [x] find: options `fields` -> `projection`
- [x] findOndAndUpdate: options `fields` -> `projection`
- [x] remove: call deleteOne
- [ ] ensureIndex(es): call createIndex(es)
- [ ] check compatibility

**Test plan**

`useFindAndModify` default to be `false` may be a breaking change.
I fix #6887 and all current CI test pass. However I'm afraid the test coverage is not enough.

I check the following option so maintainers have access to add commit on this pull request
**Allow edits from maintainers**