### PR TITLE
fix: make minLength/maxLength behave same as minlength/maxlength

### DIFF
--- a/docs/schematypes.pug
+++ b/docs/schematypes.pug
@@ -288,8 +288,8 @@ block content
     * `trim`: boolean, whether to always call `.trim()` on the value
     * `match`: RegExp, creates a [validator](./validation.html) that checks if the value matches the given regular expression
     * `enum`: Array, creates a [validator](./validation.html) that checks if the value is in the given array.
-    * `minlength`: Number, creates a [validator](./validation.html) that checks if the value length is not less than the given number
-    * `maxlength`: Number, creates a [validator](./validation.html) that checks if the value length is not greater than the given number
+    * `minLength`: Number, creates a [validator](./validation.html) that checks if the value length is not less than the given number
+    * `maxLength`: Number, creates a [validator](./validation.html) that checks if the value length is not greater than the given number
 
     <h5 id="number-validators">Number</h5>
 

--- a/lib/options/SchemaStringOptions.js
+++ b/lib/options/SchemaStringOptions.js
@@ -88,12 +88,13 @@ Object.defineProperty(SchemaStringOptions.prototype, 'uppercase', opts);
  * string's `length` is at least the given number.
  *
  * @api public
- * @property minlength
+ * @property minLength
  * @memberOf SchemaStringOptions
  * @type Number
  * @instance
  */
 
+Object.defineProperty(SchemaStringOptions.prototype, 'minLength', opts);
 Object.defineProperty(SchemaStringOptions.prototype, 'minlength', opts);
 
 /**
@@ -101,12 +102,13 @@ Object.defineProperty(SchemaStringOptions.prototype, 'minlength', opts);
  * string's `length` is at most the given number.
  *
  * @api public
- * @property maxlength
+ * @property maxLength
  * @memberOf SchemaStringOptions
  * @type Number
  * @instance
  */
 
+Object.defineProperty(SchemaStringOptions.prototype, 'maxLength', opts);
 Object.defineProperty(SchemaStringOptions.prototype, 'maxlength', opts);
 
 /*!

--- a/lib/options/SchemaStringOptions.js
+++ b/lib/options/SchemaStringOptions.js
@@ -87,6 +87,10 @@ Object.defineProperty(SchemaStringOptions.prototype, 'uppercase', opts);
  * If set, Mongoose will add a custom validator that ensures the given
  * string's `length` is at least the given number.
  *
+ * Mongoose supports two different spellings for this option: `minLength` and `minlength`.
+ * `minLength` is the recommended way to specify this option, but Mongoose also supports
+ * `minlength` (lowercase "l").
+ *
  * @api public
  * @property minLength
  * @memberOf SchemaStringOptions
@@ -100,6 +104,10 @@ Object.defineProperty(SchemaStringOptions.prototype, 'minlength', opts);
 /**
  * If set, Mongoose will add a custom validator that ensures the given
  * string's `length` is at most the given number.
+ *
+ * Mongoose supports two different spellings for this option: `maxLength` and `maxlength`.
+ * `maxLength` is the recommended way to specify this option, but Mongoose also supports
+ * `maxlength` (lowercase "l").
  *
  * @api public
  * @property maxLength

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -414,6 +414,8 @@ SchemaString.prototype.minlength = function(value, message) {
   return this;
 };
 
+SchemaString.prototype.minLength = SchemaString.prototype.minlength;
+
 /**
  * Sets a maximum length validator.
  *
@@ -467,6 +469,8 @@ SchemaString.prototype.maxlength = function(value, message) {
 
   return this;
 };
+
+SchemaString.prototype.maxLength = SchemaString.prototype.maxlength;
 
 /**
  * Sets a regexp validator.

--- a/test/docs/validation.test.js
+++ b/test/docs/validation.test.js
@@ -60,7 +60,7 @@ describe('validation docs', function() {
    *
    * - All [SchemaTypes](./schematypes.html) have the built-in [required](./api.html#schematype_SchemaType-required) validator. The required validator uses the [SchemaType's `checkRequired()` function](./api.html#schematype_SchemaType-checkRequired) to determine if the value satisfies the required validator.
    * - [Numbers](./api.html#schema-number-js) have [`min` and `max`](./schematypes.html#number-validators) validators.
-   * - [Strings](./api.html#schema-string-js) have [`enum`, `match`, `minlength`, and `maxlength`](./schematypes.html#string-validators) validators.
+   * - [Strings](./api.html#schema-string-js) have [`enum`, `match`, `minLength`, and `maxLength`](./schematypes.html#string-validators) validators.
    *
    * Each of the validator links above provide more information about how to enable them and customize their error messages.
    */

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -98,23 +98,26 @@ describe('ValidationError', function() {
     });
   });
 
-  describe('#minlength', function() {
+  describe('#minLength', function() {
     it('causes a validation error', function(done) {
       const AddressSchema = new Schema({
-        postalCode: { type: String, minlength: 5 }
+        postalCode: { type: String, minlength: 5 },
+        zipCode: { type: String, minLength: 5 }
       });
 
       const Address = mongoose.model('MinLengthAddress', AddressSchema);
 
       const model = new Address({
-        postalCode: '9512'
+        postalCode: '9512',
+        zipCode: '9512'
       });
 
       // should fail validation
       model.validate(function(err) {
-        assert.notEqual(err, null, 'String minlegth validation failed.');
+        assert.notEqual(err, null, 'String minLength validation failed.');
         assert.ok(err.message.startsWith('MinLengthAddress validation failed'));
         model.postalCode = '95125';
+        model.zipCode = '95125';
 
         // should pass validation
         model.validate(function(err) {
@@ -133,13 +136,15 @@ describe('ValidationError', function() {
       };
 
       const AddressSchema = new Schema({
-        postalCode: { type: String, minlength: 5 }
+        postalCode: { type: String, minlength: 5 },
+        zipCode: { type: String, minLength: 5 }
       });
 
       const Address = mongoose.model('gh4207', AddressSchema);
 
       const model = new Address({
-        postalCode: '9512'
+        postalCode: '9512',
+        zipCode: '9512'
       });
 
       // should fail validation
@@ -152,23 +157,26 @@ describe('ValidationError', function() {
     });
   });
 
-  describe('#maxlength', function() {
+  describe('#maxLength', function() {
     it('causes a validation error', function(done) {
       const AddressSchema = new Schema({
-        postalCode: { type: String, maxlength: 10 }
+        postalCode: { type: String, maxlength: 10 },
+        zipCode: { type: String, maxLength: 10 }
       });
 
       const Address = mongoose.model('MaxLengthAddress', AddressSchema);
 
       const model = new Address({
-        postalCode: '95125012345'
+        postalCode: '95125012345',
+        zipCode: '95125012345'
       });
 
       // should fail validation
       model.validate(function(err) {
-        assert.notEqual(err, null, 'String maxlegth validation failed.');
+        assert.notEqual(err, null, 'String maxLength validation failed.');
         assert.ok(err.message.startsWith('MaxLengthAddress validation failed'));
         model.postalCode = '95125';
+        model.zipCode = '95125';
 
         // should pass validation
         model.validate(function(err) {


### PR DESCRIPTION
**Summary**

Fixes #8777. Updated `docs/schematypes` to reflect the same.