### PR TITLE
fixes #6922 fix typo in model.js

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1305,7 +1305,7 @@ function _ensureIndexes(model, options, callback) {
       useCreateIndex = !!model.db.config.useCreateIndex;
     }
     if ('createIndex' in options) {
-      useCreateIndex = !!options.useCreateIndex;
+      useCreateIndex = !!options.createIndex;
     }
 
     const methodName = useCreateIndex ? 'createIndex' : 'ensureIndex';


### PR DESCRIPTION
re #6922 there's a typo in `@5.2.16`, `useCreateIndex` vs `createIndex` that causes any direct call to createIndexes ( *barring the workaround below* ) to always use the deprecated ensureIndexes method. 

*As the variable name is internal only ( it gets added to options when using createIndex directly ) and only causes a deprecation warning, I didn't add any new tests for this change.*

**All current tests pass.**

repo script:

### indexExample.js
```js
#!/usr/bin/env node
'use strict';
const assert = require('assert');
const mongoose = require('mongoose');
mongoose.set('useCreateIndex', true);
const URI = 'mongodb://localhost:27017/test';
const OPTS = { useNewUrlParser: true, useCreateIndex: true };
mongoose.connect(URI, OPTS);
const conn = mongoose.connection;
const Schema = mongoose.Schema;

const schema = new Schema({
  name: {
    type: String,
    index: { unique: true, background: false }
  }
}, { autoIndex: false });

const Test = mongoose.model('test', schema);
const test = new Test({ name: 'test' });

async function run() {
  await conn.dropDatabase();
  await Test.createIndexes().catch(console.error);
  await test.save();
  let found = await Test.findOne();
  assert.ok(found);
  return conn.close();
}

run();
```
### Output before change:
```
issues: ./indexExample.js
Mongoose: 5.2.16
(node:1979) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
issues:
```

### Output after change:
```
issues: ./indexExample.js
Mongoose: 5.2.17-pre
issues:
```

### Temporary Workaround
You can pass an options object with `useCreateIndexes: true` as the first parameter to `Model.createIndexes()`.

like:

```
let opts = { useCreateIndex: true }
Model.createIndexes(opts)
```

and circumvent the issue **until the next release**.
