### PR TITLE
Update connection docs and remove unused code

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -40,10 +40,9 @@ const noPasswordAuthMechanisms = [
  * @event `disconnecting`: Emitted when `connection.close()` was executed.
  * @event `disconnected`: Emitted after getting disconnected from the db.
  * @event `close`: Emitted after we `disconnected` and `onClose` executed on all of this connections models.
- * @event `reconnected`: Emitted after we `connected` and subsequently `disconnected`, followed by successfully another successfull connection.
+ * @event `reconnected`: Emitted after we `connected` and subsequently `disconnected`, followed by successfully another successful connection.
  * @event `error`: Emitted when an error occurs on this connection.
- * @event `fullsetup`: Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
- * @event `all`: Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
+ * @event `fullsetup`: Emitted after the driver has connected to primary and all secondaries if specified in the connection string.
  * @api public
  */
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -60,9 +60,6 @@ function Connection(base) {
   this._closeCalled = false;
   this._hasOpened = false;
   this.plugins = [];
-
-  this.$internalEmitter = new EventEmitter();
-  this.$internalEmitter.setMaxListeners(0);
 }
 
 /*!


### PR DESCRIPTION
**Summary**

- Now `fullsetup` event is equvalent to `all` event in mongodb-core driver.
  And mongoose no longer listens to `new` event and emits that.
  re: #3986 missing in mongoose v5.
- `$internalEmitter` was used in fix of #6967 but was refactored out in #7682