### PR TITLE
Remove redundant code.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1688,39 +1688,6 @@ Query.prototype.lean = function(v) {
 };
 
 /**
- * Returns an object containing the Mongoose-specific options for this query,
- * including `lean` and `populate`.
- *
- * Mongoose-specific options are different from normal options (`sort`, `limit`, etc.)
- * because they are **not** sent to the MongoDB server.
- *
- * ####Example:
- *
- *     const q = new Query();
- *     q.mongooseOptions().lean; // undefined
- *
- *     q.lean();
- *     q.mongooseOptions().lean; // true
- *
- * This function is useful for writing [query middleware](/docs/middleware.html).
- * Below is a full list of properties the return value from this function may have:
- *
- * - `populate`
- * - `lean`
- * - `omitUndefined`
- * - `strict`
- * - `nearSphere`
- * - `useFindAndModify`
- *
- * @return {Object} Mongoose-specific options
- * @param public
- */
-
-Query.prototype.mongooseOptions = function() {
-  return this._mongooseOptions;
-};
-
-/**
  * Adds a `$set` to this query's update without changing the operation.
  * This is useful for query middleware so you can add an update regardless
  * of whether you use `updateOne()`, `updateMany()`, `findOneAndUpdate()`, etc.


### PR DESCRIPTION
**Summary**

Query.prototype.mongooseOptions is set to a function and then immediately overwritten with another function. This change removes the first redundant assignment.
