### PR TITLE
fixes #7074 make timestamps false work again

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -840,7 +840,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
   const childHasTimestamp = this.childSchemas.
     find(s => s.schema.options.timestamps != null);
 
-  if (timestamps == null && !childHasTimestamp) {
+  if (!timestamps && !childHasTimestamp) {
     return;
   }
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -3956,6 +3956,16 @@ describe('document', function() {
       done();
     });
 
+    it('timestamps set to false works (gh-7074)', function() {
+      const schema = new Schema({ name: String }, { timestamps: false });
+      const Test = db.model('gh7074', schema);
+      return co(function*() {
+        const doc = yield Test.create({ name: 'test' });
+        assert.strictEqual(doc.updatedAt, undefined);
+        assert.strictEqual(doc.createdAt, undefined);
+      });
+    });
+
     it('timestamps with nested paths (gh-5051)', function(done) {
       const schema = new Schema({ props: {} }, {
         timestamps: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

re #7074 `timestamps: false` is causing timestamps to be added to the schema. This change tests timestamps for a falsey value instead of != null. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Added a failing test, made it pass, still using a backup computer that is apparently too slow for 30 of the tests to pass, so I'm holding my breath to see if Travis complains :smile:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

With this change, the repro code in #7074 no longer adds timestamps to the schema when set to false.