### PR TITLE
Make SchemaDefinition accept a model

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1161,10 +1161,11 @@ declare module 'mongoose' {
     virtualpath(name: string): VirtualType | null;
   }
 
-  interface SchemaDefinition {
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    [path: string]: SchemaTypeOptions<any> | Function | string | Schema | Schema[] | Array<SchemaTypeOptions<any>> | Function[] | SchemaDefinition | SchemaDefinition[];
-  }
+  type SchemaDefinitionProperty<T = undefined> = SchemaTypeOptions<any> | Function | string | Schema | Schema[] | Array<SchemaTypeOptions<any>> | Function[] | SchemaDefinition<T> | SchemaDefinition<T>[];
+
+  type SchemaDefinition<T = undefined> = T extends undefined
+    ? { [path: string]: SchemaDefinitionProperty; }
+    : { [path in keyof T]-?: SchemaDefinitionProperty<T[path]>; };
 
   interface SchemaOptions {
     /**


### PR DESCRIPTION
Make SchemaDefinition accept a model for more stricter type checking and making the schema consistent with typescript models.
