### PR TITLE
fix(index.d.ts): add missing function for Aggregate#group()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2271,6 +2271,9 @@ declare module 'mongoose' {
 
     /** Appends new custom $graphLookup operator(s) to this aggregate pipeline, performing a recursive search on a collection. */
     graphLookup(options: any): this;
+                                          
+    /** Appends new custom $group operator to this aggregate pipeline. */
+    group(arg: any): this;
 
     /** Sets the hint option for the aggregation query (ignored for < 3.6.0) */
     hint(value: Record<string, unknown> | string): this;


### PR DESCRIPTION
**Summary**
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
It adds a missing group() function to the Aggregate class(index.d.ts).

**Examples**
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
It will make the following code works in Typescript:
```Typescript
const doc = await Document.aggregate().group({
  _id: '$groupId',
  total: { $sum: 1 }
});
```