### PR TITLE
Made ValidationError.toJSON to include the error name correctly

### DIFF
--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -67,13 +67,14 @@ if (util.inspect.custom) {
 
 /*!
  * Helper for JSON.stringify
+ * Ensure `name` and `message` show up in toJSON output re: gh-9847
  */
 Object.defineProperty(ValidationError.prototype, 'toJSON', {
   enumerable: false,
   writable: false,
   configurable: true,
   value: function() {
-    return Object.assign({}, this, { message: this.message });
+    return Object.assign({}, this, { name: this.name, message: this.message });
   }
 });
 


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

This makes `ValidationError.toJSON()` to include the `name` field. This fixes issue #9847. 

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

See #9847 for example code to reproduce the error.