### PR TITLE
Doc: add an asterisk before comment, otherwise the comment line is not generated

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3699,7 +3699,7 @@ Query.prototype.update = function(conditions, doc, options, callback) {
  * @param {Object} [criteria]
  * @param {Object} [doc] the update command
  * @param {Object} [options]
- @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
+ * @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
  * @param {Function} [callback] optional params are (error, writeOpResult)
  * @return {Query} this
  * @see Model.update #model_Model.update
@@ -3753,7 +3753,7 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @param {Object} [criteria]
  * @param {Object} [doc] the update command
  * @param {Object} [options]
- @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
+ * @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
  * @see Model.update #model_Model.update


### PR DESCRIPTION
* Actually, at https://mongoosejs.com/docs/api.html we could see than `options.multipleCastError` are explained twice, only for :
  1. https://mongoosejs.com/docs/api.html#query_Query-findOneAndUpdate
  2. https://mongoosejs.com/docs/api.html#query_Query-update

* And not for:
  1.  https://mongoosejs.com/docs/api.html#query_Query-updateOne
  2. https://mongoosejs.com/docs/api.html#query_Query-updateMany

To correct this, simply add asterisk in the JSDoc