### PR TITLE
fix(connection): add useFindAndModify option in connect

### DIFF
--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -93,6 +93,8 @@ block content
     Below are some of the options that are important for tuning mongoose.
 
     * `useNewUrlParser`   - The underlying MongoDB driver has deprecated their current [connection string](https://docs.mongodb.com/manual/reference/connection-string/) parser. Because this is a major change, they added the `useNewUrlParser` flag to allow users to fall back to the old parser if they find a bug in the new parser. You should set `useNewUrlParser: true` unless that prevents you from connecting. Note that if you specify `useNewUrlParser: true`, you **must** specify a port in your connection string, like `mongodb://localhost:27017/dbname`. The new url parser does _not_ support connection strings that do not have a port, like `mongodb://localhost/dbname`.
+    * `useCreateIndex`    - False by default. Set to `true` to make Mongoose's default index build use `createIndex()` instead of `ensureIndex()` to avoid deprecation warnings from the MongoDB driver.
+    * `useFindAndModify`  - True by default. Set to `false` to make `findOneAndUpdate()` and `findOneAndRemove()` use native `findOneAndUpdate()` rather than `findAndModify()`.
     * `autoReconnect`     - The underlying MongoDB driver will automatically try to reconnect when it loses connection to MongoDB. Unless you are an extremely advanced user that wants to manage their own connection pool, do **not** set this option to `false`.
     * `reconnectTries`    - If you're connected to a single server or mongos proxy (as opposed to a replica set), the MongoDB driver will try to reconnect every `reconnectInterval` milliseconds for `reconnectTries` times, and give up afterward. When the driver gives up, the mongoose connection emits a `reconnectFailed` event. This option does nothing for replica set connections.
     * `reconnectInterval` - See `reconnectTries`
@@ -108,6 +110,8 @@ block content
     ```javascript
     const options = {
       useNewUrlParser: true,
+      useCreateIndex: true,
+      useFindAndModify: false,
       autoIndex: false, // Don't build indexes
       reconnectTries: Number.MAX_VALUE, // Never stop trying to reconnect
       reconnectInterval: 500, // Reconnect every 500ms

--- a/docs/deprecations.jade
+++ b/docs/deprecations.jade
@@ -90,6 +90,11 @@ block content
     mongoose.set('useFindAndModify', false);
     ```
 
+    You can also configure `useFindAndModify` by passing it through the connection options.
+    ```javascript
+    mongoose.connect(uri, { useFindAndModify: false });
+    ```
+
     This option affects the following model and query functions. There are
     no intentional backwards breaking changes, so you should be able to turn
     this option on without any code changes. If you discover any issues,
@@ -121,6 +126,11 @@ block content
 
     ```javascript
     mongoose.set('useCreateIndex', true);
+    ```
+
+    You can also configure `useCreateIndex` by passing it through the connection options.
+    ```javascript
+    mongoose.connect(uri, { useCreateIndex: true });
     ```
 
     There are no intentional backwards breaking changes with the `useCreateIndex`

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -449,6 +449,11 @@ Connection.prototype.openUri = function(uri, options, callback) {
       delete options.useCreateIndex;
     }
 
+    if ('useFindAndModify' in options) {
+      this.config.useFindAndModify = !!options.useFindAndModify;
+      delete options.useFindAndModify;
+    }
+
     // Backwards compat
     if (options.user || options.pass) {
       options.auth = options.auth || {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -225,6 +225,8 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
  * @param {Boolean} [options.autoIndex=true] Mongoose-specific option. Set to false to disable automatic index creation for all models associated with this connection.
  * @param {Boolean} [options.bufferCommands=true] Mongoose specific option. Set to false to [disable buffering](http://mongoosejs.com/docs/faq.html#callback_never_executes) on all models associated with this connection.
  * @param {Boolean} [options.useCreateIndex=true] Mongoose-specific option. If `true`, this connection will use [`createIndex()` instead of `ensureIndex()``true`, this connection will use [`createIndex()` instead of `ensureIndex()`](/docs/deprecations.html#-ensureindex-) for automatic index builds via [`Model.init()`](/docs/api.html#model_Model.init).
+ * @param {Boolean} [options.useFindAndModify=true] True by default. Set to `false` to make `findOneAndUpdate()` and `findOneAndRemove()` use native `findOneAndUpdate()` rather than `findAndModify()`.
+ * @param {Boolean} [options.useNewUrlParser=false] False by default. Set to `true` to make all connections set the `useNewUrlParser` option by default.
  * @param {Function} [callback]
  * @see Mongoose#createConnection #index_Mongoose-createConnection
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -1612,6 +1612,12 @@ Model.find = function find(conditions, projection, options, callback) {
 
   const mq = new this.Query({}, {}, this, this.collection);
   mq.select(projection);
+
+  const connectionConfig = this.collection.conn.config;
+  if (connectionConfig && typeof connectionConfig.useFindAndModify !== 'undefined') {
+    mq._mongooseOptions.useFindAndModify = !!connectionConfig.useFindAndModify;
+  }
+
   mq.setOptions(options);
   if (this.schema.discriminatorMapping &&
       this.schema.discriminatorMapping.isRoot &&
@@ -1748,6 +1754,12 @@ Model.findOne = function findOne(conditions, projection, options, callback) {
   // get the mongodb collection object
   const mq = new this.Query({}, {}, this, this.collection);
   mq.select(projection);
+
+  const connectionConfig = this.collection.conn.config;
+  if (connectionConfig && typeof connectionConfig.useFindAndModify !== 'undefined') {
+    mq._mongooseOptions.useFindAndModify = !!connectionConfig.useFindAndModify;
+  }
+
   mq.setOptions(options);
   if (this.schema.discriminatorMapping &&
       this.schema.discriminatorMapping.isRoot &&

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -615,6 +615,130 @@ describe('connections:', function() {
     });
   });
 
+  describe('.createConnection', () => {
+    context('without useFindAndModify option', () => {
+      let connection;
+      let AwesomeModel;
+
+      before(() => {
+        connection = mongoose.createConnection('mongodb://localhost/db');
+        AwesomeModel = connection.model('AwesomeModel', new Schema({
+          name: String
+        }));
+      });
+
+      after(() => {
+        connection.close();
+      });
+
+      it('should run .findOne with useFindAndModify as true', () => {
+        const query = AwesomeModel.findOne();
+        assert.equal(query._mongooseOptions.useFindAndModify, undefined);
+      });
+
+      it('should not modify the global options of Mongoose', () => {
+        assert.equal(mongoose.options.useFindAndModify, false);
+      });
+    });
+
+    context('with findAndModify option set', () => {
+      context('at query level', () => {
+        let connection;
+        let AwesomeModel;
+
+        before(() => {
+          connection = mongoose.createConnection('mongodb://localhost/db');
+          AwesomeModel = connection.model('AwesomeModel', new Schema({
+            name: String
+          }));
+        });
+
+        after(() => {
+          connection.close();
+        });
+
+        context('set as true', () => {
+          it('should run .findOne with useFindAndModify as true', () => {
+            const query = AwesomeModel.findOne({}, {}, {useFindAndModify: true});
+            assert.equal(query._mongooseOptions.useFindAndModify, true);
+          });
+
+          it('should not modify the global options of Mongoose', () => {
+            assert.equal(mongoose.options.useFindAndModify, false);
+          });
+        });
+
+        context('set as false', () => {
+          it('should run .findOne with useFindAndModify as false', () => {
+            const query = AwesomeModel.findOne({}, {}, {useFindAndModify: false});
+            assert.equal(query._mongooseOptions.useFindAndModify, false);
+          });
+
+          it('should not modify the global options of Mongoose', () => {
+            assert.equal(mongoose.options.useFindAndModify, false);
+          });
+        });
+      });
+
+      context('at connection level', () => {
+        context('set as true', () => {
+          let connection;
+          let AwesomeModel;
+
+          before(() => {
+            connection = mongoose.createConnection('mongodb://localhost/db', {
+              useFindAndModify: true
+            });
+            AwesomeModel = connection.model('AwesomeModel', new Schema({
+              name: String
+            }));
+          });
+
+          after(() => {
+            connection.close();
+          });
+
+          it('should run .findOne with useFindAndModify as true', () => {
+            const query = AwesomeModel.findOne();
+            assert.equal(query._mongooseOptions.useFindAndModify, true);
+          });
+
+          it('should not modify the global options of Mongoose', () => {
+            assert.equal(mongoose.options.useFindAndModify, false);
+          });
+        });
+
+        context('set as false', () => {
+          let connection;
+          let AwesomeModel;
+
+          before(() => {
+            connection = mongoose.createConnection('mongodb://localhost/db', {
+              useFindAndModify: false
+            });
+            AwesomeModel = connection.model('AwesomeModel', new Schema({
+              name: String
+            }));
+          });
+
+          after(() => {
+            connection.close();
+          });
+
+          it('should run .findOne with useFindAndModify as false', () => {
+            const query = AwesomeModel.findOne();
+            assert.equal(query._mongooseOptions.useFindAndModify, false);
+          });
+
+          it('should not modify the global options of Mongoose', () => {
+            assert.equal(mongoose.options.useFindAndModify, false);
+          });
+        });
+      });
+    });
+
+  });
+
   it('force close (gh-5664)', function(done) {
     const opts = {};
     const db = mongoose.createConnection('mongodb://localhost:27017/test', opts);


### PR DESCRIPTION
**Summary**
Add `useFindAndModify` option to config in the `Mongoose.prototype.connect`.
Also update the relationated documentation.

**Motivation**
To be consistant with the `Mongoose.prototype.set` and `Mongoose.prototype.connect` options.
It would be nice to be able to set the config as the `options` param.

**Example**
```javascript
mongoose.connect(MONGODB_URI, {
    useNewUrlParser: true,
    useFindAndModify: false,
    useCreateIndex: true
});
```
