### PR TITLE
feat(connections): Adds default database connection string support (#8354)

### DIFF
--- a/docs/connections.pug
+++ b/docs/connections.pug
@@ -134,7 +134,7 @@ block content
     * `bufferCommands`    - This is a mongoose-specific option (not passed to the MongoDB driver) that disables [mongoose's buffering mechanism](http://mongoosejs.com/docs/faq.html#callback_never_executes)
     * `user`/`pass`       - The username and password for authentication. These options are mongoose-specific, they are equivalent to the MongoDB driver's `auth.user` and `auth.password` options.
     * `autoIndex`         - By default, mongoose will automatically build indexes defined in your schema when it connects. This is great for development, but not ideal for large production deployments, because index builds can cause performance degradation. If you set `autoIndex` to false, mongoose will not automatically build indexes for **any** model associated with this connection.
-    * `dbName`            - Specifies which database to connect to and overrides any database specified in the connection string. If you're using the `mongodb+srv` syntax to connect to [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), you [should use `dbName` to specify the database](https://stackoverflow.com/questions/48917591/fail-to-connect-mongoose-to-atlas/48917626#48917626) because you currently cannot in the connection string.
+    * `dbName`            - Specifies which database to connect to and overrides any database specified in the connection string. This is useful if you are unable to specify a default database in the connection string like with [some `mongodb+srv` syntax connections](https://stackoverflow.com/questions/48917591/fail-to-connect-mongoose-to-atlas/48917626#48917626).
 
     Below are some of the options that are important for tuning mongoose.
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -605,7 +605,13 @@ Connection.prototype.openUri = function(uri, options, callback) {
       if (err) {
         return reject(err);
       }
-      this.name = dbName != null ? dbName : get(parsed, 'auth.db', null);
+      if (dbName) {
+        this.name = dbName;
+      } else if (parsed.defaultDatabase) {
+        this.name = parsed.defaultDatabase;
+      } else {
+        this.name = get(parsed, 'auth.db', null);
+      }
       this.host = get(parsed, 'hosts.0.host', 'localhost');
       this.port = get(parsed, 'hosts.0.port', 27017);
       this.user = this.user || get(parsed, 'auth.username');

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -744,6 +744,13 @@ describe('connections:', function() {
     });
   });
 
+  it('uses default database in uri if options.dbName is not provided', function() {
+    return mongoose.createConnection('mongodb://localhost:27017/default-db-name').then(db => {
+      assert.equal(db.name, 'default-db-name');
+      db.close();
+    });
+  });
+
   it('startSession() (gh-6653)', function() {
     const conn = mongoose.createConnection('mongodb://localhost:27017/test');
 


### PR DESCRIPTION
**Summary**
This solves https://github.com/Automattic/mongoose/issues/8354. It appears that previously SRV connection strings didn't allow for default databases to be in the uri. I'm not sure if that changed recently, but when connecting to our Atlas clusters we are able to specify the default database in the string.

This PR changes the logic when assigning the database name (as outlined in https://github.com/Automattic/mongoose/issues/8354) to look for `options.dbName`, then look for the default database in the connection string, then fallback to the auth db.

**Examples**
```js
mongoose.connect('mongodb+srv://<username>:<password>@cluster0.mongodb.net/defaultDatabase?w=majority')

// => results in a connection with `db.name === defaultDatabase`
```