### PR TITLE
add consistent arrow spacing by eslint

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -317,7 +317,7 @@ Model.prototype.$__handleSave = function(options, callback) {
     } else {
       const optionsWithCustomValues = Object.assign({}, options, saveOptions);
       this.constructor.exists(this.$__where(), optionsWithCustomValues)
-        .then((documentExists)=>{
+        .then((documentExists) => {
           if (!documentExists) throw new DocumentNotFoundError(this.$__where(), this.constructor.modelName);
 
           this.$__reset();

--- a/package.json
+++ b/package.json
@@ -156,6 +156,10 @@
         }
       ],
       "array-bracket-spacing": 1,
+      "arrow-spacing": ["error", {
+        "before": true,
+        "after": true
+      }],
       "object-curly-spacing": [
         "error",
         "always"

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5624,8 +5624,8 @@ describe('Model', function() {
               filter: { _id: createdUser._id }
             }
           }])
-            .then(()=>null)
-            .catch(err=>err);
+            .then(() => null)
+            .catch(err => err);
 
 
           assert.ok(err);
@@ -6668,7 +6668,7 @@ describe('Model', function() {
         { notInSchema: 1 },
         { notInSchema: 2 },
         { notInSchema: 3 }
-      ]).then(res=>res.ops);
+      ]).then(res => res.ops);
 
       // Act
       yield User.bulkWrite([

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -536,7 +536,7 @@ describe('QueryCursor', function() {
     const User = db.model('User', new Schema({ name: String }));
 
     const cursor = User.find().cursor();
-    cursor.on('data', ()=>{});
+    cursor.on('data', () => {});
 
     let closeEventTriggeredCount = 0;
     cursor.on('close', () => closeEventTriggeredCount++);
@@ -551,7 +551,7 @@ describe('QueryCursor', function() {
     const User = db.model('User', new Schema({ name: String }));
 
     const cursor = User.aggregate([{ $match: {} }]).cursor().exec();
-    cursor.on('data', ()=>{});
+    cursor.on('data', () => {});
 
     let closeEventTriggeredCount = 0;
     cursor.on('close', () => closeEventTriggeredCount++);


### PR DESCRIPTION
To avoid having to manually format the spacing before/after the arrow in an arrow function.