### PR TITLE
fix: use correct variable name

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -981,7 +981,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
 function getPositionalPathType(self, path) {
   const subpaths = path.split(/\.(\d+)\.|\.(\d+)$/).filter(Boolean);
   if (subpaths.length < 2) {
-    return self.paths.hasOwnProperty(subpaths[0]) ? self.paths[subpath[0]] : null;
+    return self.paths.hasOwnProperty(subpaths[0]) ? self.paths[subpaths[0]] : null;
   }
 
   let val = self.path(subpaths[0]);


### PR DESCRIPTION
**Summary**

Fixes a crash due to a misspelled variable name: `subpath[0]` is evaluated as `undefined[0]`. The [crash was flagged](https://lgtm.com/projects/g/Automattic/mongoose/snapshot/dist-6870015-1548143554293/files/lib/schema.js?sort=name&dir=ASC&mode=list#xcd0143b6ecb7c548:1) by the LGTM.com analysis I am working on.

`subpath` is actually defined in this method, but that happens many lines later. I suppose that is why it escaped ordinary linting.

**Examples**

I suppose a call to `getPositionalPathType({}, "123")` could cause the crash.

