### PR TITLE
Add missing projection typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2349,7 +2349,7 @@ declare module 'mongoose' {
 
     /** Appends new custom $unwind operator(s) to this aggregate pipeline. */
     unwind(...args: any[]): this;
-                                          
+
     /** Appends new custom $project operator to this aggregate pipeline. */
     project(arg: any): this
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2349,6 +2349,9 @@ declare module 'mongoose' {
 
     /** Appends new custom $unwind operator(s) to this aggregate pipeline. */
     unwind(...args: any[]): this;
+                                          
+    /** Appends new custom $project operator to this aggregate pipeline. */
+    project(arg: any): this
   }
 
   class AggregationCursor extends stream.Readable {


### PR DESCRIPTION
**Summary**

Adds missing project function to Aggregate to type definitions 

**Examples**

```
Users.aggregate().project({username: 1})
```