### PR TITLE
add setUpdate to Query.prototype

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1393,6 +1393,25 @@ Query.prototype.getUpdate = function() {
 };
 
 /**
+ * Sets the current update operation to new value.
+ *
+ * ####Example:
+ *
+ *     var query = new Query();
+ *     query.update({}, { $set: { a: 5 } });
+ *     query.setUpdate({ $set: { b: 6 } });
+ *     query.getUpdate(); // { $set: { b: 6 } }
+ *
+ * @param {Object} new update operation
+ * @return {undefined}
+ * @api public
+ */
+
+Query.prototype.setUpdate = function(val) {
+  this._update = val;
+};
+
+/**
  * Returns fields selection for this query.
  *
  * @method _fieldsForExec

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2731,4 +2731,14 @@ describe('Query', function() {
       assert.deepStrictEqual(q._conditions, { a: 1 });
     });
   });
+
+  describe('setUpdate', function() {
+    it('replaces existing update doc with new value', function() {
+      const q = new Query({}, {}, null, p1.collection);
+      q.set('testing', '123');
+      q.setUpdate({ $set: { newPath: 'newValue' } });
+      assert.strictEqual(q._update.$set.testing, undefined);
+      assert.strictEqual(q._update.$set.newPath, 'newValue');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Query.prototype.set will iterate over the keys of an input object and add them to the current update doc, but at the moment the clearest way I can tell how to completely replace query._update is to use the private property directly. This change adds a setUpdate command to overwrite the current value of _update in a query object. 

I'm not super in love with the name `setUpdate`, maybe `replaceUpdate` would be better? The only reason I stuck with `setUpdate` is because it matches `setQuery` and `setOptions`. Regardless of the name, I think having a method to replace the existing update doc entirely in a pre query hook would be nice.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I Added a failing test, made it pass, all current tests pass.
```
mongoose>: npm test -- -g 'replaces existing update doc with new value'

> mongoose@5.2.15-pre test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "replaces existing update doc with new value"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (266ms)
  1 failing

  1) Query
       setUpdate
         replaces existing update doc with new value:
     TypeError: q.setUpdate is not a function
      at Context.<anonymous> (test/query.test.js:2739:9)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'replaces existing update doc with new value'

> mongoose@5.2.15-pre test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "replaces existing update doc with new value"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (122ms)

mongoose>: npm test

> mongoose@5.2.15-pre test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․,․․,․․,․,,․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․,
  ,․․․․․․,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
  ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․
  ․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․,․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,,․․․․․․
  ․․․․․․․․․․․․․․․․

  1899 passing (1m)
  163 pending

mongoose>: git status
On branch feature-setUpdate
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   lib/query.js
        modified:   test/query.test.js

no changes added to commit (use "git add" and/or "git commit -a")
mongoose>:
```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
