### PR TITLE
[docs] Updated comments from Schema.path to proper s.path

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -214,9 +214,9 @@ SchemaType.prototype.default = function(val) {
  *     var s = new Schema({ loc: { type: [Number], index: '2d', sparse: true })
  *     var s = new Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }})
  *     var s = new Schema({ date: { type: Date, index: { unique: true, expires: '1d' }})
- *     Schema.path('my.path').index(true);
- *     Schema.path('my.date').index({ expires: 60 });
- *     Schema.path('my.path').index({ unique: true, sparse: true });
+ *     s.path('my.path').index(true);
+ *     s.path('my.date').index({ expires: 60 });
+ *     s.path('my.path').index({ unique: true, sparse: true });
  *
  * ####NOTE:
  *
@@ -242,7 +242,7 @@ SchemaType.prototype.index = function(options) {
  * ####Example:
  *
  *     var s = new Schema({ name: { type: String, unique: true }});
- *     Schema.path('name').index({ unique: true });
+ *     s.path('name').index({ unique: true });
  *
  * _NOTE: violating the constraint returns an `E11000` error from MongoDB when saving, not a Mongoose validation error._
  *
@@ -275,7 +275,7 @@ SchemaType.prototype.unique = function(bool) {
  * ###Example:
  *
  *      var s = new Schema({name : {type: String, text : true })
- *      Schema.path('name').index({text : true});
+ *      s.path('name').index({text : true});
  * @param {Boolean} bool
  * @return {SchemaType} this
  * @api public
@@ -307,7 +307,7 @@ SchemaType.prototype.text = function(bool) {
  * ####Example:
  *
  *     var s = new Schema({ name: { type: String, sparse: true } });
- *     Schema.path('name').index({ sparse: true });
+ *     s.path('name').index({ sparse: true });
  *
  * @param {Boolean} bool
  * @return {SchemaType} this
@@ -755,15 +755,15 @@ const handleIsAsync = util.deprecate(function handleIsAsync() {},
  *
  *     // or through the path API
  *
- *     Schema.path('name').required(true);
+ *     s.path('name').required(true);
  *
  *     // with custom error messaging
  *
- *     Schema.path('name').required(true, 'grrr :( ');
+ *     s.path('name').required(true, 'grrr :( ');
  *
  *     // or make a path conditionally required based on a function
  *     var isOver18 = function() { return this.age >= 18; };
- *     Schema.path('voterRegistrationId').required(isOver18);
+ *     s.path('voterRegistrationId').required(isOver18);
  *
  * The required validator uses the SchemaType's `checkRequired` function to
  * determine whether a given value satisfies the required validator. By default,


### PR DESCRIPTION
I updated Schema.path in the comments to the correct s.path where applicable as was asked of me.

I found this error when helping someone debug some code.  It looks like several typo's were made calling path on Schema, which does not exist rather than on the object s which was created as a new Schema.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change unless you added a test. -->
