### PR TITLE
feat(index.d.ts): schema methods & statics types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,10 +98,10 @@ declare module "mongoose" {
    */
   export function isValidObjectId(v: any): boolean;
 
-  export function model<T extends Document>(name: string, schema?: Schema, collection?: string, skipInit?: boolean): Model<T>;
+  export function model<T extends Document>(name: string, schema?: Schema<T>, collection?: string, skipInit?: boolean): Model<T>;
   export function model<T extends Document, U extends Model<T>>(
     name: string,
-    schema?: Schema,
+    schema?: Schema<T, U>,
     collection?: string,
     skipInit?: boolean
   ): U;

--- a/index.d.ts
+++ b/index.d.ts
@@ -241,10 +241,10 @@ declare module "mongoose" {
     models: { [index: string]: Model<any> };
 
     /** Defines or retrieves a model. */
-    model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
+    model<T extends Document>(name: string, schema?: Schema<T>, collection?: string): Model<T>;
     model<T extends Document, U extends Model<T>>(
       name: string,
-      schema?: Schema,
+      schema?: Schema<T, U>,
       collection?: string,
       skipInit?: boolean
     ): U;
@@ -1026,7 +1026,7 @@ declare module "mongoose" {
     useProjection?: boolean;
   }
 
-  class Schema<T = any> extends events.EventEmitter {
+  class Schema<D extends Document = Document, M extends Model<D> = Model<D>> extends events.EventEmitter {
     /**
      * Create a new schema
      */
@@ -1073,11 +1073,13 @@ declare module "mongoose" {
     loadClass(model: Function): this;
 
     /** Adds an instance method to documents constructed from Models compiled from this schema. */
-    method(name: string, fn: Function, opts?: any): this;
-    method(methods: any): this;
+    method<F extends keyof D>(name: F, fn: D[F]): this;
+    method(obj: { [F in keyof D]: D[F] }): this;
 
     /** Object of currently defined methods on this schema. */
-    methods: any;
+    methods: {
+      [F in keyof D]: D[F];
+    };
 
     /** The original object passed to the schema constructor */
     obj: any;
@@ -1098,21 +1100,21 @@ declare module "mongoose" {
     plugin(fn: (schema: Schema, opts?: any) => void, opts?: any): this;
 
     /** Defines a post hook for the model. */
-    post<T extends Document = Document>(method: "validate" | "save" | "remove" | "updateOne" | "deleteOne" | "init" | RegExp, fn: (this: T, res: any, next: (err?: CallbackError) => void) => void): this;
+    post<T extends Document = D>(method: "validate" | "save" | "remove" | "updateOne" | "deleteOne" | "init" | RegExp, fn: (this: T, res: any, next: (err?: CallbackError) => void) => void): this;
     post<T extends Query<any, any> = Query<any, any>>(method: string | RegExp, fn: (this: T, res: any, next: (err: CallbackError) => void) => void): this;
     post<T extends Aggregate<any> = Aggregate<any>>(method: "aggregate" | RegExp, fn: (this: T, res: Array<any>, next: (err: CallbackError) => void) => void): this;
-    post<T extends Model<any> = Model<any>>(method: "insertMany" | RegExp, fn: (this: T, res: any, next: (err: CallbackError) => void) => void): this;
+    post<T extends Model<Document> = M>(method: "insertMany" | RegExp, fn: (this: T, res: any, next: (err: CallbackError) => void) => void): this;
 
-    post<T extends Document = Document>(method: "validate" | "save" | "remove" | "updateOne" | "deleteOne" | "init" | RegExp, fn: (this: T, err: NativeError, res: any, next: (err?: CallbackError) => void) => void): this;
+    post<T extends Document = D>(method: "validate" | "save" | "remove" | "updateOne" | "deleteOne" | "init" | RegExp, fn: (this: T, err: NativeError, res: any, next: (err?: CallbackError) => void) => void): this;
     post<T extends Query<any, any> = Query<any, any>>(method: string | RegExp, fn: (this: T, err: NativeError, res: any, next: (err: CallbackError) => void) => void): this;
     post<T extends Aggregate<any> = Aggregate<any>>(method: "aggregate" | RegExp, fn: (this: T, err: NativeError, res: Array<any>, next: (err: CallbackError) => void) => void): this;
-    post<T extends Model<any> = Model<any>>(method: "insertMany" | RegExp, fn: (this: T, err: NativeError, res: any, next: (err: CallbackError) => void) => void): this;
+    post<T extends Model<Document> = M>(method: "insertMany" | RegExp, fn: (this: T, err: NativeError, res: any, next: (err: CallbackError) => void) => void): this;
 
     /** Defines a pre hook for the model. */
-    pre<T extends Document = Document>(method: "validate" | "save" | "remove" | "updateOne" | "deleteOne" | "init" | RegExp, fn: (this: T, next: (err?: CallbackError) => void) => void): this;
+    pre<T extends Document = D>(method: "validate" | "save" | "remove" | "updateOne" | "deleteOne" | "init" | RegExp, fn: (this: T, next: (err?: CallbackError) => void) => void): this;
     pre<T extends Query<any, any> = Query<any, any>>(method: string | RegExp, fn: (this: T, next: (err: CallbackError) => void) => void): this;
     pre<T extends Aggregate<any> = Aggregate<any>>(method: "aggregate" | RegExp, fn: (this: T, next: (err: CallbackError) => void) => void): this;
-    pre<T extends Model<any> = Model<any>>(method: "insertMany" | RegExp, fn: (this: T, next: (err: CallbackError) => void) => void): this;
+    pre<T extends Model<Document> = M>(method: "insertMany" | RegExp, fn: (this: T, next: (err: CallbackError) => void) => void): this;
 
     /** Object of currently defined query helpers on this schema. */
     query: any;
@@ -1130,11 +1132,13 @@ declare module "mongoose" {
     set(path: string, value: any, _tags?: any): this;
 
     /** Adds static "class" methods to Models compiled from this schema. */
-    static(name: string, fn: Function): this;
-    static(obj: { [name: string]: Function }): this;
+    static<F extends keyof M>(name: F, fn: M[F]): this;
+    static (obj: { [F in keyof M]: M[F] }): this;
 
     /** Object of currently defined statics on this schema. */
-    statics: any;
+    statics: {
+      [F in keyof M]: M[F];
+    };
 
     /** Creates a virtual type with the given name. */
     virtual(name: string, options?: any): VirtualType;
@@ -2257,7 +2261,7 @@ declare module "mongoose" {
      * @param num maximum number of records to pass to the next stage
      */
     limit(num: number): this;
-                                          
+
     /** Appends new custom $lookup operator to this aggregate pipeline. */
     lookup(options: any): this;
 
@@ -2299,7 +2303,7 @@ declare module "mongoose" {
 
     /** Sets the session for this aggregation. Useful for [transactions](/docs/transactions.html). */
     session(session: mongodb.ClientSession | null): this;
-    
+
     /**
      * Appends a new $skip operator to this aggregate pipeline.
      * @param num number of records to skip before next stage

--- a/test/typescript/models.ts
+++ b/test/typescript/models.ts
@@ -4,15 +4,15 @@ function conventionalSyntax(): void {
   interface ITest extends Document {
     foo: string;
   }
-  
-  const TestSchema = new Schema({
+
+  const TestSchema = new Schema<ITest>({
     foo: { type: String, required: true },
   });
-  
+
   const Test = connection.model<ITest>('Test', TestSchema);
-  
+
   const bar = (SomeModel: Model<ITest>) => console.log(SomeModel);
-  
+
   bar(Test);
 }
 
@@ -21,8 +21,8 @@ function tAndDocSyntax(): void {
     id: number;
     foo: string;
   }
-  
-  const TestSchema = new Schema({
+
+  const TestSchema = new Schema<ITest & Document>({
     foo: { type: String, required: true },
   });
 
@@ -42,14 +42,32 @@ const ExpiresSchema = new Schema({
 
 interface IProject extends Document {
   name: String;
+  myMethod(): number;
 }
 
 interface ProjectModel extends Model<IProject> {
   myStatic(): number;
 }
 
-const projectSchema: Schema = new Schema({ name: String });
+const projectSchema = new Schema<IProject, ProjectModel>({ name: String });
+
+projectSchema.pre('save', function () {
+  // this => IProject
+});
+
+projectSchema.post('save', function () {
+  // this => IProject
+});
+
+projectSchema.methods.myMethod = () => 10;
+
 projectSchema.statics.myStatic = () => 42;
 
 const Project = connection.model<IProject, ProjectModel>('Project', projectSchema);
 Project.myStatic();
+
+Project.create({
+  name: 'mongoose'
+}).then(project => {
+  project.myMethod();
+});


### PR DESCRIPTION
```typescript
import { Document, Model, Schema, model } from 'mongoose'
import { cryptor, validator } from '../utils'

export interface UserDocument extends Document {
  slug?: string
  username: string
  email?: string
  mobile?: string
  password: string

  comparePassword: (this: UserDocument, plain: string) => Promise<boolean>
}

export interface UserModel extends Model<UserDocument> {
  findByIdentity: (this: UserModel, identity: string) => Promise<UserDocument | null>
}

const schema = new Schema<UserDocument, UserModel>(
  {
    slug: {
      type: String,
      required: true,
      unique: true,
      maxlength: 191,
      lowercase: true,
      trim: true,
      validate: validator.isSlug
    },
    username: {
      type: String,
      required: true,
      unique: true,
      maxlength: 191,
      lowercase: true,
      trim: true
    },
    email: {
      type: String,
      unique: true,
      sparse: true,
      maxlength: 191,
      lowercase: true,
      trim: true,
      validate: validator.isEmail
    },
    mobile: {
      type: String,
      unique: true,
      sparse: true,
      maxlength: 191,
      lowercase: true,
      trim: true,
      validate: validator.isMobile
    },
    password: {
      type: String,
      required: true
    }
  },
  {
    collection: 'users',
    timestamps: true,
    versionKey: false
  }
)

schema.pre('save', async function () {
  // encrypt password
  if (this.isModified('password')) {
    this.password = await cryptor.hash(this.password)
  }
})

schema.methods.comparePassword = async function (plain: string) {
  return await cryptor.compare(plain, this.password)
}

schema.statics.findByIdentity = async function (identity: string) {
  const prop = validator.isEmail(identity) ? 'email' : validator.isMobile(identity) ? 'mobile' : 'username'
  return await this.findOne({ [prop]: identity })
}

export default model<UserDocument, UserModel>('User', schema)
```