### PR TITLE
Added dot sytnax support for alias queries.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1587,15 +1587,32 @@ Model.discriminators;
  * @return {Object} the translated 'pure' fields/conditions
  */
 Model.translateAliases = function translateAliases(fields) {
-  const aliases = this.schema.aliases;
-
   if (typeof fields === 'object') {
     // Fields is an object (query conditions or document fields)
     for (const key in fields) {
-      if (aliases[key]) {
-        fields[aliases[key]] = fields[key];
-        delete fields[key];
+      let alias;
+      const translated = [];
+      const fieldKeys = key.split('.');
+      let currentSchema = this.schema;
+      for (const field in fieldKeys) {
+        const name = fieldKeys[field];
+        if (currentSchema && currentSchema.aliases[name]) {
+          alias = currentSchema.aliases[name];
+          // Alias found,
+          translated.push(alias);
+        } else {
+          // Alias not found, so treat as un-aliased key
+          translated.push(name);
+        }
+
+        // Check if aliased path is a schema
+        if (currentSchema.paths[alias])
+          currentSchema = currentSchema.paths[alias].schema;
+        else
+          currentSchema = null;
       }
+      fields[translated.join('.')] = fields[key];
+      delete fields[key]; // We'll be using the translated key instead
     }
 
     return fields;

--- a/test/model.translateAliases.test.js
+++ b/test/model.translateAliases.test.js
@@ -11,7 +11,12 @@ const mongoose = start.mongoose;
 
 describe('model translate aliases', function() {
   it('should translate correctly', function() {
+    const Syntax =new mongoose.Schema({
+      s: { type: String, alias: 'syntax' }
+    });
+
     const Character = mongoose.model('Character', new mongoose.Schema({
+      d: { type: Syntax, alias: 'dot' },
       name: { type: String, alias: '名' },
       bio: {
         age: { type: Number, alias: '年齢' }
@@ -22,12 +27,14 @@ describe('model translate aliases', function() {
       // Translate aliases
       Character.translateAliases({
         '名': 'Stark',
-        '年齢': 30
+        '年齢': 30,
+        'dot.syntax': 'DotSyntax'
       }),
       // How translated aliases suppose to look like
       {
         name: 'Stark',
-        'bio.age': 30
+        'bio.age': 30,
+        'd.s': 'DotSyntax'
       }
     );
   });


### PR DESCRIPTION
Added dot syntax key support for Model.translateAlias function.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.jade` file or test case in the `test/docs` directory.

**Summary**

Model.translateAlias only worked for single field keys, and did not support nested field queries with dot notation.

**Examples**
```
// Given a Mongo query
{
  "AliasKey.NestedKey": "value"
}

// Can become translated to
{
  "ActualKey.ActualNestedKey": "value"
}
```

Both AliasKey and NestedKey will have the individual keys translated if they have an alias in the schema. If there is no alias, the value itself is used.