### PR TITLE
fix(css): media query for ::before on headings

### DIFF
--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -209,6 +209,12 @@ pre {
 }
 
 @media (max-width: 1160px) {
+  h2:hover::before, h3:hover::before {
+    position: static;
+    display: inline-block;
+    margin-right: .2em;
+  }
+
   .container {
     width: 100%;
     padding: 0px;


### PR DESCRIPTION
**Summary**
Adds media query for ::before, due to overlap of ::before link icon and headings. 
With this change, the heading makes space for the link icon. 

Resolves #9704 