### PR TITLE
[docs] Corrected code on SchemaType.prototype.unique()

### DIFF
--- a/docs/api/schematype.html
+++ b/docs/api/schematype.html
@@ -350,8 +350,8 @@ Schema.path(<span class="hljs-string">'name'</span>).index({ sparse: <span class
 
 <h4>Example:</h4>
 
-<pre><code><span class="hljs-keyword">var</span> s = <span class="hljs-keyword">new</span> Schema({ name: { type: <span class="hljs-built_in">String</span>, unique: <span class="hljs-literal">true</span> }});
-Schema.path(<span class="hljs-string">'name'</span>).index({ unique: <span class="hljs-literal">true</span> });</code></pre>
+<pre><code><span class="hljs-keyword">var</span> schema = <span class="hljs-keyword">new</span> Schema({ name: { type: <span class="hljs-built_in">String</span>, unique: <span class="hljs-literal">true</span> }});
+schema.path(<span class="hljs-string">'name'</span>).index({ unique: <span class="hljs-literal">true</span> });</code></pre>
 
 <p><em>NOTE: violating the constraint returns an <code>E11000</code> error from MongoDB when saving, not a Mongoose validation error.</em></p>  </div><hr class="separate-api-elements"><h3 id="schematype_SchemaType-validate"><a href="#schematype_SchemaType-validate">SchemaType.prototype.validate()</a></h3><h5>Parameters</h5><ul class="params"><li class="param">obj
 <span class="method-type">&laquo;RegExp|Function|Object&raquo;</span> validator function, or hash describing options</li><ul style="margin-top: 0.5em"><li>[obj.validator]

--- a/docs/api/schematype.html
+++ b/docs/api/schematype.html
@@ -350,8 +350,8 @@ Schema.path(<span class="hljs-string">'name'</span>).index({ sparse: <span class
 
 <h4>Example:</h4>
 
-<pre><code><span class="hljs-keyword">var</span> schema = <span class="hljs-keyword">new</span> Schema({ name: { type: <span class="hljs-built_in">String</span>, unique: <span class="hljs-literal">true</span> }});
-schema.path(<span class="hljs-string">'name'</span>).index({ unique: <span class="hljs-literal">true</span> });</code></pre>
+<pre><code><span class="hljs-keyword">var</span> s = <span class="hljs-keyword">new</span> Schema({ name: { type: <span class="hljs-built_in">String</span>, unique: <span class="hljs-literal">true</span> }});
+Schema.path(<span class="hljs-string">'name'</span>).index({ unique: <span class="hljs-literal">true</span> });</code></pre>
 
 <p><em>NOTE: violating the constraint returns an <code>E11000</code> error from MongoDB when saving, not a Mongoose validation error.</em></p>  </div><hr class="separate-api-elements"><h3 id="schematype_SchemaType-validate"><a href="#schematype_SchemaType-validate">SchemaType.prototype.validate()</a></h3><h5>Parameters</h5><ul class="params"><li class="param">obj
 <span class="method-type">&laquo;RegExp|Function|Object&raquo;</span> validator function, or hash describing options</li><ul style="margin-top: 0.5em"><li>[obj.validator]


### PR DESCRIPTION
SchemaType.prototype.unique()'s code example had an error created due to some copy and pasting.  It was obviously supposed to be var schema = with a lower case s rather than just s as schema was used in several other examples.
Then the second line was supposed to use path on the lowercase s schema rather than the capital s Schema from the mongoose object.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
