### PR TITLE
Removing ^4.11.0 as compatible with MongoDB 3.6

### DIFF
--- a/docs/compatibility.jade
+++ b/docs/compatibility.jade
@@ -33,7 +33,7 @@ block content
     * MongoDB Server 3.0.x: mongoose `^3.8.22`, `4.x`, or `5.x`
     * MongoDB Server 3.2.x: mongoose `^4.3.0` or `5.x`
     * MongoDB Server 3.4.x: mongoose `^4.7.3` or `5.x`
-    * MongoDB Server 3.6.x: mongoose `5.x`, or `^4.11.0` with `useMongoClient` and `usePushEach`
+    * MongoDB Server 3.6.x: mongoose `5.x`
     * MongoDB Server 4.0.x: mongoose `^5.2.0`
 
     Note that Mongoose 5.x dropped support for all versions of MongoDB before


### PR DESCRIPTION
(Incorrectly made this change in `compatibility.html` in an earlier pull request -  https://github.com/Automattic/mongoose/pull/7238)

Mongoose `^4.11.0` use the `2.2.X` version of the MongoDB Node.js driver (https://github.com/Automattic/mongoose/blob/4.11.0/package.json#L26) whereas only versions >= 3.0 of the driver is recommended for MongoDB 3.6 (https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#reference-compatibility-mongodb-node).

The compatibility documentation currently lists Mongoose ^4.11.0 as compatible with MongoDB 3.6. However, this version of Mongoose does not use the MongoDB Node.js driver version that is recommended for this version of MongoDB

Removing this range will prevent users from using a not-recommended version of the underlying Node.js driver on MongoDB 3.6.

Documentation change only; no testing should be needed.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
