### PR TITLE
Implement cursor population in batches, only when batchSize is passed

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -295,11 +295,6 @@ function _next(ctx, cb) {
   }
 
   if (ctx.cursor) {
-    function nextDoc(doc, pop) {
-      return ctx.query._mongooseOptions.lean ?
-        callback(null, doc) :
-        _create(ctx, doc, pop, callback);
-    }
     if (ctx.query._mongooseOptions.populate && !ctx._pop) {
       ctx._pop = helpers.preparePopulationOptionsMQ(ctx.query,
         ctx.query._mongooseOptions);
@@ -308,47 +303,13 @@ function _next(ctx, cb) {
     if (ctx.query._mongooseOptions.populate && ctx.options.batchSize > 1) {
       if (ctx._batchDocs && ctx._batchDocs.length) {
         // Return a cached populated doc
-        return nextDoc(ctx._batchDocs.shift(), ctx._pop);
+        return _nextDoc(ctx, ctx._batchDocs.shift(), ctx._pop, callback);
       } else if (ctx._batchExhausted) {
         // Internal cursor reported no more docs. Act the same here
         return callback(null, null);
       } else {
-        const _batchDocs = []
         // Request as many docs as batchSize, to populate them also in batch
-        function populateBatch() {
-          if (!_batchDocs.length) {
-            return callback(null, null);
-          }
-          ctx.query.model.populate(_batchDocs, ctx._pop, function(err, docs) {
-            if (err) {
-              return callback(err);
-            }
-
-            ctx._batchDocs = docs
-
-            nextDoc(ctx._batchDocs.shift(), ctx._pop);
-          });
-        }
-
-        function onNext(error, doc) {
-          if (error) {
-            return callback(error);
-          }
-          if (!doc) {
-            ctx._batchExhausted = true
-            return populateBatch();
-          }
-
-          _batchDocs.push(doc);
-
-          if (_batchDocs.length < ctx.options.batchSize) {
-            ctx.cursor.next(onNext);
-          } else {
-            populateBatch();
-          }
-        }
-
-        return ctx.cursor.next(onNext);
+        return ctx.cursor.next(_onNext.bind({ ctx, callback, batchDocs: [] }));
       }
     } else {
       return ctx.cursor.next(function(error, doc) {
@@ -360,14 +321,14 @@ function _next(ctx, cb) {
         }
 
         if (!ctx.query._mongooseOptions.populate) {
-          return nextDoc(doc, null);
+          return _nextDoc(ctx, doc, null, callback);
         }
 
         ctx.query.model.populate(doc, ctx._pop, function(err, doc) {
           if (err) {
             return callback(err);
           }
-          return nextDoc(doc, ctx._pop);
+          return _nextDoc(ctx, doc, ctx._pop, callback);
         });
       });
     }
@@ -376,6 +337,58 @@ function _next(ctx, cb) {
       _next(ctx, cb);
     });
   }
+}
+
+/*!
+ * ignore
+ */
+
+function _onNext(error, doc) {
+  if (error) {
+    return this.callback(error);
+  }
+  if (!doc) {
+    this.ctx._batchExhausted = true;
+    return _populateBatch.call(this);
+  }
+
+  this.batchDocs.push(doc);
+
+  if (this.batchDocs.length < this.ctx.options.batchSize) {
+    this.ctx.cursor.next(_onNext.bind(this));
+  } else {
+    _populateBatch.call(this);
+  }
+}
+
+/*!
+ * ignore
+ */
+
+function _populateBatch() {
+  if (!this.batchDocs.length) {
+    return this.callback(null, null);
+  }
+  const _this = this;
+  this.ctx.query.model.populate(this.batchDocs, this.ctx._pop, function(err, docs) {
+    if (err) {
+      return _this.callback(err);
+    }
+
+    _this.ctx._batchDocs = docs;
+
+    _nextDoc(_this.ctx, _this.ctx._batchDocs.shift(), _this.ctx._pop, _this.callback);
+  });
+}
+
+/*!
+ * ignore
+ */
+
+function _nextDoc(ctx, doc, pop, callback) {
+  return ctx.query._mongooseOptions.lean ?
+    callback(null, doc) :
+    _create(ctx, doc, pop, callback);
 }
 
 /*!

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -309,7 +309,8 @@ function _next(ctx, cb) {
         return callback(null, null);
       } else {
         // Request as many docs as batchSize, to populate them also in batch
-        return ctx.cursor.next(_onNext.bind({ ctx, callback, batchDocs: [] }));
+        ctx._batchDocs = [];
+        return ctx.cursor.next(_onNext.bind({ ctx, callback }));
       }
     } else {
       return ctx.cursor.next(function(error, doc) {
@@ -352,9 +353,9 @@ function _onNext(error, doc) {
     return _populateBatch.call(this);
   }
 
-  this.batchDocs.push(doc);
+  this.ctx._batchDocs.push(doc);
 
-  if (this.batchDocs.length < this.ctx.options.batchSize) {
+  if (this.ctx._batchDocs.length < this.ctx.options.batchSize) {
     this.ctx.cursor.next(_onNext.bind(this));
   } else {
     _populateBatch.call(this);
@@ -366,16 +367,14 @@ function _onNext(error, doc) {
  */
 
 function _populateBatch() {
-  if (!this.batchDocs.length) {
+  if (!this.ctx._batchDocs.length) {
     return this.callback(null, null);
   }
   const _this = this;
-  this.ctx.query.model.populate(this.batchDocs, this.ctx._pop, function(err, docs) {
+  this.ctx.query.model.populate(this.ctx._batchDocs, this.ctx._pop, function(err) {
     if (err) {
       return _this.callback(err);
     }
-
-    _this.ctx._batchDocs = docs;
 
     _nextDoc(_this.ctx, _this.ctx._batchDocs.shift(), _this.ctx._pop, _this.callback);
   });

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -295,33 +295,82 @@ function _next(ctx, cb) {
   }
 
   if (ctx.cursor) {
-    return ctx.cursor.next(function(error, doc) {
-      if (error) {
-        return callback(error);
-      }
-      if (!doc) {
-        return callback(null, null);
-      }
-
-      const opts = ctx.query._mongooseOptions;
-      if (!opts.populate) {
-        return opts.lean ?
-          callback(null, doc) :
-          _create(ctx, doc, null, callback);
-      }
-
-      const pop = helpers.preparePopulationOptionsMQ(ctx.query,
+    function nextDoc(doc, pop) {
+      return ctx.query._mongooseOptions.lean ?
+        callback(null, doc) :
+        _create(ctx, doc, pop, callback);
+    }
+    if (ctx.query._mongooseOptions.populate && !ctx._pop) {
+      ctx._pop = helpers.preparePopulationOptionsMQ(ctx.query,
         ctx.query._mongooseOptions);
-      pop.__noPromise = true;
-      ctx.query.model.populate(doc, pop, function(err, doc) {
-        if (err) {
-          return callback(err);
+      ctx._pop.__noPromise = true;
+    }
+    if (ctx.query._mongooseOptions.populate && ctx.options.batchSize > 1) {
+      if (ctx._batchDocs && ctx._batchDocs.length) {
+        // Return a cached populated doc
+        return nextDoc(ctx._batchDocs.shift(), ctx._pop);
+      } else if (ctx._batchExhausted) {
+        // Internal cursor reported no more docs. Act the same here
+        return callback(null, null);
+      } else {
+        const _batchDocs = []
+        // Request as many docs as batchSize, to populate them also in batch
+        function populateBatch() {
+          if (!_batchDocs.length) {
+            return callback(null, null);
+          }
+          ctx.query.model.populate(_batchDocs, ctx._pop, function(err, docs) {
+            if (err) {
+              return callback(err);
+            }
+
+            ctx._batchDocs = docs
+
+            nextDoc(ctx._batchDocs.shift(), ctx._pop);
+          });
         }
-        return opts.lean ?
-          callback(null, doc) :
-          _create(ctx, doc, pop, callback);
+
+        function onNext(error, doc) {
+          if (error) {
+            return callback(error);
+          }
+          if (!doc) {
+            ctx._batchExhausted = true
+            return populateBatch();
+          }
+
+          _batchDocs.push(doc);
+
+          if (_batchDocs.length < ctx.options.batchSize) {
+            ctx.cursor.next(onNext);
+          } else {
+            populateBatch();
+          }
+        }
+
+        return ctx.cursor.next(onNext);
+      }
+    } else {
+      return ctx.cursor.next(function(error, doc) {
+        if (error) {
+          return callback(error);
+        }
+        if (!doc) {
+          return callback(null, null);
+        }
+
+        if (!ctx.query._mongooseOptions.populate) {
+          return nextDoc(doc, null);
+        }
+
+        ctx.query.model.populate(doc, ctx._pop, function(err, doc) {
+          if (err) {
+            return callback(err);
+          }
+          return nextDoc(doc, ctx._pop);
+        });
       });
-    });
+    }
   } else {
     ctx.once('cursor', function() {
       _next(ctx, cb);

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -108,7 +108,7 @@ describe('QueryCursor', function() {
       });
     });
 
-    it('with populate', function(done) {
+    describe('with populate', function() {
       const bandSchema = new Schema({
         name: String,
         members: [{ type: mongoose.Schema.ObjectId, ref: 'Person' }]
@@ -117,37 +117,118 @@ describe('QueryCursor', function() {
         name: String
       });
 
-      const Person = db.model('Person', personSchema);
-      const Band = db.model('Band', bandSchema);
+      let Band;
 
-      const people = [
-        { name: 'Axl Rose' },
-        { name: 'Slash' },
-        { name: 'Nikki Sixx' },
-        { name: 'Vince Neil' }
-      ];
-      Person.create(people, function(error, docs) {
-        assert.ifError(error);
-        const bands = [
-          { name: 'Guns N\' Roses', members: [docs[0], docs[1]] },
-          { name: 'Motley Crue', members: [docs[2], docs[3]] }
+      beforeEach(function(done) {
+        const Person = db.model('Person', personSchema);
+        Band = db.model('Band', bandSchema);
+
+        const people = [
+          { name: 'Axl Rose' },
+          { name: 'Slash' },
+          { name: 'Nikki Sixx' },
+          { name: 'Vince Neil' },
+          { name: 'Trent Reznor' },
+          { name: 'Thom Yorke' },
+          { name: 'Billy Corgan' }
         ];
-        Band.create(bands, function(error) {
+        Person.create(people, function(error, docs) {
           assert.ifError(error);
-          const cursor =
-            Band.find().sort({ name: 1 }).populate('members').cursor();
+          const bands = [
+            { name: 'Guns N\' Roses', members: [docs[0], docs[1]] },
+            { name: 'Motley Crue', members: [docs[2], docs[3]] },
+            { name: 'Nine Inch Nails', members: [docs[4]] },
+            { name: 'Radiohead', members: [docs[5]] },
+            { name: 'The Smashing Pumpkins', members: [docs[6]] }
+          ];
+          Band.create(bands, function(error) {
+            assert.ifError(error);
+            done();
+          });
+        });
+      });
+
+      it('with populate without specify batchSize', function(done) {
+        const cursor =
+          Band.find().sort({ name: 1 }).populate('members').cursor();
+        cursor.next(function(error, doc) {
+          assert.ifError(error);
+          assert.equal(cursor.cursor.cursorState.currentLimit, 1);
+          assert.equal(doc.name, 'Guns N\' Roses');
+          assert.equal(doc.members.length, 2);
+          assert.equal(doc.members[0].name, 'Axl Rose');
+          assert.equal(doc.members[1].name, 'Slash');
           cursor.next(function(error, doc) {
             assert.ifError(error);
-            assert.equal(doc.name, 'Guns N\' Roses');
+            assert.equal(cursor.cursor.cursorState.currentLimit, 2);
+            assert.equal(doc.name, 'Motley Crue');
             assert.equal(doc.members.length, 2);
-            assert.equal(doc.members[0].name, 'Axl Rose');
-            assert.equal(doc.members[1].name, 'Slash');
+            assert.equal(doc.members[0].name, 'Nikki Sixx');
+            assert.equal(doc.members[1].name, 'Vince Neil');
             cursor.next(function(error, doc) {
-              assert.equal(doc.name, 'Motley Crue');
-              assert.equal(doc.members.length, 2);
-              assert.equal(doc.members[0].name, 'Nikki Sixx');
-              assert.equal(doc.members[1].name, 'Vince Neil');
-              done();
+              assert.ifError(error);
+              assert.equal(cursor.cursor.cursorState.currentLimit, 3);
+              assert.equal(doc.name, 'Nine Inch Nails');
+              assert.equal(doc.members.length, 1);
+              assert.equal(doc.members[0].name, 'Trent Reznor');
+              cursor.next(function(error, doc) {
+                assert.ifError(error);
+                assert.equal(cursor.cursor.cursorState.currentLimit, 4);
+                assert.equal(doc.name, 'Radiohead');
+                assert.equal(doc.members.length, 1);
+                assert.equal(doc.members[0].name, 'Thom Yorke');
+                cursor.next(function(error, doc) {
+                  assert.ifError(error);
+                  assert.equal(cursor.cursor.cursorState.currentLimit, 5);
+                  assert.equal(doc.name, 'The Smashing Pumpkins');
+                  assert.equal(doc.members.length, 1);
+                  assert.equal(doc.members[0].name, 'Billy Corgan');
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('with populate using custom batchSize', function(done) {
+        const cursor =
+          Band.find().sort({ name: 1 }).populate('members').batchSize(3).cursor();
+        cursor.next(function(error, doc) {
+          assert.ifError(error);
+          assert.equal(cursor.cursor.cursorState.currentLimit, 3);
+          assert.equal(doc.name, 'Guns N\' Roses');
+          assert.equal(doc.members.length, 2);
+          assert.equal(doc.members[0].name, 'Axl Rose');
+          assert.equal(doc.members[1].name, 'Slash');
+          cursor.next(function(error, doc) {
+            assert.ifError(error);
+            assert.equal(cursor.cursor.cursorState.currentLimit, 3);
+            assert.equal(doc.name, 'Motley Crue');
+            assert.equal(doc.members.length, 2);
+            assert.equal(doc.members[0].name, 'Nikki Sixx');
+            assert.equal(doc.members[1].name, 'Vince Neil');
+            cursor.next(function(error, doc) {
+              assert.ifError(error);
+              assert.equal(cursor.cursor.cursorState.currentLimit, 3);
+              assert.equal(doc.name, 'Nine Inch Nails');
+              assert.equal(doc.members.length, 1);
+              assert.equal(doc.members[0].name, 'Trent Reznor');
+              cursor.next(function(error, doc) {
+                assert.ifError(error);
+                assert.equal(cursor.cursor.cursorState.currentLimit, 5);
+                assert.equal(doc.name, 'Radiohead');
+                assert.equal(doc.members.length, 1);
+                assert.equal(doc.members[0].name, 'Thom Yorke');
+                cursor.next(function(error, doc) {
+                  assert.ifError(error);
+                  assert.equal(cursor.cursor.cursorState.currentLimit, 5);
+                  assert.equal(doc.name, 'The Smashing Pumpkins');
+                  assert.equal(doc.members.length, 1);
+                  assert.equal(doc.members[0].name, 'Billy Corgan');
+                  done();
+                });
+              });
             });
           });
         });


### PR DESCRIPTION
**Summary**
This adds a new feature that allows to optimize QueryCursor usage when populate is passed to the query. It requires a batchSize to be defined on the query, otherwise it will work as usual.

**Motivation**
Actually population on cursors iterates one doc at a time, running N population queries per doc which is not the best scenario for large datasets. By using a custom batchSize, the Mongo driver is already getting a batch of documents into memory, which can be safely be passed into Mongoose QueryCursor without triggering a new getMore command to the server. Then those documents can be populated together, reducing the amount of extra queries to the DB.

**Examples**
```javascript
const cursor = Model.find().populate('someRef anotherRef').batchSize(5).cursor()

// The first .next() called on the iterator will populate the 5 elements that already were on memory
// but still passing one at a time to the iterator.
// Later on the 6th, 11th, 15th .next() call, Mongo driver will issue a getMore command to the server
// and the received docs will be populated per batch again, until cursor is exhausted.
for await(const doc of cursor) {
  console.log(doc);
}
```