### PR TITLE
Minor changes to doc ("atomic" keyword made consistent)

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3577,7 +3577,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
 /**
  * Declare and/or execute this query as an update() operation.
  *
- * _All paths passed that are not $atomic operations will become `$set` ops._
+ * _All paths passed that are not [atomic](https://docs.mongodb.com/manual/tutorial/model-data-for-atomic-operations/#pattern) operations will become `$set` ops._
  *
  * This function triggers the following middleware.
  *
@@ -3616,7 +3616,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  *
  *     q.update({ $set: { name: 'bob' }}).exec(); // executed
  *
- *     // keys that are not $atomic ops become `$set`.
+ *     // keys that are not [atomic](https://docs.mongodb.com/manual/tutorial/model-data-for-atomic-operations/#pattern) ops become `$set`.
  *     // this executes the same command as the previous example.
  *     q.update({ name: 'bob' }).exec();
  *
@@ -3753,7 +3753,7 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * `update()`, except it does not support the `multi` or `overwrite` options.
  *
  * - MongoDB will update _only_ the first document that matches `criteria` regardless of the value of the `multi` option.
- * - Use `replaceOne()` if you want to overwrite an entire document rather than using atomic operators like `$set`.
+ * - Use `replaceOne()` if you want to overwrite an entire document rather than using [atomic](https://docs.mongodb.com/manual/tutorial/model-data-for-atomic-operations/#pattern) operators like `$set`.
  *
  * **Note** updateOne will _not_ fire update middleware. Use `pre('updateOne')`
  * and `post('updateOne')` instead.
@@ -3805,7 +3805,7 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
 /**
  * Declare and/or execute this query as a replaceOne() operation. Same as
  * `update()`, except MongoDB will replace the existing document and will
- * not accept any atomic operators (`$set`, etc.)
+ * not accept any [atomic](https://docs.mongodb.com/manual/tutorial/model-data-for-atomic-operations/#pattern) operators (`$set`, etc.)
  *
  * **Note** replaceOne will _not_ fire update middleware. Use `pre('replaceOne')`
  * and `post('replaceOne')` instead.


### PR DESCRIPTION
Very minor changes to the "atomic" keyword within the documentation.
I felt like i should link an official MongoDB-ref to the keywords, so new people can directly read about atomic operations in MongoDB. So i did that (https://docs.mongodb.com/manual/tutorial/model-data-for-atomic-operations/#pattern).