### PR TITLE
Upgrade mongodb driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "2.6.2",
     "bson": "~1.1.1",
     "kareem": "2.3.0",
-    "mongodb": "3.2.7",
+    "mongodb": "3.3.0",
     "mongodb-core": "3.2.7",
     "mongoose-legacy-pluralize": "1.0.2",
     "mpath": "0.6.0",


### PR DESCRIPTION

Bumped mongo driver -> v3.3.0  …
mongo-core now apart of node-mongodb-native; therefore removed core.
Updated parseConnectionString fn to come from `mongodb` now

Fixes #8078 #8083