### PR TITLE
TS: Return `Connection` from `createConnection`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,7 @@ declare module "mongoose" {
   export var connections: Connection[];
 
   /** Creates a Connection instance. */
-  export function createConnection(uri: string, options?: ConnectOptions): Promise<Connection>;
+  export function createConnection(uri: string, options?: ConnectOptions): Connection & Promise<Connection>;
   export function createConnection(): Connection;
   export function createConnection(uri: string, options: ConnectOptions, callback: (err: CallbackError, conn: Connection) => void): void;
 

--- a/test/typescript/connection.ts
+++ b/test/typescript/connection.ts
@@ -9,3 +9,5 @@ conn.openUri('mongodb://localhost:27017/test').then(() => console.log('Connected
 createConnection('mongodb://localhost:27017/test', { useNewUrlParser: true }).then((conn: Connection) => {
   conn.host;
 });
+
+createConnection('mongodb://localhost:27017/test').close();


### PR DESCRIPTION
Fixes https://github.com/Automattic/mongoose/issues/9610

This change fixes the TypeScript type definitions so that we return a
full `Connection` object from `createConnection(url)`, not just a
`Promise<Connection>`.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
