### PR TITLE
Fixes hardcode instance of class comparation

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3847,7 +3847,7 @@ function assignVals(o) {
       }, new MongooseMap({}, docs[i]));
     }
 
-    if (o.isVirtual && docs[i].constructor.name === 'model') {
+    if (o.isVirtual && docs[i] instanceof Model) {
       // If virtual populate and doc is already init-ed, need to walk through
       // the actual doc to set rather than setting `_doc` directly
       mpath.set(o.path, rawIds[i], docs[i], setValue);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Comparing if an model instance is an model instance by using the `constructor.name` property has many collateral effects. One being plugins to not have the ability to incorporate more functionality and override default behavior.

For instance, I came across this issue while having an unexpected behavior during `populate()` of an already fetched document, on a `MongoTenantModel` (a plugin that applies tenancity to mongoose). It works by creating a new instance of the Model, but with a few more pre hooks that prevents user from mutating/reading other tenants.

While this approach is correct, the comparision of `constructor.name` being equal to `model`, is false when in a MongoTenant Context, not populating the virtuals naturally.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Explanation**
Just explained above

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Demonstration**
Use a MultiTenantModel, with virtuals being populated (https://www.npmjs.com/package/mongo-tenant)