### PR TITLE
chore: changed setOptions's 'overwrite' argument to optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2075,7 +2075,7 @@ declare module 'mongoose' {
     set(path: string, value: any): this;
 
     /** Sets query options. Some options only make sense for certain operations. */
-    setOptions(options: QueryOptions, overwrite: boolean): this;
+    setOptions(options: QueryOptions, overwrite?: boolean): this;
 
     /** Sets the query conditions to the provided JSON object. */
     setQuery(val: FilterQuery<DocType> | null): void;


### PR DESCRIPTION
### Summary

I've changed the typescript modifier of the 'overwrite' argument in the Query.prototype.setOptions function to be optional, to be consistent with what is described in the documentation: https://mongoosejs.com/docs/api.html#query_Query-setOptions

### Examples

**Before**
```ts
// the 'false' parameter is required
this.model.find({ ...query, authorIds: author.id }).setOptions({ maxScan: 1000 }, false);
```

**After**
```ts
// the 'false' parameter can be omitted
this.model.find({ ...query, authorIds: author.id }).setOptions({ maxScan: 1000 });
```
