### PR TITLE
fix(index.d.ts): add the missing generic declaration for Schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1005,7 +1005,7 @@ declare module "mongoose" {
     useProjection?: boolean;
   }
 
-  class Schema extends events.EventEmitter {
+  class Schema<T = any> extends events.EventEmitter {
     /**
      * Create a new schema
      */


### PR DESCRIPTION
**Summary**

add the missing generic declaration for Schema

**Examples**

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mongoose/index.d.ts#L886