### PR TITLE
fix(query): pass correct callback for _legacyFindAndModify

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3419,7 +3419,7 @@ Query.prototype._findAndModify = function(type, callback) {
       if (error) {
         return callback(error);
       }
-      _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, callback);
+      _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, cb);
     };
 
     try {
@@ -3428,7 +3428,7 @@ Query.prototype._findAndModify = function(type, callback) {
       callback(error);
     }
   } else {
-    _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, callback);
+    _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, cb);
   }
 
   return this;


### PR DESCRIPTION
**Summary**

Fix breaking changes introduced in 5.5.3
The callback function was `cb`, in 0b849710508566e86194a925f1248a2c3d200f16 became `callback`

```diff
-  this._collection.findAndModify(castedQuery, castedDoc, opts, _wrapThunkCallback(_this, -function(error, res) {
-    return cb(error, res ? res.value : res, res);
-  }));
!  _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, callback);
```

This PR simply changes `callback` to `cb`
```diff
!  _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, callback);
+  _legacyFindAndModify.call(_this, castedQuery, castedDoc, opts, cb);
```