### PR TITLE
fix(index.d.ts): allow 2 generic types in mongoose.model function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,12 @@ declare module "mongoose" {
   export function isValidObjectId(v: any): boolean;
 
   export function model<T extends Document>(name: string, schema?: Schema, collection?: string, skipInit?: boolean): Model<T>;
+  export function model<T extends Document, U extends Model<T>>(
+    name: string,
+    schema?: Schema,
+    collection?: string,
+    skipInit?: boolean
+  ): U;
 
   /** Returns an array of model names created on this instance of Mongoose. */
   export function modelNames(): Array<string>;


### PR DESCRIPTION
fixes #9678 