### PR TITLE
fix: handle sparse nested refPath properly 

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4033,7 +4033,7 @@ function getModelsMapForPopulate(model, docs, options) {
       isRefPathArray = false;
       if (Array.isArray(modelNames)) {
         isRefPathArray = true;
-        modelNames = utils.array.flatten(modelNames);
+        modelNames = utils.array.flatten(modelNames, null, null, true);
       }
     } else {
       if (!modelNameFromQuery) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -718,27 +718,32 @@ exports.array = {};
 /*!
  * Flattens an array.
  *
- * [ 1, [ 2, 3, [4] ]] -> [1,2,3,4]
+ * [ 1, [ 2, 3, [4], [] ]] -> [1,2,3,4]
+ * [ 1, [ 2, 3, [4], [] ]] -> [1,2,3,4,null] if includeEmpty is true
  *
  * @param {Array} arr
  * @param {Function} [filter] If passed, will be invoked with each item in the array. If `filter` returns a falsey value, the item will not be included in the results.
+ * @param {Array} [ret] If passed, the flatten result will append to this array.
+ * @param {Boolean} [includeEmpty] If true, the flatten result will contains null value.
  * @return {Array}
  * @private
  */
 
-exports.array.flatten = function flatten(arr, filter, ret) {
+exports.array.flatten = function flatten(arr, filter, ret, includeEmpty) {
   ret || (ret = []);
-
-  arr.forEach(function(item) {
-    if (Array.isArray(item)) {
-      flatten(item, filter, ret);
-    } else {
-      if (!filter || filter(item)) {
-        ret.push(item);
+  if (arr.length === 0) {
+    if (includeEmpty) ret.push(null);
+  } else {
+    arr.forEach(function(item) {
+      if (Array.isArray(item)) {
+        flatten(item, filter, ret, includeEmpty);
+      } else {
+        if (!filter || filter(item)) {
+          ret.push(item);
+        }
       }
-    }
-  });
-
+    });
+  }
   return ret;
 };
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -3160,7 +3160,7 @@ describe('model: populate:', function() {
       return co(function*() {
         yield Post.create({
           text: 'Post 2',
-          comments: [{}, {
+          comments: [{
             text: 'Comment'
             // No `references`
           }]


### PR DESCRIPTION
**Summary**

Fixes #6913 by not omitting the non-existing model names during flattening model names array.

**Test plan**

Add test in the CI. Extend the original test case.
Basically, if it contains an empty object, mongoose will fail to populate the following docs properly.

Not sure if this is a good fix.