### PR TITLE
fixes #7022 add close() to ChangeStream

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -15,10 +15,13 @@ class ChangeStream extends EventEmitter {
     super();
 
     this.driverChangeStream = null;
-
+    this.closed = false;
     // This wrapper is necessary because of buffering.
     if (model.collection.buffer) {
       model.collection.addQueue(() => {
+        if (this.closed) {
+          return;
+        }
         this.driverChangeStream = model.collection.watch(pipeline, options);
         this._bindEvents();
         this.emit('ready');
@@ -38,6 +41,13 @@ class ChangeStream extends EventEmitter {
 
   _queue(cb) {
     this.once('ready', () => cb());
+  }
+
+  close() {
+    this.closed = true;
+    if (this.driverChangeStream) {
+      this.driverChangeStream.close();
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

re #7022. This change exposes the underlying ChangeStream `close()` method on mongoose ChangeStreams while honoring mongoose's ability to buffer commands. If a `watch()` operation is buffered when `close()` is called on the ChangeStream, the watch operation will never run on the underlying driver.  

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a couple of failing tests, made them pass locally. Lots of tests fail for me in master at the moment, digging into why. Creating this as is to see if they pass on Travis.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

With this code change, the repro script in #7022 can be changed to call `inserts.close()` and it works as expected.