### PR TITLE
fix(docs): fix broken references to Mongoose#Document API, and prefer mongoose.model(...) over Document#model(...)

### DIFF
--- a/docs/3.0.x/docs/guide.jade
+++ b/docs/3.0.x/docs/guide.jade
@@ -90,7 +90,7 @@ block content
     var animalSchema = new Schema({ name: String, type: String });
 
     animalSchema.methods.findSimilarTypes = function (cb) {
-      return this.model('Animal').find({ type: this.type }, cb);
+      return mongoose.model('Animal').find({ type: this.type }, cb);
     }
   p
     | Now all of our 

--- a/docs/3.1.x/docs/guide.jade
+++ b/docs/3.1.x/docs/guide.jade
@@ -90,7 +90,7 @@ block content
     var animalSchema = new Schema({ name: String, type: String });
 
     animalSchema.methods.findSimilarTypes = function (cb) {
-      return this.model('Animal').find({ type: this.type }, cb);
+      return mongoose.model('Animal').find({ type: this.type }, cb);
     }
   p
     | Now all of our 

--- a/docs/3.2.x/docs/guide.jade
+++ b/docs/3.2.x/docs/guide.jade
@@ -90,7 +90,7 @@ block content
     var animalSchema = new Schema({ name: String, type: String });
 
     animalSchema.methods.findSimilarTypes = function (cb) {
-      return this.model('Animal').find({ type: this.type }, cb);
+      return mongoose.model('Animal').find({ type: this.type }, cb);
     }
   p
     | Now all of our 

--- a/docs/3.3.x/docs/guide.jade
+++ b/docs/3.3.x/docs/guide.jade
@@ -90,7 +90,7 @@ block content
     var animalSchema = new Schema({ name: String, type: String });
 
     animalSchema.methods.findSimilarTypes = function (cb) {
-      return this.model('Animal').find({ type: this.type }, cb);
+      return mongoose.model('Animal').find({ type: this.type }, cb);
     }
   p
     | Now all of our 

--- a/docs/documents.pug
+++ b/docs/documents.pug
@@ -18,7 +18,7 @@ block content
       <a href="#native_link#"><span class="sponsor">Sponsor</span> #native_company# — #native_desc#</a>
     </div>
 
-    Mongoose [documents](./api.html#document-js) represent a one-to-one mapping
+    Mongoose [documents](./api/document.html) represent a one-to-one mapping
     to documents as stored in MongoDB. Each document is an instance of its
     [Model](./models.html).
 

--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -165,7 +165,7 @@ block content
 
       // assign a function to the "methods" object of our animalSchema
       animalSchema.methods.findSimilarTypes = function(cb) {
-        return this.model('Animal').find({ type: this.type }, cb);
+        return mongoose.model('Animal').find({ type: this.type }, cb);
       };
     ```
 

--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -156,7 +156,7 @@ block content
     <h3 id="methods"><a href="#methods">Instance methods</a></h3>
 
     Instances of `Models` are [documents](./documents.html). Documents have
-    many of their own [built-in instance methods](./api.html#document-js).
+    many of their own [built-in instance methods](./api/document.html).
     We may also define our own custom document instance methods.
 
     ```javascript

--- a/examples/geospatial/person.js
+++ b/examples/geospatial/person.js
@@ -19,7 +19,7 @@ module.exports = function() {
 
   // define a method to find the closest person
   PersonSchema.methods.findClosest = function(cb) {
-    return this.model('Person').find({
+    return mongoose.model('Person').find({
       loc: { $nearSphere: this.loc },
       name: { $ne: this.name }
     }).limit(1).exec(cb);

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -116,7 +116,7 @@ exports.SchemaType = require('./schematype.js');
 exports.utils = require('./utils.js');
 
 /**
- * The Mongoose browser [Document](#document-js) constructor.
+ * The Mongoose browser [Document](/api/document.html) constructor.
  *
  * @method Document
  * @api public

--- a/lib/index.js
+++ b/lib/index.js
@@ -903,7 +903,7 @@ Mongoose.prototype.PromiseProvider = PromiseProvider;
 Mongoose.prototype.Model = Model;
 
 /**
- * The Mongoose [Document](#document-js) constructor.
+ * The Mongoose [Document](/api/document.html) constructor.
  *
  * @method Document
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -88,7 +88,7 @@ const saveToObjectOptions = Object.assign({}, internalToObjectOptions, {
  * @param {Object} doc values for initial set
  * @param [fields] optional object containing the fields that were selected in the query which returned this document. You do **not** need to set this parameter to ensure Mongoose handles your [query projection](./api.html#query_Query-select).
  * @param {Boolean} [skipId=false] optional boolean. If true, mongoose doesn't add an `_id` field to the document.
- * @inherits Document http://mongoosejs.com/docs/api.html#document-js
+ * @inherits Document http://mongoosejs.com/docs/api/document.html
  * @event `error`: If listening to this event, 'error' is emitted when a document was saved without passing a callback and an `error` occurred. If not listening, the event bubbles to the connection used to create this Model.
  * @event `index`: Emitted after `Model#ensureIndexes` completes. If an error occurred it is passed with the event.
  * @event `index-single-start`: Emitted when an individual index starts within `Model#ensureIndexes`. The fields and options being used to build the index are also passed with the event.

--- a/lib/query.js
+++ b/lib/query.js
@@ -1640,7 +1640,7 @@ const setSafe = util.deprecate(function setSafe(options, safe) {
  * Sets the lean option.
  *
  * Documents returned from queries with the `lean` option enabled are plain
- * javascript objects, not [Mongoose Documents](#document-js). They have no
+ * javascript objects, not [Mongoose Documents](/api/document.html). They have no
  * `save` method, getters/setters, virtuals, or other Mongoose features.
  *
  * ####Example:


### PR DESCRIPTION
fixes #8899 