### PR TITLE
refactor: remove CoreMongooseArray#map, defined twice

### DIFF
--- a/lib/types/core_array.js
+++ b/lib/types/core_array.js
@@ -92,16 +92,6 @@ class CoreMongooseArray extends Array {
    * ignore
    */
 
-  map() {
-    const copy = [].concat(this);
-
-    return Array.prototype.map.apply(copy, arguments);
-  }
-
-  /*!
-   * ignore
-   */
-
   $atomics() {
     return this[arrayAtomicsSymbol];
   }


### PR DESCRIPTION
No need to add it, already defined on https://github.com/Automattic/mongoose/blob/bfccbe53d75bd71eda2a45361bf7c1196672e273/lib/types/core_array.js#L961