### PR TITLE
Documentation: Document.prototype.validateSync returns ValidationError

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1975,7 +1975,7 @@ Document.prototype.$__validate = function(callback) {
  *     }
  *
  * @param {Array|string} pathsToValidate only validate the given paths
- * @return {MongooseError|undefined} MongooseError if there are errors during validation, or undefined if there is no error.
+ * @return {ValidationError|undefined} ValidationError if there are errors during validation, or undefined if there is no error.
  * @api public
  */
 


### PR DESCRIPTION
Sources:
    1. https://github.com/Automattic/mongoose/blob/bee1e1b4669185579168d691c214d17077b8bd6e/lib/document.js#L2031
    2. https://github.com/Automattic/mongoose/blob/bee1e1b4669185579168d691c214d17077b8bd6e/lib/document.js#L2101
    3. https://github.com/Automattic/mongoose/blob/bee1e1b4669185579168d691c214d17077b8bd6e/lib/document.js#L2035

**Summary**
Document.prototype.validateSync send ValidationError (it inherit of MongooseError).

If your are ok with that thanks sources above, I will make a PR to correct @types/mongoose accordingly 
