### PR TITLE
updated mpath package version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "kareem": "2.3.1",
     "mongodb": "3.5.5",
     "mongoose-legacy-pluralize": "1.0.2",
-    "mpath": "0.6.0",
+    "mpath": "0.7.0",
     "mquery": "3.2.2",
     "ms": "2.1.2",
     "regexp-clone": "1.0.0",


### PR DESCRIPTION
The **mpath** package was recently updated (In mpath repo) because the older version of the **mpath** had vulnerability issue . the following are the PR and issues created for it, in their repo
https://github.com/aheckmann/mpath/pull/9
https://github.com/aheckmann/mpath/issues/8

**mpath** is used as dependency in mongoose , which is why added the change to update the package.
