### PR TITLE
#7912 - short-circuit populate for falsy arguments

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4452,7 +4452,7 @@ function castDoc(query, overwrite) {
 
 Query.prototype.populate = function() {
   // Bail when given no truthy arguments
-  if (![...arguments].some(arg => arg)) {
+  if (![...arguments].some(Boolean)) {
     return this;
   }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -4451,7 +4451,8 @@ function castDoc(query, overwrite) {
  */
 
 Query.prototype.populate = function() {
-  if (arguments.length === 0) {
+  // Bail when given no truthy arguments
+  if (![...arguments].some(arg => arg)) {
     return this;
   }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -4452,7 +4452,7 @@ function castDoc(query, overwrite) {
 
 Query.prototype.populate = function() {
   // Bail when given no truthy arguments
-  if (![...arguments].some(Boolean)) {
+  if (!Array.from(arguments).some(Boolean)) {
     return this;
   }
 


### PR DESCRIPTION
**Summary**

Short-circuiting when passed null or undefined allows for conditional population without having to break out of a chained query call.

**Examples**

```js
  const item = await Model
    .findById(id)
    .populate(populateParams) // no longer throws when populateParams is null or undefined
    .lean();
```
