### PR TITLE
fix: update documentation of custom _id overriding in discriminators

### DIFF
--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -186,15 +186,14 @@ describe('discriminator docs', function () {
   /**
    * A discriminator's fields are the union of the base schema's fields and
    * the discriminator schema's fields, and the discriminator schema's fields
-   * take precedence. There is one exception: the default `_id` field.
-   *
-   * You can work around this by setting the `_id` option to false in the
-   * discriminator schema as shown below.
+   * take precedence. There is one exception: the `_id` field.
+   * If a custom _id field is set on the base schema, that will always
+   * override the discriminator's _id field, as shown below.
    */
   it('Handling custom _id fields', function (done) {
     var options = {discriminatorKey: 'kind'};
 
-    // Base schema has a String `_id` and a Date `time`...
+    // Base schema has a custom String `_id` and a Date `time`...
     var eventSchema = new mongoose.Schema({_id: String, time: Date},
       options);
     var Event = mongoose.model('BaseEvent', eventSchema);
@@ -203,16 +202,16 @@ describe('discriminator docs', function () {
       url: String,
       time: String
     }, options);
-    // But the discriminator schema has a String `time`, and an implicitly added
-    // ObjectId `_id`.
+    // The discriminator schema has a String `time` and an
+    // implicitly added ObjectId `_id`.
     assert.ok(clickedLinkSchema.path('_id'));
     assert.equal(clickedLinkSchema.path('_id').instance, 'ObjectID');
     var ClickedLinkEvent = Event.discriminator('ChildEventBad',
       clickedLinkSchema);
 
-    var event1 = new ClickedLinkEvent({ _id: 'custom id', time: '4pm' });
-    // Woops, clickedLinkSchema overwrites the `time` path, but **not**
-    // the `_id` path because that was implicitly added.
+    var event1 = new ClickedLinkEvent({_id: 'custom id', time: '4pm'});
+    // clickedLinkSchema overwrites the `time` path, but **not**
+    // the `_id` path.
     assert.strictEqual(typeof event1._id, 'string');
     assert.strictEqual(typeof event1.time, 'string');
 


### PR DESCRIPTION
**Summary**

This fixes Issue 8588 which appears to be an artifact in the documentation from before [this fix](https://github.com/Automattic/mongoose/commit/3f1f1de70b00e84320cdb2cafd983e707d0d39a9) to how the discriminator code handled a custom _id in the base schema.  As I understand it, in the old code the implicit discriminator schema would still override the base, unless _id was set to 'false' in the discriminator options.  This is what the old documentation still reflects (at least in part).  However, it appears that now a custom base _id always overrides the discriminator _id.  This updates the documentation to reflect that behavior.

**Examples**

This is a test file.  The tests still run correctly--it was just the descriptions that didn't match.
