### PR TITLE
doc: add immutable type to Schema Types

### DIFF
--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -231,6 +231,7 @@ block content
     * `get`: function, defines a custom getter for this property using [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
     * `set`: function, defines a custom setter for this property using [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
     * `alias`: string, mongoose >= 4.10.0 only. Defines a [virtual](./guide.html#virtuals) with the given name that gets/sets this path.
+    * `immutable`: boolean, defines path as immutable. Mongoose prevents you from changing immutable paths unless the parent document has `isNew: true`.
 
     ```javascript
     var numberSchema = new Schema({


### PR DESCRIPTION
Adds docs for immutable types in `docs/schematypes.pug` under All Schema Types
