### PR TITLE
Removing ^4.11.0 as compatible with MongoDB 3.6

### DIFF
--- a/docs/compatibility.html
+++ b/docs/compatibility.html
@@ -23,7 +23,7 @@ server.</p>
 <li>MongoDB Server 3.0.x: mongoose <code>^3.8.22</code>, <code>4.x</code>, or <code>5.x</code></li>
 <li>MongoDB Server 3.2.x: mongoose <code>^4.3.0</code> or <code>5.x</code></li>
 <li>MongoDB Server 3.4.x: mongoose <code>^4.7.3</code> or <code>5.x</code></li>
-<li>MongoDB Server 3.6.x: mongoose <code>5.x</code>, or <code>^4.11.0</code> with <code>useMongoClient</code> and <code>usePushEach</code></li>
+<li>MongoDB Server 3.6.x: mongoose <code>5.x</code></li>
 <li>MongoDB Server 4.0.x: mongoose <code>^5.2.0</code></li>
 </ul>
 <p>Note that Mongoose 5.x dropped support for all versions of MongoDB before


### PR DESCRIPTION
Mongoose `^4.11.0` use the `2.2.X` version of the MongoDB Node.js driver (https://github.com/Automattic/mongoose/blob/4.11.0/package.json#L26) whereas only versions `>= 3.0` of the driver is recommended for MongoDB 3.6 (https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#reference-compatibility-mongodb-node).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The compatibility documentation currently lists Mongoose `^4.11.0` as compatible with MongoDB 3.6. However, this version of Mongoose does not use the MongoDB Node.js driver version that is recommended for this version of MongoDB 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Removing this range will prevent users from using a not-recommended version of the underlying Node.js driver on MongoDB 3.6.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Documentation change only; no testing should be needed. 