### PR TITLE
fix(errors) - user defines its own r/o err.toJSON

### DIFF
--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -72,10 +72,14 @@ if (util.inspect.custom) {
 /*!
  * Helper for JSON.stringify
  */
-
-ValidationError.prototype.toJSON = function() {
-  return Object.assign({}, this, { message: this.message });
-};
+Object.defineProperty(ValidationError.prototype, 'toJSON', {
+  enumerable: false,
+  writabe: false,
+  configurable: true,
+  value: function() {
+    return Object.assign({}, this, { message: this.message });
+  }
+});
 
 /*!
  * add message

--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -74,7 +74,7 @@ if (util.inspect.custom) {
  */
 Object.defineProperty(ValidationError.prototype, 'toJSON', {
   enumerable: false,
-  writabe: false,
+  writable: false,
   configurable: true,
   value: function() {
     return Object.assign({}, this, { message: this.message });

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -232,4 +232,19 @@ describe('ValidationError', function() {
 
     assert.equal(err.message, 'Validation failed');
   });
+
+  describe('when user code defines a r/o Error#toJSON', function() {
+    it('shoud not fail', function() {
+      const err = [];
+      const child = require('child_process')
+        .fork('./test/isolated/project-has-error.toJSON.js', { silent: true });
+
+      child.stderr.on('data', function(buf) { err.push(buf); });
+      child.on('exit', function(code) {
+        const stderr = err.join('');
+        assert.equal(stderr, '');
+        assert.equal(code, 0);
+      });
+    });
+  });
 });

--- a/test/isolated/project-has-error.toJSON.js
+++ b/test/isolated/project-has-error.toJSON.js
@@ -1,0 +1,9 @@
+'use strict';
+Object.defineProperty(Error.prototype, 'toJSON', {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: () => ({ from: 'Error' })
+});
+
+require('../../');


### PR DESCRIPTION
fixes #8985

When user code defines it's own Error.prototype.toJSON, which is defined as a read-only property - the fixed line crashes.
It happens specificly because of the old-school `Object.create(prototype)` thing.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
fixes #8985

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
Added tests
