### PR TITLE
fix(model): delete versionError after saving to prevent memory leak

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -467,6 +467,7 @@ Model.prototype.save = function(options, fn) {
     this.$__save(options, error => {
       this.$__.saving = undefined;
       delete this.$__.saveOptions;
+      delete this.$__.versionError;
 
       if (error) {
         this.$__handleReject(error);


### PR DESCRIPTION
**Summary**

Fix #8040 memory leak introduced in ae8206280fa9861495b6bcf62a8fc7b5d6ca60bf
