### PR TITLE
 fix(connection): avoid executing promise handler unless it's a function

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -814,7 +814,11 @@ Connection.prototype.openUri = function(uri, options, callback) {
       throw err;
     });
   this.then = function(resolve, reject) {
-    return this.$initialConnection.then(() => resolve(_this), reject);
+    return this.$initialConnection.then(() => {
+      if (typeof resolve === 'function') {
+        resolve(_this);
+      }
+    }, reject);
   };
   this.catch = function(reject) {
     return this.$initialConnection.catch(reject);

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1226,4 +1226,17 @@ describe('connections:', function() {
     });
   });
 
+  it('connection.then(...) does not throw when passed undefined (gh-9505)', function() {
+    const m = new mongoose.Mongoose;
+
+    const db = m.createConnection('mongodb://localhost:27017/test_gh9505', {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    });
+
+    assert.doesNotThrow(() => {
+      db.then(null);
+    });
+  });
+
 });


### PR DESCRIPTION
fixes #9505

This PR makes `connection.then` consistent with native promises in the sense that they don't throw execute `.then(...)` arguments unless they were functions.
```js
const p = new Promise((resolve, reject) => {
  setTimeout(() => {
    // only executes `resolve` if it's a function
    resolve('Hello');
  }, 10);
});

// does not throw
p.then(null);
```