### PR TITLE
Fix: Can't use $id with Array. #8562

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -356,7 +356,7 @@ SchemaArray.prototype.castForQuery = function($conditional, value) {
     handler = this.$conditionalHandlers[$conditional];
 
     if (!handler) {
-      return value;
+      throw new Error('Can\'t use ' + $conditional + ' with Array.');
     }
 
     val = handler.call(this, value);
@@ -501,6 +501,11 @@ handle.$regex = SchemaArray.prototype.castForQuery;
 // like `$in: [1, []]`, see gh-5913
 handle.$nin = SchemaType.prototype.$conditionalHandlers.$nin;
 handle.$in = SchemaType.prototype.$conditionalHandlers.$in;
+
+// DBRef
+handle.$id = (v) => v;
+handle.$ref = (v) => v;
+handle.$db = (v) => v;
 
 /*!
  * Module exports.

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -356,7 +356,7 @@ SchemaArray.prototype.castForQuery = function($conditional, value) {
     handler = this.$conditionalHandlers[$conditional];
 
     if (!handler) {
-      throw new Error('Can\'t use ' + $conditional + ' with Array.');
+      return value;
     }
 
     val = handler.call(this, value);


### PR DESCRIPTION
`$elemMatch` fails on property names started with `$` (like DBRef properties)

**Summary**

The PR fixes `Can't use $<property> with Array` error that occures if you try to use `$elemMatch` on a property that starts with `$` (like DBRef properties `$id`, `$ref` or `$db`).

**Examples**

Say we have a chat collection that holds all members as DBRefs (it can be a reference to any collection):
```
const ChatSchema = new Schema({
  members: {
    $ref: string;
    $id: Types.ObjectId;
    $db: string;
}[];
```

here is a query that finds a chat but also checks if a user exists in the `members` array:
```
const chat = await Chat.findOne({
  _id: ObjectId(chat_id),
  members: { $elemMatch: { $id: ObjectId(user_id) } },
})
```

the query above fails with:
```
Error: Can't use $id with Array.
    at DocumentArrayPath.SchemaArray.castForQuery (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/schema/array.js:360:13)
    at DocumentArrayPath.cast$elemMatch (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/schema/array.js:443:23)
    at DocumentArrayPath.SchemaArray.castForQuery (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/schema/array.js:363:19)
    at DocumentArrayPath.SchemaType.castForQueryWrapper (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/schematype.js:1353:17)
    at cast (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/cast.js:296:39)
    at model.Query.Query.cast (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/query.js:4683:12)
    at castQuery (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/query.js:4495:18)
    at model.Query.Query._findAndModify (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/query.js:3439:23)
    at model.Query.<anonymous> (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/query.js:3021:8)
    at model.Query._wrappedThunk [as _findOneAndUpdate] (/Users/brooth/Projects/zilzal/api/node_modules/mongoose/lib/helpers/query/wrapThunk.js:16:8)
    at /Users/brooth/Projects/zilzal/api/node_modules/kareem/index.js:278:20
    at _next (/Users/brooth/Projects/zilzal/api/node_modules/kareem/index.js:102:16)
    at process.nextTick (/Users/brooth/Projects/zilzal/api/node_modules/kareem/index.js:507:38)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```
Note: This query is working fine in mongodb.

The problem is that mongoose thinks that every property that starts with $ is a conditional, but it not always the case:
```
handler = this.$conditionalHandlers[$conditional];
if (!handler) {
   throw new Error('Can\'t use ' + $conditional + ' with Array.');
}
```

adding new handlers ($id, $ref and $db) that just return original value fixed the issue

```
// DBRef
handle.$id = (v) => v;
handle.$ref = (v) => v;
handle.$db = (v) => v;
```