### PR TITLE
Use correct `this` scope when casting query with legacy 2dsphere pairs defined in schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 sudo: false
 node_js: [10, 9, 8, 7, 6, 5, 4]
+install:
+  - travis_retry npm install
 before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.6.tgz
   - tar -zxvf mongodb-linux-x86_64-3.6.6.tgz

--- a/lib/schema/operators/geospatial.js
+++ b/lib/schema/operators/geospatial.js
@@ -44,7 +44,7 @@ function cast$geometry(val, self) {
       break;
   }
 
-  _castMinMaxDistance(this, val);
+  _castMinMaxDistance(self, val);
 
   return val;
 }

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -2430,6 +2430,20 @@ describe('model: querying:', function() {
           });
         }
       });
+      it('works with legacy 2dsphere pair in schema (gh-6937)', function() {
+        if (!mongo24_or_greater) {
+          return it.skip();
+        }
+
+        return co(function*() {
+          const Model = db.model('2dsphere-geo', schema2dsphere, 'geospatial' + random());
+          const model = new Model();
+          model.loc = [1, 2];
+          yield model.save();
+          const result = yield Model.where('loc').near({ center: { type: 'Point', coordinates: [1, 2] }, maxDistance: 10 });
+          assert.equal(result.length, 1);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
**Summary**

- Use correct `this` scope when casting query with legacy `2dsphere` pairs defined in schema.
  Fixes #6937, Re: #6893 (const let eslint auto-fix) and 3b99dbdc96006b565c2b102ec19d606de4fa7a26 (use correct context for castToNumber)

- Wrap npm install with travis_retry to mitigate npm install timeout failure and this is [recommended by travis-ci](https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies)

**Test plan**

The test is included in the CI test