### PR TITLE
Improve performance of document creation.

### DIFF
--- a/benchmarks/create.js
+++ b/benchmarks/create.js
@@ -30,8 +30,9 @@ const doc = JSON.parse(fs.readFileSync(__dirname + '/bigboard.json'));
 // console.error('reading from disk and parsing JSON took %d ms', time1);
 
 const start2 = new Date();
-for (let i = 0; i < 1000; ++i) {
+const iterations = 1000;
+for (let i = 0; i < iterations; ++i) {
   new Board(doc);
 }
 const time2 = (new Date - start2);
-console.error('creation of large object took %d ms', time2);
+console.error('creation of large object took %d ms, %d ms per object', time2, time2 / iterations);

--- a/lib/document.js
+++ b/lib/document.js
@@ -306,7 +306,7 @@ function $__applyDefaults(doc, fields, skipId, exclude, hasIncludedChildren, isB
     }
 
     const type = doc.schema.paths[p];
-    const path = p.split('.');
+    const path = p.indexOf('.') === -1 ? [p] : p.split('.');
     const len = path.length;
     let included = false;
     let doc_ = doc._doc;
@@ -982,7 +982,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
   }
 
   let schema;
-  const parts = path.split('.');
+  const parts = path.indexOf('.') === -1 ? [path] : path.split('.');
 
   // Might need to change path for top-level alias
   if (typeof this.schema.aliases[parts[0]] == 'string') {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -817,6 +817,9 @@ function _getPath(schema, path, cleanPath) {
  */
 
 function _pathToPositionalSyntax(path) {
+  if (!/\.\d+/.test(path)) {
+    return path;
+  }
   return path.replace(/\.\d+\./g, '.$.').replace(/\.\d+$/, '.$');
 }
 
@@ -1084,7 +1087,7 @@ Schema.prototype.indexedPaths = function indexedPaths() {
 
 Schema.prototype.pathType = function(path) {
   // Convert to '.$' to check subpaths re: gh-6405
-  const cleanPath = path.replace(/\.\d+\./g, '.$.').replace(/\.\d+$/, '.$');
+  const cleanPath = _pathToPositionalSyntax(path);
 
   if (this.paths.hasOwnProperty(path)) {
     return 'real';


### PR DESCRIPTION
**Summary**

Performance improvements for document creation. I used the already present `benchmarks/create.js` to validate these changes. 

The most common case for _pathToPositionalSyntax is that there's no positional syntax present. By avoiding the two calls to Regexp.replace, we can avoid creating two additional copies of the given path string per call. During document creation this function is called very frequently.

By avoiding extraneous calls to string split, we can reduce the number of string copies performed and garbage generated as a result.

**Examples**

On `benchmarks/create.js` locally:

Before:
```
creation of large object took 9617 ms
```
After:
```
creation of large object took 5320 ms, 5.32 ms per object
```
While the raw improvement doesn't seem large, on a larger document this takes the creation time from 170.11 ms per object to 90.56 ms, 80 ms per document created is a nice win.