### PR TITLE
fix : Allow  schema as a schema path name #8798

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -101,17 +101,17 @@ function Document(obj, fields, skipId, options) {
     throw new ObjectParameterError(obj, 'obj', 'Document');
   }
 
-  const schema = this.schema;
+  const reserved_schema = this.schema;
 
   if (typeof fields === 'boolean' || fields === 'throw') {
     this.$__.strictMode = fields;
     fields = undefined;
   } else {
-    this.$__.strictMode = schema.options.strict;
+    this.$__.strictMode = reserved_schema.options.strict;
     this.$__.selected = fields;
   }
 
-  const requiredPaths = schema.requiredPaths(true);
+  const requiredPaths = reserved_schema.requiredPaths(true);
   for (const path of requiredPaths) {
     this.$__.activePaths.require(path);
   }
@@ -177,7 +177,7 @@ function Document(obj, fields, skipId, options) {
     const keys = Object.keys(this._doc);
 
     keys.forEach(function(key) {
-      if (!(key in schema.tree)) {
+      if (!(key in reserved_schema.tree)) {
         defineKey(key, null, _this);
       }
     });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -589,7 +589,7 @@ reserved.isNew =
 reserved.populated =
 reserved.remove =
 reserved.save =
-reserved.schema =
+reserved.reserved_schema =
 reserved.toObject =
 reserved.validate = 1;
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1438,9 +1438,9 @@ describe('schema', function() {
 
       assert.throws(function() {
         new Schema({
-          schema: String
+          reserved_schema: String
         });
-      }, /`schema` may not be used as a schema pathname/);
+      }, /`reserved_schema` may not be used as a schema pathname/);
 
       assert.throws(function() {
         new Schema({


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

I am new at the open-source and I wanted to contribute to one of the libraries I use the most, look for a new good issue to solve and here I am. Mostly what it was about, was to allow a "schema" as a schema path name.

**Examples**

It fixs the issue #8798 actually I modify the test, at schema.test.js line 1441, so that way I make sure the solution was correct.
