### PR TITLE
Fix SchemaType.clone()

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1433,7 +1433,17 @@ SchemaType.prototype.clone = function() {
   const options = Object.assign({}, this.options);
   const schematype = new this.constructor(this.path, options, this.instance);
   schematype.validators = this.validators.slice();
-  schematype.requiredValidator = this.requiredValidator;
+  if (this.requiredValidator !== undefined) schematype.requiredValidator = this.requiredValidator;
+  if (this.defaultValue !== undefined) schematype.defaultValue = this.defaultValue;
+  if (this.$immutable !== undefined && this.options.immutable === undefined) {
+    schematype.$immutable = this.$immutable;
+
+    handleImmutable(schematype);
+  }
+  if (this._index !== undefined) schematype._index = this._index;
+  if (this.selected !== undefined) schematype.selected = this.selected;
+  if (this.isRequired !== undefined) schematype.isRequired = this.isRequired;
+  if (this.originalRequiredValue !== undefined) schematype.originalRequiredValue = this.originalRequiredValue;
   schematype.getters = this.getters.slice();
   schematype.setters = this.setters.slice();
   return schematype;

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -100,4 +100,96 @@ describe('schematype', function() {
     assert.equal(err.name, 'ValidatorError');
     assert.equal(err.message, 'name is invalid!');
   });
+
+  describe.only('clone()', function () {
+    let schemaType;
+    beforeEach(function () {
+      schemaType = Schema({ value: String }).path('value');
+    });
+
+    function cloneAndTestDeepEquals() {
+      const clone = schemaType.clone();
+      assert.deepStrictEqual(clone, schemaType);
+    }
+    
+    it('clones added default', function () {
+      schemaType.default(() => 'abc');
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added getters', function () {
+      schemaType.get(v => v.trim());
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added immutable', function () {
+      // Note: cannot compare with deep equals due to the immutable function
+      schemaType.immutable(true);
+      let clonePath = schemaType.clone();
+
+      try {
+        assert.deepStrictEqual(clonePath, schemaType)
+      }
+      catch (err) {
+        if (!err.message.startsWith('Values have same structure but are not reference-equal:'))
+          throw err;
+      }
+    });
+
+    it('clones added index', function () {
+      schemaType.index(true);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added ref', function () {
+      schemaType.ref('User');
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added required', function () {
+      schemaType.required(true);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added select: false', function () {
+      schemaType.select(false);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added setter', function () {
+      schemaType.set(v => v.trim());
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added sparse', function () {
+      schemaType.sparse(true);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added sparse (index option)', function () {
+      schemaType.sparse(true);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added text (index option)', function () {
+      schemaType.text(true);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added unique (index option)', function () {
+      schemaType.unique(true);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones added validator', function () {
+      schemaType.validate(v => v.length > 3);
+      cloneAndTestDeepEquals();
+    });
+
+    it('clones updated caster', function () {
+      schemaType.cast(v => v.length > 3 ? v : v.trim());
+      cloneAndTestDeepEquals();
+    });
+
+  })
 });

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -101,7 +101,7 @@ describe('schematype', function() {
     assert.equal(err.message, 'name is invalid!');
   });
 
-  describe.only('clone()', function () {
+  describe('clone()', function () {
     let schemaType;
     beforeEach(function () {
       schemaType = Schema({ value: String }).path('value');

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -101,9 +101,9 @@ describe('schematype', function() {
     assert.equal(err.message, 'name is invalid!');
   });
 
-  describe('clone()', function () {
+  describe.only('clone()', function() {
     let schemaType;
-    beforeEach(function () {
+    beforeEach(function() {
       schemaType = Schema({ value: String }).path('value');
     });
 
@@ -111,24 +111,24 @@ describe('schematype', function() {
       const clone = schemaType.clone();
       assert.deepStrictEqual(clone, schemaType);
     }
-    
-    it('clones added default', function () {
+
+    it('clones added default', function() {
       schemaType.default(() => 'abc');
       cloneAndTestDeepEquals();
     });
 
-    it('clones added getters', function () {
+    it('clones added getters', function() {
       schemaType.get(v => v.trim());
       cloneAndTestDeepEquals();
     });
 
-    it('clones added immutable', function () {
+    it('clones added immutable', function() {
       // Note: cannot compare with deep equals due to the immutable function
       schemaType.immutable(true);
-      let clonePath = schemaType.clone();
+      const clonePath = schemaType.clone();
 
       try {
-        assert.deepStrictEqual(clonePath, schemaType)
+        assert.deepStrictEqual(clonePath, schemaType);
       }
       catch (err) {
         if (!err.message.startsWith('Values have same structure but are not reference-equal:'))
@@ -136,60 +136,59 @@ describe('schematype', function() {
       }
     });
 
-    it('clones added index', function () {
+    it('clones added index', function() {
       schemaType.index(true);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added ref', function () {
+    it('clones added ref', function() {
       schemaType.ref('User');
       cloneAndTestDeepEquals();
     });
 
-    it('clones added required', function () {
+    it('clones added required', function() {
       schemaType.required(true);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added select: false', function () {
+    it('clones added select: false', function() {
       schemaType.select(false);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added setter', function () {
+    it('clones added setter', function() {
       schemaType.set(v => v.trim());
       cloneAndTestDeepEquals();
     });
 
-    it('clones added sparse', function () {
+    it('clones added sparse', function() {
       schemaType.sparse(true);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added sparse (index option)', function () {
+    it('clones added sparse (index option)', function() {
       schemaType.sparse(true);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added text (index option)', function () {
+    it('clones added text (index option)', function() {
       schemaType.text(true);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added unique (index option)', function () {
+    it('clones added unique (index option)', function() {
       schemaType.unique(true);
       cloneAndTestDeepEquals();
     });
 
-    it('clones added validator', function () {
+    it('clones added validator', function() {
       schemaType.validate(v => v.length > 3);
       cloneAndTestDeepEquals();
     });
 
-    it('clones updated caster', function () {
+    it('clones updated caster', function() {
       schemaType.cast(v => v.length > 3 ? v : v.trim());
       cloneAndTestDeepEquals();
     });
-
-  })
+  });
 });

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -101,7 +101,7 @@ describe('schematype', function() {
     assert.equal(err.message, 'name is invalid!');
   });
 
-  describe.only('clone()', function() {
+  describe('clone()', function() {
     let schemaType;
     beforeEach(function() {
       schemaType = Schema({ value: String }).path('value');
@@ -125,15 +125,14 @@ describe('schematype', function() {
     it('clones added immutable', function() {
       // Note: cannot compare with deep equals due to the immutable function
       schemaType.immutable(true);
-      const clonePath = schemaType.clone();
+      let clonePath = schemaType.clone();
+      assert.equal(schemaType.$immutable, clonePath.$immutable);
+      assert.equal(schemaType.setters.length, clonePath.setters.length);
 
-      try {
-        assert.deepStrictEqual(clonePath, schemaType);
-      }
-      catch (err) {
-        if (!err.message.startsWith('Values have same structure but are not reference-equal:'))
-          throw err;
-      }
+      schemaType.immutable(false);
+      clonePath = schemaType.clone();
+      assert.equal(schemaType.$immutable, clonePath.$immutable);
+      assert.equal(schemaType.setters.length, clonePath.setters.length);
     });
 
     it('clones added index', function() {


### PR DESCRIPTION
I noticed that `SchemaType.clone()` was not copying values where updates had been made after instantiation. 

I figured that testing using `assert.deepStrictEqual` made the most sense here, but perhaps it's overkill and the if (x !== undefined) are unecessary? I'll happily adjust if you have a preference.

Also, I thought the rename schema.type.test.js → test/schematype.test.js made sense as it seems to be testing shared functionality, again will adjust if you prefer the old style.