### PR TITLE
Fixes #6075 make depopulate remove populated virtuals & not throw on unpopulated docs

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3081,7 +3081,7 @@ Document.prototype.depopulate = function(path) {
   for (i = 0; i < path.length; i++) {
     populatedIds = this.populated(path[i]);
     if (!populatedIds) {
-      if (!virtualKeys.includes(path[i])) {
+      if (virtualKeys.indexOf(path[i]) === -1) {
         continue;
       } else {
         delete this.$$populatedVirtuals[path[i]];

--- a/lib/document.js
+++ b/lib/document.js
@@ -3056,10 +3056,16 @@ Document.prototype.depopulate = function(path) {
   }
   let i;
   let populatedIds;
+  const virtualKeys = this.$$populatedVirtuals ? Object.keys(this.$$populatedVirtuals) : [];
 
   if (arguments.length === 0) {
     // Depopulate all
-    const keys = Object.keys(this.$__.populated);
+    const keys = this.$__.populated ? Object.keys(this.$__.populated) : [];
+
+    for (i = 0; i < virtualKeys.length; i++) {
+      delete this.$$populatedVirtuals[virtualKeys[i]];
+      delete this._doc[virtualKeys[i]];
+    }
 
     for (i = 0; i < keys.length; i++) {
       populatedIds = this.populated(keys[i]);
@@ -3075,7 +3081,13 @@ Document.prototype.depopulate = function(path) {
   for (i = 0; i < path.length; i++) {
     populatedIds = this.populated(path[i]);
     if (!populatedIds) {
-      continue;
+      if (!virtualKeys.includes(path[i])) {
+        continue;
+      } else {
+        delete this.$$populatedVirtuals[path[i]];
+        delete this._doc[path[i]];
+        continue;
+      }
     }
     delete this.$__.populated[path[i]];
     this.$set(path[i], populatedIds);

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -638,6 +638,22 @@ describe('document.populate', function() {
     });
   });
 
+  it('doesn\'t throw when called on a doc that isn\'t populated (gh-6075)', function() {
+    const Person = db.model('gh6075', {
+      name: String
+    });
+
+    const person = new Person({ name: 'Greg Dulli' });
+    person.save(function(err, doc) {
+      assert.ifError(err);
+      try {
+        doc.depopulate();
+      } catch (e) {
+        assert.ifError(e);
+      }
+    });
+  });
+
   it('does not allow you to call populate() on nested docs (gh-4552)', function(done) {
     const EmbeddedSchema = new Schema({
       reference: {

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -565,92 +565,164 @@ describe('document.populate', function() {
     });
   });
 
-  it('can depopulate (gh-2509)', function(done) {
-    const Person = db.model('gh2509_1', {
-      name: String
+  describe('depopulate', function() {
+    it('can depopulate specific path (gh-2509)', function(done) {
+      const Person = db.model('gh2509_1', {
+        name: String
+      });
+
+      const Band = db.model('gh2509_2', {
+        name: String,
+        members: [{ type: Schema.Types.ObjectId, ref: 'gh2509_1' }],
+        lead: { type: Schema.Types.ObjectId, ref: 'gh2509_1' }
+      });
+
+      const people = [{ name: 'Axl Rose' }, { name: 'Slash' }];
+      Person.create(people, function(error, docs) {
+        assert.ifError(error);
+        const band = {
+          name: 'Guns N\' Roses',
+          members: [docs[0]._id, docs[1]],
+          lead: docs[0]._id
+        };
+        Band.create(band, function(error, band) {
+          band.populate('members', function() {
+            assert.equal(band.members[0].name, 'Axl Rose');
+            band.depopulate('members');
+            assert.ok(!band.members[0].name);
+            assert.equal(band.members[0].toString(), docs[0]._id.toString());
+            assert.equal(band.members[1].toString(), docs[1]._id.toString());
+            assert.ok(!band.populated('members'));
+            assert.ok(!band.populated('lead'));
+            band.populate('lead', function() {
+              assert.equal(band.lead.name, 'Axl Rose');
+              band.depopulate('lead');
+              assert.ok(!band.lead.name);
+              assert.equal(band.lead.toString(), docs[0]._id.toString());
+              done();
+            });
+          });
+        });
+      });
     });
 
-    const Band = db.model('gh2509_2', {
-      name: String,
-      members: [{type: Schema.Types.ObjectId, ref: 'gh2509_1'}],
-      lead: {type: Schema.Types.ObjectId, ref: 'gh2509_1'}
-    });
+    it('depopulates all (gh-6073)', function(done) {
+      const Person = db.model('gh6073_1', {
+        name: String
+      });
 
-    const people = [{name: 'Axl Rose'}, {name: 'Slash'}];
-    Person.create(people, function(error, docs) {
-      assert.ifError(error);
-      const band = {
-        name: 'Guns N\' Roses',
-        members: [docs[0]._id, docs[1]],
-        lead: docs[0]._id
-      };
-      Band.create(band, function(error, band) {
-        band.populate('members', function() {
-          assert.equal(band.members[0].name, 'Axl Rose');
-          band.depopulate('members');
-          assert.ok(!band.members[0].name);
-          assert.equal(band.members[0].toString(), docs[0]._id.toString());
-          assert.equal(band.members[1].toString(), docs[1]._id.toString());
-          assert.ok(!band.populated('members'));
-          assert.ok(!band.populated('lead'));
-          band.populate('lead', function() {
-            assert.equal(band.lead.name, 'Axl Rose');
-            band.depopulate('lead');
-            assert.ok(!band.lead.name);
-            assert.equal(band.lead.toString(), docs[0]._id.toString());
+      const Band = db.model('gh6073_2', {
+        name: String,
+        members: [{type: Schema.Types.ObjectId, ref: 'gh6073_1'}],
+        lead: {type: Schema.Types.ObjectId, ref: 'gh6073_1'}
+      });
+
+      const people = [{name: 'Axl Rose'}, {name: 'Slash'}];
+      Person.create(people, function(error, docs) {
+        assert.ifError(error);
+        const band = {
+          name: 'Guns N\' Roses',
+          members: [docs[0]._id, docs[1]],
+          lead: docs[0]._id
+        };
+        Band.create(band, function(error, band) {
+          band.populate('members lead', function() {
+            assert.ok(band.populated('members'));
+            assert.ok(band.populated('lead'));
+            assert.equal(band.members[0].name, 'Axl Rose');
+            band.depopulate();
+            assert.ok(!band.populated('members'));
+            assert.ok(!band.populated('lead'));
             done();
           });
         });
       });
     });
-  });
 
-  it('depopulate all (gh-6073)', function(done) {
-    const Person = db.model('gh6073_1', {
-      name: String
-    });
+    it('doesn\'t throw when called on a doc that is not populated (gh-6075)', function(done) {
+      const Person = db.model('gh6075', {
+        name: String
+      });
 
-    const Band = db.model('gh6073_2', {
-      name: String,
-      members: [{type: Schema.Types.ObjectId, ref: 'gh6073_1'}],
-      lead: {type: Schema.Types.ObjectId, ref: 'gh6073_1'}
-    });
-
-    const people = [{name: 'Axl Rose'}, {name: 'Slash'}];
-    Person.create(people, function(error, docs) {
-      assert.ifError(error);
-      const band = {
-        name: 'Guns N\' Roses',
-        members: [docs[0]._id, docs[1]],
-        lead: docs[0]._id
-      };
-      Band.create(band, function(error, band) {
-        band.populate('members lead', function() {
-          assert.ok(band.populated('members'));
-          assert.ok(band.populated('lead'));
-          assert.equal(band.members[0].name, 'Axl Rose');
-          band.depopulate();
-          assert.ok(!band.populated('members'));
-          assert.ok(!band.populated('lead'));
-          done();
-        });
+      const person = new Person({ name: 'Greg Dulli' });
+      person.save(function(err, doc) {
+        assert.ifError(err);
+        try {
+          doc.depopulate();
+        } catch (e) {
+          assert.ifError(e);
+        }
+        done();
       });
     });
-  });
 
-  it('doesn\'t throw when called on a doc that isn\'t populated (gh-6075)', function() {
-    const Person = db.model('gh6075', {
-      name: String
-    });
+    it('depopulates virtuals (gh-6075)', function(done) {
+      const otherSchema = new Schema({
+        val: String,
+        prop: String
+      });
 
-    const person = new Person({ name: 'Greg Dulli' });
-    person.save(function(err, doc) {
-      assert.ifError(err);
-      try {
-        doc.depopulate();
-      } catch (e) {
-        assert.ifError(e);
-      }
+      const schema = new Schema({
+        others: [String],
+        single: String
+      }, { toJSON: { virtuals: true } });
+
+      schema.virtual('$others', {
+        ref: 'gh6075_other',
+        localField: 'others',
+        foreignField: 'val'
+      });
+
+      schema.virtual('$single', {
+        ref: 'gh6075_other',
+        localField: 'single',
+        foreignField: 'val',
+        justOne: true
+      });
+
+      schema.virtual('$last', {
+        ref: 'gh6075_other',
+        localField: 'single',
+        foreignField: 'val',
+        justOne: true
+      });
+
+      const Other = db.model('gh6075_other', otherSchema);
+      const Test = db.model('gh6075_test', schema);
+
+      const others = 'abc'.split('').map(c => {
+        return new Other({
+          val: `other${c}`,
+          prop: `xyz${c}`
+        });
+      });
+
+      const test = new Test({
+        others: others.map(d => d.val),
+        single: others[1].val
+      });
+
+      Other.create(others).
+        then(() => {
+          return test.save();
+        }).
+        then((saved) => {
+          return saved.populate('$others $single').execPopulate();
+        }).
+        then((populated) => {
+          assert.strictEqual(populated.$others.length, 3);
+          assert.strictEqual(populated.$single.prop, 'xyzb');
+          populated.depopulate();
+          assert.strictEqual(populated.$others, null);
+          assert.strictEqual(populated.$single, null);
+          return populated.populate('$last').execPopulate();
+        }).
+        then((populatedAgain) => {
+          assert.strictEqual(populatedAgain.$last.prop, 'xyzb');
+          populatedAgain.depopulate('$last');
+          assert.strictEqual(populatedAgain.$last, null);
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
re #6075 when `depopulate()` is called on a doc that has either not been populated, or only has populated virtuals , it throws an error. Also, `depopulate()` does not currently remove populated virtuals whether or not they are passed into depopulate explicitly e.g. `depopulate('$someVirtuallyPopulatedPath')`  or implied with `depopulate()`. 

This change fixes the error, and makes `depopulate()` remove both explicit and implicit populated virtual paths.

I added a test for calling `depopulate()` on an unpopulated doc, and a test for both implicit and explicit depopulation of virtuals. All current tests pass.

```
mongoose>: npm test -- -g 'depopulate'

> mongoose@5.3.6 test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "depopulate"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․

  9 passing (443ms)

mongoose>:
mongoose>: npm test -- --no-warnings

> mongoose@5.3.6 test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "--no-warnings"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․,․․,․․,․,,․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ,,․․․․․․․․․․․․․․,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․
  ․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․,․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,
  ,,,,,,․․․․․․․․․․․․․․․․․․․․․․

  2097 passing (57s)
  37 pending

mongoose>:
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
