### PR TITLE
Fix rawResult not returned when inserted with options {new:false,upsert:true,rawResult:true}

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1968,7 +1968,7 @@ Query.prototype.collation = function(value) {
  */
 
 Query.prototype._completeOne = function(doc, res, callback) {
-  if (!doc) {
+  if (!doc && !this.options.rawResult) {
     return callback(null, null);
   }
 
@@ -2720,6 +2720,11 @@ function completeOne(model, doc, res, options, fields, userProvidedFields, pop, 
     {populated: pop}
     : undefined;
 
+  if(options.rawResult && doc == null){
+	  _init(null);
+	  return null;
+  }
+
   const casted = helpers.createModel(model, doc, fields, userProvidedFields);
   try {
     casted.init(doc, opts, _init);
@@ -2732,12 +2737,17 @@ function completeOne(model, doc, res, options, fields, userProvidedFields, pop, 
       return process.nextTick(() => callback(err));
     }
 
-    casted.$session(options.session);
 
     if (options.rawResult) {
-      res.value = casted;
+	  if(doc && casted){
+        casted.$session(options.session);
+		res.value = casted;
+	  }else{
+	    res.value = null;
+      }
       return process.nextTick(() => callback(null, res));
     }
+    casted.$session(options.session);
     process.nextTick(() => callback(null, casted));
   }
 }

--- a/lib/query.js
+++ b/lib/query.js
@@ -2720,9 +2720,9 @@ function completeOne(model, doc, res, options, fields, userProvidedFields, pop, 
     {populated: pop}
     : undefined;
 
-  if(options.rawResult && doc == null){
-	  _init(null);
-	  return null;
+  if (options.rawResult && doc == null) {
+    _init(null);
+    return null;
   }
 
   const casted = helpers.createModel(model, doc, fields, userProvidedFields);
@@ -2739,11 +2739,11 @@ function completeOne(model, doc, res, options, fields, userProvidedFields, pop, 
 
 
     if (options.rawResult) {
-	  if(doc && casted){
+      if (doc && casted) {
         casted.$session(options.session);
-		res.value = casted;
-	  }else{
-	    res.value = null;
+        res.value = casted;
+      } else {
+        res.value = null;
       }
       return process.nextTick(() => callback(null, res));
     }

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -838,6 +838,30 @@ describe('model: findOneAndUpdate:', function() {
       });
     });
   });
+  it('return rawResult when doing an upsert & new=false gh-7770', function(done) {
+    const thingSchema = new Schema({
+      _id: String,
+      flag: {
+        type: Boolean,
+        default: false
+      }
+    });
+
+    const Thing = db.model('gh-7770', thingSchema);
+    const key = 'some-new-id';
+
+    Thing.findOneAndUpdate({_id: key}, {$set: {flag: false}}, {upsert: true, new: false, rawResult:true}).exec(function(err, rawResult) {
+      assert.ifError(err);
+      assert.equal(rawResult.lastErrorObject.updatedExisting, false );
+      Thing.findOneAndUpdate({_id: key}, {$set: {flag: true}}, {upsert: true, new: false, rawResult: true}).exec(function(err, rawResult2) {
+        assert.ifError(err);
+        assert.equal(rawResult2.lastErrorObject.updatedExisting, true );
+        assert.equal(rawResult2.value._id, key);
+        assert.equal(rawResult2.value.flag, false);
+        done();
+      });
+    });
+  });
 
   it('allows properties to be set to null gh-1643', function(done) {
     const thingSchema = new Schema({


### PR DESCRIPTION
**Summary**

This PR fixes the issue desribed in #7770.
Model.findOneAndUpdate() does not return the rawResults when an insert is done with the following options, {new:false,rawResult:true,upsert:true}.

When the result is returned the document can be null and the rawResult should still be returned.  A check to see if the document is present prevents this.

**Examples**
Before the fix the following code returned a null.
```
var mongoose = require('mongoose');
mongoose.connect('mongodb://localhost/test', {useNewUrlParser: true});
var db = mongoose.connection;
var kittySchema = new mongoose.Schema({
	name: String,
	type:Number
});
var Kitten = mongoose.model('Kitten', kittySchema);
db.on('error', console.error.bind(console, 'connection error:'));
db.once('open', function() {
	// we're connected!
	
	Kitten.findOneAndUpdate({name : 'Cat'},{$set:{type:1}},{upsert:true, new: false, rawResult : true,useFindAndModify:false}, function (err, rawResult) {
		if (err) return console.error(err);
		console.log(rawResult);
	})
});
```
After the fix the code returned the following document.
```
{ lastErrorObject: 
   { n: 1,
     updatedExisting: false,
     upserted: 5cd03b891341cc7b3248365f },
  value: null,
  ok: 1,
  operationTime: Timestamp { _bsontype: 'Timestamp', low_: 1, high_: 1557150601 },
  '$clusterTime': 
   { clusterTime: Timestamp { _bsontype: 'Timestamp', low_: 1, high_: 1557150601 },
     signature: { hash: [Binary], keyId: 0 } } }
```
The test "returns rawResult when doing an upsert & new=false gh-7770" tests the expected result.
