### PR TITLE
feat(model): add `Model.events.on('error')` for reporting all errors that occur on a model

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -700,7 +700,7 @@ Aggregate.prototype.explain = function(callback) {
         }
         cb(null, result);
       });
-  });
+  }, this._model.events);
 };
 
 /**
@@ -963,7 +963,7 @@ Aggregate.prototype.exec = function(callback) {
         });
       });
     });
-  });
+  }, model.events);
 };
 
 /**

--- a/lib/browserDocument.js
+++ b/lib/browserDocument.js
@@ -74,6 +74,12 @@ Document.prototype = Object.create(NodeJSDocument.prototype);
 Document.prototype.constructor = Document;
 
 /*!
+ * ignore
+ */
+
+Document.events = new EventEmitter();
+
+/*!
  * Browser doc exposes the event emitter API
  */
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -593,7 +593,8 @@ Document.prototype.update = function update() {
  */
 
 Document.prototype.updateOne = function updateOne(doc, options, callback) {
-  return utils.promiseOrCallback(callback, cb => this.$__updateOne(doc, options, cb));
+  return utils.promiseOrCallback(callback,
+    cb => this.$__updateOne(doc, options, cb), this.constructor.events);
 };
 
 /*!
@@ -1702,7 +1703,7 @@ Document.prototype.validate = function(options, callback) {
 
   return utils.promiseOrCallback(callback, cb => this.$__validate(function(error) {
     cb(error);
-  }));
+  }), this.constructor.events);
 };
 
 /*!
@@ -3008,7 +3009,7 @@ Document.prototype.populate = function populate() {
 Document.prototype.execPopulate = function(callback) {
   return utils.promiseOrCallback(callback, cb => {
     this.populate(cb);
-  });
+  }, this.constructor.events);
 };
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -158,6 +158,26 @@ Model.prototype.$where;
 
 Model.prototype.baseModelName;
 
+/**
+ * Event emitter that reports any errors that occurred. Useful for global error
+ * handling.
+ *
+ * ####Example:
+ *
+ *     MyModel.events.on('error', err => console.log(err.message));
+ *
+ *     // Prints a 'CastError' because of the above handler
+ *     await MyModel.findOne({ _id: 'notanid' }).catch({} => {});
+ *
+ * @api public
+ * @fires error whenever any query or model function errors
+ * @property events
+ * @memberOf Model
+ * @static
+ */
+
+Model.events;
+
 /*!
  * ignore
  */
@@ -432,7 +452,7 @@ Model.prototype.save = function(options, fn) {
       }
       cb(null, this);
     });
-  });
+  }, this.constructor.events);
 };
 
 /*!
@@ -857,7 +877,7 @@ Model.prototype.remove = function remove(options, fn) {
 
   return utils.promiseOrCallback(fn, cb => {
     this.$__remove(options, cb);
-  });
+  }, this.constructor.events);
 };
 
 /**
@@ -1130,7 +1150,7 @@ Model.createCollection = function createCollection(options, callback) {
       this.collection = this.db.collection(this.collection.collectionName, options);
       cb(null, this.collection);
     }));
-  });
+  }, this.events);
 };
 
 /**
@@ -1237,7 +1257,7 @@ Model.syncIndexes = function syncIndexes(options, callback) {
         cb(null, dropped);
       });
     });
-  });
+  }, this.events);
 };
 
 /**
@@ -1265,7 +1285,7 @@ Model.listIndexes = function init(callback) {
     } else {
       _listIndexes(cb);
     }
-  });
+  }, this.events);
 };
 
 /**
@@ -1314,7 +1334,7 @@ Model.ensureIndexes = function ensureIndexes(options, callback) {
       }
       cb(null);
     });
-  });
+  }, this.events);
 };
 
 /**
@@ -2673,7 +2693,7 @@ Model.create = function create(doc, options, callback) {
         cb.apply(this, [null].concat(savedDocs));
       }
     });
-  });
+  }, this.events);
 };
 
 /**
@@ -2781,7 +2801,7 @@ Model.insertMany = function(arr, options, callback) {
   }
   return utils.promiseOrCallback(callback, cb => {
     this.$__insertMany(arr, options, cb);
-  });
+  }, this.events);
 };
 
 /*!
@@ -2957,7 +2977,7 @@ Model.bulkWrite = function(ops, options, callback) {
         cb(null, res);
       });
     });
-  });
+  }, this.events);
 };
 
 /**
@@ -3277,7 +3297,7 @@ Model.mapReduce = function mapReduce(o, callback) {
 
       cb(null, res);
     });
-  });
+  }, this.events);
 };
 
 /**
@@ -3433,7 +3453,7 @@ Model.geoSearch = function(conditions, options, callback) {
         res.results[i].init(temp, {}, init);
       }
     });
-  });
+  }, this.events);
 };
 
 /**
@@ -3520,7 +3540,7 @@ Model.populate = function(docs, paths, callback) {
 
   return utils.promiseOrCallback(callback, cb => {
     _populate(_this, docs, paths, cache, cb);
-  });
+  }, this.events);
 };
 
 /*!
@@ -4393,6 +4413,7 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   model.db = model.prototype.db = connection;
   model.discriminators = model.prototype.discriminators = undefined;
   model[modelSymbol] = true;
+  model.events = new EventEmitter();
 
   model.prototype.$__setSchema(schema);
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -3843,7 +3843,7 @@ Query.prototype.exec = function exec(op, callback) {
       }
       cb(null, res);
     });
-  });
+  }, this.model.events);
 };
 
 /**

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -82,6 +82,7 @@ function _createConstructor(schema, options) {
   EmbeddedDocument.schema = schema;
   EmbeddedDocument.prototype.constructor = EmbeddedDocument;
   EmbeddedDocument.$isArraySubdocument = true;
+  EmbeddedDocument.events = new EventEmitter();
 
   // apply methods
   for (const i in schema.methods) {

--- a/lib/schema/embedded.js
+++ b/lib/schema/embedded.js
@@ -78,6 +78,7 @@ function _createConstructor(schema) {
   _embedded.prototype.constructor = _embedded;
   _embedded.schema = schema;
   _embedded.$isSingleNested = true;
+  _embedded.events = new EventEmitter();
   _embedded.prototype.toBSON = function() {
     return this.toObject(internalToObjectOptions);
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,6 +14,8 @@ const mpath = require('mpath');
 const ms = require('ms');
 const Buffer = require('safe-buffer').Buffer;
 
+const emittedSymbol = Symbol.for('mongoose:emitted');
+
 let MongooseBuffer;
 let MongooseArray;
 let Document;
@@ -229,15 +231,25 @@ const clone = exports.clone;
  * ignore
  */
 
-exports.promiseOrCallback = function promiseOrCallback(callback, fn) {
+exports.promiseOrCallback = function promiseOrCallback(callback, fn, ee) {
   if (typeof callback === 'function') {
-    try {
-      return fn(callback);
-    } catch (error) {
-      return process.nextTick(() => {
-        throw error;
-      });
-    }
+    return fn(function(error) {
+      if (error != null) {
+        if (ee.listeners('error').length > 0 && !error[emittedSymbol]) {
+          error[emittedSymbol] = true;
+          ee.emit('error', error);
+        }
+        try {
+          callback(error);
+        } catch (error) {
+          return process.nextTick(() => {
+            throw error;
+          });
+        }
+        return;
+      }
+      callback.apply(this, arguments);
+    });
   }
 
   const Promise = PromiseProvider.get();
@@ -245,6 +257,10 @@ exports.promiseOrCallback = function promiseOrCallback(callback, fn) {
   return new Promise((resolve, reject) => {
     fn(function(error, res) {
       if (error != null) {
+        if (ee.listeners('error').length > 0 && !error[emittedSymbol]) {
+          error[emittedSymbol] = true;
+          ee.emit('error', error);
+        }
         return reject(error);
       }
       if (arguments.length > 2) {


### PR DESCRIPTION
Fix #7125

```javascript
// Will print out errors in queries, aggregations, `save()`, etc.
Model.events.on('error', err => { console.log(err); });
```

@Fonger @lineus @NishantDesai1306 any thoughts?