### PR TITLE
refactor(utils): moving promiseOrCallback to helpers/promiseOrCallback

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -7,6 +7,7 @@
 const AggregationCursor = require('./cursor/AggregationCursor');
 const Query = require('./query');
 const applyGlobalMaxTimeMS = require('./helpers/query/applyGlobalMaxTimeMS');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const util = require('util');
 const utils = require('./utils');
 const read = Query.prototype.read;
@@ -699,7 +700,7 @@ Aggregate.prototype.redact = function(expression, thenExpr, elseExpr) {
 Aggregate.prototype.explain = function(callback) {
   const model = this._model;
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     if (!this._pipeline.length) {
       const err = new Error('Aggregate has empty pipeline');
       return cb(err);
@@ -954,7 +955,7 @@ Aggregate.prototype.exec = function(callback) {
     return new AggregationCursor(this);
   }
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
 
     prepareDiscriminatorPipeline(this);
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -12,6 +12,7 @@ const MongooseError = require('./error/index');
 const PromiseProvider = require('./promise_provider');
 const TimeoutError = require('./error/timeout');
 const applyPlugins = require('./helpers/schema/applyPlugins');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const get = require('./helpers/get');
 const immediate = require('./helpers/immediate');
 const mongodb = require('mongodb');
@@ -469,7 +470,7 @@ function _wrapConnHelper(fn) {
       Array.prototype.slice.call(arguments);
     const disconnectedError = new MongooseError('Connection ' + this.id +
       ' was disconnected when calling `' + fn.name + '`');
-    return utils.promiseOrCallback(cb, cb => {
+    return promiseOrCallback(cb, cb => {
       // Make it ok to call collection helpers before `mongoose.connect()`
       // as long as `mongoose.connect()` is called on the same tick.
       // Re: gh-8534
@@ -859,7 +860,7 @@ Connection.prototype.close = function(force, callback) {
 
   this.$wasForceClosed = !!force;
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     this._close(force, cb);
   });
 };

--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -6,9 +6,9 @@
 
 const MongooseError = require('../error/mongooseError');
 const Readable = require('stream').Readable;
+const promiseOrCallback = require('../helpers/promiseOrCallback');
 const eachAsync = require('../helpers/cursor/eachAsync');
 const util = require('util');
-const utils = require('../utils');
 
 /**
  * An AggregationCursor is a concurrency primitive for processing aggregation
@@ -164,7 +164,7 @@ AggregationCursor.prototype._markError = function(error) {
  */
 
 AggregationCursor.prototype.close = function(callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     this.cursor.close(error => {
       if (error) {
         cb(error);
@@ -187,7 +187,7 @@ AggregationCursor.prototype.close = function(callback) {
  */
 
 AggregationCursor.prototype.next = function(callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     _next(this, cb);
   });
 };

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -5,10 +5,10 @@
 'use strict';
 
 const Readable = require('stream').Readable;
+const promiseOrCallback = require('../helpers/promiseOrCallback');
 const eachAsync = require('../helpers/cursor/eachAsync');
 const helpers = require('../queryhelpers');
 const util = require('util');
-const utils = require('../utils');
 
 /**
  * A QueryCursor is a concurrency primitive for processing query results
@@ -157,7 +157,7 @@ QueryCursor.prototype._markError = function(error) {
  */
 
 QueryCursor.prototype.close = function(callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     this.cursor.close(error => {
       if (error) {
         cb(error);
@@ -180,7 +180,7 @@ QueryCursor.prototype.close = function(callback) {
  */
 
 QueryCursor.prototype.next = function(callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     _next(this, function(error, doc) {
       if (error) {
         return cb(error);

--- a/lib/document.js
+++ b/lib/document.js
@@ -16,6 +16,7 @@ const StrictModeError = require('./error/strict');
 const ValidationError = require('./error/validation');
 const ValidatorError = require('./error/validator');
 const VirtualType = require('./virtualtype');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const cleanModifiedSubpaths = require('./helpers/document/cleanModifiedSubpaths');
 const compile = require('./helpers/document/compile').compile;
 const defineKey = require('./helpers/document/compile').defineKey;
@@ -2050,7 +2051,7 @@ Document.prototype.validate = function(pathsToValidate, options, callback) {
     pathsToValidate = null;
   }
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     if (parallelValidate != null) {
       return cb(parallelValidate);
     }
@@ -3516,7 +3517,7 @@ Document.prototype.populate = function populate() {
  */
 
 Document.prototype.execPopulate = function(callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     this.populate(cb);
   }, this.constructor.events);
 };

--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -4,7 +4,6 @@
  * Module dependencies.
  */
 
-
 const promiseOrCallback = require('../promiseOrCallback');
 
 /**

--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -4,7 +4,8 @@
  * Module dependencies.
  */
 
-const utils = require('../../utils');
+
+const promiseOrCallback = require('../promiseOrCallback');
 
 /**
  * Execute `fn` for every document in the cursor. If `fn` returns a promise,
@@ -88,7 +89,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
     }
   };
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     iterate(cb);
   });
 };

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -123,7 +123,7 @@ function applyHooks(model, schema, options) {
     const originalMethod = objToDecorate[method];
     objToDecorate[method] = function() {
       const args = Array.prototype.slice.call(arguments);
-      const cb = args.pop();
+      const cb = args.slice(-1).pop();
       const argsWithoutCallback = typeof cb === 'function' ?
         args.slice(0, args.length - 1) : args;
       return promiseOrCallback(cb, callback => {

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const symbols = require('../../schema/symbols');
-const utils = require('../../utils');
+const promiseOrCallback = require('../promiseOrCallback');
 
 /*!
  * ignore
@@ -123,10 +123,10 @@ function applyHooks(model, schema, options) {
     const originalMethod = objToDecorate[method];
     objToDecorate[method] = function() {
       const args = Array.prototype.slice.call(arguments);
-      const cb = utils.last(args);
+      const cb = args.pop();
       const argsWithoutCallback = typeof cb === 'function' ?
         args.slice(0, args.length - 1) : args;
-      return utils.promiseOrCallback(cb, callback => {
+      return promiseOrCallback(cb, callback => {
         return this[`$__${method}`].apply(this,
           argsWithoutCallback.concat([callback]));
       }, model.events);

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const middlewareFunctions = require('../query/applyQueryMiddleware').middlewareFunctions;
-const utils = require('../../utils');
+const promiseOrCallback = require('../promiseOrCallback');
 
 module.exports = function applyStaticHooks(model, hooks, statics) {
   const kareemOptions = {
@@ -35,7 +35,7 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
           call(arguments, 0, cb == null ? numArgs : numArgs - 1);
         // Special case: can't use `Kareem#wrap()` because it doesn't currently
         // support wrapped functions that return a promise.
-        return utils.promiseOrCallback(cb, callback => {
+        return promiseOrCallback(cb, callback => {
           hooks.execPre(key, model, args, function(err) {
             if (err != null) {
               return callback(err);

--- a/lib/helpers/promiseOrCallback.js
+++ b/lib/helpers/promiseOrCallback.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const PromiseProvider = require('../promise_provider');
+
+const emittedSymbol = Symbol.for('mongoose:emitted');
+
+module.exports = function promiseOrCallback(callback, fn, ee) {
+  if (typeof callback === 'function') {
+    return fn(function(error) {
+      if (error != null) {
+        if (ee != null && ee.listeners('error').length > 0 && !error[emittedSymbol]) {
+          error[emittedSymbol] = true;
+          ee.emit('error', error);
+        }
+        try {
+          callback(error);
+        } catch (error) {
+          return process.nextTick(() => {
+            throw error;
+          });
+        }
+        return;
+      }
+      callback.apply(this, arguments);
+    });
+  }
+
+  const Promise = PromiseProvider.get();
+
+  return new Promise((resolve, reject) => {
+    fn(function(error, res) {
+      if (error != null) {
+        if (ee != null && ee.listeners('error').length > 0 && !error[emittedSymbol]) {
+          error[emittedSymbol] = true;
+          ee.emit('error', error);
+        }
+        return reject(error);
+      }
+      if (arguments.length > 2) {
+        return resolve(Array.prototype.slice.call(arguments, 1));
+      }
+      resolve(res);
+    });
+  });
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ const Query = require('./query');
 const Model = require('./model');
 const applyPlugins = require('./helpers/schema/applyPlugins');
 const get = require('./helpers/get');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const legacyPluralize = require('mongoose-legacy-pluralize');
 const utils = require('./utils');
 const pkg = require('../package.json');
@@ -343,7 +344,7 @@ Mongoose.prototype.connect = function(uri, options, callback) {
 Mongoose.prototype.disconnect = function(callback) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     let remaining = _mongoose.connections.length;
     if (remaining <= 0) {
       return cb(null);

--- a/lib/model.js
+++ b/lib/model.js
@@ -43,6 +43,7 @@ const leanPopulateMap = require('./helpers/populate/leanPopulateMap');
 const modifiedPaths = require('./helpers/update/modifiedPaths');
 const mpath = require('mpath');
 const parallelLimit = require('./helpers/parallelLimit');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const parseProjection = require('./helpers/projection/parseProjection');
 const util = require('util');
 const utils = require('./utils');
@@ -465,7 +466,7 @@ Model.prototype.save = function(options, fn) {
 
   fn = this.constructor.$handleCallbackError(fn);
 
-  return utils.promiseOrCallback(fn, cb => {
+  return promiseOrCallback(fn, cb => {
     cb = this.constructor.$wrapCallback(cb);
 
     if (parallelSave) {
@@ -911,7 +912,7 @@ Model.prototype.remove = function remove(options, fn) {
 
   fn = this.constructor.$handleCallbackError(fn);
 
-  return utils.promiseOrCallback(fn, cb => {
+  return promiseOrCallback(fn, cb => {
     cb = this.constructor.$wrapCallback(cb);
     this.$__remove(options, cb);
   }, this.constructor.events);
@@ -947,7 +948,7 @@ Model.prototype.deleteOne = function deleteOne(options, fn) {
 
   fn = this.constructor.$handleCallbackError(fn);
 
-  return utils.promiseOrCallback(fn, cb => {
+  return promiseOrCallback(fn, cb => {
     cb = this.constructor.$wrapCallback(cb);
     this.$__deleteOne(options, cb);
   }, this.constructor.events);
@@ -1294,7 +1295,7 @@ Model.createCollection = function createCollection(options, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
 
     this.db.createCollection(this.collection.collectionName, options, utils.tick((error) => {
@@ -1335,7 +1336,7 @@ Model.syncIndexes = function syncIndexes(options, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
 
     this.createCollection(err => {
@@ -1373,7 +1374,7 @@ Model.cleanIndexes = function cleanIndexes(callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     const collection = this.collection;
 
     this.listIndexes((err, indexes) => {
@@ -1490,7 +1491,7 @@ Model.listIndexes = function init(callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
 
     // Buffering
@@ -1541,7 +1542,7 @@ Model.ensureIndexes = function ensureIndexes(options, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
 
     _ensureIndexes(this, options || {}, error => {
@@ -3050,7 +3051,7 @@ Model.create = function create(doc, options, callback) {
     }
   }
 
-  return utils.promiseOrCallback(cb, cb => {
+  return promiseOrCallback(cb, cb => {
     cb = this.$wrapCallback(cb);
     if (args.length === 0) {
       return cb(null);
@@ -3236,7 +3237,7 @@ Model.insertMany = function(arr, options, callback) {
     callback = options;
     options = null;
   }
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     this.$__insertMany(arr, options, cb);
   }, this.events);
 };
@@ -3460,7 +3461,7 @@ Model.bulkWrite = function(ops, options, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
     each(validations, (fn, cb) => fn(cb), error => {
       if (error) {
@@ -3825,7 +3826,7 @@ Model.mapReduce = function mapReduce(o, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
 
     if (!Model.mapReduce.schema) {
@@ -3965,7 +3966,7 @@ Model.aggregate = function aggregate(pipeline, callback) {
  */
 
 Model.validate = function validate(obj, pathsToValidate, context, callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     const schema = this.schema;
     let paths = Object.keys(schema.paths);
 
@@ -4075,7 +4076,7 @@ Model.geoSearch = function(conditions, options, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
     let error;
     if (conditions === undefined || !utils.isObject(conditions)) {
@@ -4211,7 +4212,7 @@ Model.populate = function(docs, paths, callback) {
 
   callback = this.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
     _populate(_this, docs, paths, cache, cb);
   }, this.events);

--- a/lib/query.js
+++ b/lib/query.js
@@ -18,6 +18,7 @@ const castArrayFilters = require('./helpers/update/castArrayFilters');
 const castUpdate = require('./helpers/query/castUpdate');
 const completeMany = require('./helpers/query/completeMany');
 const get = require('./helpers/get');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminatorByValue');
 const hasDollarKeys = require('./helpers/query/hasDollarKeys');
 const helpers = require('./queryhelpers');
@@ -3754,7 +3755,7 @@ function _updateThunk(op, callback) {
  */
 
 Query.prototype.validate = function validate(castedDoc, options, isOverwriting, callback) {
-  return utils.promiseOrCallback(callback, cb => {
+  return promiseOrCallback(callback, cb => {
     try {
       if (isOverwriting) {
         castedDoc.validate(cb);
@@ -4339,7 +4340,7 @@ Query.prototype.exec = function exec(op, callback) {
 
   callback = this.model.$handleCallbackError(callback);
 
-  return utils.promiseOrCallback(callback, (cb) => {
+  return promiseOrCallback(callback, (cb) => {
     cb = this.model.$wrapCallback(cb);
 
     if (!_this.op) {

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -12,7 +12,7 @@ const ValidationError = require('../error/validation');
 const immediate = require('../helpers/immediate');
 const internalToObjectOptions = require('../options').internalToObjectOptions;
 const get = require('../helpers/get');
-const utils = require('../utils');
+const promiseOrCallback = require('../helpers/promiseOrCallback');
 const util = require('util');
 
 const documentArrayParent = require('../helpers/symbols').documentArrayParent;
@@ -146,7 +146,7 @@ EmbeddedDocument.prototype.save = function(options, fn) {
       'if you\'re sure this behavior is right for your app.');
   }
 
-  return utils.promiseOrCallback(fn, cb => {
+  return promiseOrCallback(fn, cb => {
     this.$__save(cb);
   });
 };

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -3,7 +3,7 @@
 const Document = require('../document');
 const immediate = require('../helpers/immediate');
 const internalToObjectOptions = require('../options').internalToObjectOptions;
-const utils = require('../utils');
+const promiseOrCallback = require('../helpers/promiseOrCallback');
 
 const documentArrayParent = require('../helpers/symbols').documentArrayParent;
 
@@ -76,7 +76,7 @@ Subdocument.prototype.save = function(options, fn) {
       'if you\'re sure this behavior is right for your app.');
   }
 
-  return utils.promiseOrCallback(fn, cb => {
+  return promiseOrCallback(fn, cb => {
     this.$__save(cb);
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -254,7 +254,7 @@ const clone = exports.clone;
  * ignore
  */
 
-exports.promiseOrCallback = promiseOrCallback
+exports.promiseOrCallback = promiseOrCallback;
 
 /*!
  * ignore

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,16 +7,14 @@
 const Decimal = require('./types/decimal128');
 const ObjectId = require('./types/objectid');
 const PopulateOptions = require('./options/PopulateOptions');
-const PromiseProvider = require('./promise_provider');
 const cloneRegExp = require('regexp-clone');
 const get = require('./helpers/get');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const sliced = require('sliced');
 const mpath = require('mpath');
 const ms = require('ms');
 const symbols = require('./helpers/symbols');
 const Buffer = require('safe-buffer').Buffer;
-
-const emittedSymbol = Symbol.for('mongoose:emitted');
 
 let MongooseBuffer;
 let MongooseArray;
@@ -256,45 +254,7 @@ const clone = exports.clone;
  * ignore
  */
 
-exports.promiseOrCallback = function promiseOrCallback(callback, fn, ee) {
-  if (typeof callback === 'function') {
-    return fn(function(error) {
-      if (error != null) {
-        if (ee != null && ee.listeners('error').length > 0 && !error[emittedSymbol]) {
-          error[emittedSymbol] = true;
-          ee.emit('error', error);
-        }
-        try {
-          callback(error);
-        } catch (error) {
-          return process.nextTick(() => {
-            throw error;
-          });
-        }
-        return;
-      }
-      callback.apply(this, arguments);
-    });
-  }
-
-  const Promise = PromiseProvider.get();
-
-  return new Promise((resolve, reject) => {
-    fn(function(error, res) {
-      if (error != null) {
-        if (ee != null && ee.listeners('error').length > 0 && !error[emittedSymbol]) {
-          error[emittedSymbol] = true;
-          ee.emit('error', error);
-        }
-        return reject(error);
-      }
-      if (arguments.length > 2) {
-        return resolve(Array.prototype.slice.call(arguments, 1));
-      }
-      resolve(res);
-    });
-  });
-};
+exports.promiseOrCallback = promiseOrCallback
 
 /*!
  * ignore

--- a/test/helpers/promiseOrCallback.test.js
+++ b/test/helpers/promiseOrCallback.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const assert = require('assert');
+const promiseOrCallback = require('../../lib/helpers/promiseOrCallback');
+
+describe('promiseOrCallback()', () => {
+  const myError = new Error('This is My Error');
+  const myRes = 'My Res';
+  const myOtherArg = 'My Other Arg';
+
+  describe('apply callback', () => {
+    it('without error', (done) => {
+      promiseOrCallback(
+        (error, arg, otherArg) => {
+          assert.equal(arg, myRes);
+          assert.equal(otherArg, myOtherArg);
+          assert.equal(error, undefined);
+          done();
+        },
+        (fn) => { fn(null, myRes, myOtherArg); }
+      );
+    });
+
+    describe('with error', () => {
+      it('without event emitter', (done) => {
+        promiseOrCallback(
+          (error) => {
+            assert.equal(error, myError);
+            done();
+          },
+          (fn) => { fn(myError); }
+        );
+      });
+
+      it('with event emitter', (done) => {
+        promiseOrCallback(
+          () => { },
+          (fn) => { return fn(myError); },
+          {
+            listeners: () => [1],
+            emit: (eventType, error) => {
+              assert.equal(eventType, 'error');
+              assert.equal(error, myError);
+              done();
+            }
+          }
+        );
+      });
+    });
+  });
+
+  describe('chain promise', () => {
+    describe('without error', () => {
+      it('two args', (done) => {
+        const promise = promiseOrCallback(
+          null,
+          (fn) => { fn(null, myRes); }
+        );
+        promise.then((res) => {
+          assert.equal(res, myRes);
+          done();
+        });
+      });
+
+      it('more args', (done) => {
+        const promise = promiseOrCallback(
+          null,
+          (fn) => { fn(null, myRes, myOtherArg); }
+        );
+        promise.then((args) => {
+          assert.equal(args[0], myRes);
+          assert.equal(args[1], myOtherArg);
+          done();
+        });
+      });
+    });
+
+    describe('with error', () => {
+      it('without event emitter', (done) => {
+        const promise = promiseOrCallback(
+          null,
+          (fn) => { fn(myError); }
+        );
+        promise.catch((error) => {
+          assert.equal(error, myError);
+          done();
+        });
+      });
+
+
+      it('with event emitter', (done) => {
+        const promise = promiseOrCallback(
+          null,
+          (fn) => { return fn(myError); },
+          {
+            listeners: () => [1],
+            emit: (eventType, error) => {
+              assert.equal(eventType, 'error');
+              assert.equal(error, myError);
+            }
+          }
+        );
+        promise.catch((error) => {
+          assert.equal(error, myError);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Trying to make things less dependent of utils.js

**Summary**

I'm just reducing the complexity of some modules dependency reducing unnecessary context import.

**Examples**

`eachAsync.js` that require `utils.js` only to use `promiseOrCallback`, but since `utils.js` requires basically all package.

[Dependency graph](https://github.com/sverweij/) of lib/helpers/cursor/eachAsync.js:
- [Before this change](https://user-images.githubusercontent.com/863299/74076890-2fc03a00-49fa-11ea-9642-7337a21412e2.png) 
- After this change:
![Dependency Graph](https://user-images.githubusercontent.com/863299/74076803-706b8380-49f9-11ea-806c-2c55e559b366.png)
