### PR TITLE
fix docs: validateBeforeSave 

### DIFF
--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -853,7 +853,7 @@ block content
     var schema = new Schema({ name: String });
     schema.set('validateBeforeSave', false);
     schema.path('name').validate(function (value) {
-        return v != null;
+        return value != null;
     });
     var M = mongoose.model('Person', schema);
     var m = new M({ name: null });


### PR DESCRIPTION
**Summary**

There was an error in a Schema option (`validateBeforeSave`) example. 

**Examples**

The parameter name of the `validate` function is **`value`**, so the inner variable name must be the same as well.
