### PR TITLE
Fixes #6677 add getPopulatedPaths to Query.prototype

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3836,6 +3836,25 @@ Query.prototype.populate = function() {
 };
 
 /**
+ * Gets a list of paths to be populated by this query
+ *
+ * ####Example:
+ *      bookSchema.pre('findOne', function() {
+ *        let keys = this.getPopulatedPaths(); // ['author']
+ *      })
+ *      ...
+ *      Book.findOne({}).populate('author')
+ *
+ * @return {Array} an array of strings representing populated paths
+ * @api public
+ */
+
+Query.prototype.getPopulatedPaths = function getPopulatedPaths() {
+  const obj = this._mongooseOptions.populate || {};
+  return Object.keys(obj);
+};
+
+/**
  * Casts this query to the schema of `model`
  *
  * ####Note

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2731,4 +2731,44 @@ describe('Query', function() {
       assert.deepStrictEqual(q._conditions, { a: 1 });
     });
   });
+
+  describe('getPopulatedPaths', function() {
+    it('doesn\'t break on a query without population (gh-6677)', function() {
+      const schema = new Schema({ name: String });
+      schema.pre('findOne', function() {
+        assert.deepStrictEqual(this.getPopulatedPaths(), []);
+      });
+
+      const Model = db.model('gh6677_model', schema);
+
+      return co(function*() {
+        yield Model.findOne({});
+      });
+    });
+
+    it('returns an array of populated paths as strings (gh-6677)', function() {
+      const otherSchema = new Schema({ name: String });
+      const schema = new Schema({
+        other: {
+          type: Schema.Types.ObjectId,
+          ref: 'gh6677_other'
+        }
+      });
+      schema.pre('findOne', function() {
+        assert.deepStrictEqual(this.getPopulatedPaths(), ['other']);
+      });
+
+      const Other = db.model('gh6677_other', otherSchema);
+      const Test = db.model('gh6677_test', schema);
+
+      const other = new Other({ name: 'one' });
+      const test = new Test({ other: other._id });
+
+      return co(function*() {
+        yield other.save();
+        yield test.save();
+        yield Test.findOne({}).populate('other');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Per #6677 this adds a method to Query.prototype called getPopulatedPaths that returns an array of strings representing the populated paths in the current query.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added 2 failing tests, made them pass, all current tests pass:
```
mongoose>: npm test -- -g gh-6677

> mongoose@5.2.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6677"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database

unhandledRejection in "getPopulatedPathsdoesn't break on a query without population (gh-6677)": TypeError: this.getPopulatedPaths is not a function
    at model.Query.<anonymous> (/Users/lineus/dev/opc/mongoose/test/query.test.js:2739:37)
    at next (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:63:31)
    at Kareem.execPre (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:86:8)
    at Kareem.wrap (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:265:8)
    at model.Query._findOne (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:339:11)
    at model.Query.Query.findOne (/Users/lineus/dev/opc/mongoose/lib/query.js:1973:8)
    at utils.promiseOrCallback (/Users/lineus/dev/opc/mongoose/lib/query.js:3653:19)
    at Promise (/Users/lineus/dev/opc/mongoose/lib/utils.js:246:5)
    at new Promise (<anonymous>)
    at Object.promiseOrCallback (/Users/lineus/dev/opc/mongoose/lib/utils.js:245:10)
    at model.Query.exec (/Users/lineus/dev/opc/mongoose/lib/query.js:3647:16)
    at model.Query.Query.then (/Users/lineus/dev/opc/mongoose/lib/query.js:3674:15)
    at Context.<anonymous> (/Users/lineus/dev/opc/mongoose/test/query.test.js:2742:25)
    at callFnAsync (/Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runnable.js:400:21)
    at Test.Runnable.run (/Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runnable.js:342:7)
    at Runner.runTest (/Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runner.js:455:10)
    at /Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runner.js:573:12
    at next (/Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runner.js:369:14)
    at /Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runner.js:379:7
    at next (/Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runner.js:303:14)
    at Immediate._onImmediate (/Users/lineus/dev/opc/mongoose/node_modules/mocha/lib/runner.js:347:5)
    at runCallback (timers.js:794:20)
    at tryOnImmediate (timers.js:752:5)
    at processImmediate [as _immediateCallback] (timers.js:729:5)

  !unhandledRejection in "getPopulatedPathsreturns an array of populated paths as strings (gh-6677)": TypeError:this.getPopulatedPaths is not a function
    at model.Query.<anonymous> (/Users/lineus/dev/opc/mongoose/test/query.test.js:2754:37)
    at next (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:63:31)
    at Kareem.execPre (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:86:8)
    at Kareem.wrap (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:265:8)
    at model.Query._findOne (/Users/lineus/dev/opc/mongoose/node_modules/kareem/index.js:339:11)
    at model.Query.Query.findOne (/Users/lineus/dev/opc/mongoose/lib/query.js:1973:8)
    at utils.promiseOrCallback (/Users/lineus/dev/opc/mongoose/lib/query.js:3653:19)
    at Promise (/Users/lineus/dev/opc/mongoose/lib/utils.js:246:5)
    at new Promise (<anonymous>)
    at Object.promiseOrCallback (/Users/lineus/dev/opc/mongoose/lib/utils.js:245:10)
    at model.Query.exec (/Users/lineus/dev/opc/mongoose/lib/query.js:3647:16)
    at model.Query.Query.then (/Users/lineus/dev/opc/mongoose/lib/query.js:3674:15)
    at /Users/lineus/dev/opc/mongoose/test/query.test.js:2766:50
    at Generator.next (<anonymous>)
    at onFulfilled (/Users/lineus/dev/opc/mongoose/node_modules/co/index.js:65:19)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
!

  0 passing (4s)
  2 failing

  1) Query
       getPopulatedPaths
         doesn't break on a query without population (gh-6677):
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/lineus/dev/opc/mongoose/test/query.test.js)


  2) Query
       getPopulatedPaths
         returns an array of populated paths as strings (gh-6677):
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/lineus/dev/opc/mongoose/test/query.test.js)




npm ERR! Test failed.  See above for more details.
mongoose>:

mongoose>: npm test -- -g gh-6677

> mongoose@5.2.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-6677"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․

  2 passing (501ms)

mongoose>:

mongoose>: npm test

> mongoose@5.2.13-pre test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,
  ,,,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․,․․,․,,․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․,,․․․․․․․․․․․․,,․․․․․․,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
  ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․
  ․․․․․․․․․․․․․․․․․․,․․․․․․․․,․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․,,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․

  1888 passing (55s)
  163 pending

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The following script demonstrates that it works as expected:

### 6677.js
```js
#!/usr/bin/env node
'use strict';

const assert = require('assert');
const mongoose = require('mongoose');
mongoose.connect('mongodb://localhost:27017/test', { useNewUrlParser: true });
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const otherSchema = new Schema({
  name: String
});

const schema = new Schema({
  nested: {
    other: {
      type: Schema.Types.ObjectId,
      ref: 'other'
    }
  }
});

schema.pre('findOne', function() {
  let keys = this.getPopulatedPaths();
  assert.deepStrictEqual(keys, ['nested.other']);
  console.log('Assertion 1 Passed.');
});

const Other = mongoose.model('other', otherSchema);
const Test = mongoose.model('test', schema);

const other = new Other({ name: 'test' });
const test = new Test({ nested: { other: other._id } });

async function run() {
  await conn.dropDatabase();
  await other.save();
  await test.save();
  let doc = await Test.findOne({}).populate('nested.other');
  assert.strictEqual(doc.nested.other.name, 'test');
  console.log('Assertion 2 passed.');
  return conn.close();
}

run();

```
### Output:
```
issues: ./6677.js
Assertion 1 Passed.
Assertion 2 passed.
issues:
```