### PR TITLE
Added Model.createWithOptions(doc, options, cb) to handle usage of cr…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2869,6 +2869,117 @@ Model.create = function create(doc, options, callback) {
   }, this.events);
 };
 
+
+/**
+ * Another shortcut (aside from Model.create) for saving one or more documents to the database.
+ * `MyModel.createWithOptions(docs, options)` does `new MyModel(doc).save(options)` for every doc in
+ * docs.
+ *
+ * This function triggers the following middleware.
+ *
+ * - `save()`
+ *
+ * ####Example:
+ *
+ *     // pass a doc, options, and a callback
+ *     Candy.create({ type: 'jelly bean' }, { validateBeforeSave: false }, function (err, jellybean) {
+ *       if (err) // ...
+ *     });
+ *
+ *     // pass an array of docs
+ *     var array = [{ type: 'jelly bean' }, { type: 'snickers' }];
+ *     Candy.create(array, { validateBeforeSave: false }, function (err, candies) {
+ *       if (err) // ...
+ *
+ *       var jellybean = candies[0];
+ *       var snickers = candies[1];
+ *       // ...
+ *     });
+ *
+ *     // callback is optional; use the returned promise if you like:
+ *     var promise = Candy.create({ type: 'jawbreaker' }, { validateBeforeSave: false });
+ *     promise.then(function (jawbreaker) {
+ *       // ...
+ *     })
+ *
+ * @param {Array|Object} docs Documents to insert, as a spread or array
+ * @param {Object} [options] Options passed down to `save()`. To specify `options`, `docs` **must** be an array, not a spread.
+ * @param {Function} [callback] callback
+ * @return {Promise}
+ * @api public
+ */
+
+Model.createWithOptions = function create(doc, options, cb) {
+  if (!options || typeof options !== 'object') {
+    throw new Error('Options is required when calling createWithOptions method.');
+  }
+
+  const isMulti = Array.isArray(doc);
+
+  const args = isMulti ? doc : [doc];
+  const discriminatorKey = this.schema.options.discriminatorKey;
+
+  if (cb) {
+    cb = this.$wrapCallback(cb);
+  }
+
+  return utils.promiseOrCallback(cb, cb => {
+    if (args.length === 0) {
+      return cb(null);
+    }
+
+    const toExecute = [];
+    let firstError;
+    args.forEach(doc => {
+      toExecute.push(callback => {
+        const Model = this.discriminators && doc[discriminatorKey] != null ?
+          this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this, doc[discriminatorKey]) :
+          this;
+        if (Model == null) {
+          throw new Error(`Discriminator "${doc[discriminatorKey]}" not ` +
+            `found for model "${this.modelName}"`);
+        }
+        let toSave = doc;
+        const callbackWrapper = (error, doc) => {
+          if (error) {
+            if (!firstError) {
+              firstError = error;
+            }
+            return callback(null, { error: error });
+          }
+          callback(null, { doc: doc });
+        };
+
+        if (!(toSave instanceof Model)) {
+          try {
+            toSave = new Model(toSave);
+          } catch (error) {
+            return callbackWrapper(error);
+          }
+        }
+
+        toSave.save(options, callbackWrapper);
+      });
+    });
+
+    parallel(toExecute, (error, res) => {
+      const savedDocs = [];
+      const len = res.length;
+      for (let i = 0; i < len; ++i) {
+        if (res[i].doc) {
+          savedDocs.push(res[i].doc);
+        }
+      }
+
+      if (firstError) {
+        return cb(firstError, savedDocs);
+      }
+
+      cb(null, isMulti ? savedDocs : savedDocs[0]);
+    });
+  }, this.events);
+};
+
 /**
  * _Requires a replica set running MongoDB >= 3.6.0._ Watches the
  * underlying collection for changes using

--- a/lib/model.js
+++ b/lib/model.js
@@ -2882,13 +2882,13 @@ Model.create = function create(doc, options, callback) {
  * ####Example:
  *
  *     // pass a doc, options, and a callback
- *     Candy.create({ type: 'jelly bean' }, { validateBeforeSave: false }, function (err, jellybean) {
+ *     Candy.createWithOptions({ type: 'jelly bean' }, { validateBeforeSave: false }, function (err, jellybean) {
  *       if (err) // ...
  *     });
  *
  *     // pass an array of docs
  *     var array = [{ type: 'jelly bean' }, { type: 'snickers' }];
- *     Candy.create(array, { validateBeforeSave: false }, function (err, candies) {
+ *     Candy.createWithOptions(array, { validateBeforeSave: false }, function (err, candies) {
  *       if (err) // ...
  *
  *       var jellybean = candies[0];
@@ -2897,7 +2897,7 @@ Model.create = function create(doc, options, callback) {
  *     });
  *
  *     // callback is optional; use the returned promise if you like:
- *     var promise = Candy.create({ type: 'jawbreaker' }, { validateBeforeSave: false });
+ *     var promise = Candy.createWithOptions({ type: 'jawbreaker' }, { validateBeforeSave: false });
  *     promise.then(function (jawbreaker) {
  *       // ...
  *     })

--- a/lib/model.js
+++ b/lib/model.js
@@ -2909,7 +2909,7 @@ Model.create = function create(doc, options, callback) {
  * @api public
  */
 
-Model.createWithOptions = function create(doc, options, cb) {
+Model.createWithOptions = function createWithOptions(doc, options, cb) {
   if (!options || typeof options !== 'object') {
     throw new Error('Options is required when calling createWithOptions method.');
   }


### PR DESCRIPTION
Model.create currently doesn't (can't?) support passing of options. There will be times when a developer needs to pass options like validateBeforeSave when creating a new document.

This pull request introduces a new method on Model called createWithOptions. This is similar to Model.create, except this method allows and requires passing of options.


