### PR TITLE
Performance Bottleneck with creation of ServerSelectionError and CastError

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4892,11 +4892,11 @@ Model.$handleCallbackError = function(callback) {
  */
 
 Model.$wrapCallback = function(callback) {
-  const serverSelectionError = new ServerSelectionError();
   const _this = this;
 
   return function(err) {
     if (err != null && err.name === 'MongoServerSelectionError') {
+      const serverSelectionError = new ServerSelectionError();
       arguments[0] = serverSelectionError.assimilateError(err);
     }
     if (err != null && err.name === 'MongoNetworkError' && err.message.endsWith('timed out')) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4368,7 +4368,7 @@ Query.prototype.exec = function exec(op, callback) {
 
     this._hooks.execPre('exec', this, [], (error) => {
       if (error != null) {
-        return cb(_cleanCastErrorStack(new CastError(), error));
+        return cb(_cleanCastErrorStack(error));
       }
       let thunk = '_' + this.op;
       if (this.op === 'update') {
@@ -4378,12 +4378,12 @@ Query.prototype.exec = function exec(op, callback) {
       }
       this[thunk].call(this, (error, res) => {
         if (error) {
-          return cb(_cleanCastErrorStack(new CastError(), error));
+          return cb(_cleanCastErrorStack(error));
         }
 
         this._hooks.execPost('exec', this, [], {}, (error) => {
           if (error) {
-            return cb(_cleanCastErrorStack(new CastError(), error));
+            return cb(_cleanCastErrorStack(error));
           }
 
           cb(null, res);
@@ -4397,8 +4397,9 @@ Query.prototype.exec = function exec(op, callback) {
  * ignore
  */
 
-function _cleanCastErrorStack(castError, error) {
+function _cleanCastErrorStack(error) {
   if (error instanceof CastError) {
+    const castError = new CastError();
     castError.copy(error);
     return castError;
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -4348,7 +4348,6 @@ Query.prototype.exec = function exec(op, callback) {
   const _this = this;
   // Ensure that `exec()` is the first thing that shows up in
   // the stack when cast errors happen.
-  const castError = new CastError();
 
   if (typeof op === 'function') {
     callback = op;
@@ -4369,7 +4368,7 @@ Query.prototype.exec = function exec(op, callback) {
 
     this._hooks.execPre('exec', this, [], (error) => {
       if (error != null) {
-        return cb(_cleanCastErrorStack(castError, error));
+        return cb(_cleanCastErrorStack(new CastError(), error));
       }
       let thunk = '_' + this.op;
       if (this.op === 'update') {
@@ -4379,12 +4378,12 @@ Query.prototype.exec = function exec(op, callback) {
       }
       this[thunk].call(this, (error, res) => {
         if (error) {
-          return cb(_cleanCastErrorStack(castError, error));
+          return cb(_cleanCastErrorStack(new CastError(), error));
         }
 
         this._hooks.execPost('exec', this, [], {}, (error) => {
           if (error) {
-            return cb(_cleanCastErrorStack(castError, error));
+            return cb(_cleanCastErrorStack(new CastError(), error));
           }
 
           cb(null, res);

--- a/lib/query.js
+++ b/lib/query.js
@@ -4348,6 +4348,7 @@ Query.prototype.exec = function exec(op, callback) {
   const _this = this;
   // Ensure that `exec()` is the first thing that shows up in
   // the stack when cast errors happen.
+  const castError = new CastError();
 
   if (typeof op === 'function') {
     callback = op;
@@ -4368,7 +4369,7 @@ Query.prototype.exec = function exec(op, callback) {
 
     this._hooks.execPre('exec', this, [], (error) => {
       if (error != null) {
-        return cb(_cleanCastErrorStack(error));
+        return cb(_cleanCastErrorStack(castError, error));
       }
       let thunk = '_' + this.op;
       if (this.op === 'update') {
@@ -4378,12 +4379,12 @@ Query.prototype.exec = function exec(op, callback) {
       }
       this[thunk].call(this, (error, res) => {
         if (error) {
-          return cb(_cleanCastErrorStack(error));
+          return cb(_cleanCastErrorStack(castError, error));
         }
 
         this._hooks.execPost('exec', this, [], {}, (error) => {
           if (error) {
-            return cb(_cleanCastErrorStack(error));
+            return cb(_cleanCastErrorStack(castError, error));
           }
 
           cb(null, res);
@@ -4397,9 +4398,8 @@ Query.prototype.exec = function exec(op, callback) {
  * ignore
  */
 
-function _cleanCastErrorStack(error) {
+function _cleanCastErrorStack(castError, error) {
   if (error instanceof CastError) {
-    const castError = new CastError();
     castError.copy(error);
     return castError;
   }


### PR DESCRIPTION
**Summary**

While running performance tests, I realized, that mongoose creates alot of unnecessary ServerSelectionErrors and CastErrors. My Flamegraphs get hot.

**Examples**

before:
![Bildschirmfoto von 2020-06-13 03-40-38](https://user-images.githubusercontent.com/5059100/84557023-c34aa400-ad27-11ea-815d-b1d06bbae731.png)

after fixing ServerSelectionError

![Bildschirmfoto von 2020-06-13 03-40-55](https://user-images.githubusercontent.com/5059100/84557035-d493b080-ad27-11ea-9b76-a656d72a5e9c.png)

after fixing CastError
![Bildschirmfoto von 2020-06-13 03-41-03](https://user-images.githubusercontent.com/5059100/84557039-d8bfce00-ad27-11ea-8702-f30a886915d3.png)
