### PR TITLE
docs(api): fixed typo in Mongoose.prototype.connection description

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -643,7 +643,7 @@ Mongoose.prototype.plugin = function(fn, opts) {
 };
 
 /**
- * The Mongoose module's default connection. Equivalent to `mongoose.connections][0]`, see [`connections`](#mongoose_Mongoose-connections).
+ * The Mongoose module's default connection. Equivalent to `mongoose.connections[0]`, see [`connections`](#mongoose_Mongoose-connections).
  *
  * ####Example:
  *


### PR DESCRIPTION
**Summary**

Fixed typo in `Mongoose.prototype.connection`'s description.

**Examples**

Removed the extra closing bracket in `mongoose.connections][0]`.