### PR TITLE
Fix $session inside pre validate hooks for bulkWrite/insertMany

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -11,16 +11,17 @@ const setDefaultsOnInsert = require('../setDefaultsOnInsert');
  * validating the individual op.
  */
 
-module.exports = function castBulkWrite(model, op) {
+module.exports = function castBulkWrite(model, op, options) {
   const now = model.base.now();
-
   if (op['insertOne']) {
     return (callback) => {
       const doc = new model(op['insertOne']['document']);
       if (model.schema.options.timestamps != null) {
         doc.initializeTimestamps();
       }
-
+      if (options.session != null) {
+        doc.$session(options.session);
+      }
       op['insertOne']['document'] = doc;
       op['insertOne']['document'].validate({ __noPromise: true }, function(error) {
         if (error) {
@@ -96,6 +97,9 @@ module.exports = function castBulkWrite(model, op) {
       const doc = new model(op['replaceOne']['replacement'], null, true);
       if (model.schema.options.timestamps != null) {
         doc.initializeTimestamps();
+      }
+      if (options.session != null) {
+        doc.$session(options.session);
       }
       op['replaceOne']['replacement'] = doc;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3063,6 +3063,9 @@ Model.$__insertMany = function(arr, options, callback) {
       if (!(doc instanceof _this)) {
         doc = new _this(doc);
       }
+      if (options.session != null) {
+        doc.$session(options.session);
+      }
       doc.validate({ __noPromise: true }, function(error) {
         if (error) {
           // Option `ordered` signals that insert should be continued after reaching
@@ -3221,7 +3224,7 @@ Model.bulkWrite = function(ops, options, callback) {
   }
   options = options || {};
 
-  const validations = ops.map(op => castBulkWrite(this, op));
+  const validations = ops.map(op => castBulkWrite(this, op, options));
 
   return utils.promiseOrCallback(callback, cb => {
     parallel(validations, error => {


### PR DESCRIPTION
**Summary**

Fix access to `$session()` inside pre validate middleware for bulkWrite(#7769) and insertMany(related bug)

**Examples**

See the test
