### PR TITLE
WIP: fix(document): allow validation of moddelless documents on node side

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ const STATES = require('./connectionstate');
 const Types = require('./types');
 const Query = require('./query');
 const Model = require('./model');
+const BrowserDocument = require('./browserDocument');
 const Document = require('./document');
 const applyPlugins = require('./helpers/schema/applyPlugins');
 const get = require('./helpers/get');
@@ -395,6 +396,25 @@ Mongoose.prototype.pluralize = function(fn) {
   }
   return _mongoose._pluralize;
 };
+
+
+Mongoose.prototype.ephemodel = function(schema, skipInit) {
+  let ephemodel = function Ephemodel(doc, fields, skipId) {
+    if (doc instanceof Schema) {
+      throw new TypeError('Argument to `Ephemodel` must be a POJO, ' +
+        '**not** a schema. Make sure you\'re calling `mongoose.ephemodel()`, not ' +
+        '`mongoose.Ephemodel()`.');
+    }
+    BrowserDocument.call(this, doc, this.schema, fields, skipId, skipInit);
+  };
+  ephemodel.__proto__ = BrowserDocument;
+
+  ephemodel.prototype = Object.create(BrowserDocument.prototype);
+  ephemodel.prototype.constructor = ephemodel;
+
+  ephemodel.prototype.schema = schema;
+  return ephemodel;
+}
 
 /**
  * Defines a model or retrieves it.


### PR DESCRIPTION
Hi - this PR is incomplete because it lacks tests, docs, etc. because I wanted to see if you're okay with this approach first.  To me it improves DX and is also a little more maintainable b/c it makes the code paths the same on the client-side and server-side with respect to non-persistent documents.

If you're okay with this direction, please let me know if you have a better idea for a name than "ephemodel" (ephemeral model) :-/. 

Fix #8237, fix #8272, and improve DX by making ephemeral models similar
to normal ones

**Summary**

This fixes modelless document validation on the server-side by sharing its exact same code path with that of browser-side documents.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Browser-side syntax is currently broken on the server-side, so making models for DTO-type sanitizers can currently only be done by making a REAL model.

**Examples**

```javascript
const Ephey = goosey.ephemodel(new goosey.Schema({hair: Number}));
const dockey = new Ephey({hair: 'red', eyes: 'green'});
console.log(dockey.validateSync());
console.log(dockey.toObject());
```
...prints...

> { ValidationError: Validation failed: hair: Cast to Number failed for value "red" at path "hair"
...and...
> {}

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
