### PR TITLE
Add StrictModeError to MongooseError

### DIFF
--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -166,3 +166,15 @@ MongooseError.MissingSchemaError = require('./missingSchema');
  */
 
 MongooseError.DivergentArrayError = require('./divergentArray');
+
+/**
+ * Thrown when your try to pass values to model contrtuctor that 
+ * were not specified in schema or change immutable properties when
+ * `strict` mode is `"throw"`
+ *
+ * @api public
+ * @memberOf Error
+ * @static StrictModeError
+ */
+
+MongooseError.StrictModeError = require('./strict');


### PR DESCRIPTION
**Summary**

StrictModeError is one of possible Mongoose errors, it should be added to MongooseError

**Examples**

const StrictModeError = require('mongoose').Error
