### PR TITLE
Support deleteOne options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1751,21 +1751,30 @@ Model.remove = function remove(conditions, callback) {
  * Like `Model.remove()`, this function does **not** trigger `pre('remove')` or `post('remove')` hooks.
  *
  * @param {Object} conditions
+ * @param {Object} [options] optional see [`Query.prototype.setOptions()`](http://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback]
  * @return {Query}
  * @api public
  */
 
-Model.deleteOne = function deleteOne(conditions, callback) {
+Model.deleteOne = function deleteOne(conditions, options, callback) {
   if (typeof conditions === 'function') {
     callback = conditions;
     conditions = {};
+    options = null;
+  }
+  else if (typeof options === 'function') {
+    callback = options;
+    options = null;
   }
 
   // get the mongodb collection object
   const mq = new this.Query(conditions, {}, this, this.collection);
+  mq.setOptions(options);
 
-  callback = this.$wrapCallback(callback);
+  if (callback) {
+    callback = this.$wrapCallback(callback);
+  }
 
   return mq.deleteOne(callback);
 };

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -276,7 +276,7 @@ describe('transactions', function() {
     });
   });
 
-  it('deleteMany (gh-6805)', function() {
+  it('deleteOne and deleteMany (gh-7857)(gh-6805)', function() {
     const Character = db.model('Character', new Schema({ name: String }), 'Character');
 
     let session = null;
@@ -293,9 +293,10 @@ describe('transactions', function() {
         ], { session: session });
       }).
       then(() => Character.deleteMany({ name: /Lannister/ }, { session: session })).
+      then(() => Character.deleteOne({ name: 'Jon Snow' }, { session: session })).
       then(() => Character.find({}).session(session)).
       then(res => {
-        assert.equal(res.length, 2);
+        assert.equal(res.length, 1);
         session.commitTransaction();
       });
   });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4859,6 +4859,32 @@ describe('Model', function() {
       });
     });
 
+    it('deleteOne() with options (gh-7857)', function(done) {
+      const schema = new Schema({
+        name: String
+      });
+      const Character = db.model('gh7857', schema);
+
+      const arr = [
+        { name: 'Tyrion Lannister' },
+        { name: 'Cersei Lannister' },
+        { name: 'Jon Snow' },
+        { name: 'Daenerys Targaryen' }
+      ];
+      Character.insertMany(arr, function(err, docs) {
+        assert.ifError(err);
+        assert.equal(docs.length, 4);
+        Character.deleteOne({ name: 'Jon Snow' }, { w: 1 }, function(err) {
+          assert.ifError(err);
+          Character.find({}, function(err, docs) {
+            assert.ifError(err);
+            assert.equal(docs.length, 3);
+            done();
+          });
+        });
+      });
+    });
+
     it('deleteMany() with options (gh-6805)', function(done) {
       const schema = new Schema({
         name: String


### PR DESCRIPTION
**Summary**

Related to #6805 #6810 (add missing Model.deleteMany options support)
This PR add missing options argument for `Model.deleteOne` and will fixes #7857

**Examples**
See test
