### PR TITLE
chore: update `mongodb` to fix secutiry issue from `bl` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "^1.1.4",
     "kareem": "2.3.1",
-    "mongodb": "3.6.0",
+    "mongodb": "3.6.1",
     "mongoose-legacy-pluralize": "1.0.2",
     "mpath": "0.7.0",
     "mquery": "3.2.2",


### PR DESCRIPTION
Using `mongodb` version `3.6.1` to fix [this issue](https://github.com/advisories/GHSA-pp7h-53gx-mx7r) and update patch changes.

- Remote Memory Exposure in `bl`: https://github.com/advisories/GHSA-pp7h-53gx-mx7r
- `mongodb` changelog: https://github.com/mongodb/node-mongodb-native/releases/tag/v3.6.1

Thanks for review!