### PR TITLE
perf: delay constructing ServerSelectionError

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4903,11 +4903,11 @@ Model.$handleCallbackError = function(callback) {
  */
 
 Model.$wrapCallback = function(callback) {
-  const serverSelectionError = new ServerSelectionError();
   const _this = this;
 
   return function(err) {
     if (err != null && err.name === 'MongoServerSelectionError') {
+      const serverSelectionError = new ServerSelectionError();
       arguments[0] = serverSelectionError.assimilateError(err);
     }
     if (err != null && err.name === 'MongoNetworkError' && err.message.endsWith('timed out')) {


### PR DESCRIPTION
**Summary**

`MongooseServerSelectionError` is showing up as a dominator in our CPU profiles. As far as I can tell, this change has no behavior impact. The stack should be the same since `err`'s stack is assigned to `serverSelectionError` via `assimilateError`.

**Examples**

Run `node --inspect-brk ./benchmarks/benchjs/read.js` with everything but `Read - Mongoose - With lean` commented out, open the profiler (chrome devtools), start profiling, ...

Before:
![image](https://user-images.githubusercontent.com/469365/82098505-4e516380-96c2-11ea-97f5-a0f8823fcc63.png)

After:
![image](https://user-images.githubusercontent.com/469365/82098513-55787180-96c2-11ea-92b5-0ffb4c6f299a.png)

The benchmark values seem to be very noisy, but after a bunch of runs it comes out ~12% faster.

(The other error classes that show up in the above profile haven't shown up in our application profiles as dominators.)

---

Changing the Mongoose errors to use real ECMAScript classes that extend `Error` nearly doubles their performance (although avoiding them in the first place is better). I thought Mongoose needs to support back to Node.js v4 (classes without flags didn't come until v6), but I see plenty of usages of `class` in the code base. Are they okay to use?