### PR TITLE
export mongoose.cast

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ const get = require('./helpers/get');
 const legacyPluralize = require('mongoose-legacy-pluralize');
 const utils = require('./utils');
 const pkg = require('../package.json');
-
+const cast = require('./cast');
 const removeSubdocs = require('./plugins/removeSubdocs');
 const saveSubdocs = require('./plugins/saveSubdocs');
 const validateBeforeSave = require('./plugins/validateBeforeSave');
@@ -50,7 +50,6 @@ require('./helpers/printJestWarning');
  *
  * @api public
  */
-
 function Mongoose(options) {
   this.connections = [];
   this.models = {};
@@ -99,7 +98,7 @@ function Mongoose(options) {
     ]
   });
 }
-
+Mongoose.prototype.cast = cast;
 /**
  * Expose connection states for user-land
  *


### PR DESCRIPTION

**Summary**
export the function of cast, so could cast the customer query to native mongodb query 
**Examples**
```js
const mongoose = require('mongoose');
const Schema = mongoose.Schema;
const cast = mongoose.cast;

let schema = new Schema({x: String,y:Number});
let custom_query = {x: [123, 456],y:'123'};
let native_query = cast(schema, custom_query);
console.log(native_query) //{ x: { '$in': [ '123', '456' ] }, y: 123 }
```