### PR TITLE
Fix mistake in populate documentation

### DIFF
--- a/docs/populate.jade
+++ b/docs/populate.jade
@@ -128,7 +128,7 @@ block content
     [left join](https://www.w3schools.com/sql/sql_join_left.asp) in SQL.
 
     ```javascript
-    await Story.deleteMany({ title: 'Casino Royale' });
+    await Person.deleteMany({ name: 'Ian Fleming' });
 
     const story = await Story.findOne({ title: 'Casino Royale' }).populate('author');
     story.author; // `null`


### PR DESCRIPTION
In the section "What If There's No Foreign Document?", I found the sample code confusing, I believe it's a mistake.

After `Story.deleteMany` the story "Casino Ryale" not exists anymore. so we can't `findOne`. the `story` it returned should be `null` and `story.author` will throw `TypeError: Cannot read property 'author' of null`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
