### PR TITLE
Fix all indexes not being created for a model if one fails

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1527,6 +1527,7 @@ Model.createIndexes = function createIndexes(options, callback) {
 
 function _ensureIndexes(model, options, callback) {
   const indexes = model.schema.indexes();
+  let indexError;
 
   options = options || {};
 
@@ -1534,7 +1535,7 @@ function _ensureIndexes(model, options, callback) {
     if (err && !model.$caught) {
       model.emit('error', err);
     }
-    model.emit('index', err);
+    model.emit('index', err || indexError);
     callback && callback(err);
   };
 
@@ -1606,7 +1607,12 @@ function _ensureIndexes(model, options, callback) {
     model.collection[methodName](indexFields, indexOptions, utils.tick(function(err, name) {
       indexSingleDone(err, indexFields, indexOptions, name);
       if (err) {
-        return done(err);
+        if (!indexError) {
+          indexError = err;
+        }
+        if (!model.$caught) {
+          model.emit('error', err);
+        }
       }
       create();
     }));

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -283,21 +283,23 @@ describe('model', function() {
     });
 
     it('when one index creation errors', function(done) {
-      const User = new Schema({
-        name: { type: String },
-        secondValue: { type: Boolean }
-      });
+      const userSchema = {
+        name: {type: String},
+        secondValue: {type: Boolean}
+      };
+
+      const User = new Schema(userSchema);
       User.index({ name: 1 });
 
-      const User2 = new Schema({
-        name: {type: String, index: true, unique: true},
-        secondValue: {type: Boolean, index: true}
-      });
+      const User2 = new Schema(userSchema);
       User2.index({ name: 1 }, { unique: true });
       User2.index({ secondValue: 1 });
 
       const collectionName = 'deepindexedmodel' + random();
-      const UserModel = db.model('SingleIndexedModel', User, collectionName);
+      // Create model with first schema to initialize indexes
+      db.model('SingleIndexedModel', User, collectionName);
+
+      // Create model with second schema in same collection to add new indexes
       const UserModel2 = db.model('DuplicateIndexedModel', User2, collectionName);
       let assertions = 0;
 


### PR DESCRIPTION
**Summary**

We have some older indexes with `safe: null` set as an option on a 10s of million documents collection. Because of this index creation fails on them now since the options don't match coming from mongoose, we know this is the case but we don't have time allocated to fix them yet. However, we also noticed that new indexes that are not affected by that problem were not being created because it seems if one index fails, all following indexes for that model are skipped.

**Examples**
This is designed to fix the issue I reported here: #8181 and I also did add a test to show the issue

**Other notes**
I originally just removed the done(err) line, however that seems to have caused a test to fail in regards to errors not being emitted on the model. For that reason I added the more complex logic to continue to emit errors without stopping the index process.