### PR TITLE
Move `Query#map()` functions to run before post hooks to support `orFail()` with `findOneAndUpdate()`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2737,8 +2737,6 @@ Query.prototype._findOneAndUpdate = function(callback) {
     return callback(this.error());
   }
 
-  const callback = _wrapThunkCallback(this, callback);
-
   this._findAndModify('update', callback);
 };
 
@@ -3101,7 +3099,7 @@ Query.prototype._findAndModify = function(type, callback) {
     }
 
     if (type === 'remove') {
-      collection.findOneAndDelete(castedQuery, opts, utils.tick(function(error, res) {
+      collection.findOneAndDelete(castedQuery, opts, _wrapThunkCallback(_this, function(error, res) {
         return cb(error, res ? res.value : res, res);
       }));
 
@@ -3120,7 +3118,7 @@ Query.prototype._findAndModify = function(type, callback) {
           castedDoc = castedDoc.toBSON();
         }
 
-        collection[updateMethod](castedQuery, castedDoc, opts, utils.tick(function(error, res) {
+        collection[updateMethod](castedQuery, castedDoc, opts, _wrapThunkCallback(_this, function(error, res) {
           return cb(error, res ? res.value : res, res);
         }));
       };
@@ -3134,7 +3132,7 @@ Query.prototype._findAndModify = function(type, callback) {
       if (castedDoc && castedDoc.toBSON) {
         castedDoc = castedDoc.toBSON();
       }
-      collection[updateMethod](castedQuery, castedDoc, opts, utils.tick(function(error, res) {
+      collection[updateMethod](castedQuery, castedDoc, opts, _wrapThunkCallback(_this, function(error, res) {
         return cb(error, res ? res.value : res, res);
       }));
     }
@@ -3150,7 +3148,7 @@ Query.prototype._findAndModify = function(type, callback) {
       if (castedDoc && castedDoc.toBSON) {
         castedDoc = castedDoc.toBSON();
       }
-      _this._collection.findAndModify(castedQuery, castedDoc, opts, utils.tick(function(error, res) {
+      _this._collection.findAndModify(castedQuery, castedDoc, opts, _wrapThunkCallback(_this, function(error, res) {
         return cb(error, res ? res.value : res, res);
       }));
     };
@@ -3164,7 +3162,7 @@ Query.prototype._findAndModify = function(type, callback) {
     if (castedDoc && castedDoc.toBSON) {
       castedDoc = castedDoc.toBSON();
     }
-    this._collection.findAndModify(castedQuery, castedDoc, opts, utils.tick(function(error, res) {
+    this._collection.findAndModify(castedQuery, castedDoc, opts, _wrapThunkCallback(_this, function(error, res) {
       return cb(error, res ? res.value : res, res);
     }));
   }
@@ -3814,7 +3812,7 @@ Query.prototype.exec = function exec(op, callback) {
         cb(error);
         return;
       }
-      
+
       cb(null, res);
     });
   });

--- a/lib/query.js
+++ b/lib/query.js
@@ -1709,6 +1709,8 @@ Query.prototype._find = function(callback) {
     return null;
   }
 
+  callback = _wrapThunkCallback(this, callback);
+
   this._applyPaths();
   this._fields = this._castFields(this._fields);
 
@@ -1940,7 +1942,7 @@ Query.prototype._findOne = function(callback) {
       return null;
     }
 
-    this._completeOne(doc, null, callback);
+    this._completeOne(doc, null, _wrapThunkCallback(this, callback));
   });
 };
 
@@ -2423,6 +2425,8 @@ Query.prototype._remove = function(callback) {
     return this;
   }
 
+  callback = _wrapThunkCallback(this, callback);
+
   return Query.base.remove.call(this, helpers.handleWriteOpResult(callback));
 };
 
@@ -2483,6 +2487,8 @@ Query.prototype._deleteOne = function(callback) {
     return this;
   }
 
+  callback = _wrapThunkCallback(this, callback);
+
   return Query.base.deleteOne.call(this, helpers.handleWriteOpResult(callback));
 };
 
@@ -2542,6 +2548,8 @@ Query.prototype._deleteMany = function(callback) {
     callback(this.error());
     return this;
   }
+
+  callback = _wrapThunkCallback(this, callback);
 
   return Query.base.deleteMany.call(this, helpers.handleWriteOpResult(callback));
 };
@@ -2728,6 +2736,8 @@ Query.prototype._findOneAndUpdate = function(callback) {
   if (this.error() != null) {
     return callback(this.error());
   }
+
+  const callback = _wrapThunkCallback(this, callback);
 
   this._findAndModify('update', callback);
 };
@@ -2921,7 +2931,7 @@ Query.prototype._findOneAndDelete = function(callback) {
     }
   }
 
-  this._collection.collection.findOneAndDelete(filter, options, (err, res) => {
+  this._collection.collection.findOneAndDelete(filter, options, _wrapThunkCallback(this, (err, res) => {
     if (err) {
       return callback(err);
     }
@@ -2929,7 +2939,7 @@ Query.prototype._findOneAndDelete = function(callback) {
     const doc = res.value;
 
     return this._completeOne(doc, res, callback);
-  });
+  }));
 };
 
 /*!
@@ -3231,6 +3241,8 @@ function _updateThunk(op, callback) {
     callback(this.error());
     return null;
   }
+
+  callback = _wrapThunkCallback(this, callback);
 
   const castedQuery = this._conditions;
   let castedDoc;
@@ -3726,7 +3738,19 @@ Query.prototype.orFail = function(err) {
       case 'update':
       case 'updateMany':
       case 'updateOne':
-        if (res.nModified === 0) {
+        if (get(res, 'result.nModified') === 0) {
+          err = typeof err === 'function' ? err.call(this) : err;
+          throw err;
+        }
+        break;
+      case 'findOneAndDelete':
+        if (get(res, 'lastErrorObject.n') === 0) {
+          err = typeof err === 'function' ? err.call(this) : err;
+          throw err;
+        }
+        break;
+      case 'findOneAndUpdate':
+        if (get(res, 'lastErrorObject.updatedExisting') === false) {
           err = typeof err === 'function' ? err.call(this) : err;
           throw err;
         }
@@ -3790,17 +3814,33 @@ Query.prototype.exec = function exec(op, callback) {
         cb(error);
         return;
       }
-      for (const fn of this._transforms) {
-        try {
-          res = fn(res);
-        } catch (error) {
-          return cb(error);
-        }
-      }
+      
       cb(null, res);
     });
   });
 };
+
+/*!
+ * ignore
+ */
+
+function _wrapThunkCallback(query, cb) {
+  return function(error, res) {
+    if (error != null) {
+      return cb(error);
+    }
+
+    for (const fn of query._transforms) {
+      try {
+        res = fn(res);
+      } catch (error) {
+        return cb(error);
+      }
+    }
+
+    return cb(null, res);
+  };
+}
 
 /**
  * Executes the query returning a `Promise` which will be

--- a/lib/query.js
+++ b/lib/query.js
@@ -1880,7 +1880,7 @@ Query.prototype.collation = function(value) {
 
 Query.prototype._completeOne = function(doc, res, callback) {
   if (!doc) {
-    return callback(null, null, res);
+    return callback(null, null);
   }
 
   const model = this.model;
@@ -1892,7 +1892,7 @@ Query.prototype._completeOne = function(doc, res, callback) {
   const options = this.options;
 
   if (options.explain) {
-    return callback(null, doc, res);
+    return callback(null, doc);
   }
 
   if (!mongooseOptions.populate) {
@@ -2581,7 +2581,7 @@ function completeOne(model, doc, res, options, fields, userProvidedFields, pop, 
       res.value = casted;
       return process.nextTick(() => callback(null, res));
     }
-    process.nextTick(() => callback(null, casted, res));
+    process.nextTick(() => callback(null, casted));
   }
 }
 
@@ -3170,7 +3170,7 @@ function _completeOneLean(doc, res, opts, callback) {
   if (opts.rawResult) {
     return callback(null, res);
   }
-  return callback(null, doc, res);
+  return callback(null, doc);
 }
 
 /*!
@@ -3709,7 +3709,7 @@ Query.prototype.map = function(fn) {
  */
 
 Query.prototype.orFail = function(err) {
-  this.map((res, raw) => {
+  this.map(res => {
     switch (this.op) {
       case 'find':
         if (res.length === 0) {
@@ -3727,18 +3727,6 @@ Query.prototype.orFail = function(err) {
       case 'updateMany':
       case 'updateOne':
         if (res.nModified === 0) {
-          err = typeof err === 'function' ? err.call(this) : err;
-          throw err;
-        }
-        break;
-      case 'findOneAndDelete':
-        if (get(raw, 'lastErrorObject.n') === 0) {
-          err = typeof err === 'function' ? err.call(this) : err;
-          throw err;
-        }
-        break;
-      case 'findOneAndUpdate':
-        if (get(raw, 'lastErrorObject.updatedExisting') === false) {
           err = typeof err === 'function' ? err.call(this) : err;
           throw err;
         }
@@ -3791,28 +3779,27 @@ Query.prototype.exec = function exec(op, callback) {
     callback = this.model.$wrapCallback(callback);
   }
 
-  const forceSingle = true;
   return utils.promiseOrCallback(callback, (cb) => {
     if (!_this.op) {
       cb();
       return;
     }
 
-    this[this.op].call(this, (error, res, extra) => {
+    this[this.op].call(this, (error, res) => {
       if (error) {
         cb(error);
         return;
       }
       for (const fn of this._transforms) {
         try {
-          res = fn(res, extra);
+          res = fn(res);
         } catch (error) {
           return cb(error);
         }
       }
-      cb(null, res, extra);
+      cb(null, res);
     });
-  }, forceSingle);
+  });
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -226,16 +226,10 @@ exports.clone = function clone(obj, options) {
 const clone = exports.clone;
 
 /*!
- * Before returning to the user, Mongoose will call this function to ensure
- * if a callback is provided, Mongoose uses the callback, otherwise Mongoose
- * returns a promise.
- *
- * @param {Function|null} callback if this parameter is a function, Mongoose will call it and not return a promise
- * @param {Function} fn thunk that Mongoose should execute and wrap in a promise if necessary.
- * @param {Boolean} [forceSingle] Promises can only resolve to a single value, but you can call a callback with multiple args. By default, `promiseOrCallback` will convert multi-arg callbacks into an array for promises. If this is set, `promiseOrCallback` will just take the first value.
+ * ignore
  */
 
-exports.promiseOrCallback = function promiseOrCallback(callback, fn, forceSingle) {
+exports.promiseOrCallback = function promiseOrCallback(callback, fn) {
   if (typeof callback === 'function') {
     try {
       return fn(callback);
@@ -253,7 +247,7 @@ exports.promiseOrCallback = function promiseOrCallback(callback, fn, forceSingle
       if (error != null) {
         return reject(error);
       }
-      if (arguments.length > 2 && !forceSingle) {
+      if (arguments.length > 2) {
         return resolve(Array.prototype.slice.call(arguments, 1));
       }
       resolve(res);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2968,6 +2968,36 @@ describe('Query', function() {
         assert.equal(res.name, 'Test');
       });
     });
+
+    it('executes before post hooks (gh-7280)', function() {
+      return co(function*() {
+        const schema = new Schema({ name: String });
+        const docs = [];
+        schema.post('findOne', function(doc, next) {
+          docs.push(doc);
+          next();
+        });
+        const Model = db.model('gh7280', schema);
+
+        yield Model.create({ name: 'Test' });
+
+        let threw = false;
+        try {
+          yield Model.findOne({ name: 'na' }).orFail(new Error('Oops!'));
+        } catch (error) {
+          assert.ok(error);
+          assert.equal(error.message, 'Oops!');
+          threw = true;
+        }
+        assert.ok(threw);
+        assert.equal(docs.length, 0);
+
+        // Shouldn't throw
+        const res = yield Model.findOne({ name: 'Test' }).orFail(new Error('Oops'));
+        assert.equal(res.name, 'Test');
+        assert.equal(docs.length, 1);
+      });
+    });
   });
 
   describe('getPopulatedPaths', function() {


### PR DESCRIPTION
Re: #7280