### PR TITLE
feat(schema): make pojo paths optionally become subdoc instead of Mixed (closes #7494)

### DIFF
--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -47,7 +47,7 @@ block content
       var Schema = mongoose.Schema;
 
       var blogSchema = new Schema({
-        title:  String,
+        title:  String, // String is shorthand for {type: String}
         author: String,
         body:   String,
         comments: [{ body: String, date: Date }],
@@ -67,9 +67,21 @@ block content
     will be cast to its associated [SchemaType](./api.html#schematype_SchemaType).
     For example, we've defined a property `title` which will be cast to the
     [String](./api.html#schema-string-js) SchemaType and property `date`
-    which will be cast to a `Date` SchemaType. Keys may also be assigned
-    nested objects containing further key/type definitions like
-    the `meta` property above.
+    which will be cast to a `Date` SchemaType.
+
+    Notice above that if a property only requires a type, it can be specified using
+    a shorthand notation (contrast the `title` property above with the `date`
+    property).
+    
+    Keys may also be assigned nested objects containing further key/type definitions
+    like the `meta` property above.  This will happen whenever a key's value is a POJO
+    that lacks a bona-fide `type` property.  In these cases, only the leaves in a tree
+    are given actual paths in the schema (like `meta.votes` and `meta.favs` above),
+    and the branches do not have actual paths.  A side-effect of this is that `meta`
+    above cannot have its own validation.  If validation is needed up the tree, a path
+    needs to be created up the tree - see the [Subdocuments](./subdocs.html) section
+    for more information no how to do this.  Also read the [Mixed](./schematypes.html)
+    subsection of the SchemaTypes guide for some gotchas.
 
     The permitted SchemaTypes are:
 

--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -335,19 +335,29 @@ block content
     const Any = new Schema({ any: Object });
     const Any = new Schema({ any: Schema.Types.Mixed });
     const Any = new Schema({ any: mongoose.Mixed });
-    // Note that if you're using `type`, putting _any_ POJO as the `type` will
+    // Note that by default, if you're using `type`, putting _any_ POJO as the `type` will
     // make the path mixed.
     const Any = new Schema({
       any: {
         type: { foo: String }
-      }
+      } // "any" will be Mixed - everything inside is ignored.
     });
+    // However, as of Mongoose 5.8.0, this behavior can be overridden with typePojoToMixed.
+    // In that case, it will create a single nested subdocument type instead.
+    const Any = new Schema({
+      any: {
+        type: { foo: String }
+      } // "any" will be a single nested subdocument.
+    }, {typePojoToMixed: false});
     ```
 
-    Since it is a schema-less type, you can change the value to anything else you
+    Since Mixed is a schema-less type, you can change the value to anything else you
     like, but Mongoose loses the ability to auto detect and save those changes.
     To tell Mongoose that the value of a Mixed type has changed, you need to
     call `doc.markModified(path)`, passing the path to the Mixed type you just changed.
+
+    To avoid these side-effects, a [Subdocument](./subdocs.html) path may be used
+    instead.
 
     ```javascript
     person.anything = { x: [3, 4, { y: "changed" }] };

--- a/docs/subdocs.pug
+++ b/docs/subdocs.pug
@@ -33,6 +33,10 @@ block content
       child: childSchema
     });
     ```
+    Aside from code reuse, one important reason to use subdocuments is to create
+    a path where there would otherwise not be one to allow for validation over
+    a group of fields (e.g. dateRange.fromDate <= dateRange.toDate).
+
   :markdown
     <ul class="toc">
       <li><a href="#what-is-a-subdocument-">What is a Subdocument?</a></li>
@@ -40,7 +44,8 @@ block content
       <li><a href="#adding-subdocs-to-arrays">Adding Subdocs to Arrays</a></li>
       <li><a href="#removing-subdocs">Removing Subdocs</a></li>
       <li><a href="#subdoc-parents">Parents of Subdocs</a></li>
-      <li><a href="#altsyntax">Alternate declaration syntax for arrays</a></li>
+      <li><a href="#altsyntaxarrays">Alternate declaration syntax for arrays</a></li>
+      <li><a href="#altsyntaxsingle">Alternate declaration syntax for single subdocuments</a></li>
     </ul>
 
     ### What is a Subdocument?
@@ -211,7 +216,7 @@ block content
     doc.level1.level2.ownerDocument() === doc; // true
     ```
 
-  h4#altsyntax Alternate declaration syntax for arrays
+  h4#altsyntaxarrays Alternate declaration syntax for arrays
   :markdown
     If you create a schema with an array of objects, mongoose will automatically
     convert the object to a schema for you:
@@ -222,6 +227,26 @@ block content
     // Equivalent
     var parentSchema = new Schema({
       children: [new Schema({ name: 'string' })]
+    });
+    ```
+
+  h4#altsyntaxsingle Alternate declaration syntax for single subdocuments
+  :markdown
+    Similarly, single subdocuments also have a shorthand whereby you can omit
+    wrapping the schema with an instance of Schema.  However, for historical
+    reasons, this alternate declaration must be enabled via an option (either
+    on the parent schema instantiation or on the mongoose instance).
+    ```javascript
+    var parentSchema = new Schema({
+      child: { type: { name: 'string' } }
+    }, { typePojoToMixed: false });
+    // Equivalent
+    var parentSchema = new Schema({
+      child: new Schema({ name: 'string' })
+    });
+    // Not equivalent!  Careful - a Mixed path is created instead!
+    var parentSchema = new Schema({
+      child: { type: { name: 'string' } }
     });
     ```
   h3#next Next Up

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,6 +157,7 @@ Mongoose.prototype.driver = require('./driver');
  * - 'toJSON': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toJSON()`](/docs/api.html#document_Document-toJSON), for determining how Mongoose documents get serialized by `JSON.stringify()`
  * - 'strict': true by default, may be `false`, `true`, or `'throw'`. Sets the default strict mode for schemas.
  * - 'selectPopulatedPaths': true by default. Set to false to opt out of Mongoose adding all fields that you `populate()` to your `select()`. The schema-level option `selectPopulatedPaths` overwrites this one.
+ * - 'typePojoToMixed': true by default, may be `false` or `true`. Sets the default typePojoToMixed for schemas.
  * - 'maxTimeMS': If set, attaches [maxTimeMS](https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/) to every query
  * - 'autoIndex': true by default. Set to false to disable automatic index creation for all models associated with this Mongoose instance.
  *

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -62,7 +62,7 @@ let id = 0;
  * - [toJSON](/docs/guide.html#toJSON) - object - no default
  * - [toObject](/docs/guide.html#toObject) - object - no default
  * - [typeKey](/docs/guide.html#typeKey) - string - defaults to 'type'
- * - [typePojoToMixed](/docs/guide.html#typePojoToMixed) - boolean - defaults to true
+ * - [typePojoToMixed](/docs/guide.html#typePojoToMixed) - boolean - defaults to true. Determines whether a type set to a POJO becomes a Mixed path or a Subdocument
  * - [useNestedStrict](/docs/guide.html#useNestedStrict) - boolean - defaults to false
  * - [validateBeforeSave](/docs/guide.html#validateBeforeSave) - bool - defaults to `true`
  * - [versionKey](/docs/guide.html#versionKey): string - defaults to "__v"
@@ -365,7 +365,7 @@ Schema.prototype.defaultOptions = function(options) {
     noVirtualId: false, // deprecated, use { id: false }
     id: true,
     typeKey: 'type',
-    typePojoToMixed: true
+    typePojoToMixed: 'typePojoToMixed' in baseOptions ? baseOptions.typePojoToMixed : true
   }, utils.clone(options));
 
   if (options.read) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -62,6 +62,7 @@ let id = 0;
  * - [toJSON](/docs/guide.html#toJSON) - object - no default
  * - [toObject](/docs/guide.html#toObject) - object - no default
  * - [typeKey](/docs/guide.html#typeKey) - string - defaults to 'type'
+ * - [typePojoToMixed](/docs/guide.html#typePojoToMixed) - boolean - defaults to true
  * - [useNestedStrict](/docs/guide.html#useNestedStrict) - boolean - defaults to false
  * - [validateBeforeSave](/docs/guide.html#validateBeforeSave) - bool - defaults to `true`
  * - [versionKey](/docs/guide.html#versionKey): string - defaults to "__v"
@@ -363,7 +364,8 @@ Schema.prototype.defaultOptions = function(options) {
     _id: true,
     noVirtualId: false, // deprecated, use { id: false }
     id: true,
-    typeKey: 'type'
+    typeKey: 'type',
+    typePojoToMixed: true
   }, utils.clone(options));
 
   if (options.read) {
@@ -423,23 +425,39 @@ Schema.prototype.add = function add(obj, prefix) {
         '`, got value "' + obj[key][0] + '"');
     }
 
-    if (utils.isPOJO(obj[key]) &&
-        (!obj[key][this.options.typeKey] || (this.options.typeKey === 'type' && obj[key].type.type))) {
-      if (Object.keys(obj[key]).length) {
-        // nested object { last: { name: String }}
-        this.nested[fullPath] = true;
-        this.add(obj[key], fullPath + '.');
-      } else {
-        if (prefix) {
-          this.nested[prefix.substr(0, prefix.length - 1)] = true;
-        }
-        this.path(fullPath, obj[key]); // mixed type
-      }
-    } else {
+    if (!utils.isPOJO(obj[key])) {
+      // Special-case: Non-POJO definitely a path so leaf at this node
       if (prefix) {
         this.nested[prefix.substr(0, prefix.length - 1)] = true;
       }
       this.path(prefix + key, obj[key]);
+    } else if (Object.keys(obj[key]).length < 1) {
+      // Special-case: {} always interpreted as Mixed path so leaf at this node
+      if (prefix) {
+        this.nested[prefix.substr(0, prefix.length - 1)] = true;
+      }
+      this.path(fullPath, obj[key]); // mixed type
+    } else if (!obj[key][this.options.typeKey] || (this.options.typeKey === 'type' && obj[key].type.type)) {
+      // Special-case: POJO with no bona-fide type key - interpret as tree of deep paths so recurse
+      // nested object { last: { name: String }}
+      this.nested[fullPath] = true;
+      this.add(obj[key], fullPath + '.');
+    } else {
+      // There IS a bona-fide type key that may also be a POJO
+      if(!this.options.typePojoToMixed && utils.isPOJO(obj[key][this.options.typeKey])) {
+        // If a POJO is the value of a type key, make it a subdocument
+        if (prefix) {
+          this.nested[prefix.substr(0, prefix.length - 1)] = true;
+        }
+        const schemaWrappedPath = Object.assign({}, obj[key], { type: new Schema(obj[key][this.options.typeKey]) });
+        this.path(prefix + key, schemaWrappedPath);
+      } else {
+        // Either the type is non-POJO or we interpret it as Mixed anyway
+        if (prefix) {
+          this.nested[prefix.substr(0, prefix.length - 1)] = true;
+        }
+        this.path(prefix + key, obj[key]);
+      }
     }
   }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -444,7 +444,7 @@ Schema.prototype.add = function add(obj, prefix) {
       this.add(obj[key], fullPath + '.');
     } else {
       // There IS a bona-fide type key that may also be a POJO
-      if(!this.options.typePojoToMixed && utils.isPOJO(obj[key][this.options.typeKey])) {
+      if (!this.options.typePojoToMixed && utils.isPOJO(obj[key][this.options.typeKey])) {
         // If a POJO is the value of a type key, make it a subdocument
         if (prefix) {
           this.nested[prefix.substr(0, prefix.length - 1)] = true;

--- a/test/types.embeddeddocumentdeclarative.test.js
+++ b/test/types.embeddeddocumentdeclarative.test.js
@@ -53,7 +53,7 @@ describe('types.embeddeddocumentdeclarative', function() {
       const ParentSchema = new mongoose.Schema(ParentSchemaDef, {typePojoToMixed: false});
       it('interprets the POJO as a subschema (gh-7494)', function(done) {
         assert.equal(ParentSchema.paths.child.instance, 'Embedded');
-        assert.equal(ParentSchema.paths.child['$isSingleNested'], true);
+        assert.strictEqual(ParentSchema.paths.child['$isSingleNested'], true);
         done();
       });
       it('enforces provided schema on the child path, unlike Mixed (gh-7494)', function(done) {
@@ -68,7 +68,7 @@ describe('types.embeddeddocumentdeclarative', function() {
         const princessZelda = kingDaphnes.child.toObject();
 
         assert.equal(princessZelda.name, 'Princess Zelda');
-        assert.equal(princessZelda.mixedUp, undefined);
+        assert.strictEqual(princessZelda.mixedUp, undefined);
         done();
       });
     });
@@ -112,16 +112,16 @@ describe('types.embeddeddocumentdeclarative', function() {
         child: {
           name: 'Prince Komali',
           type: 'Medli',
-          confidence: 0,
+          confidence: 1,
         }
       });
 
       assert.equal(grandmother.child.name, 'Rito Chieftan');
       assert.equal(grandmother.child.type, 'Mother');
-      assert.equal(grandmother.child.confidence, undefined);
+      assert.strictEqual(grandmother.child.confidence, undefined);
       assert.equal(ritoChieftan.child.name, 'Prince Komali');
       assert.equal(ritoChieftan.child.type, 'Medli');
-      assert.equal(ritoChieftan.child.confidence, undefined);
+      assert.strictEqual(ritoChieftan.child.confidence, undefined);
       done();
     });
   });

--- a/test/types.embeddeddocumentdeclarative.test.js
+++ b/test/types.embeddeddocumentdeclarative.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const assert = require('assert');
+const start = require('./common');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+/**
+ * Test.
+ */
+
+describe('types.embeddeddocumentdeclarative', function() {
+  let GrandChildSchema;
+  let ChildSchema;
+  let ParentSchema;
+
+  before(function() {
+    GrandChildSchema = {
+      name: String
+    };
+
+    ChildSchema = {
+      name: String,
+      children: [GrandChildSchema]
+    };
+
+    ParentSchema = new Schema({
+      name: String,
+      typePojoToMixed: false,
+      child: ChildSchema
+    });
+
+    mongoose.model('Parent-7494-EmbeddedDeclarative', ParentSchema);
+  });
+
+  it('returns a proper ownerDocument (gh-7494)', function(done) {
+    const Parent = mongoose.model('Parent-7494-EmbeddedDeclarative');
+    const p = new Parent({
+      name: 'Parent Parentson',
+      child: {
+        name: 'Child Parentson',
+        children: [
+          {
+            name: 'GrandChild Parentson'
+          }
+        ]
+      }
+    });
+
+    assert.equal(p._id, p.child.children[0].ownerDocument()._id);
+    done();
+  });
+});

--- a/test/types.embeddeddocumentdeclarative.test.js
+++ b/test/types.embeddeddocumentdeclarative.test.js
@@ -15,44 +15,114 @@ const Schema = mongoose.Schema;
  */
 
 describe('types.embeddeddocumentdeclarative', function() {
-  let GrandChildSchema;
-  let ChildSchema;
-  let ParentSchema;
-
-  before(function() {
-    GrandChildSchema = {
-      name: String
+  describe('with a parent with a field with type set to a POJO', function() {
+    const ChildSchemaDef = {
+      name: String,
     };
 
-    ChildSchema = {
+    const ParentSchemaDef = {
       name: String,
-      children: [GrandChildSchema]
-    };
-
-    ParentSchema = new Schema({
-      name: String,
-      typePojoToMixed: false,
-      child: ChildSchema
-    });
-
-    mongoose.model('Parent-7494-EmbeddedDeclarative', ParentSchema);
-  });
-
-  it('returns a proper ownerDocument (gh-7494)', function(done) {
-    const Parent = mongoose.model('Parent-7494-EmbeddedDeclarative');
-    const p = new Parent({
-      name: 'Parent Parentson',
       child: {
-        name: 'Child Parentson',
-        children: [
-          {
-            name: 'GrandChild Parentson'
-          }
-        ]
+        type: ChildSchemaDef,
       }
-    });
+    };
 
-    assert.equal(p._id, p.child.children[0].ownerDocument()._id);
-    done();
+    describe('with the default legacy behavior (typePojoToMixed=true)', function() {
+      const ParentSchema = new mongoose.Schema(ParentSchemaDef);
+      it('interprets the POJO as Mixed (gh-7494)', function(done) {
+        assert.equal(ParentSchema.paths.child.instance, 'Mixed');
+        done();
+      });
+      it('does not enforce provided schema on the child path (gh-7494)', function(done) {
+        const ParentModel = mongoose.model('ParentModel-7494-EmbeddedDeclarativeMixed', ParentSchema);
+        const swampGuide = new ParentModel({
+          name: 'Swamp Guide',
+          child: {
+            name: 'Tingle',
+            mixedUp: 'very',
+          }
+        });
+        const tingle = swampGuide.toObject().child;
+
+        assert.equal(tingle.name, 'Tingle');
+        assert.equal(tingle.mixedUp, 'very');
+        done();
+      });
+    });
+    describe('with the optional subschema behavior (typePojoToMixed=false)', function() {
+      const ParentSchema = new mongoose.Schema(ParentSchemaDef, {typePojoToMixed: false});
+      it('interprets the POJO as a subschema (gh-7494)', function(done) {
+        assert.equal(ParentSchema.paths.child.instance, 'Embedded');
+        assert.equal(ParentSchema.paths.child['$isSingleNested'], true);
+        done();
+      });
+      it('enforces provided schema on the child path, unlike Mixed (gh-7494)', function(done) {
+        const ParentModel = mongoose.model('ParentModel-7494-EmbeddedDeclarativeSubschema', ParentSchema);
+        const kingDaphnes = new ParentModel({
+          name: 'King Daphnes Nohansen Hyrule',
+          child: {
+            name: 'Princess Zelda',
+            mixedUp: 'not',
+          }
+        });
+        const princessZelda = kingDaphnes.child.toObject();
+
+        assert.equal(princessZelda.name, 'Princess Zelda');
+        assert.equal(princessZelda.mixedUp, undefined);
+        done();
+      });
+    });
+  });
+  describe('with a parent with a POJO field with a field "type" with a type set to "String"', function() {
+    const ParentSchemaDef = {
+      name: String,
+      child: {
+        name: String,
+        type: {
+          type: String,
+        },
+      }
+    };
+    const ParentSchemaNotMixed = new Schema(ParentSchemaDef);
+    const ParentSchemaNotSubdoc = new Schema(ParentSchemaDef, {typePojoToMixed: false});
+    it('does not create a path for child in either option', function(done) {
+      assert.equal(ParentSchemaNotMixed.paths['child.name'].instance, 'String');
+      assert.equal(ParentSchemaNotSubdoc.paths['child.name'].instance, 'String');
+      done();
+    });
+    it('treats type as a property name not a type in both options', function(done) {
+      assert.equal(ParentSchemaNotMixed.paths['child.type'].instance, 'String');
+      assert.equal(ParentSchemaNotSubdoc.paths['child.type'].instance, 'String');
+      done();
+    });
+    it('enforces provided schema on the child tree in both options, unlike Mixed (gh-7494)', function(done) {
+      const ParentModelNotMixed = mongoose.model('ParentModel-7494-EmbeddedDeclarativeNestedNotMixed', ParentSchemaNotMixed);
+      const ParentModelNotSubdoc = mongoose.model('ParentModel-7494-EmbeddedDeclarativeNestedNotSubdoc', ParentSchemaNotSubdoc);
+
+      const grandmother = new ParentModelNotMixed({
+        name: 'Grandmother',
+        child: {
+          name: 'Rito Chieftan',
+          type: 'Mother',
+          confidence: 10,
+        }
+      });
+      const ritoChieftan = new ParentModelNotSubdoc({
+        name: 'Rito Chieftan',
+        child: {
+          name: 'Prince Komali',
+          type: 'Medli',
+          confidence: 0,
+        }
+      });
+
+      assert.equal(grandmother.child.name, 'Rito Chieftan');
+      assert.equal(grandmother.child.type, 'Mother');
+      assert.equal(grandmother.child.confidence, undefined);
+      assert.equal(ritoChieftan.child.name, 'Prince Komali');
+      assert.equal(ritoChieftan.child.type, 'Medli');
+      assert.equal(ritoChieftan.child.confidence, undefined);
+      done();
+    });
   });
 });


### PR DESCRIPTION
Note: Might also close #7181 and close #7408 too...

- default behaves as previous releases did
- embeddeddocument test copied to cover declarative syntax

- otherwise, type: somePojo turns somePojo into subdocument and Mixed paths are only created when explicitly requested via Mixed or {}

I think it's probably also a good idea to make this option a base option too, but wanted to ask for blessing first.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
It creates an option that makes type keys valued as POJOs create a subschema instead of Mixed.  The existing behavior is unaltered by default.

This also helps full-stack monorepo use-cases that share the schema configuration object between the client-side project and the server-side project, because the schema configuration object can specify subschemas without importing Mongoose.Schema (so client-side can use mongoose/browser and server-side can use mongoose itself).

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

See test ;).

