### PR TITLE
Fixes #7202 don't set parent timestamps because a child has timestamps set to false

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -853,8 +853,12 @@ Schema.prototype.hasMixedParent = function(path) {
  * @api private
  */
 Schema.prototype.setupTimestamp = function(timestamps) {
-  const childHasTimestamp = this.childSchemas.
-    find(s => s.schema.options.timestamps != null);
+  const childHasTimestamp = this.childSchemas.find(withTimestamp);
+
+  function withTimestamp(s) {
+    const ts = s.schema.options.timestamps;
+    return ts == true || ts == null;
+  }
 
   if (!timestamps && !childHasTimestamp) {
     return;

--- a/test/timestamps.test.js
+++ b/test/timestamps.test.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const start = require('./common');
 
 const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
 
 describe('timestamps', function() {
   let db;
@@ -160,6 +161,23 @@ describe('timestamps', function() {
         assert.ok(doc.ts.updatedAt.valueOf() >= startTime);
         done();
       });
+    });
+  });
+
+  it('no timestamps added when parent/child timestamps explicitly false (gh-7202)', function(done) {
+    const subSchema = new Schema({}, { timestamps: false });
+    const schema = new Schema({ sub: subSchema }, { timestamps: false });
+
+    const Test = db.model('gh7202', schema);
+    const test = new Test({ sub: {} });
+
+    test.save((err, saved) => {
+      assert.ifError(err);
+      assert.strictEqual(saved.createdAt, undefined);
+      assert.strictEqual(saved.updatedAt, undefined);
+      assert.strictEqual(saved.sub.createdAt, undefined);
+      assert.strictEqual(saved.sub.updatedAt, undefined);
+      done();
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

re: #7202 when explicitly creating a parent schema with `timestamps: false` that has a childSchema with `timestamps: false` the parent winds up with timestamps because the callback passed to childSchemas.find() only tests for loosely not equal to null. This change fixes that behavior.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

added a failing test, made it pass, all current tests pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
