### PR TITLE
fixes #7099 orFail() returns undefined when a match IS found

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3707,13 +3707,16 @@ Query.prototype.orFail = function(err) {
           err = typeof err === 'function' ? err.call(this) : err;
           throw err;
         }
-        break;
+        return res;
+        // there's no need for a break below the return, as this code is unreachable
+        // break
       case 'findOne':
         if (res == null) {
           err = typeof err === 'function' ? err.call(this) : err;
           throw err;
         }
-        break;
+        return res;
+        //break;
       case 'update':
       case 'updateMany':
       case 'updateOne':
@@ -3721,7 +3724,8 @@ Query.prototype.orFail = function(err) {
           err = typeof err === 'function' ? err.call(this) : err;
           throw err;
         }
-        break;
+        return res;
+        //break;
       case 'deleteMany':
       case 'deleteOne':
       case 'remove':
@@ -3729,7 +3733,8 @@ Query.prototype.orFail = function(err) {
           err = typeof err === 'function' ? err.call(this) : err;
           throw err;
         }
-        break;
+        return res;
+        //break;
       default:
         break;
     }


### PR DESCRIPTION
Fixes issue #7099: "orFail() returns undefined when a match IS found"

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Fixes issue #7099: "orFail() returns undefined when a match IS found" -->
