### PR TITLE
Fixes populate "getter" option on embedded documents

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4190,7 +4190,7 @@ function getModelsMapForPopulate(model, docs, options) {
 
     const localFieldPathType = modelSchema._getPathType(localField);
     const localFieldPath = localFieldPathType === 'real' ? modelSchema.paths[localField] : localFieldPathType.schema;
-    const localFieldGetters = localFieldPath ? localFieldPath.getters : [];
+    const localFieldGetters = localFieldPath && localFieldPath.getters ? localFieldPath.getters : [];
     let ret;
 
     const _populateOptions = get(options, 'options', {});

--- a/lib/model.js
+++ b/lib/model.js
@@ -4188,7 +4188,8 @@ function getModelsMapForPopulate(model, docs, options) {
       foreignField = foreignField.call(doc);
     }
 
-    const localFieldPath = modelSchema.paths[localField];
+    const localFieldPathType = modelSchema._getPathType(localField);
+    const localFieldPath = localFieldPathType === 'real' ? modelSchema.paths[localField] : localFieldPathType.schema;
     const localFieldGetters = localFieldPath ? localFieldPath.getters : [];
     let ret;
 
@@ -4199,7 +4200,14 @@ function getModelsMapForPopulate(model, docs, options) {
       options.isVirtual && get(virtual, 'options.getters', false);
     if (localFieldGetters.length > 0 && getters) {
       const hydratedDoc = (doc.$__ != null) ? doc : model.hydrate(doc);
-      ret = localFieldPath.applyGetters(doc[localField], hydratedDoc);
+      const localFieldValue = utils.getValue(localField, doc);
+      if (Array.isArray(localFieldValue)) {
+        const localFieldHydratedValue = utils.getValue(localField.split('.').slice(0, -1), hydratedDoc);
+        ret = localFieldValue.map((localFieldArrVal, localFieldArrIndex) =>
+          localFieldPath.applyGetters(localFieldArrVal, localFieldHydratedValue[localFieldArrIndex]));
+      } else {
+        ret = localFieldPath.applyGetters(localFieldValue, hydratedDoc);
+      }
     } else {
       ret = convertTo_id(utils.getValue(localField, doc));
     }

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -833,4 +833,68 @@ describe('document.populate', function() {
       });
     });
   });
+
+  describe('#populated() with getters on embedded schema (gh-7521)', function() {
+    let Team;
+    let Player;
+
+    before(function() {
+      const playerSchema = mongoose.Schema({
+        _id: String,
+      });
+
+      const teamSchema = mongoose.Schema({
+        captain: {
+          type: String,
+          ref: 'gh7521_Player',
+          get: (v) => {
+            if (!v || typeof v !== 'string') {
+              return v;
+            }
+
+            return v.split(' ')[0];
+          }
+        },
+        players: [new mongoose.Schema({
+          player: {
+            type: String,
+            ref: 'gh7521_Player',
+            get: (v) => {
+              if (!v || typeof v !== 'string') {
+                return v;
+              }
+
+              return v.split(' ')[0];
+            }
+          }
+        })],
+      });
+
+      Player = db.model('gh7521_Player', playerSchema);
+      Team = db.model('gh7521_Team', teamSchema);
+    });
+
+    it('works with populate', function() {
+      return co(function*() {
+        const player1 = yield Player.create({ _id: 'John' });
+        yield Player.create({ _id: 'Foo' });
+        const createdTeam = yield Team.create({ captain: 'John Doe', players: [{ player: 'John Doe' }, { player: 'Foo Bar' }] });
+
+        const team = yield Team.findOne({ _id: createdTeam._id })
+          .populate({ path: 'captain', options: { getters: true } })
+          .populate({ path: 'players.player', options: { getters: true } })
+          .exec();
+
+        console.log(team);
+        console.log(player1);
+        assert.ok(team.captain);
+        assert.strictEqual(team.captain._id, 'John');
+        assert.strictEqual(team.players.length, 2);
+        assert.ok(team.players[0].player);
+        assert.ok(team.players[1].player);
+        assert.strictEqual(team.players[0].player._id, 'John');
+        assert.strictEqual(team.players[1].player._id, 'Foo');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fix for #7520

```javascript
// Will call getters for "bars.bar"
Foo.findOne({ _id: '5c657e2beca6210c78090082' }).populate({ path: 'bars.bar', options: { getters: true } });
```