### PR TITLE
Fixes #5144 add useNestedStrict to query options

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -123,7 +123,12 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
 
   let aggregatedError = null;
 
-  const useNestedStrict = schema.options.useNestedStrict;
+  let useNestedStrict;
+  if (options.useNestedStrict === undefined) {
+    useNestedStrict = schema.options.useNestedStrict;
+  } else {
+    useNestedStrict = options.useNestedStrict;
+  }
 
   while (i--) {
     key = keys[i];

--- a/lib/query.js
+++ b/lib/query.js
@@ -3765,10 +3765,16 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
     omitUndefined = this._mongooseOptions.omitUndefined;
   }
 
+  let useNestedStrict;
+  if ('useNestedStrict' in this.options) {
+    useNestedStrict = this.options.useNestedStrict;
+  }
+
   return castUpdate(this.schema, obj, {
     overwrite: overwrite,
     strict: strict,
-    omitUndefined
+    omitUndefined,
+    useNestedStrict: useNestedStrict
   }, this, this._conditions);
 };
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1536,6 +1536,27 @@ describe('Query', function() {
           });
         });
       });
+
+      describe('useNestedStrict', function() {
+        it('overrides schema useNestedStrict: false (gh-5144)', function() {
+          const subSchema = new Schema({}, { strict: false });
+          const schema = new Schema({
+            name: String,
+            nested: subSchema
+          }, { strict: 'throw' });
+
+          const Test = db.model('gh5144', schema);
+          const test = new Test({ name: 'Test1' });
+          return co(function*() {
+            yield test.save();
+            const cond = { _id: test._id };
+            const update = { 'nested.v': 'xyz' };
+            const opts = { new: true, useNestedStrict: true };
+            const doc = yield Test.findOneAndUpdate(cond, update, opts);
+            assert.strictEqual(doc.toObject().nested.v, 'xyz');
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Per #5144 this PR adds the ability to override the schema useNestedStrict option on a per query basis.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a failing test, made it pass, all current tests pass:
```
mongoose>: npm test -- -g 'gh-5144'

> mongoose@5.2.12 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-5144"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (598ms)
  1 failing

  1) Query
       options
         read
           useNestedStrict
             overrides schema useNestedStrict: false (gh-5144):
     StrictModeError: Field `nested.v` is not in schema and strict mode is set to throw.
      at new StrictModeError (lib/error/strict.js:24:11)
      at walkUpdatePath (lib/helpers/query/castUpdate.js:243:17)
      at castUpdate (lib/helpers/query/castUpdate.js:79:18)
      at model.Query._castUpdate (lib/query.js:3768:10)
      at castDoc (lib/query.js:3795:18)
      at model.Query.Query._findAndModify (lib/query.js:2967:19)
      at model.Query.Query._findOneAndUpdate (lib/query.js:2676:8)
      at process.nextTick (node_modules/kareem/index.js:333:33)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)



npm ERR! Test failed.  See above for more details.
mongoose>:
mongoose>: npm test -- -g 'gh-5144'

> mongoose@5.2.12 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-5144"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (526ms)

mongoose>:
mongoose>: npm test

> mongoose@5.2.12 test /Users/lineus/dev/opc/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,
  ,,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․,․․,․,,․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․,,․․․․․․․․․․․․․,,․․․․․․,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
  ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․,,․․․
  ․․․․․․․․․․․․․․․․․․․․,․․․․․․․․,․,․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․,,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․

  1896 passing (54s)
  165 pending

mongoose>:
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The following script works as expected after these changes:

### 5108.js
```js
#!/usr/bin/env node
'use strict';

const mongoose = require('mongoose');
mongoose.set('useFindAndModify', false);
mongoose.connect('mongodb://localhost:27017/test', { useNewUrlParser: true });
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const subSchema = new Schema({}, { strict: false });

const schema = new Schema({
  name: String,
  nested: subSchema
}, { strict: 'throw' });

const Test = mongoose.model('test', schema);

const test = new Test({ name: 'Test1' });

async function run() {
  await conn.dropDatabase();
  await test.save();
  let cond = {};
  let update = { 'nested.x.a': 'test' };
  let opts = { new: true };
  try {
    let doc = await Test.findOneAndUpdate(cond, update, opts);
    console.log(doc);
  } catch(e) {
    console.log('first update failed');
    opts.useNestedStrict = true;
    let doc = await Test.findOneAndUpdate(cond, update, opts);
    console.log(doc);
  }
  return conn.close();
}

run();
```
### Output:
```
issues: ./5108.js
first update failed
{ _id: 5b8f239ef4a7cc4c89dc9bd2,
  name: 'Test1',
  __v: 0,
  nested: { _id: 5b8f239ff4a7cc4c89dc9bd3, x: { a: 'test' } } }
issues:
```