### PR TITLE
refactor(utils): moving clone to helpers/clone

### DIFF
--- a/lib/browserDocument.js
+++ b/lib/browserDocument.js
@@ -11,7 +11,7 @@ const Schema = require('./schema');
 const ObjectId = require('./types/objectid');
 const ValidationError = MongooseError.ValidationError;
 const applyHooks = require('./helpers/model/applyHooks');
-const utils = require('./utils');
+const isObject = require('./helpers/isObject');
 
 /**
  * Document constructor.
@@ -30,7 +30,7 @@ function Document(obj, schema, fields, skipId, skipInit) {
     return new Document(obj, schema, fields, skipId, skipInit);
   }
 
-  if (utils.isObject(schema) && !schema.instanceOfSchema) {
+  if (isObject(schema) && !schema.instanceOfSchema) {
     schema = new Schema(schema);
   }
 
@@ -85,14 +85,12 @@ Document.events = new EventEmitter();
 
 Document.$emitter = new EventEmitter();
 
-utils.each(
-  ['on', 'once', 'emit', 'listeners', 'removeListener', 'setMaxListeners',
-    'removeAllListeners', 'addListener'],
-  function(emitterFn) {
-    Document[emitterFn] = function() {
-      return Document.$emitter[emitterFn].apply(Document.$emitter, arguments);
-    };
-  });
+['on', 'once', 'emit', 'listeners', 'removeListener', 'setMaxListeners',
+  'removeAllListeners', 'addListener'].forEach(function(emitterFn) {
+  Document[emitterFn] = function() {
+    return Document.$emitter[emitterFn].apply(Document.$emitter, arguments);
+  };
+});
 
 /*!
  * Module exports.

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -10,7 +10,8 @@ const castTextSearch = require('./schema/operators/text');
 const get = require('./helpers/get');
 const isOperator = require('./helpers/query/isOperator');
 const util = require('util');
-const utils = require('./utils');
+const isObject = require('./helpers/isObject');
+const isMongooseObject = require('./helpers/isMongooseObject');
 
 const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
 
@@ -139,7 +140,7 @@ module.exports = function cast(schema, obj, options, context) {
           continue;
         }
 
-        if (utils.isObject(val)) {
+        if (isObject(val)) {
           // handle geo schemas that use object notation
           // { loc: { long: Number, lat: Number }
 
@@ -203,7 +204,7 @@ module.exports = function cast(schema, obj, options, context) {
                   context: context
                 });
               }
-              if (utils.isMongooseObject(value.$geometry)) {
+              if (isMongooseObject(value.$geometry)) {
                 value.$geometry = value.$geometry.toObject({
                   transform: false,
                   virtuals: false
@@ -212,7 +213,7 @@ module.exports = function cast(schema, obj, options, context) {
               value = value.$geometry.coordinates;
             } else if (geo === '$geoWithin') {
               if (value.$geometry) {
-                if (utils.isMongooseObject(value.$geometry)) {
+                if (isMongooseObject(value.$geometry)) {
                   value.$geometry = value.$geometry.toObject({ virtuals: false });
                 }
                 const geoWithinType = value.$geometry.type;
@@ -224,7 +225,7 @@ module.exports = function cast(schema, obj, options, context) {
               } else {
                 value = value.$box || value.$polygon || value.$center ||
                   value.$centerSphere;
-                if (utils.isMongooseObject(value)) {
+                if (isMongooseObject(value)) {
                   value = value.toObject({ virtuals: false });
                 }
               }
@@ -325,7 +326,7 @@ module.exports = function cast(schema, obj, options, context) {
 function _cast(val, numbertype, context) {
   if (Array.isArray(val)) {
     val.forEach(function(item, i) {
-      if (Array.isArray(item) || utils.isObject(item)) {
+      if (Array.isArray(item) || isObject(item)) {
         return _cast(item, numbertype, context);
       }
       val[i] = numbertype.castForQueryWrapper({ val: item, context: context });
@@ -336,7 +337,7 @@ function _cast(val, numbertype, context) {
     while (nearLen--) {
       const nkey = nearKeys[nearLen];
       const item = val[nkey];
-      if (Array.isArray(item) || utils.isObject(item)) {
+      if (Array.isArray(item) || isObject(item)) {
         _cast(item, numbertype, context);
         val[nkey] = item;
       } else {

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -276,7 +276,8 @@ function format(obj, sub, color) {
     return obj;
   }
 
-  let x = require('../../utils').clone(obj, {transform: false});
+  const clone = require('../../helpers/clone');
+  let x = clone(obj, {transform: false});
 
   if (x.constructor.name === 'Binary') {
     x = 'BinData(' + x.sub_type + ', "' + x.toString('base64') + '")';

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -1,0 +1,135 @@
+'use strict';
+
+
+const cloneRegExp = require('regexp-clone');
+const Decimal = require('../types/decimal128');
+const ObjectId = require('../types/objectid');
+const specialProperties = require('./specialProperties');
+const isMongooseObject = require('./isMongooseObject');
+const getFunctionName = require('./getFunctionName');
+const isBsonType = require('./isBsonType');
+const isObject = require('./isObject');
+const symbols = require('./symbols');
+
+
+/*!
+ * Object clone with Mongoose natives support.
+ *
+ * If options.minimize is true, creates a minimal data object. Empty objects and undefined values will not be cloned. This makes the data payload sent to MongoDB as small as possible.
+ *
+ * Functions are never cloned.
+ *
+ * @param {Object} obj the object to clone
+ * @param {Object} options
+ * @param {Boolean} isArrayChild true if cloning immediately underneath an array. Special case for minimize.
+ * @return {Object} the cloned object
+ * @api private
+ */
+
+function clone(obj, options, isArrayChild) {
+  if (obj == null) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return cloneArray(obj, options);
+  }
+
+  if (isMongooseObject(obj)) {
+    // Single nested subdocs should apply getters later in `applyGetters()`
+    // when calling `toObject()`. See gh-7442, gh-8295
+    if (options && options._skipSingleNestedGetters && obj.$isSingleNested) {
+      options = Object.assign({}, options, { getters: false });
+    }
+    if (options && options.json && typeof obj.toJSON === 'function') {
+      return obj.toJSON(options);
+    }
+    return obj.toObject(options);
+  }
+
+  if (obj.constructor) {
+    switch (getFunctionName(obj.constructor)) {
+      case 'Object':
+        return cloneObject(obj, options, isArrayChild);
+      case 'Date':
+        return new obj.constructor(+obj);
+      case 'RegExp':
+        return cloneRegExp(obj);
+      default:
+        // ignore
+        break;
+    }
+  }
+
+  if (obj instanceof ObjectId) {
+    return new ObjectId(obj.id);
+  }
+
+  if (isBsonType(obj, 'Decimal128')) {
+    if (options && options.flattenDecimals) {
+      return obj.toJSON();
+    }
+    return Decimal.fromString(obj.toString());
+  }
+
+  if (!obj.constructor && isObject(obj)) {
+    // object created with Object.create(null)
+    return cloneObject(obj, options, isArrayChild);
+  }
+
+  if (obj[symbols.schemaTypeSymbol]) {
+    return obj.clone();
+  }
+
+  // If we're cloning this object to go into a MongoDB command,
+  // and there's a `toBSON()` function, assume this object will be
+  // stored as a primitive in MongoDB and doesn't need to be cloned.
+  if (options && options.bson && typeof obj.toBSON === 'function') {
+    return obj;
+  }
+
+  if (obj.valueOf != null) {
+    return obj.valueOf();
+  }
+
+  return cloneObject(obj, options, isArrayChild);
+}
+module.exports = clone;
+
+/*!
+ * ignore
+ */
+
+function cloneObject(obj, options, isArrayChild) {
+  const minimize = options && options.minimize;
+  const ret = {};
+  let hasKeys;
+
+  for (const k in obj) {
+    if (specialProperties.has(k)) {
+      continue;
+    }
+
+    // Don't pass `isArrayChild` down
+    const val = clone(obj[k], options);
+
+    if (!minimize || (typeof val !== 'undefined')) {
+      if (minimize === false && typeof val === 'undefined') {
+        delete ret[k];
+      } else {
+        hasKeys || (hasKeys = true);
+        ret[k] = val;
+      }
+    }
+  }
+
+  return minimize && !isArrayChild ? hasKeys && ret : ret;
+}
+
+function cloneArray(arr, options) {
+  const ret = [];
+  for (let i = 0, l = arr.length; i < l; i++) {
+    ret.push(clone(arr[i], options, true));
+  }
+  return ret;
+}

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -6,7 +6,7 @@
 
 const Decimal128 = require('../types/decimal128');
 const ObjectId = require('../types/objectid');
-const utils = require('../utils');
+const isMongooseObject = require('./isMongooseObject');
 
 exports.flatten = flatten;
 exports.modifiedPaths = modifiedPaths;
@@ -17,7 +17,7 @@ exports.modifiedPaths = modifiedPaths;
 
 function flatten(update, path, options, schema) {
   let keys;
-  if (update && utils.isMongooseObject(update) && !Buffer.isBuffer(update)) {
+  if (update && isMongooseObject(update) && !Buffer.isBuffer(update)) {
     keys = Object.keys(update.toObject({ transform: false, virtuals: false }));
   } else {
     keys = Object.keys(update || {});
@@ -78,7 +78,7 @@ function modifiedPaths(update, path, result) {
     let val = update[key];
 
     result[path + key] = true;
-    if (utils.isMongooseObject(val) && !Buffer.isBuffer(val)) {
+    if (isMongooseObject(val) && !Buffer.isBuffer(val)) {
       val = val.toObject({ transform: false, virtuals: false });
     }
     if (shouldFlatten(val)) {

--- a/lib/helpers/getFunctionName.js
+++ b/lib/helpers/getFunctionName.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function(fn) {
+  if (fn.name) {
+    return fn.name;
+  }
+  return (fn.toString().trim().match(/^function\s*([^\s(]+)/) || [])[1];
+};

--- a/lib/helpers/isBsonType.js
+++ b/lib/helpers/isBsonType.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const get = require('./get');
+
+/*!
+ * Get the bson type, if it exists
+ */
+
+function isBsonType(obj, typename) {
+  return get(obj, '_bsontype', void 0) === typename;
+}
+
+module.exports = isBsonType;

--- a/lib/helpers/isMongooseObject.js
+++ b/lib/helpers/isMongooseObject.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/*!
+ * Returns if `v` is a mongoose object that has a `toObject()` method we can use.
+ *
+ * This is for compatibility with libs like Date.js which do foolish things to Natives.
+ *
+ * @param {any} v
+ * @api private
+ */
+
+module.exports = function(v) {
+  if (v == null) {
+    return false;
+  }
+
+  return v.$__ != null || // Document
+    v.isMongooseArray || // Array or Document Array
+    v.isMongooseBuffer || // Buffer
+    v.$isMongooseMap; // Map
+};

--- a/lib/helpers/isObject.js
+++ b/lib/helpers/isObject.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/*!
+ * Determines if `arg` is an object.
+ *
+ * @param {Object|Array|String|Function|RegExp|any} arg
+ * @api private
+ * @return {Boolean}
+ */
+
+module.exports = function(arg) {
+  if (Buffer.isBuffer(arg)) {
+    return true;
+  }
+  return Object.prototype.toString.call(arg) === '[object Object]';
+};

--- a/lib/helpers/schema/getIndexes.js
+++ b/lib/helpers/schema/getIndexes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const get = require('../get');
-const utils = require('../../utils');
+const helperIsObject = require('../isObject');
 
 /*!
  * Gather all indexes defined in the schema, including single nested,
@@ -62,7 +62,7 @@ module.exports = function getIndexes(schema) {
 
       if (index !== false && index !== null && index !== undefined) {
         const field = {};
-        const isObject = utils.isObject(index);
+        const isObject = helperIsObject(index);
         const options = isObject ? index : {};
         const type = typeof index === 'string' ? index :
           isObject ? index.type :

--- a/lib/helpers/specialProperties.js
+++ b/lib/helpers/specialProperties.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = new Set(['__proto__', 'constructor', 'prototype']);

--- a/lib/options/PopulateOptions.js
+++ b/lib/options/PopulateOptions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('../utils');
+const clone = require('../helpers/clone');
 
 class PopulateOptions {
   constructor(obj) {
@@ -9,7 +9,7 @@ class PopulateOptions {
     if (obj == null) {
       return;
     }
-    obj = utils.clone(obj);
+    obj = clone(obj);
     Object.assign(this, obj);
     if (typeof obj.subPopulate === 'object') {
       this.populate = obj.subPopulate;

--- a/lib/options/SchemaTypeOptions.js
+++ b/lib/options/SchemaTypeOptions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('../utils');
+const clone = require('../helpers/clone');
 
 /**
  * The options defined on a schematype.
@@ -19,7 +19,7 @@ class SchemaTypeOptions {
     if (obj == null) {
       return this;
     }
-    Object.assign(this, utils.clone(obj));
+    Object.assign(this, clone(obj));
   }
 }
 

--- a/lib/options/removeOptions.js
+++ b/lib/options/removeOptions.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const utils = require('../utils');
+const clone = require('../helpers/clone');
 
 class RemoveOptions {
   constructor(obj) {
     if (obj == null) {
       return;
     }
-    Object.assign(this, utils.clone(obj));
+    Object.assign(this, clone(obj));
   }
 }
 

--- a/lib/options/saveOptions.js
+++ b/lib/options/saveOptions.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const utils = require('../utils');
+const clone = require('../helpers/clone');
 
 class SaveOptions {
   constructor(obj) {
     if (obj == null) {
       return;
     }
-    Object.assign(this, utils.clone(obj));
+    Object.assign(this, clone(obj));
   }
 }
 

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -10,7 +10,7 @@ const get = require('./helpers/get');
 const getDiscriminatorByValue =
   require('./helpers/discriminator/getDiscriminatorByValue');
 const isDefiningProjection = require('./helpers/projection/isDefiningProjection');
-const utils = require('./utils');
+const clone = require('./helpers/clone');
 
 /*!
  * Prepare a set of path options for query population.
@@ -21,7 +21,7 @@ const utils = require('./utils');
  */
 
 exports.preparePopulationOptions = function preparePopulationOptions(query, options) {
-  const pop = utils.object.vals(query.options.populate);
+  const pop = Object.values(query.options.populate);
 
   // lean options should trickle through all queries
   if (options.lean != null) {
@@ -43,7 +43,7 @@ exports.preparePopulationOptions = function preparePopulationOptions(query, opti
  */
 
 exports.preparePopulationOptionsMQ = function preparePopulationOptionsMQ(query, options) {
-  const pop = utils.object.vals(query._mongooseOptions.populate);
+  const pop = Object.values(query._mongooseOptions.populate);
 
   // lean options should trickle through all queries
   if (options.lean != null) {
@@ -97,7 +97,7 @@ exports.createModel = function createModel(model, doc, fields, userProvidedField
   if (key && value && model.discriminators) {
     const discriminator = model.discriminators[value] || getDiscriminatorByValue(model, value);
     if (discriminator) {
-      const _fields = utils.clone(userProvidedFields);
+      const _fields = clone(userProvidedFields);
       exports.applyPaths(_fields, discriminator.schema);
       return new discriminator(undefined, _fields, true);
     }

--- a/lib/schema/mixed.js
+++ b/lib/schema/mixed.js
@@ -6,7 +6,7 @@
 
 const SchemaType = require('../schematype');
 const symbols = require('./symbols');
-const utils = require('../utils');
+const isObject = require('../helpers/isObject');
 
 /**
  * Mixed SchemaType constructor.
@@ -23,7 +23,7 @@ function Mixed(path, options) {
     if (Array.isArray(def) && def.length === 0) {
       // make sure empty array defaults are handled
       options.default = Array;
-    } else if (!options.shared && utils.isObject(def) && Object.keys(def).length === 0) {
+    } else if (!options.shared && isObject(def) && Object.keys(def).length === 0) {
       // prevent odd "shared" objects between documents
       options.default = function() {
         return {};

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -3,7 +3,7 @@
 const Mixed = require('../schema/mixed');
 const get = require('../helpers/get');
 const util = require('util');
-const utils = require('../utils');
+const specialProperties = require('../helpers/specialProperties');
 
 const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
@@ -195,7 +195,7 @@ function checkValidKey(key) {
   if (key.includes('.')) {
     throw new Error(`Mongoose maps do not support keys that contain ".", got "${key}"`);
   }
-  if (utils.specialProperties.has(key)) {
+  if (specialProperties.has(key)) {
     throw new Error(`Mongoose maps do not support reserved key name "${key}"`);
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,23 +4,22 @@
  * Module dependencies.
  */
 
+const ms = require('ms');
+const mpath = require('mpath');
+const sliced = require('sliced');
+const Buffer = require('safe-buffer').Buffer;
 const Decimal = require('./types/decimal128');
 const ObjectId = require('./types/objectid');
 const PopulateOptions = require('./options/PopulateOptions');
-const cloneRegExp = require('regexp-clone');
-const get = require('./helpers/get');
+const clone = require('./helpers/clone');
+const isObject = require('./helpers/isObject');
+const isBsonType = require('./helpers/isBsonType');
+const getFunctionName = require('./helpers/getFunctionName');
+const isMongooseObject = require('./helpers/isMongooseObject');
 const promiseOrCallback = require('./helpers/promiseOrCallback');
-const sliced = require('sliced');
-const mpath = require('mpath');
-const ms = require('ms');
-const symbols = require('./helpers/symbols');
-const Buffer = require('safe-buffer').Buffer;
+const specialProperties = require('./helpers/specialProperties');
 
-let MongooseBuffer;
-let MongooseArray;
 let Document;
-
-const specialProperties = new Set(['__proto__', 'constructor', 'prototype']);
 
 exports.specialProperties = specialProperties;
 
@@ -149,14 +148,6 @@ exports.deepEqual = function deepEqual(a, b) {
 };
 
 /*!
- * Get the bson type, if it exists
- */
-
-function isBsonType(obj, typename) {
-  return get(obj, '_bsontype', void 0) === typename;
-}
-
-/*!
  * Get the last element of an array
  */
 
@@ -167,88 +158,7 @@ exports.last = function(arr) {
   return void 0;
 };
 
-/*!
- * Object clone with Mongoose natives support.
- *
- * If options.minimize is true, creates a minimal data object. Empty objects and undefined values will not be cloned. This makes the data payload sent to MongoDB as small as possible.
- *
- * Functions are never cloned.
- *
- * @param {Object} obj the object to clone
- * @param {Object} options
- * @param {Boolean} isArrayChild true if cloning immediately underneath an array. Special case for minimize.
- * @return {Object} the cloned object
- * @api private
- */
-
-exports.clone = function clone(obj, options, isArrayChild) {
-  if (obj == null) {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    return cloneArray(obj, options);
-  }
-
-  if (isMongooseObject(obj)) {
-    // Single nested subdocs should apply getters later in `applyGetters()`
-    // when calling `toObject()`. See gh-7442, gh-8295
-    if (options && options._skipSingleNestedGetters && obj.$isSingleNested) {
-      options = Object.assign({}, options, { getters: false });
-    }
-    if (options && options.json && typeof obj.toJSON === 'function') {
-      return obj.toJSON(options);
-    }
-    return obj.toObject(options);
-  }
-
-  if (obj.constructor) {
-    switch (exports.getFunctionName(obj.constructor)) {
-      case 'Object':
-        return cloneObject(obj, options, isArrayChild);
-      case 'Date':
-        return new obj.constructor(+obj);
-      case 'RegExp':
-        return cloneRegExp(obj);
-      default:
-        // ignore
-        break;
-    }
-  }
-
-  if (obj instanceof ObjectId) {
-    return new ObjectId(obj.id);
-  }
-  if (isBsonType(obj, 'Decimal128')) {
-    if (options && options.flattenDecimals) {
-      return obj.toJSON();
-    }
-    return Decimal.fromString(obj.toString());
-  }
-
-  if (!obj.constructor && exports.isObject(obj)) {
-    // object created with Object.create(null)
-    return cloneObject(obj, options, isArrayChild);
-  }
-
-  if (obj[symbols.schemaTypeSymbol]) {
-    return obj.clone();
-  }
-
-  // If we're cloning this object to go into a MongoDB command,
-  // and there's a `toBSON()` function, assume this object will be
-  // stored as a primitive in MongoDB and doesn't need to be cloned.
-  if (options && options.bson && typeof obj.toBSON === 'function') {
-    return obj;
-  }
-
-  if (obj.valueOf != null) {
-    return obj.valueOf();
-  }
-
-  return cloneObject(obj, options, isArrayChild);
-};
-const clone = exports.clone;
+exports.clone = clone;
 
 /*!
  * ignore
@@ -275,43 +185,6 @@ exports.omit = function omit(obj, keys) {
   return ret;
 };
 
-/*!
- * ignore
- */
-
-function cloneObject(obj, options, isArrayChild) {
-  const minimize = options && options.minimize;
-  const ret = {};
-  let hasKeys;
-
-  for (const k in obj) {
-    if (specialProperties.has(k)) {
-      continue;
-    }
-
-    // Don't pass `isArrayChild` down
-    const val = clone(obj[k], options);
-
-    if (!minimize || (typeof val !== 'undefined')) {
-      if (minimize === false && typeof val === 'undefined') {
-        delete ret[k];
-      } else {
-        hasKeys || (hasKeys = true);
-        ret[k] = val;
-      }
-    }
-  }
-
-  return minimize && !isArrayChild ? hasKeys && ret : ret;
-}
-
-function cloneArray(arr, options) {
-  const ret = [];
-  for (let i = 0, l = arr.length; i < l; i++) {
-    ret.push(clone(arr[i], options, true));
-  }
-  return ret;
-}
 
 /*!
  * Shallow copies defaults into options.
@@ -451,20 +324,7 @@ exports.toObject = function toObject(obj) {
   return obj;
 };
 
-/*!
- * Determines if `arg` is an object.
- *
- * @param {Object|Array|String|Function|RegExp|any} arg
- * @api private
- * @return {Boolean}
- */
-
-exports.isObject = function(arg) {
-  if (Buffer.isBuffer(arg)) {
-    return true;
-  }
-  return Object.prototype.toString.call(arg) === '[object Object]';
-};
+exports.isObject = isObject;
 
 /*!
  * Determines if `arg` is a plain old JavaScript object (POJO). Specifically,
@@ -574,31 +434,7 @@ exports.isMongooseType = function(v) {
   return v instanceof ObjectId || v instanceof Decimal || v instanceof Buffer;
 };
 
-/*!
- * Returns if `v` is a mongoose object that has a `toObject()` method we can use.
- *
- * This is for compatibility with libs like Date.js which do foolish things to Natives.
- *
- * @param {any} v
- * @api private
- */
-
-exports.isMongooseObject = function(v) {
-  Document || (Document = require('./document'));
-  MongooseArray || (MongooseArray = require('./types').Array);
-  MongooseBuffer || (MongooseBuffer = require('./types').Buffer);
-
-  if (v == null) {
-    return false;
-  }
-
-  return v.$__ != null || // Document
-    v.isMongooseArray || // Array or Document Array
-    v.isMongooseBuffer || // Buffer
-    v.$isMongooseMap; // Map
-};
-
-const isMongooseObject = exports.isMongooseObject;
+exports.isMongooseObject = isMongooseObject;
 
 /*!
  * Converts `expires` options of index objects to `expiresAfterSeconds` options for MongoDB.
@@ -949,13 +785,7 @@ exports.buffer.areEqual = function(a, b) {
   return true;
 };
 
-exports.getFunctionName = function(fn) {
-  if (fn.name) {
-    return fn.name;
-  }
-  return (fn.toString().trim().match(/^function\s*([^\s(]+)/) || [])[1];
-};
-
+exports.getFunctionName = getFunctionName;
 /*!
  * Decorate buffers
  */

--- a/test/helpers/clone.test.js
+++ b/test/helpers/clone.test.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const assert = require('assert');
+const clone = require('../../lib/helpers/clone');
+const symbols = require('../../lib/helpers/symbols');
+const ObjectId = require('../../lib/types/objectid');
+const Decimal = require('../../lib/types/decimal128');
+
+describe.only('clone', () => {
+  describe('falsy', () => {
+    it('is null when null', () => {
+      assert.deepStrictEqual(clone(null), null);
+    });
+
+    it('is false when false', () => {
+      assert.deepStrictEqual(clone(false), false);
+    });
+
+    it('is undefined when undefined', () => {
+      assert.deepStrictEqual(clone(undefined), undefined);
+    });
+
+    it('is 0 when 0', () => {
+      assert.deepStrictEqual(clone(0), 0);
+    });
+  });
+
+  describe('Array', () => {
+    it('clones first level', () => {
+      const base = [1, 2];
+      const cloned = clone(base);
+      assert.deepStrictEqual(cloned, base);
+      cloned[0] = 2;
+      assert.deepStrictEqual(base, [1, 2]);
+      assert.deepStrictEqual(cloned, [2, 2]);
+    });
+
+    it('clones deeper', () => {
+      const base = [0, [1], { 2: 2 }];
+      const cloned = clone(base);
+      assert.deepStrictEqual(cloned, base);
+      cloned[0] = 1;
+      cloned[1][0] = 2;
+      cloned[2][2] = 3;
+      assert.deepStrictEqual(cloned, [1, [2], { 2: 3 }]);
+      assert.deepStrictEqual(base, [0, [1], { 2: 2 }]);
+    });
+  });
+
+  describe('mongoose object', () => {
+    it('use toObject', () => {
+      const base = {
+        $__: true,
+        myAttr: 'myAttrVal',
+        toObject() {
+          const obj = JSON.parse(JSON.stringify(base));
+          obj.toObject = base.toObject;
+          return obj;
+        }
+      };
+      const cloned = clone(base);
+      assert.deepStrictEqual(cloned, base);
+      cloned.myAttr = 'otherAttrVal';
+      assert.equal(base.myAttr, 'myAttrVal');
+      assert.equal(cloned.myAttr, 'otherAttrVal');
+    });
+
+    it('use toJSON', () => {
+      const base = {
+        $__: true,
+        myAttr: 'myAttrVal',
+        toJSON: () => JSON.stringify({ $__: true, myAttr: 'myAttrVal' })
+      };
+      const cloned = JSON.parse(clone(base, { json: true }));
+      assert.equal(cloned.myAttr, 'myAttrVal');
+      cloned.myAttr = 'otherAttrVal';
+      assert.equal(base.myAttr, 'myAttrVal');
+      assert.equal(cloned.myAttr, 'otherAttrVal');
+    });
+
+    it('skipSingleNestedGetters', () => {
+      const baseOpts = { _skipSingleNestedGetters: true, $isSingleNested: true };
+      const base = {
+        $__: true,
+        myAttr: 'myAttrVal',
+        $isSingleNested: true,
+        toObject(cloneOpts) {
+          assert.deepStrictEqual(
+            Object.assign({}, baseOpts, { getters: false }),
+            cloneOpts
+          );
+          const obj = JSON.parse(JSON.stringify(base));
+          obj.toObject = base.toObject;
+          return obj;
+        }
+      };
+      const cloned = clone(base, baseOpts);
+      assert.deepStrictEqual(cloned, base);
+      cloned.myAttr = 'otherAttrVal';
+      assert.equal(base.myAttr, 'myAttrVal');
+      assert.equal(cloned.myAttr, 'otherAttrVal');
+    });
+  });
+
+  describe('global objects', () => {
+    describe('constructor is Object', () => {
+      it('!minimize || isArrayChild', () => {
+        const base = { myAttr: 'myAttrVal' };
+        const cloned = clone(base);
+        assert.deepStrictEqual(cloned, base);
+        cloned.myAttr = 'otherAttrVal';
+        assert.equal(base.myAttr, 'myAttrVal');
+        assert.equal(cloned.myAttr, 'otherAttrVal');
+      });
+
+      it('!constructor && !minimize || isArrayChild', () => {
+        const base = Object.create(null);
+        base.myAttr = 'myAttrVal';
+        const cloned = clone(base);
+        assert.equal(base.myAttr, cloned.myAttr);
+        cloned.myAttr = 'otherAttrVal';
+        assert.equal(base.myAttr, 'myAttrVal');
+        assert.equal(cloned.myAttr, 'otherAttrVal');
+      });
+
+      it('minimize && !isArrayChild && hasKey', () => {
+        const base = { myAttr: 'myAttrVal', otherAttr: undefined, prototype: 'p' };
+        const cloned = clone(base, { minimize: true }, true);
+        assert.equal(base.myAttr, cloned.myAttr);
+        assert.deepStrictEqual(Object.keys(base), ['myAttr', 'otherAttr', 'prototype']);
+        assert.deepStrictEqual(Object.keys(cloned), ['myAttr']);
+      });
+
+      it('minimize and !isArrayChild && !hasKey', () => {
+        const base = { otherAttr: undefined, prototype: 'p' };
+        const cloned = clone(base, { minimize: true }, false);
+        assert.equal(cloned, null);
+      });
+    });
+
+    describe('constructor is Data', () => {
+      it('return new equal date ', () => {
+        const base = new Date();
+        const cloned = clone(base);
+        assert.deepStrictEqual(base, cloned);
+      });
+    });
+
+    describe('constructor is RegExp', () => {
+      it('return new equal date ', () => {
+        const base = new RegExp(/A-Z.*/);
+        const cloned = clone(base);
+        assert.deepStrictEqual(base, cloned);
+      });
+    });
+  });
+
+  describe('mongo object', () => {
+    it('is instance of ObjectId', () => {
+      const base = new ObjectId();
+      const cloned = clone(base);
+      assert.deepStrictEqual(base, cloned);
+    });
+  });
+
+  describe('schema type', () => {
+    it('have schemaTypeSymbol property', () => {
+      const base = {
+        myAttr: 'myAttrVal',
+        [symbols.schemaTypeSymbol]: 'MyType',
+        clone() {
+          return {
+            myAttr: this.myAttr,
+          };
+        }
+      };
+      const cloned = clone(base);
+      assert.deepStrictEqual(base.myAttr, cloned.myAttr);
+    });
+  });
+
+  describe('bson', () => {
+    it('Decimal128', () => {
+      const base = {
+        _bsontype: 'Decimal128',
+        toString() { return '128'; }
+      };
+      base.constructor = undefined;
+      const cloned = clone(base);
+      const expected = Decimal.fromString(base.toString());
+      assert.deepStrictEqual(cloned, expected);
+    });
+
+    it('Decimal128 (flatternDecimal)', () => {
+      const base = {
+        _bsontype: 'Decimal128',
+        toJSON() { return 128; }
+      };
+      base.constructor = undefined;
+      const cloned = clone(base, { flattenDecimals: true });
+      assert.deepStrictEqual(cloned, base.toJSON());
+    });
+
+    it('does nothing', () => {
+      class BeeSon {
+        constructor() { this.myAttr = 'myAttrVal'; }
+        toBSON( ) {}
+      }
+      const base = new BeeSon();
+      const cloned = clone(base, { bson: true });
+      assert.equal(base.myAttr, cloned.myAttr);
+      cloned.myAttr = 'otherAttrVal';
+      assert.equal(base.myAttr, 'otherAttrVal');
+      assert.equal(cloned.myAttr, 'otherAttrVal');
+    });
+  });
+
+  describe('wrapper', () => {
+
+  });
+
+  describe('any else', () => {
+    it('valueOf', () => {
+      let called = false;
+      class Wrapper {
+        constructor(myAttr) {
+          this.myAttr = myAttr;
+        }
+        valueOf() {
+          called = true;
+          return new Wrapper(this.myAttr);
+        }
+      }
+      const base = new Wrapper('myAttrVal');
+      const cloned = clone(base);
+      assert.ok(called);
+      assert.deepStrictEqual(cloned, base);
+      cloned.myAttr = 'otherAttrVal';
+      assert.equal(base.myAttr, 'myAttrVal');
+      assert.equal(cloned.myAttr, 'otherAttrVal');
+    });
+
+    it('cloneObject', () => {
+      class CloneMe {
+        constructor(myAttr) {
+          this.myAttr = myAttr;
+        }
+      }
+      const base = new CloneMe('myAttrVal');
+      base.valueOf = undefined;
+      const cloned = clone(base);
+      assert.equal(base.myAttr, cloned.myAttr);
+      cloned.myAttr = 'otherAttrVal';
+      assert.equal(base.myAttr, 'myAttrVal');
+      assert.equal(cloned.myAttr, 'otherAttrVal');
+      // I can't say it's expected behavior, but is how it's behave.
+      assert.equal(typeof cloned, 'object');
+      assert.equal(cloned.constructor, Object);
+    });
+  });
+});

--- a/test/helpers/getFunctionName.test.js
+++ b/test/helpers/getFunctionName.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('assert');
+const getFunctionName = require('../../lib/helpers/getFunctionName');
+
+describe('getFunctionName', () => {
+  it('return fn.name', () => {
+    assert.equal(getFunctionName({ name: 'fnName'}), 'fnName');
+  });
+
+  it('return function name', () => {
+    assert.equal(getFunctionName(function fnName() {}), 'fnName');
+  });
+
+  it('return function functionName', () => {
+    assert.equal(getFunctionName(function functionName() {}), 'functionName');
+  });
+
+  it('return undefined for arrow function', () => {
+    // I can't say it's expected behavior, but is how it's behave.
+    assert.equal(getFunctionName(() => []), undefined);
+  });
+});

--- a/test/helpers/isBsonType.test.js
+++ b/test/helpers/isBsonType.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('assert');
+const isBsonType = require('../../lib/helpers/isBsonType');
+
+describe('isBsonType', () => {
+  it('true for any object with _bsontype property equal typename', () => {
+    assert.ok(isBsonType({ _bsontype: 'MyType' }, 'MyType'));
+  });
+
+  it('true for any object without _bsontype property and undefined typename', () => {
+    assert.ok(isBsonType({ }));
+  });
+
+  it('false for any object with _bsontype property different of typename', () => {
+    assert.ok(!isBsonType({ _bsontype: 'MyType' }, 'OtherType'));
+  });
+
+  it('false for any object without _bsontype property', () => {
+    // I can't say it's expected behavior, but is how it's behave.
+    assert.ok(!isBsonType({ }, 'OtherType'));
+  });
+});

--- a/test/helpers/isBsonType.test.js
+++ b/test/helpers/isBsonType.test.js
@@ -17,7 +17,6 @@ describe('isBsonType', () => {
   });
 
   it('false for any object without _bsontype property', () => {
-    // I can't say it's expected behavior, but is how it's behave.
     assert.ok(!isBsonType({ }, 'OtherType'));
   });
 });

--- a/test/helpers/isMongooseObject.test.js
+++ b/test/helpers/isMongooseObject.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('assert');
+const isMongooseObject = require('../../lib/helpers/isMongooseObject');
+
+describe('isMongooseObject', () => {
+  it('is when value.$__ != null', () => {
+    assert.ok(isMongooseObject({ $__: !null }));
+  });
+
+  it('is when value.isMongooseArray is truthy', () => {
+    assert.ok(isMongooseObject({ isMongooseArray: true }));
+  });
+
+  it('is when value.isMongooseBuffer is truthy', () => {
+    assert.ok(isMongooseObject({ isMongooseBuffer: true }));
+  });
+
+  it('is when value.$isMongooseMap is truthy', () => {
+    assert.ok(isMongooseObject({ $isMongooseMap: true }));
+  });
+
+  it('is not when anything else', () => {
+    assert.ok(!isMongooseObject(''));
+    assert.ok(!isMongooseObject([]));
+    assert.ok(!isMongooseObject({}));
+    assert.ok(!isMongooseObject(/./));
+    assert.ok(!isMongooseObject(null));
+    assert.ok(!isMongooseObject(false));
+    assert.ok(!isMongooseObject(undefined));
+    assert.ok(!isMongooseObject(new Array));
+    assert.ok(!isMongooseObject(new Function));
+    assert.ok(!isMongooseObject(new Object));
+    assert.ok(!isMongooseObject(new RegExp));
+    assert.ok(!isMongooseObject(new String));
+    assert.ok(!isMongooseObject(Buffer.from([])));
+  });
+});

--- a/test/helpers/isObject.test.js
+++ b/test/helpers/isObject.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('assert');
+const isObject = require('../../lib/helpers/isObject');
+
+describe('isObject', () => {
+  describe('true for', () => {
+    it('{}', () => {
+      assert.ok(isObject({}));
+    });
+
+    it('Buffer', () => {
+      assert.ok(isObject(Buffer.from([])));
+    });
+
+    it('Object', () => {
+      assert.ok(isObject(new Object));
+    });
+  });
+
+  describe('false for', () => {
+    it('""', () => {
+      assert.ok(!isObject(''));
+    });
+
+    it('/.*/', () => {
+      assert.ok(!isObject(/.*/));
+    });
+
+    it('[]', () => {
+      assert.ok(!isObject([]));
+    });
+
+    it('Array', () => {
+      assert.ok(!isObject(new Array));
+    });
+
+    it('Function', () => {
+      assert.ok(!isObject(new Function));
+    });
+
+    it('RegExp', () => {
+      assert.ok(!isObject(new RegExp));
+    });
+
+    it('String', () => {
+      assert.ok(!isObject(new String));
+    });
+
+    it('"[object Object]"', () => {
+      assert.ok(!isObject('[object Object]'));
+    });
+  });
+});


### PR DESCRIPTION
**Summary**

Trying to make things less dependent of utils.js

This time. `utils.clone`.

Since clone has some dependencies from utils, moved also:
- `utils.specialProperties` to helpers/specialProperties;
- `utils.isMongooseObject` to helpers/isMongooseObject;
- `utils.getFunctionName` to helpers/getFunctionName;
- `utils.isBsonType` to helpers/isBsonType;
- `utils.isObject` to helpers/isObject.

I'd resisted to temptation to refactor methods, with two exception:
- `util.object.vals` changed by `Object.values` (lib/queryhelpers.js);
- `utils.each` changed `forEach` (lib/browserDocument.js).

**Examples**

Instead of require dependencies of [lib/utils.js](https://user-images.githubusercontent.com/863299/74390425-03346580-4de0-11ea-80a3-be3318613acd.png) to these files:
- lib/browserDocument.js;
- lib/cast.js;
- lib/drivers/node-mongodb-native/collection.js;
- lib/helpers/common.js;
- lib/helpers/schema/getIndexes.js;
- lib/options/PopulateOptions.js;
- lib/options/SchemaTypeOptions.js;
- lib/options/removeOptions.js;
- lib/options/saveOptions.js;
- lib/queryhelpers.js;
- lib/schema/mixed.js;
- lib/types/map.js.


Now they require:
![dependencygraphCore](https://user-images.githubusercontent.com/863299/74390368-cf594000-4ddf-11ea-92a5-407de7e3216a.png)

I'm not fan of code comments but I leave two in tests:
1. `getFunctionName` of arrow function return undefined:
  This isn't a bug, is a JS limitation.
2. `cloneObject` change constructor of clone:
  This may be a bug in some unknown edge case.

Some related thing I noted is that Document require utils, that require Document :repeat: 

Graphs by [dependency-cruiser](https://github.com/sverweij/dependency-cruiser)