### PR TITLE
fix(transaction): fix saving new documents w/ arrays in transactions

### DIFF
--- a/lib/plugins/trackTransaction.js
+++ b/lib/plugins/trackTransaction.js
@@ -84,7 +84,7 @@ function mergeAtomics(destination, source) {
     destination.$addToSet = (destination.$addToSet || []).concat(source.$addToSet);
   }
   if (source.$set != null) {
-    destination.$set = Object.assign(destination.$set, source.$set);
+    destination.$set = Object.assign(destination.$set || {}, source.$set);
   }
 
   return destination;

--- a/test/es-next/transactions.test.es6.js
+++ b/test/es-next/transactions.test.es6.js
@@ -404,4 +404,19 @@ describe('transactions', function() {
     assert.deepEqual(newDoc.arr, []);
     assert.deepEqual(newDoc.arr2, ['foo', 'bar']);
   });
+
+  it('can save a new document with an array', async function () {
+    const schema = Schema({ arr: [String] });
+
+    const Test = db.model('new_doc_array', schema);
+
+    await Test.createCollection();
+    const doc = new Test({ arr: ['foo'] });
+    await db.transaction(async (session) => {
+      await doc.save({ session });
+    });
+
+    const createdDoc = await Test.collection.findOne();
+    assert.deepEqual(createdDoc.arr, ['foo']);
+  });
 });


### PR DESCRIPTION
**Summary**

Fix a bug with transaction tracking when saving a new document that has array fields:
```
     TypeError: Cannot convert undefined or null to object
      at Function.assign (<anonymous>)
      at mergeAtomics (lib/plugins/trackTransaction.js:87:31)
      at _getAtomics (lib/plugins/trackTransaction.js:66:31)
      at model.<anonymous> (lib/plugins/trackTransaction.js:26:30)
```

**Examples**

See added test for minimal reproduction.