### PR TITLE
Fix: allow dynamic foreignField in virtual populate

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -92,6 +92,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     const virtual = _virtualRes == null ? null : _virtualRes.virtual;
 
     let localField;
+    let foreignField;
     let count = false;
     if (virtual && virtual.options) {
       const virtualPrefix = _virtualRes.nestedSchemaPath ?
@@ -101,13 +102,16 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
       } else {
         localField = virtualPrefix + virtual.options.localField;
       }
+      if (typeof virtual.options.foreignField === 'function') {
+        foreignField = virtualPrefix + virtual.options.foreignField.call(doc, doc);
+      } else {
+        foreignField = virtualPrefix + virtual.options.foreignField;
+      }
       count = virtual.options.count;
     } else {
       localField = options.path;
+      foreignField = '_id';
     }
-    let foreignField = virtual && virtual.options ?
-      virtual.options.foreignField :
-      '_id';
 
     // `justOne = null` means we don't know from the schema whether the end
     // result should be an array or a single doc. This can result from

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -103,9 +103,9 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
         localField = virtualPrefix + virtual.options.localField;
       }
       if (typeof virtual.options.foreignField === 'function') {
-        foreignField = virtualPrefix + virtual.options.foreignField.call(doc, doc);
+        foreignField = virtual.options.foreignField.call(doc, doc);
       } else {
-        foreignField = virtualPrefix + virtual.options.foreignField;
+        foreignField = virtual.options.foreignField;
       }
       count = virtual.options.count;
     } else {


### PR DESCRIPTION
**Summary**

Allows the use of a function in `foreignField` when doing a virtual populate, so it can be dynamic just like `localField`.

https://mongoosejs.com/docs/populate.html#populate-virtuals

**Examples**

```
AssignmentSchema.virtual('assigned', {
  ref: doc => doc.adminId ? 'Admin' : 'User',
  localField: '_id',
  foreignField: doc => doc.adminId ? 'adminId' : 'userId',
  justOne: true
});
```
