### PR TITLE
📝 fixed confusing sentence in Schema docs

### DIFF
--- a/docs/guide.pug
+++ b/docs/guide.pug
@@ -378,7 +378,7 @@ block content
     const personSchema = new Schema({
       n: {
         type: String,
-        // Now accessing `name` will get you the value of `n`, and setting `n` will set the value of `name`
+        // Now accessing `name` will get you the value of `n`, and setting `name` will set the value of `n`
         alias: 'name'
       }
     });


### PR DESCRIPTION
**Summary**

I've found a sentence in [the Schema Aliases section](https://mongoosejs.com/docs/guide.html#aliases) that seems to be mistaken and confusing.

---

```
Now accessing `name` will get you the value of `n`, and setting `n` will set the value of `name`
```

I think it should say ```setting `name` will set the value of `n` ```.

The example a few lines below also supports my assumption:

```js
person.name = 'Not Val';
console.log(person); // { n: 'Not Val' }
```