### PR TITLE
Update Options for Model.findOneAndUpdate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ To contribute to the [guide](http://mongoosejs.com/docs/guide.html) or [quick st
 
 If you'd like to preview your documentation changes, first commit your changes to your local master branch, then execute:
 
+* `npm install`
 * `make docclean`
 * `make gendocs`
 * `node static.js`

--- a/lib/model.js
+++ b/lib/model.js
@@ -2369,6 +2369,7 @@ Model.$where = function $where() {
  *
  * - `new`: bool - if true, return the modified document rather than the original. defaults to false (changed in 4.0)
  * - `upsert`: bool - creates the object if it doesn't exist. defaults to false.
+ * - `overwrite`: bool - if true, replace the entire document.
  * - `fields`: {Object|String} - Field selection. Equivalent to `.select(fields).findOneAndUpdate()`
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
  * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
@@ -2430,6 +2431,7 @@ Model.$where = function $where() {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.returnOriginal=null] An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace(conditions, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
+ * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object|String|Array<String>} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Function} [callback]
  * @return {Query}

--- a/lib/query.js
+++ b/lib/query.js
@@ -1298,6 +1298,7 @@ Query.prototype.getOptions = function() {
  * - [timestamps](https://mongoosejs.com/docs/guide.html#timestamps): If `timestamps` is set in the schema, set this option to `false` to skip timestamps for that particular update. Has no effect if `timestamps` is not enabled in the schema options.
  * - omitUndefined: delete any properties whose value is `undefined` when casting an update. In other words, if this is set, Mongoose will delete `baz` from the update in `Model.updateOne({}, { foo: 'bar', baz: undefined })` before sending the update to the server.
  * - overwriteDiscriminatorKey: allow setting the discriminator key in the update. Will use the correct discriminator schema if the update changes the discriminator key.
+ * - overwrite: replace the entire document
  *
  * The following options are only for `find()`, `findOne()`, `findById()`, `findOneAndUpdate()`, and `findByIdAndUpdate()`:
  *


### PR DESCRIPTION
**Summary**

The current documentation for [`Model.findOneAndUpdate`](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndUpdate) inconsistently document the `overwrite` and `upsert` options between the narrative and tagged parts of the source documentation.  The [`Query.prototype.setOptions`](https://mongoosejs.com/docs/api.html#query_Query-setOptions) does not list the `overwrite`.  From what I could tell it looks like `overwrite` is valid for all write operations.

I also found I had to run `npm install` before running the the documentation make commands, so I through that in the instructions to make it obvious.

_Sidenote:_  I noticed some of the other options are inconsistently documented between the tagged and narrative sections of the documentation. Is there a good place to look in the source code to identify if/where they are applicable so the documentation for those can be updated accordingly?