### PR TITLE
Add height: 100% to #menu

### DIFF
--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -116,6 +116,7 @@ li.version ul.pure-menu-children {
   bottom: 231px;
   background-color: #eee;
   width: 250px;
+  height: 100%;
   border-right: 1px solid #ddd;
   overflow-y: auto;
 }


### PR DESCRIPTION

![mongoose1](https://user-images.githubusercontent.com/29314494/58812578-8f0eb480-85f8-11e9-9025-bf0b70f00f70.png)
![mongoose2](https://user-images.githubusercontent.com/29314494/58812579-8f0eb480-85f8-11e9-9e39-54474e4e4d1c.png)

**Summary**

This issue is causing the menu to not fill the entire page height.