### PR TITLE
remove dynamic import statements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,16 +4,7 @@
  * Module dependencies.
  */
 
-if (global.MONGOOSE_DRIVER_PATH) {
-  const deprecationWarning = 'The `MONGOOSE_DRIVER_PATH` global property is ' +
-    'deprecated. Use `mongoose.driver.set()` instead.';
-  const setDriver = require('util').deprecate(function() {
-    require('./driver').set(require(global.MONGOOSE_DRIVER_PATH));
-  }, deprecationWarning);
-  setDriver();
-} else {
-  require('./driver').set(require('./drivers/node-mongodb-native'));
-}
+require('./driver').set(require('./drivers/node-mongodb-native'));
 
 const Document = require('./document');
 const Schema = require('./schema');
@@ -732,19 +723,17 @@ Mongoose.prototype.connections;
  * Driver dependent APIs
  */
 
-const driver = global.MONGOOSE_DRIVER_PATH || './drivers/node-mongodb-native';
 
 /*!
  * Connection
  */
-
-const Connection = require(driver + '/connection');
+const Connection = require('./drivers/node-mongodb-native/connection');
 
 /*!
  * Collection
  */
 
-const Collection = require(driver + '/collection');
+const Collection = require('./drivers/node-mongodb-native/collection');
 
 /**
  * The Mongoose Aggregate constructor


### PR DESCRIPTION
**Summary**
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Importing from paths generated at runtime breaks 
parcel, see (https://github.com/parcel-bundler/parcel/issues/4031),
or esbuild, see (https://github.com/evanw/esbuild/issues/480).
By removing the calls to the deprecated global MONGOOSE_DRIVER_PATH
this issue can be resolved.

**Examples**
Lines linke this cause problems because the path will not be resolved by eslint etc.
```
const Connection = require(driver + '/connection');
```
Fixes: https://github.com/Automattic/mongoose/issues/9603

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
