### PR TITLE
fix(model): return validation errors when all docs are invalid & rawR…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3350,6 +3350,14 @@ Model.$__insertMany = function(arr, options, callback) {
     });
     // Quickly escape while there aren't any valid docAttributes
     if (docAttributes.length < 1) {
+      if (rawResult) {
+        const res = {
+          mongoose: {
+            validationErrors: validationErrors
+          }
+        };
+        return callback(null, res);
+      }
       callback(null, []);
       return;
     }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4651,6 +4651,83 @@ describe('Model', function() {
       });
     });
 
+    it('insertMany() validation error with ordered true when all documents are invalid', function(done) {
+      const schema = new Schema({
+        name: { type: String, required: true }
+      });
+      const Movie = db.model('Movie', schema);
+
+      const arr = [
+        { foo: 'The Phantom Menace' },
+        { foobar: 'The Force Awakens' }
+      ];
+      const opts = { ordered: true };
+      Movie.insertMany(arr, opts, function(error, res) {
+        assert.ok(error);
+        assert.equal(res, undefined);
+        assert.equal(error.name, 'ValidationError');
+        done();
+      });
+    });
+
+    it('insertMany() validation error with ordered false when all documents are invalid', function(done) {
+      const schema = new Schema({
+        name: { type: String, required: true }
+      });
+      const Movie = db.model('Movie', schema);
+
+      const arr = [
+        { foo: 'The Phantom Menace' },
+        { foobar: 'The Force Awakens' }
+      ];
+      const opts = { ordered: false };
+      Movie.insertMany(arr, opts, function(error, res) {
+        assert.ifError(error);
+        assert.equal(res.length, 0);
+        assert.equal(error, null);
+        done();
+      });
+    });
+
+    it('insertMany() validation error with ordered true and rawResult true when all documents are invalid', function(done) {
+      const schema = new Schema({
+        name: { type: String, required: true }
+      });
+      const Movie = db.model('Movie', schema);
+
+      const arr = [
+        { foo: 'The Phantom Menace' },
+        { foobar: 'The Force Awakens' }
+      ];
+      const opts = { ordered: true, rawResult: true };
+      Movie.insertMany(arr, opts, function(error, res) {
+        assert.ok(error);
+        assert.equal(res, undefined);
+        assert.equal(error.name, 'ValidationError');
+        done();
+      });
+    });
+
+    it('insertMany() validation error with ordered false and rawResult true when all documents are invalid', function(done) {
+      const schema = new Schema({
+        name: { type: String, required: true }
+      });
+      const Movie = db.model('Movie', schema);
+
+      const arr = [
+        { foo: 'The Phantom Menace' },
+        { foobar: 'The Force Awakens' }
+      ];
+      const opts = { ordered: false, rawResult: true };
+      Movie.insertMany(arr, opts, function(error, res) {
+        assert.ifError(error);
+        assert.equal(res.mongoose.validationErrors.length, 2);
+        assert.equal(res.mongoose.validationErrors[0].name, 'ValidationError');
+        assert.equal(res.mongoose.validationErrors[1].name, 'ValidationError');
+        done();
+      });
+    });
+
     it('insertMany() depopulate (gh-4590)', function(done) {
       const personSchema = new Schema({
         name: String


### PR DESCRIPTION
fixes: #8776 , #7822 , partially #5337 

**Summary**

The current behaviour of `insertMany` when all the documents are invalid and `order : false` is returning a `[]`. (I think later on we would want to be able to provide those validation errors to the caller instead of just a `[]` as discussed here #5337)

When `rawResult` is also `true` and all the documents are invalid, currently it still returns a `[]`. By merging the PR, mongoose in this scenario will properly return a `{ mongoose : { validationErrors: [...errors] }` which it should as `rawResult : true`.

I've added tests which covers all the possible configurations for the above scenario using `order` & `rawResult` when the docs are all invalid.
