### PR TITLE
Fix issue when using find in a collection with nested schema array

### DIFF
--- a/lib/helpers/schematype/handleImmutable.js
+++ b/lib/helpers/schematype/handleImmutable.js
@@ -17,7 +17,7 @@ module.exports = function(schematype) {
 
 function createImmutableSetter(path) {
   return function immutableSetter(v) {
-    if (this.$__ == null) {
+    if (this == null || this.$__ == null) {
       return v;
     }
     if (this.isNew) {


### PR DESCRIPTION
**Summary**

When casting an Schema type array of objects the `applySetters` is called with no scope leading `immutableSetter` to have this as null and thus breaking at line 20 with the following error:

`Cannot read property '$__' of undefined`

This issue was introduced on version 5.6.0, I can't replicate in version 5.5.15

This change fix the error.
