### PR TITLE
Discriminator: Remove unnecessary merge of schema with itself

### DIFF
--- a/lib/helpers/model/discriminator.js
+++ b/lib/helpers/model/discriminator.js
@@ -72,8 +72,6 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     if (baseSchema.paths._id &&
         baseSchema.paths._id.options &&
         !baseSchema.paths._id.options.auto) {
-      const originalSchema = schema;
-      utils.merge(schema, originalSchema);
       delete schema.paths._id;
       delete schema.tree._id;
     }

--- a/lib/schema/SingleNestedPath.js
+++ b/lib/schema/SingleNestedPath.js
@@ -291,7 +291,7 @@ SingleNestedPath.prototype.doValidateSync = function(value, scope, options) {
  */
 
 SingleNestedPath.prototype.discriminator = function(name, schema, value) {
-  discriminator(this.caster, name, schema, value);
+  schema = discriminator(this.caster, name, schema, value);
 
   this.caster.discriminators[name] = _createConstructor(schema, this.caster);
 

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -213,8 +213,8 @@ describe('discriminator docs', function () {
     var event1 = new ClickedLinkEvent({ _id: 'custom id', time: '4pm' });
     // Woops, clickedLinkSchema overwrites the `time` path, but **not**
     // the `_id` path because that was implicitly added.
-    assert.ok(typeof event1._id === 'string');
-    assert.ok(typeof event1.time === 'string');
+    assert.strictEqual(typeof event1._id, 'string');
+    assert.strictEqual(typeof event1.time, 'string');
 
     // acquit:ignore:start
     done();

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -312,7 +312,7 @@ describe('model', function() {
       });
 
       it('inherits statics', function(done) {
-        assert.strictEqual(Employee.findByGender, EmployeeSchema.statics.findByGender);
+        assert.strictEqual(Employee.findByGender, PersonSchema.statics.findByGender);
         assert.strictEqual(Employee.findByDepartment, EmployeeSchema.statics.findByDepartment);
         assert.equal(Person.findByDepartment, undefined);
         done();
@@ -1329,7 +1329,7 @@ describe('model', function() {
       // Delete every model
       afterEach(function() { mongoose.deleteModel(/.+/); });
 
-      it('does not modify _id path of the passed in schema the _id is not auto generated', function() {
+      it('does not modify _id path of the passed in schema the _id is not auto generated (gh-8543)', function() {
         const model = mongoose.model('Model', new mongoose.Schema({ _id: Number }));
         const passedInSchema = new mongoose.Schema({});
         model.discriminator('Discrimintaor', passedInSchema);
@@ -1338,7 +1338,7 @@ describe('model', function() {
 
       function throwErrorOnClone() { throw new Error('clone() was called on the unrelated schema'); };
 
-      it('when the base schema has an _id that is not auto generated', function() {
+      it('when the base schema has an _id that is not auto generated (gh-8543) (gh-8546)', function() {
         const unrelatedSchema = new mongoose.Schema({});
         unrelatedSchema.clone = throwErrorOnClone;
         mongoose.model('UnrelatedModel', unrelatedSchema);

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -1329,6 +1329,13 @@ describe('model', function() {
       // Delete every model
       afterEach(function() { mongoose.deleteModel(/.+/); });
 
+      it('does not modify _id path of the passed in schema the _id is not auto generated', function() {
+        const model = mongoose.model('Model', new mongoose.Schema({ _id: Number }));
+        const passedInSchema = new mongoose.Schema({});
+        model.discriminator('Discrimintaor', passedInSchema);
+        assert.equal(passedInSchema.path('_id').instance, 'ObjectID');
+      });
+
       function throwErrorOnClone() { throw new Error('clone() was called on the unrelated schema'); };
 
       it('when the base schema has an _id that is not auto generated', function() {

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -1324,6 +1324,22 @@ describe('model', function() {
 
       mongoose.deleteModel(/Model/);
     });
+
+    describe('does not have unintended side effects', function() {
+      // Delete every model
+      afterEach(function() { mongoose.deleteModel(/.+/); });
+
+      function throwErrorOnClone() { throw new Error('clone() was called on the unrelated schema'); };
+
+      it('when the base schema has an _id that is not auto generated', function() {
+        const unrelatedSchema = new mongoose.Schema({});
+        unrelatedSchema.clone = throwErrorOnClone;
+        mongoose.model('UnrelatedModel', unrelatedSchema);
+
+        const model = mongoose.model('Model', new mongoose.Schema({ _id: mongoose.Types.ObjectId }, { _id: false }));
+        model.discriminator('Discrimintaor', new mongoose.Schema({}).clone());
+      });
+    });
   });
 
   describe('bug fixes', function() {

--- a/test/schema.singlenestedpath.test.js
+++ b/test/schema.singlenestedpath.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const mongoose = require('./common').mongoose;
+
+const assert = require('assert');
+
+const Schema = mongoose.Schema;
+
+describe('SingleNestedPath', function() {
+  describe('discriminator()', function() {
+    describe('recursive nested discriminators', function() {
+      it('allow multiple levels of data in the schema', function() {
+        const singleEventSchema = new Schema({
+          message: String,
+        }, { _id: false, discriminatorKey: 'kind' });
+
+        const subEventSchema = new Schema({
+          sub_events: [singleEventSchema]
+        }, {_id: false});
+
+        subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
+          
+        let currentEventLevel = subEventSchema;
+        for (let i = 0; i < 5; i++) {
+          const subEventSchemaDiscriminators = currentEventLevel.path('sub_events').schema.discriminators;
+          assert.ok(subEventSchemaDiscriminators);
+          assert.ok(subEventSchemaDiscriminators.SubEvent)
+          currentEventLevel = subEventSchemaDiscriminators.SubEvent;
+        }
+      });
+
+      it('allow multiple levels of data in a document', function() {
+        const singleEventSchema = new Schema({
+          message: String,
+        }, { _id: false, discriminatorKey: 'kind' });
+
+        const subEventSchema = new Schema({
+          sub_events: [singleEventSchema]
+        }, {_id: false});
+
+        subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
+
+        const SubEvent = mongoose.model('MultiLevelDataDoc', subEventSchema);
+        const multiLevel = {
+          // To create a recursive document, the schema was modified, so kind & message are added
+          kind: 'SubEvent',
+          message: 'level 1',
+          sub_events: [{ 
+            kind: 'SubEvent', 
+            message: 'level 2',
+            sub_events: [{ 
+              kind: 'SubEvent',
+              message: 'level 3',
+              sub_events: [{ 
+                kind: 'SubEvent', 
+                message: 'level 4',
+                sub_events: [{ 
+                  kind: 'SubEvent', 
+                  message: 'level 5',
+                  sub_events: [], 
+                }], 
+              }],
+            }],
+          }]
+        };
+        const subEvent = SubEvent(multiLevel);
+        
+        assert.deepStrictEqual(multiLevel, subEvent.toJSON());
+      });
+
+      it('allow multiple levels of data in the schema when the base schema has _id without auto', function() {
+        const singleEventSchema = new Schema({
+          _id: { type: Number, required: true },
+          message: String,
+        }, { discriminatorKey: 'kind' });
+          
+        const subEventSchema = new Schema({
+          sub_events: [singleEventSchema]
+        });
+
+        subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
+        
+        // To create a recursive document, the schema was modified, so the _id property is now a number
+        assert.equal(subEventSchema.path('_id').instance, 'Number');
+          
+        let currentEventLevel = subEventSchema;
+        for (let i = 0; i < 5; i++) {
+          const subEventSchemaDiscriminators = currentEventLevel.path('sub_events').schema.discriminators;
+          assert.ok(subEventSchemaDiscriminators);
+          assert.ok(subEventSchemaDiscriminators.SubEvent)
+          currentEventLevel = subEventSchemaDiscriminators.SubEvent;
+          assert.equal(currentEventLevel.path('_id').instance, 'Number');
+        }
+      });
+
+      it('allow multiple levels of data in a document when the base schema has _id without auto', function() {
+        const singleEventSchema = new Schema({
+          _id: { type: Number, required: true },
+          message: String,
+        }, { discriminatorKey: 'kind' });
+          
+        const subEventSchema = new Schema({
+          sub_events: [singleEventSchema]
+        });
+
+        subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
+        
+        const SubEvent = mongoose.model('MultiLevelDataWithIdDoc', subEventSchema);
+        const multiLevel = {
+          // To create a recursive document, the schema was modified, so kind & message are added & _id is now Number
+          _id: 1,
+          kind: 'SubEvent',
+          message: 'level 1',
+          sub_events: [{
+            _id: 1,
+            kind: 'SubEvent', 
+            message: 'level 2',
+            sub_events: [{ 
+              _id: 1,
+              kind: 'SubEvent',
+              message: 'level 3',
+              sub_events: [{ 
+                _id: 1,
+                kind: 'SubEvent', 
+                message: 'level 4',
+                sub_events: [{ 
+                  _id: 1,
+                  kind: 'SubEvent', 
+                  message: 'level 5',
+                  sub_events: [], 
+                }], 
+              }],
+            }],
+          }]
+        };
+        const subEvent = SubEvent(multiLevel);
+
+        assert.deepStrictEqual(multiLevel, subEvent.toJSON());
+      });
+    })
+  });
+});

--- a/test/schema.singlenestedpath.test.js
+++ b/test/schema.singlenestedpath.test.js
@@ -23,12 +23,12 @@ describe('SingleNestedPath', function() {
         }, {_id: false});
 
         subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
-          
+
         let currentEventLevel = subEventSchema;
         for (let i = 0; i < 5; i++) {
           const subEventSchemaDiscriminators = currentEventLevel.path('sub_events').schema.discriminators;
           assert.ok(subEventSchemaDiscriminators);
-          assert.ok(subEventSchemaDiscriminators.SubEvent)
+          assert.ok(subEventSchemaDiscriminators.SubEvent);
           currentEventLevel = subEventSchemaDiscriminators.SubEvent;
         }
       });
@@ -49,26 +49,26 @@ describe('SingleNestedPath', function() {
           // To create a recursive document, the schema was modified, so kind & message are added
           kind: 'SubEvent',
           message: 'level 1',
-          sub_events: [{ 
-            kind: 'SubEvent', 
+          sub_events: [{
+            kind: 'SubEvent',
             message: 'level 2',
-            sub_events: [{ 
+            sub_events: [{
               kind: 'SubEvent',
               message: 'level 3',
-              sub_events: [{ 
-                kind: 'SubEvent', 
+              sub_events: [{
+                kind: 'SubEvent',
                 message: 'level 4',
-                sub_events: [{ 
-                  kind: 'SubEvent', 
+                sub_events: [{
+                  kind: 'SubEvent',
                   message: 'level 5',
-                  sub_events: [], 
-                }], 
+                  sub_events: [],
+                }],
               }],
             }],
           }]
         };
         const subEvent = SubEvent(multiLevel);
-        
+
         assert.deepStrictEqual(multiLevel, subEvent.toJSON());
       });
 
@@ -77,21 +77,21 @@ describe('SingleNestedPath', function() {
           _id: { type: Number, required: true },
           message: String,
         }, { discriminatorKey: 'kind' });
-          
+
         const subEventSchema = new Schema({
           sub_events: [singleEventSchema]
         });
 
         subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
-        
+
         // To create a recursive document, the schema was modified, so the _id property is now a number
         assert.equal(subEventSchema.path('_id').instance, 'Number');
-          
+
         let currentEventLevel = subEventSchema;
         for (let i = 0; i < 5; i++) {
           const subEventSchemaDiscriminators = currentEventLevel.path('sub_events').schema.discriminators;
           assert.ok(subEventSchemaDiscriminators);
-          assert.ok(subEventSchemaDiscriminators.SubEvent)
+          assert.ok(subEventSchemaDiscriminators.SubEvent);
           currentEventLevel = subEventSchemaDiscriminators.SubEvent;
           assert.equal(currentEventLevel.path('_id').instance, 'Number');
         }
@@ -102,13 +102,13 @@ describe('SingleNestedPath', function() {
           _id: { type: Number, required: true },
           message: String,
         }, { discriminatorKey: 'kind' });
-          
+
         const subEventSchema = new Schema({
           sub_events: [singleEventSchema]
         });
 
         subEventSchema.path('sub_events').discriminator('SubEvent', subEventSchema);
-        
+
         const SubEvent = mongoose.model('MultiLevelDataWithIdDoc', subEventSchema);
         const multiLevel = {
           // To create a recursive document, the schema was modified, so kind & message are added & _id is now Number
@@ -117,22 +117,22 @@ describe('SingleNestedPath', function() {
           message: 'level 1',
           sub_events: [{
             _id: 1,
-            kind: 'SubEvent', 
+            kind: 'SubEvent',
             message: 'level 2',
-            sub_events: [{ 
+            sub_events: [{
               _id: 1,
               kind: 'SubEvent',
               message: 'level 3',
-              sub_events: [{ 
+              sub_events: [{
                 _id: 1,
-                kind: 'SubEvent', 
+                kind: 'SubEvent',
                 message: 'level 4',
-                sub_events: [{ 
+                sub_events: [{
                   _id: 1,
-                  kind: 'SubEvent', 
+                  kind: 'SubEvent',
                   message: 'level 5',
-                  sub_events: [], 
-                }], 
+                  sub_events: [],
+                }],
               }],
             }],
           }]
@@ -141,6 +141,6 @@ describe('SingleNestedPath', function() {
 
         assert.deepStrictEqual(multiLevel, subEvent.toJSON());
       });
-    })
+    });
   });
 });


### PR DESCRIPTION
This is a fix to an issue I have been having. 

My understanding of `utils.merge` is that if you merge an object with itself nothing should happen. Therefore, I think the below merge is redundant.

However, more importantly to me, this merge actually has quite of a lot of (I presume) unintended side effects, which I am not clear on the best approach to fix. I will raise this as a separate issue. 