### PR TITLE
fix(map): disallow setting map key with special properties

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -3,6 +3,7 @@
 const Mixed = require('../schema/mixed');
 const get = require('../helpers/get');
 const util = require('util');
+const utils = require('../utils');
 
 /*!
  * ignore
@@ -191,6 +192,9 @@ function checkValidKey(key) {
   }
   if (key.includes('.')) {
     throw new Error(`Mongoose maps do not support keys that contain ".", got "${key}"`);
+  }
+  if (utils.specialProperties.has(key)) {
+    throw new Error(`Mongoose maps do not support reserved key name "${key}"`);
   }
 }
 


### PR DESCRIPTION
**Summary**
Not doing this for security reason ( `__proto__` is sanitized correctly ). Just do this check for consistency as we can't set these special proprieties in normal schema.

**Examples**

The following script will save the document in MongoDB successfully without any error.
Show the exact data saved into MongoDB:
```sh
> db.users.find().pretty()
{
	"_id" : ObjectId("5cc23627c76b9141f33b0264"),
	"name" : "Fonger",
	"characteristics" : {
		"__proto__" : "1",
		"constructor" : "2",
		"prototype" : "3"
	},
	"__v" : 0
}
> 
```

Query in Mongoose:
```
Mongoose: users.insertOne({ _id: ObjectId("5cc238642f34f543e42f6f31"), name: 'Fonger', characteristics: Map { '__proto__' => '1', 'constructor' => '2', 'prototype' => '3' }, __v: 0 })
{ _id: 5cc238642f34f543e42f6f31,
  name: 'Fonger',
  characteristics:
   Map { '__proto__' => '1', 'constructor' => '2', 'prototype' => '3' },
  __v: 0 }

//  __proto__ is missing. constructor, prototype show.
Mongoose: users.findOne({ _id: ObjectId("5cc238642f34f543e42f6f31") }, { projection: {} })
{ _id: 5cc238642f34f543e42f6f31,
  name: 'Fonger',
  characteristics: Map { 'constructor' => '2', 'prototype' => '3' },
  __v: 0 }
```

```js
const mongoose = require("mongoose");
const Schema = mongoose.Schema;

mongoose.set('debug', true);
mongoose.set("useNewUrlParser", true);
mongoose.set("useFindAndModify", false);
mongoose.set("useCreateIndex", true);


const userSchema = new Schema({
  name: String,
  characteristics: {
    type: Map,
    of: String
  }
});

const User = mongoose.model("User", userSchema);

mongoose.connect("mongodb://localhost:27017/test-map").then(async () => {
  const map = new Map();
  map.set('__proto__', '1');
  map.set('constructor', '2');
  map.set('prototype', '3');
  
  const newUser = new User({
    name: 'Fonger',
    characteristics: map
  });

  await newUser.save();
  console.log(newUser);

  const editUser = await User.findById(newUser._id);
  console.log(editUser);
  // print constructor => '2', prototype => '3'   __proto__ is missing.
});
```