### PR TITLE
Fixes #6952 make array op casting work with strict:false and {}

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -259,7 +259,7 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
         }
 
         if (Array.isArray(obj[key]) && (op === '$addToSet' || op === '$push') && key !== '$each') {
-          if (schematype.caster && !schematype.caster.$isMongooseArray) {
+          if (schematype && schematype.caster && !schematype.caster.$isMongooseArray) {
             obj[key] = { $each: obj[key] };
           }
         }

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -1167,6 +1167,22 @@ describe('model query casting', function() {
       });
     });
   });
+  it('array ops don\'t break with strict:false (gh-6952)', function(done) {
+    const schema = new Schema({}, { strict: false });
+    const Test = db.model('gh6952', schema);
+    Test.create({ outerArray: [] })
+      .then(function(created) {
+        const toBePushedObj = { innerArray: ['onetwothree'] };
+        const update = { $push: { outerArray: toBePushedObj } };
+        const opts = { new: true };
+        return Test.findOneAndUpdate({ _id: created._id }, update, opts);
+      })
+      .then(function(updated) {
+        const doc = updated.toObject();
+        assert.strictEqual(doc.outerArray[0].innerArray[0], 'onetwothree');
+        done();
+      });
+  });
 });
 
 function _geojsonPoint(coordinates) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

#6952 demonstrates that ` { strict: false }` array op casting fails. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

made a failing test, made it pass, all current tests pass:
```
mongoose>: npm test -- -g 'gh-6952'

> mongoose@5.2.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6952"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

unhandledRejection in "model query castingarray ops don't break with strict:false (gh-6952)": TypeError: Cannot read property 'caster' of undefined
    at walkUpdatePath (/Users/lineus/dev/opc/mongoose/lib/helpers/query/castUpdate.js:262:26)
    at walkUpdatePath (/Users/lineus/dev/opc/mongoose/lib/helpers/query/castUpdate.js:209:20)
    at castUpdate (/Users/lineus/dev/opc/mongoose/lib/helpers/query/castUpdate.js:79:18)
    at model.Query._castUpdate (/Users/lineus/dev/opc/mongoose/lib/query.js:3714:10)
    at castDoc (/Users/lineus/dev/opc/mongoose/lib/query.js:3741:18)
    at model.Query.Query._findAndModify (/Users/lineus/dev/opc/mongoose/lib/query.js:2965:19)
    at model.Query.Query._findOneAndUpdate (/Users/lineus/dev/opc/mongoose/lib/query.js:2674:8)
    at process.nextTick (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:333:33)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)

  !

  0 passing (2s)
  1 failing

  1) model query casting
       array ops don't break with strict:false (gh-6952):
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/lineus/dev/opc/mongoose/test/model.query.casting.test.js)




npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'gh-6952'

> mongoose@5.2.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6952"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (526ms)

mongoose>: npm test

> mongoose@5.2.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,
  ,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․,․․,․,,․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․,,․․․․․․․․․․․․,,․․․․․․,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
  ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․
  ․․․․․․․․․․․․․․․,․․․․․․․․,․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,
  ,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․

  1883 passing (56s)
  163 pending

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
The output of the repro code in #6952 no longer throws an error, but instead works as expected.