### PR TITLE
Update schema.js

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -509,7 +509,7 @@ Schema.prototype.add = function add(obj, prefix) {
         // Propage `typePojoToMixed` to implicitly created schemas
         const opts = { typePojoToMixed: false };
         const _schema = new Schema(obj[key][this.options.typeKey], opts);
-        const schemaWrappedPath = Object.assign({}, obj[key], { type: _schema });
+        const schemaWrappedPath = Object.assign({}, obj[key], { [this.options.typeKey]: _schema });
         this.path(prefix + key, schemaWrappedPath);
       } else {
         // Either the type is non-POJO or we interpret it as Mixed anyway


### PR DESCRIPTION

**Summary**

I've been trying to debug the following problem: when a custom `typeKey` and `typePojoToMixed: false` are passed as options to a schema, schema properties under the new typeKey that are a POJO get set as Mixed in the schema. This is incorrect, the type should be dynamically converted to a subschema, as per the line I have changed in this PR.
My change preserves the `typeKey` during the Object.assign, instead of using the default key of `type`.

**Examples**

```
const schema = mongoose.Schema({ a: { $type: { b: String, c: String } }}, { typeKey: '$type', typePojoToMixed: false });

// current buggy behavior: 
console.log({ schema }) // Schema { ..., paths: {  'a': [Mixed] } }   

// expected behavior: 
console.log({ schema }) // Schema { ..., paths: {  'a.b': [SchemaString], 'a.c': [SchemaString] } }   
```