### PR TITLE
docs: add useNewUrlParser to mongoose.connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Both `connect` and `createConnection` take a `mongodb://` URI, or the parameters
 ```js
 const mongoose = require('mongoose');
 
-mongoose.connect('mongodb://localhost/my_database');
+mongoose.connect('mongodb://localhost/my_database', {useNewUrlParser: true});
 ```
 
 Once connected, the `open` event is fired on the `Connection` instance. If you're using `mongoose.connect`, the `Connection` is `mongoose.connection`. Otherwise, `mongoose.createConnection` return value is a `Connection`.

--- a/docs/connections.jade
+++ b/docs/connections.jade
@@ -31,7 +31,7 @@ block content
     You can also specify several more parameters in the `uri`:
 
     ```javascript
-    mongoose.connect('mongodb://username:password@host:port/database?options...');
+    mongoose.connect('mongodb://username:password@host:port/database?options...', {useNewUrlParser: true});
     ```
 
     See the [mongodb connection string spec](http://docs.mongodb.org/manual/reference/connection-string/) for more detail.

--- a/docs/index.jade
+++ b/docs/index.jade
@@ -35,7 +35,7 @@ block content
     ```javascript
     // getting-started.js
     var mongoose = require('mongoose');
-    mongoose.connect('mongodb://localhost/test');
+    mongoose.connect('mongodb://localhost/test', {useNewUrlParser: true});
     ```
 
     We have a pending connection to the test database running on localhost.

--- a/docs/models.jade
+++ b/docs/models.jade
@@ -87,7 +87,7 @@ block content
     uses is open. Every model has an associated connection. When you use
     `mongoose.model()`, your model will use the default mongoose connection.
     ```javascript
-    mongoose.connect('localhost', 'gettingstarted');
+    mongoose.connect('mongodb://localhost/gettingstarted', {useNewUrlParser: true});
     ```
   :markdown
     If you create a custom connection, use that connection's `model()` function


### PR DESCRIPTION
**Summary**
Adds `{ addNewUrlParser: true }` to `mongoose.connect()` on some documentation pages. 
Also fixes an outdated mongoose.connect() on the Models page. 

For example:
`mongoose.connect('mongodb://localhost/my_database', {useNewUrlParser: true});`
Instead of:
`mongoose.connect('mongodb://localhost/my_database');`

Please also note that there are further mongoose.connect() lines without `useNewUrlParser` on `connections.jade`, `faq.jade` and `guide.jade`. I haven't replaced those because it looks like their primary purpose is to demonstrate some sort of connection option. 