### PR TITLE
Add missing getters and setters copy when cloning (see issue #8111)

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1407,6 +1407,8 @@ SchemaType.prototype.clone = function() {
   const schematype = new this.constructor(this.path, options, this.instance);
   schematype.validators = this.validators.slice();
   schematype.requiredValidator = this.requiredValidator;
+  schematype.getters = this.getters.slice();
+  schematype.setters = this.setters.slice();
   return schematype;
 };
 


### PR DESCRIPTION
**Summary**
Related to issue https://github.com/Automattic/mongoose/issues/8111, cloning is not well handled.
I update a schematype by adding a setter (`schematype.set(...)`), and then when I clone the schematype, I loose the setters. There is the same behaviour with the getters.

**Examples**
```
const mongoose = require('mongoose');

(async () => {

  const schema = new mongoose.Schema({
    field: {type: String, required: true}
  });

  schema.path('field').set(value => value ? value.toUpperCase() : value);

  // Test not ok

  const TestKo = mongoose.model('TestKo', schema.clone()); //>> cloned

  const testKo = new TestKo({field: 'It shall all be upper'});

  console.error(testKo.field);

  // Test ok
  const TestOk = mongoose.model('TestOk', schema); //>> not cloned

  const testOk = new TestOk({field: 'It is all upper'});

  console.log(testOk.field);

})();
```
