### PR TITLE
Run string cast on $options

### DIFF
--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -577,7 +577,7 @@ SchemaString.prototype.$conditionalHandlers =
       $gte: handleSingle,
       $lt: handleSingle,
       $lte: handleSingle,
-      $options: handleSingle,
+      $options: String,
       $regex: handleSingle,
       $not: handleSingle
     });

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -802,6 +802,17 @@ describe('model query casting', function() {
       assert.equal(result.tags.$options, 'img');
       done();
     });
+    it('does not cast with uppercase (gh-7800)', function(done) {
+      const testSchema = new Schema({
+        name: { type: String, uppercase: true }
+      });
+
+      const Model = db.model('gh7800', testSchema);
+      const result = Model.find({}).cast(Model, {name: {$regex: /a/, $options: 'i'}});
+
+      assert.equal(result.name.$options, 'i');
+      done();
+    });
   });
 
   describe('$elemMatch', function() {


### PR DESCRIPTION
**Summary**

Apply the fix in #1462 $conditionalHandlers for String schema #7800 

https://github.com/Automattic/mongoose/blob/c08002049442d0f87c99819529177f9ba148048b/lib/schema/array.js#L439-L442

Maybe we can throw an error if `$options` is not of type string.

**Examples**

See test

Close&Reopen to re-trigger travis-ci test.