### PR TITLE
fix usage of arguments while buffering commands

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -116,7 +116,7 @@ const syncCollectionMethods = { watch: true };
 function iter(i) {
   NativeCollection.prototype[i] = function() {
     const collection = this.collection;
-    const args = arguments;
+    const args = Array.from(arguments);
     const _this = this;
     const debug = get(_this, 'conn.base.options.debug');
     const lastArg = arguments[arguments.length - 1];
@@ -130,11 +130,11 @@ function iter(i) {
         throw new Error('Collection method ' + i + ' is synchronous');
       }
       if (typeof lastArg === 'function') {
-        this.addQueue(i, arguments);
+        this.addQueue(i, args);
         return;
       }
       return new this.Promise((resolve, reject) => {
-        this.addQueue(i, [].concat(arguments).concat([(err, res) => {
+        this.addQueue(i, [].concat(args).concat([(err, res) => {
           if (err != null) {
             return reject(err);
           }


### PR DESCRIPTION
# Problems
`insertMany([a,b])` throws

    MongoError: docs parameter must be an array of documents

The following code:

     collection.insertOne({foo:'bar'}).then(res =>
       collection.findOne({_id: res.insertedId})
     ).then(doc => console.log(doc));
prints

    { '0': { foo: 'bar' }, _id: 5cb71e14f1bb5261dfdd629d }
instead of

    { _id: 5cb71e14f1bb5261dfdd629d, foo: 'bar' }

# Cause

`arguments` was used as an `Array` argument of `concat` when queuing commands. 
Note:

    (function() {return [].concat(arguments);})(1,2,3) === [Arguments]
but

    (function() {return Array.from(arguments);})(1,2,3) === [1,2,3]

# Solution

Wrap `arguments` in `Array.from()`.