### PR TITLE
[doc] add information about array to string cast

### DIFF
--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -249,14 +249,15 @@ block content
     ```
 
     If you pass an element that has a `toString()` function, Mongoose will call it,
-    unless the `toString()` function is strictly equal to `Object.prototype.toString()`.
+    unless the element is an array or `toString()` function is strictly equal to
+    `Object.prototype.toString()`.
 
     ```javascript
     new Person({ name: 42 }).name; // "42" as a string
     new Person({ name: { toString: () => 42 } }).name; // "42" as a string
 
-    // "undefined", will get a cast error if you `save()` this document 
-    new Person({ name: { foo: 42 } }).name; 
+    // "undefined", will get a cast error if you `save()` this document
+    new Person({ name: { foo: 42 } }).name;
     ```
 
     <h4 id="numbers">Number</h4>

--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -249,7 +249,7 @@ block content
     ```
 
     If you pass an element that has a `toString()` function, Mongoose will call it,
-    unless the element is an array or `toString()` function is strictly equal to
+    unless the element is an array or the `toString()` function is strictly equal to
     `Object.prototype.toString()`.
 
     ```javascript


### PR DESCRIPTION
**Summary**

Guide currently states `If you pass an element that has a toString() function, Mongoose will call it, unless the toString() function is strictly equal to Object.prototype.toString()` which is not correct as `.toString()` is also not called for arrays

Related issue: https://github.com/Automattic/mongoose/issues/7619