### PR TITLE
docs(faq): remove faq ipv6

### DIFF
--- a/docs/faq.pug
+++ b/docs/faq.pug
@@ -30,6 +30,7 @@ block content
       <a href="#native_link#"><span class="sponsor">Sponsor</span> #native_company# — #native_desc#</a>
     </div>
 
+
     <hr id="array-changes-not-saved" />
 
     <a href="#array-changes-not-saved">**Q**</a>. Why don't my changes to arrays get saved when I update an element
@@ -71,6 +72,7 @@ block content
     doc.docArray[3] = { name: 'changed' };
     doc.save();
     ```
+
 
     <hr id="unique-doesnt-work" />
 
@@ -124,6 +126,7 @@ block content
     rather than relying on mongoose to do it for you. The `unique` option for schemas is
     convenient for development and documentation, but mongoose is *not* an index management solution.
 
+
     <hr id="nested-properties" />
 
     <a href="#nested-properties">**Q**</a>. When I have a nested property in a schema, mongoose adds empty objects by default. Why?
@@ -154,6 +157,7 @@ block content
     must always be defined as an object on a mongoose document, even if `nested`
     is undefined on the underlying [POJO](./guide.html#minimize).
 
+
     <hr id="destructured-imports" />
 
     <a href="#destructured-imports">**Q**</a>. When I use named imports like `import { set } from 'mongoose'`, I
@@ -178,6 +182,7 @@ block content
     const { foo } = require('./file1');
     foo(); // "undefined"
     ```
+
 
     <hr id="arrow-functions" />
 
@@ -208,6 +213,7 @@ block content
       console.log(this);
     });
     ```
+
 
     <hr id="type-key">
 
@@ -253,6 +259,7 @@ block content
     });
     ```
 
+
     <hr id="populate_sort_order" />
 
     <a href="#populate_sort_order">**Q**</a>. I'm populating a nested property under an array like the below code:
@@ -278,6 +285,7 @@ block content
     connect to MongoDB. Read the [buffering section of the connection docs](./connections.html#buffering)
     for more information.
 
+
     <hr id="enable_debugging" />
 
     <a href="#enable_debugging">**Q**</a>. How can I enable debugging?
@@ -293,6 +301,7 @@ block content
 
     All executed collection methods will log output of their arguments to your
     console.
+
 
     <hr id="callback_never_executes" />
 
@@ -319,12 +328,14 @@ block content
     mongoose.set('bufferCommands', false);
     ```
 
+
     <hr id="creating_connections" />
 
     <a href="#creating_connections">**Q**</a>. Should I create/destroy a new connection for each database operation?
 
     **A**. No. Open your connection when your application starts up and leave
     it open until the application shuts down.
+
 
     <hr id="overwrite-model-error" />
 
@@ -351,6 +362,7 @@ block content
     var Kitten = connection.model('Kitten', kittySchema);
     ```
 
+
     <hr id="array-defaults" />
 
     <a href="#array-defaults">**Q**</a>. How can I change mongoose's default behavior of initializing an array
@@ -365,6 +377,8 @@ block content
       }
     });
     ```
+
+
     <hr id="initialize-array-path-null" />
     
     <a href="#initialize-array-path-null">**Q**</a>. How can I initialize an array path to `null`?
@@ -388,6 +402,7 @@ block content
     $group, etc. the type of a property may change during the aggregation. If you want
     to query by date using the aggregation framework, you're responsible for ensuring
     that you're passing in a valid date.
+
 
     <hr id="date_changes" />
 
@@ -444,6 +459,7 @@ block content
     instead queries using (numDocuments * limit) as the limit. If you need the correct limit, you should use the
     [perDocumentLimit](/docs/populate.html#limit-vs-perDocumentLimit) option (new in Mongoose 5.9.0). Just keep in
     mind that populate() will execute a separate query for each document.
+
 
     <hr id="add_something" />
 

--- a/docs/faq.pug
+++ b/docs/faq.pug
@@ -429,19 +429,6 @@ block content
     **A**. Technically, any 12 character string is a valid [ObjectId](https://docs.mongodb.com/manual/reference/bson-types/#objectid).
     Consider using a regex like `/^[a-f0-9]{24}$/` to test whether a string is exactly 24 hex characters.
 
-    <hr id="slow-localhost" />
-
-    <a href="#slow-localhost">**Q**</a>. I'm connecting to `localhost` and it takes me nearly 1 second to connect. How do I fix this?
-
-    **A**. The underlying MongoDB driver defaults to looking for IPv6 addresses, so the most likely cause is that your `localhost` DNS mapping isn't configured to handle IPv6. Use `127.0.0.1` instead of `localhost` or use the `family` option as shown in the [connection docs](https://mongoosejs.com/docs/connections.html#options).
-
-    ```javascript
-    // One alternative is to bypass 'localhost'
-    mongoose.connect('mongodb://127.0.0.1:27017/test');
-    // Another option is to specify the `family` option, which tells the
-    // MongoDB driver to only look for IPv4 addresses rather than IPv6 first.
-    mongoose.connect('mongodb://localhost:27017/test', { family: 4 });
-    ```
 
     <hr id="map-keys-strings" />
 


### PR DESCRIPTION
We added this question due to #6566

This is fixed in the driver somewhere along the way, and we don't need to manually use `family: 4` anymore.

```js
const mongoose = require('mongoose');

run().catch(console.error);

async function run() {
  const before = Date.now();
  await mongoose.connect('mongodb://localhost:27017/test');
  console.log(`Connected in: ${Date.now() - before}ms.`);
}
```

Output:
```
Connected in: 22ms.
```