### PR TITLE
gitignore correct syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 lib-cov
-**.swp
+*.swp
 *.sw*
 node_modules/
 *.orig


### PR DESCRIPTION
Hi,

The current pattern `**.swp` is invalid: 

> A pattern with '**' that does not have a slash on either side used to be an invalid one https://github.com/git/git/commit/627186d0206dcb219c43f8e6670b4487802a4921

Probably you want say `*.swp` ? Because on recent version of git as the link above say your syntax means `*\*.swp`


