### PR TITLE
Update middlewar.pug file

### DIFF
--- a/docs/middleware.pug
+++ b/docs/middleware.pug
@@ -333,7 +333,7 @@ block content
 
     ```javascript
     // Only document middleware
-    schema.pre('remove', { document: true, query: false}, function() {
+    schema.pre('remove', { document: true, query: false }, function() {
       console.log('Removing doc!');
     });
 

--- a/docs/middleware.pug
+++ b/docs/middleware.pug
@@ -339,7 +339,7 @@ block content
 
     // Only query middleware. This will get called when you do `Model.remove()`
     // but not `doc.remove()`.
-    schema.pre('remove', { query: true, document: flse }, function() {
+    schema.pre('remove', { query: true, document: false }, function() {
       console.log('Removing!');
     });
     ```

--- a/docs/middleware.pug
+++ b/docs/middleware.pug
@@ -329,17 +329,17 @@ block content
     You can pass options to [`Schema.pre()`](/docs/api.html#schema_Schema-pre)
     and [`Schema.post()`](/docs/api.html#schema_Schema-post) to switch whether
     Mongoose calls your `remove()` hook for [`Document.remove()`](/docs/api.html#model_Model-remove)
-    or [`Model.remove()`](/docs/api.html#model_Model.remove):
+    or [`Model.remove()`](/docs/api.html#model_Model.remove). Note here that you need to set both `document` and `query` properties in the passed object:
 
     ```javascript
     // Only document middleware
-    schema.pre('remove', { document: true }, function() {
+    schema.pre('remove', { document: true, query: false}, function() {
       console.log('Removing doc!');
     });
 
     // Only query middleware. This will get called when you do `Model.remove()`
     // but not `doc.remove()`.
-    schema.pre('remove', { query: true }, function() {
+    schema.pre('remove', { query: true, document: flse }, function() {
       console.log('Removing!');
     });
     ```


### PR DESCRIPTION
**Summary**

The documentation does not specificly addresses that both properties 'query' and 'document' must be assigned in order for the 'remove' middleware to execute for the right context (that is on the query or the document).

**Examples**
`   	
			
	  const schema = new mongoose.Schema({...});
		
	//middleware on document remove only
	//like in doc.remove()	
      schema.pre("remove", {query: false, document: true});
    
    //middleware on query remove only 
	//like in Model.remove()
      schema.post("remove", {query: true, document: false});
`