### PR TITLE
Allow array of validators in SchemaTypeOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1303,7 +1303,7 @@ declare module "mongoose" {
     alias?: string;
 
     /** Function or object describing how to validate this schematype. See [validation docs](https://mongoosejs.com/docs/validation.html). */
-    validate?: RegExp | [RegExp, string] | Function | [Function , string] | ValidateOpts<T>;
+    validate?: RegExp | [RegExp, string] | Function | [Function , string] | ValidateOpts<T> | ValidateOpts<T>[];
 
     /** Allows overriding casting logic for this individual path. If a string, the given string overwrites Mongoose's default cast error message. */
     cast?: string;


### PR DESCRIPTION
**Summary**

Allows schemas with an array of validators (`ValidateOpts`) to be passed, currently the typescript type only allows to pass a single validator.

**Examples**

https://github.com/Automattic/mongoose/blob/master/lib/schematype.js#L713-L717
