### PR TITLE
docs(model): fix typo `projetion` to `projection`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -78,7 +78,7 @@ const subclassedSymbol = Symbol('mongoose#Model#subclassed');
  *     const userFromDb = await UserModel.findOne({ name: 'Foo' });
  *
  * @param {Object} doc values for initial set
- * @param [fields] optional object containing the fields that were selected in the query which returned this document. You do **not** need to set this parameter to ensure Mongoose handles your [query projetion](./api.html#query_Query-select).
+ * @param [fields] optional object containing the fields that were selected in the query which returned this document. You do **not** need to set this parameter to ensure Mongoose handles your [query projection](./api.html#query_Query-select).
  * @inherits Document http://mongoosejs.com/docs/api.html#document-js
  * @event `error`: If listening to this event, 'error' is emitted when a document was saved without passing a callback and an `error` occurred. If not listening, the event bubbles to the connection used to create this Model.
  * @event `index`: Emitted after `Model#ensureIndexes` completes. If an error occurred it is passed with the event.


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.jade` file or test case in the `test/docs` directory.

**Summary**

There was a small typo in the js doc for [Model()](https://mongoosejs.com/docs/api.html#model_Model): `projetion` instead of `projection` for 

> optional «[fields]» object containing the fields that were selected in the query which returned this document. You do not need to set this parameter to ensure Mongoose handles your query **projetion**.