### PR TITLE
Document#depopulate with empty array fields

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3339,7 +3339,7 @@ Document.prototype.depopulate = function(path) {
     if (virtualKeys.indexOf(path[i]) !== -1) {
       delete this.$$populatedVirtuals[path[i]];
       delete this._doc[path[i]];
-    } else {
+    } else if (populatedIds) {
       this.$set(path[i], populatedIds);
     }
   }

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -725,6 +725,37 @@ describe('document.populate', function() {
           done();
         });
     });
+
+    it('depopulates field with empty array (gh-7740)', function() {
+      db.model(
+        'gh_7740_1',
+        new mongoose.Schema({
+          name: String,
+          chapters: Number
+        })
+      );
+      const Author = db.model(
+        'gh_7740_2',
+        new mongoose.Schema({
+          name: String,
+          books: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'gh_7740_1' }], default: [] },
+        })
+      );
+
+      return co(function*() {
+        const author = new Author({
+          name: 'Fonger',
+          books: []
+        });
+        yield author.save();
+        yield author.populate('books').execPopulate();
+        assert.ok(author.books);
+        assert.strictEqual(author.books.length, 0);
+        author.depopulate('books');
+        assert.ok(author.books);
+        assert.strictEqual(author.books.length, 0);
+      });
+    });
   });
 
   it('does not allow you to call populate() on nested docs (gh-4552)', function(done) {


### PR DESCRIPTION
**Summary**

If there's no populatedIds (undefined), don't $set the value to undefined.
depopulate() with no arguments will depopulate all fields and have already handled this case correctly with:
`if (!populatedIds) { continue } `

https://github.com/Automattic/mongoose/blob/9645d87223ce753387a3d393c686b31d4459c807/lib/document.js#L3324-L3332

However the same check is not applied when depopulating with a specific path.
This PR simply fixes this for #7740

**Examples**
see the test