### PR TITLE
Add redact and readConcern helper to Aggregate

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -7,6 +7,7 @@ var Query = require('./query');
 var util = require('util');
 var utils = require('./utils');
 var read = Query.prototype.read;
+var readConcern = Query.prototype.readConcern;
 
 /**
  * Aggregate constructor used for building aggregation pipelines. Do not
@@ -570,6 +571,79 @@ Aggregate.prototype.read = function(pref, tags) {
 };
 
 /**
+ * Sets the readConcern level for the aggregation query.
+ *
+ * ####Example:
+ *
+ *     Model.aggregate(..).readConcern('majority').exec(callback)
+ *
+ * @param {String} level one of the listed read concern level or their aliases
+ * @see mongodb https://docs.mongodb.com/manual/reference/read-concern/
+ * @return {Query} this
+ * @api public
+ */
+
+Aggregate.prototype.readConcern = function(level) {
+  if (!this.options) {
+    this.options = {};
+  }
+  readConcern.call(this, level);
+  return this;
+};
+
+/**
+ * Appends a new $redact operator to this aggregate pipeline.
+ *
+ * If 3 arguments are supplied, Mongoose will wrap them with if-then-else of $cond operator respectively
+ * If `thenExpr` or `elseExpr` is string, make sure it starts with $$, like `$$DESCEND`, `$$PRUNE` or `$$KEEP`.
+ *
+ * ####Example:
+ *
+ *     Model.aggregate(...)
+ *      .redact({
+ *        $cond: {
+ *          if: { $eq: [ '$level', 5 ] },
+ *          then: '$$PRUNE',
+ *          else: '$$DESCEND'
+ *        }
+ *      })
+ *      .exec();
+ *
+ *     // $redact often comes with $cond operator, you can also use the following syntax provided by mongoose
+ *     Model.aggregate(...)
+ *      .redact({ $eq: [ '$level', 5 ] }, '$$PRUNE', '$$DESCEND')
+ *      .exec();
+ *
+ * @param {Object} expression redact options or conditional expression
+ * @param {String|Object} [thenExpr] true case for the condition
+ * @param {String|Object} [elseExpr] false case for the condition
+ * @return {Aggregate} this
+ * @see $redact https://docs.mongodb.com/manual/reference/operator/aggregation/redact/
+ * @api public
+ */
+
+Aggregate.prototype.redact = function(expression, thenExpr, elseExpr) {
+  if (arguments.length === 3) {
+    if ((typeof thenExpr === 'string' && !thenExpr.startsWith('$$')) ||
+        (typeof elseExpr === 'string' && !elseExpr.startsWith('$$'))) {
+      throw new Error('If thenExpr or elseExpr is string, it must start with $$. e.g. $$DESCEND, $$PRUNE, $$KEEP');
+    }
+
+    expression = {
+      $cond: {
+        if: expression,
+        then: thenExpr,
+        else: elseExpr
+      }
+    };
+  } else if (arguments.length !== 1) {
+    throw new TypeError('Invalid arguments');
+  }
+
+  return this.append({$redact: expression});
+};
+
+/**
  * Execute the aggregation with explain
  *
  * ####Example:
@@ -748,6 +822,7 @@ Aggregate.prototype.collation = function(collation) {
  * Combines multiple aggregation pipelines.
  *
  * ####Example:
+ *
  *     Model.aggregate(...)
  *      .facet({
  *        books: [{ groupBy: '$author' }],

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -558,6 +558,8 @@ Aggregate.prototype.sort = function(arg) {
  *
  * @param {String} pref one of the listed preference options or their aliases
  * @param {Array} [tags] optional tags for this query
+ * @return {Aggregate} this
+ * @api public
  * @see mongodb http://docs.mongodb.org/manual/applications/replication/#read-preference
  * @see driver http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences
  */
@@ -579,7 +581,7 @@ Aggregate.prototype.read = function(pref, tags) {
  *
  * @param {String} level one of the listed read concern level or their aliases
  * @see mongodb https://docs.mongodb.com/manual/reference/read-concern/
- * @return {Query} this
+ * @return {Aggregate} this
  * @api public
  */
 
@@ -768,6 +770,8 @@ Aggregate.prototype.option = function(value) {
  * @param {Object} options
  * @param {Number} options.batchSize set the cursor batch size
  * @param {Boolean} [options.useMongooseAggCursor] use experimental mongoose-specific aggregation cursor (for `eachAsync()` and other query cursor semantics)
+ * @return {Aggregate} this
+ * @api public
  * @see mongodb http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html
  */
 
@@ -788,6 +792,8 @@ Aggregate.prototype.cursor = function(options) {
  *
  * @param {String} flag
  * @param {Boolean} value
+ * @return {Aggregate} this
+ * @api public
  * @see mongodb http://mongodb.github.io/node-mongodb-native/2.2/api/Cursor.html#addCursorFlag
  */
 
@@ -807,6 +813,8 @@ Aggregate.prototype.addCursorFlag = function(flag, value) {
  *     Model.aggregate(..).collation({ locale: 'en_US', strength: 1 }).exec();
  *
  * @param {Object} collation options
+ * @return {Aggregate} this
+ * @api public
  * @see mongodb http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate
  */
 

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -409,6 +409,30 @@ describe('aggregate: ', function() {
     });
   });
 
+  describe('redact', function() {
+    const pipelineResult = [{ $redact: { $cond: { if: { $eq: ['$level', 5] }, then: '$$PRUNE', else: '$$DESCEND' } } }];
+    it('works', function(done) {
+      const aggregate = new Aggregate();
+      aggregate.redact({
+        $cond: {
+          if: { $eq: [ '$level', 5 ] },
+          then: '$$PRUNE',
+          else: '$$DESCEND'
+        }
+      });
+      assert.deepEqual(aggregate._pipeline, pipelineResult);
+
+      done();
+    });
+    it('works with (condition, string, string)', function(done) {
+      const aggregate = new Aggregate();
+      aggregate.redact({ $eq: ['$level', 5] }, '$$PRUNE', '$$DESCEND');
+      assert.deepEqual(aggregate._pipeline, pipelineResult);
+
+      done();
+    });
+  });
+
   describe('Mongo 3.4 operators', function() {
     before(function(done) {
       onlyTestAtOrAbove('3.4', this, done);
@@ -931,21 +955,23 @@ describe('aggregate: ', function() {
           throw err;
         }
         var mongo26_or_greater = version[0] > 2 || (version[0] === 2 && version[1] >= 6);
+        var mongo32_or_greater = version[0] > 3 || (version[0] === 3 && version[1] >= 2);
 
         var m = db.model('Employee');
         var match = { $match: { sal: { $gt: 15000 } } };
         var pref = 'primaryPreferred';
         var aggregate = m.aggregate([match]).read(pref);
+        assert.equal(aggregate.options.readPreference.mode, pref);
         if (mongo26_or_greater) {
           aggregate.allowDiskUse(true);
           aggregate.option({maxTimeMS: 1000});
-        }
-
-
-        assert.equal(aggregate.options.readPreference.mode, pref);
-        if (mongo26_or_greater) {
           assert.equal(aggregate.options.allowDiskUse, true);
           assert.equal(aggregate.options.maxTimeMS, 1000);
+        }
+
+        if (mongo32_or_greater) {
+          aggregate.readConcern('m');
+          assert.deepEqual(aggregate.options.readConcern, { level: 'majority' });
         }
 
         aggregate.


### PR DESCRIPTION
### Add redact helper

```js
Model.aggregate().redact({
  $cond: {
    if: { $eq: [ '$level', 5 ] },
    then: '$$PRUNE',
    else: '$$DESCEND'
  }
})
```

`$redact` often comes with `$cond` operator, If 3 arguments are supplied,
Mongoose will wrap them with `if`-`then`-`else` of `$cond` operator respectively

```js
Model.aggregate().redact({ $eq: ['$level', 5] }, '$$PRUNE', '$$DESCEND')
```

### Add missing readConcern from Query
```js
Model.aggregate().readConcern('m'); // specify majority read concern
```

### Test Plan

Included in CI test