### PR TITLE
test(mixed): add failing test to see #7144

### DIFF
--- a/test/schema.mixed.test.js
+++ b/test/schema.mixed.test.js
@@ -34,4 +34,25 @@ describe('schematype mixed', function() {
       done();
     });
   });
+
+  describe('mixed types with dot', function() {
+    it('should enable key with dot(.) on mixed types', function(done) {
+      const s = new Schema({ raw: { type: Schema.Types.Mixed } });
+      const M = mongoose.model('M1', s);
+
+      const raw = {
+        '@odata.etag': 'blah',
+        id: 'id',
+      };
+
+      const m1 = new M({
+        raw
+      }).save()
+        .then(data => {
+          assert.equal(data.raw).toEqual(raw);
+
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

I've upgraded mongoose from 5.1.4 to 5.3.10 and some tests in our codebase started failing.
This is my attempt to provide a failing test to help debug this issue.
The test is not working, is it possible to use async await on tests? it would make writing tests much easier.
I'm not sure either if the test is in the right file

I've got this error when running the tests:

```
  1) schematype mixed
       mixed types with dot
         should enable key with dot(.) on mixed types:
     OverwriteModelError: Cannot overwrite `M1` model once compiled.
      at new OverwriteModelError (lib/error/overwriteModel.js:20:11)
      at Mongoose.model (lib/index.js:427:13)
      at Context.<anonymous> (test/schema.mixed.test.js:41:26)
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
run to get the error
`npm test -- -g 'schema'`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
