### PR TITLE
Fixed Typos

### DIFF
--- a/docs/populate.pug
+++ b/docs/populate.pug
@@ -150,7 +150,7 @@ block content
     story.populated('author'); // truthy
 
     story.depopulate('author'); // Make `author` not populated anymore
-    story.populated('author'); // falsy
+    story.populated('author'); // false
     ```
 
     A common reason for checking whether a path is populated is getting the `author`
@@ -162,7 +162,7 @@ block content
     story.author._id; // ObjectId
 
     story.depopulate('author'); // Make `author` not populated anymore
-    story.populated('author'); // falsy
+    story.populated('author'); // false
 
     story.author instanceof ObjectId; // true
     story.author._id; // ObjectId, because Mongoose adds a special getter


### PR DESCRIPTION
Changed `falsy` to `false`
Unless you want it like `falsy` for some reason.

Really simple pull request here.