### PR TITLE
refactor(error): convert errors to classes extending Error

### DIFF
--- a/lib/error/browserMissingSchema.js
+++ b/lib/error/browserMissingSchema.js
@@ -6,30 +6,20 @@
 
 const MongooseError = require('./');
 
-/*!
- * MissingSchema Error constructor.
- *
- * @inherits MongooseError
- */
 
-function MissingSchemaError() {
-  const msg = 'Schema hasn\'t been registered for document.\n'
-          + 'Use mongoose.Document(name, schema)';
-  MongooseError.call(this, msg);
-  this.name = 'MissingSchemaError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class MissingSchemaError extends MongooseError {
+  /*!
+   * MissingSchema Error constructor.
+   */
+  constructor() {
+    super('Schema hasn\'t been registered for document.\n'
+      + 'Use mongoose.Document(name, schema)');
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-MissingSchemaError.prototype = Object.create(MongooseError.prototype);
-MissingSchemaError.prototype.constructor = MongooseError;
+Object.defineProperty(MissingSchemaError.prototype, 'name', {
+  value: 'MongooseError'
+});
 
 /*!
  * exports

--- a/lib/error/cast.js
+++ b/lib/error/cast.js
@@ -17,98 +17,101 @@ const util = require('util');
  * @api private
  */
 
-function CastError(type, value, path, reason, schemaType) {
-  // If no args, assume we'll `init()` later.
-  if (arguments.length > 0) {
-    this.init(type, value, path, reason, schemaType);
+class CastError extends MongooseError {
+  constructor(type, value, path, reason, schemaType) {
+    // If no args, assume we'll `init()` later.
+    if (arguments.length > 0) {
+      const stringValue = getStringValue(value);
+      const messageFormat = getMessageFormat(schemaType);
+      const msg = formatMessage(null, type, stringValue, path, messageFormat);
+      super(msg);
+      this.init(type, value, path, reason, schemaType);
+    } else {
+      super(formatMessage());
+    }
   }
 
-  MongooseError.call(this, this.formatMessage());
-  this.name = 'CastError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+  /*!
+   * ignore
+   */
+  init(type, value, path, reason, schemaType) {
+    this.stringValue = getStringValue(value);
+    this.messageFormat = getMessageFormat(schemaType);
+    this.kind = type;
+    this.value = value;
+    this.path = path;
+    this.reason = reason;
+  }
+
+  /*!
+   * ignore
+   * @param {Readonly<CastError>} other
+   */
+  copy(other) {
+    this.messageFormat = other.messageFormat;
+    this.stringValue = other.stringValue;
+    this.kind = other.kind;
+    this.value = other.value;
+    this.path = other.path;
+    this.reason = other.reason;
+    this.message = other.message;
+  }
+
+  /*!
+   * ignore
+   */
+  setModel(model) {
+    this.model = model;
+    this.message = formatMessage(model, this.kind, this.stringValue, this.path,
+      this.messageFormat);
+  }
+}
+
+Object.defineProperty(CastError.prototype, 'name', {
+  value: 'CastError'
+});
+
+function getStringValue(value) {
+  let stringValue = util.inspect(value);
+  stringValue = stringValue.replace(/^'|'$/g, '"');
+  if (!stringValue.startsWith('"')) {
+    stringValue = '"' + stringValue + '"';
+  }
+  return stringValue;
+}
+
+function getMessageFormat(schemaType) {
+  const messageFormat = get(schemaType, 'options.cast', null);
+  if (typeof messageFormat === 'string') {
+    return messageFormat;
   }
 }
 
 /*!
- * Inherits from MongooseError.
- */
-
-CastError.prototype = Object.create(MongooseError.prototype);
-CastError.prototype.constructor = MongooseError;
-
-/*!
  * ignore
  */
 
-CastError.prototype.init = function init(type, value, path, reason, schemaType) {
-  let stringValue = util.inspect(value);
-  stringValue = stringValue.replace(/^'/, '"').replace(/'$/, '"');
-  if (!stringValue.startsWith('"')) {
-    stringValue = '"' + stringValue + '"';
-  }
-
-  const messageFormat = get(schemaType, 'options.cast', null);
-  if (typeof messageFormat === 'string') {
-    this.messageFormat = schemaType.options.cast;
-  }
-  this.stringValue = stringValue;
-  this.kind = type;
-  this.value = value;
-  this.path = path;
-  this.reason = reason;
-};
-
-/*!
- * ignore
- */
-
-CastError.prototype.copy = function copy(other) {
-  this.messageFormat = other.messageFormat;
-  this.stringValue = other.stringValue;
-  this.kind = other.kind;
-  this.value = other.value;
-  this.path = other.path;
-  this.reason = other.reason;
-  this.message = other.message;
-};
-
-/*!
- * ignore
- */
-
-CastError.prototype.setModel = function(model) {
-  this.model = model;
-  this.message = this.formatMessage(model);
-};
-
-/*!
- * ignore
- */
-
-CastError.prototype.formatMessage = function(model) {
-  if (this.messageFormat != null) {
-    let ret = this.messageFormat.
-      replace('{KIND}', this.kind).
-      replace('{VALUE}', this.stringValue).
-      replace('{PATH}', this.path);
+function formatMessage(model, kind, stringValue, path, messageFormat) {
+  if (messageFormat != null) {
+    let ret = messageFormat.
+      replace('{KIND}', kind).
+      replace('{VALUE}', stringValue).
+      replace('{PATH}', path);
     if (model != null) {
       ret = ret.replace('{MODEL}', model.modelName);
     }
 
     return ret;
   } else {
-    let ret = 'Cast to ' + this.kind + ' failed for value ' +
-      this.stringValue + ' at path "' + this.path + '"';
+    let ret = 'Cast to ' + kind + ' failed for value ' +
+      stringValue + ' at path "' + path + '"';
     if (model != null) {
       ret += ' for model "' + model.modelName + '"';
     }
 
     return ret;
   }
-};
+}
 
 /*!
  * exports

--- a/lib/error/disconnected.js
+++ b/lib/error/disconnected.js
@@ -6,35 +6,26 @@
 
 const MongooseError = require('./');
 
+
 /**
  * The connection failed to reconnect and will never successfully reconnect to
  * MongoDB without manual intervention.
- *
- * @param {String} type
- * @param {String} value
- * @inherits MongooseError
  * @api private
  */
-
-function DisconnectedError(connectionString) {
-  MongooseError.call(this, 'Ran out of retries trying to reconnect to "' +
-    connectionString + '". Try setting `server.reconnectTries` and ' +
-    '`server.reconnectInterval` to something higher.');
-  this.name = 'DisconnectedError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class DisconnectedError extends MongooseError {
+  /**
+   * @param {String} connectionString
+   */
+  constructor(connectionString) {
+    super('Ran out of retries trying to reconnect to "' +
+      connectionString + '". Try setting `server.reconnectTries` and ' +
+      '`server.reconnectInterval` to something higher.');
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-DisconnectedError.prototype = Object.create(MongooseError.prototype);
-DisconnectedError.prototype.constructor = MongooseError;
-
+Object.defineProperty(DisconnectedError.prototype, 'name', {
+  value: 'DisconnectedError'
+});
 
 /*!
  * exports

--- a/lib/error/divergentArray.js
+++ b/lib/error/divergentArray.js
@@ -7,39 +7,28 @@
 
 const MongooseError = require('./');
 
-/*!
- * DivergentArrayError constructor.
- *
- * @inherits MongooseError
- */
-
-function DivergentArrayError(paths) {
-  const msg = 'For your own good, using `document.save()` to update an array '
-          + 'which was selected using an $elemMatch projection OR '
-          + 'populated using skip, limit, query conditions, or exclusion of '
-          + 'the _id field when the operation results in a $pop or $set of '
-          + 'the entire array is not supported. The following '
-          + 'path(s) would have been modified unsafely:\n'
-          + '  ' + paths.join('\n  ') + '\n'
-          + 'Use Model.update() to update these arrays instead.';
-  // TODO write up a docs page (FAQ) and link to it
-
-  MongooseError.call(this, msg);
-  this.name = 'DivergentArrayError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class DivergentArrayError extends MongooseError {
+  /*!
+   * DivergentArrayError constructor.
+   * @param {Array<String>} paths
+   */
+  constructor(paths) {
+    const msg = 'For your own good, using `document.save()` to update an array '
+            + 'which was selected using an $elemMatch projection OR '
+            + 'populated using skip, limit, query conditions, or exclusion of '
+            + 'the _id field when the operation results in a $pop or $set of '
+            + 'the entire array is not supported. The following '
+            + 'path(s) would have been modified unsafely:\n'
+            + '  ' + paths.join('\n  ') + '\n'
+            + 'Use Model.update() to update these arrays instead.';
+    // TODO write up a docs page (FAQ) and link to it
+    super(msg);
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-DivergentArrayError.prototype = Object.create(MongooseError.prototype);
-DivergentArrayError.prototype.constructor = MongooseError;
-
+Object.defineProperty(DivergentArrayError.prototype, 'name', {
+  value: 'DivergentArrayError'
+});
 
 /*!
  * exports

--- a/lib/error/missingSchema.js
+++ b/lib/error/missingSchema.js
@@ -7,30 +7,21 @@
 
 const MongooseError = require('./');
 
-/*!
- * MissingSchema Error constructor.
- *
- * @inherits MongooseError
- */
-
-function MissingSchemaError(name) {
-  const msg = 'Schema hasn\'t been registered for model "' + name + '".\n'
-          + 'Use mongoose.model(name, schema)';
-  MongooseError.call(this, msg);
-  this.name = 'MissingSchemaError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class MissingSchemaError extends MongooseError {
+  /*!
+   * MissingSchema Error constructor.
+   * @param {String} name
+   */
+  constructor(name) {
+    const msg = 'Schema hasn\'t been registered for model "' + name + '".\n'
+            + 'Use mongoose.model(name, schema)';
+    super(msg);
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-MissingSchemaError.prototype = Object.create(MongooseError.prototype);
-MissingSchemaError.prototype.constructor = MongooseError;
+Object.defineProperty(MissingSchemaError.prototype, 'name', {
+  value: 'MissingSchemaError'
+});
 
 /*!
  * exports

--- a/lib/error/mongooseError.js
+++ b/lib/error/mongooseError.js
@@ -4,22 +4,10 @@
  * ignore
  */
 
-function MongooseError(msg) {
-  Error.call(this);
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
-  }
-  this.message = msg;
-  this.name = 'MongooseError';
-}
+class MongooseError extends Error { }
 
-/*!
- * Inherits from Error.
- */
-
-MongooseError.prototype = Object.create(Error.prototype);
-MongooseError.prototype.constructor = Error;
+Object.defineProperty(MongooseError.prototype, 'name', {
+  value: 'MongooseError'
+});
 
 module.exports = MongooseError;

--- a/lib/error/notFound.js
+++ b/lib/error/notFound.js
@@ -7,46 +7,35 @@
 const MongooseError = require('./');
 const util = require('util');
 
-/*!
- * OverwriteModel Error constructor.
- *
- * @inherits MongooseError
- */
+class DocumentNotFoundError extends MongooseError {
+  /*!
+   * OverwriteModel Error constructor.
+   */
+  constructor(filter, model, numAffected, result) {
+    let msg;
+    const messages = MongooseError.messages;
+    if (messages.DocumentNotFoundError != null) {
+      msg = typeof messages.DocumentNotFoundError === 'function' ?
+        messages.DocumentNotFoundError(filter, model) :
+        messages.DocumentNotFoundError;
+    } else {
+      msg = 'No document found for query "' + util.inspect(filter) +
+        '" on model "' + model + '"';
+    }
 
-function DocumentNotFoundError(filter, model, numAffected, result) {
-  let msg;
-  const messages = MongooseError.messages;
-  if (messages.DocumentNotFoundError != null) {
-    msg = typeof messages.DocumentNotFoundError === 'function' ?
-      messages.DocumentNotFoundError(filter, model) :
-      messages.DocumentNotFoundError;
-  } else {
-    msg = 'No document found for query "' + util.inspect(filter) +
-      '" on model "' + model + '"';
+    super(msg);
+
+    this.result = result;
+    this.numAffected = numAffected;
+    this.filter = filter;
+    // Backwards compat
+    this.query = filter;
   }
-
-  MongooseError.call(this, msg);
-
-  this.name = 'DocumentNotFoundError';
-  this.result = result;
-  this.numAffected = numAffected;
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
-  }
-
-  this.filter = filter;
-  // Backwards compat
-  this.query = filter;
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-DocumentNotFoundError.prototype = Object.create(MongooseError.prototype);
-DocumentNotFoundError.prototype.constructor = MongooseError;
+Object.defineProperty(DocumentNotFoundError.prototype, 'name', {
+  value: 'DocumentNotFoundError'
+});
 
 /*!
  * exports

--- a/lib/error/objectExpected.js
+++ b/lib/error/objectExpected.js
@@ -6,33 +6,25 @@
 
 const MongooseError = require('./');
 
-/**
- * Strict mode error constructor
- *
- * @param {String} type
- * @param {String} value
- * @inherits MongooseError
- * @api private
- */
 
-function ObjectExpectedError(path, val) {
-  const typeDescription = Array.isArray(val) ? 'array' : 'primitive value';
-  MongooseError.call(this, 'Tried to set nested object field `' + path +
-    `\` to ${typeDescription} \`` + val + '` and strict mode is set to throw.');
-  this.name = 'ObjectExpectedError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class ObjectExpectedError extends MongooseError {
+  /**
+   * Strict mode error constructor
+   *
+   * @param {string} type
+   * @param {string} value
+   * @api private
+   */
+  constructor(path, val) {
+    const typeDescription = Array.isArray(val) ? 'array' : 'primitive value';
+    super('Tried to set nested object field `' + path +
+      `\` to ${typeDescription} \`` + val + '` and strict mode is set to throw.');
+    this.path = path;
   }
-  this.path = path;
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-ObjectExpectedError.prototype = Object.create(MongooseError.prototype);
-ObjectExpectedError.prototype.constructor = MongooseError;
+Object.defineProperty(ObjectExpectedError.prototype, 'name', {
+  value: 'ObjectExpectedError'
+});
 
 module.exports = ObjectExpectedError;

--- a/lib/error/objectParameter.js
+++ b/lib/error/objectParameter.js
@@ -6,33 +6,25 @@
 
 const MongooseError = require('./');
 
-/**
- * Constructor for errors that happen when a parameter that's expected to be
- * an object isn't an object
- *
- * @param {Any} value
- * @param {String} paramName
- * @param {String} fnName
- * @inherits MongooseError
- * @api private
- */
-
-function ObjectParameterError(value, paramName, fnName) {
-  MongooseError.call(this, 'Parameter "' + paramName + '" to ' + fnName +
-    '() must be an object, got ' + value.toString());
-  this.name = 'ObjectParameterError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class ObjectParameterError extends MongooseError {
+  /**
+   * Constructor for errors that happen when a parameter that's expected to be
+   * an object isn't an object
+   *
+   * @param {Any} value
+   * @param {String} paramName
+   * @param {String} fnName
+   * @api private
+   */
+  constructor(value, paramName, fnName) {
+    super('Parameter "' + paramName + '" to ' + fnName +
+      '() must be an object, got ' + value.toString());
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
 
-ObjectParameterError.prototype = Object.create(MongooseError.prototype);
-ObjectParameterError.prototype.constructor = MongooseError;
+Object.defineProperty(ObjectParameterError.prototype, 'name', {
+  value: 'ObjectParameterError'
+});
 
 module.exports = ObjectParameterError;

--- a/lib/error/overwriteModel.js
+++ b/lib/error/overwriteModel.js
@@ -7,28 +7,20 @@
 
 const MongooseError = require('./');
 
-/*!
- * OverwriteModel Error constructor.
- *
- * @inherits MongooseError
- */
 
-function OverwriteModelError(name) {
-  MongooseError.call(this, 'Cannot overwrite `' + name + '` model once compiled.');
-  this.name = 'OverwriteModelError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class OverwriteModelError extends MongooseError {
+  /*!
+   * OverwriteModel Error constructor.
+   * @param {String} name
+   */
+  constructor(name) {
+    super('Cannot overwrite `' + name + '` model once compiled.');
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-OverwriteModelError.prototype = Object.create(MongooseError.prototype);
-OverwriteModelError.prototype.constructor = MongooseError;
+Object.defineProperty(OverwriteModelError.prototype, 'name', {
+  value: 'OverwriteModelError'
+});
 
 /*!
  * exports

--- a/lib/error/parallelSave.js
+++ b/lib/error/parallelSave.js
@@ -6,25 +6,22 @@
 
 const MongooseError = require('./');
 
-/**
- * ParallelSave Error constructor.
- *
- * @inherits MongooseError
- * @api private
- */
-
-function ParallelSaveError(doc) {
-  const msg = 'Can\'t save() the same doc multiple times in parallel. Document: ';
-  MongooseError.call(this, msg + doc._id);
-  this.name = 'ParallelSaveError';
+class ParallelSaveError extends MongooseError {
+  /**
+   * ParallelSave Error constructor.
+   *
+   * @param {Document} doc
+   * @api private
+   */
+  constructor(doc) {
+    const msg = 'Can\'t save() the same doc multiple times in parallel. Document: ';
+    super(msg + doc._id);
+  }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-ParallelSaveError.prototype = Object.create(MongooseError.prototype);
-ParallelSaveError.prototype.constructor = MongooseError;
+Object.defineProperty(ParallelSaveError.prototype, 'name', {
+  value: 'ParallelSaveError'
+});
 
 /*!
  * exports

--- a/lib/error/parallelValidate.js
+++ b/lib/error/parallelValidate.js
@@ -6,25 +6,23 @@
 
 const MongooseError = require('./mongooseError');
 
-/**
- * ParallelValidate Error constructor.
- *
- * @inherits MongooseError
- * @api private
- */
 
-function ParallelValidateError(doc) {
-  const msg = 'Can\'t validate() the same doc multiple times in parallel. Document: ';
-  MongooseError.call(this, msg + doc._id);
-  this.name = 'ParallelValidateError';
+class ParallelValidateError extends MongooseError {
+  /**
+   * ParallelValidate Error constructor.
+   *
+   * @param {Document} doc
+   * @api private
+   */
+  constructor(doc) {
+    const msg = 'Can\'t validate() the same doc multiple times in parallel. Document: ';
+    super(msg + doc._id);
+  }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-ParallelValidateError.prototype = Object.create(MongooseError.prototype);
-ParallelValidateError.prototype.constructor = MongooseError;
+Object.defineProperty(ParallelValidateError.prototype, 'name', {
+  value: 'ParallelValidateError'
+});
 
 /*!
  * exports

--- a/lib/error/serverSelection.js
+++ b/lib/error/serverSelection.js
@@ -8,32 +8,6 @@ const MongooseError = require('./mongooseError');
 const allServersUnknown = require('../helpers/topology/allServersUnknown');
 const isAtlas = require('../helpers/topology/isAtlas');
 
-/**
- * MongooseServerSelectionError constructor
- *
- * @param {String} type
- * @param {String} value
- * @inherits MongooseError
- * @api private
- */
-
-function MongooseServerSelectionError(message) {
-  MongooseError.call(this, message);
-  this.name = 'MongooseServerSelectionError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
-  }
-}
-
-/*!
- * Inherits from MongooseError.
- */
-
-MongooseServerSelectionError.prototype = Object.create(MongooseError.prototype);
-MongooseServerSelectionError.prototype.constructor = MongooseError;
-
 /*!
  * ignore
  */
@@ -42,18 +16,31 @@ const atlasMessage = 'Could not connect to any servers in your MongoDB Atlas ' +
   'cluster. Make sure your current IP address is on your Atlas cluster\'s IP ' +
   'whitelist: https://docs.atlas.mongodb.com/security-whitelist/.';
 
-MongooseServerSelectionError.prototype.assimilateError = function(err) {
-  const reason = err.reason;
-  // Special message for a case that is likely due to IP whitelisting issues.
-  const isAtlasWhitelistError = isAtlas(reason) && allServersUnknown(reason);
-  this.message = isAtlasWhitelistError ?
-    atlasMessage :
-    err.message;
-  Object.assign(this, err, {
-    name: 'MongooseServerSelectionError'
-  });
+class MongooseServerSelectionError extends MongooseError {
+  /**
+   * MongooseServerSelectionError constructor
+   *
+   * @api private
+   */
+  assimilateError(err) {
+    const reason = err.reason;
+    // Special message for a case that is likely due to IP whitelisting issues.
+    const isAtlasWhitelistError = isAtlas(reason) && allServersUnknown(reason);
+    this.message = isAtlasWhitelistError ?
+      atlasMessage :
+      err.message;
+    for (const key in err) {
+      if (key !== 'name') {
+        this[key] = err[key];
+      }
+    }
 
-  return this;
-};
+    return this;
+  }
+}
+
+Object.defineProperty(MongooseServerSelectionError.prototype, 'name', {
+  value: 'MongooseServerSelectionError'
+});
 
 module.exports = MongooseServerSelectionError;

--- a/lib/error/strict.js
+++ b/lib/error/strict.js
@@ -6,34 +6,28 @@
 
 const MongooseError = require('./');
 
-/**
- * Strict mode error constructor
- *
- * @param {String} type
- * @param {String} value
- * @inherits MongooseError
- * @api private
- */
 
-function StrictModeError(path, msg, immutable) {
-  msg = msg || 'Field `' + path + '` is not in schema and strict ' +
-    'mode is set to throw.';
-  MongooseError.call(this, msg);
-  this.name = 'StrictModeError';
-  this.isImmutableError = !!immutable;
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+class StrictModeError extends MongooseError {
+  /**
+   * Strict mode error constructor
+   *
+   * @param {String} path
+   * @param {String} [msg]
+   * @param {Boolean} [immutable]
+   * @inherits MongooseError
+   * @api private
+   */
+  constructor(path, msg, immutable) {
+    msg = msg || 'Field `' + path + '` is not in schema and strict ' +
+      'mode is set to throw.';
+    super(msg);
+    this.isImmutableError = !!immutable;
+    this.path = path;
   }
-  this.path = path;
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-StrictModeError.prototype = Object.create(MongooseError.prototype);
-StrictModeError.prototype.constructor = MongooseError;
+Object.defineProperty(StrictModeError.prototype, 'name', {
+  value: 'StrictModeError'
+});
 
 module.exports = StrictModeError;

--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -7,59 +7,56 @@
 const MongooseError = require('./');
 const util = require('util');
 
-/**
- * Document Validation Error
- *
- * @api private
- * @param {Document} instance
- * @inherits MongooseError
- */
 
-function ValidationError(instance) {
-  this.errors = {};
-  this._message = '';
+class ValidationError extends MongooseError {
+  /**
+   * Document Validation Error
+   *
+   * @api private
+   * @param {Document} [instance]
+   * @inherits MongooseError
+   */
+  constructor(instance) {
+    let _message;
+    if (instance && instance.constructor.name === 'model') {
+      _message = instance.constructor.modelName + ' validation failed';
+    } else {
+      _message = 'Validation failed';
+    }
 
-  if (instance && instance.constructor.name === 'model') {
-    this._message = instance.constructor.modelName + ' validation failed';
-  } else {
-    this._message = 'Validation failed';
+    super(_message);
+
+    this.errors = {};
+    this._message = _message;
+
+    if (instance) {
+      instance.errors = this.errors;
+    }
   }
-  MongooseError.call(this, this._message);
-  this.name = 'ValidationError';
 
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+  /**
+   * Console.log helper
+   */
+  toString() {
+    return this.name + ': ' + _generateMessage(this);
   }
 
-  if (instance) {
-    instance.errors = this.errors;
+  /*!
+   * inspect helper
+   */
+  inspect() {
+    return Object.assign(new Error(this.message), this);
+  }
+
+  /*!
+  * add message
+  */
+  addError(path, error) {
+    this.errors[path] = error;
+    this.message = this._message + ': ' + _generateMessage(this);
   }
 }
 
-/*!
- * Inherits from MongooseError.
- */
-
-ValidationError.prototype = Object.create(MongooseError.prototype);
-ValidationError.prototype.constructor = MongooseError;
-
-/**
- * Console.log helper
- */
-
-ValidationError.prototype.toString = function() {
-  return this.name + ': ' + _generateMessage(this);
-};
-
-/*!
- * inspect helper
- */
-
-ValidationError.prototype.inspect = function() {
-  return Object.assign(new Error(this.message), this);
-};
 
 if (util.inspect.custom) {
   /*!
@@ -81,14 +78,10 @@ Object.defineProperty(ValidationError.prototype, 'toJSON', {
   }
 });
 
-/*!
- * add message
- */
 
-ValidationError.prototype.addError = function(path, error) {
-  this.errors[path] = error;
-  this.message = this._message + ': ' + _generateMessage(this);
-};
+Object.defineProperty(ValidationError.prototype, 'name', {
+  value: 'ValidationError'
+});
 
 /*!
  * ignore

--- a/lib/error/validator.js
+++ b/lib/error/validator.js
@@ -6,43 +6,44 @@
 
 const MongooseError = require('./');
 
-/**
- * Schema validator error
- *
- * @param {Object} properties
- * @inherits MongooseError
- * @api private
- */
 
-function ValidatorError(properties) {
-  let msg = properties.message;
-  if (!msg) {
-    msg = MongooseError.messages.general.default;
+class ValidatorError extends MongooseError {
+  /**
+   * Schema validator error
+   *
+   * @param {Object} properties
+   * @api private
+   */
+  constructor(properties) {
+    let msg = properties.message;
+    if (!msg) {
+      msg = MongooseError.messages.general.default;
+    }
+
+    const message = formatMessage(msg, properties);
+    super(message);
+
+    properties = Object.assign({}, properties, { message: message });
+    this.properties = properties;
+    this.kind = properties.type;
+    this.path = properties.path;
+    this.value = properties.value;
+    this.reason = properties.reason;
   }
 
-  const message = this.formatMessage(msg, properties);
-  MongooseError.call(this, message);
-
-  properties = Object.assign({}, properties, { message: message });
-  this.name = 'ValidatorError';
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this);
-  } else {
-    this.stack = new Error().stack;
+  /*!
+   * toString helper
+   * TODO remove? This defaults to `${this.name}: ${this.message}`
+   */
+  toString() {
+    return this.message;
   }
-  this.properties = properties;
-  this.kind = properties.type;
-  this.path = properties.path;
-  this.value = properties.value;
-  this.reason = properties.reason;
 }
 
-/*!
- * Inherits from MongooseError
- */
 
-ValidatorError.prototype = Object.create(MongooseError.prototype);
-ValidatorError.prototype.constructor = MongooseError;
+Object.defineProperty(ValidatorError.prototype, 'name', {
+  value: 'ValidatorError'
+});
 
 /*!
  * The object used to define this validator. Not enumerable to hide
@@ -55,11 +56,14 @@ Object.defineProperty(ValidatorError.prototype, 'properties', {
   value: null
 });
 
+// Exposed for testing
+ValidatorError.prototype.formatMessage = formatMessage;
+
 /*!
  * Formats error messages
  */
 
-ValidatorError.prototype.formatMessage = function(msg, properties) {
+function formatMessage(msg, properties) {
   if (typeof msg === 'function') {
     return msg(properties);
   }
@@ -73,15 +77,7 @@ ValidatorError.prototype.formatMessage = function(msg, properties) {
   }
 
   return msg;
-};
-
-/*!
- * toString helper
- */
-
-ValidatorError.prototype.toString = function() {
-  return this.message;
-};
+}
 
 /*!
  * exports

--- a/lib/error/version.js
+++ b/lib/error/version.js
@@ -6,28 +6,28 @@
 
 const MongooseError = require('./');
 
-/**
- * Version Error constructor.
- *
- * @inherits MongooseError
- * @api private
- */
-
-function VersionError(doc, currentVersion, modifiedPaths) {
-  const modifiedPathsStr = modifiedPaths.join(', ');
-  MongooseError.call(this, 'No matching document found for id "' + doc._id +
-    '" version ' + currentVersion + ' modifiedPaths "' + modifiedPathsStr + '"');
-  this.name = 'VersionError';
-  this.version = currentVersion;
-  this.modifiedPaths = modifiedPaths;
+class VersionError extends MongooseError {
+  /**
+   * Version Error constructor.
+   *
+   * @param {Document} doc
+   * @param {Number} currentVersion
+   * @param {Array<String>} modifiedPaths
+   * @api private
+   */
+  constructor(doc, currentVersion, modifiedPaths) {
+    const modifiedPathsStr = modifiedPaths.join(', ');
+    super('No matching document found for id "' + doc._id +
+      '" version ' + currentVersion + ' modifiedPaths "' + modifiedPathsStr + '"');
+    this.version = currentVersion;
+    this.modifiedPaths = modifiedPaths;
+  }
 }
 
-/*!
- * Inherits from MongooseError.
- */
 
-VersionError.prototype = Object.create(MongooseError.prototype);
-VersionError.prototype.constructor = MongooseError;
+Object.defineProperty(VersionError.prototype, 'name', {
+  value: 'VersionError'
+});
 
 /*!
  * exports


### PR DESCRIPTION
**Summary**

Converts all errors to real ECMAScript classes that extend Error. This gives a significant performance improvement.

CPU profiles for one of the read benchmarks:

Before:
![image](https://user-images.githubusercontent.com/469365/82131205-eff2b680-978f-11ea-8805-89a9d83bdfdc.png)

After:
![image](https://user-images.githubusercontent.com/469365/82131200-df424080-978f-11ea-9a64-85a64660ac1c.png)

I also corrected a few of the JSDoc type annotations that looked like copy/paste errors along the way.
