### PR TITLE
don't throw error when comparing options with/without collation

### DIFF
--- a/lib/helpers/indexes/isIndexEqual.js
+++ b/lib/helpers/indexes/isIndexEqual.js
@@ -17,6 +17,9 @@ module.exports = function isIndexEqual(key, options, dbIndex) {
       continue;
     }
     if (key === 'collation') {
+      if (!(key in options) || !(key in dbIndex)) {
+        return false;
+      }
       const definedKeys = Object.keys(options.collation);
       const schemaCollation = options.collation;
       const dbCollation = dbIndex.collation;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**
On a collection, and in the schema, have an index with and without a collation. Run `syncIndexes()`, it fails at line 21 with `TypeError: Cannot convert undefined or null to object` when `key` is "collation" but `options.collation` is undefined.

**Examples**
Example arguments to isIndexesEqual that throw an error:
```
key = { name: 1 };
options = { unique: true, background: true };
dbIndex = {
  v: 2,
  unique: true,
  key: { name: 1 },
  name: 'name_case_insensitive',
  ns: 'main.tags',
  background: true,
  collation: {
    locale: 'en',
    caseLevel: false,
    caseFirst: 'off',
    strength: 2,
    numericOrdering: false,
    alternate: 'non-ignorable',
    maxVariable: 'punct',
    normalization: false,
    backwards: false,
    version: '57.1'
  }
};
```