### PR TITLE
feat(mongoose): throw an error if calling `mongoose.connect()` multiple times while connected

### DIFF
--- a/docs/connections.pug
+++ b/docs/connections.pug
@@ -153,7 +153,7 @@ block content
 
     // Or using promises
     mongoose.connect(uri, options).then(
-      () => { /** ready to use. The `mongoose.connect()` promise resolves to undefined. */ },
+      () => { /** ready to use. The `mongoose.connect()` promise resolves to mongoose instance. */ },
       err => { /** handle initial connection error */ }
     );
     ```

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -726,11 +726,11 @@ Connection.prototype._close = function(force, callback) {
   this._closeCalled = true;
 
   switch (this.readyState) {
-    case 0: // disconnected
+    case STATES.disconnected:
       callback();
       break;
 
-    case 1: // connected
+    case STATES.connected:
       this.readyState = STATES.disconnecting;
       this.doClose(force, function(err) {
         if (err) {
@@ -741,13 +741,13 @@ Connection.prototype._close = function(force, callback) {
       });
 
       break;
-    case 2: // connecting
+    case STATES.connecting:
       this.once('open', function() {
         _this.close(callback);
       });
       break;
 
-    case 3: // disconnecting
+    case STATES.disconnecting:
       this.once('close', function() {
         callback();
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -287,6 +287,9 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
 Mongoose.prototype.connect = function() {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
   const conn = _mongoose.connection;
+  if (conn.readyState !== STATES.disconnected) {
+    throw new _mongoose.Error('You can not `mongoose.connect()` multiple times while connected.');
+  }
   return conn.openUri(arguments[0], arguments[1], arguments[2]).then(() => _mongoose);
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -679,7 +679,28 @@ describe('mongoose module:', function() {
     const Model = mongoose.model('gh6813', new Schema({ name: String }));
     assert.ok(Model);
   });
+  it('throws an error if calling `mongoose.connect()` multiple times while connected (gh-7814)', function() {
+    const mong = new Mongoose();
+    return co(function*() {
+      const errorRegex = /multiple times while connected/;
 
+      // throws while connecting
+      const connectPromise = mong.connect(uri, options);
+      assert.throws(() => mong.connect(uri, options), errorRegex);
+
+      // throws after connected
+      yield connectPromise;
+      assert.throws(() => mong.connect(uri, options), errorRegex);
+
+      // throws while disconnecting
+      const disconnectPromise = mong.disconnect();
+      assert.throws(() => mong.connect(uri, options), errorRegex);
+
+      // does not throw after disconnected
+      yield disconnectPromise;
+      yield mong.connect(uri, options);
+    });
+  });
   describe('connecting with a signature of uri, options, function', function() {
     it('with single mongod', function(done) {
       const mong = new Mongoose();


### PR DESCRIPTION
**Summary**

This may prevent developers from the misuse of mongoose. Resolves #7814.

EDIT: sorry for the wrong issue reference (not 7813)