### PR TITLE
fix(schema): return this when Schema.prototype.add is called with Sch…

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -397,7 +397,7 @@ Schema.prototype.defaultOptions = function(options) {
 Schema.prototype.add = function add(obj, prefix) {
   if (obj instanceof Schema) {
     merge(this, obj);
-    return;
+    return this;
   }
 
   // Special case: setting top-level `_id` to false should convert to disabling

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1200,8 +1200,15 @@ describe('schema', function() {
 
     it('returns the schema instance', function() {
       const schema = new Schema({ name: String });
-      const ret = schema.clone().add({ age: Number });
-      assert.ok(ret instanceof Schema);
+      const ret = schema.add({ age: Number });
+      assert.strictEqual(ret, schema);
+    });
+
+    it('returns the schema instance when schema instance is passed', function() {
+      const schemaA = new Schema({ name: String });
+      const schemaB = new Schema({ age: Number });
+      const ret = schemaB.add(schemaA);
+      assert.strictEqual(ret, schemaB);
     });
 
     it('merging nested objects (gh-662)', function(done) {


### PR DESCRIPTION
Since the first implementation of the feature that lets one pass a `Schema` instance as argument to the `Schema.prototype.add()` method back in version [`5.3.0`](https://github.com/Automattic/mongoose/commit/e326952307753e259bf86a73405d36d90d65d967) (commit: e326952307753e259bf86a73405d36d90d65d967) there is a bug.

The addition (merging) works as expected but the return value is `undefined` instead of the `Schema` instance like [the API reference specifies it](https://mongoosejs.com/docs/api.html#schema_Schema-add).

This is a quick fix that returns the `this` instance as return value to allow further chaining.