### PR TITLE
Fix link to Query.prototype.select

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1907,7 +1907,7 @@ Model.deleteMany = function deleteMany(conditions, options, callback) {
  *     promise.addBack(function (err, docs) {});
  *
  * @param {Object} conditions
- * @param {Object|String} [projection] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String} [projection] optional fields to return, see [`Query.prototype.select()`](http://mongoosejs.com/docs/api.html#query_Query-select)
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](http://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback]
  * @return {Query}


### PR DESCRIPTION
**Summary**

The link from [Model.findById()](https://mongoosejs.com/docs/api/model.html#model_Model.findById) to [Query.prototype.select()](http://mongoosejs.com/docs/api.html#query_Query-select) is broken in the [current docs](https://mongoosejs.com/docs/api/model.html#model_Model.findById).

This change updates the url to [http://mongoosejs.com/docs/api.html#query_Query-select](http://mongoosejs.com/docs/api.html#query_Query-select) in the JSDoc.

