### PR TITLE
Correctly catch the error when insertMany fails to initialize the document

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3206,10 +3206,15 @@ Model.$__insertMany = function(arr, options, callback) {
 
   const toExecute = [];
   const validationErrors = [];
+
   arr.forEach(function(doc) {
     toExecute.push(function(callback) {
       if (!(doc instanceof _this)) {
-        doc = new _this(doc);
+        try {
+          doc = new _this(doc);
+        } catch (err) {
+          return callback(err);
+        }
       }
       if (options.session != null) {
         doc.$session(options.session);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4909,6 +4909,18 @@ describe('Model', function() {
       });
     });
 
+    it('insertMany() with non object array error can be catched (gh-8363)', function(done) {
+      const schema = mongoose.Schema({
+        _id: mongoose.Schema.Types.ObjectId,
+        url: { type: String }
+      });
+      const Image = db.model('gh8363', schema);
+      Image.insertMany(['a', 'b', 'c']).catch((error) => {
+        assert.equal(error.name, 'ObjectParameterError');
+        done();
+      });
+    });
+
     it('insertMany() return docs with empty modifiedPaths (gh-7852)', function() {
       const schema = new Schema({
         name: { type: String }


### PR DESCRIPTION
**Summary**

Fix #8363. Correctly catch the error with callback when insertMany fails to initialize the document.
This can prevent DOS attack when inserting user-provided data.

This fix handles it like [`Model.create([...])` does](https://github.com/Automattic/mongoose/blob/33412d91d044daade5a135c7f35f607591c75a09/lib/model.js#L3021-L3027).

Note: I've tested `Model.bulkWrite()` `insertOne()/replaceOne()` and I can confirm that it's not affected by this bug because `$handleCallbackError` wrap the entire bulkWrite callback handler and it catches the error during `castBulkWrite()`.

However, in `Model.insertMany()`, `parallelLimit()` individual callbacks are not wrapped in that general handler (although $__insertMany is) so we need this fix.

**Examples**

See the test case


