### PR TITLE
fix(model): delete $versionError after saving to prevent memory leak

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -465,7 +465,7 @@ Model.prototype.save = function(options, fn) {
     this.$__save(options, error => {
       this.$__.saving = undefined;
       delete this.$__.saveOptions;
-      delete this.$__.versionError;
+      delete this.$__.$versionError;
 
       if (error) {
         this.$__handleReject(error);


### PR DESCRIPTION
The original fix in PR #8048 has a typo. This PR really fixes the issue.