### PR TITLE
TransactionOptions support within transaction wrapper

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -448,7 +448,7 @@ Connection.prototype.startSession = _wrapConnHelper(function startSession(option
  *
  *       // Throw an error to abort the transaction
  *       throw new Error('Oops!');
- *     }).catch(() => {});
+ *     },{ readPreference: 'primary' }).catch(() => {});
  *
  *     // true, `transaction()` reset the document's state because the
  *     // transaction was aborted.
@@ -456,14 +456,15 @@ Connection.prototype.startSession = _wrapConnHelper(function startSession(option
  *
  * @method transaction
  * @param {Function} fn Function to execute in a transaction
+ * @param {mongodb.TransactionOptions} [options] Optional settings for the transaction
  * @return {Promise<Any>} promise that resolves to the returned value of `fn`
  * @api public
  */
 
-Connection.prototype.transaction = function transaction(fn) {
+Connection.prototype.transaction = function transaction(fn, options) {
   return this.startSession().then(session => {
     session[sessionNewDocuments] = new Map();
-    return session.withTransaction(() => fn(session)).
+    return session.withTransaction(() => fn(session), options).
       then(res => {
         delete session[sessionNewDocuments];
         return res;

--- a/test/es-next/transactions.test.es6.js
+++ b/test/es-next/transactions.test.es6.js
@@ -419,4 +419,21 @@ describe('transactions', function() {
     const createdDoc = await Test.collection.findOne();
     assert.deepEqual(createdDoc.arr, ['foo']);
   });
+
+  it('can save a new document with an array and read within transaction', async function () {
+    const schema = Schema({ arr: [String] });
+
+    const Test = db.model('new_doc_array', schema);
+
+    await Test.createCollection();
+    const doc = new Test({ arr: ['foo'] });
+    await db.transaction(
+      async (session) => {
+        await doc.save({ session });
+        const testDocs = await Test.collection.find({}).session(session);
+        assert.deepStrictEqual(testDocs.length, 1);
+      },
+      { readPreference: 'primary' }
+    );
+  });
 });


### PR DESCRIPTION
**Summary**

Currently I am using `withTransaction` to handle the transaction in my code. As mongoose introduced transaction wrapper to handle Mongoose document state https://mongoosejs.com/docs/api/connection.html#connection_Connection-transaction

There is no option to provide the `mongodb.TransactionOption` basically supported by `withTransaction` method.

Added support to pass the `mongodb.TransactionOptions`

**Examples**

      const doc = new Person({ name: 'Will Riker' });
      await db.transaction(async function setRank(session) {
        doc.rank = 'Captain';
        await doc.save({ session });
        doc.isNew; // false
 
        // Throw an error to abort the transaction
        throw new Error('Oops!');
      },{ readPreference: 'primary' }).catch(() => {});
 
      // true, `transaction()` reset the document's state because the
      // transaction was aborted.
      doc.isNew;
