### PR TITLE
(docs) add useUnifiedTopology to homepage example

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -121,7 +121,7 @@ html(lang='en')
         :markdown
           ```javascript
           const mongoose = require('mongoose');
-          mongoose.connect('mongodb://localhost:27017/test', {useNewUrlParser: true});
+          mongoose.connect('mongodb://localhost:27017/test', {useNewUrlParser: true, useUnifiedTopology: true});
 
           const Cat = mongoose.model('Cat', { name: String });
 


### PR DESCRIPTION
This prevents the deprecation warning for unified topology on the example on the homepage. 