### PR TITLE
fixes #7098 don't skip casting the update for array of array values

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -411,7 +411,7 @@ function castUpdateVal(schema, val, op, $conditional, context, path) {
     return schema.castForQueryWrapper({
       val: val,
       context: context,
-      $skipQueryCastForUpdate: val != null && schema.$isMongooseArray
+      $skipQueryCastForUpdate: val != null && schema.$isMongooseArray && schema.$parentSchema
     });
   }
 


### PR DESCRIPTION
re: #7098, when updating a value in an array of arrays, we shouldn't skip query casting on the value. This change uses the `schematype.$parentSchema` value to detect if the current array is a top level array, only skipping casting on those that are.

I added a failing test, made it pass, all existing tests pass:
```
mongoose>: npm test -- -g 'gh-7098'

> mongoose@5.3.9-pre test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-7098"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  !

  0 passing (381ms)
  1 failing

  1) model: update:
       bug fixes
         doesn't skip casting the query on nested arrays (gh-7098):

      AssertionError [ERR_ASSERTION]: Input A expected to strictly deep-equal input B:
+ expected - actual

- []
+ [
+   [
+     0,
+     1
+   ],
+   [
+     200,
+     3
+   ],
+   [
+     4,
+     5
+   ]
+ ]
      + expected - actual

      -[]
      +[
      +  [
      +    0
      +    1
      +  ]
      +  [
      +    200
      +    3
      +  ]
      +  [
      +    4
      +    5
      +  ]
      +]

      at /Users/lineus/dev/node/src/mongoose/test/model.update.test.js:2576:16
      at Generator.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at process._tickCallback (internal/process/next_tick.js:68:7)



npm ERR! Test failed.  See above for more details.
mongoose>:
mongoose>: npm test -- -g 'gh-7098'

> mongoose@5.3.9-pre test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "-g" "gh-7098"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․

  1 passing (394ms)

mongoose>:
mongoose>: npm test -- --no-warnings

> mongoose@5.3.9-pre test /Users/lineus/dev/node/src/mongoose
> mocha --exit test/*.test.js test/**/*.test.js "--no-warnings"


 You're not testing shards!
 Please set the MONGOOSE_SHARD_TEST_URI env variable.
 e.g: `mongodb://localhost:27017/database
 Sharding must already be enabled on your database


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․,․․,․․,․,,․․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․,,․․․․․․․․․․․․․․,,,,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․․․․․․,,․․․․․․․․․․․․․․․․․․․․
  ․․․,․․․․․․․․,․,․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․,,,,,,,,
  ,․․․․․․․․․․․․․․․․․․․․․․

  2103 passing (53s)
  37 pending

mongoose>:
```

the following is an expanded version of the repro code from #7098, all assertions pass with this change:

### 7098.js
```js
#!/usr/bin/env node
'use strict';

const assert = require('assert');
const mongoose = require('mongoose');
const { Schema, connection} = mongoose;
const DB = '7098';
const URI = `mongodb://localhost:27017/${DB}`;
const OPTS = { family: 4, useNewUrlParser: true };

const nestedSchema = new Schema({
  xyz: [[Number]]
});
const schema = new Schema({
  xyz: [[{ type: Number }]],
  nested: nestedSchema
});

const Test = mongoose.model('test', schema);

const test = new Test({
  xyz: [
    [ 0, 1 ],
    [ 2, 3 ],
    [ 4, 5 ]
  ],
  nested: {
    xyz: [
      [0, 1],
      [2, 3],
      [4, 5]
    ],
  }
});

const bulkObject = [{
  updateOne: {
    filter: { _id: test._id },
    upsert: false,
    update: { $set: { 'xyz.1.0': '200', 'nested.xyz.1.0': '200' } }
  }
}];


async function run() {
  // assert.strictEqual(mongoose.version, '5.3.8') // the assertions below fail on 5.3.8
  assert.strictEqual(mongoose.version, '5.3.9-pre');
  await mongoose.connect(URI, OPTS);
  await connection.dropDatabase();
  const inserted = await Test.create(test);
  assert.deepStrictEqual(inserted.toObject().xyz, [[0, 1], [2, 3], [4, 5]]);
  assert.deepStrictEqual(inserted.toObject().nested.xyz, [[0, 1], [2, 3], [4, 5]]);
  await Test.bulkWrite(bulkObject);
  const updated = await Test.collection.findOne({});
  assert.deepStrictEqual(updated.xyz, [[0, 1], [200, 3], [4, 5]]);
  assert.deepStrictEqual(updated.nested.xyz, [[0, 1], [200, 3], [4, 5]]);
  console.log('All Assertions Pass.');
  await connection.close();
}

run().catch(error);

function error(e) {
  console.error(e);
  return connection.close();
}

```
### Output:
```
issues: ./7098.js
All Assertions Pass.
issues:
```

