### PR TITLE
fix: validate nested paths on Model.validate(...)

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2136,10 +2136,10 @@ function _getPathsToValidate(doc) {
   }));
 
 
-  function addToPaths(p) { paths.add(p); }
   Object.keys(doc.$__.activePaths.states.init).forEach(addToPaths);
   Object.keys(doc.$__.activePaths.states.modify).forEach(addToPaths);
   Object.keys(doc.$__.activePaths.states.default).forEach(addToPaths);
+  function addToPaths(p) { paths.add(p); }
 
   const subdocs = doc.$__getAllSubdocs();
   const modifiedPaths = doc.modifiedPaths();
@@ -2340,9 +2340,9 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
     total++;
 
     process.nextTick(function() {
-      const p = _this.schema.path(path);
+      const schemaType = _this.schema.path(path);
 
-      if (!p) {
+      if (!schemaType) {
         return --total || complete();
       }
 
@@ -2369,11 +2369,11 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
         skipSchemaValidators: skipSchemaValidators[path],
         path: path
       };
-      p.doValidate(val, function(err) {
-        if (err && (!p.$isMongooseDocumentArray || err.$isArrayValidatorError)) {
-          if (p.$isSingleNested &&
+      schemaType.doValidate(val, function(err) {
+        if (err && (!schemaType.$isMongooseDocumentArray || err.$isArrayValidatorError)) {
+          if (schemaType.$isSingleNested &&
               err instanceof ValidationError &&
-              p.schema.options.storeSubdocValidationError === false) {
+              schemaType.schema.options.storeSubdocValidationError === false) {
             return --total || complete();
           }
           _this.invalidate(path, err, undefined, true);

--- a/lib/model.js
+++ b/lib/model.js
@@ -4082,7 +4082,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
           }
         }
         _checkDone();
-      }, context);
+      }, context, { path: path });
     }
 
     function pushNestedArrayPaths(nestedArray, path) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4029,11 +4029,22 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
       });
     }
 
+    for (const path of paths) {
+      const schemaType = schema.path(path);
+      if (!schemaType || !schemaType.$isMongooseArray) {
+        continue;
+      }
+
+      const val = get(obj, path);
+      pushNestedArrayPaths(val, path);
+    }
+
     let remaining = paths.length;
     let error = null;
+
     for (const path of paths) {
-      const schematype = schema.path(path);
-      if (schematype == null) {
+      const schemaType = schema.path(path);
+      if (schemaType == null) {
         _checkDone();
         continue;
       }
@@ -4048,7 +4059,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
 
       if (val != null) {
         try {
-          val = schematype.cast(val);
+          val = schemaType.cast(val);
           cur[pieces[pieces.length - 1]] = val;
         } catch (err) {
           error = error || new ValidationError();
@@ -4059,7 +4070,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
         }
       }
 
-      schematype.doValidate(val, err => {
+      schemaType.doValidate(val, err => {
         if (err) {
           error = error || new ValidationError();
           if (err instanceof ValidationError) {
@@ -4072,6 +4083,20 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
         }
         _checkDone();
       }, context);
+    }
+
+    function pushNestedArrayPaths(nestedArray, path) {
+      if (nestedArray == null) {
+        return;
+      }
+
+      for (let i = 0; i < nestedArray.length; ++i) {
+        if (Array.isArray(nestedArray[i])) {
+          pushNestedArrayPaths(nestedArray[i], path + '.' + i);
+        } else {
+          paths.push(path + '.' + i);
+        }
+      }
     }
 
     function _checkDone() {

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1227,24 +1227,12 @@ function asyncValidate(validator, scope, value, props, cb) {
  */
 
 SchemaType.prototype.doValidateSync = function(value, scope, options) {
-  let err = null;
   const path = this.path;
   const count = this.validators.length;
 
   if (!count) {
     return null;
   }
-
-  const validate = function(ok, validatorProperties) {
-    if (err) {
-      return;
-    }
-    if (ok !== undefined && !ok) {
-      const ErrorConstructor = validatorProperties.ErrorConstructor || ValidatorError;
-      err = new ErrorConstructor(validatorProperties);
-      err[validatorErrorSymbol] = true;
-    }
-  };
 
   let validators = this.validators;
   if (value === void 0) {
@@ -1255,6 +1243,7 @@ SchemaType.prototype.doValidateSync = function(value, scope, options) {
     }
   }
 
+  let err = null;
   validators.forEach(function(v) {
     if (err) {
       return;
@@ -1278,28 +1267,44 @@ SchemaType.prototype.doValidateSync = function(value, scope, options) {
 
     if (validator instanceof RegExp) {
       validate(validator.test(value), validatorProperties);
-    } else if (typeof validator === 'function') {
-      try {
-        if (validatorProperties.propsParameter) {
-          ok = validator.call(scope, value, validatorProperties);
-        } else {
-          ok = validator.call(scope, value);
-        }
-      } catch (error) {
-        ok = false;
-        validatorProperties.reason = error;
-      }
-
-      // Skip any validators that return a promise, we can't handle those
-      // synchronously
-      if (ok != null && typeof ok.then === 'function') {
-        return;
-      }
-      validate(ok, validatorProperties);
+      return;
     }
+
+    if (typeof validator !== 'function') {
+      return;
+    }
+
+    try {
+      if (validatorProperties.propsParameter) {
+        ok = validator.call(scope, value, validatorProperties);
+      } else {
+        ok = validator.call(scope, value);
+      }
+    } catch (error) {
+      ok = false;
+      validatorProperties.reason = error;
+    }
+
+    // Skip any validators that return a promise, we can't handle those
+    // synchronously
+    if (ok != null && typeof ok.then === 'function') {
+      return;
+    }
+    validate(ok, validatorProperties);
   });
 
   return err;
+
+  function validate(ok, validatorProperties) {
+    if (err) {
+      return;
+    }
+    if (ok !== undefined && !ok) {
+      const ErrorConstructor = validatorProperties.ErrorConstructor || ValidatorError;
+      err = new ErrorConstructor(validatorProperties);
+      err[validatorErrorSymbol] = true;
+    }
+  }
 };
 
 /**

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1089,7 +1089,68 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     return fn(null);
   }
 
-  const validate = function(ok, validatorProperties) {
+  const _this = this;
+  validators.forEach(function(v) {
+    if (err) {
+      return;
+    }
+
+    const validator = v.validator;
+    let ok;
+
+    const validatorProperties = utils.clone(v);
+    validatorProperties.path = options && options.path ? options.path : path;
+    validatorProperties.value = value;
+
+    if (validator instanceof RegExp) {
+      validate(validator.test(value), validatorProperties);
+      return;
+    }
+
+    if (typeof validator !== 'function') {
+      return;
+    }
+
+    if (value === undefined && validator !== _this.requiredValidator) {
+      validate(true, validatorProperties);
+      return;
+    }
+
+    if (validatorProperties.isAsync) {
+      asyncValidate(validator, scope, value, validatorProperties, validate);
+      return;
+    }
+
+    try {
+      if (validatorProperties.propsParameter) {
+        ok = validator.call(scope, value, validatorProperties);
+      } else {
+        ok = validator.call(scope, value);
+      }
+    } catch (error) {
+      ok = false;
+      validatorProperties.reason = error;
+      if (error.message) {
+        validatorProperties.message = error.message;
+      }
+    }
+
+    if (ok != null && typeof ok.then === 'function') {
+      ok.then(
+        function(ok) { validate(ok, validatorProperties); },
+        function(error) {
+          validatorProperties.reason = error;
+          validatorProperties.message = error.message;
+          ok = false;
+          validate(ok, validatorProperties);
+        });
+    } else {
+      validate(ok, validatorProperties);
+    }
+
+  });
+
+  function validate(ok, validatorProperties) {
     if (err) {
       return;
     }
@@ -1107,59 +1168,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
         fn(err);
       });
     }
-  };
-
-  const _this = this;
-  validators.forEach(function(v) {
-    if (err) {
-      return;
-    }
-
-    const validator = v.validator;
-    let ok;
-
-    const validatorProperties = utils.clone(v);
-    validatorProperties.path = options && options.path ? options.path : path;
-    validatorProperties.value = value;
-
-    if (validator instanceof RegExp) {
-      validate(validator.test(value), validatorProperties);
-    } else if (typeof validator === 'function') {
-      if (value === undefined && validator !== _this.requiredValidator) {
-        validate(true, validatorProperties);
-        return;
-      }
-      if (validatorProperties.isAsync) {
-        asyncValidate(validator, scope, value, validatorProperties, validate);
-      } else {
-        try {
-          if (validatorProperties.propsParameter) {
-            ok = validator.call(scope, value, validatorProperties);
-          } else {
-            ok = validator.call(scope, value);
-          }
-        } catch (error) {
-          ok = false;
-          validatorProperties.reason = error;
-          if (error.message) {
-            validatorProperties.message = error.message;
-          }
-        }
-        if (ok != null && typeof ok.then === 'function') {
-          ok.then(
-            function(ok) { validate(ok, validatorProperties); },
-            function(error) {
-              validatorProperties.reason = error;
-              validatorProperties.message = error.message;
-              ok = false;
-              validate(ok, validatorProperties);
-            });
-        } else {
-          validate(ok, validatorProperties);
-        }
-      }
-    }
-  });
+  }
 };
 
 /*!

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6436,12 +6436,12 @@ describe('Model', function() {
 
   it('Model.validate(...) validates paths in arrays (gh-8821)', function() {
     const userSchema = new Schema({
-      friends: [{ type: String, required: true }]
+      friends: [{ type: String, required: true, minlength: 3 }]
     });
 
     const User = db.model('User', userSchema);
     return co(function*() {
-      const err = yield User.validate({ friends: [null, ''] }).catch(err => err);
+      const err = yield User.validate({ friends: [null, 'A'] }).catch(err => err);
 
       assert.ok(err.errors['friends.0']);
       assert.ok(err.errors['friends.1']);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6434,6 +6434,19 @@ describe('Model', function() {
     });
   });
 
+  it('Model.validate(...) validates paths in arrays (gh-8821)', function() {
+    const userSchema = new Schema({
+      friends: [{ type: String, required: true }]
+    });
+
+    const User = db.model('User', userSchema);
+    return co(function*() {
+      const err = yield new User({ friends: [null] }).validate().catch(err => err);
+
+      assert.ok(err.message.indexOf('`friends.0` is required') !== -1);
+    });
+  });
+
   it('sets correct `Document#op` with `save()` (gh-8439)', function() {
     const schema = Schema({ name: String });
     const ops = [];

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6441,9 +6441,10 @@ describe('Model', function() {
 
     const User = db.model('User', userSchema);
     return co(function*() {
-      const err = yield User.validate({ friends: [null] }).catch(err => err);
+      const err = yield User.validate({ friends: [null, ''] }).catch(err => err);
 
-      assert.ok(err.message.indexOf('`friends.0` is required') !== -1);
+      assert.ok(err.errors['friends.0']);
+      assert.ok(err.errors['friends.1']);
     });
   });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6441,7 +6441,7 @@ describe('Model', function() {
 
     const User = db.model('User', userSchema);
     return co(function*() {
-      const err = yield new User({ friends: [null] }).validate().catch(err => err);
+      const err = yield User.validate({ friends: [null] }).catch(err => err);
 
       assert.ok(err.message.indexOf('`friends.0` is required') !== -1);
     });


### PR DESCRIPTION
fixes: #8821

but I've been facing an issue with the errors being returned, I am getting {PATH} replaced with `friends.$` instead of `friends.0`, which would make all the errors in an array be omitted except for the last one.

@vkarpov15 I probably spent too much trying to figure this one out, any idea how I can make `SchemaType#doValidate(...)` change `friends.$` into `friends.0`?

**EDIT:** I figured it out, just needed to add `doValidateOptions: { path }`