### PR TITLE
[WIP] Fixes #8658

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4429,10 +4429,7 @@ function _execPopulateQuery(mod, match, select, assignmentOpts, callback) {
     delete queryOptions.skip;
   }
 
-  if (queryOptions.perDocumentLimit != null && queryOptions.limit != null) {
-    throw new Error('Can not use `limit` and `perDocumentLimit` at the same time. Model `' + mod.model.modelName + '`.' );
-  }
-  else if (queryOptions.perDocumentLimit != null) {
+  if (queryOptions.perDocumentLimit != null) {
     queryOptions.limit = queryOptions.perDocumentLimit;
     delete queryOptions.perDocumentLimit;
   } else if (queryOptions.limit != null) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4424,11 +4424,15 @@ function _execPopulateQuery(mod, match, select, assignmentOpts, callback) {
     limit: mod.options.limit,
     perDocumentLimit: mod.options.perDocumentLimit
   }, mod.options.options);
+
   if (mod.count) {
     delete queryOptions.skip;
   }
 
-  if (queryOptions.perDocumentLimit != null) {
+  if (queryOptions.perDocumentLimit != null && queryOptions.limit != null) {
+    throw new Error('Can not use `limit` and `perDocumentLimit` at the same time. Model `' + mod.model.modelName + '`.' );
+  }
+  else if (queryOptions.perDocumentLimit != null) {
     queryOptions.limit = queryOptions.perDocumentLimit;
     delete queryOptions.perDocumentLimit;
   } else if (queryOptions.limit != null) {

--- a/lib/options/PopulateOptions.js
+++ b/lib/options/PopulateOptions.js
@@ -14,6 +14,11 @@ class PopulateOptions {
     if (typeof obj.subPopulate === 'object') {
       this.populate = obj.subPopulate;
     }
+
+
+    if (obj.perDocumentLimit != null && obj.limit != null) {
+      throw new Error('Can not use `limit` and `perDocumentLimit` at the same time. Path: `' + obj.path + '`.' );
+    }
   }
 }
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -9200,4 +9200,26 @@ describe('model: populate:', function() {
       assert.deepEqual(res[0].toObject().list[0].data, { sourceId: 123 });
     });
   });
+
+  it.only('throws an error when using limit with perDocumentLimit', function() {
+    return co(function *() {
+
+      const User = db.model('User',userSchema);
+      const BlogPost = db.model('BlogPost',blogPostSchema);
+
+      const blogPosts = yield BlogPost.create([{title:'JS 101'},{title:'Mocha 101'}]);
+      const user = yield User.create({blogposts: blogPosts});
+
+
+      let err;
+      try {
+        yield User.find({_id:user._id}).populate({ path: 'blogposts', perDocumentLimit: 2,limit:1 });
+      } catch (error) {
+        err = error;
+      }
+
+      assert(err);
+      assert.equal(err.message,'Can not use `limit` and `perDocumentLimit` at the same time. Model `BlogPost`.');
+    });
+  });
 });

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -9201,9 +9201,8 @@ describe('model: populate:', function() {
     });
   });
 
-  it.only('throws an error when using limit with perDocumentLimit', function() {
+  it('throws an error when using limit with perDocumentLimit', function() {
     return co(function *() {
-
       const User = db.model('User',userSchema);
       const BlogPost = db.model('BlogPost',blogPostSchema);
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -9218,7 +9218,7 @@ describe('model: populate:', function() {
       }
 
       assert(err);
-      assert.equal(err.message,'Can not use `limit` and `perDocumentLimit` at the same time. Model `BlogPost`.');
+      assert.equal(err.message,'Can not use `limit` and `perDocumentLimit` at the same time. Path: `blogposts`.');
     });
   });
 });


### PR DESCRIPTION
Fixes #8658
I made changes so that `populate(...)` throws an error when provided both `limit` and `perDocumentLimit`, but I can't catch the error and assert on it in my tests for some reason.

Getting Uncaught Error even though I am using try/catch inside the `co(...)` call. Any idea why that might be?

```js
  it('throws an error when using limit with perDocumentLimit', function() {
    return co(function *() {
      const User = db.model('User',userSchema);
      const BlogPost = db.model('BlogPost',blogPostSchema);

      const blogPosts = yield BlogPost.create([{title:'JS 101'},{title:'Mocha 101'}]);
      const user = yield User.create({blogposts: blogPosts});


      let err;
      try {
        yield User.find({_id:user._id}).populate({ path: 'blogposts', perDocumentLimit: 2,limit:1 });
      } catch (error) {
        err = error; // doesn't really get here, just throws uncaught error
      }

      assert(err);
      assert.equal(err.message,'Can not use `limit` and `perDocumentLimit` at the same time. Model `BlogPost`.');
    });
  });
```

Uncaught Error:
```
Uncaught Error: Can not use `limit` and `perDocumentLimit` at the same time. Model `BlogPost`.               
 at _execPopulateQuery (lib\model.js:4433:11)                                                                
 at populate (lib\model.js:4392:24)                                                                          
 at _populate (lib\model.js:4270:5)                                                                          
 at mongoose\lib\model.js:4245:5                                    
 at promiseOrCallback (lib\helpers\promiseOrCallback.js:9:12)                                                
 at Function.Model.populate (lib\model.js:4243:10)                                                           
 at cb (lib\query.js:1934:17)                                                                                
 at mongoose\node_modules\mongodb\lib\utils.js:726:5                
 at handleCallback (node_modules\mongodb\lib\utils.js:128:55)                                                
 at mongoose\node_modules\mongodb\lib\cursor.js:835:66              
 at handleCallback (node_modules\mongodb\lib\utils.js:128:55)                                                
 at completeClose (node_modules\mongodb\lib\cursor.js:929:16)                                                
 at Cursor.close (node_modules\mongodb\lib\cursor.js:948:12)                                                 
 at mongoose\node_modules\mongodb\lib\cursor.js:835:27              
 at handleCallback (node_modules\mongodb\lib\core\cursor.js:32:5)                                            
 at mongoose\node_modules\mongodb\lib\core\cursor.js:694:38         
 at mongoose\node_modules\mongodb\lib\core\cursor.js:703:39         
 at Cursor._endSession (node_modules\mongodb\lib\core\cursor.js:404:7)                                       
 at _setCursorNotifiedImpl (node_modules\mongodb\lib\core\cursor.js:703:10)                                  
 at setCursorNotified (node_modules\mongodb\lib\core\cursor.js:694:3)                                        
 at setCursorDeadAndNotified (node_modules\mongodb\lib\core\cursor.js:687:3)                                 
 at nextFunction (node_modules\mongodb\lib\core\cursor.js:848:5)                                             
 at Cursor._next (node_modules\mongodb\lib\core\cursor.js:202:5)                                             
 at fetchDocs (node_modules\mongodb\lib\cursor.js:827:16)                                                    
 at mongoose\node_modules\mongodb\lib\cursor.js:854:11              
 at handleCallback (node_modules\mongodb\lib\core\cursor.js:32:5)                                            
 at nextFunction (node_modules\mongodb\lib\core\cursor.js:879:5)                                             
 at mongoose\node_modules\mongodb\lib\core\cursor.js:754:7          
 at done (node_modules\mongodb\lib\core\cursor.js:463:7)                                                     
 at queryCallback (node_modules\mongodb\lib\core\cursor.js:509:18)                                           
 at mongoose\node_modules\mongodb\lib\core\cursor.js:559:9          
 at executeCallback (node_modules\mongodb\lib\operations\execute_operation.js:70:5)                          
 at callbackWithRetry (node_modules\mongodb\lib\operations\execute_operation.js:118:14)                      
 at mongoose\node_modules\mongodb\lib\cmap\connection_pool.js:352:13
 at handleOperationResult (node_modules\mongodb\lib\core\sdam\server.js:487:5)                               
 at MessageStream.messageHandler (node_modules\mongodb\lib\cmap\connection.js:270:5)                         
 at processIncomingData (node_modules\mongodb\lib\cmap\message_stream.js:144:12)                             
 at MessageStream._write (node_modules\mongodb\lib\cmap\message_stream.js:42:5)                              
 at doWrite (_stream_writable.js:431:12)                                                                     
 at writeOrBuffer (_stream_writable.js:415:5)                                                                
 at MessageStream.Writable.write (_stream_writable.js:305:11)                                                
 at Socket.ondata (_stream_readable.js:726:22)                                                               
 at addChunk (_stream_readable.js:308:12)                                                                    
 at readableAddChunk (_stream_readable.js:289:11)                                                            
 at Socket.Readable.push (_stream_readable.js:223:10)                                                        
 at TCP.onStreamRead (internal/stream_base_commons.js:182:23)                                                
```
```