### PR TITLE
fix(index.d.ts): id's are more type strict

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -477,8 +477,8 @@ declare module 'mongoose' {
      */
     getChanges(): UpdateQuery<this>;
 
-    /** The string version of this documents _id. */
-    id?: any;
+    /** The string version of this documents _id. Sometimes it's ObjectId when sub-documents were not populated */
+    id?: string | mongodb.ObjectId;
 
     /** Signal that we desire an increment of this documents version. */
     increment(): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -478,7 +478,7 @@ declare module 'mongoose' {
     getChanges(): UpdateQuery<this>;
 
     /** The string version of this documents _id. Sometimes it's ObjectId when sub-documents were not populated */
-    id?: string | mongodb.ObjectId;
+    id?: string | mongodb.ObjectId;
 
     /** Signal that we desire an increment of this documents version. */
     increment(): this;

--- a/test/typescript/createBasicSchemaDefinition.ts
+++ b/test/typescript/createBasicSchemaDefinition.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'bson';
 import { Schema, model, Document } from 'mongoose';
 
 const schema: Schema = new Schema({
@@ -16,7 +17,7 @@ const schema: Schema = new Schema({
 
 interface ITest extends Document {
   name?: string;
-  id?: number;
+  id?: string | ObjectId;
   tags?: string[];
   author?: { name: string };
   followers?: { name: string }[];

--- a/test/typescript/createBasicSchemaDefinition.ts
+++ b/test/typescript/createBasicSchemaDefinition.ts
@@ -17,7 +17,7 @@ const schema: Schema = new Schema({
 
 interface ITest extends Document {
   name?: string;
-  id?: string | ObjectId;
+  id?: string | ObjectId;
   tags?: string[];
   author?: { name: string };
   followers?: { name: string }[];


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

With this change the document ID's will reflect better what is actually going on.

As far as I know usually the `id` is a string. But sometimes it can be a `ObjectId`. For example when a sub-sub-document was not populated.

These changes make the types better. Because I don't know that `id` is ever anything else than `string` or `ObjectId`

These changes do not contradict with https://github.com/Automattic/mongoose/issues/9723 as the use case is still valid that ID's can be anything (valid).