### PR TITLE
Fix typo in error message thrown by unimplemented createIndex

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -143,7 +143,7 @@ Collection.prototype.ensureIndex = function() {
  */
 
 Collection.prototype.createIndex = function() {
-  throw new Error('Collection#ensureIndex unimplemented by driver');
+  throw new Error('Collection#createIndex unimplemented by driver');
 };
 
 /**


### PR DESCRIPTION
**Summary**

I was reading through the `lib/collection.js` while working on a different project, and happened to notice what appears to be a typo in the error message thrown by `Collection.prototype.createIndex`. If `createIndex` is missing, it complains that `ensureIndex` is missing instead.

Perhaps, this is expected behavior, if so feel free to close it. Just thought I'd do my good deed for the day. 😄 

**Examples**

I don't have a working example of this error being thrown.
