### PR TITLE
Update faq.jade

### DIFF
--- a/docs/faq.jade
+++ b/docs/faq.jade
@@ -103,7 +103,7 @@ block content
 
     MongoDB persists indexes, so you only need to rebuild indexes if you're starting
     with a fresh database or you ran `db.dropDatabase()`. In a production environment,
-    you should [create your indexes using the MongoDB shell])(https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/)
+    you should [create your indexes using the MongoDB shell](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/)
     rather than relying on mongoose to do it for you. The `unique` option for schemas is
     convenient for development and documentation, but mongoose is *not* an index management solution.
 


### PR DESCRIPTION
Remove extra parenthesis in hyperlink definition.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The hyperlink to MongoDB reference about index creation was not generated due to a typo.

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

The line:

```
[create your indexes using the MongoDB shell])(https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/)
```

has been changed to:

```
[create your indexes using the MongoDB shell](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/)
```