### PR TITLE
build(test) Improve test target

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lint": "eslint .",
     "release": "git pull && git push origin master --tags && npm publish",
     "release-legacy": "git pull origin 4.x && git push origin 4.x --tags && npm publish --tag legacy",
-    "test": "mocha --exit test/*.test.js test/**/*.test.js",
+    "test": "mocha --exit",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   },
   "main": "./index.js",
@@ -142,6 +142,10 @@
           "message": "Don't use Mocha's global context"
         }
       ]
+    },
+    "mocha": {
+      "extension": ["test.js"],
+      "watch-files": ["test/**/*.js"]
     }
   }
 }


### PR DESCRIPTION
Adds a mocha section to package.json to allow the removal of the
file path arguments in the test script target for mocha. Doing this
enables the developer to now invoke testing on a single file more
easily like so:

`$ npm test test/utils.test.js`