### PR TITLE
feat(debug): #8963 `shell` option for date format (ISODate)

### DIFF
--- a/docs/faq.pug
+++ b/docs/faq.pug
@@ -300,6 +300,9 @@ block content
     
     // disable colors in debug mode
     mongoose.set('debug', { color: false })
+
+    // get mongodb-shell friendly output (ISODate)
+    mongoose.set('debug', { shell: true })
     ```
 
     All executed collection methods will log output of their arguments to your

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -168,7 +168,9 @@ function iter(i) {
       } else if (debug instanceof stream.Writable) {
         this.$printToStream(_this.name, i, args, debug);
       } else {
-        this.$print(_this.name, i, args, typeof debug.color === 'undefined' ? true : debug.color);
+        const color = debug.color == null ? true : debug.color;
+        const shell = debug.shell == null ? false : debug.shell;
+        this.$print(_this.name, i, args, color, shell);
       }
     }
 
@@ -213,13 +215,13 @@ for (const key of Object.keys(Collection.prototype)) {
  * @method $print
  */
 
-NativeCollection.prototype.$print = function(name, i, args, color) {
+NativeCollection.prototype.$print = function(name, i, args, color, shell) {
   const moduleName = color ? '\x1B[0;36mMongoose:\x1B[0m ' : 'Mongoose: ';
   const functionCall = [name, i].join('.');
   const _args = [];
   for (let j = args.length - 1; j >= 0; --j) {
     if (this.$format(args[j]) || _args.length) {
-      _args.unshift(this.$format(args[j], color));
+      _args.unshift(this.$format(args[j], color, shell));
     }
   }
   const params = '(' + _args.join(', ') + ')';
@@ -254,10 +256,10 @@ NativeCollection.prototype.$printToStream = function(name, i, args, stream) {
  * @method $format
  */
 
-NativeCollection.prototype.$format = function(arg, color) {
+NativeCollection.prototype.$format = function(arg, color, shell) {
   const type = typeof arg;
   if (type === 'function' || type === 'undefined') return '';
-  return format(arg, false, color);
+  return format(arg, false, color, shell);
 };
 
 /*!
@@ -279,10 +281,14 @@ function map(o) {
 function formatObjectId(x, key) {
   x[key] = inspectable('ObjectId("' + x[key].toHexString() + '")');
 }
-function formatDate(x, key) {
-  x[key] = inspectable('new Date("' + x[key].toUTCString() + '")');
+function formatDate(x, key, shell) {
+  if (shell) {
+    x[key] = inspectable('ISODate("' + x[key].toUTCString() + '")');
+  } else {
+    x[key] = inspectable('new Date("' + x[key].toUTCString() + '")');
+  }
 }
-function format(obj, sub, color) {
+function format(obj, sub, color, shell) {
   if (obj && typeof obj.toBSON === 'function') {
     obj = obj.toBSON();
   }
@@ -326,7 +332,7 @@ function format(obj, sub, color) {
         } else if (x[key].constructor.name === 'ObjectID') {
           formatObjectId(x, key);
         } else if (x[key].constructor.name === 'Date') {
-          formatDate(x, key);
+          formatDate(x, key, shell);
         } else if (x[key].constructor.name === 'ClientSession') {
           x[key] = inspectable('ClientSession("' +
             get(x[key], 'id.id.buffer', '').toString('hex') + '")');

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Test dependencies.
+ */
+
+const assert = require('assert');
+const start = require('./common');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+/**
+ * Setup.
+ */
+
+const testSchema = new Schema({
+  dob: Date
+}, {
+  timestamps: {
+    createdAt: 'created_at'
+  }
+});
+
+
+/**
+ * Test.
+ */
+
+describe('debug: shell', function() {
+  let db;
+  let testModel;
+
+  let lastLog;
+  let originalConsole = console.info;
+  let originalDebugOption = mongoose.options.debug
+
+  before(function(done) {
+    db = start();
+    testModel = db.model('Test', testSchema);
+
+    // monkey patch to read debug output
+    console.info = function() {
+      lastLog = arguments[0];
+      if (originalDebugOption) {
+        originalConsole.apply(console, arguments);
+      };
+    }
+
+    done();
+  });
+
+  after(function(done) {
+    // revert monkey patch
+    console.info = originalConsole;
+    mongoose.set('debug', originalDebugOption)
+    db.close(done);
+  });
+
+  it('no-shell', async function() {
+    mongoose.set('debug', {shell: false});
+    await testModel.create({dob: new Date()});
+    assert.equal(true, lastLog.includes('new Date'));
+  });
+
+  it('shell', async function() {
+    mongoose.set('debug', {shell: true});
+    await testModel.create({dob: new Date()});
+    assert.equal(true, lastLog.includes('ISODate'));
+  });
+
+});


### PR DESCRIPTION
**Summary**

Closes #8963, adding a new option `shell` to debug option for logging mongodb-shell friendly output to console.

```mongoose.set('debug', {shell: true})```

**Examples**

1. `mongoose.set('debug')` / `mongoose.set('debug', {shell: false})`

```
Mongoose: Test.insertOne({ _id: ObjectId("5fa9417a6b9b371b344e3760"), dob: new Date("Mon, 09 Nov 2020 13:17:46 GMT"), __v: 0}, { session: null })
```

2. `mongoose.set('debug', {shell: true})`

```
Mongoose: Test.insertOne({ _id: ObjectId("5fa9417a6b9b371b344e3760"), dob: ISODate("Mon, 09 Nov 2020 13:17:46 GMT"), __v: 0}, { session: null })
```