### PR TITLE
Update handleImmutable.js

### DIFF
--- a/lib/helpers/query/handleImmutable.js
+++ b/lib/helpers/query/handleImmutable.js
@@ -3,7 +3,7 @@
 const StrictModeError = require('../../error/strict');
 
 module.exports = function handleImmutable(schematype, strict, obj, key, fullPath) {
-  if (schematype == null || !schematype.options.immutable) {
+  if (!schematype || !schematype.options || !schematype.options.immutable) {
     return false;
   }
   if (strict === false) {


### PR DESCRIPTION
check schemaType.options not undefined

**Summary**
I'm hitting a problem where queries fail with a Schema that has arrays of mixed objects, for some reason throws an error here when tries to find "immutable" of undefined.

Thanks