### PR TITLE
fix(utils.deepEqual): make `deepEqual` treat objects with different order of keys as different

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,10 +124,6 @@ exports.deepEqual = function deepEqual(a, b) {
     return false;
   }
 
-  // the same set of keys (although not necessarily the same order),
-  ka.sort();
-  kb.sort();
-
   // ~~~cheap key test
   for (i = ka.length - 1; i >= 0; i--) {
     if (ka[i] !== kb[i]) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -211,6 +211,19 @@ describe('utils', function() {
     done();
   });
 
+  it('`deepEqual` treats objects with different order of keys as different (gh-9571)', function() {
+    const user1 = {
+      name: 'Hafez',
+      age: 26
+    };
+    const user2 = {
+      age: 26,
+      name: 'Hafez'
+    };
+
+    assert.equal(utils.deepEqual(user1, user2), false);
+  });
+
   describe('clone', function() {
     it('retains RegExp options gh-1355', function(done) {
       const a = new RegExp('hello', 'igm');


### PR DESCRIPTION
re #9571