### PR TITLE
fix(index.d.ts): allow Model.create param1 overwrite

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -630,11 +630,11 @@ declare module 'mongoose' {
     countDocuments(filter: FilterQuery<T>, callback?: (err: any, count: number) => void): Query<number, T>;
 
     /** Creates a new document or documents */
-    create(doc: T | DocumentDefinition<T>): Promise<T>;
-    create(docs: Array<T | DocumentDefinition<T>>, options?: SaveOptions): Promise<Array<T>>;
-    create(...docs: Array<T | DocumentDefinition<T>>): Promise<T>;
-    create(doc: T | DocumentDefinition<T>, callback: (err: CallbackError, doc: T) => void): void;
-    create(docs: Array<T | DocumentDefinition<T>>, callback: (err: CallbackError, docs: Array<T>) => void): void;
+    create<Z = T | DocumentDefinition<T>>(doc: Z): Promise<T>;
+    create<Z = T | DocumentDefinition<T>>(docs: Array<Z>, options?: SaveOptions): Promise<Array<T>>;
+    create<Z = T | DocumentDefinition<T>>(...docs: Array<Z>): Promise<T>;
+    create<Z = T | DocumentDefinition<T>>(doc: Z, callback: (err: CallbackError, doc: T) => void): void;
+    create<Z = T | DocumentDefinition<T>>(docs: Array<Z>, callback: (err: CallbackError, docs: Array<T>) => void): void;
 
     /**
      * Create the collection for this model. By default, if no indexes are specified,


### PR DESCRIPTION
**Summary**

Allow to overwrite the first param of `Model.create` ([like in `@types/mongoose`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3ca6e2420bb5dbef73e971871890e5f47f1f0d79/types/mongoose/index.d.ts#L3306-L3315))

**Examples**

when not allowing to overwrite this, then when using classes or an type with set (and/or get), then the user could not overwrite it to exclude them and typescript would complain that this set(&get) would be missing
(use case: typegoose, having properties & functions & static functions in one class, and typescript does not allow to filter for set(&get))