### PR TITLE
Fix: Cannot read property '$__' of undefined

### DIFF
--- a/lib/helpers/document/cleanModifiedSubpaths.js
+++ b/lib/helpers/document/cleanModifiedSubpaths.js
@@ -9,6 +9,9 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
   const skipDocArrays = options.skipDocArrays;
 
   let deleted = 0;
+  if (!doc) {
+    return deleted;
+  }
   for (const modifiedPath of Object.keys(doc.$__.activePaths.states.modify)) {
     if (skipDocArrays) {
       const schemaType = doc.schema.path(modifiedPath);


### PR DESCRIPTION
I'm receiving this error on `create` and `update` in `feathers-js` app using the `feathers-mongoose` adapter. It only happens on certain models. Could this fix be included? Or does it more like a patch instead of targeting the real root cause?