### PR TITLE
Fix a typo in `Query.prototype.distinct` docstring

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2368,7 +2368,7 @@ Query.prototype.__distinct = wrapThunk(function __distinct(callback) {
 });
 
 /**
- * Declares or executes a distict() operation.
+ * Declares or executes a distinct() operation.
  *
  * Passing a `callback` executes the query.
  *


### PR DESCRIPTION
**Summary**

This fixes a typo in `Query.prototype.distinct` docstring

