### PR TITLE
Fix virtuals cloning

### DIFF
--- a/lib/helpers/schema/merge.js
+++ b/lib/helpers/schema/merge.js
@@ -12,7 +12,7 @@ module.exports = function merge(s1, s2) {
   }
 
   for (const virtual in s2.virtuals) {
-    s1.virtual[virtual] = s2.virtual[virtual].clone();
+    s1.virtuals[virtual] = s2.virtuals[virtual].clone();
   }
 
   s1.s.hooks.merge(s2.s.hooks, false);


### PR DESCRIPTION
**Summary**

Looks like there's a typo in code for merging two schemas. `schema.virtual` is a method, not the map of virtuals.
