### PR TITLE
Fix `visit it` URL in FAQ

### DIFF
--- a/docs/faq.pug
+++ b/docs/faq.pug
@@ -433,5 +433,5 @@ block content
     **Something to add?**
 
     If you'd like to contribute to this page, please
-    [visit it](https://github.com/Automattic/mongoose/tree/master/docs/faq.jade)
+    [visit it](https://github.com/Automattic/mongoose/tree/master/docs/faq.pug)
     on github and use the [Edit](https://github.com/blog/844-forking-with-the-edit-button) button to send a pull request.


### PR DESCRIPTION
**Summary**

Simple typo fix for a dead link.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

Now the text becomes: [visit it](https://github.com/Automattic/mongoose/tree/master/docs/faq.pug)


