### PR TITLE
fix: accept $comment in a $match pipeline

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1079,7 +1079,7 @@ function isOperator(obj) {
     return false;
   }
 
-  const k = Object.keys(obj);
+  const k = Object.keys(obj).filter(key => key !== '$comment');
 
   return k.length === 1 && k.some(key => { return key[0] === '$'; });
 }

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -136,6 +136,10 @@ describe('aggregate: ', function() {
       assert.throws(function() {
         aggregate.append([{ $a: 1 }, { a: 1 }]);
       }, regexp);
+
+      assert.throws(function() {
+        aggregate.append([{ $a: 1, $b: 1 }]);
+      }, regexp);
     });
 
     it('does not throw when 0 args passed', function() {
@@ -143,6 +147,14 @@ describe('aggregate: ', function() {
 
       assert.doesNotThrow(function() {
         aggregate.append();
+      });
+    });
+
+    it('does not throw when $comment is passed along with $match', function() {
+      const aggregate = new Aggregate();
+
+      assert.doesNotThrow(function() {
+        aggregate.append([{ $match: { a: 5 }, $comment: 'match comment' }]);
       });
     });
 


### PR DESCRIPTION
**The problem**

According to the [mongodb documentation](https://docs.mongodb.com/manual/reference/operator/query/comment/#attach-a-comment-to-an-aggregation-expression) it is possible to add a `$comment` entry in a `$match` pipeline stage in this way : 

```js
db.records.aggregate( [
   { $match: { x: { $gt: 0 }, $comment: "Don't allow negative inputs." } },
] )
```

This behaviour does not work because the function : `isOperator` does not allow stage if it has multiple keys.


**The solution**

This PR allow a stage to have multiple keys **only if** the second one if a `$comment` key.

**Tests**

Tests on the behaviour has been added as well as tests on the previous behaviour.


**PS**

Thx for your usefull lib ;) 