### PR TITLE
fix: sync Node.JS version with mongodb driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: false
-node_js: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4]
+node_js: [14, 13, 12, 11, 10]
 install:
   - travis_retry npm install
 before_script:

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "main": "./index.js",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10"
   },
   "bugs": {
     "url": "https://github.com/Automattic/mongoose/issues/new"


### PR DESCRIPTION
**Summary**

This PR syncs `engines` field in `package.json`, that currently requires a minimum of Node.JS 4.0 to the minimum requirements of underlying `mongodb` driver (it's 10 for 3.x - https://github.com/mongodb/node-mongodb-native/blob/fa052a514be0a485831fe5e01c3c6eafe2b23140/package.json#L65).
While for most libraries that change should be considered a breaking change, I assume in this case it's a bug fix, because many features of MongoDB driver will anyway fail on Node 4.x


