### PR TITLE
fix: typo in docs related to Schema.index

### DIFF
--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -74,7 +74,7 @@ block content
     Notice above that if a property only requires a type, it can be specified using
     a shorthand notation (contrast the `title` property above with the `date`
     property).
-    
+
     Keys may also be assigned nested objects containing further key/type definitions
     like the `meta` property above.  This will happen whenever a key's value is a POJO
     that lacks a bona-fide `type` property.  In these cases, only the leaves in a tree
@@ -148,7 +148,7 @@ block content
 
     const doc = new Model();
     await doc.save(); // Throws "document must have an _id before saving"
-    
+
     doc._id = 1;
     await doc.save(); // works
     ```
@@ -239,6 +239,8 @@ block content
     Defining indexes at the schema level is necessary when creating
     [compound indexes](https://docs.mongodb.com/manual/core/index-compound/).
 
+    Please note that the field names within the [index](./api/schema.html#schema_Schema-index) method, should be wrapped within single quotes.
+
     ```javascript
       var animalSchema = new Schema({
         name: String,
@@ -246,7 +248,7 @@ block content
         tags: { type: [String], index: true } // field level
       });
 
-      animalSchema.index({ name: 1, type: -1 }); // schema level
+      animalSchema.index({ 'name': 1, 'type': -1 }); // schema level
     ```
 
     When your application starts up, Mongoose automatically calls [`createIndex`](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#db.collection.createIndex) for each defined index in your schema.
@@ -463,7 +465,7 @@ block content
     a capped collection if you set the [`capped` schema option](#capped). Like
     `autoIndex`, setting `autoCreate` to true is helpful for development and
     test environments.
-    
+
     Unfortunately, `createCollection()` cannot change an existing collection.
     For example, if you add `capped: 1024` to your schema and the existing
     collection is not capped, `createCollection()` will throw an error.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1586,7 +1586,7 @@ Schema.prototype.static = function(name, fn) {
  *
  * ####Example
  *
- *     schema.index({ first: 1, last: -1 })
+ *     schema.index({ 'first': 1, 'last': -1 })
  *
  * @param {Object} fields
  * @param {Object} [options] Options to pass to [MongoDB driver's `createIndex()` function](http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#createIndex)


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

When trying to use the [Schema.prototype.index()](https://mongoosejs.com/docs/api/schema.html#schema_Schema-index) method, to add a compound index to our schema, our team found that it didn't work as expected (it still allowed duplicated documents on those keys to be inserted).

```
schema.index({ first: 1, last: -1 }, {unique: true)
```

However, by research and chance, we found that by adding simple quotes to the keys, the problem was solved:

```
schema.index({ 'first': 1, 'last': -1 }, {unique: true)
```

Therefore, we have updated the documentation to prevent future users  from coming to this bug.

Thanks!

![](https://media.giphy.com/media/xmz2JEFmNsGru/giphy.gif)

ps) Many thanks to @Ollebacx & @Marcosmm1 for their support!