### PR TITLE
[#8093] Fixes performance of update validator, and flatten function logic

### DIFF
--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -33,15 +33,14 @@ function flatten(update, path, options, schema) {
     result[path + key] = val;
 
     // Avoid going into mixed paths if schema is specified
-    if (schema != null && schema.paths[path + key] != null && schema.paths[path + key].instance === 'Mixed') {
-      continue;
-    }
+    const keySchema = schema && schema.path(path + key);
+    if (keySchema && keySchema.instance === 'Mixed') continue;
 
     if (shouldFlatten(val)) {
       if (options && options.skipArrays && Array.isArray(val)) {
         continue;
       }
-      const flat = flatten(val, path + key, options);
+      const flat = flatten(val, path + key, options, schema);
       for (const k in flat) {
         result[k] = flat[k];
       }

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -33,7 +33,7 @@ function flatten(update, path, options, schema) {
     result[path + key] = val;
 
     // Avoid going into mixed paths if schema is specified
-    const keySchema = schema && schema.path(path + key);
+    const keySchema = schema && schema.path && schema.path(path + key);
     if (keySchema && keySchema.instance === 'Mixed') continue;
 
     if (shouldFlatten(val)) {

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -54,7 +54,7 @@ module.exports = function(query, schema, castedDoc, options, callback) {
         continue;
       }
       modifiedPaths(castedDoc[keys[i]], '', modified);
-      const flat = flatten(castedDoc[keys[i]]);
+      const flat = flatten(castedDoc[keys[i]], null, null, schema);
       const paths = Object.keys(flat);
       const numPaths = paths.length;
       for (let j = 0; j < numPaths; ++j) {
@@ -79,7 +79,7 @@ module.exports = function(query, schema, castedDoc, options, callback) {
 
   if (!hasDollarUpdate) {
     modifiedPaths(castedDoc, '', modified);
-    updatedValues = flatten(castedDoc);
+    updatedValues = flatten(castedDoc, null, null, schema);
     updatedKeys = Object.keys(updatedValues);
   }
 
@@ -94,12 +94,6 @@ module.exports = function(query, schema, castedDoc, options, callback) {
   function iter(i, v) {
     const schemaPath = schema._getSchema(updates[i]);
     if (schemaPath == null) {
-      return;
-    }
-
-    // gh-4305: `_getSchema()` will report all sub-fields of a 'Mixed' path
-    // as 'Mixed', so avoid double validating them.
-    if (schemaPath instanceof Mixed && schemaPath.path !== updates[i]) {
       return;
     }
 


### PR DESCRIPTION
Fixes #8093

Before this commit the `flatten(..)` function failed to deliver what it promised. Namely, it entered into Mixed paths of objects.
    
The update validator, on its side, did not pass the casted doc schema into `flatten(..)`. If the casted doc contained a large Mixed field, all its paths were added into the list of updated paths. They were lated ignored by now removed check for schemaPath type, but performance was already hurt.
    
This commit makes sure that inner sub-paths of Mixed paths are not included into the array of paths at all, thus no further checks of that are necessary, and the performance is restored.