### PR TITLE
Reports Validation Errors for push()-ed Subdocs with Correct Index Path

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -362,7 +362,9 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
 
     if (value[i] instanceof Subdocument) {
       // Might not have the correct index yet, so ensure it does.
-      value[i].$setIndex(i);
+      if (value[i].__index == null) {
+        value[i].$setIndex(i);
+      }
     } else if (value[i] != null) {
       if (init) {
         if (doc) {


### PR DESCRIPTION
**Summary**

Fix #7724 that was introduced in 764735b9bb2a577c3b5fce773bc866a75ca86474

**Examples**

See the test case in section `describe('push()', ...)` of `types.documentarray.test.js`