### PR TITLE
BREAKING CHANGE: call setters with `priorVal` as 2nd parameter, and with new subdocument as context if creating new document

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -920,8 +920,6 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
       return this;
     }
-  } else {
-    this.$__.$setCalled.add(path);
   }
 
   function _handleIndex(i) {
@@ -953,7 +951,6 @@ Document.prototype.$set = function $set(path, val, type, options) {
         !(this.schema.paths[pathName] &&
         this.schema.paths[pathName].options &&
         this.schema.paths[pathName].options.ref)) {
-      this.$__.$setCalled.add(prefix + key);
       this.$set(path[key], prefix + key, constructing, options);
     } else if (strict) {
       // Don't overwrite defaults with undefined keys (gh-3981)

--- a/lib/internal.js
+++ b/lib/internal.js
@@ -30,7 +30,6 @@ function InternalCache() {
   this.pathsToScopes = {};
   this.cachedRequired = {};
   this.session = null;
-  this.$setCalled = new Set();
 
   // embedded docs
   this.ownerDocument = undefined;

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -271,9 +271,9 @@ SchemaString.prototype.lowercase = function(shouldApply) {
   if (arguments.length > 0 && !shouldApply) {
     return this;
   }
-  return this.set(function(v, self) {
+  return this.set(v => {
     if (typeof v !== 'string') {
-      v = self.cast(v);
+      v = this.cast(v);
     }
     if (v) {
       return v.toLowerCase();
@@ -307,9 +307,9 @@ SchemaString.prototype.uppercase = function(shouldApply) {
   if (arguments.length > 0 && !shouldApply) {
     return this;
   }
-  return this.set(function(v, self) {
+  return this.set(v => {
     if (typeof v !== 'string') {
-      v = self.cast(v);
+      v = this.cast(v);
     }
     if (v) {
       return v.toUpperCase();
@@ -349,9 +349,9 @@ SchemaString.prototype.trim = function(shouldTrim) {
   if (arguments.length > 0 && !shouldTrim) {
     return this;
   }
-  return this.set(function(v, self) {
+  return this.set(v => {
     if (typeof v !== 'string') {
-      v = self.cast(v);
+      v = this.cast(v);
     }
     if (v) {
       return v.trim();

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -986,9 +986,8 @@ SchemaType.prototype._applySetters = function(value, scope, init, priorVal) {
   const caster = this.caster;
 
   for (const setter of utils.clone(setters).reverse()) {
-    v = setter.call(scope, v, this);
+    v = setter.call(scope, v, priorVal, this);
   }
-
 
   if (Array.isArray(v) && caster && caster.setters) {
     const newVal = [];

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -18,36 +18,11 @@ module.exports = Subdocument;
 function Subdocument(value, fields, parent, skipId, options) {
   this.$isSingleNested = true;
 
-  const hasPriorDoc = options != null && options.priorDoc;
-  let initedPaths = null;
-  if (hasPriorDoc) {
-    this._doc = Object.assign({}, options.priorDoc._doc);
-    delete this._doc[this.schema.options.discriminatorKey];
-    initedPaths = Object.keys(options.priorDoc._doc || {}).
-      filter(key => key !== this.schema.options.discriminatorKey);
-  }
   if (parent != null) {
     // If setting a nested path, should copy isNew from parent re: gh-7048
     options = Object.assign({}, { isNew: parent.isNew }, options);
   }
   Document.call(this, value, fields, skipId, options);
-
-  if (hasPriorDoc) {
-    for (const key of initedPaths) {
-      if (!this.$__.activePaths.states.modify[key] &&
-          !this.$__.activePaths.states.default[key] &&
-          !this.$__.$setCalled.has(key)) {
-        const schematype = this.schema.path(key);
-        const def = schematype == null ? void 0 : schematype.getDefault(this);
-        if (def === void 0) {
-          delete this._doc[key];
-        } else {
-          this._doc[key] = def;
-          this.$__.activePaths.default(key);
-        }
-      }
-    }
-  }
 }
 
 Subdocument.prototype = Object.create(Document.prototype);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3640,6 +3640,23 @@ describe('Query', function() {
     });
   });
 
+  it('setter priorVal (gh-8629)', function() {
+    const priorVals = [];
+    const schema = Schema({
+      name: {
+        type: String,
+        set: (v, priorVal) => {
+          priorVals.push(priorVal);
+          return v;
+        }
+      }
+    });
+    const Model = db.model('Test', schema);
+
+    return Model.updateOne({}, { name: 'bar' }).exec().
+      then(() => assert.deepEqual(priorVals, [null]));
+  });
+
   describe('clone', function() {
     let Model;
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -543,7 +543,7 @@ describe('schema', function() {
     });
 
     it('scope', function(done) {
-      function lowercase(v, self) {
+      function lowercase(v, cur, self) {
         assert.equal(this.a, 'b');
         assert.equal(self.path, 'name');
         return v.toLowerCase();


### PR DESCRIPTION
Fix #8629

There's some messy edge cases that come in when you have custom setters underneath nested subdocs, and you're creating a new subdoc. For example:

```javascript
      const Model = db.model('Test', Schema({
        name: String,
        profile: {
          type: Schema({ age: Number }, { _id: false }),
          set: function(v, priorVal) {
            // What should this be if `doc.profile.toObject() === { age: 29 }`
            // and I do `doc.profile = { age: 30 }`?
            this.age;
            // If `this.age === 29`, what happens if I change `this.age` in the setter?
            return v;
          }
        }
      }));
```

We've created some messy workarounds, but I think the cleanest way to do this going forward is to pass the current value as the 2nd parameter to the setter. In Mongoose 5, `this.age` will be 29, but with this PR `this.age` will be undefined but `priorVal` will be 29. I think this approach gives us the least code to maintain while also giving us a useful feature: accessing the prior value in a setter without relying on `this`.

What do you think @AbdelrahmanHafez ?