### PR TITLE
Fixes #7010 use dynamic require only when needed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,11 @@
  * Module dependencies.
  */
 
-const driverPath = global.MONGOOSE_DRIVER_PATH ||
-  './drivers/node-mongodb-native';
-require('./driver').set(require(driverPath));
+if (global.MONGOOSE_DRIVER_PATH) {
+  require('./driver').set(require(global.MONGOOSE_DRIVER_PATH));
+} else {
+  require('./driver').set(require('./drivers/node-mongodb-native'));
+}
 
 const Schema = require('./schema');
 const SchemaType = require('./schematype');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
As discussed in #7010 when using mongoose in AWS Lambda along with Webpack, the build succeeds but during runtime it throws the below error
```
"Error: Cannot find module './drivers/node-mongodb-native'"
```

Because we're using dynamic requires in [lib/index.js#L9](https://github.com/Automattic/mongoose/blob/master/lib/index.js#L9) to use `global.MONGOOSE_DRIVER_PATH ||
  './drivers/node-mongodb-native'`

This PR, doesn't change any logical part, it just makes the code friendlier for webpack to parse.
