### PR TITLE
make Schema.prototype.{add,remove} return the Schema instance

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -364,6 +364,7 @@ Schema.prototype.defaultOptions = function(options) {
  *
  * @param {Object} obj
  * @param {String} prefix
+ * @returns {Schema} the Schema instance
  * @api public
  */
 
@@ -1439,7 +1440,7 @@ Schema.prototype.virtualpath = function(name) {
  * Removes the given `path` (or [`paths`]).
  *
  * @param {String|Array} path
- *
+ * @returns {Schema} the Schema instance
  * @api public
  */
 Schema.prototype.remove = function(path) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -411,6 +411,7 @@ Schema.prototype.add = function add(obj, prefix) {
   const addedKeys = Object.keys(obj).
     map(key => prefix ? prefix + key : key);
   aliasFields(this, addedKeys);
+  return this;
 };
 
 /**
@@ -1460,6 +1461,7 @@ Schema.prototype.remove = function(path) {
       }
     }, this);
   }
+  return this;
 };
 
 /**

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1198,6 +1198,12 @@ describe('schema', function() {
       done();
     });
 
+    it('returns the schema instance', function() {
+      const schema = new Schema({ name: String });
+      const ret = schema.clone().add({ age: Number });
+      assert.ok(ret instanceof Schema);
+    });
+
     it('merging nested objects (gh-662)', function(done) {
       const MergedSchema = new Schema({
         a: {
@@ -1640,6 +1646,11 @@ describe('schema', function() {
         f: String,
         g: [String]
       });
+    });
+
+    it('returns the schema instance', function() {
+      const ret = this.schema.clone().remove('g');
+      assert.ok(ret instanceof Schema);
     });
 
     it('removes a single path', function(done) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

per #3056 This change returns the Schema instance from both `Schema.add()` and `Schema.remove()`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added two new failing tests, made them pass:
```
mongoose>: npm test -- -g 'returns the schema instance'

> mongoose@5.3.3 test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "returns the schema instance"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !!

  0 passing (3s)
  2 failing

  1) schema
       #add()
         returns the schema instance:

      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  func.apply(thisObj, args)

      + expected - actual

      -false
      +true

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as ok] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/schema.test.js:1204:14)

  2) schema
       remove()
         returns the schema instance:

      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  func.apply(thisObj, args)

      + expected - actual

      -false
      +true

      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as ok] (node_modules/empower-core/lib/decorate.js:51:30)
      at Context.<anonymous> (test/schema.test.js:1654:14)



npm ERR! Test failed.  See above for more details.
mongoose>: npm test -- -g 'returns the schema instance'

> mongoose@5.3.3 test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "returns the schema instance"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․

  2 passing (3s)

mongoose>:
```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This change makes it possible to use `remove()` and `add()` inline in a schema path.