### PR TITLE
Add missing overload to Model.validate (#9877)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -753,6 +753,7 @@ declare module 'mongoose' {
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
     validate(callback?: (err: any) => void): Promise<void>;
     validate(optional: any, callback?: (err: any) => void): Promise<void>;
+    validate(optional: any, pathsToValidate: string[], callback?: (err: any) => void): Promise<void>;
 
     /** Watches the underlying collection for changes using [MongoDB change streams](https://docs.mongodb.com/manual/changeStreams/). */
     watch(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
This PR fixes #9877

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
Now if you type Model.validate({key: "value"}, ["key"]) on a ts project, ts compiler doesn't warn about invalid arguments 
`Argument of type 'string[]' is not assignable to parameter of type '(err: any) => void'. Type 'string[]' provides no match for the signature '(err: any): void'.`