### PR TITLE
feat(document): validateUpdatedOnly option. only validates modified

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1731,7 +1731,7 @@ Document.prototype.validate = function(options, callback) {
     options = null;
   }
 
-  return utils.promiseOrCallback(callback, cb => this.$__validate(function(error) {
+  return utils.promiseOrCallback(callback, cb => this.$__validate(options, function(error) {
     cb(error);
   }), this.constructor.events);
 };
@@ -1862,7 +1862,23 @@ function _getPathsToValidate(doc) {
  * ignore
  */
 
-Document.prototype.$__validate = function(callback) {
+Document.prototype.$__validate = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
+
   const _this = this;
   const _complete = () => {
     const err = this.$__.validationError;
@@ -1884,7 +1900,9 @@ Document.prototype.$__validate = function(callback) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  const paths = pathDetails[0];
+  const paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (paths.length === 0) {
@@ -1979,8 +1997,19 @@ Document.prototype.$__validate = function(callback) {
  * @api public
  */
 
-Document.prototype.validateSync = function(pathsToValidate) {
+Document.prototype.validateSync = function(pathsToValidate, options) {
   const _this = this;
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
 
   if (typeof pathsToValidate === 'string') {
     pathsToValidate = pathsToValidate.split(' ');
@@ -1988,7 +2017,9 @@ Document.prototype.validateSync = function(pathsToValidate) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  let paths = pathDetails[0];
+  let paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (pathsToValidate && pathsToValidate.length) {

--- a/lib/plugins/validateBeforeSave.js
+++ b/lib/plugins/validateBeforeSave.js
@@ -26,7 +26,13 @@ module.exports = function(schema) {
 
     // Validate
     if (shouldValidate) {
-      this.validate(function(error) {
+      const hasValidateModifiedOnlyOption = options &&
+          (typeof options === 'object') &&
+          ('validateModifiedOnly' in options);
+      const validateOptions = hasValidateModifiedOnlyOption ?
+        {validateModifiedOnly: options.validateModifiedOnly} :
+        null;
+      this.validate(validateOptions, function(error) {
         return _this.schema.s.hooks.execPost('save:error', _this, [ _this], { error: error }, function(error) {
           next(error);
         });


### PR DESCRIPTION
schema option that can be overridden on validate, validateSync, and save

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
#7421 - ignore validation on unmodified paths

Abandoned yucky post-filtering approach in #7483.

- [x] Still unresolved: https://github.com/Automattic/mongoose/pull/7483#discussion_r253687434 - are you sure I should add it?

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

see tests ;)
