### PR TITLE
Fix: removed the extra word on comment doc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2266,7 +2266,7 @@ declare module 'mongoose' {
     count(countName: string): this;
 
     /**
-     * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
+     * Sets the cursor option for the aggregation query (ignored for < 2.6.0).
      */
     cursor(options?: Record<string, unknown>): this;
 


### PR DESCRIPTION
Removed a small typo on code comments.