### PR TITLE
Allow null in Boolean.convertTo(True|False) functions (#9146).

### DIFF
--- a/lib/cast/boolean.js
+++ b/lib/cast/boolean.js
@@ -14,15 +14,14 @@ const CastError = require('../error/cast');
  */
 
 module.exports = function castBoolean(value, path) {
-  if (value == null) {
-    return value;
-  }
-
   if (module.exports.convertToTrue.has(value)) {
     return true;
   }
   if (module.exports.convertToFalse.has(value)) {
     return false;
+  }
+  if (value == null) {
+    return value;
   }
   throw new CastError('boolean', value, path);
 };

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -224,6 +224,8 @@ SchemaBoolean.prototype.castForQuery = function($conditional, val) {
   return this._castForQuery($conditional);
 };
 
+SchemaBoolean.prototype.castNull = true;
+
 /*!
  * Module exports.
  */

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1055,7 +1055,7 @@ SchemaType.prototype._applySetters = function(value, scope, init, priorVal) {
 SchemaType.prototype.applySetters = function(value, scope, init, priorVal, options) {
   let v = this._applySetters(value, scope, init, priorVal, options);
 
-  if (v == null) {
+  if (v == null && !this.castNull) {
     return v;
   }
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**
Allow Boolean.convertToFalse Set to take null. See [comment](https://github.com/Automattic/mongoose/issues/9146#issuecomment-656084916) on #9146 for motivation.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```
const mongoose = require('/home/sam/src/mongoose/index.js');
const { Schema } = mongoose;
mongoose.Schema.Types.Boolean.convertToFalse.add(null);
console.log(mongoose.Schema.Types.Boolean.convertToFalse);
const M = mongoose.model('Test', new Schema({ b: Boolean }));
console.log(new M({ b: null })); // false
```