### PR TITLE
Fix typo

### DIFF
--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -80,7 +80,7 @@ block content
     and the branches do not have actual paths.  A side-effect of this is that `meta`
     above cannot have its own validation.  If validation is needed up the tree, a path
     needs to be created up the tree - see the [Subdocuments](./subdocs.html) section
-    for more information no how to do this.  Also read the [Mixed](./schematypes.html)
+    for more information on how to do this.  Also read the [Mixed](./schematypes.html)
     subsection of the SchemaTypes guide for some gotchas.
 
     The permitted SchemaTypes are:


### PR DESCRIPTION
**Summary**

Fix typo in the guide section of the documentation 

