### PR TITLE
fix(populate): populate virtuals defined on child discriminators

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -17,8 +17,6 @@ const schemaMixedSymbol = require('../../schema/symbols').schemaMixedSymbol;
 
 module.exports = function getModelsMapForPopulate(model, docs, options) {
   let i;
-  let doc;
-  const len = docs.length;
   const available = {};
   const map = [];
   const modelNameFromQuery = options.model && options.model.modelName || options.model;
@@ -31,16 +29,14 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
   let modelForFindSchema;
 
   const originalModel = options.model;
-  let isVirtual = false;
   const modelSchema = model.schema;
+  let isVirtual = false;
 
   let allSchemaTypes = getSchemaTypes(modelSchema, null, options.path);
   allSchemaTypes = Array.isArray(allSchemaTypes) ? allSchemaTypes : [allSchemaTypes].filter(v => v != null);
   const _firstWithRefPath = allSchemaTypes.find(schematype => get(schematype, 'options.refPath', null) != null);
 
-  for (i = 0; i < len; i++) {
-    doc = docs[i];
-
+  for (const doc of docs) {
     schema = getSchemaTypes(modelSchema, doc, options.path);
     const isUnderneathDocArray = schema && schema.$isUnderneathDocArray;
     if (isUnderneathDocArray && get(options, 'options.sort') != null) {
@@ -317,6 +313,8 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     }
   }
 
+  return map;
+
   function _getModelNames(doc, schema) {
     let modelNames;
     let discriminatorKey;
@@ -431,8 +429,6 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
 
     return { modelNames: modelNames, isRefPath: isRefPath, refPath: normalizedRefPath };
   }
-
-  return map;
 };
 
 /*!

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -17,6 +17,8 @@ const schemaMixedSymbol = require('../../schema/symbols').schemaMixedSymbol;
 
 module.exports = function getModelsMapForPopulate(model, docs, options) {
   let i;
+  let doc;
+  const len = docs.length;
   const available = {};
   const map = [];
   const modelNameFromQuery = options.model && options.model.modelName || options.model;
@@ -29,14 +31,16 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
   let modelForFindSchema;
 
   const originalModel = options.model;
-  const modelSchema = model.schema;
   let isVirtual = false;
+  const modelSchema = model.schema;
 
   let allSchemaTypes = getSchemaTypes(modelSchema, null, options.path);
   allSchemaTypes = Array.isArray(allSchemaTypes) ? allSchemaTypes : [allSchemaTypes].filter(v => v != null);
   const _firstWithRefPath = allSchemaTypes.find(schematype => get(schematype, 'options.refPath', null) != null);
 
-  for (const doc of docs) {
+  for (i = 0; i < len; i++) {
+    doc = docs[i];
+
     schema = getSchemaTypes(modelSchema, doc, options.path);
     const isUnderneathDocArray = schema && schema.$isUnderneathDocArray;
     if (isUnderneathDocArray && get(options, 'options.sort') != null) {

--- a/lib/helpers/populate/getVirtual.js
+++ b/lib/helpers/populate/getVirtual.js
@@ -10,6 +10,7 @@ function getVirtual(schema, name) {
   if (schema.virtuals[name]) {
     return { virtual: schema.virtuals[name], path: void 0 };
   }
+
   const parts = name.split('.');
   let cur = '';
   let nestedSchemaPath = '';
@@ -57,6 +58,13 @@ function getVirtual(schema, name) {
       nestedSchemaPath += (nestedSchemaPath.length > 0 ? '.' : '') + cur;
       cur = '';
       continue;
+    }
+
+    if (schema.discriminators) {
+      for (const discriminatorKey of Object.keys(schema.discriminators)) {
+        const virtualFromDiscriminator = getVirtual(schema.discriminators[discriminatorKey], name);
+        if (virtualFromDiscriminator) return virtualFromDiscriminator;
+      }
     }
 
     return null;


### PR DESCRIPTION
fixes: #8924

This attempts to find virtuals on the current schema, if nothing is found, it traverses depth-first in discriminators for that field.