### PR TITLE
fix(index.d.ts): allow required function in array definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1381,7 +1381,7 @@ declare module 'mongoose' {
      * path cannot be set to a nullish value. If a function, Mongoose calls the
      * function and only checks for nullish values if the function returns a truthy value.
      */
-    required?: boolean | (() => boolean) | [boolean, string];
+    required?: boolean | (() => boolean) | [boolean, string] | [() => boolean, string];
 
     /**
      * The default value for this path. If a function, Mongoose executes the function

--- a/test/typescript/schema.ts
+++ b/test/typescript/schema.ts
@@ -23,6 +23,15 @@ const movieSchema: Schema = new Schema({
     type: String,
     enum: Genre,
     required: true
+  },
+  actionIntensity: {
+    type: Number,
+    required: [
+      function(this: { genre: Genre }) {
+        return this.genre === Genre.Action;
+      },
+      'Action intensity required for action genre'
+    ]
   }
 });
 


### PR DESCRIPTION
**Summary**

The `required` field supports defining an array with a function and a message. Modifying the typescript definitions to reflect that.