### PR TITLE
fix(index.d.ts): allow specify type of _id

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -363,11 +363,11 @@ declare module "mongoose" {
     getIndexes(): any;
   }
 
-  class Document {
+  class Document<T = any> {
     constructor(doc?: any);
 
     /** This documents _id. */
-    _id?: any;
+    _id?: T;
 
     /** This documents __v. */
     __v?: number;
@@ -456,7 +456,7 @@ declare module "mongoose" {
      * document has an `_id`, in which case this function falls back to using
      * `deepEqual()`.
      */
-    equals(doc: Document): boolean;
+    equals(doc: Document<T>): boolean;
 
     /** Hash containing current validation errors. */
     errors?: Error.ValidationError;


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
When we want make an complex type and change the type of `_id` the typescript say its is `any` if we don't make something like that :
```ts
type FixedDocument<T> = (T extends {_id?: any } ? Omit<Document, '_id'> : Document) & T
// OR
interface Account extends Omit<Document, '_id'> {
  _id: number
  username: string
}
```

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
Now this is more easier and we no longer need `Omit<Document, '_id'>`.
```ts
interface Account extends Document<number> {
  username: string
}