### PR TITLE
fix(document): prepend private methods getValue and setValue with $

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -872,14 +872,14 @@ Document.prototype.$set = function $set(path, val, type, options) {
   if (pathType === 'nested' && val) {
     if (typeof val === 'object' && val != null) {
       if (!merge) {
-        this.setValue(path, null);
+        this.$__setValue(path, null);
         cleanModifiedSubpaths(this, path);
       } else {
         return this.$set(val, path, constructing);
       }
 
       const keys = Object.keys(val);
-      this.setValue(path, {});
+      this.$__setValue(path, {});
       for (const key of keys) {
         this.$set(path + '.' + key, val[key], constructing);
       }
@@ -959,7 +959,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
       if (!this.isSelected(curPath)) {
         this.unmarkModified(curPath);
       }
-      cur = this.getValue(curPath);
+      cur = this.$__getValue(curPath);
     }
   }
 
@@ -987,12 +987,12 @@ Document.prototype.$set = function $set(path, val, type, options) {
   // if this doc is being constructed we should not trigger getters
   const priorVal = (() => {
     if (this.$__.$options.priorDoc != null) {
-      return this.$__.$options.priorDoc.getValue(path);
+      return this.$__.$options.priorDoc.$__getValue(path);
     }
     if (constructing) {
       return void 0;
     }
-    return this.getValue(path);
+    return this.$__getValue(path);
   })();
 
   if (!schema) {
@@ -1271,7 +1271,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
  * @api private
  */
 
-Document.prototype.getValue = function(path) {
+Document.prototype.$__getValue = function(path) {
   return utils.getValue(path, this._doc);
 };
 
@@ -1283,7 +1283,7 @@ Document.prototype.getValue = function(path) {
  * @api private
  */
 
-Document.prototype.setValue = function(path, val) {
+Document.prototype.$__setValue = function(path, val) {
   utils.setValue(path, val, this._doc);
   return this;
 };
@@ -1955,7 +1955,7 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
-    const val = doc.getValue(path);
+    const val = doc.$__getValue(path);
     if (val) {
       const numElements = val.length;
       for (let j = 0; j < numElements; ++j) {
@@ -1969,7 +1969,7 @@ function _getPathsToValidate(doc) {
   for (i = 0; i < len; ++i) {
     const pathToCheck = paths[i];
     if (doc.schema.nested[pathToCheck]) {
-      let _v = doc.getValue(pathToCheck);
+      let _v = doc.$__getValue(pathToCheck);
       if (isMongooseObject(_v)) {
         _v = _v.toObject({ transform: false });
       }
@@ -1989,7 +1989,7 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
-    const val = doc.getValue(path);
+    const val = doc.$__getValue(path);
     if (val == null) {
       continue;
     }
@@ -2094,7 +2094,7 @@ Document.prototype.$__validate = function(options, callback) {
         return;
       }
 
-      const val = _this.getValue(path);
+      const val = _this.$__getValue(path);
       const scope = path in _this.$__.pathsToScopes ?
         _this.$__.pathsToScopes[path] :
         _this;
@@ -2192,7 +2192,7 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
       return;
     }
 
-    const val = _this.getValue(path);
+    const val = _this.$__getValue(path);
     const err = p.doValidateSync(val, _this, {
       skipSchemaValidators: skipSchemaValidators[path],
       path: path
@@ -2365,7 +2365,7 @@ Document.prototype.$__reset = function reset() {
 
   this.$__.activePaths
     .map('init', 'modify', function(i) {
-      return _this.getValue(i);
+      return _this.$__getValue(i);
     })
     .filter(function(val) {
       return val && val instanceof Array && val.isMongooseDocumentArray && val.length;
@@ -2387,7 +2387,7 @@ Document.prototype.$__reset = function reset() {
 
   this.$__.activePaths.
     map('init', 'modify', function(i) {
-      return _this.getValue(i);
+      return _this.$__getValue(i);
     }).
     filter(function(val) {
       return val && val.$isSingleNested;
@@ -2434,7 +2434,7 @@ Document.prototype.$__dirty = function() {
   let all = this.$__.activePaths.map('modify', function(path) {
     return {
       path: path,
-      value: _this.getValue(path),
+      value: _this.$__getValue(path),
       schema: _this.$__path(path)
     };
   });
@@ -2442,12 +2442,12 @@ Document.prototype.$__dirty = function() {
   // gh-2558: if we had to set a default and the value is not undefined,
   // we have to save as well
   all = all.concat(this.$__.activePaths.map('default', function(path) {
-    if (path === '_id' || _this.getValue(path) == null) {
+    if (path === '_id' || _this.$__getValue(path) == null) {
       return;
     }
     return {
       path: path,
-      value: _this.getValue(path),
+      value: _this.$__getValue(path),
       schema: _this.$__path(path)
     };
   }));
@@ -2526,7 +2526,7 @@ Document.prototype.$__getArrayPathsToValidate = function() {
   // validate all document arrays.
   return this.$__.activePaths
     .map('init', 'modify', function(i) {
-      return this.getValue(i);
+      return this.$__getValue(i);
     }.bind(this))
     .filter(function(val) {
       return val && val instanceof Array && val.isMongooseDocumentArray && val.length;

--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -195,7 +195,7 @@ function valueFilter(val, assignmentOpts, populateOptions) {
 
 function maybeRemoveId(subdoc, assignmentOpts) {
   if (assignmentOpts.excludeId) {
-    if (typeof subdoc.setValue === 'function') {
+    if (typeof subdoc.$__setValue === 'function') {
       delete subdoc._doc._id;
     } else {
       delete subdoc._id;

--- a/lib/model.js
+++ b/lib/model.js
@@ -359,7 +359,7 @@ Model.prototype.$__save = function(options, callback) {
         this.$__.version = undefined;
 
         const key = this.schema.options.versionKey;
-        const version = this.getValue(key) || 0;
+        const version = this.$__getValue(key) || 0;
 
         if (numAffected <= 0) {
           // the update failed. pass an error back
@@ -370,7 +370,7 @@ Model.prototype.$__save = function(options, callback) {
 
         // increment version if was successful
         if (doIncrement) {
-          this.setValue(key, version + 1);
+          this.$__setValue(key, version + 1);
         }
       }
 
@@ -397,7 +397,7 @@ function generateVersionError(doc, modifiedPaths) {
   if (!key) {
     return null;
   }
-  const version = doc.getValue(key) || 0;
+  const version = doc.$__getValue(key) || 0;
   return new VersionError(doc, version, modifiedPaths);
 }
 
@@ -785,7 +785,7 @@ Model.prototype.$__version = function(where, delta) {
 
   if (where === true) {
     // this is an insert
-    if (key) this.setValue(key, delta[key] = 0);
+    if (key) this.$__setValue(key, delta[key] = 0);
     return;
   }
 
@@ -801,7 +801,7 @@ Model.prototype.$__version = function(where, delta) {
 
   // $push $addToSet don't need the where clause set
   if (VERSION_WHERE === (VERSION_WHERE & this.$__.version)) {
-    const value = this.getValue(key);
+    const value = this.$__getValue(key);
     if (value != null) where[key] = value;
   }
 

--- a/lib/plugins/sharding.js
+++ b/lib/plugins/sharding.js
@@ -67,7 +67,7 @@ function storeShard() {
   let val;
 
   for (let i = 0; i < len; ++i) {
-    val = this.getValue(paths[i]);
+    val = this.$__getValue(paths[i]);
     if (val == null) {
       orig[paths[i]] = val;
     } else if (utils.isMongooseObject(val)) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1030,7 +1030,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
       let ts = defaultTimestamp;
       if (this.isNew) {
         if (createdAt != null) {
-          ts = this.getValue(createdAt);
+          ts = this.$__getValue(createdAt);
         } else if (auto_id) {
           ts = this._id.getTimestamp();
         }

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -319,7 +319,7 @@ describe('document.populate', function() {
         assert.ifError(err);
 
         // stuff an ad-hoc value in
-        post.setValue('idontexist', user1._id);
+        post.$__setValue('idontexist', user1._id);
 
         // populate the non-schema value by passing an explicit model
         post.populate({path: 'idontexist', model: 'doc.populate.u'}, function(err, post) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -211,7 +211,7 @@ describe('document', function() {
       doc.nested.setAge = 10;
       assert.equal(doc.nested.age, 10);
       doc.nested.setr = 'set it';
-      assert.equal(doc.getValue('nested.setr'), 'set it setter');
+      assert.equal(doc.$__getValue('nested.setr'), 'set it setter');
 
       const doc2 = new TestDocument();
       doc2.init({

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1829,7 +1829,7 @@ describe('Model', function() {
       let num = a.number;
       assert.equal(called, true);
       assert.equal(num.valueOf(), 100);
-      assert.equal(a.getValue('number').valueOf(), 50);
+      assert.equal(a.$__getValue('number').valueOf(), 50);
 
       called = false;
       const b = new A;
@@ -1838,7 +1838,7 @@ describe('Model', function() {
       num = b.number;
       assert.equal(called, true);
       assert.equal(num.valueOf(), 100);
-      assert.equal(b.getValue('number').valueOf(), 50);
+      assert.equal(b.$__getValue('number').valueOf(), 50);
       done();
     });
 


### PR DESCRIPTION
**Summary**
- Prepend 2 document internal methods tagged `@api private` with `$` to avoid conflicts. Resolves #7869

  ```diff
  /**
   * Gets a raw value from a path (no getters)
   *
   * @param {String} path
   * @api private
   */

  -Document.prototype.getValue = function(path) {
  +Document.prototype.$__getValue = function(path) {
    return utils.getValue(path, this._doc);
  };

  /**
   * Sets a raw value for a path (no casting, setters, transformations)
   *
   * @param {String} path
   * @param {Object} value
   * @api private
   */

  -Document.prototype.setValue = function(path, val) {
  +Document.prototype.$__setValue = function(path, val) {
    utils.setValue(path, val, this._doc);
    return this;
  };
  ```

  Maybe it's good to use Symbol but I think other if we do that, all other internal methods should be 
  updated too.
