### PR TITLE
Fixed issue, when in child schema has timestamp property

### DIFF
--- a/lib/helpers/update/applyTimestampsToChildren.js
+++ b/lib/helpers/update/applyTimestampsToChildren.js
@@ -99,7 +99,7 @@ function applyTimestampsToChildren(now, update, schema) {
           childPath = childPath.substr(0, firstDot);
 
           update.$set[parentPath.path + '.' + childPath + '.' + updatedAt] = now;
-        } else if (path.schema != null && path.schema != schema) {
+        } else if (path.schema != null && path.schema != schema && update.$set[key]) {
           timestamps = path.schema.options.timestamps;
           createdAt = handleTimestampOption(timestamps, 'createdAt');
           updatedAt = handleTimestampOption(timestamps, 'updatedAt');


### PR DESCRIPTION
**Summary**
Error happens when main schema has array of children with timestamps and the array is not exists in model.
When updating "other" field and array "name" is not exists,  error appears.

Error message:

TypeError: Cannot set property 'createdDate' of undefined at applyTimestampsToChildren (/node_modules/mongoose/lib/helpers/update/applyTimestampsToChildren.js:112:41)


**Examples**
```
const nameSchema = new mongoose.Schema({
	name: String,
}, { _id: false, timestamps: { createdAt: 'createdDate', updatedAt: false} });

const mainSchema = new mongoose.Schema({
        other: String,
	name: {
		type: [nameSchema],
		select: false
	}
});
```