### PR TITLE
test(model): add test for issue #8040 re: #8048 #8326

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3816,6 +3816,23 @@ describe('Model', function() {
         });
       });
     });
+    it('should clear $versionError and saveOptions after saved (gh-8040)', function(done) {
+      const schema = new Schema({name: String});
+      const Model = db.model('gh8040', schema);
+      const doc = new Model({
+        name: 'Fonger'
+      });
+
+      const savePromise = doc.save();
+      assert.ok(doc.$__.$versionError);
+      assert.ok(doc.$__.saveOptions);
+
+      savePromise.then(function() {
+        assert.ok(!doc.$__.$versionError);
+        assert.ok(!doc.$__.saveOptions);
+        done();
+      }).catch(done);
+    });
   });
 
 


### PR DESCRIPTION

**Summary**

Add test to make sure `$__.versionError` `$__.saveOptions` are generated during saving and are cleared after saved to prevent memory leak.

https://github.com/Automattic/mongoose/pull/8326#issuecomment-553609848
> vkarpov15: I'll merge this for now, but can you also write a test for this please? Basically make sure that `$versionError` exists before and no longer exists after.


