### PR TITLE
allow setting timestamps to false for bulkWrite

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -54,7 +54,7 @@ module.exports = function castBulkWrite(model, op, options) {
             upsert: op['updateOne'].upsert
           });
         }
-        if (model.schema.$timestamps != null) {
+        if (model.schema.$timestamps != null && op['updateOne'].timestamps !== false) {
           const createdAt = model.schema.$timestamps.createdAt;
           const updatedAt = model.schema.$timestamps.updatedAt;
           applyTimestampsToUpdate(now, createdAt, updatedAt, op['updateOne']['update'], {});
@@ -87,7 +87,7 @@ module.exports = function castBulkWrite(model, op, options) {
             upsert: op['updateMany'].upsert
           });
         }
-        if (model.schema.$timestamps != null) {
+        if (model.schema.$timestamps != null && op['updateMany'].timestamps !== false) {
           const createdAt = model.schema.$timestamps.createdAt;
           const updatedAt = model.schema.$timestamps.updatedAt;
           applyTimestampsToUpdate(now, createdAt, updatedAt, op['updateMany']['update'], {});

--- a/lib/model.js
+++ b/lib/model.js
@@ -3451,11 +3451,13 @@ function _setIsNew(doc, val) {
  * @param {Object} [opts.updateOne.filter] Update the first document that matches this filter
  * @param {Object} [opts.updateOne.update] An object containing [update operators](https://docs.mongodb.com/manual/reference/operator/update/)
  * @param {Boolean} [opts.updateOne.upsert=false] If true, insert a doc if none match
+ * @param {Boolean} [opts.updateOne.timestamps=true] If false, do not apply [timestamps](https://mongoosejs.com/docs/guide.html#timestamps) to the operation
  * @param {Object} [opts.updateOne.collation] The [MongoDB collation](https://thecodebarbarian.com/a-nodejs-perspective-on-mongodb-34-collations) to use
  * @param {Array} [opts.updateOne.arrayFilters] The [array filters](https://thecodebarbarian.com/a-nodejs-perspective-on-mongodb-36-array-filters.html) used in `update`
  * @param {Object} [opts.updateMany.filter] Update all the documents that match this filter
  * @param {Object} [opts.updateMany.update] An object containing [update operators](https://docs.mongodb.com/manual/reference/operator/update/)
  * @param {Boolean} [opts.updateMany.upsert=false] If true, insert a doc if no documents match `filter`
+ * @param {Boolean} [opts.updateMany.timestamps=true] If false, do not apply [timestamps](https://mongoosejs.com/docs/guide.html#timestamps) to the operation
  * @param {Object} [opts.updateMany.collation] The [MongoDB collation](https://thecodebarbarian.com/a-nodejs-perspective-on-mongodb-34-collations) to use
  * @param {Array} [opts.updateMany.arrayFilters] The [array filters](https://thecodebarbarian.com/a-nodejs-perspective-on-mongodb-36-array-filters.html) used in `update`
  * @param {Object} [opts.deleteOne.filter] Delete the first document that matches this filter

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6537,4 +6537,29 @@ describe('Model', function() {
       assert.ok(err.message.indexOf('notInSchema') !== -1, err.message);
     });
   });
+
+  it('bulkWrite can disable timestamps with updateOne, and updateMany', function() {
+    const userSchema = new Schema({
+      name: String
+    }, { timestamps: true });
+
+    const User = db.model('User', userSchema);
+
+    return co(function*() {
+      const [user1, user2] = yield User.create([{ name: 'Hafez1' }, { name: 'Hafez2' }]);
+
+      yield User.bulkWrite([
+        { updateOne: { filter: { _id: user1._id }, update: { name: 'John1' }, timestamps: false } },
+        { updateMany: { filter: { _id: user2._id }, update: { name: 'John2' }, timestamps: false } }
+      ]);
+
+      const [updatedUser1, updatedUser2] = yield Promise.all([
+        User.findOne({ _id: user1._id }),
+        User.findOne({ _id: user2._id })
+      ]);
+
+      assert.deepEqual(user1.updatedAt, updatedUser1.updatedAt);
+      assert.deepEqual(user2.updatedAt, updatedUser2.updatedAt);
+    });
+  });
 });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6546,20 +6546,20 @@ describe('Model', function() {
     const User = db.model('User', userSchema);
 
     return co(function*() {
-      const [user1, user2] = yield User.create([{ name: 'Hafez1' }, { name: 'Hafez2' }]);
+      const users = yield User.create([{ name: 'Hafez1' }, { name: 'Hafez2' }]);
 
       yield User.bulkWrite([
-        { updateOne: { filter: { _id: user1._id }, update: { name: 'John1' }, timestamps: false } },
-        { updateMany: { filter: { _id: user2._id }, update: { name: 'John2' }, timestamps: false } }
+        { updateOne: { filter: { _id: users[0]._id }, update: { name: 'John1' }, timestamps: false } },
+        { updateMany: { filter: { _id: users[1]._id }, update: { name: 'John2' }, timestamps: false } }
       ]);
 
-      const [updatedUser1, updatedUser2] = yield Promise.all([
-        User.findOne({ _id: user1._id }),
-        User.findOne({ _id: user2._id })
+      const usersAfterUpdate = yield Promise.all([
+        User.findOne({ _id: users[0]._id }),
+        User.findOne({ _id: users[1]._id })
       ]);
 
-      assert.deepEqual(user1.updatedAt, updatedUser1.updatedAt);
-      assert.deepEqual(user2.updatedAt, updatedUser2.updatedAt);
+      assert.deepEqual(users[0].updatedAt, usersAfterUpdate[0].updatedAt);
+      assert.deepEqual(users[1].updatedAt, usersAfterUpdate[1].updatedAt);
     });
   });
 });


### PR DESCRIPTION
fixes #8745 

However, when using `mongoose.set('debug', true);` this seems to actually send the `timestamps: false` option all the way to the mongo side.

Curious if this will cause any weird scenarios.