### PR TITLE
fix(query): add missing options for deleteOne and deleteMany in Query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2603,6 +2603,7 @@ Query.prototype._remove = wrapThunk(function(callback) {
  *     res.deletedCount;
  *
  * @param {Object|Query} [filter] mongodb selector
+ * @param {Object} [options] optional see [`Query.prototype.setOptions()`](http://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback] optional params are (error, mongooseDeleteResult)
  * @return {Query} this
  * @see deleteWriteOpResult http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~deleteWriteOpResult
@@ -2610,10 +2611,16 @@ Query.prototype._remove = wrapThunk(function(callback) {
  * @api public
  */
 
-Query.prototype.deleteOne = function(filter, callback) {
+Query.prototype.deleteOne = function(filter, options, callback) {
   if (typeof filter === 'function') {
     callback = filter;
     filter = null;
+    options = null;
+  } else if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  } else {
+    this.setOptions(options);
   }
 
   filter = utils.toObject(filter);
@@ -2679,6 +2686,7 @@ Query.prototype._deleteOne = wrapThunk(function(callback) {
  *     res.deletedCount;
  *
  * @param {Object|Query} [filter] mongodb selector
+ * @param {Object} [options] optional see [`Query.prototype.setOptions()`](http://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback] optional params are (error, mongooseDeleteResult)
  * @return {Query} this
  * @see deleteWriteOpResult http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~deleteWriteOpResult
@@ -2686,10 +2694,16 @@ Query.prototype._deleteOne = wrapThunk(function(callback) {
  * @api public
  */
 
-Query.prototype.deleteMany = function(filter, callback) {
+Query.prototype.deleteMany = function(filter, options, callback) {
   if (typeof filter === 'function') {
     callback = filter;
     filter = null;
+    options = null;
+  } else if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  } else {
+    this.setOptions(options);
   }
 
   filter = utils.toObject(filter);


### PR DESCRIPTION
**Summary**

Apply the same fix #6810 #7860 for Query instance. They were only for Model.

This will solve @krlozadan's issue. It seems he gets the model via Query instance.
See https://github.com/Automattic/mongoose/pull/6810#issuecomment-513302970