### PR TITLE
remove duplicate omitUndefined options

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3862,7 +3862,6 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](http://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://docs.mongodb.com/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](/docs/guide.html#writeConcern)
- * @param {Boolean} [options.omitUndefined=false] If true, delete any properties whose value is `undefined` when casting an update. In other words, if this is set, Mongoose will delete `baz` from the update in `Model.updateOne({}, { foo: 'bar', baz: undefined })` before sending the update to the server.
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
@@ -3928,7 +3927,6 @@ Query.prototype.update = function(conditions, doc, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](http://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://docs.mongodb.com/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](/docs/guide.html#writeConcern)
- * @param {Boolean} [options.omitUndefined=false] If true, delete any properties whose value is `undefined` when casting an update. In other words, if this is set, Mongoose will delete `baz` from the update in `Model.updateOne({}, { foo: 'bar', baz: undefined })` before sending the update to the server.
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
@@ -3995,7 +3993,6 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](http://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://docs.mongodb.com/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](/docs/guide.html#writeConcern)
- * @param {Boolean} [options.omitUndefined=false] If true, delete any properties whose value is `undefined` when casting an update. In other words, if this is set, Mongoose will delete `baz` from the update in `Model.updateOne({}, { foo: 'bar', baz: undefined })` before sending the update to the server.
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
@@ -4060,7 +4057,6 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](http://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://docs.mongodb.com/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](/docs/guide.html#writeConcern)
- * @param {Boolean} [options.omitUndefined=false] If true, delete any properties whose value is `undefined` when casting an update. In other words, if this is set, Mongoose will delete `baz` from the update in `Model.updateOne({}, { foo: 'bar', baz: undefined })` before sending the update to the server.
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Duplicate `omitUndefined ` options are removed from `Query#replaceOne`, `Query#update`, `Query#updateMany` and `Query#updateOne` documentations.

fixes #8348 
