### PR TITLE
feat(clone) Check for & use `cloneOf` method when cloning objects

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -199,6 +199,10 @@ exports.clone = function clone(obj, options, isArrayChild) {
     return obj.toObject(options);
   }
 
+  if (typeof obj.cloneOf === 'function') {
+    return obj.cloneOf();
+  }
+
   if (obj.constructor) {
     switch (exports.getFunctionName(obj.constructor)) {
       case 'Object':

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -254,6 +254,22 @@ describe('utils', function() {
 
       return Promise.resolve();
     });
+
+    it('invokes cloneOf method on object before valueOf if exists', function(done) {
+      const o = Object.create({
+        cloneOf() {
+          this.cloneOfCalled = true;
+          return this;
+        },
+      });
+
+      const out = utils.clone(o);
+      assert.deepEqual(out, o);
+      assert.equal(o.cloneOfCalled, true);
+      assert.equal(out.valueOfCalled, undefined);
+
+      done();
+    });
   });
 
   it('array.flatten', function(done) {


### PR DESCRIPTION
Adds a check in the `clone` function to see if the given parameter has
a `cloneOf` method.  If the method exists then the `clone` method
assumes that this method will return a clone of the called object and
thus invokes it to complete its task.

Fixes #8299