### PR TITLE
fix(update): immutable properties are ignored in bulk upserts

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -46,7 +46,8 @@ module.exports = function castBulkWrite(model, op, options) {
         });
         op['updateOne']['update'] = castUpdate(model.schema, op['updateOne']['update'], {
           strict: strict,
-          overwrite: false
+          overwrite: false,
+          upsert: op['updateOne'].upsert
         });
 
         if (op['updateOne'].setDefaultsOnInsert) {
@@ -80,7 +81,8 @@ module.exports = function castBulkWrite(model, op, options) {
         });
         op['updateMany']['update'] = castUpdate(model.schema, op['updateMany']['update'], {
           strict: strict,
-          overwrite: false
+          overwrite: false,
+          upsert: op['updateMany'].upsert
         });
         if (op['updateMany'].setDefaultsOnInsert) {
           setDefaultsOnInsert(op['updateMany']['filter'], model.schema, op['updateMany']['update'], {

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -42,6 +42,10 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     return obj;
   }
 
+  if (options.upsert) {
+    moveImmutableProperties(schema, obj, context);
+  }
+
   const ops = Object.keys(obj);
   let i = ops.length;
   const ret = {};
@@ -50,8 +54,6 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
   const overwrite = options.overwrite;
 
   filter = filter || {};
-
-  moveImmutableProperties(schema, obj, context);
 
   while (i--) {
     const op = ops[i];

--- a/lib/helpers/update/moveImmutableProperties.js
+++ b/lib/helpers/update/moveImmutableProperties.js
@@ -4,8 +4,8 @@ const get = require('../get');
 
 /**
  * Given an update, move all $set on immutable properties to $setOnInsert.
- * No need to check for upserts, because there's no harm in setting
- * $setOnInsert even if `upsert` is false.
+ * This should only be called for upserts, because $setOnInsert bypasses the
+ * strictness check for immutable properties.
  */
 
 module.exports = function moveImmutableProperties(schema, update, ctx) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4493,6 +4493,11 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
     useNestedStrict = this.options.useNestedStrict;
   }
 
+  let upsert;
+  if ('upsert' in this.options) {
+    upsert = this.options.upsert;
+  }
+
   let schema = this.schema;
   const filter = this._conditions;
   if (schema != null &&
@@ -4510,7 +4515,8 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
     overwrite: overwrite,
     strict: strict,
     omitUndefined,
-    useNestedStrict: useNestedStrict
+    useNestedStrict: useNestedStrict,
+    upsert: upsert
   }, this, this._conditions);
 };
 

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -3325,6 +3325,29 @@ describe('model: updateOne: ', function() {
     });
   });
 
+  it('moves $set of immutable properties to $setOnInsert (gh-8951)', function() {
+    const Model = db.model('Test', Schema({
+      name: String,
+      age: { type: Number, default: 25, immutable: true }
+    }));
+
+    return co(function*() {
+      yield Model.bulkWrite([
+        {
+          updateOne: {
+            filter: { name: 'John' },
+            update: { name: 'John', age: 20 },
+            upsert: true,
+            setDefaultsOnInsert: true
+          }
+        }
+      ]);
+
+      const doc = yield Model.findOne().lean();
+      assert.equal(doc.age, 20);
+    });
+  });
+
   it('updates buffers with `runValidators` successfully (gh-8580)', function() {
     const Test = db.model('Test', Schema({
       data: { type: Buffer, required: true }


### PR DESCRIPTION
Fixes #8951 

The cause of this issue, as I understand it:

- In `castUpdate()`, the keys of the update are taken _before_ the call to `moveImmutableProperties()` but this call can modify the keys (i.e. it adds a `$setOnInsert` key if it does not exist already and moves immutable properties under it).

- In the case of `bulkWrite()`, contrary to e.g. `updateOne()`, `_decorateUpdateWithVersionKey()` is not called, so the update object does not already have a `$setOnInsert` key. It is then ignored by `castUpdate()`  because `moveImmutableProperties()` is called too late.

The proposed solution:

- Moved `moveImmutableProperties()` a bit earlier, before the keys of the update are taken, so that `castUpdate()` works on the correct set of keys.

- I thought that would be enough, but actually it breaks a test for the `strict: 'throw'` behavior (see test for #7671), because if `moveImmutableProperties()` is called for a regular update (not an upsert), it will move the immutable properties under `$setOnInsert` and bypass the strictness check.

- The solution is to call `moveImmutableProperties()` only for upserts (so I had to propagate the `upsert` option to `castUpdate()` for this).

Edit: rebased to remove trailing blank lines.