### PR TITLE
Fix minor spelling error in Query Casting documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If you'd like to preview your documentation changes, first commit your changes t
 * `make gendocs`
 * `node static.js`
 
-Visit `http://localhost:8088` and you should see the docs with your local changes. Make sure you `git reset --hard` before commiting, because changes to `docs/*` should **not** be in PRs.
+Visit `http://localhost:8088` and you should see the docs with your local changes. Make sure you `git reset --hard` before committing, because changes to `docs/*` should **not** be in PRs.
 
 ### Plugins website
 

--- a/docs/tutorials/query_casting.md
+++ b/docs/tutorials/query_casting.md
@@ -27,7 +27,7 @@ By default, Mongoose does **not** cast filter properties that aren't in your sch
 [require:Cast Tutorial.*not in schema]
 ```
 
-You can configure this behavior using the [`strictQuery` option for schemas](https://mongoosejs.com/docs/guide.html#strictQuery). This option is analagous to the [`strict` option](https://mongoosejs.com/docs/guide.html#strict). Setting `strictQuery` to `true` removes non-schema properties from the filter:
+You can configure this behavior using the [`strictQuery` option for schemas](https://mongoosejs.com/docs/guide.html#strictQuery). This option is analogous to the [`strict` option](https://mongoosejs.com/docs/guide.html#strict). Setting `strictQuery` to `true` removes non-schema properties from the filter:
 
 ```javascript
 [require:Cast Tutorial.*strictQuery true]


### PR DESCRIPTION
**Summary**
The [Query Casting](https://mongoosejs.com/docs/tutorials/query_casting.html) documentation has a minor spelling error in it for `analogous`. 

While preparing to send this PR, I found another minor one in the contributing guidelines.

**Solution**
Two very minor spelling fixes.