### PR TITLE
feat(browser): pre-compile mongoose/browser

### DIFF
--- a/build-browser.js
+++ b/build-browser.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const config = require('./webpack.config.js');
+const webpack = require('webpack');
+
+const compiler = webpack(config);
+
+console.log('Starting browser build...');
+compiler.run((err, stats) => {
+  if (err) {
+    console.err(stats.toString());
+    console.err('Browser build unsuccessful.');
+    process.exit(1);
+  }
+  console.log(stats.toString());
+  console.log('Browser build successful.');
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
   },
   "scripts": {
     "lint": "eslint .",
+    "build-browser": "node build-browser.js",
+    "prepublishOnly": "npm run build-browser",
     "release": "git pull && git push origin master --tags && npm publish",
     "release-legacy": "git pull origin 4.x && git push origin 4.x --tags && npm publish --tag legacy",
     "test": "mocha --exit test/*.test.js test/**/*.test.js",
@@ -88,7 +90,7 @@
     "url": "git://github.com/Automattic/mongoose.git"
   },
   "homepage": "https://mongoosejs.com",
-  "browser": "./browser.js",
+  "browser": "./dist/browser.umd.js",
   "eslintConfig": {
     "extends": [
       "eslint:recommended"

--- a/test/files/sample.js
+++ b/test/files/sample.js
@@ -1,5 +1,5 @@
 'use strict';
-import mongoose from '../../browser.js';
+import mongoose from './dist/browser.umd.js';
 
 const doc = new mongoose.Document({}, new mongoose.Schema({
   name: String

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -16,58 +16,49 @@ describe('webpack', function() {
       this.skip();
     }
     const webpack = require('webpack');
-    this.timeout(45000);
+    this.timeout(90000);
     // acquit:ignore:end
-    const config = {
-      entry: ['./test/files/sample.js'],
-      // acquit:ignore:start
-      output: {
-        path: `${__dirname}/files`
-      },
-      // acquit:ignore:end
-      module: {
-        rules: [
-          {
-            test: /\.js$/,
-            include: [
-              /\/mongoose\//i,
-              /\/kareem\//i
-            ],
-            loader: 'babel-loader',
-            options: {
-              presets: ['es2015']
-            }
-          }
-        ]
-      },
-      node: {
-        // Replace these Node.js native modules with empty objects, Mongoose's
-        // browser library does not use them.
-        // See https://webpack.js.org/configuration/node/
-        dns: 'empty',
-        fs: 'empty',
-        'module': 'empty',
-        net: 'empty',
-        tls: 'empty'
-      },
-      target: 'web',
-      mode: 'production'
-    };
-    // acquit:ignore:start
-    webpack(config, utils.tick(function(error, stats) {
-      assert.ifError(error);
-      assert.deepEqual(stats.compilation.errors, []);
+    const webpackBundle = require('../webpack.config.js');
+    const webpackBundleForTest = Object.assign({}, webpackBundle, {
+      output: Object.assign({}, webpackBundle.output, { path: `${__dirname}/files` })
+    });
+    webpack(webpackBundleForTest, utils.tick(function(bundleBuildError, bundleBuildStats) {
+      assert.ifError(bundleBuildError);
+      assert.deepEqual(bundleBuildStats.compilation.errors, []);
 
       // Avoid expressions in `require()` because that scares webpack (gh-6705)
-      assert.ok(!stats.compilation.warnings.
+      assert.ok(!bundleBuildStats.compilation.warnings.
         find(msg => msg.toString().startsWith('ModuleDependencyWarning:')));
 
-      const content = fs.readFileSync(`${__dirname}/files/main.js`, 'utf8');
+      const bundleContent = fs.readFileSync(`${__dirname}/files/dist/browser.umd.js`, 'utf8');
 
-      acorn.parse(content, { ecmaVersion: 5 });
+      acorn.parse(bundleContent, { ecmaVersion: 5 });
 
-      done();
+      const baseConfig = require('../webpack.base.config.js');
+      const config = Object.assign({}, baseConfig, {
+        entry: ['./test/files/sample.js'],
+        // acquit:ignore:start
+        output: {
+          path: `${__dirname}/files`
+        },
+        // acquit:ignore:end
+      });
+      // acquit:ignore:start
+      webpack(config, utils.tick(function(error, stats) {
+        assert.ifError(error);
+        assert.deepEqual(stats.compilation.errors, []);
+
+        // Avoid expressions in `require()` because that scares webpack (gh-6705)
+        assert.ok(!stats.compilation.warnings.
+          find(msg => msg.toString().startsWith('ModuleDependencyWarning:')));
+
+        const content = fs.readFileSync(`${__dirname}/files/main.js`, 'utf8');
+
+        acorn.parse(content, { ecmaVersion: 5 });
+
+        done();
+      }));
+      // acquit:ignore:end
     }));
-    // acquit:ignore:end
   });
 });

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: [
+          /\/mongoose\//i,
+          /\/kareem\//i,
+        ],
+        loader: 'babel-loader',
+        options: {
+          presets: ['es2015']
+        }
+      }
+    ]
+  },
+  node: {
+    // Replace these Node.js native modules with empty objects, Mongoose's
+    // browser library does not use them.
+    // See https://webpack.js.org/configuration/node/
+    dns: 'empty',
+    fs: 'empty',
+    module: 'empty',
+    net: 'empty',
+    tls: 'empty',
+  },
+  target: 'web',
+  mode: 'production',
+};
+
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const paths = require('path');
+
+const base = require('./webpack.base.config.js');
+
+const webpackConfig = Object.assign({}, base, {
+  entry: require.resolve('./browser.js'),
+  output: {
+    filename: './dist/browser.umd.js',
+    path: paths.resolve(__dirname, ''),
+    library: 'mongoose',
+    libraryTarget: 'umd',
+    // override default 'window' globalObject so browser build will work in SSR environments
+    // may become unnecessary in webpack 5
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
+  },
+  externals: [
+    /^node_modules\/.+$/
+  ],
+});
+
+module.exports = webpackConfig;
+


### PR DESCRIPTION
Fix #7219

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Prebuilt mongoose/browser configured in a way that can be consumed in environments that don't have "window" too.  Webpack test also updated to test the exact same webpack config as the build.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
