### PR TITLE
`mongoose.model() --> mongoose.model()

### DIFF
--- a/docs/middleware.pug
+++ b/docs/middleware.pug
@@ -261,7 +261,7 @@ block content
     ```
 
     This means that you must add all middleware and [plugins](/docs/plugins.html)
-    **before** calling [`mongoose.model()](/docs/api/mongoose.html#mongoose_Mongoose-model).
+    **before** calling [mongoose.model()](/docs/api/mongoose.html#mongoose_Mongoose-model).
     The below script will print out "Hello from pre save":
 
     ```javascript

--- a/docs/middleware.pug
+++ b/docs/middleware.pug
@@ -261,7 +261,7 @@ block content
     ```
 
     This means that you must add all middleware and [plugins](/docs/plugins.html)
-    **before** calling [mongoose.model()](/docs/api/mongoose.html#mongoose_Mongoose-model).
+    **before** calling [`mongoose.model()`](/docs/api/mongoose.html#mongoose_Mongoose-model).
     The below script will print out "Hello from pre save":
 
     ```javascript


### PR DESCRIPTION
MD link format fixed

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

MD url format is fixed in this PR

**Examples**

The problem : MD code was being rendered as is : [`mongoose.model()](/docs/api/mongoose.html#mongoose_Mongoose-model).
