### PR TITLE
Fix Setter of Array of Document Array

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -377,7 +377,7 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
         subdoc = new Constructor(null, value, true, selected, i);
         value[i] = subdoc.init(value[i]);
       } else {
-        if (prev && (subdoc = prev.id(value[i]._id))) {
+        if (prev && typeof prev.id === 'function') {
           subdoc = prev.id(value[i]._id);
         }
 

--- a/test/schema.documentarray.test.js
+++ b/test/schema.documentarray.test.js
@@ -73,4 +73,28 @@ describe('schema.documentarray', function() {
     assert.ok(!schema2.childSchemas[0].schema.$implicitlyCreated);
     done();
   });
+
+  it('supports set with array of document arrays (gh-7799)', function() {
+    const subSchema = new Schema({
+      title: String
+    });
+
+    const nestedSchema = new Schema({
+      nested: [[ subSchema ]]
+    });
+
+    const Nested = mongoose.model('gh7799', nestedSchema);
+
+    const doc = new Nested({nested: [[{ title: 'cool' }, { title: 'not cool' }]]});
+    assert.equal(doc.nested[0].length, 2);
+    assert.equal(doc.nested[0][0].title, 'cool');
+
+    doc.set({nested: [[{ title: 'new' }]]});
+    assert.equal(doc.nested[0].length, 1);
+    assert.equal(doc.nested[0][0].title, 'new');
+
+    doc.nested = [[{ title: 'first' }, { title: 'second' },{ title: 'third' }]];
+    assert.equal(doc.nested[0].length, 3);
+    assert.equal(doc.nested[0][1].title, 'second');
+  });
 });


### PR DESCRIPTION
**Summary**

Correctly handle documentarray setters for #7799 
`{ nested: [[ childSchema ]] }`

**Examples**

See test `npm test -- -g "gh-7799"`

EDIT:
Close & Reopen PR to re-trigger travis-ci.
EDIT2:
It seems travis-ci is quite unstable now and always failing with timeout error.