### PR TITLE
test and Fixes #8531 - only call validate once for subdocuments

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2103,7 +2103,8 @@ function _getPathsToValidate(doc) {
   const modifiedPaths = doc.modifiedPaths();
   for (i = 0; i < len; ++i) {
     subdoc = subdocs[i];
-    if (doc.isModified(subdoc.$basePath, modifiedPaths) &&
+    if (subdoc.$basePath &&
+        doc.isModified(subdoc.$basePath, modifiedPaths) &&
         !doc.isDirectModified(subdoc.$basePath) &&
         !doc.$isDefault(subdoc.$basePath)) {
       // Remove child paths for now, because we'll be validating the whole

--- a/lib/document.js
+++ b/lib/document.js
@@ -2097,24 +2097,22 @@ function _getPathsToValidate(doc) {
   paths = paths.concat(Object.keys(doc.$__.activePaths.states.modify));
   paths = paths.concat(Object.keys(doc.$__.activePaths.states.default));
 
-  if (!doc.ownerDocument) {
-    const subdocs = doc.$__getAllSubdocs();
-    let subdoc;
-    len = subdocs.length;
-    const modifiedPaths = doc.modifiedPaths();
-    for (i = 0; i < len; ++i) {
-      subdoc = subdocs[i];
-      if (doc.isModified(subdoc.$basePath, modifiedPaths) &&
-          !doc.isDirectModified(subdoc.$basePath) &&
-          !doc.$isDefault(subdoc.$basePath)) {
-        // Remove child paths for now, because we'll be validating the whole
-        // subdoc
-        paths = paths.filter(function(p) {
-          return p != null && p.indexOf(subdoc.$basePath + '.') !== 0;
-        });
-        paths.push(subdoc.$basePath);
-        skipSchemaValidators[subdoc.$basePath] = true;
-      }
+  const subdocs = doc.$__getAllSubdocs();
+  let subdoc;
+  len = subdocs.length;
+  const modifiedPaths = doc.modifiedPaths();
+  for (i = 0; i < len; ++i) {
+    subdoc = subdocs[i];
+    if (doc.isModified(subdoc.$basePath, modifiedPaths) &&
+        !doc.isDirectModified(subdoc.$basePath) &&
+        !doc.$isDefault(subdoc.$basePath)) {
+      // Remove child paths for now, because we'll be validating the whole
+      // subdoc
+      paths = paths.filter(function(p) {
+        return p != null && p.indexOf(subdoc.$basePath + '.') !== 0;
+      });
+      paths.push(subdoc.$basePath); // This can cause duplicates, make unique below
+      skipSchemaValidators[subdoc.$basePath] = true;
     }
   }
 
@@ -2187,6 +2185,7 @@ function _getPathsToValidate(doc) {
     }
   }
 
+  paths = Array.from(new Set(paths));
   return [paths, skipSchemaValidators];
 }
 


### PR DESCRIPTION
It turns out that due to a check which I can't find a reason for the logic for removing subdocuments from the "paths" list when running validators only ran on the root document -- this is not a problem most of the time, it just results in the validators running multiple times on some embedded paths, but in some slightly weird cases it can result in validate being called twice -- and the second time is deeper in the stack from the first validate.

Combined with the check for multiple parallel calls to `validate()` this resulted in a fatal error when saving a document with changes to those documents which triggered that case.

A test has been added in this pull request which reproduced the error and which after the fix no longer reproduces the error.

This fixes #8531 