### PR TITLE
fix(index.d.ts): reorder create typings to allow array desctructuring

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -630,11 +630,11 @@ declare module 'mongoose' {
     countDocuments(filter: FilterQuery<T>, callback?: (err: any, count: number) => void): Query<number, T>;
 
     /** Creates a new document or documents */
-    create<DocContents = T | DocumentDefinition<T>>(doc: DocContents): Promise<T>;
     create<DocContents = T | DocumentDefinition<T>>(docs: DocContents[], options?: SaveOptions): Promise<T[]>;
+    create<DocContents = T | DocumentDefinition<T>>(doc: DocContents): Promise<T>;
     create<DocContents = T | DocumentDefinition<T>>(...docs: DocContents[]): Promise<T[]>;
-    create<DocContents = T | DocumentDefinition<T>>(doc: DocContents, callback: (err: CallbackError, doc: T) => void): void;
     create<DocContents = T | DocumentDefinition<T>>(docs: DocContents[], callback: (err: CallbackError, docs: T[]) => void): void;
+    create<DocContents = T | DocumentDefinition<T>>(doc: DocContents, callback: (err: CallbackError, doc: T) => void): void;
 
     /**
      * Create the collection for this model. By default, if no indexes are specified,

--- a/test/typescript/create.ts
+++ b/test/typescript/create.ts
@@ -19,3 +19,10 @@ Test.insertMany({ name: 'test' }).then((doc: ITest) => console.log(doc.name));
 Test.insertMany([{ name: 'test' }], { session: null }).then((docs: ITest[]) => console.log(docs[0].name));
 
 Test.create([{ name: 'test' }], { validateBeforeSave: true }).then((docs: ITest[]) => console.log(docs[0].name));
+
+(async() => {
+  const [t1] = await Test.create([{ name: 'test' }]);
+  const [t2, t3, t4] = await Test.create({ name: 'test' }, { name: 'test' }, { name: 'test' });
+  (await Test.create([{ name: 'test' }]))[0];
+  (await Test.create({ name: 'test' }))._id;
+})();


### PR DESCRIPTION
**Summary**

Current typings do not allow array destructuring, as TypeScript chooses `create<DocContents = T | DocumentDefinition<T>>(doc: DocContents): Promise<T>;` definition even while using `create` with arrays.