### PR TITLE
docs: add flattenMaps and aliases to Document#toObject()

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3067,7 +3067,7 @@ Document.prototype.$toObject = function(options, json) {
  * ####Options:
  *
  * - `getters` apply all getters (path and virtual getters), defaults to false
- * - `aliases` apply all aliases `if virtuals=true`, defaults to true
+ * - `aliases` apply all aliases if `virtuals=true`, defaults to true
  * - `virtuals` apply virtual getters (can override `getters` option), defaults to false
  * - `minimize` remove empty objects, defaults to true
  * - `transform` a transform function to apply to the resulting document before returning

--- a/lib/document.js
+++ b/lib/document.js
@@ -3067,11 +3067,13 @@ Document.prototype.$toObject = function(options, json) {
  * ####Options:
  *
  * - `getters` apply all getters (path and virtual getters), defaults to false
+ * - `aliases` apply all aliases `if virtuals=true`, defaults to true
  * - `virtuals` apply virtual getters (can override `getters` option), defaults to false
- * - `minimize` remove empty objects (defaults to true)
+ * - `minimize` remove empty objects, defaults to true
  * - `transform` a transform function to apply to the resulting document before returning
- * - `depopulate` depopulate any populated paths, replacing them with their original refs (defaults to false)
- * - `versionKey` whether to include the version key (defaults to true)
+ * - `depopulate` depopulate any populated paths, replacing them with their original refs, defaults to false
+ * - `versionKey` whether to include the version key, defaults to true
+ * - `flattenMaps` convert Maps to POJOs. Useful if you want to JSON.stringify() the result of toObject(), defaults to false
  *
  * ####Getters/Virtuals
  *


### PR DESCRIPTION
fixes #8901 