### PR TITLE
fix: don't use addCursorFlag in tests #7394

### DIFF
--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -1261,7 +1261,7 @@ describe('aggregate: ', function() {
 
     const cursor = MyModel.
       aggregate([{ $match: { name: 'test' } }]).
-      addCursorFlag('noCursorTimeout', true).
+      option({'noCursorTimeout': true}).
       cursor().
       exec();
 

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -422,7 +422,7 @@ describe('QueryCursor', function() {
 
     const User = db.model('gh4814', userSchema);
 
-    const cursor = User.find().cursor().option({'noCursorTimeout': true});
+    const cursor = User.find().option({'noCursorTimeout': true});
 
     cursor.on('cursor', function() {
       assert.equal(cursor.cursor.s.cmd.noCursorTimeout, true);

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -422,7 +422,7 @@ describe('QueryCursor', function() {
 
     const User = db.model('gh4814', userSchema);
 
-    const cursor = User.find().option({'noCursorTimeout': true});
+    const cursor = User.find().cursor().addCursorFlag('noCursorTimeout', true);
 
     cursor.on('cursor', function() {
       assert.equal(cursor.cursor.s.cmd.noCursorTimeout, true);

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -422,7 +422,7 @@ describe('QueryCursor', function() {
 
     const User = db.model('gh4814', userSchema);
 
-    const cursor = User.find().cursor().addCursorFlag('noCursorTimeout', true);
+    const cursor = User.find().cursor().option({'noCursorTimeout': true});
 
     cursor.on('cursor', function() {
       assert.equal(cursor.cursor.s.cmd.noCursorTimeout, true);


### PR DESCRIPTION
Fixes #7394 : "addCursorFlag is deprecated" warning when tests are run