### PR TITLE
Reset modifiedPaths after successful insertMany

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3123,6 +3123,7 @@ Model.$__insertMany = function(arr, options, callback) {
         return;
       }
       for (let i = 0; i < docAttributes.length; ++i) {
+        docAttributes[i].$__reset();
         docAttributes[i].isNew = false;
         docAttributes[i].emit('isNew', false);
         docAttributes[i].constructor.emit('isNew', false);

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -838,6 +838,24 @@ describe('model: findOneAndUpdate:', function() {
       });
     });
   });
+  it('return hydrated document (gh-7734 gh-7735)', function() {
+    const fruitSchema = new Schema({
+      name: { type: String }
+    });
+
+    const Fruit = db.model('gh-7734', fruitSchema);
+    return co(function*() {
+      let fruit = yield Fruit.create({ name: 'Apple' });
+
+      fruit = yield Fruit.findOneAndUpdate({}, { $set: { name: 'Banana' }},
+        { new: true, useFindAndModify: false });
+      assert.ok(fruit instanceof mongoose.Document);
+
+      fruit = yield Fruit.findOneAndUpdate({}, { $set: { name: 'Cherry' }},
+        { new: true, useFindAndModify: true });
+      assert.ok(fruit instanceof mongoose.Document);
+    });
+  });
   it('return rawResult when doing an upsert & new=false gh-7770', function(done) {
     const thingSchema = new Schema({
       _id: String,

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4859,6 +4859,23 @@ describe('Model', function() {
       });
     });
 
+    it('insertMany() return docs with empty modifiedPaths (gh-7852)', function() {
+      const schema = new Schema({
+        name: { type: String }
+      });
+
+      const Food = db.model('gh7852', schema);
+
+      return co(function*() {
+        const foods = yield Food.insertMany([
+          { name: 'Rice dumplings' },
+          { name: 'Beef noodle' }
+        ]);
+        assert.equal(foods[0].modifiedPaths().length, 0);
+        assert.equal(foods[1].modifiedPaths().length, 0);
+      });
+    });
+
     it('deleteOne() with options (gh-7857)', function(done) {
       const schema = new Schema({
         name: String


### PR DESCRIPTION
**Summary**

- Reset modifiedPaths after successful insertMany to fix #7852
  Handle it like `Model.create` which calls `Model.save` internally.
  It eventually calls `this.$__reset()` function on each newly created document.
- Add missing repro script for #7736 because that was a severe regression.

**Examples**

See test