### PR TITLE
feat(update): basic support for update pipelines in MongoDB 4.2

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -22,8 +22,19 @@ const utils = require('../../utils');
  */
 
 module.exports = function castUpdate(schema, obj, options, context, filter) {
-  if (!obj) {
+  if (obj == null) {
     return undefined;
+  }
+  options = options || {};
+
+  // Update pipeline
+  if (Array.isArray(obj)) {
+    const len = obj.length;
+    options.pipeline = true;
+    for (let i = 0; i < len; ++i) {
+      obj[i] = castUpdate(schema, obj[i], options, context, filter);
+    }
+    return obj;
   }
 
   const ops = Object.keys(obj);
@@ -74,7 +85,10 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     val = ret[op];
     hasDollarKey = hasDollarKey || op.startsWith('$');
 
-    if (val &&
+    if (op === '$unset' && options.pipeline) {
+      hasKeys = true;
+      castPipelineOperator(op, val);
+    } else if (val &&
         typeof val === 'object' &&
         !Buffer.isBuffer(val) &&
         (!overwrite || hasDollarKey)) {
@@ -100,6 +114,20 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
 
   return hasKeys && ret;
 };
+
+/*!
+ * ignore
+ */
+
+function castPipelineOperator(op, val) {
+  if (op === '$unset') {
+    if (!Array.isArray(val) || val.find(v => typeof v !== 'string')) {
+      throw new Error('Invalid $unset in pipeline, must be an array of strings');
+    }
+  }
+
+  return val;
+}
 
 /*!
  * Walk each path of obj and cast its values

--- a/lib/query.js
+++ b/lib/query.js
@@ -3599,12 +3599,29 @@ const _legacyFindAndModify = util.deprecate(function(filter, update, opts, cb) {
  */
 
 Query.prototype._mergeUpdate = function(doc) {
-  if (!this._update) this._update = {};
+  if (doc == null || (typeof doc === 'object' && Object.keys(doc).length === 0)) {
+    return;
+  }
+
+  if (!this._update) {
+    this._update = Array.isArray(doc) ? [] : {};
+  }
   if (doc instanceof Query) {
+    if (Array.isArray(this._update)) {
+      throw new Error('Cannot mix array and object updates');
+    }
     if (doc._update) {
       utils.mergeClone(this._update, doc._update);
     }
+  } else if (Array.isArray(doc)) {
+    if (!Array.isArray(this._update)) {
+      throw new Error('Cannot mix array and object updates');
+    }
+    this._update = this._update.concat(doc);
   } else {
+    if (Array.isArray(this._update)) {
+      throw new Error('Cannot mix array and object updates');
+    }
     utils.mergeClone(this._update, doc);
   }
 };
@@ -3654,6 +3671,7 @@ function _updateThunk(op, callback) {
 
   ++this._executionCount;
 
+  console.log('FT', this._update)
   this._update = utils.clone(this._update, options);
   const isOverwriting = this.options.overwrite && !hasDollarKeys(this._update);
   if (isOverwriting) {
@@ -4153,7 +4171,7 @@ function _update(query, op, filter, doc, options, callback) {
     return query;
   }
 
-  return Query.base[op].call(query, filter, doc, options, callback);
+  return Query.base[op].call(query, filter, void 0, options, callback);
 }
 
 /**


### PR DESCRIPTION
Re: #8225, looks like we're going to need some significant work to support [aggregation pipelines in updates](https://docs.mongodb.com/manual/reference/method/db.collection.updateOne/#updateone-behavior-aggregation-pipeline). This is at least a basic proof of concept.