### PR TITLE
allow customization of array required validator

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -146,6 +146,56 @@ SchemaArray.options = { castNonArrays: true };
 SchemaArray.prototype = Object.create(SchemaType.prototype);
 SchemaArray.prototype.constructor = SchemaArray;
 
+/*!
+ * ignore
+ */
+
+SchemaArray._checkRequired = SchemaType.prototype.checkRequired;
+
+/**
+ * Override the function the required validator uses to check whether an array
+ * passes the `required` check.
+ *
+ * ####Example:
+ *
+ *     // Require non-empty array to pass `required` check
+ *     mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
+ *
+ *     const M = mongoose.model({ arr: { type: Array, required: true } });
+ *     new M({ arr: [] }).validateSync(); // `null`, validation fails!
+ *
+ * @param {Function} fn
+ * @return {Function}
+ * @function checkRequired
+ * @static
+ * @api public
+ */
+
+SchemaArray.checkRequired = SchemaType.checkRequired;
+
+/**
+ * Check if the given value satisfies the `required` validator.
+ *
+ * @param {Any} value
+ * @param {Document} doc
+ * @return {Boolean}
+ * @api public
+ */
+
+SchemaArray.prototype.checkRequired = function checkRequired(value, doc) {
+  if (SchemaType._isRef(this, value, doc, true)) {
+    return !!value;
+  }
+
+  // `require('util').inherits()` does **not** copy static properties, and
+  // plugins like mongoose-float use `inherits()` for pre-ES6.
+  const _checkRequired = typeof this.constructor.checkRequired == 'function' ?
+    this.constructor.checkRequired() :
+    SchemaArray.checkRequired();
+
+  return _checkRequired(value);
+};
+
 /**
  * Adds an enum validator if this is an array of strings. Equivalent to
  * `SchemaString.prototype.enum()`

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -397,7 +397,7 @@ describe('schema', function() {
       it('array required custom required', function(done) {
         const requiredOrig = mongoose.Schema.Types.Array.checkRequired();
         mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
-        const doneWrapper = (err = null) => {
+        const doneWrapper = (err) => {
           mongoose.Schema.Types.Array.checkRequired(requiredOrig);
           done(err);
         };

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -394,6 +394,31 @@ describe('schema', function() {
         });
       });
 
+      it.only('array required custom required', function(done) {
+        const requiredOrig = mongoose.Schema.Types.Array.checkRequired();
+        mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
+        const doneWrapper = (err = null) => {
+          mongoose.Schema.Types.Array.checkRequired(requiredOrig);
+          done(err);
+        };
+
+        const Loki = new Schema({
+          likes: {type: Array, required: true}
+        });
+
+        let remaining = 2;
+
+        Loki.path('likes').doValidate([], function(err) {
+          assert.ok(err instanceof ValidatorError);
+          --remaining || doneWrapper();
+        });
+
+        Loki.path('likes').doValidate(['cake'], function(err) {
+          assert(!err);
+          --remaining || doneWrapper();
+        });
+      });
+
       it('boolean required', function(done) {
         const Animal = new Schema({
           isFerret: {type: Boolean, required: true}

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -394,7 +394,7 @@ describe('schema', function() {
         });
       });
 
-      it.only('array required custom required', function(done) {
+      it('array required custom required', function(done) {
         const requiredOrig = mongoose.Schema.Types.Array.checkRequired();
         mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
         const doneWrapper = (err = null) => {


### PR DESCRIPTION
**Summary**
In mongoose v5.x - the behavior of `required` on array fields was changed. On some SchemaTypes like String, you are able to override the default behavior. This adds the same functionality to Array. See: https://mongoosejs.com/docs/migrating_to_5.html#array-required

**Examples**
This change allows you to revert mongoose v5 behavior back to mongoose v4 behavior for backwards-compatibility purposes:
```js
mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
```
