### PR TITLE
docs: add schema and how to set default sub-schema to schematype options

### DIFF
--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -81,6 +81,7 @@ block content
     - [Array](#arrays)
     - [Decimal128](./api.html#mongoose_Mongoose-Decimal128)
     - [Map](#maps)
+    - [Schema](#schemas)
 
     <h4>Example</h4>
 
@@ -660,6 +661,28 @@ block content
 
     // Good, do this instead of declaring a getter on `arr`
     schema.path('arr.0.url').get(v => `${root}${v}`);
+    ```
+
+    <h3 id="schemas"><a href="#schemas">Schemas</a></h3>
+
+    To declare a path as another [schema](./guide.html#definition),
+    set `type` to the sub-schema's instance.
+
+    To set a default value based on the sub-schema's shape, simply set a default value,
+    and the value will be cast based on the sub-schema's definition before being set
+    during document creation.
+
+    ```javascript
+    const subSchema = new mongoose.Schema({
+      // some schema definition here
+    });
+
+    const schema = new mongoose.Schema({
+      data: {
+        type: subSchema
+        default: {}
+      }
+    });
     ```
 
     <h3 id="customtypes"><a href="#customtypes">Creating Custom Types</a></h3>


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
I recently ran into this issue https://github.com/Automattic/mongoose/issues/9104 when upgrading mongoose. I was surprised to find that schemas were not listed as a potential schematype option and wanted to point others toward how to set a sub-schema as the default value.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
N/A
