### PR TITLE
enhancement(connection): make server selection error less deterministic

### DIFF
--- a/lib/error/serverSelection.js
+++ b/lib/error/serverSelection.js
@@ -38,9 +38,10 @@ MongooseServerSelectionError.prototype.constructor = MongooseError;
  * ignore
  */
 
-const atlasMessage = 'Could not connect to any servers in your MongoDB Atlas ' +
-  'cluster. Make sure your current IP address is on your Atlas cluster\'s IP ' +
-  'whitelist: https://docs.atlas.mongodb.com/security-whitelist/.';
+const atlasMessage = 'Could not connect to any servers in your MongoDB Atlas cluster. ' +
+  'One common reason is that you\'re trying to access the database from ' +
+  'an IP that isn\'t whitelisted. Make sure your current IP address is on your Atlas ' +
+  'cluster\'s IP whitelist: https://docs.atlas.mongodb.com/security-whitelist/';
 
 MongooseServerSelectionError.prototype.assimilateError = function(err) {
   const reason = err.reason;


### PR DESCRIPTION
fixes #9006

The current error message could give the impression that this **is** the reason the connection failed, not just a common reason. According to https://github.com/Automattic/mongoose/issues/9006#issue-618882548 there are other possible reasons (such as incorrect credentials), this PR makes it so that the message is less deterministic.