### PR TITLE
docs(populate, faq): separate limit-vs-perDocumentLimit into its own section, add FAQ for populate and limit

### DIFF
--- a/docs/faq.pug
+++ b/docs/faq.pug
@@ -449,6 +449,12 @@ block content
 
     **A**. Because the Map eventually gets stored in MongoDB where the keys must be strings.
 
+    <hr id="limit-vs-perDocumentLimit" />
+
+    <a href="#limit-vs-perDocumentLimit">**Q**</a>. I am using `Model.find(...).populate(...)` with the `limit` option, but getting fewer results than the limit. What gives?
+
+    **A**. In order to avoid executing a separate query for each document returned from the `find` query, Mongoose instead queries using (numDocuments * limit) as the limit. If you need the correct limit, you should use the [perDocumentLimit](/api/populate.html##limit-vs-perDocumentLimit) option (new in Mongoose 5.9.0). Just keep in mind that populate() will execute a separate query for each document.
+
     <hr id="add_something" />
 
     **Something to add?**

--- a/docs/populate.pug
+++ b/docs/populate.pug
@@ -262,6 +262,8 @@ block content
       exec();
     ```
 
+    <h3 id="limit-vs-perDocumentLimit"><a href="#limit-vs-perDocumentLimit">limit vs. perDocumentLimit</a></h3>
+
     Populate does support a `limit` option, however, it currently
     does **not** limit on a per-document basis. For example, suppose
     you have 2 stories:


### PR DESCRIPTION
fixes #8917