### PR TITLE
Fixed translateAliases bug.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1611,8 +1611,11 @@ Model.translateAliases = function translateAliases(fields) {
         else
           currentSchema = null;
       }
-      fields[translated.join('.')] = fields[key];
-      delete fields[key]; // We'll be using the translated key instead
+
+      const translatedKey = translated.join('.');
+      fields[translatedKey] = fields[key];
+      if (translatedKey !== key)
+        delete fields[key]; // We'll be using the translated key instead
     }
 
     return fields;

--- a/test/model.translateAliases.test.js
+++ b/test/model.translateAliases.test.js
@@ -26,6 +26,7 @@ describe('model translate aliases', function() {
     assert.deepEqual(
       // Translate aliases
       Character.translateAliases({
+        '_id': '1',
         '名': 'Stark',
         '年齢': 30,
         'dot.syntax': 'DotSyntax'
@@ -33,6 +34,7 @@ describe('model translate aliases', function() {
       // How translated aliases suppose to look like
       {
         name: 'Stark',
+        '_id': '1',
         'bio.age': 30,
         'd.s': 'DotSyntax'
       }


### PR DESCRIPTION
**Summary**

Unaliased keys were being deleted, rather than being returned unharmed. Also added a test with an '_id' query key to make sure it checks for this case.

**Examples**

Query
`{ '_id': ObjectId(...), 'someAliasedKey': '123' }

Schema
Schema with an alias for 'someAliasedKey' but not '_id' (or if _id isn't in the user's schema at all).

'_id' query will be deleted from the return of translateAliases, even though 'someAliasedKey' survives.