### PR TITLE
docs(website): fix OpenCollective sponsor link

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -209,7 +209,8 @@ html(lang='en')
           </div>
 
           <div class="sponsor">
-            Sponsor [Mongoose on OpenCollective](https://opencollective.com/mongoose) to get your company's logo above!
+            Sponsor <a href="https://opencollective.com/mongoose">Mongoose on OpenCollective</a>
+            to get your company's logo above!
           </div>
 
     p#footer Licensed under MIT. Copyright 2011 <a href="http://learnboost.com">LearnBoost</a>.


### PR DESCRIPTION
pug fail to parse the markdown link when mixing with html.
https://mongoosejs.com
![image](https://user-images.githubusercontent.com/5862369/59544571-64502480-8f45-11e9-8489-4f81f96c8f74.png)

