### PR TITLE
fix(document): use the complete path name of a property when avoiding overwriting default values with undefined

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -957,9 +957,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
       this.$__.$setCalled.add(prefix + key);
       this.$set(path[key], prefix + key, constructing, options);
     } else if (strict) {
-      // Don't overwrite defaults with undefined keys (gh-3981)
+      // Don't overwrite defaults with undefined keys (gh-3981) (gh-9039)
       if (constructing && path[key] === void 0 &&
-          this.get(key) !== void 0) {
+          this.get(pathName) !== void 0) {
         return;
       }
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -9000,4 +9000,20 @@ describe('document', function() {
       assert.ok(!user.updatedAt);
     });
   });
+
+  it('Sets default when passing undefined as value for a key in a nested subdoc (gh-????)', function() {
+    const Test = db.model('Test', {
+      nested: {
+        prop: {
+          type: String,
+          default: 'some default value'
+        }
+      }
+    });
+
+    return co(function*() {
+      const doc = yield Test.create({ nested: { prop: undefined } });
+      assert.equal(doc.nested.prop, 'some default value');
+    });
+  });
 });

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -9001,7 +9001,7 @@ describe('document', function() {
     });
   });
 
-  it('Sets default when passing undefined as value for a key in a nested subdoc (gh-????)', function() {
+  it('Sets default when passing undefined as value for a key in a nested subdoc (gh-9039)', function() {
     const Test = db.model('Test', {
       nested: {
         prop: {


### PR DESCRIPTION
**Summary**
This prevents Mongoose from overwriting default values with undefined for nested documents

**Examples**
See #9039
