### PR TITLE
Fixing #8774

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1775,14 +1775,12 @@ Schema.prototype.virtual = function(name, options) {
     const virtual = this.virtual(name);
     virtual.options = options;
     return virtual.
-      get(function() {
-        if (!this.$$populatedVirtuals) {
-          this.$$populatedVirtuals = {};
-        }
-        if (this.$$populatedVirtuals.hasOwnProperty(name)) {
+      get(function(_v) {
+        if (this.$$populatedVirtuals &&
+          this.$$populatedVirtuals.hasOwnProperty(name)) {
           return this.$$populatedVirtuals[name];
         }
-        return void 0;
+        return _v;
       }).
       set(function(_v) {
         if (!this.$$populatedVirtuals) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1780,6 +1780,7 @@ Schema.prototype.virtual = function(name, options) {
           this.$$populatedVirtuals.hasOwnProperty(name)) {
           return this.$$populatedVirtuals[name];
         }
+        if (_v == null) return undefined;
         return _v;
       }).
       set(function(_v) {


### PR DESCRIPTION
Default getter should return value when it is passed in.

**Summary**

The default getter on virtual populate fields does not work well when trying to apply getters to lean POJO's. In fact, it just returns undefined because it is expecting a mongoose document. Detailed in #8774 . This change will allow the `mongoose-lean-getters` extension to fully work for virtuals and also conceptually makes sense.

**Examples**

Here's the relevant thing that you can do now, even with a lean document:
```js
  const virtualKeys = Object.keys(schema.virtuals);
  for (let i = 0; i < virtualKeys.length; ++i) {
    const virtualPath = virtualKeys[i];
    const virtualType = schema.virtuals[virtualPath];
    mpath.set(virtualPath, virtualType.applyGetters(mpath.get(virtualPath, doc), doc, true), doc);
  }
```
You can now call `applyGetters` on a POJO and have it work correctly.
