### PR TITLE
refactor test for #8331

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5541,18 +5541,14 @@ describe('Model', function() {
         return co(function*() {
           const createdUser = yield User.create({ name: 'Hafez' });
 
-          let err;
+          const err = yield User.bulkWrite([{
+            updateOne: {
+              filter: { _id: createdUser._id }
+            }
+          }])
+            .then(()=>null)
+            .catch(err=>err);
 
-          try {
-            yield User.bulkWrite([{
-              updateOne: {
-                filter: { _id: createdUser._id }
-              }
-            }]);
-          }
-          catch (_err) {
-            err = _err;
-          }
 
           assert.ok(err);
           assert.equal(err.message, 'Must provide an update object.');


### PR DESCRIPTION
In response to https://github.com/Automattic/mongoose/pull/8693#discussion_r395913438 cool tips, used `.then(()=>null).catch(err=>err);` to catch the error instead of the try/catch block.