### PR TITLE
Replace var with const in docs and test files

### DIFF
--- a/docs/connections.pug
+++ b/docs/connections.pug
@@ -63,7 +63,7 @@ block content
 
     ```javascript
     mongoose.connect('mongodb://localhost:27017/myapp', {useNewUrlParser: true});
-    var MyModel = mongoose.model('Test', new Schema({ name: String }));
+    const MyModel = mongoose.model('Test', new Schema({ name: String }));
     // Works
     MyModel.findOne(function(error, result) { /* ... */ });
     ```
@@ -74,7 +74,7 @@ block content
     connecting.
 
     ```javascript
-    var MyModel = mongoose.model('Test', new Schema({ name: String }));
+    const MyModel = mongoose.model('Test', new Schema({ name: String }));
     // Will just hang until mongoose successfully connects
     MyModel.findOne(function(error, result) { /* ... */ });
 

--- a/docs/faq.pug
+++ b/docs/faq.pug
@@ -88,10 +88,10 @@ block content
     For example, if MongoDB doesn't already have a unique index on `name`, the below code will not error despite the fact that `unique` is true.
 
     ```javascript
-    var schema = new mongoose.Schema({
+    const schema = new mongoose.Schema({
       name: { type: String, unique: true }
     });
-    var Model = db.model('Test', schema);
+    const Model = db.model('Test', schema);
 
     Model.create([{ name: 'Val' }, { name: 'Val' }], function(err) {
       console.log(err); // No error, unless index was already built
@@ -101,10 +101,10 @@ block content
     However, if you wait for the index to build using the `Model.on('index')` event, attempts to save duplicates will correctly error.
 
     ```javascript
-    var schema = new mongoose.Schema({
+    const schema = new mongoose.Schema({
       name: { type: String, unique: true }
     });
-    var Model = db.model('Test', schema);
+    const Model = db.model('Test', schema);
 
     Model.on('index', function(err) { // <-- Wait for model's indexes to finish
       assert.ifError(err);
@@ -135,12 +135,12 @@ block content
     <a href="#nested-properties">**Q**</a>. When I have a nested property in a schema, mongoose adds empty objects by default. Why?
 
     ```javascript
-    var schema = new mongoose.Schema({
+    const schema = new mongoose.Schema({
       nested: {
         prop: String
       }
     });
-    var Model = db.model('Test', schema);
+    const Model = db.model('Test', schema);
 
     // The below prints `{ _id: /* ... */, nested: {} }`, mongoose assigns
     // `nested` to an empty object `{}` by default.
@@ -198,7 +198,7 @@ block content
     // Do **NOT** use arrow functions as shown below unless you're certain
     // that's what you want. If you're reading this FAQ, odds are you should
     // just be using a conventional function.
-    var schema = new mongoose.Schema({
+    const schema = new mongoose.Schema({
       propWithGetter: {
         type: String,
         get: v => {
@@ -320,7 +320,7 @@ block content
     mongoose.connection.on('error', handleError);
 
     // if connecting on a separate connection
-    var conn = mongoose.createConnection(..);
+    const conn = mongoose.createConnection(..);
     conn.on('error', handleError);
     ```
 
@@ -355,14 +355,14 @@ block content
     same name, create a new connection and bind the model to the connection.
 
     ```javascript
-    var mongoose = require('mongoose');
-    var connection = mongoose.createConnection(..);
+    const mongoose = require('mongoose');
+    const connection = mongoose.createConnection(..);
 
     // use mongoose.Schema
-    var kittySchema = mongoose.Schema({ name: String });
+    const kittySchema = mongoose.Schema({ name: String });
 
     // use connection.model
-    var Kitten = connection.model('Kitten', kittySchema);
+    const Kitten = connection.model('Kitten', kittySchema);
     ```
 
 

--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -179,7 +179,7 @@ block content
     to them.
 
     ```javascript
-      var Animal = mongoose.model('Animal', animalSchema);
+      const Animal = mongoose.model('Animal', animalSchema);
       const dog = new Animal({ type: 'dog' });
 
       dog.findSimilarTypes((err, dogs) => {
@@ -492,7 +492,7 @@ block content
     to false.
 
     ```javascript
-    var schema = new Schema({..}, { bufferCommands: false });
+    const schema = new Schema({..}, { bufferCommands: false });
     ```
 
     The schema `bufferCommands` option overrides the global `bufferCommands` option.
@@ -550,7 +550,7 @@ block content
 
     // disabled id
     const schema = new Schema({ name: String }, { id: false });
-    var Page = mongoose.model('Page', schema);
+    const Page = mongoose.model('Page', schema);
     const p = new Page({ name: 'mongodb.org' });
     console.log(p.id); // undefined
     ```
@@ -1135,7 +1135,7 @@ block content
 
     ```javascript
     const childSchema = new Schema({}, { strict: false });
-    var parentSchema = new Schema({ child: childSchema },
+    const parentSchema = new Schema({ child: childSchema },
       { strict: 'throw', useNestedStrict: true });
     const Parent = mongoose.model('Parent', parentSchema);
     Parent.update({}, { 'child.name': 'Luke Skywalker' }, error => {

--- a/docs/index.pug
+++ b/docs/index.pug
@@ -21,7 +21,7 @@ block content
     Next install Mongoose from the command line using `npm`:
 
     ```
-    $ npm install mongoose
+    $ npm install mongoose --save
     ```
 
     Now say we like fuzzy kittens and want to record every kitten we ever meet

--- a/docs/middleware.pug
+++ b/docs/middleware.pug
@@ -105,7 +105,7 @@ block content
     middleware calls `next`.
 
     ```javascript
-    var schema = new Schema(..);
+    const schema = new Schema(..);
     schema.pre('save', function(next) {
       // do stuff
       next();
@@ -133,7 +133,7 @@ block content
     to prevent the rest of your middleware function from running when you call `next()`.
 
     ```javascript
-    var schema = new Schema(..);
+    const schema = new Schema(..);
     schema.pre('save', function(next) {
       if (foo()) {
         console.log('calling next!');
@@ -426,7 +426,7 @@ block content
     Error handling middleware can then transform the error however you want.
 
     ```javascript
-    var schema = new Schema({
+    const schema = new Schema({
       name: {
         type: String,
         // Will trigger a MongoError with code 11000 when
@@ -466,7 +466,7 @@ block content
       }
     });
 
-    var people = [{ name: 'Axl Rose' }, { name: 'Slash' }];
+    const people = [{ name: 'Axl Rose' }, { name: 'Slash' }];
     Person.create(people, function(error) {
       Person.update({ name: 'Slash' }, { $set: { name: 'Axl Rose' } }, function(error) {
         // `error.message` will be "There was a duplicate key error"

--- a/docs/models.pug
+++ b/docs/models.pug
@@ -47,8 +47,8 @@ block content
     for you.
 
     ```javascript
-    var schema = new mongoose.Schema({ name: 'string', size: 'string' });
-    var Tank = mongoose.model('Tank', schema);
+    const schema = new mongoose.Schema({ name: 'string', size: 'string' });
+    const Tank = mongoose.model('Tank', schema);
     ```
   :markdown
     The first argument is the _singular_ name of the collection your model is
@@ -66,9 +66,9 @@ block content
     them and saving to the database is easy.
 
     ```javascript
-    var Tank = mongoose.model('Tank', yourSchema);
+    const Tank = mongoose.model('Tank', yourSchema);
 
-    var small = new Tank({ size: 'small' });
+    const small = new Tank({ size: 'small' });
     small.save(function (err) {
       if (err) return handleError(err);
       // saved!
@@ -97,8 +97,8 @@ block content
     If you create a custom connection, use that connection's `model()` function
     instead.
     ```javascript
-    var connection = mongoose.createConnection('mongodb://localhost:27017/test');
-    var Tank = connection.model('Tank', yourSchema);
+    const connection = mongoose.createConnection('mongodb://localhost:27017/test');
+    const Tank = connection.model('Tank', yourSchema);
     ```
   h3(id="querying") Querying
   :markdown

--- a/docs/populate.pug
+++ b/docs/populate.pug
@@ -430,7 +430,7 @@ block content
     Say you have a user schema which keeps track of the user's friends.
 
     ```javascript
-    var userSchema = new Schema({
+    const userSchema = new Schema({
       name: String,
       friends: [{ type: ObjectId, ref: 'User' }]
     });

--- a/docs/queries.pug
+++ b/docs/queries.pug
@@ -62,7 +62,7 @@ block content
     When executing a query with a `callback` function, you specify your query as a JSON document. The JSON document's syntax is the same as the [MongoDB shell](http://docs.mongodb.org/manual/tutorial/query-documents/).
 
     ```javascript
-    var Person = mongoose.model('Person', yourSchema);
+    const Person = mongoose.model('Person', yourSchema);
 
     // find each person with a last name matching 'Ghost', selecting the `name` and `occupation` fields
     Person.findOne({ 'name.last': 'Ghost' }, 'name occupation', function (err, person) {
@@ -83,7 +83,7 @@ block content
 
     ```javascript
     // find each person with a last name matching 'Ghost'
-    var query = Person.findOne({ 'name.last': 'Ghost' });
+    const query = Person.findOne({ 'name.last': 'Ghost' });
 
     // selecting the `name` and `occupation` fields
     query.select('name occupation');

--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -86,7 +86,7 @@ block content
     <h4>Example</h4>
 
     ```javascript
-    var schema = new Schema({
+    const schema = new Schema({
       name:    String,
       binary:  Buffer,
       living:  Boolean,
@@ -117,9 +117,9 @@ block content
 
     // example use
 
-    var Thing = mongoose.model('Thing', schema);
+    const Thing = mongoose.model('Thing', schema);
 
-    var m = new Thing;
+    const m = new Thing;
     m.name = 'Statue of Liberty';
     m.age = 125;
     m.updated = new Date;
@@ -196,11 +196,11 @@ block content
     a `type` property.
 
     ```javascript
-    var schema1 = new Schema({
+    const schema1 = new Schema({
       test: String // `test` is a path of type String
     });
 
-    var schema2 = new Schema({
+    const schema2 = new Schema({
       // The `test` object contains the "SchemaType options"
       test: { type: String } // `test` is a path of type string
     });
@@ -210,7 +210,7 @@ block content
     for a path. For example, if you want to lowercase a string before saving:
 
     ```javascript
-    var schema2 = new Schema({
+    const schema2 = new Schema({
       test: {
         type: String,
         lowercase: true // Always convert `test` to lowercase
@@ -271,7 +271,7 @@ block content
     * `sparse`: boolean, whether to define a [sparse index](https://docs.mongodb.com/manual/core/index-sparse/) on this property.
 
     ```javascript
-    var schema2 = new Schema({
+    const schema2 = new Schema({
       test: {
         type: String,
         index: true,
@@ -362,7 +362,7 @@ block content
     [Built-in `Date` methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) are [__not__ hooked into](https://github.com/Automattic/mongoose/issues/1598) the mongoose change tracking logic which in English means that if you use a `Date` in your document and modify it with a method like `setMonth()`, mongoose will be unaware of this change and `doc.save()` will not persist this modification. If you must modify `Date` types using built-in methods, tell mongoose about the change with `doc.markModified('pathToYourDate')` before saving.
 
     ```javascript
-    var Assignment = mongoose.model('Assignment', { dueDate: Date });
+    const Assignment = mongoose.model('Assignment', { dueDate: Date });
     Assignment.findOne(function (err, doc) {
       doc.dueDate.setMonth(3);
       doc.save(callback); // THIS DOES NOT SAVE YOUR CHANGE
@@ -502,8 +502,8 @@ block content
     _document arrays_.
 
     ```javascript
-    var ToySchema = new Schema({ name: String });
-    var ToyBoxSchema = new Schema({
+    const ToySchema = new Schema({ name: String });
+    const ToyBoxSchema = new Schema({
       toys: [ToySchema],
       buffers: [Buffer],
       strings: [String],
@@ -515,14 +515,14 @@ block content
     Arrays are special because they implicitly have a default value of `[]` (empty array).
 
     ```javascript
-    var ToyBox = mongoose.model('ToyBox', ToyBoxSchema);
+    const ToyBox = mongoose.model('ToyBox', ToyBoxSchema);
     console.log((new ToyBox()).toys); // []
     ```
 
     To overwrite this default, you need to set the default value to `undefined`
 
     ```javascript
-    var ToyBoxSchema = new Schema({
+    const ToyBoxSchema = new Schema({
       toys: {
         type: [ToySchema],
         default: undefined
@@ -534,10 +534,10 @@ block content
     `Mixed`:
 
     ```javascript
-    var Empty1 = new Schema({ any: [] });
-    var Empty2 = new Schema({ any: Array });
-    var Empty3 = new Schema({ any: [Schema.Types.Mixed] });
-    var Empty4 = new Schema({ any: [{}] });
+    const Empty1 = new Schema({ any: [] });
+    const Empty2 = new Schema({ any: Array });
+    const Empty3 = new Schema({ any: [Schema.Types.Mixed] });
+    const Empty4 = new Schema({ any: [{}] });
     ```
 
     <h4 id="maps">Maps</h4>
@@ -705,7 +705,7 @@ block content
     given path.
 
     ```javascript
-    var sampleSchema = new Schema({ name: { type: String, required: true } });
+    const sampleSchema = new Schema({ name: { type: String, required: true } });
     console.log(sampleSchema.path('name'));
     // Output looks like:
     /**

--- a/docs/subdocs.pug
+++ b/docs/subdocs.pug
@@ -27,9 +27,9 @@ block content
     distinct notions of subdocuments: [arrays of subdocuments](https://masteringjs.io/tutorials/mongoose/array#document-arrays) and single nested
     subdocuments.
     ```javascript
-    var childSchema = new Schema({ name: 'string' });
+    const childSchema = new Schema({ name: 'string' });
 
-    var parentSchema = new Schema({
+    const parentSchema = new Schema({
       // Array of subdocuments
       children: [childSchema],
       // Single nested subdocuments. Caveat: single nested subdocs only work
@@ -62,8 +62,8 @@ block content
     not saved individually, they are saved whenever their top-level parent
     document is saved.
     ```javascript
-    var Parent = mongoose.model('Parent', parentSchema);
-    var parent = new Parent({ children: [{ name: 'Matt' }, { name: 'Sarah' }] })
+    const Parent = mongoose.model('Parent', parentSchema);
+    const parent = new Parent({ children: [{ name: 'Matt' }, { name: 'Sarah' }] })
     parent.children[0].name = 'Matthew';
 
     // `parent.children[0].save()` is a no-op, it triggers middleware but
@@ -85,7 +85,7 @@ block content
       next();
     });
 
-    var parent = new Parent({ children: [{ name: 'invalid' }] });
+    const parent = new Parent({ children: [{ name: 'invalid' }] });
     parent.save(function (err) {
       console.log(err.message) // #sadpanda
     });
@@ -98,7 +98,7 @@ block content
 
     ```javascript
     // Below code will print out 1-4 in order
-    var childSchema = new mongoose.Schema({ name: 'string' });
+    const childSchema = new mongoose.Schema({ name: 'string' });
 
     childSchema.pre('validate', function(next) {
       console.log('2');
@@ -110,7 +110,7 @@ block content
       next();
     });
 
-    var parentSchema = new mongoose.Schema({
+    const parentSchema = new mongoose.Schema({
       child: childSchema
     });
 
@@ -184,7 +184,7 @@ block content
     special [id](./api.html#types_documentarray_MongooseDocumentArray-id) method
     for searching a document array to find a document with a given `_id`.
     ```javascript
-    var doc = parent.children.id(_id);
+    const doc = parent.children.id(_id);
     ```
   h3#adding-subdocs-to-arrays Adding Subdocs to Arrays
   :markdown
@@ -194,12 +194,12 @@ block content
     [addToSet](./api.html#mongoosearray_MongooseArray-addToSet),
     and others cast arguments to their proper types transparently:
     ```javascript
-    var Parent = mongoose.model('Parent');
-    var parent = new Parent;
+    const Parent = mongoose.model('Parent');
+    const parent = new Parent;
 
     // create a comment
     parent.children.push({ name: 'Liesl' });
-    var subdoc = parent.children[0];
+    const subdoc = parent.children[0];
     console.log(subdoc) // { _id: '501d86090d371bab2c0341c5', name: 'Liesl' }
     subdoc.isNew; // true
 
@@ -213,7 +213,7 @@ block content
     [create](./api.html#types_documentarray_MongooseDocumentArray.create)
     method of MongooseArrays.
     ```javascript
-    var newdoc = parent.children.create({ name: 'Aaron' });
+    const newdoc = parent.children.create({ name: 'Aaron' });
     ```
   h3#removing-subdocs Removing Subdocs
   :markdown
@@ -280,11 +280,11 @@ block content
     convert the object to a schema for you:
 
     ```javascript
-    var parentSchema = new Schema({
+    const parentSchema = new Schema({
       children: [{ name: 'string' }]
     });
     // Equivalent
-    var parentSchema = new Schema({
+    const parentSchema = new Schema({
       children: [new Schema({ name: 'string' })]
     });
     ```

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -125,7 +125,7 @@ Aggregate.prototype.model = function(model) {
  *     aggregate.append({ $project: { field: 1 }}, { $limit: 2 });
  *
  *     // or pass an array
- *     var pipeline = [{ $match: { daw: 'Logic Audio X' }} ];
+ *     const pipeline = [{ $match: { daw: 'Logic Audio X' }} ];
  *     aggregate.append(pipeline);
  *
  * @param {Object} ops operator(s) to append
@@ -793,7 +793,7 @@ Aggregate.prototype.session = function(session) {
  *
  * ####Example:
  *
- *     var agg = Model.aggregate(..).option({ allowDiskUse: true }); // Set the `allowDiskUse` option
+ *     const agg = Model.aggregate(..).option({ allowDiskUse: true }); // Set the `allowDiskUse` option
  *     agg.options; // `{ allowDiskUse: true }`
  *
  * @param {Object} options keys to merge into current options
@@ -820,7 +820,7 @@ Aggregate.prototype.option = function(value) {
  *
  * ####Example:
  *
- *     var cursor = Model.aggregate(..).cursor({ batchSize: 1000 }).exec();
+ *     const cursor = Model.aggregate(..).cursor({ batchSize: 1000 }).exec();
  *     cursor.eachAsync(function(doc, i) {
  *       // use doc
  *     });
@@ -960,7 +960,7 @@ Aggregate.prototype.pipeline = function() {
  *     aggregate.exec(callback);
  *
  *     // Because a promise is returned, the `callback` is optional.
- *     var promise = aggregate.exec();
+ *     const promise = aggregate.exec();
  *     promise.then(..);
  *
  * @see Promise #promise_Promise

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -48,9 +48,9 @@ exports.Error = require('./error/index');
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
- *     var Schema = mongoose.Schema;
- *     var CatSchema = new Schema(..);
+ *     const mongoose = require('mongoose');
+ *     const Schema = mongoose.Schema;
+ *     const CatSchema = new Schema(..);
  *
  * @method Schema
  * @api public
@@ -63,8 +63,8 @@ exports.Schema = require('./schema');
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
- *     var array = mongoose.Types.Array;
+ *     const mongoose = require('mongoose');
+ *     const array = mongoose.Types.Array;
  *
  * ####Types:
  *
@@ -76,8 +76,8 @@ exports.Schema = require('./schema');
  *
  * Using this exposed access to the `ObjectId` type, we can construct ids on demand.
  *
- *     var ObjectId = mongoose.Types.ObjectId;
- *     var id1 = new ObjectId;
+ *     const ObjectId = mongoose.Types.ObjectId;
+ *     const id1 = new ObjectId;
  *
  * @property Types
  * @api public

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1091,17 +1091,17 @@ Connection.prototype.plugin = function(fn, opts) {
 /**
  * Defines or retrieves a model.
  *
- *     var mongoose = require('mongoose');
- *     var db = mongoose.createConnection(..);
+ *     const mongoose = require('mongoose');
+ *     const db = mongoose.createConnection(..);
  *     db.model('Venue', new Schema(..));
- *     var Ticket = db.model('Ticket', new Schema(..));
- *     var Venue = db.model('Venue');
+ *     const Ticket = db.model('Ticket', new Schema(..));
+ *     const Venue = db.model('Venue');
  *
  * _When no `collection` argument is passed, Mongoose produces a collection name by passing the model `name` to the [utils.toCollectionName](#utils_exports.toCollectionName) method. This method pluralizes the name. If you don't like this behavior, either pass a collection name or set your schemas collection name option._
  *
  * ####Example:
  *
- *     var schema = new Schema({ name: String }, { collection: 'actor' });
+ *     const schema = new Schema({ name: String }, { collection: 'actor' });
  *
  *     // or
  *
@@ -1109,8 +1109,8 @@ Connection.prototype.plugin = function(fn, opts) {
  *
  *     // or
  *
- *     var collectionName = 'actor'
- *     var M = conn.model('Actor', schema, collectionName)
+ *     const collectionName = 'actor'
+ *     const M = conn.model('Actor', schema, collectionName)
  *
  * @param {String|Function} name the model name or class extending Model
  * @param {Schema} [schema] a schema. necessary when defining a model

--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -125,7 +125,7 @@ if (Symbol.asyncIterator != null) {
  *       on('data', function(doc) { console.log(doc.foo); });
  *
  *     // Or map documents returned by `.next()`
- *     var cursor = Thing.find({ name: /^hello/ }).
+ *     const cursor = Thing.find({ name: /^hello/ }).
  *       cursor().
  *       map(function (doc) {
  *         doc.foo = "bar";

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -118,7 +118,7 @@ QueryCursor.prototype._read = function() {
  *       on('data', function(doc) { console.log(doc.foo); });
  *
  *     // Or map documents returned by `.next()`
- *     var cursor = Thing.find({ name: /^hello/ }).
+ *     const cursor = Thing.find({ name: /^hello/ }).
  *       cursor().
  *       map(function (doc) {
  *         doc.foo = "bar";

--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -3,7 +3,7 @@
  * The default built-in validator error messages. These may be customized.
  *
  *     // customize within each schema or globally like so
- *     var mongoose = require('mongoose');
+ *     const mongoose = require('mongoose');
  *     mongoose.Error.messages.String.enum  = "Your custom message for {PATH}.";
  *
  * As you might have noticed, error messages support basic templating

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,18 +228,18 @@ Mongoose.prototype.get = Mongoose.prototype.set;
  *     db = mongoose.createConnection('mongodb://user:pass@localhost:port/database');
  *
  *     // and options
- *     var opts = { db: { native_parser: true }}
+ *     const opts = { db: { native_parser: true }}
  *     db = mongoose.createConnection('mongodb://user:pass@localhost:port/database', opts);
  *
  *     // replica sets
  *     db = mongoose.createConnection('mongodb://user:pass@localhost:port,anotherhost:port,yetanother:port/database');
  *
  *     // and options
- *     var opts = { replset: { strategy: 'ping', rs_name: 'testSet' }}
+ *     const opts = { replset: { strategy: 'ping', rs_name: 'testSet' }}
  *     db = mongoose.createConnection('mongodb://user:pass@localhost:port,anotherhost:port,yetanother:port/database', opts);
  *
  *     // and options
- *     var opts = { server: { auto_reconnect: false }, user: 'username', pass: 'mypassword' }
+ *     const opts = { server: { auto_reconnect: false }, user: 'username', pass: 'mypassword' }
  *     db = mongoose.createConnection('localhost', 'database', port, opts)
  *
  *     // initialize now, connect later
@@ -294,14 +294,14 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
  *     mongoose.connect('mongodb://user:pass@localhost:port/database');
  *
  *     // replica sets
- *     var uri = 'mongodb://user:pass@localhost:port,anotherhost:port,yetanother:port/mydatabase';
+ *     const uri = 'mongodb://user:pass@localhost:port,anotherhost:port,yetanother:port/mydatabase';
  *     mongoose.connect(uri);
  *
  *     // with options
  *     mongoose.connect(uri, options);
  *
  *     // optional callback that gets fired when initial connection completed
- *     var uri = 'mongodb://nonexistent.domain:27000';
+ *     const uri = 'mongodb://nonexistent.domain:27000';
  *     mongoose.connect(uri, function(error) {
  *       // if error is truthy, the initial connection failed.
  *     })
@@ -427,17 +427,17 @@ Mongoose.prototype.pluralize = function(fn) {
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
+ *     const mongoose = require('mongoose');
  *
  *     // define an Actor model with this mongoose instance
  *     const schema = new Schema({ name: String });
  *     mongoose.model('Actor', schema);
  *
  *     // create a new connection
- *     var conn = mongoose.createConnection(..);
+ *     const conn = mongoose.createConnection(..);
  *
  *     // create Actor model
- *     var Actor = conn.model('Actor', schema);
+ *     const Actor = conn.model('Actor', schema);
  *     conn.model('Actor') === Actor; // true
  *     conn.model('Actor', schema) === Actor; // true, same schema
  *     conn.model('Actor', schema, 'actors') === Actor; // true, same schema and collection name
@@ -449,7 +449,7 @@ Mongoose.prototype.pluralize = function(fn) {
  *
  * ####Example:
  *
- *     var schema = new Schema({ name: String }, { collection: 'actor' });
+ *     const schema = new Schema({ name: String }, { collection: 'actor' });
  *
  *     // or
  *
@@ -457,8 +457,8 @@ Mongoose.prototype.pluralize = function(fn) {
  *
  *     // or
  *
- *     var collectionName = 'actor'
- *     var M = mongoose.model('Actor', schema, collectionName)
+ *     const collectionName = 'actor'
+ *     const M = mongoose.model('Actor', schema, collectionName)
  *
  * @param {String|Function} name model name or class extending Model
  * @param {Schema} [schema] the schema to use.
@@ -673,7 +673,7 @@ Mongoose.prototype.plugin = function(fn, opts) {
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
+ *     const mongoose = require('mongoose');
  *     mongoose.connect(...);
  *     mongoose.connection.on('error', cb);
  *
@@ -788,8 +788,8 @@ Mongoose.prototype.version = pkg.version;
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
- *     var mongoose2 = new mongoose.Mongoose();
+ *     const mongoose = require('mongoose');
+ *     const mongoose2 = new mongoose.Mongoose();
  *
  * @method Mongoose
  * @api public
@@ -802,9 +802,9 @@ Mongoose.prototype.Mongoose = Mongoose;
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
- *     var Schema = mongoose.Schema;
- *     var CatSchema = new Schema(..);
+ *     const mongoose = require('mongoose');
+ *     const Schema = mongoose.Schema;
+ *     const CatSchema = new Schema(..);
  *
  * @method Schema
  * @api public
@@ -849,8 +849,8 @@ Mongoose.prototype.VirtualType = VirtualType;
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
- *     var array = mongoose.Types.Array;
+ *     const mongoose = require('mongoose');
+ *     const array = mongoose.Types.Array;
  *
  * ####Types:
  *
@@ -862,8 +862,8 @@ Mongoose.prototype.VirtualType = VirtualType;
  *
  * Using this exposed access to the `ObjectId` type, we can construct ids on demand.
  *
- *     var ObjectId = mongoose.Types.ObjectId;
- *     var id1 = new ObjectId;
+ *     const ObjectId = mongoose.Types.ObjectId;
+ *     const id1 = new ObjectId;
  *
  * @property Types
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -1021,7 +1021,7 @@ Model.prototype.$__deleteOne = Model.prototype.$__remove;
  *
  * ####Example:
  *
- *     var doc = new Tank;
+ *     const doc = new Tank;
  *     doc.model('User').findById(id, callback);
  *
  * @param {String} name model name
@@ -1096,15 +1096,15 @@ Model.exists = function exists(filter, options, callback) {
  *     }
  *     util.inherits(BaseSchema, Schema);
  *
- *     var PersonSchema = new BaseSchema();
- *     var BossSchema = new BaseSchema({ department: String });
+ *     const PersonSchema = new BaseSchema();
+ *     const BossSchema = new BaseSchema({ department: String });
  *
- *     var Person = mongoose.model('Person', PersonSchema);
- *     var Boss = Person.discriminator('Boss', BossSchema);
+ *     const Person = mongoose.model('Person', PersonSchema);
+ *     const Boss = Person.discriminator('Boss', BossSchema);
  *     new Boss().__t; // "Boss". `__t` is the default `discriminatorKey`
  *
- *     var employeeSchema = new Schema({ boss: ObjectId });
- *     var Employee = Person.discriminator('Employee', employeeSchema, 'staff');
+ *     const employeeSchema = new Schema({ boss: ObjectId });
+ *     const Employee = Person.discriminator('Employee', employeeSchema, 'staff');
  *     new Employee().__t; // "staff" because of 3rd argument above
  *
  * @param {String} name discriminator model name
@@ -1204,10 +1204,10 @@ for (const i in EventEmitter.prototype) {
  *
  * ####Example:
  *
- *     var eventSchema = new Schema({ thing: { type: 'string', unique: true }})
+ *     const eventSchema = new Schema({ thing: { type: 'string', unique: true }})
  *     // This calls `Event.init()` implicitly, so you don't need to call
  *     // `Event.init()` on your own.
- *     var Event = mongoose.model('Event', eventSchema);
+ *     const Event = mongoose.model('Event', eventSchema);
  *
  *     Event.init().then(function(Event) {
  *       // You can also use `Event.on('index')` if you prefer event emitters
@@ -1291,8 +1291,8 @@ Model.init = function init(callback) {
  *
  * ####Example:
  *
- *     var userSchema = new Schema({ name: String })
- *     var User = mongoose.model('User', userSchema);
+ *     const userSchema = new Schema({ name: String })
+ *     const User = mongoose.model('User', userSchema);
  *
  *     User.createCollection().then(function(collection) {
  *       console.log('Collection is created!');
@@ -1505,8 +1505,8 @@ Model.listIndexes = function init(callback) {
  *
  * ####Example:
  *
- *     var eventSchema = new Schema({ thing: { type: 'string', unique: true }})
- *     var Event = mongoose.model('Event', eventSchema);
+ *     const eventSchema = new Schema({ thing: { type: 'string', unique: true }})
+ *     const Event = mongoose.model('Event', eventSchema);
  *
  *     Event.on('index', function (err) {
  *       if (err) console.error(err); // error occurred during index creation
@@ -2283,7 +2283,7 @@ Model.count = function count(conditions, callback) {
  *       console.log('unique urls with more than 100 clicks', result);
  *     })
  *
- *     var query = Link.distinct('url');
+ *     const query = Link.distinct('url');
  *     query.exec(callback);
  *
  * @param {String} field
@@ -2392,7 +2392,7 @@ Model.$where = function $where() {
  *
  * ####Example:
  *
- *     var query = { name: 'borne' };
+ *     const query = { name: 'borne' };
  *     Model.findOneAndUpdate(query, { name: 'jason bourne' }, options, callback)
  *
  *     // is sent as
@@ -3195,7 +3195,7 @@ Model.startSession = function() {
  *
  * ####Example:
  *
- *     var arr = [{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }];
+ *     const arr = [{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }];
  *     Movies.insertMany(arr, function(error, docs) {});
  *
  * @param {Array|Object|*} doc(s)
@@ -3494,7 +3494,7 @@ Model.bulkWrite = function(ops, options, callback) {
  * ####Example:
  *
  *     // hydrate previous data into a Mongoose document
- *     var mongooseCandy = Candy.hydrate({ _id: '54108337212ffb6d459f854c', type: 'jelly bean' });
+ *     const mongooseCandy = Candy.hydrate({ _id: '54108337212ffb6d459f854c', type: 'jelly bean' });
  *
  * @param {Object} obj
  * @param {Object|String} [projection] optional projection containing which fields should be selected for this document
@@ -3552,7 +3552,7 @@ Model.hydrate = function(obj, projection) {
  *
  * ####Example:
  *
- *     var query = { name: 'borne' };
+ *     const query = { name: 'borne' };
  *     Model.update(query, { name: 'jason bourne' }, options, callback);
  *
  *     // is sent as
@@ -3762,7 +3762,7 @@ function _update(model, op, conditions, doc, options, callback) {
  *
  * ####Example:
  *
- *     var o = {};
+ *     const o = {};
  *     // `map()` and `reduce()` are run on the MongoDB server, not Node.js,
  *     // these functions are converted to strings
  *     o.map = function () { emit(this.name, 1) };
@@ -3795,7 +3795,7 @@ function _update(model, op, conditions, doc, options, callback) {
  *
  * ####Example:
  *
- *     var o = {};
+ *     const o = {};
  *     // You can also define `map()` and `reduce()` as strings if your
  *     // linter complains about `emit()` not being defined
  *     o.map = 'function () { emit(this.name, 1) }';
@@ -3813,10 +3813,10 @@ function _update(model, op, conditions, doc, options, callback) {
  *     // `mapReduce()` returns a promise. However, ES6 promises can only
  *     // resolve to exactly one value,
  *     o.resolveToObject = true;
- *     var promise = User.mapReduce(o);
+ *     const promise = User.mapReduce(o);
  *     promise.then(function (res) {
- *       var model = res.model;
- *       var stats = res.stats;
+ *       const model = res.model;
+ *       const stats = res.stats;
  *       console.log('map reduce took %d ms', stats.processtime)
  *       return model.find().where('value').gt(10).exec();
  *     }).then(function (docs) {
@@ -4087,7 +4087,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
  *
  * ####Example:
  *
- *     var options = { near: [10, 10], maxDistance: 5 };
+ *     const options = { near: [10, 10], maxDistance: 5 };
  *     Locations.geoSearch({ type : "house" }, options, function(err, res) {
  *       console.log(res);
  *     });
@@ -4183,7 +4183,7 @@ Model.geoSearch = function(conditions, options, callback) {
  *
  *     // populates a single object
  *     User.findById(id, function (err, user) {
- *       var opts = [
+ *       const opts = [
  *         { path: 'company', match: { x: 1 }, select: 'name' },
  *         { path: 'notes', options: { limit: 10 }, model: 'override' }
  *       ];
@@ -4195,9 +4195,9 @@ Model.geoSearch = function(conditions, options, callback) {
  *
  *     // populates an array of objects
  *     User.find(match, function (err, users) {
- *       var opts = [{ path: 'company', match: { x: 1 }, select: 'name' }];
+ *       const opts = [{ path: 'company', match: { x: 1 }, select: 'name' }];
  *
- *       var promise = User.populate(users, opts);
+ *       const promise = User.populate(users, opts);
  *       promise.then(console.log).end();
  *     })
  *
@@ -4210,13 +4210,13 @@ Model.geoSearch = function(conditions, options, callback) {
  *     //   weapon: { type: ObjectId, ref: 'Weapon' }
  *     // });
  *
- *     var user = { name: 'Indiana Jones', weapon: 389 };
+ *     const user = { name: 'Indiana Jones', weapon: 389 };
  *     Weapon.populate(user, { path: 'weapon', model: 'Weapon' }, function (err, user) {
  *       console.log(user.weapon.name); // whip
  *     })
  *
  *     // populate many plain objects
- *     var users = [{ name: 'Indiana Jones', weapon: 389 }]
+ *     const users = [{ name: 'Indiana Jones', weapon: 389 }]
  *     users.push({ name: 'Batman', weapon: 8921 })
  *     Weapon.populate(users, { path: 'weapon' }, function (err, users) {
  *       users.forEach(function (user) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -141,10 +141,10 @@ Query.use$geoWithin = mquery.use$geoWithin;
  *     // Create a query for adventure movies and read from the primary
  *     // node in the replica-set unless it is down, in which case we'll
  *     // read from a secondary node.
- *     var query = Movie.find({ tags: 'adventure' }).read('primaryPreferred');
+ *     const query = Movie.find({ tags: 'adventure' }).read('primaryPreferred');
  *
  *     // create a custom Query constructor based off these settings
- *     var Adventure = query.toConstructor();
+ *     const Adventure = query.toConstructor();
  *
  *     // Adventure is now a subclass of mongoose.Query and works the same way but with the
  *     // default query parameters and options set.
@@ -1256,7 +1256,7 @@ Query.prototype.wtimeout = function wtimeout(ms) {
  *
  * ####Example:
  *
- *     var query = new Query();
+ *     const query = new Query();
  *     query.limit(10);
  *     query.setOptions({ maxTimeMS: 1000 })
  *     query.getOptions(); // { limit: 10, maxTimeMS: 1000 }
@@ -1447,7 +1447,7 @@ Query.prototype.getFilter = function() {
  *
  * ####Example:
  *
- *     var query = new Query();
+ *     const query = new Query();
  *     query.find({ a: 1 }).where('b').gt(2);
  *     query.getQuery(); // { a: 1, b: { $gt: 2 } }
  *
@@ -1464,7 +1464,7 @@ Query.prototype.getQuery = function() {
  *
  * ####Example:
  *
- *     var query = new Query();
+ *     const query = new Query();
  *     query.find({ a: 1 })
  *     query.setQuery({ a: 2 });
  *     query.getQuery(); // { a: 2 }
@@ -1483,7 +1483,7 @@ Query.prototype.setQuery = function(val) {
  *
  * ####Example:
  *
- *     var query = new Query();
+ *     const query = new Query();
  *     query.update({}, { $set: { a: 5 } });
  *     query.getUpdate(); // { $set: { a: 5 } }
  *
@@ -1500,7 +1500,7 @@ Query.prototype.getUpdate = function() {
  *
  * ####Example:
  *
- *     var query = new Query();
+ *     const query = new Query();
  *     query.update({}, { $set: { a: 5 } });
  *     query.setUpdate({ $set: { b: 6 } });
  *     query.getUpdate(); // { $set: { b: 6 } }
@@ -1801,8 +1801,8 @@ Query.prototype.get = function get(path) {
  * custom errors.
  *
  * ####Example:
- *     var TestSchema = new Schema({ num: Number });
- *     var TestModel = db.model('Test', TestSchema);
+ *     const TestSchema = new Schema({ num: Number });
+ *     const TestModel = db.model('Test', TestSchema);
  *     TestModel.find({ num: 'not a number' }).error(new Error('woops')).exec(function(error) {
  *       // `error` will be a cast error because `num` failed to cast
  *     });
@@ -2162,7 +2162,7 @@ Query.prototype._findOne = wrapThunk(function(callback) {
  *
  * ####Example
  *
- *     var query  = Kitten.where({ color: 'white' });
+ *     const query  = Kitten.where({ color: 'white' });
  *     query.findOne(function (err, kitten) {
  *       if (err) return handleError(err);
  *       if (kitten) {
@@ -2309,7 +2309,7 @@ Query.prototype._estimatedDocumentCount = wrapThunk(function(callback) {
  *
  * ####Example:
  *
- *     var countQuery = model.where({ 'color': 'black' }).count();
+ *     const countQuery = model.where({ 'color': 'black' }).count();
  *
  *     query.count({ color: 'black' }).count(callback)
  *
@@ -3897,7 +3897,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  *
  * The operation is only executed when a callback is passed. To force execution without a callback, we must first call update() and then execute it by using the `exec()` method.
  *
- *     var q = Model.where({ _id: id });
+ *     const q = Model.where({ _id: id });
  *     q.update({ $set: { name: 'bob' }}).update(); // not executed
  *
  *     q.update({ $set: { name: 'bob' }}).exec(); // executed
@@ -3907,11 +3907,11 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  *     q.update({ name: 'bob' }).exec();
  *
  *     // overwriting with empty docs
- *     var q = Model.where({ _id: id }).setOptions({ overwrite: true })
+ *     const q = Model.where({ _id: id }).setOptions({ overwrite: true })
  *     q.update({ }, callback); // executes
  *
  *     // multi update with overwrite to empty doc
- *     var q = Model.where({ _id: id });
+ *     const q = Model.where({ _id: id });
  *     q.setOptions({ multi: true, overwrite: true })
  *     q.update({ });
  *     q.update(callback); // executed
@@ -4349,8 +4349,8 @@ function _orFailError(err, query) {
  *
  * ####Examples:
  *
- *     var promise = query.exec();
- *     var promise = query.exec('update');
+ *     const promise = query.exec();
+ *     const promise = query.exec('update');
  *
  *     query.exec(callback);
  *     query.exec('find', callback);
@@ -4877,7 +4877,7 @@ Query.prototype._applyPaths = function applyPaths() {
  *
  *     // Or you can use `.next()` to manually get the next doc in the stream.
  *     // `.next()` returns a promise, so you can use promises or callbacks.
- *     var cursor = Thing.find({ name: /^hello/ }).cursor();
+ *     const cursor = Thing.find({ name: /^hello/ }).cursor();
  *     cursor.next(function(error, doc) {
  *       console.log(doc);
  *     });
@@ -5021,15 +5021,15 @@ Query.prototype.tailable = function(val, opts) {
  *
  * ####Example
  *
- *     var polyA = [[[ 10, 20 ], [ 10, 40 ], [ 30, 40 ], [ 30, 20 ]]]
+ *     const polyA = [[[ 10, 20 ], [ 10, 40 ], [ 30, 40 ], [ 30, 20 ]]]
  *     query.where('loc').within().geometry({ type: 'Polygon', coordinates: polyA })
  *
  *     // or
- *     var polyB = [[ 0, 0 ], [ 1, 1 ]]
+ *     const polyB = [[ 0, 0 ], [ 1, 1 ]]
  *     query.where('loc').within().geometry({ type: 'LineString', coordinates: polyB })
  *
  *     // or
- *     var polyC = [ 0, 0 ]
+ *     const polyC = [ 0, 0 ]
  *     query.where('loc').within().geometry({ type: 'Point', coordinates: polyC })
  *
  *     // or
@@ -5222,8 +5222,8 @@ if (Symbol.asyncIterator != null) {
  *
  * ####Example
  *
- *     var lowerLeft = [40.73083, -73.99756]
- *     var upperRight= [40.741404,  -73.988135]
+ *     const lowerLeft = [40.73083, -73.99756]
+ *     const upperRight= [40.741404,  -73.988135]
  *
  *     query.where('loc').within().box(lowerLeft, upperRight)
  *     query.box({ ll : lowerLeft, ur : upperRight })
@@ -5259,13 +5259,13 @@ Query.prototype.box = function(ll, ur) {
  *
  * ####Example
  *
- *     var area = { center: [50, 50], radius: 10, unique: true }
+ *     const area = { center: [50, 50], radius: 10, unique: true }
  *     query.where('loc').within().circle(area)
  *     // alternatively
  *     query.circle('loc', area);
  *
  *     // spherical calculations
- *     var area = { center: [50, 50], radius: 10, unique: true, spherical: true }
+ *     const area = { center: [50, 50], radius: 10, unique: true, spherical: true }
  *     query.where('loc').within().circle(area)
  *     // alternatively
  *     query.circle('loc', area);
@@ -5304,7 +5304,7 @@ Query.prototype.center = Query.base.circle;
  *
  * ####Example
  *
- *     var area = { center: [50, 50], radius: 10 };
+ *     const area = { center: [50, 50], radius: 10 };
  *     query.where('loc').within().centerSphere(area);
  *
  * @deprecated

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -41,9 +41,9 @@ let id = 0;
  *
  * ####Example:
  *
- *     var child = new Schema({ name: String });
- *     var schema = new Schema({ name: String, age: Number, children: [child] });
- *     var Tree = mongoose.model('Tree', schema);
+ *     const child = new Schema({ name: String });
+ *     const schema = new Schema({ name: String, age: Number, children: [child] });
+ *     const Tree = mongoose.model('Tree', schema);
  *
  *     // setting schema options
  *     new Schema({ name: String }, { _id: false, autoIndex: false })
@@ -228,7 +228,7 @@ Object.defineProperty(Schema.prototype, 'childSchemas', {
  *
  * ####Example:
  *
- *     var schema = new Schema({ a: String }).add({ b: String });
+ *     const schema = new Schema({ a: String }).add({ b: String });
  *     schema.obj; // { a: String }
  *
  * @api public
@@ -565,7 +565,7 @@ Schema.prototype.add = function add(obj, prefix) {
  *
  * _NOTE:_ Use of these terms as method names is permitted, but play at your own risk, as they may be existing mongoose document methods you are stomping on.
  *
- *      var schema = new Schema(..);
+ *      const schema = new Schema(..);
  *      schema.methods.init = function () {} // potentially breaking
  */
 
@@ -1366,7 +1366,7 @@ Schema.prototype.queue = function(name, args) {
  *
  * ####Example
  *
- *     var toySchema = new Schema({ name: String, created: Date });
+ *     const toySchema = new Schema({ name: String, created: Date });
  *
  *     toySchema.pre('save', function(next) {
  *       if (!this.created) this.created = new Date;
@@ -1428,7 +1428,7 @@ Schema.prototype.pre = function(name) {
 /**
  * Defines a post hook for the document
  *
- *     var schema = new Schema(..);
+ *     const schema = new Schema(..);
  *     schema.post('save', function (doc) {
  *       console.log('this fired after a document was saved');
  *     });
@@ -1441,9 +1441,9 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fired after you ran `updateMany()` or `deleteMany()`);
  *     });
  *
- *     var Model = mongoose.model('Model', schema);
+ *     const Model = mongoose.model('Model', schema);
  *
- *     var m = new Model(..);
+ *     const m = new Model(..);
  *     m.save(function(err) {
  *       console.log('this fires after the `post` hook');
  *     });
@@ -1522,15 +1522,15 @@ Schema.prototype.plugin = function(fn, opts) {
  *
  * ####Example
  *
- *     var schema = kittySchema = new Schema(..);
+ *     const schema = kittySchema = new Schema(..);
  *
  *     schema.method('meow', function () {
  *       console.log('meeeeeoooooooooooow');
  *     })
  *
- *     var Kitty = mongoose.model('Kitty', schema);
+ *     const Kitty = mongoose.model('Kitty', schema);
  *
- *     var fizz = new Kitty;
+ *     const fizz = new Kitty;
  *     fizz.meow(); // meeeeeooooooooooooow
  *
  * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
@@ -2198,8 +2198,8 @@ module.exports = exports = Schema;
  *
  * ####Example:
  *
- *     var mongoose = require('mongoose');
- *     var ObjectId = mongoose.Schema.Types.ObjectId;
+ *     const mongoose = require('mongoose');
+ *     const ObjectId = mongoose.Schema.Types.ObjectId;
  *
  * ####Types:
  *
@@ -2214,7 +2214,7 @@ module.exports = exports = Schema;
  *
  * Using this exposed access to the `Mixed` SchemaType, we can use them in our schema.
  *
- *     var Mixed = mongoose.Schema.Types.Mixed;
+ *     const Mixed = mongoose.Schema.Types.Mixed;
  *     new mongoose.Schema({ _user: Mixed })
  *
  * @api public

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -213,9 +213,9 @@ SchemaBuffer.prototype.cast = function(value, doc, init) {
  *
  * ####Example:
  *
- *     var s = new Schema({ uuid: { type: Buffer, subtype: 4 });
- *     var M = db.model('M', s);
- *     var m = new M({ uuid: 'test string' });
+ *     const s = new Schema({ uuid: { type: Buffer, subtype: 4 });
+ *     const M = db.model('M', s);
+ *     const m = new M({ uuid: 'test string' });
  *     m.uuid._subtype; // 4
  *
  * @param {Number} subtype the default subtype

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -131,7 +131,7 @@ SchemaDate.cast = function cast(caster) {
  *     new Schema({ createdAt: { type: Date, expires: '1.5h' }});
  *
  *     // expire in 7 days
- *     var schema = new Schema({ createdAt: Date });
+ *     const schema = new Schema({ createdAt: Date });
  *     schema.path('createdAt').expires('7d');
  *
  * @param {Number|String} when
@@ -205,9 +205,9 @@ SchemaDate.prototype.checkRequired = function(value, doc) {
  *
  * ####Example:
  *
- *     var s = new Schema({ d: { type: Date, min: Date('1970-01-01') })
- *     var M = db.model('M', s)
- *     var m = new M({ d: Date('1969-12-31') })
+ *     const s = new Schema({ d: { type: Date, min: Date('1970-01-01') })
+ *     const M = db.model('M', s)
+ *     const m = new M({ d: Date('1969-12-31') })
  *     m.save(function (err) {
  *       console.error(err) // validator error
  *       m.d = Date('2014-12-08');
@@ -216,10 +216,10 @@ SchemaDate.prototype.checkRequired = function(value, doc) {
  *
  *     // custom error messages
  *     // We can also use the special {MIN} token which will be replaced with the invalid value
- *     var min = [Date('1970-01-01'), 'The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN}).'];
- *     var schema = new Schema({ d: { type: Date, min: min })
- *     var M = mongoose.model('M', schema);
- *     var s= new M({ d: Date('1969-12-31') });
+ *     const min = [Date('1970-01-01'), 'The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN}).'];
+ *     const schema = new Schema({ d: { type: Date, min: min })
+ *     const M = mongoose.model('M', schema);
+ *     const s= new M({ d: Date('1969-12-31') });
  *     s.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `d` (1969-12-31) is before the limit (1970-01-01).
  *     })
@@ -267,9 +267,9 @@ SchemaDate.prototype.min = function(value, message) {
  *
  * ####Example:
  *
- *     var s = new Schema({ d: { type: Date, max: Date('2014-01-01') })
- *     var M = db.model('M', s)
- *     var m = new M({ d: Date('2014-12-08') })
+ *     const s = new Schema({ d: { type: Date, max: Date('2014-01-01') })
+ *     const M = db.model('M', s)
+ *     const m = new M({ d: Date('2014-12-08') })
  *     m.save(function (err) {
  *       console.error(err) // validator error
  *       m.d = Date('2013-12-31');
@@ -278,10 +278,10 @@ SchemaDate.prototype.min = function(value, message) {
  *
  *     // custom error messages
  *     // We can also use the special {MAX} token which will be replaced with the invalid value
- *     var max = [Date('2014-01-01'), 'The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX}).'];
- *     var schema = new Schema({ d: { type: Date, max: max })
- *     var M = mongoose.model('M', schema);
- *     var s= new M({ d: Date('2014-12-08') });
+ *     const max = [Date('2014-01-01'), 'The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX}).'];
+ *     const schema = new Schema({ d: { type: Date, max: max })
+ *     const M = mongoose.model('M', schema);
+ *     const s= new M({ d: Date('2014-12-08') });
  *     s.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `d` (2014-12-08) exceeds the limit (2014-01-01).
  *     })

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -179,9 +179,9 @@ SchemaNumber.prototype.checkRequired = function checkRequired(value, doc) {
  *
  * ####Example:
  *
- *     var s = new Schema({ n: { type: Number, min: 10 })
- *     var M = db.model('M', s)
- *     var m = new M({ n: 9 })
+ *     const s = new Schema({ n: { type: Number, min: 10 })
+ *     const M = db.model('M', s)
+ *     const m = new M({ n: 9 })
  *     m.save(function (err) {
  *       console.error(err) // validator error
  *       m.n = 10;
@@ -190,10 +190,10 @@ SchemaNumber.prototype.checkRequired = function checkRequired(value, doc) {
  *
  *     // custom error messages
  *     // We can also use the special {MIN} token which will be replaced with the invalid value
- *     var min = [10, 'The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN}).'];
- *     var schema = new Schema({ n: { type: Number, min: min })
- *     var M = mongoose.model('Measurement', schema);
- *     var s= new M({ n: 4 });
+ *     const min = [10, 'The value of path `{PATH}` ({VALUE}) is beneath the limit ({MIN}).'];
+ *     const schema = new Schema({ n: { type: Number, min: min })
+ *     const M = mongoose.model('Measurement', schema);
+ *     const s= new M({ n: 4 });
  *     s.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `n` (4) is beneath the limit (10).
  *     })
@@ -233,9 +233,9 @@ SchemaNumber.prototype.min = function(value, message) {
  *
  * ####Example:
  *
- *     var s = new Schema({ n: { type: Number, max: 10 })
- *     var M = db.model('M', s)
- *     var m = new M({ n: 11 })
+ *     const s = new Schema({ n: { type: Number, max: 10 })
+ *     const M = db.model('M', s)
+ *     const m = new M({ n: 11 })
  *     m.save(function (err) {
  *       console.error(err) // validator error
  *       m.n = 10;
@@ -244,10 +244,10 @@ SchemaNumber.prototype.min = function(value, message) {
  *
  *     // custom error messages
  *     // We can also use the special {MAX} token which will be replaced with the invalid value
- *     var max = [10, 'The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX}).'];
- *     var schema = new Schema({ n: { type: Number, max: max })
- *     var M = mongoose.model('Measurement', schema);
- *     var s= new M({ n: 4 });
+ *     const max = [10, 'The value of path `{PATH}` ({VALUE}) exceeds the limit ({MAX}).'];
+ *     const schema = new Schema({ n: { type: Number, max: max })
+ *     const M = mongoose.model('Measurement', schema);
+ *     const s= new M({ n: 4 });
  *     s.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `n` (4) exceeds the limit (10).
  *     })
@@ -287,10 +287,10 @@ SchemaNumber.prototype.max = function(value, message) {
  *
  * ####Example:
  *
- *     var s = new Schema({ n: { type: Number, enum: [1, 2, 3] });
- *     var M = db.model('M', s);
+ *     const s = new Schema({ n: { type: Number, enum: [1, 2, 3] });
+ *     const M = db.model('M', s);
  *
- *     var m = new M({ n: 4 });
+ *     const m = new M({ n: 4 });
  *     await m.save(); // throws validation error
  *
  *     m.n = 3;

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -171,10 +171,10 @@ SchemaString.checkRequired = SchemaType.checkRequired;
  *
  * ####Example:
  *
- *     var states = ['opening', 'open', 'closing', 'closed']
- *     var s = new Schema({ state: { type: String, enum: states }})
- *     var M = db.model('M', s)
- *     var m = new M({ state: 'invalid' })
+ *     const states = ['opening', 'open', 'closing', 'closed']
+ *     const s = new Schema({ state: { type: String, enum: states }})
+ *     const M = db.model('M', s)
+ *     const m = new M({ state: 'invalid' })
  *     m.save(function (err) {
  *       console.error(String(err)) // ValidationError: `invalid` is not a valid enum value for path `state`.
  *       m.state = 'open'
@@ -182,13 +182,13 @@ SchemaString.checkRequired = SchemaType.checkRequired;
  *     })
  *
  *     // or with custom error messages
- *     var enum = {
+ *     const enum = {
  *       values: ['opening', 'open', 'closing', 'closed'],
  *       message: 'enum validator failed for path `{PATH}` with value `{VALUE}`'
  *     }
- *     var s = new Schema({ state: { type: String, enum: enum })
- *     var M = db.model('M', s)
- *     var m = new M({ state: 'invalid' })
+ *     const s = new Schema({ state: { type: String, enum: enum })
+ *     const M = db.model('M', s)
+ *     const m = new M({ state: 'invalid' })
  *     m.save(function (err) {
  *       console.error(String(err)) // ValidationError: enum validator failed for path `state` with value `invalid`
  *       m.state = 'open'
@@ -249,9 +249,9 @@ SchemaString.prototype.enum = function() {
  *
  * ####Example:
  *
- *     var s = new Schema({ email: { type: String, lowercase: true }})
- *     var M = db.model('M', s);
- *     var m = new M({ email: 'SomeEmail@example.COM' });
+ *     const s = new Schema({ email: { type: String, lowercase: true }})
+ *     const M = db.model('M', s);
+ *     const m = new M({ email: 'SomeEmail@example.COM' });
  *     console.log(m.email) // someemail@example.com
  *     M.find({ email: 'SomeEmail@example.com' }); // Queries by 'someemail@example.com'
  *
@@ -287,9 +287,9 @@ SchemaString.prototype.lowercase = function(shouldApply) {
  *
  * ####Example:
  *
- *     var s = new Schema({ caps: { type: String, uppercase: true }})
- *     var M = db.model('M', s);
- *     var m = new M({ caps: 'an example' });
+ *     const s = new Schema({ caps: { type: String, uppercase: true }})
+ *     const M = db.model('M', s);
+ *     const m = new M({ caps: 'an example' });
  *     console.log(m.caps) // AN EXAMPLE
  *     M.find({ caps: 'an example' }) // Matches documents where caps = 'AN EXAMPLE'
  *
@@ -325,11 +325,11 @@ SchemaString.prototype.uppercase = function(shouldApply) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, trim: true }});
- *     var M = db.model('M', s);
- *     var string = ' some name ';
+ *     const s = new Schema({ name: { type: String, trim: true }});
+ *     const M = db.model('M', s);
+ *     const string = ' some name ';
  *     console.log(string.length); // 11
- *     var m = new M({ name: string });
+ *     const m = new M({ name: string });
  *     console.log(m.name.length); // 9
  *
  *     // Equivalent to `findOne({ name: string.trim() })`
@@ -365,9 +365,9 @@ SchemaString.prototype.trim = function(shouldTrim) {
  *
  * ####Example:
  *
- *     var schema = new Schema({ postalCode: { type: String, minlength: 5 })
- *     var Address = db.model('Address', schema)
- *     var address = new Address({ postalCode: '9512' })
+ *     const schema = new Schema({ postalCode: { type: String, minlength: 5 })
+ *     const Address = db.model('Address', schema)
+ *     const address = new Address({ postalCode: '9512' })
  *     address.save(function (err) {
  *       console.error(err) // validator error
  *       address.postalCode = '95125';
@@ -376,10 +376,10 @@ SchemaString.prototype.trim = function(shouldTrim) {
  *
  *     // custom error messages
  *     // We can also use the special {MINLENGTH} token which will be replaced with the minimum allowed length
- *     var minlength = [5, 'The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).'];
- *     var schema = new Schema({ postalCode: { type: String, minlength: minlength })
- *     var Address = mongoose.model('Address', schema);
- *     var address = new Address({ postalCode: '9512' });
+ *     const minlength = [5, 'The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).'];
+ *     const schema = new Schema({ postalCode: { type: String, minlength: minlength })
+ *     const Address = mongoose.model('Address', schema);
+ *     const address = new Address({ postalCode: '9512' });
  *     address.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512`) is shorter than the minimum length (5).
  *     })
@@ -419,9 +419,9 @@ SchemaString.prototype.minlength = function(value, message) {
  *
  * ####Example:
  *
- *     var schema = new Schema({ postalCode: { type: String, maxlength: 9 })
- *     var Address = db.model('Address', schema)
- *     var address = new Address({ postalCode: '9512512345' })
+ *     const schema = new Schema({ postalCode: { type: String, maxlength: 9 })
+ *     const Address = db.model('Address', schema)
+ *     const address = new Address({ postalCode: '9512512345' })
  *     address.save(function (err) {
  *       console.error(err) // validator error
  *       address.postalCode = '95125';
@@ -430,10 +430,10 @@ SchemaString.prototype.minlength = function(value, message) {
  *
  *     // custom error messages
  *     // We can also use the special {MAXLENGTH} token which will be replaced with the maximum allowed length
- *     var maxlength = [9, 'The value of path `{PATH}` (`{VALUE}`) exceeds the maximum allowed length ({MAXLENGTH}).'];
- *     var schema = new Schema({ postalCode: { type: String, maxlength: maxlength })
- *     var Address = mongoose.model('Address', schema);
- *     var address = new Address({ postalCode: '9512512345' });
+ *     const maxlength = [9, 'The value of path `{PATH}` (`{VALUE}`) exceeds the maximum allowed length ({MAXLENGTH}).'];
+ *     const schema = new Schema({ postalCode: { type: String, maxlength: maxlength })
+ *     const Address = mongoose.model('Address', schema);
+ *     const address = new Address({ postalCode: '9512512345' });
  *     address.validate(function (err) {
  *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512512345`) exceeds the maximum allowed length (9).
  *     })
@@ -475,9 +475,9 @@ SchemaString.prototype.maxlength = function(value, message) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, match: /^a/ }})
- *     var M = db.model('M', s)
- *     var m = new M({ name: 'I am invalid' })
+ *     const s = new Schema({ name: { type: String, match: /^a/ }})
+ *     const M = db.model('M', s)
+ *     const m = new M({ name: 'I am invalid' })
  *     m.validate(function (err) {
  *       console.error(String(err)) // "ValidationError: Path `name` is invalid (I am invalid)."
  *       m.name = 'apples'
@@ -487,17 +487,17 @@ SchemaString.prototype.maxlength = function(value, message) {
  *     })
  *
  *     // using a custom error message
- *     var match = [ /\.html$/, "That file doesn't end in .html ({VALUE})" ];
- *     var s = new Schema({ file: { type: String, match: match }})
- *     var M = db.model('M', s);
- *     var m = new M({ file: 'invalid' });
+ *     const match = [ /\.html$/, "That file doesn't end in .html ({VALUE})" ];
+ *     const s = new Schema({ file: { type: String, match: match }})
+ *     const M = db.model('M', s);
+ *     const m = new M({ file: 'invalid' });
  *     m.validate(function (err) {
  *       console.log(String(err)) // "ValidationError: That file doesn't end in .html (invalid)"
  *     })
  *
  * Empty strings, `undefined`, and `null` values always pass the match validator. If you require these values, enable the `required` validator also.
  *
- *     var s = new Schema({ name: { type: String, match: /^a/, required: true }})
+ *     const s = new Schema({ name: { type: String, match: /^a/, required: true }})
  *
  * @param {RegExp} regExp regular expression to test against
  * @param {String} [message] optional custom error message

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -204,9 +204,9 @@ SchemaType.get = function(getter) {
  *
  * ####Example:
  *
- *     var schema = new Schema({ n: { type: Number, default: 10 })
- *     var M = db.model('M', schema)
- *     var m = new M;
+ *     const schema = new Schema({ n: { type: Number, default: 10 })
+ *     const M = db.model('M', schema)
+ *     const m = new M;
  *     console.log(m.n) // 10
  *
  * Defaults can be either `functions` which return the value to use as the default or the literal value itself. Either way, the value will be cast based on its schema type before being set during document creation.
@@ -214,13 +214,13 @@ SchemaType.get = function(getter) {
  * ####Example:
  *
  *     // values are cast:
- *     var schema = new Schema({ aNumber: { type: Number, default: 4.815162342 }})
- *     var M = db.model('M', schema)
- *     var m = new M;
+ *     const schema = new Schema({ aNumber: { type: Number, default: 4.815162342 }})
+ *     const M = db.model('M', schema)
+ *     const m = new M;
  *     console.log(m.aNumber) // 4.815162342
  *
  *     // default unique objects for Mixed types:
- *     var schema = new Schema({ mixed: Schema.Types.Mixed });
+ *     const schema = new Schema({ mixed: Schema.Types.Mixed });
  *     schema.path('mixed').default(function () {
  *       return {};
  *     });
@@ -228,13 +228,13 @@ SchemaType.get = function(getter) {
  *     // if we don't use a function to return object literals for Mixed defaults,
  *     // each document will receive a reference to the same object literal creating
  *     // a "shared" object instance:
- *     var schema = new Schema({ mixed: Schema.Types.Mixed });
+ *     const schema = new Schema({ mixed: Schema.Types.Mixed });
  *     schema.path('mixed').default({});
- *     var M = db.model('M', schema);
- *     var m1 = new M;
+ *     const M = db.model('M', schema);
+ *     const m1 = new M;
  *     m1.mixed.added = 1;
  *     console.log(m1.mixed); // { added: 1 }
- *     var m2 = new M;
+ *     const m2 = new M;
  *     console.log(m2.mixed); // { added: 1 }
  *
  * @param {Function|any} val the default value
@@ -267,11 +267,11 @@ SchemaType.prototype.default = function(val) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, index: true })
- *     var s = new Schema({ loc: { type: [Number], index: 'hashed' })
- *     var s = new Schema({ loc: { type: [Number], index: '2d', sparse: true })
- *     var s = new Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }})
- *     var s = new Schema({ date: { type: Date, index: { unique: true, expires: '1d' }})
+ *     const s = new Schema({ name: { type: String, index: true })
+ *     const s = new Schema({ loc: { type: [Number], index: 'hashed' })
+ *     const s = new Schema({ loc: { type: [Number], index: '2d', sparse: true })
+ *     const s = new Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }})
+ *     const s = new Schema({ date: { type: Date, index: { unique: true, expires: '1d' }})
  *     s.path('my.path').index(true);
  *     s.path('my.date').index({ expires: 60 });
  *     s.path('my.path').index({ unique: true, sparse: true });
@@ -299,7 +299,7 @@ SchemaType.prototype.index = function(options) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, unique: true }});
+ *     const s = new Schema({ name: { type: String, unique: true }});
  *     s.path('name').index({ unique: true });
  *
  * _NOTE: violating the constraint returns an `E11000` error from MongoDB when saving, not a Mongoose validation error._
@@ -332,7 +332,7 @@ SchemaType.prototype.unique = function(bool) {
  *
  * ###Example:
  *
- *      var s = new Schema({name : {type: String, text : true })
+ *      const s = new Schema({name : {type: String, text : true })
  *      s.path('name').index({text : true});
  * @param {Boolean} bool
  * @return {SchemaType} this
@@ -364,7 +364,7 @@ SchemaType.prototype.text = function(bool) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, sparse: true } });
+ *     const s = new Schema({ name: { type: String, sparse: true } });
  *     s.path('name').index({ sparse: true });
  *
  * @param {Boolean} bool
@@ -484,10 +484,10 @@ SchemaType.prototype.transform = function(fn) {
  *     }
  *
  *     // defining within the schema
- *     var s = new Schema({ name: { type: String, set: capitalize }});
+ *     const s = new Schema({ name: { type: String, set: capitalize }});
  *
  *     // or with the SchemaType
- *     var s = new Schema({ name: String })
+ *     const s = new Schema({ name: String })
  *     s.path('name').set(capitalize);
  *
  * Setters allow you to transform the data before it gets to the raw mongodb
@@ -504,17 +504,17 @@ SchemaType.prototype.transform = function(fn) {
  *       return v.toLowerCase();
  *     }
  *
- *     var UserSchema = new Schema({
+ *     const UserSchema = new Schema({
  *       email: { type: String, set: toLower }
  *     });
  *
- *     var User = db.model('User', UserSchema);
+ *     const User = db.model('User', UserSchema);
  *
- *     var user = new User({email: 'AVENUE@Q.COM'});
+ *     const user = new User({email: 'AVENUE@Q.COM'});
  *     console.log(user.email); // 'avenue@q.com'
  *
  *     // or
- *     var user = new User();
+ *     const user = new User();
  *     user.email = 'Avenue@Q.com';
  *     console.log(user.email); // 'avenue@q.com'
  *     User.updateOne({ _id: _id }, { $set: { email: 'AVENUE@Q.COM' } }); // update to 'avenue@q.com'
@@ -536,13 +536,13 @@ SchemaType.prototype.transform = function(fn) {
  *       }
  *     }
  *
- *     var VirusSchema = new Schema({
+ *     const VirusSchema = new Schema({
  *       name: { type: String, required: true, set: inspector },
  *       taxonomy: { type: String, set: inspector }
  *     })
  *
- *     var Virus = db.model('Virus', VirusSchema);
- *     var v = new Virus({ name: 'Parvoviridae', taxonomy: 'Parvovirinae' });
+ *     const Virus = db.model('Virus', VirusSchema);
+ *     const v = new Virus({ name: 'Parvoviridae', taxonomy: 'Parvovirinae' });
  *
  *     console.log(v.name);     // name is required
  *     console.log(v.taxonomy); // Parvovirinae
@@ -589,10 +589,10 @@ SchemaType.prototype.set = function(fn) {
  *     }
  *
  *     // defining within the schema
- *     var s = new Schema({ born: { type: Date, get: dob })
+ *     const s = new Schema({ born: { type: Date, get: dob })
  *
  *     // or by retreiving its SchemaType
- *     var s = new Schema({ born: Date })
+ *     const s = new Schema({ born: Date })
  *     s.path('born').get(dob)
  *
  * Getters allow you to transform the representation of the data as it travels from the raw mongodb document to the value that you see.
@@ -603,11 +603,11 @@ SchemaType.prototype.set = function(fn) {
  *       return '****-****-****-' + cc.slice(cc.length-4, cc.length);
  *     }
  *
- *     var AccountSchema = new Schema({
+ *     const AccountSchema = new Schema({
  *       creditCardNumber: { type: String, get: obfuscate }
  *     });
  *
- *     var Account = db.model('Account', AccountSchema);
+ *     const Account = db.model('Account', AccountSchema);
  *
  *     Account.findById(id, function (err, found) {
  *       console.log(found.creditCardNumber); // '****-****-****-1234'
@@ -623,12 +623,12 @@ SchemaType.prototype.set = function(fn) {
  *       }
  *     }
  *
- *     var VirusSchema = new Schema({
+ *     const VirusSchema = new Schema({
  *       name: { type: String, required: true, get: inspector },
  *       taxonomy: { type: String, get: inspector }
  *     })
  *
- *     var Virus = db.model('Virus', VirusSchema);
+ *     const Virus = db.model('Virus', VirusSchema);
  *
  *     Virus.findById(id, function (err, virus) {
  *       console.log(virus.name);     // name is required
@@ -667,12 +667,12 @@ SchemaType.prototype.get = function(fn) {
  *
  *     // with a custom error message
  *
- *     var custom = [validator, 'Uh oh, {PATH} does not equal "something".']
+ *     const custom = [validator, 'Uh oh, {PATH} does not equal "something".']
  *     new Schema({ name: { type: String, validate: custom }});
  *
  *     // adding many validators at a time
  *
- *     var many = [
+ *     const many = [
  *         { validator: validator, msg: 'uh oh' }
  *       , { validator: anotherValidator, msg: 'failed' }
  *     ]
@@ -680,7 +680,7 @@ SchemaType.prototype.get = function(fn) {
  *
  *     // or utilizing SchemaType methods directly:
  *
- *     var schema = new Schema({ name: 'string' });
+ *     const schema = new Schema({ name: 'string' });
  *     schema.path('name').validate(validator, 'validation of `{PATH}` failed with value `{VALUE}`');
  *
  * ####Error message templates:
@@ -730,11 +730,11 @@ SchemaType.prototype.get = function(fn) {
  *
  * If validation fails during `pre('save')` and no callback was passed to receive the error, an `error` event will be emitted on your Models associated db [connection](#connection_Connection), passing the validation error object along.
  *
- *     var conn = mongoose.createConnection(..);
+ *     const conn = mongoose.createConnection(..);
  *     conn.on('error', handleError);
  *
- *     var Product = conn.model('Product', yourSchema);
- *     var dvd = new Product(..);
+ *     const Product = conn.model('Product', yourSchema);
+ *     const dvd = new Product(..);
  *     dvd.save(); // emits error on the `conn` above
  *
  * If you want to handle these errors at the Model level, add an `error`
@@ -818,15 +818,15 @@ const handleIsAsync = util.deprecate(function handleIsAsync() {},
  *
  * ####Example:
  *
- *     var s = new Schema({ born: { type: Date, required: true })
+ *     const s = new Schema({ born: { type: Date, required: true })
  *
  *     // or with custom error message
  *
- *     var s = new Schema({ born: { type: Date, required: '{PATH} is required!' })
+ *     const s = new Schema({ born: { type: Date, required: '{PATH} is required!' })
  *
  *     // or with a function
  *
- *     var s = new Schema({
+ *     const s = new Schema({
  *       userId: ObjectId,
  *       username: {
  *         type: String,
@@ -835,7 +835,7 @@ const handleIsAsync = util.deprecate(function handleIsAsync() {},
  *     })
  *
  *     // or with a function and a custom message
- *     var s = new Schema({
+ *     const s = new Schema({
  *       userId: ObjectId,
  *       username: {
  *         type: String,
@@ -855,7 +855,7 @@ const handleIsAsync = util.deprecate(function handleIsAsync() {},
  *     s.path('name').required(true, 'grrr :( ');
  *
  *     // or make a path conditionally required based on a function
- *     var isOver18 = function() { return this.age >= 18; };
+ *     const isOver18 = function() { return this.age >= 18; };
  *     s.path('voterRegistrationId').required(isOver18);
  *
  * The required validator uses the SchemaType's `checkRequired` function to

--- a/lib/types/buffer.js
+++ b/lib/types/buffer.js
@@ -168,7 +168,7 @@ MongooseBuffer.mixin = {
  *
  * ####SubTypes:
  *
- *   var bson = require('bson')
+ *   const bson = require('bson')
  *   bson.BSON_BINARY_SUBTYPE_DEFAULT
  *   bson.BSON_BINARY_SUBTYPE_FUNCTION
  *   bson.BSON_BINARY_SUBTYPE_BYTE_ARRAY
@@ -238,7 +238,7 @@ MongooseBuffer.mixin.equals = function(other) {
  *
  * ####SubTypes:
  *
- *   var bson = require('bson')
+ *   const bson = require('bson')
  *   bson.BSON_BINARY_SUBTYPE_DEFAULT
  *   bson.BSON_BINARY_SUBTYPE_FUNCTION
  *   bson.BSON_BINARY_SUBTYPE_BYTE_ARRAY

--- a/lib/types/core_array.js
+++ b/lib/types/core_array.js
@@ -123,7 +123,7 @@ class CoreMongooseArray extends Array {
    *
    *      doc.array = [1,2,3];
    *
-   *      var shifted = doc.array.$shift();
+   *      const shifted = doc.array.$shift();
    *      console.log(shifted); // 1
    *      console.log(doc.array); // [2,3]
    *
@@ -170,7 +170,7 @@ class CoreMongooseArray extends Array {
    *
    *      doc.array = [1,2,3];
    *
-   *      var popped = doc.array.$pop();
+   *      const popped = doc.array.$pop();
    *      console.log(popped); // 3
    *      console.log(doc.array); // [1,2]
    *
@@ -389,7 +389,7 @@ class CoreMongooseArray extends Array {
    * ####Example:
    *
    *     console.log(doc.array) // [2,3,4]
-   *     var added = doc.array.addToSet(4,5);
+   *     const added = doc.array.addToSet(4,5);
    *     console.log(doc.array) // [2,3,4,5]
    *     console.log(added)     // [5]
    *
@@ -723,9 +723,9 @@ class CoreMongooseArray extends Array {
    * ####Example:
    *
    *     // given documents based on the following
-   *     var Doc = mongoose.model('Doc', new Schema({ array: [Number] }));
+   *     const Doc = mongoose.model('Doc', new Schema({ array: [Number] }));
    *
-   *     var doc = new Doc({ array: [2,3,4] })
+   *     const doc = new Doc({ array: [2,3,4] })
    *
    *     console.log(doc.array) // [2,3,4]
    *
@@ -757,7 +757,7 @@ class CoreMongooseArray extends Array {
    * ####Example:
    *
    *     doc.array = [2,3];
-   *     var res = doc.array.shift();
+   *     const res = doc.array.shift();
    *     console.log(res) // 2
    *     console.log(doc.array) // [3]
    *

--- a/lib/types/decimal128.js
+++ b/lib/types/decimal128.js
@@ -3,7 +3,7 @@
  *
  * ####Example
  *
- *     var id = new mongoose.Types.ObjectId;
+ *     const id = new mongoose.Types.ObjectId;
  *
  * @constructor ObjectId
  */

--- a/lib/types/documentarray.js
+++ b/lib/types/documentarray.js
@@ -114,7 +114,7 @@ class CoreDocumentArray extends CoreMongooseArray {
    *
    * ####Example:
    *
-   *     var embeddedDoc = m.array.id(some_id);
+   *     const embeddedDoc = m.array.id(some_id);
    *
    * @return {EmbeddedDocument|null} the subdocument or null if not found.
    * @param {ObjectId|String|Number|Buffer} id

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -85,7 +85,7 @@ EmbeddedDocument.prototype.$setIndex = function(index) {
  *
  * ####Example:
  *
- *     var doc = blogpost.comments.id(hexstring);
+ *     const doc = blogpost.comments.id(hexstring);
  *     doc.mixed.type = 'changed';
  *     doc.markModified('mixed.type');
  *

--- a/lib/types/objectid.js
+++ b/lib/types/objectid.js
@@ -3,7 +3,7 @@
  *
  * ####Example
  *
- *     var id = new mongoose.Types.ObjectId;
+ *     const id = new mongoose.Types.ObjectId;
  *
  * @constructor ObjectId
  */

--- a/lib/virtualtype.js
+++ b/lib/virtualtype.js
@@ -77,7 +77,7 @@ VirtualType.prototype.clone = function() {
  *
  * ####Example:
  *
- *     var virtual = schema.virtual('fullname');
+ *     const virtual = schema.virtual('fullname');
  *     virtual.get(function(value, virtual, doc) {
  *       return this.name.first + ' ' + this.name.last;
  *     });
@@ -105,7 +105,7 @@ VirtualType.prototype.get = function(fn) {
  *
  *     const virtual = schema.virtual('fullname');
  *     virtual.set(function(value, virtual, doc) {
- *       var parts = value.split(' ');
+ *       const parts = value.split(' ');
  *       this.name.first = parts[0];
  *       this.name.last = parts[1];
  *     });

--- a/test/docs/defaults.test.js
+++ b/test/docs/defaults.test.js
@@ -27,24 +27,24 @@ describe('defaults docs', function () {
    * strictly `undefined`.
    */
   it('Declaring defaults in your schema', function(done) {
-    var schema = new Schema({
+    const schema = new Schema({
       name: String,
       role: { type: String, default: 'guitarist' }
     });
 
-    var Person = db.model('Person', schema);
+    const Person = db.model('Person', schema);
 
-    var axl = new Person({ name: 'Axl Rose', role: 'singer' });
+    const axl = new Person({ name: 'Axl Rose', role: 'singer' });
     assert.equal(axl.role, 'singer');
 
-    var slash = new Person({ name: 'Slash' });
+    const slash = new Person({ name: 'Slash' });
     assert.equal(slash.role, 'guitarist');
 
-    var izzy = new Person({ name: 'Izzy', role: undefined });
+    const izzy = new Person({ name: 'Izzy', role: undefined });
     assert.equal(izzy.role, 'guitarist');
 
     // Defaults do **not** run on `null`, `''`, or value other than `undefined`.
-    var foo = new Person({ name: 'Bar', role: null });
+    const foo = new Person({ name: 'Bar', role: null });
     assert.strictEqual(foo.role, null);
 
     Person.create(axl, slash, function(error) {
@@ -65,7 +65,7 @@ describe('defaults docs', function () {
    * execute that function and use the return value as the default.
    */
   it('Default functions', function() {
-    var schema = new Schema({
+    const schema = new Schema({
       title: String,
       date: {
         type: Date,
@@ -74,9 +74,9 @@ describe('defaults docs', function () {
       }
     });
 
-    var BlogPost = db.model('BlogPost', schema);
+    const BlogPost = db.model('BlogPost', schema);
 
-    var post = new BlogPost({title: '5 Best Arnold Schwarzenegger Movies'});
+    const post = new BlogPost({title: '5 Best Arnold Schwarzenegger Movies'});
 
     // The post has a default Date set to now
     assert.ok(post.date.getTime() >= Date.now() - 1000);
@@ -97,16 +97,16 @@ describe('defaults docs', function () {
    * using MongoDB server < 2.4.0, do **not** use `setDefaultsOnInsert`.
    */
   it('The `setDefaultsOnInsert` option', function(done) {
-    var schema = new Schema({
+    const schema = new Schema({
       title: String,
       genre: {type: String, default: 'Action'}
     });
 
-    var Movie = db.model('Movie', schema);
+    const Movie = db.model('Movie', schema);
 
-    var query = {};
-    var update = {title: 'The Terminator'};
-    var options = {
+    const query = {};
+    const update = {title: 'The Terminator'};
+    const options = {
       // Return the document after updates are applied
       new: true,
       // Create a document if one isn't found. Required

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var assert = require('assert');
-var mongoose = require('../../');
+const assert = require('assert');
+const mongoose = require('../../');
 
-var Schema = mongoose.Schema;
+const Schema = mongoose.Schema;
 
 describe('discriminator docs', function () {
-  var Event;
-  var ClickedLinkEvent;
-  var SignedUpEvent;
-  var db;
+  let Event;
+  let ClickedLinkEvent;
+  let SignedUpEvent;
+  let db;
 
   before(function (done) {
     db = mongoose.createConnection('mongodb://localhost:27017/mongoose_test');
 
-    var eventSchema = new mongoose.Schema({time: Date});
+    const eventSchema = new mongoose.Schema({time: Date});
     Event = db.model('_event', eventSchema);
 
     ClickedLinkEvent = Event.discriminator('ClickedLink',
@@ -48,22 +48,22 @@ describe('discriminator docs', function () {
    * is the union of the base schema and the discriminator schema.
    */
   it('The `model.discriminator()` function', function (done) {
-    var options = {discriminatorKey: 'kind'};
+    const options = {discriminatorKey: 'kind'};
 
-    var eventSchema = new mongoose.Schema({time: Date}, options);
-    var Event = mongoose.model('Event', eventSchema);
+    const eventSchema = new mongoose.Schema({time: Date}, options);
+    const Event = mongoose.model('Event', eventSchema);
 
     // ClickedLinkEvent is a special type of Event that has
     // a URL.
-    var ClickedLinkEvent = Event.discriminator('ClickedLink',
+    const ClickedLinkEvent = Event.discriminator('ClickedLink',
       new mongoose.Schema({url: String}, options));
 
     // When you create a generic event, it can't have a URL field...
-    var genericEvent = new Event({time: Date.now(), url: 'google.com'});
+    const genericEvent = new Event({time: Date.now(), url: 'google.com'});
     assert.ok(!genericEvent.url);
 
     // But a ClickedLinkEvent can
-    var clickedEvent =
+    const clickedEvent =
       new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
     assert.ok(clickedEvent.url);
 
@@ -79,11 +79,11 @@ describe('discriminator docs', function () {
    * instances.
    */
   it('Discriminators save to the Event model\'s collection', function (done) {
-    var event1 = new Event({time: Date.now()});
-    var event2 = new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
-    var event3 = new SignedUpEvent({time: Date.now(), user: 'testuser'});
+    const event1 = new Event({time: Date.now()});
+    const event2 = new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
+    const event3 = new SignedUpEvent({time: Date.now(), user: 'testuser'});
 
-    var save = function (doc, callback) {
+    const save = function (doc, callback) {
       doc.save(function (error, doc) {
         callback(error, doc);
       });
@@ -107,9 +107,9 @@ describe('discriminator docs', function () {
    * this document is an instance of.
    */
   it('Discriminator keys', function (done) {
-    var event1 = new Event({time: Date.now()});
-    var event2 = new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
-    var event3 = new SignedUpEvent({time: Date.now(), user: 'testuser'});
+    const event1 = new Event({time: Date.now()});
+    const event2 = new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
+    const event3 = new SignedUpEvent({time: Date.now(), user: 'testuser'});
 
     assert.ok(!event1.__t);
     assert.equal(event2.__t, 'ClickedLink');
@@ -126,9 +126,9 @@ describe('discriminator docs', function () {
    * are smart enough to account for discriminators.
    */
   it('Discriminators add the discriminator key to queries', function (done) {
-    var event1 = new Event({time: Date.now()});
-    var event2 = new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
-    var event3 = new SignedUpEvent({time: Date.now(), user: 'testuser'});
+    const event1 = new Event({time: Date.now()});
+    const event2 = new ClickedLinkEvent({time: Date.now(), url: 'google.com'});
+    const event3 = new SignedUpEvent({time: Date.now(), user: 'testuser'});
 
     Promise.all([event1.save(), event2.save(), event3.save()]).
       then(() => ClickedLinkEvent.find({})).
@@ -148,31 +148,31 @@ describe('discriminator docs', function () {
    * without affecting the base schema.
    */
   it('Discriminators copy pre and post hooks', function (done) {
-    var options = {discriminatorKey: 'kind'};
+    const options = {discriminatorKey: 'kind'};
 
-    var eventSchema = new mongoose.Schema({time: Date}, options);
-    var eventSchemaCalls = 0;
+    const eventSchema = new mongoose.Schema({time: Date}, options);
+    let eventSchemaCalls = 0;
     eventSchema.pre('validate', function (next) {
       ++eventSchemaCalls;
       next();
     });
-    var Event = mongoose.model('GenericEvent', eventSchema);
+    const Event = mongoose.model('GenericEvent', eventSchema);
 
-    var clickedLinkSchema = new mongoose.Schema({url: String}, options);
-    var clickedSchemaCalls = 0;
+    const clickedLinkSchema = new mongoose.Schema({url: String}, options);
+    let clickedSchemaCalls = 0;
     clickedLinkSchema.pre('validate', function (next) {
       ++clickedSchemaCalls;
       next();
     });
-    var ClickedLinkEvent = Event.discriminator('ClickedLinkEvent',
+    const ClickedLinkEvent = Event.discriminator('ClickedLinkEvent',
       clickedLinkSchema);
 
-    var event1 = new ClickedLinkEvent();
+    const event1 = new ClickedLinkEvent();
     event1.validate(function() {
       assert.equal(eventSchemaCalls, 1);
       assert.equal(clickedSchemaCalls, 1);
 
-      var generic = new Event();
+      const generic = new Event();
       generic.validate(function() {
         assert.equal(eventSchemaCalls, 2);
         assert.equal(clickedSchemaCalls, 1);
@@ -191,14 +191,14 @@ describe('discriminator docs', function () {
    * override the discriminator's _id field, as shown below.
    */
   it('Handling custom _id fields', function (done) {
-    var options = {discriminatorKey: 'kind'};
+    const options = {discriminatorKey: 'kind'};
 
     // Base schema has a custom String `_id` and a Date `time`...
-    var eventSchema = new mongoose.Schema({_id: String, time: Date},
+    const eventSchema = new mongoose.Schema({_id: String, time: Date},
       options);
-    var Event = mongoose.model('BaseEvent', eventSchema);
+    const Event = mongoose.model('BaseEvent', eventSchema);
 
-    var clickedLinkSchema = new mongoose.Schema({
+    const clickedLinkSchema = new mongoose.Schema({
       url: String,
       time: String
     }, options);
@@ -206,10 +206,10 @@ describe('discriminator docs', function () {
     // implicitly added ObjectId `_id`.
     assert.ok(clickedLinkSchema.path('_id'));
     assert.equal(clickedLinkSchema.path('_id').instance, 'ObjectID');
-    var ClickedLinkEvent = Event.discriminator('ChildEventBad',
+    const ClickedLinkEvent = Event.discriminator('ChildEventBad',
       clickedLinkSchema);
 
-    var event1 = new ClickedLinkEvent({_id: 'custom id', time: '4pm'});
+    const event1 = new ClickedLinkEvent({_id: 'custom id', time: '4pm'});
     // clickedLinkSchema overwrites the `time` path, but **not**
     // the `_id` path.
     assert.strictEqual(typeof event1._id, 'string');
@@ -225,19 +225,19 @@ describe('discriminator docs', function () {
    * the discriminator key for you.
    */
   it('Using discriminators with `Model.create()`', function(done) {
-    var Schema = mongoose.Schema;
-    var shapeSchema = new Schema({
+    const Schema = mongoose.Schema;
+    const shapeSchema = new Schema({
       name: String
     }, { discriminatorKey: 'kind' });
 
-    var Shape = db.model('Shape', shapeSchema);
+    const Shape = db.model('Shape', shapeSchema);
 
-    var Circle = Shape.discriminator('Circle',
+    const Circle = Shape.discriminator('Circle',
       new Schema({ radius: Number }));
-    var Square = Shape.discriminator('Square',
+    const Square = Shape.discriminator('Square',
       new Schema({ side: Number }));
 
-    var shapes = [
+    const shapes = [
       { name: 'Test' },
       { kind: 'Circle', radius: 5 },
       { kind: 'Square', side: 10 }
@@ -267,17 +267,17 @@ describe('discriminator docs', function () {
    * `post()` after calling `discriminator()`
    */
   it('Embedded discriminators in arrays', function(done) {
-    var eventSchema = new Schema({ message: String },
+    const eventSchema = new Schema({ message: String },
       { discriminatorKey: 'kind', _id: false });
 
-    var batchSchema = new Schema({ events: [eventSchema] });
+    const batchSchema = new Schema({ events: [eventSchema] });
 
     // `batchSchema.path('events')` gets the mongoose `DocumentArray`
-    var docArray = batchSchema.path('events');
+    const docArray = batchSchema.path('events');
 
     // The `events` array can contain 2 different types of events, a
     // 'clicked' event that requires an element id that was clicked...
-    var clickedSchema = new Schema({
+    const clickedSchema = new Schema({
       element: {
         type: String,
         required: true
@@ -285,20 +285,20 @@ describe('discriminator docs', function () {
     }, { _id: false });
     // Make sure to attach any hooks to `eventSchema` and `clickedSchema`
     // **before** calling `discriminator()`.
-    var Clicked = docArray.discriminator('Clicked', clickedSchema);
+    const Clicked = docArray.discriminator('Clicked', clickedSchema);
 
     // ... and a 'purchased' event that requires the product that was purchased.
-    var Purchased = docArray.discriminator('Purchased', new Schema({
+    const Purchased = docArray.discriminator('Purchased', new Schema({
       product: {
         type: String,
         required: true
       }
     }, { _id: false }));
 
-    var Batch = db.model('EventBatch', batchSchema);
+    const Batch = db.model('EventBatch', batchSchema);
 
     // Create a new batch of events with different kinds
-    var batch = {
+    const batch = {
       events: [
         { kind: 'Clicked', element: '#hero', message: 'hello' },
         { kind: 'Purchased', product: 'action-figure-1', message: 'world' }
@@ -339,23 +339,23 @@ describe('discriminator docs', function () {
    */
 
   it('Recursive embedded discriminators in arrays', function(done) {
-    var singleEventSchema = new Schema({ message: String },
+    const singleEventSchema = new Schema({ message: String },
       { discriminatorKey: 'kind', _id: false });
 
-    var eventListSchema = new Schema({ events: [singleEventSchema] });
+    const eventListSchema = new Schema({ events: [singleEventSchema] });
 
-    var subEventSchema = new Schema({
+    const subEventSchema = new Schema({
        sub_events: [singleEventSchema]
     }, { _id: false });
 
-    var SubEvent = subEventSchema.path('sub_events').
+    const SubEvent = subEventSchema.path('sub_events').
       discriminator('SubEvent', subEventSchema);
     eventListSchema.path('events').discriminator('SubEvent', subEventSchema);
 
-    var Eventlist = db.model('EventList', eventListSchema);
+    const Eventlist = db.model('EventList', eventListSchema);
 
     // Create a new batch of events with different kinds
-    var list = {
+    const list = {
       events: [
         { kind: 'SubEvent', sub_events: [{kind:'SubEvent', sub_events:[], message:'test1'}], message: 'hello' },
         { kind: 'SubEvent', sub_events: [{kind:'SubEvent', sub_events:[{kind:'SubEvent', sub_events:[], message:'test3'}], message:'test2'}], message: 'world' }

--- a/test/docs/promises.test.js
+++ b/test/docs/promises.test.js
@@ -1,11 +1,11 @@
 'use strict';
-var PromiseProvider = require('../../lib/promise_provider');
-var assert = require('assert');
-var mongoose = require('../../');
+const PromiseProvider = require('../../lib/promise_provider');
+const assert = require('assert');
+const mongoose = require('../../');
 
 describe('promises docs', function () {
-  var Band;
-  var db;
+  let Band;
+  let db;
 
   before(function (done) {
     db = mongoose.createConnection('mongodb://localhost:27017/mongoose_test');
@@ -33,12 +33,12 @@ describe('promises docs', function () {
    * You can also read more about [promises in Mongoose](https://masteringjs.io/tutorials/mongoose/promise).
    */
   it('Built-in Promises', function (done) {
-    var gnr = new Band({
+    const gnr = new Band({
       name: "Guns N' Roses",
       members: ['Axl', 'Slash']
     });
 
-    var promise = gnr.save();
+    const promise = gnr.save();
     assert.ok(promise instanceof Promise);
 
     promise.then(function (doc) {
@@ -56,11 +56,11 @@ describe('promises docs', function () {
    * a fully-fledged promise, use the `.exec()` function.
    */
   it('Queries are not promises', function (done) {
-    var query = Band.findOne({name: "Guns N' Roses"});
+    const query = Band.findOne({name: "Guns N' Roses"});
     assert.ok(!(query instanceof Promise));
 
     // acquit:ignore:start
-    var outstanding = 2;
+    let outstanding = 2;
     // acquit:ignore:end
 
     // A query is not a fully-fledged promise, but it does have a `.then()`.
@@ -73,7 +73,7 @@ describe('promises docs', function () {
     });
 
     // `.exec()` gives you a fully-fledged promise
-    var promise = query.exec();
+    const promise = query.exec();
     assert.ok(promise instanceof Promise);
 
     promise.then(function (doc) {
@@ -126,7 +126,7 @@ describe('promises docs', function () {
       return done();
     }
     // acquit:ignore:end
-    var query = Band.findOne({name: "Guns N' Roses"});
+    const query = Band.findOne({name: "Guns N' Roses"});
 
     // Use bluebird
     mongoose.Promise = require('bluebird');

--- a/test/docs/schemas.test.js
+++ b/test/docs/schemas.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var assert = require('assert');
-var mongoose = require('../../');
+const assert = require('assert');
+const mongoose = require('../../');
 
 describe('Advanced Schemas', function () {
-  var db;
-  var Schema = mongoose.Schema;
+  let db;
+  let Schema = mongoose.Schema;
 
   before(function() {
     db = mongoose.createConnection('mongodb://localhost:27017/mongoose_test');
@@ -52,7 +52,7 @@ describe('Advanced Schemas', function () {
     }
 
     schema.loadClass(PersonClass);
-    var Person = db.model('Person', schema);
+    const Person = db.model('Person', schema);
 
     Person.create({ firstName: 'Jon', lastName: 'Snow' }).
       then(doc => {

--- a/test/docs/schematypes.test.js
+++ b/test/docs/schematypes.test.js
@@ -1,10 +1,10 @@
 'use strict';
-var assert = require('assert');
-var mongoose = require('../../');
+const assert = require('assert');
+const mongoose = require('../../');
 
 describe('schemaTypes', function () {
-  var db;
-  var Schema = mongoose.Schema;
+  let db;
+  let Schema = mongoose.Schema;
 
   before(function() {
     db = mongoose.createConnection('mongodb://localhost:27017/mongoose_test');
@@ -37,7 +37,7 @@ describe('schemaTypes', function () {
       // validate the provided `val` and throw a `CastError` if you
       // can't convert it.
       cast(val) {
-        var _val = Number(val);
+        let _val = Number(val);
         if (isNaN(_val)) {
           throw new Error('Int8: ' + val + ' is not a number');
         }
@@ -53,10 +53,10 @@ describe('schemaTypes', function () {
     // Don't forget to add `Int8` to the type registry
     mongoose.Schema.Types.Int8 = Int8;
 
-    var testSchema = new Schema({ test: Int8 });
-    var Test = mongoose.model('CustomTypeExample', testSchema);
+    const testSchema = new Schema({ test: Int8 });
+    const Test = mongoose.model('CustomTypeExample', testSchema);
 
-    var t = new Test();
+    const t = new Test();
     t.test = 'abc';
     assert.ok(t.validateSync());
     assert.equal(t.validateSync().errors['test'].name, 'CastError');

--- a/test/docs/validation.test.js
+++ b/test/docs/validation.test.js
@@ -1,12 +1,12 @@
 'use strict';
-var assert = require('assert');
-var mongoose = require('../../');
+const assert = require('assert');
+const mongoose = require('../../');
 
-var Promise = global.Promise || require('bluebird');
+const Promise = global.Promise || require('bluebird');
 
 describe('validation docs', function() {
-  var db;
-  var Schema = mongoose.Schema;
+  let db;
+  let Schema = mongoose.Schema;
 
   before(function() {
     db = mongoose.createConnection('mongodb://localhost:27017/mongoose_test', {
@@ -32,16 +32,16 @@ describe('validation docs', function() {
    */
 
   it('Validation', function(done) {
-    var schema = new Schema({
+    const schema = new Schema({
       name: {
         type: String,
         required: true
       }
     });
-    var Cat = db.model('Cat', schema);
+    const Cat = db.model('Cat', schema);
 
     // This cat has no name :(
-    var cat = new Cat();
+    const cat = new Cat();
     cat.save(function(error) {
       assert.equal(error.errors['name'].message,
         'Path `name` is required.');
@@ -66,7 +66,7 @@ describe('validation docs', function() {
    */
 
   it('Built-in Validators', function(done) {
-    var breakfastSchema = new Schema({
+    const breakfastSchema = new Schema({
       eggs: {
         type: Number,
         min: [6, 'Too few eggs'],
@@ -84,14 +84,14 @@ describe('validation docs', function() {
         }
       }
     });
-    var Breakfast = db.model('Breakfast', breakfastSchema);
+    const Breakfast = db.model('Breakfast', breakfastSchema);
 
-    var badBreakfast = new Breakfast({
+    const badBreakfast = new Breakfast({
       eggs: 2,
       bacon: 0,
       drink: 'Milk'
     });
-    var error = badBreakfast.validateSync();
+    let error = badBreakfast.validateSync();
     assert.equal(error.errors['eggs'].message,
       'Too few eggs');
     assert.ok(!error.errors['bacon']);
@@ -171,7 +171,7 @@ describe('validation docs', function() {
    * [`SchemaType#validate()` API docs](./api.html#schematype_SchemaType-validate).
    */
   it('Custom Validators', function(done) {
-    var userSchema = new Schema({
+    const userSchema = new Schema({
       phone: {
         type: String,
         validate: {
@@ -184,9 +184,9 @@ describe('validation docs', function() {
       }
     });
 
-    var User = db.model('user', userSchema);
-    var user = new User();
-    var error;
+    const User = db.model('user', userSchema);
+    const user = new User();
+    let error;
 
     user.phone = '555.0123';
     error = user.validateSync();
@@ -259,12 +259,12 @@ describe('validation docs', function() {
    */
 
   it('Validation Errors', function(done) {
-    var toySchema = new Schema({
+    const toySchema = new Schema({
       color: String,
       name: String
     });
 
-    var validator = function(value) {
+    const validator = function(value) {
       return /red|white|gold/i.test(value);
     };
     toySchema.path('color').validate(validator,
@@ -276,9 +276,9 @@ describe('validation docs', function() {
       return true;
     }, 'Name `{VALUE}` is not valid');
 
-    var Toy = db.model('Toy', toySchema);
+    const Toy = db.model('Toy', toySchema);
 
-    var toy = new Toy({ color: 'Green', name: 'Power Ranger' });
+    const toy = new Toy({ color: 'Green', name: 'Power Ranger' });
 
     toy.save(function (err) {
       // `err` is a ValidationError object
@@ -342,7 +342,7 @@ describe('validation docs', function() {
    */
 
   it('Required Validators On Nested Objects', function(done) {
-    var personSchema = new Schema({
+    let personSchema = new Schema({
       name: {
         first: String,
         last: String
@@ -355,7 +355,7 @@ describe('validation docs', function() {
     }, /Cannot.*'required'/);
 
     // To make a nested object required, use a single nested schema
-    var nameSchema = new Schema({
+    const nameSchema = new Schema({
       first: String,
       last: String
     });
@@ -367,10 +367,10 @@ describe('validation docs', function() {
       }
     });
 
-    var Person = db.model('Person', personSchema);
+    const Person = db.model('Person', personSchema);
 
-    var person = new Person();
-    var error = person.validateSync();
+    const person = new Person();
+    const error = person.validateSync();
     assert.ok(error.errors['name']);
     // acquit:ignore:start
     done();
@@ -392,18 +392,18 @@ describe('validation docs', function() {
    * caveats.
    */
   it('Update Validators', function(done) {
-    var toySchema = new Schema({
+    const toySchema = new Schema({
       color: String,
       name: String
     });
 
-    var Toy = db.model('Toys', toySchema);
+    const Toy = db.model('Toys', toySchema);
 
     Toy.schema.path('color').validate(function (value) {
       return /red|green|blue/i.test(value);
     }, 'Invalid color');
 
-    var opts = { runValidators: true };
+    const opts = { runValidators: true };
     Toy.updateOne({}, { color: 'not a color' }, opts, function (err) {
       assert.equal(err.errors.color.message,
         'Invalid color');
@@ -423,7 +423,7 @@ describe('validation docs', function() {
    */
 
   it('Update Validators and `this`', function(done) {
-    var toySchema = new Schema({
+    const toySchema = new Schema({
       color: String,
       name: String
     });
@@ -438,14 +438,14 @@ describe('validation docs', function() {
       return true;
     });
 
-    var Toy = db.model('ActionFigure', toySchema);
+    const Toy = db.model('ActionFigure', toySchema);
 
-    var toy = new Toy({ color: 'red', name: 'Red Power Ranger' });
-    var error = toy.validateSync();
+    const toy = new Toy({ color: 'red', name: 'Red Power Ranger' });
+    const error = toy.validateSync();
     assert.ok(error.errors['color']);
 
-    var update = { color: 'red', name: 'Red Power Ranger' };
-    var opts = { runValidators: true };
+    const update = { color: 'red', name: 'Red Power Ranger' };
+    const opts = { runValidators: true };
 
     Toy.updateOne({}, update, opts, function(error) {
       // The update validator throws an error:
@@ -466,7 +466,7 @@ describe('validation docs', function() {
 
   it('The `context` option', function(done) {
     // acquit:ignore:start
-    var toySchema = new Schema({
+    const toySchema = new Schema({
       color: String,
       name: String
     });
@@ -480,11 +480,11 @@ describe('validation docs', function() {
       return true;
     });
 
-    var Toy = db.model('Figure', toySchema);
+    const Toy = db.model('Figure', toySchema);
 
-    var update = { color: 'blue', name: 'Red Power Ranger' };
+    const update = { color: 'blue', name: 'Red Power Ranger' };
     // Note the context option
-    var opts = { runValidators: true, context: 'query' };
+    const opts = { runValidators: true, context: 'query' };
 
     Toy.updateOne({}, update, opts, function(error) {
       assert.ok(error.errors['color']);
@@ -506,17 +506,17 @@ describe('validation docs', function() {
 
   it('Update Validators Only Run On Updated Paths', function(done) {
     // acquit:ignore:start
-    var outstanding = 2;
+    let outstanding = 2;
     // acquit:ignore:end
-    var kittenSchema = new Schema({
+    const kittenSchema = new Schema({
       name: { type: String, required: true },
       age: Number
     });
 
-    var Kitten = db.model('Kitten', kittenSchema);
+    const Kitten = db.model('Kitten', kittenSchema);
 
-    var update = { color: 'blue' };
-    var opts = { runValidators: true };
+    const update = { color: 'blue' };
+    const opts = { runValidators: true };
     Kitten.updateOne({}, update, opts, function(err) {
       // Operation succeeds despite the fact that 'name' is not specified
       // acquit:ignore:start
@@ -524,7 +524,7 @@ describe('validation docs', function() {
       // acquit:ignore:end
     });
 
-    var unset = { $unset: { name: 1 } };
+    const unset = { $unset: { name: 1 } };
     Kitten.updateOne({}, unset, opts, function(err) {
       // Operation fails because 'name' is required
       assert.ok(err);
@@ -555,7 +555,7 @@ describe('validation docs', function() {
    */
 
   it('Update Validators Only Run For Some Operations', function(done) {
-    var testSchema = new Schema({
+    const testSchema = new Schema({
       number: { type: Number, max: 0 },
       arr: [{ message: { type: String, maxlength: 10 } }]
     });
@@ -566,10 +566,10 @@ describe('validation docs', function() {
       return v.length < 2;
     });
 
-    var Test = db.model('Test', testSchema);
+    const Test = db.model('Test', testSchema);
 
-    var update = { $inc: { number: 1 } };
-    var opts = { runValidators: true };
+    let update = { $inc: { number: 1 } };
+    const opts = { runValidators: true };
     Test.updateOne({}, update, opts, function(error) {
       // There will never be a validation error here
       update = { $push: [{ message: 'hello' }, { message: 'world' }] };
@@ -589,22 +589,22 @@ describe('validation docs', function() {
    */
 
   it('On $push and $addToSet', function(done) {
-    var testSchema = new Schema({
+    const testSchema = new Schema({
       numbers: [{ type: Number, max: 0 }],
       docs: [{
         name: { type: String, required: true }
       }]
     });
 
-    var Test = db.model('TestPush', testSchema);
+    const Test = db.model('TestPush', testSchema);
 
-    var update = {
+    const update = {
       $push: {
         numbers: 1,
         docs: { name: null }
       }
     };
-    var opts = { runValidators: true };
+    const opts = { runValidators: true };
     Test.updateOne({}, update, opts, function(error) {
       assert.ok(error.errors['numbers']);
       assert.ok(error.errors['docs']);

--- a/test/es-next/promises.test.es6.js
+++ b/test/es-next/promises.test.es6.js
@@ -1,11 +1,11 @@
 'use strict';
-var PromiseProvider = require('../../lib/promise_provider');
-var assert = require('assert');
-var mongoose = require('../../');
+const PromiseProvider = require('../../lib/promise_provider');
+const assert = require('assert');
+const mongoose = require('../../');
 
 describe('promises docs', function () {
-  var Band;
-  var db;
+  let Band;
+  let db;
 
   before(function (done) {
     db = mongoose.createConnection('mongodb://localhost:27017/mongoose_test');
@@ -35,12 +35,12 @@ describe('promises docs', function () {
    * You can also read more about [promises in Mongoose](https://masteringjs.io/tutorials/mongoose/promise).
    */
   it('Built-in Promises', function (done) {
-    var gnr = new Band({
+    const gnr = new Band({
       name: "Guns N' Roses",
       members: ['Axl', 'Slash']
     });
 
-    var promise = gnr.save();
+    const promise = gnr.save();
     assert.ok(promise instanceof Promise);
 
     promise.then(function (doc) {
@@ -58,11 +58,11 @@ describe('promises docs', function () {
    * a fully-fledged promise, use the `.exec()` function.
    */
   it('Queries are not promises', function (done) {
-    var query = Band.findOne({name: "Guns N' Roses"});
+    const query = Band.findOne({name: "Guns N' Roses"});
     assert.ok(!(query instanceof Promise));
 
     // acquit:ignore:start
-    var outstanding = 2;
+    let outstanding = 2;
     // acquit:ignore:end
 
     // A query is not a fully-fledged promise, but it does have a `.then()`.
@@ -75,7 +75,7 @@ describe('promises docs', function () {
     });
 
     // `.exec()` gives you a fully-fledged promise
-    var promise = query.exec();
+    const promise = query.exec();
     assert.ok(promise instanceof Promise);
 
     promise.then(function (doc) {
@@ -166,7 +166,7 @@ describe('promises docs', function () {
       return done();
     }
     // acquit:ignore:end
-    var query = Band.findOne({name: "Guns N' Roses"});
+    const query = Band.findOne({name: "Guns N' Roses"});
 
     // Use bluebird
     mongoose.Promise = require('bluebird');

--- a/tools/auth.js
+++ b/tools/auth.js
@@ -6,7 +6,7 @@ const mongodb = require('mongodb');
 
 co(function*() {
   // Create new instance
-  var server = new Server('mongod', {
+  const server = new Server('mongod', {
     auth: null,
     dbpath: '/data/db/27017'
   });

--- a/tools/repl.js
+++ b/tools/repl.js
@@ -3,10 +3,10 @@
 const co = require('co');
 
 co(function*() {
-  var ReplSet = require('mongodb-topology-manager').ReplSet;
+  const ReplSet = require('mongodb-topology-manager').ReplSet;
 
   // Create new instance
-  var topology = new ReplSet('mongod', [{
+  const topology = new ReplSet('mongod', [{
     // mongod process options
     options: {
       bind_ip: 'localhost', port: 31000, dbpath: `/data/db/31000`

--- a/tools/sharded.js
+++ b/tools/sharded.js
@@ -3,10 +3,10 @@
 const co = require('co');
 
 co(function*() {
-  var Sharded = require('mongodb-topology-manager').Sharded;
+  const Sharded = require('mongodb-topology-manager').Sharded;
 
   // Create new instance
-  var topology = new Sharded({
+  const topology = new Sharded({
     mongod: 'mongod',
     mongos: 'mongos'
   });


### PR DESCRIPTION
**Summary**

Documentation and test cases are using the old **var** keyword for variable declaration. This makes the document look outdated. This PR fixes the variable declaration using const and let in the documentation and test cases.