### PR TITLE
set mongodb options in distinct

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2452,10 +2452,10 @@ Query.prototype.countDocuments = function(conditions, callback) {
 };
 
 /**
- * Thunk around findOne()
+ * Thunk around distinct()
  *
  * @param {Function} [callback]
- * @see findOne http://docs.mongodb.org/manual/reference/method/db.collection.findOne/
+ * @see distinct http://docs.mongodb.org/manual/reference/method/db.collection.distinct/
  * @api private
  */
 
@@ -2467,9 +2467,11 @@ Query.prototype.__distinct = wrapThunk(function __distinct(callback) {
     return null;
   }
 
+  const options = this._optionsForExec();
+
   // don't pass in the conditions because we already merged them in
   this._collection.collection.
-    distinct(this._distinct, this._conditions, callback);
+    distinct(this._distinct, this._conditions, options, callback);
 });
 
 /**


### PR DESCRIPTION
**Summary**
Query options do not get passed to the mongodb nodejs driver when performing a distinct query, e.g. maxTimeMS or readPreference. Fix that by passing the options in.

**Examples**
```js
mongoose.set('debug', true);
await mongoose.connect(MONGO_URI);
const Model = mongoose.model(
  'model',
  ...
);
await Model.distinct('field').read('secondary');
```
_debug output before change:_
`Mongoose: models.distinct('field', {})`
query appears in active operations on primary

_debug output after change:_
`Mongoose: models.distinct('field', {}, { readPreference: ReadPreference { mode: 'secondary', tags: undefined }})`
query does not appear in active operations on primary
