### PR TITLE
Fix: Retaining null value for populated documents when _id is suppressed

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -243,7 +243,7 @@ function valueFilter(val, assignmentOpts, populateOptions) {
  */
 
 function maybeRemoveId(subdoc, assignmentOpts) {
-  if (assignmentOpts.excludeId) {
+  if (subdoc != null && assignmentOpts.excludeId) {
     if (typeof subdoc.$__setValue === 'function') {
       delete subdoc._doc._id;
     } else {


### PR DESCRIPTION
**Summary**

Fix #9336 

Added a null check to push null subdoc, preventing the error described in #9336.


