### PR TITLE
Copy plugins from base schema when creating a discriminator

### DIFF
--- a/lib/helpers/model/discriminator.js
+++ b/lib/helpers/model/discriminator.js
@@ -158,7 +158,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     schema.options.id = id;
     schema.s.hooks = model.schema.s.hooks.merge(schema.s.hooks);
 
-    schema.plugins = Array.prototype.slice(baseSchema.plugins);
+    schema.plugins = Array.prototype.slice.call(baseSchema.plugins);
     schema.callQueue = baseSchema.callQueue.concat(schema.callQueue);
     delete schema._requiredpaths; // reset just in case Schema#requiredPaths() was called on either schema
   }

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -1309,6 +1309,19 @@ describe('model', function() {
         });
       });
     });
+
+    it.only('should copy plugins', function () {
+      const plugin = (schema) => { };
+
+      const schema = new Schema({ value: String });
+      schema.plugin(plugin)
+      const model = mongoose.model('Model', schema);
+
+      const discriminator = model.discriminator('Desc', new Schema({ anotherValue: String }));
+
+      const copiedPlugin = discriminator.schema.plugins.find(p => p.fn === plugin);
+      assert.ok(!!copiedPlugin);
+    });
   });
 
   describe('bug fixes', function() {

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -1310,7 +1310,7 @@ describe('model', function() {
       });
     });
 
-    it.only('should copy plugins', function () {
+    it('should copy plugins', function () {
       const plugin = (schema) => { };
 
       const schema = new Schema({ value: String });


### PR DESCRIPTION
**Summary**

While debugging a problem I was having, I noticed the following issue: the base schema's plugins are not being copied to the discriminator's plugin. I have investigated the change and have not identified anything that would be impacted. At least, as far as I can see, the plugin functions are only called when creating schema or calling `schema.plugin()`. Still, I lost some time trying to work out if this was the cause of my problem and so figured this could be helpful if it saves someone else going down this rabbit hole.

My only concern is that it may be confusing to see a plugin listed that is designed to manipulates the schema when the schema has not been manipulated. I struggled to think of an appropriate example (that wasn't redundant) and the best I could come up with was:

`js
const simplePlugin = (schema) => {
    const valuePath = schema.path('value');

    if (valuePath && !valuePath.isRequired)
        valuePath.required(true);
}
`

I figure it would be confusing to see this plugin listed for a discriminator when value was not on the base schema but is for the discrimintaing one and so is not required. So, alternatively if you prefer, we could flag that the plugin was only applied to the base by doing something along the lines of:

`js
schema.plugins = Array.prototype.slice.call(baseSchema.plugins).forEach(p => { p.baseSchemaOnly = true });
`