### PR TITLE
Fix #7889

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -39,9 +39,12 @@ function MongooseArray(values, path, doc) {
   // TODO: replace this with `new CoreMongooseArray().concat()` when we remove
   // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
   const arr = new CoreMongooseArray();
+  arr[arrayAtomicsSymbol] = {};
 
   if (Array.isArray(values)) {
     values.forEach(v => { arr.push(v); });
+
+    arr[arrayAtomicsSymbol] = values[arrayAtomicsSymbol] || {};
   }
 
   const keysMA = Object.keys(MongooseArray.mixin);
@@ -52,7 +55,6 @@ function MongooseArray(values, path, doc) {
 
   arr[arrayPathSymbol] = path;
   arr.validators = [];
-  arr[arrayAtomicsSymbol] = {};
   arr[arraySchemaSymbol] = void 0;
   if (util.inspect.custom) {
     arr[util.inspect.custom] = arr.inspect;


### PR DESCRIPTION
This is my second attempt to fix #7889,

The idea is simple: when population reassigns the array, we copy all atomics from the old array. It makes my improved test case pass.