### PR TITLE
docs(api) fix Connection.close return param

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -757,7 +757,7 @@ const handleUseMongoClient = function handleUseMongoClient(options) {
  *
  * @param {Boolean} [force] optional
  * @param {Function} [callback] optional
- * @return {Connection} self
+ * @return {Promise}
  * @api public
  */
 


### PR DESCRIPTION
**Summary**

I've fixed jsdoc for Connection.close public method. It's in fact returning a promise, not a Connection object.