### PR TITLE
Update mongodb dependency to 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "~1.1.1",
     "kareem": "2.3.1",
-    "mongodb": "3.3.5",
+    "mongodb": "3.4.0",
     "mongoose-legacy-pluralize": "1.0.2",
     "mpath": "0.6.0",
     "mquery": "3.2.2",


### PR DESCRIPTION
**Summary**
Connecting via `ssl: true` in a Docker Container through a SSH Tunnel fails for me.

Using `mongodb@3.4` and the new `tls: true` parameters works as expected.

Would be great if mongoose could be updated to use the latest `mongodb@3.4` instead of `3.3.4`

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Examples**

Connecting via SSL in 3.3.5:
```js
const options = {
        ssl: true,
        sslCA: [ fs.readFileSync( process.env.MONGODB_CA ) ],
        sslCert: fs.readFileSync( process.env.MONGODB_CERT ),
        sslKey: fs.readFileSync( process.env.MONGODB_KEY ),
        // ... other options
    };
```

Connecting via SSL in 3.4:
```js
const options = {
        tls: true,
        tlsCAFile: process.env.MONGODB_CA,
        tlsCertificateKeyFile: process.env.MONGODB_CERT,
        // ... other options
    };
```

The depreceated ssl options still work so no change is necessary.