### PR TITLE
fix: rollback breaking change to applySetters

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1051,12 +1051,21 @@ SchemaType.prototype.getDefault = function(scope, init) {
  * @api private
  */
 
-SchemaType.prototype._applySetters = function(value, scope) {
+SchemaType.prototype._applySetters = function(value, scope, init, priorVal) {
   let v = value;
   const setters = this.setters;
+  const caster = this.caster;
 
   for (const setter of utils.clone(setters).reverse()) {
     v = setter.call(scope, v, this);
+  }
+
+  if (Array.isArray(v) && caster && caster.setters) {
+    let newVal = [];
+    for (let i = 0; i < v.length; i++) {
+      newVal.push(caster.applySetters(v[i], scope, init, priorVal));
+    }
+    v = newVal;
   }
 
   return v;


### PR DESCRIPTION
👋 first of all I want to say thank you for this project, its great!

**Summary**

I faced problem with applySetters not working same way in 5.11.12 as it was in 5.11.11 and earlier version.

**Examples**

This code in my case started to write array of strings to database instead of array of ObjectId's like it used to be.

```
const ElementSchema = new Schema({
  name: 'string',
  nested: [{ type: Schema.Types.ObjectId, ref: 'Nested' }]
});
const NestedSchema = new Schema({});

const el = await Element.findById(eleValue._id).populate({ path: 'nested', model: NestedElement });
el.nested = ['123456789012345678901234'];
await el.save()
```

I've added test case to my PR so you could try it out.

Thank you