### PR TITLE
SchemaTypeOptions.type is optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1365,7 +1365,7 @@ declare module 'mongoose' {
   }
 
   interface SchemaTypeOptions<T> {
-    type: T;
+    type?: T;
 
     /** Defines a virtual with the given name that gets/sets this path. */
     alias?: string;


### PR DESCRIPTION
type must be optional to support schemas using the [typeKey option](https://mongoosejs.com/docs/guide.html#typeKey) and [nested paths](https://mongoosejs.com/docs/subdocs.html#subdocuments-versus-nested-paths).


This PR reverts a change that was merged a few days ago:
https://github.com/Automattic/mongoose/commit/968bd8a57d735f97a2cf1686ba1efc8bf23593d4#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8R1367
