### PR TITLE
fix anchor tag in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Anyone can file an expense. If the expense makes sense for the development of th
 ### Contributors
 
 Thank you to all the people who have already contributed to mongoose!
-<a href="graphs/contributors"><img src="https://opencollective.com/mongoose/contributors.svg?width=890" /></a>
+<a href="https://github.com/Automattic/mongoose/graphs/contributors"><img src="https://opencollective.com/mongoose/contributors.svg?width=890" /></a>
 
 
 ### Backers


### PR DESCRIPTION
when viewing a .md file not from the root of the repository
(e.g. https://github.com/Automattic/mongoose/blob/master/CONTRIBUTING.md), relative paths add `/blob/master/` thus breaking the link.

Hence I changed the link to an absolute path (url)

There's also a "become a backer" button in the "contributors" section which is probably unwanted because the button in used in the next paragraph, but I didn't edit that.