### PR TITLE
Feature/fix just one default

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -101,7 +101,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     // result should be an array or a single doc. This can result from
     // populating a POJO using `Model.populate()`
     let justOne = null;
-    if ('justOne' in options) {
+    if ('justOne' in options && options.justOne !== void 0) {
       justOne = options.justOne;
     } else if (virtual && virtual.options && virtual.options.refPath) {
       const normalizedRefPath =

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -7823,7 +7823,7 @@ describe('model: populate:', function() {
     });
   });
 
-  it.only('handles virtual justOne if it is not set, is lean, and subfields are selected', function() {
+  it('handles virtual justOne if it is not set, is lean, and subfields are selected', function() {
     const postSchema = new Schema({
       name: String
     });


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

Commit a33c82eef made a change to how PopulateOptions was constructed where all options were copied from the original; previously some options were only copied if they were truthy. The slightly weird result of this was a bug which causes a virtual populate field to fail to correctly default to `justOne: false` as it should.

I opted to just fix the place where it was treating the undefined value differently than a value not being present to minimize side effects.

Oddly enough it only seems to cause an issue if you're doing a lean query with a populate specifying specific subfields on a virtual field. *shrug*. This became a critical issue for us today so I tracked it down.

**Examples**

I added a unit test which can be used to reproduce the issue and verify the fix.
