### PR TITLE
test(model): fix flaky text for model.populate

### DIFF
--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -9294,7 +9294,7 @@ describe('model: populate:', function() {
           { title: 'test3', user: new mongoose.Types.ObjectId() }
         ]);
 
-        const posts = yield Post.find().populate({ path: 'user', options: { clone: true } }).lean();
+        const posts = yield Post.find().populate({ path: 'user', options: { clone: true } }).sort('title').lean();
 
         posts[0].user.name = 'val2';
         assert.equal(posts[1].user.name, 'val');


### PR DESCRIPTION
This test sometimes falsely fails, because documents aren't always fetched in the order they are `create(...)`ed in.

I'll look more into this, and see if create inserts documents in the order they're passed in, meanwhile, this should fix this test.