### PR TITLE
Fix subdocument types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1047,7 +1047,7 @@ declare module "mongoose" {
   }
 
   interface SchemaDefinition {
-    [path: string]: SchemaTypeOptions<any> | Function | string | Schema | Schema[] | Array<SchemaTypeOptions<any>> | Function[];
+    [path: string]: SchemaTypeOptions<any> | Function | string | Schema | Schema[] | Array<SchemaTypeOptions<any>> | Function[] | SchemaDefinition | SchemaDefinition[];
   }
 
   interface SchemaOptions {

--- a/test/typescript/createBasicSchemaDefinition.ts
+++ b/test/typescript/createBasicSchemaDefinition.ts
@@ -10,7 +10,7 @@ const schema: Schema = new Schema({
 interface ITest extends Document {
   name?: string;
   tags?: string[];
-  authors?: { name: string };
+  author?: { name: string };
   followers?: { name: string }[];
 }
 

--- a/test/typescript/createBasicSchemaDefinition.ts
+++ b/test/typescript/createBasicSchemaDefinition.ts
@@ -2,12 +2,16 @@ import { Schema, model, Document } from 'mongoose';
 
 const schema: Schema = new Schema({
   name: { type: 'String' },
-  tags: [String]
+  tags: [String],
+  author: { name: String },
+  followers: [{ name: String }]
 }, { collection: 'mytest', versionKey: '_version' });
 
 interface ITest extends Document {
   name?: string;
   tags?: string[];
+  authors?: { name: string };
+  followers?: { name: string }[];
 }
 
 const Test = model<ITest>('Test', schema);


### PR DESCRIPTION
With the new types shipping with 5.11, sub-documents in schemas and arrays of sub-documents error on compile.
This PR attempts to resolve the issue.
Fixes #9631.