### PR TITLE
feat(document): validateUpdatedOnly option. ignores valid on unmodified

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1726,13 +1726,43 @@ Document.prototype.isDirectSelected = function isDirectSelected(path) {
  */
 
 Document.prototype.validate = function(options, callback) {
+  const _this = this;
+
   if (typeof options === 'function') {
     callback = options;
     options = null;
   }
 
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
+
   return utils.promiseOrCallback(callback, cb => this.$__validate(function(error) {
-    cb(error);
+    if(shouldValidateModifiedOnly && error.name === 'ValidationError') {
+      let errorsOnModified = {};
+      for (const key in error.errors) {
+        if(_this.isModified(error.errors[key].path)) {
+          errorsOnModified[key] = error.errors[key];
+        }
+      }
+      if(Object.keys(errorsOnModified).length === 0) {
+        // swallow error
+        cb(null);
+      }
+      else {
+        cb(Object.assign({}, error, {errors: errorsOnModified}));
+      }
+    }
+    else {
+      cb(error);
+    }
   }), this.constructor.events);
 };
 
@@ -1979,8 +2009,19 @@ Document.prototype.$__validate = function(callback) {
  * @api public
  */
 
-Document.prototype.validateSync = function(pathsToValidate) {
+Document.prototype.validateSync = function(pathsToValidate, options = {}) {
   const _this = this;
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
 
   if (typeof pathsToValidate === 'string') {
     pathsToValidate = pathsToValidate.split(' ');
@@ -1988,7 +2029,9 @@ Document.prototype.validateSync = function(pathsToValidate) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  let paths = pathDetails[0];
+  let paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (pathsToValidate && pathsToValidate.length) {

--- a/lib/plugins/validateBeforeSave.js
+++ b/lib/plugins/validateBeforeSave.js
@@ -26,7 +26,13 @@ module.exports = function(schema) {
 
     // Validate
     if (shouldValidate) {
-      this.validate(function(error) {
+      const hasValidateModifiedOnlyOption = options &&
+          (typeof options === 'object') &&
+          ('validateModifiedOnly' in options);
+      const validateOptions = hasValidateModifiedOnlyOption ?
+        {validateModifiedOnly: options.validateModifiedOnly} :
+        null;
+      this.validate(validateOptions, function(error) {
         return _this.schema.s.hooks.execPost('save:error', _this, [ _this], { error: error }, function(error) {
           next(error);
         });

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -2276,6 +2276,57 @@ describe('document', function() {
       });
     });
 
+    it('does not filter validation on unmodified paths when validateModifiedOnly not set (gh-7421)', function(done) {
+      const testSchema = new Schema({ title: { type: String, required: true }, other: String });
+
+      const Test = db.model('gh7421_1', testSchema);
+
+      Test.create([{}], {validateBeforeSave: false}, function(createError, docs) {
+        assert.equal(createError, null);
+        let doc = docs[0];
+        doc.other = 'something';
+        assert.ok(doc.validateSync().errors);
+        doc.save(function (error, updatedDoc) {
+          assert.ok(error.errors);
+          done();
+        });
+      });
+    });
+
+    it('filters out validation on unmodified paths when validateModifiedOnly set (gh-7421)', function(done) {
+      const testSchema = new Schema({ title: { type: String, required: true }, other: String });
+
+      const Test = db.model('gh7421_2', testSchema);
+
+      Test.create([{}], {validateBeforeSave: false}, function(createError, docs) {
+        assert.equal(createError, null);
+        let doc = docs[0];
+        doc.other = 'something';
+        assert.equal(doc.validateSync(undefined, {validateModifiedOnly: true}), null);
+        doc.save({validateModifiedOnly: true}, function (error, updatedDoc) {
+          assert.equal(error, null);
+          done();
+        });
+      });
+    });
+
+    it('does not filter validation on modified paths when validateModifiedOnly set (gh-7421)', function(done) {
+      const testSchema = new Schema({ title: { type: String, required: true }, other: String });
+
+      const Test = db.model('gh7421_3', testSchema);
+
+      Test.create([{title: 'title'}], {validateBeforeSave: false}, function(createError, docs) {
+        assert.equal(createError, null);
+        let doc = docs[0];
+        doc.title = '';
+        assert.ok(doc.validateSync(undefined, {validateModifiedOnly: true}).errors);
+        doc.save({validateModifiedOnly: true}, function (error, updatedDoc) {
+          assert.ok(error.errors);
+          done();
+        });
+      });
+    });
+
     it('handles non-errors', function(done) {
       const schema = new Schema({
         name: { type: String, required: true }


### PR DESCRIPTION
schema option that can be overridden on validate, validateSync, and save

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#7421 - ignore validation on unmodified paths

Just wanted to draft this up to see if you're okay with this approach cause I'm not so sure about it.

For validateSync I was able to do it by pre-filtering the list of paths to validate.  I tried to do the same approach with validate, but when I messed with the signature of $__validate, it seemed to break the hooks.

So for regular validate, this PR post-filters the error and swallows it if there's none left :see_no_evil:.  It's technically not a performance regression because without this option we'd be running them anyway, but still.

Anyway, let me know if I should abandon this approach or not.  Otherwise, I think it still needs more tests for nested schemas and schema-level-default, and documentation, etc.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

examples in tests ;)

