### PR TITLE
add configuration for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base", ":rebaseStalePrs", ":preserveSemverRanges"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["config:base", ":rebaseStalePrs", ":preserveSemverRanges"]
+  "extends": ["config:base", ":rebaseStalePrs", ":preserveSemverRanges"],
+  "devDependencies": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
resolves #5953

**Summary**

Renovate can open a pull request when a newer version of a dependency, outside the allowed semantic version range becomes available.

**Examples**

Here is the example output PRs based off the current dependencies: https://github.com/ChristianMurphy/mongoose/pulls?utf8=%E2%9C%93&q=is%3Apr+chore+deps

renovate can be run by any user on the project with committer access.

```
npm install --global renovate
renovate --token {github access token} Automattic/mongoose
```

Renovate Website: https://renovatebot.com
Renovate Github: https://github.com/renovatebot/renovate
