### PR TITLE
Doc ValidationError

### DIFF
--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -43,6 +43,7 @@ MongooseError.CastError = require('./cast');
 
 /**
  * An instance of this error class will be returned when [validation](/docs/validation.html) failed.
+ * It contains a hash of ValidatorError and / or CastError
  *
  * @api public
  */

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -43,7 +43,8 @@ MongooseError.CastError = require('./cast');
 
 /**
  * An instance of this error class will be returned when [validation](/docs/validation.html) failed.
- * It contains a hash of ValidatorError and / or CastError
+ * The `errors` property contains an object whose keys are the paths that failed and whose values are
+ * instances of CastError or ValidationError.
  *
  * @api public
  */

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1011,13 +1011,13 @@ describe('document', function() {
   });
 
   describe('Errors', function() {
-    it('MongooseErrors should be instances of Error (gh-209)', function(done) {
+    it('MongooseError should be instances of Error (gh-209)', function(done) {
       const MongooseError = require('../lib/error');
       const err = new MongooseError('Some message');
       assert.ok(err instanceof Error);
       done();
     });
-    it('ValidationErrors should be instances of Error', function(done) {
+    it('ValidationError should be instances of Error', function(done) {
       const ValidationError = Document.ValidationError;
       const err = new ValidationError(new TestDocument);
       assert.ok(err instanceof Error);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1011,13 +1011,13 @@ describe('document', function() {
   });
 
   describe('Errors', function() {
-    it('MongooseError should be instances of Error (gh-209)', function(done) {
+    it('MongooseErrors should be instances of Error (gh-209)', function(done) {
       const MongooseError = require('../lib/error');
       const err = new MongooseError('Some message');
       assert.ok(err instanceof Error);
       done();
     });
-    it('ValidationError should be instances of Error', function(done) {
+    it('ValidationErrors should be instances of Error', function(done) {
       const ValidationError = Document.ValidationError;
       const err = new ValidationError(new TestDocument);
       assert.ok(err instanceof Error);


### PR DESCRIPTION
Actually ValidationError seems to be an hash of CastError and ValidatorError. Therefore I make the proposal to say that in the doc. 

Proof:

```sh
$ grep "new ValidationError" * -R
document.js:    this.$__.validationError = new ValidationError(this);
helpers/query/castUpdate.js:  aggregatedError = aggregatedError || new ValidationError();
helpers/updateValidators.js:        const err = new ValidationError(null);
```

Furthermore, there I've seen a small typo error under  test/document.test.js therefore I propose to push the correction in this current PR. 