### PR TITLE
fix: added changes to pass session in model create to rollback

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2600,13 +2600,18 @@ Model.create = function create(doc, options, callback) {
     options = options != null && typeof options === 'object' ? options : {};
   } else {
     const last = arguments[arguments.length - 1];
-    options = {};
+    options = options.session ? { session: options.session } : {};
     // Handle falsy callbacks re: #5061
     if (typeof last === 'function' || !last) {
       cb = last;
       args = utils.args(arguments, 0, arguments.length - 1);
     } else {
-      args = utils.args(arguments);
+      if (!options.session)
+        args = utils.args(arguments);
+      else {
+        args = utils.args(arguments);
+        args.splice(-1,1);
+      }
     }
   }
 

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -148,6 +148,26 @@ describe('transactions', function() {
       });
   });
 
+  it('create document and pass as object with session (pr-7296)', function() {
+    const User = db.model('pr7296_User', new Schema({ name: String }));
+
+    let session = null;
+    return db.createCollection('pr7296_User').
+      then(() => db.startSession()).
+      then(_session => {
+        session = _session;
+        session.startTransaction();
+        return User.create({ name: 'foo' }, { session: session });
+      }).
+      then(user => {
+        session.commitTransaction();
+      }).
+      then(() => User.findOne({ name: 'foo' })).
+      then(user => {
+        assert.ok(user);
+      });
+  });
+
   it('aggregate', function() {
     const Event = db.model('Event', new Schema({ createdAt: Date }), 'Event');
 


### PR DESCRIPTION
**Summary**

Added session param in create method. This is made optional to work on all existing cases and passed as a session instead of a document-spread only if it contains a 'session' key.

**Test plan**

The 'options' param consisting the session to rollback or commit the transaction is appended.