### PR TITLE
fix(index.d.ts): make options optional for `toObject`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1653,7 +1653,7 @@ declare module "mongoose" {
       shift(): T;
 
       /** Returns a native js Array. */
-      toObject(options: ToObjectOptions): any;
+      toObject(options?: ToObjectOptions): any;
 
       /** Wraps [`Array#unshift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking. */
       unshift(...args: any[]): number;
@@ -1695,7 +1695,7 @@ declare module "mongoose" {
 
     class Map<V> extends global.Map<string, V> {
       /** Converts a Mongoose map into a vanilla JavaScript map. */
-      toObject(options: ToObjectOptions & { flattenMaps?: boolean }): any;
+      toObject(options?: ToObjectOptions & { flattenMaps?: boolean }): any;
     }
 
     var ObjectId: ObjectIdConstructor;


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
When we want use `toObject` on `Map` or `Array` types we need pass unnecessary options.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
Before this we need to pass an empty object for call `toObject` like :
```ts
found.array.toObject({})
found.map.toObject({})
```

After this PR we can omit the options like :
```ts
found.array.toObject()
found.map.toObject()
```