### PR TITLE
fix modelName being used as value to partialFilterExpression index

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1494,8 +1494,14 @@ function _decorateDiscriminatorIndexOptions(model, indexOptions) {
   if (model.baseModelName != null && indexOptions.unique &&
       !('partialFilterExpression' in indexOptions) &&
       !('sparse' in indexOptions)) {
+    
+    const value = (
+      model.schema.discriminatorMapping &&
+      model.schema.discriminatorMapping.value
+    ) || model.modelName
+
     indexOptions.partialFilterExpression = {
-      [model.schema.options.discriminatorKey]: model.modelName
+      [model.schema.options.discriminatorKey]: value
     };
   }
   return indexOptions;


### PR DESCRIPTION
**Summary**

The issue is described here: #7634. If the third parameter is used in a `Model.discriminator()` method it should be used as a value to `partialFilterExpression` index instead of the `model.modelName`.

**Examples**

Consider the following example:

```js
let BasePaymentSchema = new mongoose.Schema({
  amount: mongoose.Types.Decimal128
}, {
  discriminatorKey: 'provider'
})

let BasePayment = mongoose.model('Payment', BasePaymentSchema)

let PaypalPaymentSchema = new mongoose.Schema({
  transactionId: {
    type: String,
    unique: true
  }
})

let PaypalPayment = BasePayment.discriminator(
  'PaypalPayment',
  PaypalPaymentSchema,
  'paypal' // This value should be in discriminator field
)
```

Before the fix `db.payments.getIndexes()` returns:

```json
{
  "v": 2,
  "unique": true,
  "key": {
    "transactionId": 1
  },
  "name": "transactionId_1",
  "ns": "my-database.payments",
  "background": true,
  "partialFilterExpression": {
    "provider": "PaypalPayment"
  }
}
```

After the fix:

```json
{
  "v": 2,
  "unique": true,
  "key": {
    "transactionId": 1
  },
  "name": "transactionId_1",
  "ns": "my-database.payments",
  "background": true,
  "partialFilterExpression": {
    "provider": "paypal"
  }
}
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
