### PR TITLE
Support $unset update operation for MongooseMap#delete

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -83,6 +83,11 @@ class MongooseMap extends Map {
     }
   }
 
+  delete(key) {
+    this.set(key, undefined);
+    super.delete(key);
+  }
+
   toBSON() {
     return new Map(this);
   }


### PR DESCRIPTION
**Summary**

Simply set the field to `undefined` to make Model#save works and also call `super.delete(key)` to remove the key from the Map.

**Examples**

See test