### PR TITLE
Update api.html

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -4186,7 +4186,7 @@ aggregate.append(pipeline);</code></pre></div><hr class="separate-api-elements">
 <h4>Example:</h4>
 
 <pre><code><span class="hljs-keyword">var</span> cursor = Model.aggregate(..).cursor({ batchSize: <span class="hljs-number">1000</span> }).exec();
-cursor.eachAsync(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">error, doc</span>) </span>{
+cursor.eachAsync(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">doc</span>) </span>{
   <span class="hljs-comment">// use doc</span>
 });</code></pre></div><hr class="separate-api-elements"><h3 id="aggregate_Aggregate-exec"><a href="#aggregate_Aggregate-exec">Aggregate.prototype.exec()</a></h3><h5>Parameters</h5><ul class="params"><li class="param">[callback]
 <span class="method-type">&laquo;Function&raquo;</span> </li></ul><h5>Returns:</h5><ul><li><span class="method-type">&laquo;Promise&raquo;</span> </li></ul><div><p>Executes the aggregate pipeline on the currently bound Model.</p>


### PR DESCRIPTION
Aggregation cursor eachAsync function only get the document as parameter


> If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

I haven't found how in the  mongoose/docs/api.pug  I could do this modification.