### PR TITLE
chore: add Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+name: Test
 on: push
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on: push
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -24,16 +24,16 @@ jobs:
 
       - name: Setup
         run: |
-          wget -q http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.2.tgz
-          tar xf mongodb-linux-x86_64-ubuntu1604-4.0.2.tgz
+          wget -q http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.2.tgz
+          tar xf mongodb-linux-x86_64-ubuntu1804-4.0.2.tgz
           mkdir -p ./data/db/27017 ./data/db/27000
           printf "\n--timeout 8000" >> ./test/mocha.opts
-          ./mongodb-linux-x86_64-ubuntu1604-4.0.2/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
+          ./mongodb-linux-x86_64-ubuntu1804-4.0.2/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
           sleep 2
           mongod --version
           mkdir ./test/typescript/node_modules
           ln -s `pwd` ./test/typescript/node_modules/mongoose
-          echo `pwd`/mongodb-linux-x86_64-ubuntu1604-4.0.2/bin >> $GITHUB_PATH
+          echo `pwd`/mongodb-linux-x86_64-ubuntu1804-4.0.2/bin >> $GITHUB_PATH
 
       - run: npm test
 
@@ -46,9 +46,9 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 15
+          node-version: 14
 
-      - run: npm install eslint
+      - run: npm install
 
       - name: Linter
         run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    name: Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Upgrade Node 5 npm
+        run: npm install -g npm@3
+        if: ${{ matrix.node == 5 }}
+
+      - run: npm install
+
+      - name: Setup
+        run: |
+          wget -q http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.2.tgz
+          tar xf mongodb-linux-x86_64-ubuntu1604-4.0.2.tgz
+          mkdir -p ./data/db/27017 ./data/db/27000
+          printf "\n--timeout 8000" >> ./test/mocha.opts
+          ./mongodb-linux-x86_64-ubuntu1604-4.0.2/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
+          sleep 2
+          mongod --version
+          mkdir ./test/typescript/node_modules
+          ln -s `pwd` ./test/typescript/node_modules/mongoose
+          echo `pwd`/mongodb-linux-x86_64-ubuntu1604-4.0.2/bin >> $GITHUB_PATH
+
+      - run: npm test
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Linter
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 15
+
+      - run: npm install eslint
+
+      - name: Linter
+        run: npm run lint

--- a/test/common.js
+++ b/test/common.js
@@ -215,6 +215,7 @@ after(function(done) {
 });
 
 module.exports.server = server = new Server('mongod', {
+  bind_ip: '127.0.0.1',
   port: 27000,
   dbpath: './data/db/27000'
 });

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -223,7 +223,7 @@ describe('connections:', function() {
           }).
           then(function() {
             return new Promise(function(resolve) {
-              setTimeout(function() { resolve(); }, 1000);
+              setTimeout(function() { resolve(); }, 3000);
             });
           }).
           then(function() {

--- a/test/es-next/promises.test.es6.js
+++ b/test/es-next/promises.test.es6.js
@@ -170,14 +170,19 @@ describe('promises docs', function () {
 
     // Use bluebird
     mongoose.Promise = require('bluebird');
-    assert.equal(query.exec().constructor, require('bluebird'));
+    const bluebirdPromise = query.exec();
+    assert.equal(bluebirdPromise.constructor, require('bluebird'));
 
     // Use q. Note that you **must** use `require('q').Promise`.
     mongoose.Promise = require('q').Promise;
-    assert.ok(query.exec() instanceof require('q').makePromise);
+    const qPromise = query.exec();
+    assert.ok(qPromise instanceof require('q').makePromise);
 
     // acquit:ignore:start
-    done();
+    // Wait for promises
+    bluebirdPromise.then(qPromise).then(function () {
+      done();
+    });
     // acquit:ignore:end
   });
 });

--- a/test/typescript/main.test.js
+++ b/test/typescript/main.test.js
@@ -5,7 +5,7 @@ const typescript = require('typescript');
 const tsconfig = require('./tsconfig.json');
 
 describe('typescript syntax', function() {
-  this.timeout(10000);
+  this.timeout(60000);
 
   it('base', function() {
     const errors = runTest('base.ts');


### PR DESCRIPTION
**Summary**
Add Github Actions for CI.
https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing#building-on-a-public-repositories-only

~Issues:~
- ~`server.start()` for `connection.test.js` [times out](https://github.com/YC/mongoose/runs/1521306207?check_suite_focus=true) on 18.04, so I kept it at 16.04~
- ~There seems to be test cases which fail intermittently.~

~https://github.com/YC/mongoose/runs/1523805152?check_suite_focus=true~
~https://github.com/YC/mongoose/runs/1523805216?check_suite_focus=true~

This test case still fails intermittently.

https://github.com/YC/mongoose/runs/1523777151?check_suite_focus=true
https://github.com/YC/mongoose/runs/1530156061?check_suite_focus=true
```
  1) connections:
       openUri (gh-5304)
         connection events
           reconnectFailed (gh-4027):

      AssertionError [ERR_ASSERTION]: 0 == 1
      + expected - actual

      -0
      +1
      
      at /home/runner/work/mongoose/mongoose/test/connection.test.js:296:20
```