### PR TITLE
[WIP] refactor: use (for-of) instead of for (let i = 0...) when iterating on arrays

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -370,8 +370,7 @@ Aggregate.prototype.unwind = function() {
   const args = utils.args(arguments);
 
   const res = [];
-  for (let i = 0; i < args.length; ++i) {
-    const arg = args[i];
+  for (const arg of args) {
     if (arg && typeof arg === 'object') {
       res.push({ $unwind: arg });
     } else if (typeof arg === 'string') {

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -303,9 +303,11 @@ module.exports = function cast(schema, obj, options, context) {
         }
       } else if (Array.isArray(val) && ['Buffer', 'Array'].indexOf(schematype.instance) === -1) {
         const casted = [];
-        for (let valIndex = 0; valIndex < val.length; valIndex++) {
+        const valuesArray = val;
+
+        for (const _val of valuesArray) {
           casted.push(schematype.castForQueryWrapper({
-            val: val[valIndex],
+            val: _val,
             context: context
           }));
         }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -119,11 +119,11 @@ Collection.prototype.addQueue = function(name, args) {
  */
 
 Collection.prototype.doQueue = function() {
-  for (let i = 0, l = this.queue.length; i < l; i++) {
-    if (typeof this.queue[i][0] === 'function') {
-      this.queue[i][0].apply(this, this.queue[i][1]);
+  for (const method of this.queue) {
+    if (typeof method[0] === 'function') {
+      method[0].apply(this, method[1]);
     } else {
-      this[this.queue[i][0]].apply(this, this.queue[i][1]);
+      this[method[0]].apply(this, method[1]);
     }
   }
   this.queue = [];

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -109,8 +109,8 @@ Object.defineProperty(Connection.prototype, 'readyState', {
     if (this._readyState !== val) {
       this._readyState = val;
       // [legacy] loop over the otherDbs on this connection and change their state
-      for (let i = 0; i < this.otherDbs.length; i++) {
-        this.otherDbs[i].readyState = val;
+      for (const db of this.otherDbs) {
+        db.readyState = val;
       }
 
       // loop over relatedDbs on this connection and change their state

--- a/lib/document.js
+++ b/lib/document.js
@@ -99,9 +99,9 @@ function Document(obj, fields, skipId, options) {
     this.$__.selected = fields;
   }
 
-  const required = schema.requiredPaths(true);
-  for (let i = 0; i < required.length; ++i) {
-    this.$__.activePaths.require(required[i]);
+  const requiredPaths = schema.requiredPaths(true);
+  for (const path of requiredPaths) {
+    this.$__.activePaths.require(path);
   }
 
   this.$__.emitter.setMaxListeners(0);
@@ -303,11 +303,13 @@ Document.prototype.$op;
 function $__hasIncludedChildren(fields) {
   const hasIncludedChildren = {};
   const keys = Object.keys(fields);
-  for (let j = 0; j < keys.length; ++j) {
-    const parts = keys[j].split('.');
+
+  for (const key of keys) {
+    const parts = key.split('.');
     const c = [];
-    for (let k = 0; k < parts.length; ++k) {
-      c.push(parts[k]);
+
+    for (const part of parts) {
+      c.push(part);
       hasIncludedChildren[c.join('.')] = 1;
     }
   }
@@ -581,6 +583,7 @@ function markArraySubdocsPopulated(doc, populated) {
       if (val == null) {
         continue;
       }
+
       if (val.isMongooseDocumentArray) {
         for (let j = 0; j < val.length; ++j) {
           val[j].populated(rest, item._docs[id] == null ? [] : item._docs[id][j], item);
@@ -2902,10 +2905,8 @@ function applyQueue(doc) {
   if (!q.length) {
     return;
   }
-  let pair;
 
-  for (let i = 0; i < q.length; ++i) {
-    pair = q[i];
+  for (const pair of q) {
     if (pair[0] !== 'pre' && pair[0] !== 'post' && pair[0] !== 'on') {
       doc[pair[0]].apply(doc, pair[1]);
     }
@@ -3552,8 +3553,8 @@ Document.prototype.populate = function populate() {
   if (args.length) {
     // use hash to remove duplicate paths
     const res = utils.populate.apply(null, args);
-    for (let i = 0; i < res.length; ++i) {
-      pop[res[i].path] = res[i];
+    for (const populateOptions of res) {
+      pop[populateOptions.path] = populateOptions;
     }
   }
 
@@ -3711,16 +3712,17 @@ Document.prototype.depopulate = function(path) {
   if (typeof path === 'string') {
     path = path.split(' ');
   }
+
   let populatedIds;
   const virtualKeys = this.$$populatedVirtuals ? Object.keys(this.$$populatedVirtuals) : [];
   const populated = get(this, '$__.populated', {});
 
   if (arguments.length === 0) {
     // Depopulate all
-    for (let i = 0; i < virtualKeys.length; i++) {
-      delete this.$$populatedVirtuals[virtualKeys[i]];
-      delete this._doc[virtualKeys[i]];
-      delete populated[virtualKeys[i]];
+    for (const virtualKey of virtualKeys) {
+      delete this.$$populatedVirtuals[virtualKey];
+      delete this._doc[virtualKey];
+      delete populated[virtualKey];
     }
 
     const keys = Object.keys(populated);
@@ -3736,15 +3738,15 @@ Document.prototype.depopulate = function(path) {
     return this;
   }
 
-  for (let i = 0; i < path.length; i++) {
-    populatedIds = this.populated(path[i]);
-    delete populated[path[i]];
+  for (const singlePath of path) {
+    populatedIds = this.populated(singlePath);
+    delete populated[singlePath];
 
-    if (virtualKeys.indexOf(path[i]) !== -1) {
-      delete this.$$populatedVirtuals[path[i]];
-      delete this._doc[path[i]];
+    if (virtualKeys.indexOf(singlePath) !== -1) {
+      delete this.$$populatedVirtuals[singlePath];
+      delete this._doc[singlePath];
     } else if (populatedIds) {
-      this.$set(path[i], populatedIds);
+      this.$set(singlePath, populatedIds);
     }
   }
   return this;

--- a/lib/document.js
+++ b/lib/document.js
@@ -532,8 +532,7 @@ Document.prototype.$__init = function(doc, opts) {
   // If doc._id is not null or undefined
   if (doc._id != null && opts.populated && opts.populated.length) {
     const id = String(doc._id);
-    for (let i = 0; i < opts.populated.length; ++i) {
-      const item = opts.populated[i];
+    for (const item of opts.populated) {
       if (item.isVirtual) {
         this.populated(item.path, utils.getValue(item.path, doc), item);
       } else {
@@ -3726,13 +3725,13 @@ Document.prototype.depopulate = function(path) {
 
     const keys = Object.keys(populated);
 
-    for (let i = 0; i < keys.length; i++) {
-      populatedIds = this.populated(keys[i]);
+    for (const key of keys) {
+      populatedIds = this.populated(key);
       if (!populatedIds) {
         continue;
       }
-      delete populated[keys[i]];
-      this.$set(keys[i], populatedIds);
+      delete populated[key];
+      this.$set(key, populatedIds);
     }
     return this;
   }

--- a/lib/error/validator.js
+++ b/lib/error/validator.js
@@ -63,14 +63,15 @@ ValidatorError.prototype.formatMessage = function(msg, properties) {
   if (typeof msg === 'function') {
     return msg(properties);
   }
+
   const propertyNames = Object.keys(properties);
-  for (let i = 0; i < propertyNames.length; ++i) {
-    const propertyName = propertyNames[i];
+  for (const propertyName of propertyNames) {
     if (propertyName === 'message') {
       continue;
     }
     msg = msg.replace('{' + propertyName.toUpperCase() + '}', properties[propertyName]);
   }
+
   return msg;
 };
 

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -128,8 +128,10 @@ function cloneObject(obj, options, isArrayChild) {
 
 function cloneArray(arr, options) {
   const ret = [];
-  for (let i = 0, l = arr.length; i < l; i++) {
-    ret.push(clone(arr[i], options, true));
+
+  for (const item of arr) {
+    ret.push(clone(item, options, true));
   }
+
   return ret;
 }

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -59,9 +59,9 @@ function applyHooks(model, schema, options) {
     applyHooks(childModel, type.schema, options);
     if (childModel.discriminators != null) {
       const keys = Object.keys(childModel.discriminators);
-      for (let j = 0; j < keys.length; ++j) {
-        applyHooks(childModel.discriminators[keys[j]],
-          childModel.discriminators[keys[j]].schema, options);
+      for (const key of keys) {
+        applyHooks(childModel.discriminators[key],
+          childModel.discriminators[key].schema, options);
       }
     }
   }

--- a/lib/helpers/model/discriminator.js
+++ b/lib/helpers/model/discriminator.js
@@ -80,9 +80,10 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     // See gh-6076
     const baseSchemaPaths = Object.keys(baseSchema.paths);
     const conflictingPaths = [];
-    for (let i = 0; i < baseSchemaPaths.length; ++i) {
-      if (schema.nested[baseSchemaPaths[i]]) {
-        conflictingPaths.push(baseSchemaPaths[i]);
+
+    for (const path of baseSchemaPaths) {
+      if (schema.nested[path]) {
+        conflictingPaths.push(path);
       }
     }
 
@@ -95,8 +96,8 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     });
 
     // Clean up conflicting paths _after_ merging re: gh-6076
-    for (let i = 0; i < conflictingPaths.length; ++i) {
-      delete schema.paths[conflictingPaths[i]];
+    for (const conflictingPath of conflictingPaths) {
+      delete schema.paths[conflictingPath];
     }
 
     // Rebuild schema models because schemas may have been merged re: #7884
@@ -134,18 +135,16 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     const keys = Object.keys(schema.options);
     schema.options.discriminatorKey = baseSchema.options.discriminatorKey;
 
-    for (let i = 0; i < keys.length; ++i) {
-      const _key = keys[i];
+    for (const _key of keys) {
       if (!CUSTOMIZABLE_DISCRIMINATOR_OPTIONS[_key]) {
         if (!utils.deepEqual(schema.options[_key], baseSchema.options[_key])) {
           throw new Error('Can\'t customize discriminator option ' + _key +
-              ' (can only modify ' +
-              Object.keys(CUSTOMIZABLE_DISCRIMINATOR_OPTIONS).join(', ') +
-              ')');
+          ' (can only modify ' +
+          Object.keys(CUSTOMIZABLE_DISCRIMINATOR_OPTIONS).join(', ') +
+          ')');
         }
       }
     }
-
     schema.options = utils.clone(baseSchema.options);
     if (toJSON) schema.options.toJSON = toJSON;
     if (toObject) schema.options.toObject = toObject;

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -53,11 +53,12 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     let normalizedRefPath = _firstWithRefPath ? get(_firstWithRefPath, 'options.refPath', null) : null;
 
     if (Array.isArray(schema)) {
-      for (let j = 0; j < schema.length; ++j) {
+      const schemasArray = schema;
+      for (const _schema of schemasArray) {
         let _modelNames;
         let res;
         try {
-          res = _getModelNames(doc, schema[j]);
+          res = _getModelNames(doc, _schema);
           _modelNames = res.modelNames;
           isRefPath = isRefPath || res.isRefPath;
           normalizedRefPath = normalizeRefPath(normalizedRefPath, doc, options.path) ||
@@ -73,9 +74,9 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
           continue;
         }
         modelNames = modelNames || [];
-        for (let x = 0; x < _modelNames.length; ++x) {
-          if (modelNames.indexOf(_modelNames[x]) === -1) {
-            modelNames.push(_modelNames[x]);
+        for (const modelName of _modelNames) {
+          if (modelNames.indexOf(modelName) === -1) {
+            modelNames.push(modelName);
           }
         }
       }
@@ -216,8 +217,8 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     if (isRefPath && normalizedRefPath != null) {
       const pieces = normalizedRefPath.split('.');
       let cur = '';
-      for (let i = 0; i < pieces.length; ++i) {
-        cur = cur + (cur.length === 0 ? '' : '.') + pieces[i];
+      for (const piece of pieces) {
+        cur = cur + (cur.length === 0 ? '' : '.') + piece;
         const schematype = modelSchema.path(cur);
         if (schematype != null &&
             schematype.$isMongooseArray &&

--- a/lib/helpers/populate/getSchemaTypes.js
+++ b/lib/helpers/populate/getSchemaTypes.js
@@ -88,10 +88,10 @@ module.exports = function getSchemaTypes(schema, doc, path) {
 
           if (schemas != null && schemas.length > 0) {
             ret = [];
-            for (let i = 0; i < schemas.length; ++i) {
+            for (const schema of schemas) {
               const _ret = search(
                 parts.slice(p),
-                schemas[i],
+                schema,
                 subdoc ? mpath.get(trypath, subdoc) : null,
                 nestedPath.concat(parts.slice(0, p))
               );

--- a/lib/helpers/query/selectPopulatedFields.js
+++ b/lib/helpers/query/selectPopulatedFields.js
@@ -11,17 +11,17 @@ module.exports = function selectPopulatedFields(query) {
     const paths = Object.keys(opts.populate);
     const userProvidedFields = query._userProvidedFields || {};
     if (query.selectedInclusively()) {
-      for (let i = 0; i < paths.length; ++i) {
-        if (!isPathInFields(userProvidedFields, paths[i])) {
-          query.select(paths[i]);
-        } else if (userProvidedFields[paths[i]] === 0) {
-          delete query._fields[paths[i]];
+      for (const path of paths) {
+        if (!isPathInFields(userProvidedFields, path)) {
+          query.select(path);
+        } else if (userProvidedFields[path] === 0) {
+          delete query._fields[path];
         }
       }
     } else if (query.selectedExclusively()) {
-      for (let i = 0; i < paths.length; ++i) {
-        if (userProvidedFields[paths[i]] == null) {
-          delete query._fields[paths[i]];
+      for (const path of paths) {
+        if (userProvidedFields[path] == null) {
+          delete query._fields[path];
         }
       }
     }

--- a/lib/helpers/schema/applyPlugins.js
+++ b/lib/helpers/schema/applyPlugins.js
@@ -7,8 +7,8 @@ module.exports = function applyPlugins(schema, plugins, options, cacheKey) {
   schema[cacheKey] = true;
 
   if (!options || !options.skipTopLevel) {
-    for (let i = 0; i < plugins.length; ++i) {
-      schema.plugin(plugins[i][0], plugins[i][1]);
+    for (const plugin of plugins) {
+      schema.plugin(plugin[0], plugin[1]);
     }
   }
 
@@ -35,8 +35,7 @@ module.exports = function applyPlugins(schema, plugins, options, cacheKey) {
   const applyPluginsToDiscriminators = options.applyPluginsToDiscriminators;
 
   const keys = Object.keys(discriminators);
-  for (let i = 0; i < keys.length; ++i) {
-    const discriminatorKey = keys[i];
+  for (const discriminatorKey of keys) {
     const discriminatorSchema = discriminators[discriminatorKey];
 
     applyPlugins(discriminatorSchema, plugins,

--- a/lib/helpers/schema/getIndexes.js
+++ b/lib/helpers/schema/getIndexes.js
@@ -24,10 +24,8 @@ module.exports = function getIndexes(schema) {
 
     prefix = prefix || '';
     const keys = Object.keys(schema.paths);
-    const length = keys.length;
 
-    for (let i = 0; i < length; ++i) {
-      const key = keys[i];
+    for (const key of keys) {
       const path = schema.paths[key];
       if (baseSchema != null && baseSchema.paths[key]) {
         // If looking at an embedded discriminator schema, don't look at paths

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -171,43 +171,27 @@ module.exports = function(query, schema, castedDoc, options, callback) {
   }
 
   const arrayUpdates = Object.keys(arrayAtomicUpdates);
-  for (i = 0; i < arrayUpdates.length; ++i) {
-    (function(i) {
-      let schemaPath = schema._getSchema(arrayUpdates[i]);
-      if (schemaPath && schemaPath.$isMongooseDocumentArray) {
+  for (const arrayUpdate of arrayUpdates) {
+    let schemaPath = schema._getSchema(arrayUpdate);
+    if (schemaPath && schemaPath.$isMongooseDocumentArray) {
+      validatorsToExecute.push(function(callback) {
+        schemaPath.doValidate(
+          arrayAtomicUpdates[arrayUpdate],
+          getValidationCallback(arrayUpdate, validationErrors, callback),
+          options && options.context === 'query' ? query : null);
+      });
+    } else {
+      schemaPath = schema._getSchema(arrayUpdate + '.0');
+      for (const atomicUpdate of arrayAtomicUpdates[arrayUpdate]) {
         validatorsToExecute.push(function(callback) {
           schemaPath.doValidate(
-            arrayAtomicUpdates[arrayUpdates[i]],
-            function(err) {
-              if (err) {
-                err.path = arrayUpdates[i];
-                validationErrors.push(err);
-              }
-              callback(null);
-            },
-            options && options.context === 'query' ? query : null);
+            atomicUpdate,
+            getValidationCallback(arrayUpdate, validationErrors, callback),
+            options && options.context === 'query' ? query : null,
+            { updateValidator: true });
         });
-      } else {
-        schemaPath = schema._getSchema(arrayUpdates[i] + '.0');
-        for (let j = 0; j < arrayAtomicUpdates[arrayUpdates[i]].length; ++j) {
-          (function(j) {
-            validatorsToExecute.push(function(callback) {
-              schemaPath.doValidate(
-                arrayAtomicUpdates[arrayUpdates[i]][j],
-                function(err) {
-                  if (err) {
-                    err.path = arrayUpdates[i];
-                    validationErrors.push(err);
-                  }
-                  callback(null);
-                },
-                options && options.context === 'query' ? query : null,
-                { updateValidator: true });
-            });
-          })(j);
-        }
       }
-    })(i);
+    }
   }
 
   if (callback != null) {
@@ -250,4 +234,15 @@ module.exports = function(query, schema, castedDoc, options, callback) {
     }
     callback(null);
   }
+
+  function getValidationCallback(arrayUpdate, validationErrors, callback) {
+    return function(err) {
+      if (err) {
+        err.path = arrayUpdate;
+        validationErrors.push(err);
+      }
+      callback(null);
+    };
+  }
 };
+

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -171,8 +171,7 @@ module.exports = function(query, schema, castedDoc, options, callback) {
   }
 
   const arrayUpdates = Object.keys(arrayAtomicUpdates);
-  const numArrayUpdates = arrayUpdates.length;
-  for (i = 0; i < numArrayUpdates; ++i) {
+  for (i = 0; i < arrayUpdates.length; ++i) {
     (function(i) {
       let schemaPath = schema._getSchema(arrayUpdates[i]);
       if (schemaPath && schemaPath.$isMongooseDocumentArray) {

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -227,9 +227,11 @@ module.exports = function(query, schema, castedDoc, options, callback) {
   function _done(callback) {
     if (validationErrors.length) {
       const err = new ValidationError(null);
-      for (let i = 0; i < validationErrors.length; ++i) {
-        err.addError(validationErrors[i].path, validationErrors[i]);
+
+      for (const validationError of validationErrors) {
+        err.addError(validationError.path, validationError);
       }
+
       return callback(err);
     }
     callback(null);

--- a/lib/model.js
+++ b/lib/model.js
@@ -3368,10 +3368,12 @@ Model.$__insertMany = function(arr, options, callback) {
         callback(error, null);
         return;
       }
-      for (let i = 0; i < docAttributes.length; ++i) {
-        docAttributes[i].$__reset();
-        _setIsNew(docAttributes[i], false);
+
+      for (const attribute of docAttributes) {
+        attribute.$__reset();
+        _setIsNew(attribute, false);
       }
+
       if (rawResult) {
         if (ordered === false) {
           // Decorate with mongoose validation errors in case of unordered,
@@ -4273,16 +4275,15 @@ Model.populate = function(docs, paths, callback) {
  */
 
 function _populate(model, docs, paths, cache, callback) {
-  const length = paths.length;
   let pending = paths.length;
 
-  if (length === 0) {
+  if (paths.length === 0) {
     return callback(null, docs);
   }
 
   // each path has its own query options and must be executed separately
-  for (let i = 0; i < length; ++i) {
-    populate(model, docs, paths[i], next);
+  for (const path of paths) {
+    populate(model, docs, path, next);
   }
 
   function next(err) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4515,9 +4515,8 @@ function _assign(model, vals, mod, assignmentOpts) {
       _val = utils.getValue(foreignField, val);
       if (Array.isArray(_val)) {
         _val = utils.array.flatten(_val);
-        const _valLength = _val.length;
-        for (let j = 0; j < _valLength; ++j) {
-          let __val = _val[j];
+
+        for (let __val of _val) {
           if (__val instanceof Document) {
             __val = __val._id;
           }

--- a/lib/model.js
+++ b/lib/model.js
@@ -4015,12 +4015,14 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
       paths = paths.filter(p => {
         const pieces = p.split('.');
         let cur = pieces[0];
-        for (let i = 0; i < pieces.length; ++i) {
+
+        for (const piece of pieces) {
           if (_pathsToValidate.has(cur)) {
             return true;
           }
-          cur += '.' + pieces[i];
+          cur += '.' + piece;
         }
+
         return _pathsToValidate.has(p);
       });
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -70,9 +70,8 @@ function Query(conditions, options, model, collection) {
   // this is the case where we have a CustomQuery, we need to check if we got
   // options passed in, and if we did, merge them in
   const keys = Object.keys(options);
-  for (let i = 0; i < keys.length; ++i) {
-    const k = keys[i];
-    this._mongooseOptions[k] = options[k];
+  for (const key of keys) {
+    this._mongooseOptions[key] = options[key];
   }
 
   if (collection) {
@@ -4604,14 +4603,14 @@ Query.prototype.populate = function() {
     const readConcern = this.options.readConcern;
     const readPref = this.options.readPreference;
 
-    for (let i = 0; i < res.length; ++i) {
-      if (readConcern != null && get(res[i], 'options.readConcern') == null) {
-        res[i].options = res[i].options || {};
-        res[i].options.readConcern = readConcern;
+    for (const populateOptions of res) {
+      if (readConcern != null && get(populateOptions, 'options.readConcern') == null) {
+        populateOptions.options = populateOptions.options || {};
+        populateOptions.options.readConcern = readConcern;
       }
-      if (readPref != null && get(res[i], 'options.readPreference') == null) {
-        res[i].options = res[i].options || {};
-        res[i].options.readPreference = readPref;
+      if (readPref != null && get(populateOptions, 'options.readPreference') == null) {
+        populateOptions.options = populateOptions.options || {};
+        populateOptions.options.readPreference = readPref;
       }
     }
   }
@@ -4620,10 +4619,10 @@ Query.prototype.populate = function() {
 
   if (opts.lean != null) {
     const lean = opts.lean;
-    for (let i = 0; i < res.length; ++i) {
-      if (get(res[i], 'options.lean') == null) {
-        res[i].options = res[i].options || {};
-        res[i].options.lean = lean;
+    for (const populateOptions of res) {
+      if (get(populateOptions, 'options.lean') == null) {
+        populateOptions.options = populateOptions.options || {};
+        populateOptions.options.lean = lean;
       }
     }
   }
@@ -4634,12 +4633,13 @@ Query.prototype.populate = function() {
 
   const pop = opts.populate;
 
-  for (let i = 0; i < res.length; ++i) {
-    const path = res[i].path;
-    if (pop[path] && pop[path].populate && res[i].populate) {
-      res[i].populate = pop[path].populate.concat(res[i].populate);
+  for (const populateOptions of res) {
+    const path = populateOptions.path;
+    if (pop[path] && pop[path].populate && populateOptions.populate) {
+      populateOptions.populate = pop[path].populate.concat(populateOptions.populate);
     }
-    pop[res[i].path] = res[i];
+
+    pop[populateOptions.path] = populateOptions;
   }
 
   return this;
@@ -5326,12 +5326,7 @@ Query.prototype.selectedExclusively = function selectedExclusively() {
   }
 
   const keys = Object.keys(this._fields);
-  if (keys.length === 0) {
-    return false;
-  }
-
-  for (let i = 0; i < keys.length; ++i) {
-    const key = keys[i];
+  for (const key of keys) {
     if (key === '_id') {
       continue;
     }

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -174,8 +174,8 @@ exports.applyPaths = function applyPaths(fields, schema) {
     // check for parent exclusions
     const pieces = path.split('.');
     let cur = '';
-    for (let i = 0; i < pieces.length; ++i) {
-      cur += cur.length ? '.' + pieces[i] : pieces[i];
+    for (const piece of pieces) {
+      cur += cur.length ? '.' + piece : piece;
       if (excluded.indexOf(cur) !== -1) {
         return;
       }
@@ -186,8 +186,8 @@ exports.applyPaths = function applyPaths(fields, schema) {
     // project out everything else under the parent path
     if (!exclude && get(type, 'options.$skipDiscriminatorCheck', false)) {
       let cur = '';
-      for (let i = 0; i < pieces.length; ++i) {
-        cur += (cur.length === 0 ? '' : '.') + pieces[i];
+      for (const piece of pieces) {
+        cur += (cur.length === 0 ? '' : '.') + piece;
         const projection = get(fields, cur, false);
         if (projection && typeof projection !== 'object') {
           return;
@@ -203,8 +203,8 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
   switch (exclude) {
     case true:
-      for (let i = 0; i < excluded.length; ++i) {
-        fields[excluded[i]] = 0;
+      for (const fieldName of excluded) {
+        fields[fieldName] = 0;
       }
       break;
     case false:
@@ -214,8 +214,8 @@ exports.applyPaths = function applyPaths(fields, schema) {
           schema.paths['_id'].options.select === false) {
         fields._id = 0;
       }
-      for (let i = 0; i < selected.length; ++i) {
-        fields[selected[i]] = 1;
+      for (const fieldName of selected) {
+        fields[fieldName] = 1;
       }
       break;
     case undefined:
@@ -231,8 +231,8 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
       // user didn't specify fields, implies returning all fields.
       // only need to apply excluded fields and delete any plus paths
-      for (let i = 0; i < excluded.length; ++i) {
-        fields[excluded[i]] = 0;
+      for (const fieldName of excluded) {
+        fields[fieldName] = 0;
       }
       break;
   }

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -163,9 +163,8 @@ exports.applyPaths = function applyPaths(fields, schema) {
         fields._id = 0;
       }
 
-      for (let i = 0; i < selected.length; ++i) {
-        const fieldSelectionValue = fields[selected[i]] != null ? fields[selected[i]] : 1;
-        fields[selected[i]] = fieldSelectionValue;
+      for (const fieldName of selected) {
+        fields[fieldName] = fields[fieldName] || 1;
       }
       break;
     case undefined:

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -460,8 +460,7 @@ Schema.prototype.add = function add(obj, prefix) {
   prefix = prefix || '';
   const keys = Object.keys(obj);
 
-  for (let i = 0; i < keys.length; ++i) {
-    const key = keys[i];
+  for (const key of keys) {
     const fullPath = prefix + key;
 
     if (obj[key] == null) {
@@ -1486,10 +1485,9 @@ Schema.prototype.plugin = function(fn, opts) {
       'got "' + (typeof fn) + '"');
   }
 
-  if (opts &&
-      opts.deduplicate) {
-    for (let i = 0; i < this.plugins.length; ++i) {
-      if (this.plugins[i].fn === fn) {
+  if (opts && opts.deduplicate) {
+    for (const plugin of this.plugins) {
+      if (plugin.fn === fn) {
         return this;
       }
     }
@@ -1908,10 +1906,13 @@ Schema.prototype.remove = function(path) {
 function _deletePath(schema, name) {
   const pieces = name.split('.');
   const last = pieces.pop();
+
   let branch = schema.tree;
-  for (let i = 0; i < pieces.length; ++i) {
-    branch = branch[pieces[i]];
+
+  for (const piece of pieces) {
+    branch = branch[piece];
   }
+
   delete branch[last];
 }
 

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -534,8 +534,8 @@ handle.$or = handle.$and = function(val) {
   }
 
   const ret = [];
-  for (let i = 0; i < val.length; ++i) {
-    ret.push(cast(this.casterConstructor.schema, val[i]));
+  for (const obj of val) {
+    ret.push(cast(this.casterConstructor.schema, obj));
   }
 
   return ret;

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -224,9 +224,9 @@ SchemaString.prototype.enum = function() {
     errorMessage = MongooseError.messages.String.enum;
   }
 
-  for (let i = 0; i < values.length; i++) {
-    if (undefined !== values[i]) {
-      this.enumValues.push(this.cast(values[i]));
+  for (const value of values) {
+    if (value !== undefined) {
+      this.enumValues.push(this.cast(value));
     }
   }
 

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -972,17 +972,17 @@ SchemaType.prototype.getDefault = function(scope, init) {
 SchemaType.prototype._applySetters = function(value, scope, init, priorVal) {
   let v = value;
   const setters = this.setters;
-  let len = setters.length;
   const caster = this.caster;
 
-  while (len--) {
-    v = setters[len].call(scope, v, this);
+  for (const setter of setters) {
+    v = setter.call(scope, v, this);
   }
 
   if (Array.isArray(v) && caster && caster.setters) {
     const newVal = [];
-    for (let i = 0; i < v.length; i++) {
-      newVal.push(caster.applySetters(v[i], scope, init, priorVal));
+
+    for (const value of v) {
+      newVal.push(caster.applySetters(value, scope, init, priorVal));
     }
     v = newVal;
   }

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -980,9 +980,10 @@ SchemaType.prototype._applySetters = function(value, scope, init, priorVal) {
   const setters = this.setters;
   const caster = this.caster;
 
-  for (const setter of setters) {
+  for (const setter of utils.clone(setters).reverse()) {
     v = setter.call(scope, v, this);
   }
+
 
   if (Array.isArray(v) && caster && caster.setters) {
     const newVal = [];
@@ -992,6 +993,7 @@ SchemaType.prototype._applySetters = function(value, scope, init, priorVal) {
     }
     v = newVal;
   }
+
 
   return v;
 };

--- a/lib/types/core_array.js
+++ b/lib/types/core_array.js
@@ -911,8 +911,8 @@ function _isAllSubdocs(docs, ref) {
   if (!ref) {
     return false;
   }
-  for (let i = 0; i < docs.length; ++i) {
-    const arg = docs[i];
+
+  for (const arg of docs) {
     if (arg == null) {
       return false;
     }

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -135,25 +135,26 @@ class CoreDocumentArray extends CoreMongooseArray {
       casted = null;
     }
 
-    for (let i = 0, l = this.length; i < l; i++) {
-      if (!this[i]) {
+    for (const val of this) {
+      if (!val) {
         continue;
       }
-      _id = this[i].get('_id');
+
+      _id = val.get('_id');
 
       if (_id === null || typeof _id === 'undefined') {
         continue;
       } else if (_id instanceof Document) {
         sid || (sid = String(id));
         if (sid == _id._id) {
-          return this[i];
+          return val;
         }
       } else if (!(id instanceof ObjectId) && !(_id instanceof ObjectId)) {
         if (utils.deepEqual(id, _id)) {
-          return this[i];
+          return val;
         }
       } else if (casted == _id) {
-        return this[i];
+        return val;
       }
     }
 

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -138,9 +138,11 @@ class MongooseMap extends Map {
     if (!this.$__deferred) {
       return;
     }
-    for (let i = 0; i < this.$__deferred.length; ++i) {
-      this.set(this.$__deferred[i].key, this.$__deferred[i].value);
+
+    for (const keyValueObject of this.$__deferred) {
+      this.set(keyValueObject.key, keyValueObject.value);
     }
+
     this.$__deferred = null;
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -301,8 +301,8 @@ exports.toObject = function toObject(obj) {
   if (Array.isArray(obj)) {
     ret = [];
 
-    for (let i = 0, len = obj.length; i < len; ++i) {
-      ret.push(toObject(obj[i]));
+    for (const doc of obj) {
+      ret.push(toObject(doc));
     }
 
     return ret;
@@ -557,8 +557,8 @@ function _populateObj(obj) {
     obj.options = exports.clone(obj.options);
   }
 
-  for (let i = 0; i < paths.length; ++i) {
-    ret.push(new PopulateOptions(Object.assign({}, obj, { path: paths[i] })));
+  for (const path of paths) {
+    ret.push(new PopulateOptions(Object.assign({}, obj, { path: path })));
   }
 
   return ret;
@@ -737,22 +737,22 @@ exports.array.unique = function(arr) {
   const primitives = {};
   const ids = {};
   const ret = [];
-  const length = arr.length;
-  for (let i = 0; i < length; ++i) {
-    if (typeof arr[i] === 'number' || typeof arr[i] === 'string' || arr[i] == null) {
-      if (primitives[arr[i]]) {
+
+  for (const item of arr) {
+    if (typeof item === 'number' || typeof item === 'string' || item == null) {
+      if (primitives[item]) {
         continue;
       }
-      ret.push(arr[i]);
-      primitives[arr[i]] = true;
-    } else if (arr[i] instanceof ObjectId) {
-      if (ids[arr[i].toString()]) {
+      ret.push(item);
+      primitives[item] = true;
+    } else if (item instanceof ObjectId) {
+      if (ids[item.toString()]) {
         continue;
       }
-      ret.push(arr[i]);
-      ids[arr[i].toString()] = true;
+      ret.push(item);
+      ids[item.toString()] = true;
     } else {
-      ret.push(arr[i]);
+      ret.push(item);
     }
   }
 
@@ -873,8 +873,8 @@ exports.mergeClone = function(to, fromObj) {
  */
 
 exports.each = function(arr, fn) {
-  for (let i = 0; i < arr.length; ++i) {
-    fn(arr[i]);
+  for (const item of arr) {
+    fn(item);
   }
 };
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -6339,9 +6339,9 @@ describe('document', function() {
         name: {
           type: String,
           set: function(v) {
-            const sp = v.split(' ');
-            for (let i = 0; i < sp.length; ++i) {
-              this.keywords.push(sp[i]);
+            const splitStrings = v.split(' ');
+            for (const keyword of splitStrings) {
+              this.keywords.push(keyword);
             }
             return v;
           }

--- a/test/model.geosearch.test.js
+++ b/test/model.geosearch.test.js
@@ -43,8 +43,8 @@ describe('model', function() {
         geos[3] = new Geo({ pos: [1, -1], type: 'house' });
         let count = geos.length;
 
-        for (let i = 0; i < geos.length; i++) {
-          geos[i].save(function(err) {
+        for (const geo of geos) {
+          geo.save(function(err) {
             assert.ifError(err);
             --count || next();
           });
@@ -84,8 +84,8 @@ describe('model', function() {
         geos[3] = new Geo({ pos: [1, -1], type: 'house' });
         let count = geos.length;
 
-        for (let i = 0; i < geos.length; i++) {
-          geos[i].save(function(err) {
+        for (const geo of geos) {
+          geo.save(function(err) {
             assert.ifError(err);
             --count || next();
           });

--- a/test/types.number.test.js
+++ b/test/types.number.test.js
@@ -68,8 +68,8 @@ describe('types.number', function() {
     const items = [1, '2', '0', null, '', new String('47'), new Number(5), Number(47), Number('09'), 0x12];
     let err;
     try {
-      for (let i = 0, len = items.length; i < len; ++i) {
-        n.cast(items[i]);
+      for (const item of items) {
+        n.cast(item);
       }
     } catch (e) {
       err = e;

--- a/website.js
+++ b/website.js
@@ -42,8 +42,9 @@ function getVersion() {
 
 function getLatestLegacyVersion(startsWith) {
   const hist = fs.readFileSync('./History.md', 'utf8').replace(/\r/g, '\n').split('\n');
-  for (let i = 0; i < hist.length; ++i) {
-    const line = (hist[i] || '').trim();
+
+  for (const rawLine of hist) {
+    const line = (rawLine || '').trim();
     if (!line) {
       continue;
     }
@@ -52,6 +53,7 @@ function getLatestLegacyVersion(startsWith) {
       return match[1];
     }
   }
+
   throw new Error('no match found');
 }
 


### PR DESCRIPTION
I've always found it shorter, and clearer to use for..of
```js
for (const item of arr) {
  // do stuff
}
```
instead of using indexes
```js
for (let i = 0; i < arr.length; i++) {
  const item = arr[i]; 
  // do stuff
}
```

Of course there are cases where indexes are necessary, those will not be changed, waiting to hear if @vkarpov15 approves of these changes, I'd like to take the time and refactor this wherever possible in the codebase.