### PR TITLE
fix(map): throw TypeError if keys are not string

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -21,14 +21,7 @@ class MongooseMap extends Map {
   }
 
   $init(key, value) {
-    if (key.startsWith('$')) {
-      throw new Error('Mongoose maps do not support keys that start with ' +
-        '`$`, got "' + key + '"');
-    }
-    if (key.indexOf('.') !== -1) {
-      throw new Error('Mongoose maps do not support keys that contain `.`, ' +
-        'got "' + key + '"');
-    }
+    this.$__checkValidKey(key);
 
     super.set(key, value);
 
@@ -38,14 +31,7 @@ class MongooseMap extends Map {
   }
 
   set(key, value) {
-    if (key.startsWith('$')) {
-      throw new Error('Mongoose maps do not support keys that start with ' +
-        '`$`, got "' + key + '"');
-    }
-    if (key.indexOf('.') !== -1) {
-      throw new Error('Mongoose maps do not support keys that contain `.`, ' +
-        'got "' + key + '"');
-    }
+    this.$__checkValidKey(key);
 
     // Weird, but because you can't assign to `this` before calling `super()`
     // you can't get access to `$__schemaType` to cast in the initial call to
@@ -117,6 +103,19 @@ class MongooseMap extends Map {
       this.set(this.$__deferred[i].key, this.$__deferred[i].value);
     }
     this.$__deferred = null;
+  }
+
+  $__checkValidKey(key) {
+    const keyType = typeof key;
+    if (keyType !== 'string') {
+      throw new TypeError(`Mongoose maps only support string keys, got ${keyType}`);
+    }
+    if (key.startsWith('$')) {
+      throw new Error(`Mongoose maps do not support keys that start with "$", got "${key}"`);
+    }
+    if (key.includes('.')) {
+      throw new Error(`Mongoose maps do not support keys that contain ".", got "${key}"`);
+    }
   }
 }
 


### PR DESCRIPTION
Note:

I've tested that **String**.prototype.includes work on Node 4.0.0.
However, **Array**.prototype.includes does not work on Node 4.0.0 yet.
Since the original code use String.prototype.startsWith, so I replace indexOf() with includes() for consistency.

EDIT: it seems travis-ci hangs forever for no reason