### PR TITLE
chore: use startsWith, endsWith and includes for String

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -373,7 +373,7 @@ Aggregate.prototype.unwind = function() {
       res.push({ $unwind: arg });
     } else if (typeof arg === 'string') {
       res.push({
-        $unwind: (arg && arg.charAt(0) === '$') ? arg : '$' + arg
+        $unwind: (arg && arg.startsWith('$')) ? arg : '$' + arg
       });
     } else {
       throw new Error('Invalid arg "' + arg + '" to unwind(), ' +
@@ -459,7 +459,7 @@ Aggregate.prototype.sortByCount = function(arg) {
     return this.append({ $sortByCount: arg });
   } else if (typeof arg === 'string') {
     return this.append({
-      $sortByCount: (arg && arg.charAt(0) === '$') ? arg : '$' + arg
+      $sortByCount: (arg && arg.startsWith('$')) ? arg : '$' + arg
     });
   } else {
     throw new TypeError('Invalid arg "' + arg + '" to sortByCount(), ' +
@@ -510,7 +510,7 @@ Aggregate.prototype.graphLookup = function(options) {
     const startWith = cloneOptions.startWith;
 
     if (startWith && typeof startWith === 'string') {
-      cloneOptions.startWith = cloneOptions.startWith.charAt(0) === '$' ?
+      cloneOptions.startWith = cloneOptions.startWith.startsWith('$') ?
         cloneOptions.startWith :
         '$' + cloneOptions.startWith;
     }

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -245,7 +245,7 @@ module.exports = function cast(schema, obj, options, context) {
         continue;
       } else if (val.constructor.name === 'Object') {
         any$conditionals = Object.keys(val).some(function(k) {
-          return k.charAt(0) === '$' && k !== '$id' && k !== '$ref';
+          return k.startsWith('$') && k !== '$id' && k !== '$ref';
         });
 
         if (!any$conditionals) {
@@ -266,7 +266,7 @@ module.exports = function cast(schema, obj, options, context) {
             if ($cond === '$not') {
               if (nested && schematype && !schematype.caster) {
                 _keys = Object.keys(nested);
-                if (_keys.length && _keys[0].charAt(0) === '$') {
+                if (_keys.length && _keys[0].startsWith('$')) {
                   for (const key in nested) {
                     nested[key] = schematype.castForQueryWrapper({
                       $conditional: key,

--- a/lib/document.js
+++ b/lib/document.js
@@ -1221,7 +1221,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
       // Small hack for gh-1638: if we're overwriting the entire array, ignore
       // paths that were modified before the array overwrite
       this.$__.activePaths.forEach(function(modifiedPath) {
-        if (modifiedPath.indexOf(path + '.') === 0) {
+        if (modifiedPath.startsWith(path + '.')) {
           _this.$__.activePaths.ignore(modifiedPath);
         }
       });
@@ -1625,7 +1625,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
     });
     return isModifiedChild || paths.some(function(path) {
       return directModifiedPaths.some(function(mod) {
-        return mod === path || path.indexOf(mod + '.') === 0;
+        return mod === path || path.startsWith(mod + '.');
       });
     });
   }
@@ -1773,11 +1773,11 @@ Document.prototype.isSelected = function isSelected(path) {
         continue;
       }
 
-      if (cur.indexOf(pathDot) === 0) {
+      if (cur.startsWith(pathDot)) {
         return inclusive || cur !== pathDot;
       }
 
-      if (pathDot.indexOf(cur + '.') === 0) {
+      if (pathDot.startsWith(cur + '.')) {
         return inclusive;
       }
     }

--- a/lib/error/cast.js
+++ b/lib/error/cast.js
@@ -19,7 +19,7 @@ const util = require('util');
 function CastError(type, value, path, reason) {
   let stringValue = util.inspect(value);
   stringValue = stringValue.replace(/^'/, '"').replace(/'$/, '"');
-  if (stringValue.charAt(0) !== '"') {
+  if (!stringValue.startsWith('"')) {
     stringValue = '"' + stringValue + '"';
   }
   MongooseError.call(this, 'Cast to ' + type + ' failed for value ' +

--- a/lib/helpers/document/cleanModifiedSubpaths.js
+++ b/lib/helpers/document/cleanModifiedSubpaths.js
@@ -19,7 +19,7 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
         continue;
       }
     }
-    if (modifiedPath.indexOf(path + '.') === 0) {
+    if (modifiedPath.startsWith(path + '.')) {
       delete doc.$__.activePaths.states.modify[modifiedPath];
       ++deleted;
     }

--- a/lib/helpers/projection/isInclusive.js
+++ b/lib/helpers/projection/isInclusive.js
@@ -20,7 +20,7 @@ module.exports = function isInclusive(projection) {
   for (let i = 0; i < numProps; ++i) {
     const prop = props[i];
     // Plus paths can't define the projection (see gh-7050)
-    if (prop.charAt(0) === '+') {
+    if (prop.startsWith('+')) {
       continue;
     }
     // If field is truthy (1, true, etc.) and not an object, then this

--- a/lib/helpers/query/castFilterPath.js
+++ b/lib/helpers/query/castFilterPath.js
@@ -3,7 +3,7 @@
 module.exports = function castFilterPath(query, schematype, val) {
   const ctx = query;
   const any$conditionals = Object.keys(val).some(function(k) {
-    return k.charAt(0) === '$' && k !== '$id' && k !== '$ref';
+    return k.startsWith('$') && k !== '$id' && k !== '$ref';
   });
 
   if (!any$conditionals) {
@@ -24,7 +24,7 @@ module.exports = function castFilterPath(query, schematype, val) {
     if ($cond === '$not') {
       if (nested && schematype && !schematype.caster) {
         const _keys = Object.keys(nested);
-        if (_keys.length && _keys[0].charAt(0) === '$') {
+        if (_keys.length && _keys[0].startsWith('$')) {
           for (const key in nested) {
             nested[key] = schematype.castForQueryWrapper({
               $conditional: key,

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -70,7 +70,7 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
   while (i--) {
     const op = ops[i];
     val = ret[op];
-    hasDollarKey = hasDollarKey || op.charAt(0) === '$';
+    hasDollarKey = hasDollarKey || op.startsWith('$');
 
     if (val &&
         typeof val === 'object' &&

--- a/lib/helpers/query/hasDollarKeys.js
+++ b/lib/helpers/query/hasDollarKeys.js
@@ -8,7 +8,7 @@ module.exports = function(obj) {
   const keys = Object.keys(obj);
   const len = keys.length;
   for (let i = 0; i < len; ++i) {
-    if (keys[i].charAt(0) === '$') {
+    if (keys[i].startsWith('$')) {
       return true;
     }
   }

--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -29,7 +29,7 @@ module.exports = function(filter, schema, castedDoc, options) {
   }
 
   for (let i = 0; i < numKeys; ++i) {
-    if (keys[i].charAt(0) === '$') {
+    if (keys[i].startsWith('$')) {
       modifiedPaths(castedDoc[keys[i]], '', modified);
       hasDollarUpdate = true;
     }
@@ -49,7 +49,7 @@ module.exports = function(filter, schema, castedDoc, options) {
       const numConditionKeys = conditionKeys.length;
       let hasDollarKey = false;
       for (let j = 0; j < numConditionKeys; ++j) {
-        if (conditionKeys[j].charAt(0) === '$') {
+        if (conditionKeys[j].startsWith('$')) {
           hasDollarKey = true;
           break;
         }

--- a/lib/helpers/update/applyTimestampsToChildren.js
+++ b/lib/helpers/update/applyTimestampsToChildren.js
@@ -21,7 +21,7 @@ function applyTimestampsToChildren(now, update, schema) {
   let timestamps;
   let path;
 
-  const hasDollarKey = keys.length && keys[0].charAt(0) === '$';
+  const hasDollarKey = keys.length && keys[0].startsWith('$');
 
   if (hasDollarKey) {
     if (update.$push) {

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -63,7 +63,7 @@ module.exports = function(query, schema, castedDoc, options) {
         key = keys[i];
         // With `$pull` we might flatten `$in`. Skip stuff nested under `$in`
         // for the rest of the logic, it will get handled later.
-        if (updatedPath.indexOf('$') !== -1) {
+        if (updatedPath.includes('$')) {
           continue;
         }
         if (key === '$set' || key === '$setOnInsert' ||

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -38,7 +38,7 @@ module.exports = function(query, schema, castedDoc, options) {
   let i;
 
   for (i = 0; i < numKeys; ++i) {
-    if (keys[i].charAt(0) === '$') {
+    if (keys[i].startsWith('$')) {
       hasDollarUpdate = true;
       if (keys[i] === '$push' || keys[i] === '$addToSet') {
         _keys = Object.keys(castedDoc[keys[i]]);

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -245,7 +245,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
       }
       // Any leftover plus paths must in the schema, so delete them (gh-7017)
       for (const key of Object.keys(fields || {})) {
-        if (key.charAt(0) === '+') {
+        if (key.startsWith('+')) {
           delete fields[key];
         }
       }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1927,8 +1927,7 @@ Schema.prototype._getPathType = function(path) {
  */
 
 function isArrayFilter(piece) {
-  return piece.indexOf('$[') === 0 &&
-    piece.lastIndexOf(']') === piece.length - 1;
+  return piece.startsWith('$[') && piece.endsWith(']');
 }
 
 /*!

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -612,9 +612,9 @@ Schema.prototype.path = function(path, obj) {
         !utils.hasUserDefinedProperty(obj.of, this.options.typeKey);
       _mapType = isInlineSchema ? new Schema(obj.of) : obj.of;
     }
-    this.paths[path + '.$*'] = this.interpretAsType(mapPath,
+    this.paths[mapPath] = this.interpretAsType(mapPath,
       _mapType, this.options);
-    schemaType.$__schemaType = this.paths[path + '.$*'];
+    schemaType.$__schemaType = this.paths[mapPath];
   }
 
   if (schemaType.$isSingleNested) {

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -417,7 +417,7 @@ function cast$elemMatch(val) {
   for (let i = 0; i < numKeys; ++i) {
     const key = keys[i];
     const value = val[key];
-    if (key.indexOf('$') === 0 && value) {
+    if (key.startsWith('$') && value) {
       val[key] = this.castForQuery(key, value);
     }
   }

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -459,12 +459,12 @@ function scopePaths(array, fields, init) {
 
   while (i--) {
     key = keys[i];
-    if (key.indexOf(path) === 0) {
+    if (key.startsWith(path)) {
       sub = key.substring(path.length);
       if (sub === '$') {
         continue;
       }
-      if (sub.indexOf('$.') === 0) {
+      if (sub.startsWith('$.')) {
         sub = sub.substr(2);
       }
       hasKeys || (hasKeys = true);


### PR DESCRIPTION
**Summary**

- @vkarpov15 had a commit to replace `.charAt(0)` with `startsWith` re: 8d68ff709ee12a50dd64fd3f0471258feb746a13. Update to keep consistent coding style. 
-  Reuse `mapPath` variable re: https://github.com/Automattic/mongoose/commit/eb5078ee8bd2230dd1564401c4e04dfa0a3cbca5#r33900662
- Replace `indexOf` and `lastIndexOf` with `startsWith`, `endsWith` or `includes` for **String***.

**Caveat**

`arr.indexOf(x) !== -1` is not replaced with `arr.includes(x)`.
The reason is that, unlike `String.prototype.includes` is available after node.js v4.0, `Array.prototype.includes` is available after node.js v**6.0**.

I tested the node.js compatibility and mentioned this before in my PR #6968. 