### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2168,7 +2168,7 @@ declare module 'mongoose' {
   type FunctionPropertyNames<T> = {
     // The 1 & T[K] check comes from: https://stackoverflow.com/questions/55541275/typescript-check-for-the-any-type
     // eslint-disable-next-line @typescript-eslint/ban-types
-    [K in keyof T]: 0 extends (1 & T[K]) ? never : (T[K] extends Function ? K : never)
+    [K in keyof T]: 0 extends (1 & T[K]) ? any : (T[K] extends Function ? K : never)
   }[keyof T];
 
   type actualPrimitives = string | boolean | number | bigint | symbol | null | undefined;


### PR DESCRIPTION
fix? `type` is not assignable to type 'never' in update operators
![image](https://user-images.githubusercontent.com/11459225/104090127-b07e5a80-5289-11eb-97e2-bb46c43ac582.png)

using mongoose "^5.11.11"
i removed @types/mongoose
i tried chanding @types/mongodb .d.ts file, no luck

this change is working and is good enough for me