### PR TITLE
fix(index.d.ts): add missing overloaded function for Document#populate()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -539,6 +539,7 @@ declare module 'mongoose' {
      * [`execPopulate()`](#document_Document-execPopulate).
      */
     populate(path: string, callback?: (err: CallbackError, res: this) => void): this;
+    populate(path: string, names: string, callback?: (err: any, res: this) => void): this;
     populate(opts: PopulateOptions | Array<PopulateOptions>, callback?: (err: CallbackError, res: this) => void): this;
 
     /** Gets _id(s) used during population of the given `path`. If the path was not populated, returns `undefined`. */


### PR DESCRIPTION
**Summary**

add missing overloaded function for Document#populate()

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

```
await post.populate('author', 'id username').execPopulate();
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
