### PR TITLE
Minor documentation-corrections + fixed function-signature "Query.comment"

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -799,7 +799,7 @@ Query.prototype.mod = function() {
  * @method comment
  * @memberOf Query
  * @instance
- * @param {Number} val
+ * @param {String} val
  * @see comment http://docs.mongodb.org/manual/reference/operator/comment/
  * @api public
  */

--- a/lib/query.js
+++ b/lib/query.js
@@ -118,7 +118,7 @@ Query.base = mquery.prototype;
  *
  *     mongoose.Query.use$geoWithin = false;
  *
- * MongoDB 2.4 deprecated the use of `$within`, replacing it with `$geoWithin`. Mongoose uses `$geoWithin` by default (which is 100% backward compatible with $within). If you are running an older version of MongoDB, set this flag to `false` so your `within()` queries continue to work.
+ * MongoDB 2.4 deprecated the use of `$within`, replacing it with `$geoWithin`. Mongoose uses `$geoWithin` by default (which is 100% backward compatible with `$within`). If you are running an older version of MongoDB, set this flag to `false` so your `within()` queries continue to work.
  *
  * @see http://docs.mongodb.org/manual/reference/operator/geoWithin/
  * @default true
@@ -374,7 +374,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $gt query condition.
+ * Specifies a `$gt` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -395,7 +395,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $gte query condition.
+ * Specifies a `$gte` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -409,7 +409,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $lt query condition.
+ * Specifies a `$lt` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -423,7 +423,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $lte query condition.
+ * Specifies a `$lte` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -437,7 +437,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $ne query condition.
+ * Specifies a `$ne` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -451,7 +451,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies an $in query condition.
+ * Specifies an `$in` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -465,7 +465,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies an $nin query condition.
+ * Specifies an `$nin` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -479,7 +479,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies an $all query condition.
+ * Specifies an `$all` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -499,7 +499,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $size query condition.
+ * Specifies a `$size` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -522,7 +522,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $regex query condition.
+ * Specifies a `$regex` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -536,7 +536,7 @@ Query.prototype.slice = function() {
  */
 
 /**
- * Specifies a $maxDistance query condition.
+ * Specifies a `maxDistance` query condition.
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
@@ -689,7 +689,7 @@ Query.prototype.mod = function() {
  */
 
 /**
- * Specifies a $slice projection for an array.
+ * Specifies a `$slice` projection for an array.
  *
  * ####Example
  *
@@ -1467,7 +1467,7 @@ Query.prototype._fieldsForExec = function() {
 
 
 /**
- * Return an update document with corrected $set operations.
+ * Return an update document with corrected `$set` operations.
  *
  * @method _updateForExec
  * @api private
@@ -3577,7 +3577,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
 /**
  * Declare and/or execute this query as an update() operation.
  *
- * _All paths passed that are not $atomic operations will become $set ops._
+ * _All paths passed that are not $atomic operations will become `$set` ops._
  *
  * This function triggers the following middleware.
  *
@@ -3616,7 +3616,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  *
  *     q.update({ $set: { name: 'bob' }}).exec(); // executed
  *
- *     // keys that are not $atomic ops become $set.
+ *     // keys that are not $atomic ops become `$set`.
  *     // this executes the same command as the previous example.
  *     q.update({ name: 'bob' }).exec();
  *
@@ -4775,7 +4775,7 @@ if (Symbol.asyncIterator != null) {
 }
 
 /**
- * Specifies a $polygon condition
+ * Specifies a `$polygon` condition
  *
  * ####Example
  *
@@ -4794,7 +4794,7 @@ if (Symbol.asyncIterator != null) {
  */
 
 /**
- * Specifies a $box condition
+ * Specifies a `$box` condition
  *
  * ####Example
  *
@@ -4831,7 +4831,7 @@ Query.prototype.box = function(ll, ur) {
 };
 
 /**
- * Specifies a $center or $centerSphere condition.
+ * Specifies a `$center` or `$centerSphere` condition.
  *
  * ####Example
  *
@@ -4874,7 +4874,7 @@ Query.prototype.box = function(ll, ur) {
 Query.prototype.center = Query.base.circle;
 
 /**
- * _DEPRECATED_ Specifies a $centerSphere condition
+ * _DEPRECATED_ Specifies a `$centerSphere` condition
  *
  * **Deprecated.** Use [circle](#query_Query-circle) instead.
  *


### PR DESCRIPTION
This PR fixes some minor formating-issues within the documentation and, in addition to that, corrects the function-signature of "Query.prototype.comment()" to a `String` instead `Number`.

This is my first PR here, so please tell me, if there is anything that i can do better in the future.