### PR TITLE
fix(index.d.ts): allow `useCreateIndex` in connection options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,6 +127,8 @@ declare module "mongoose" {
     useFindAndModify?: boolean;
     /** Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection. */
     autoCreate?: boolean;
+    /** False by default. If `true`, this connection will use `createIndex()` instead of `ensureIndex()` for automatic index builds via `Model.init()`. */
+    useCreateIndex?: boolean;
   }
 
   class Connection extends events.EventEmitter {

--- a/test/typescript/connectSyntax.ts
+++ b/test/typescript/connectSyntax.ts
@@ -1,8 +1,12 @@
 import { connect } from 'mongoose';
 
 // Promise
-connect('mongodb://localhost:27017/test', { useNewUrlParser: true, useUnifiedTopology: true }).
-  then(mongoose => console.log(mongoose.connect));
+connect('mongodb://localhost:27017/test', {
+  useNewUrlParser: true,
+  useFindAndModify: true,
+  useCreateIndex: true,
+  useUnifiedTopology: true,
+}).then(mongoose => console.log(mongoose.connect));
 
 // Callback
 connect('mongodb://localhost:27017/test', { useNewUrlParser: true, useUnifiedTopology: true }, (err: Error) => {


### PR DESCRIPTION
Updated the TypeScript example to mirror the example given in the
[deprecation warning docs][1].

[1]: https://mongoosejs.com/docs/deprecations.html