### PR TITLE
Gh 9374 from 6.0

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,6 +19,7 @@ const immediate = require('./helpers/immediate');
 const mongodb = require('mongodb');
 const pkg = require('../package.json');
 const utils = require('./utils');
+const processConnectionOptions = require('./helpers/processConnectionOptions');
 
 const arrayAtomicsSymbol = require('./helpers/symbols').arrayAtomicsSymbol;
 const sessionNewDocuments = require('./helpers/symbols').sessionNewDocuments;
@@ -718,8 +719,9 @@ Connection.prototype.openUri = function(uri, options, callback) {
   const Promise = PromiseProvider.get();
   const _this = this;
 
+  options = processConnectionOptions(uri, options);
+
   if (options) {
-    options = utils.clone(options);
     const autoIndex = options.config && options.config.autoIndex != null ?
       options.config.autoIndex :
       options.autoIndex;

--- a/lib/helpers/processConnectionOptions.js
+++ b/lib/helpers/processConnectionOptions.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const clone = require('./clone');
+const MongooseError = require('../error/index');
+
+function processConnectionOptions(uri, options) {
+  const opts = options ? options : {};
+  const readPreference = opts.readPreference
+    ? opts.readPreference
+    : getUriReadPreference(uri);
+
+  const resolvedOpts = readPreference
+    ? resolveOptsConflicts(readPreference, opts)
+    : opts;
+
+  return clone(resolvedOpts);
+}
+
+function resolveOptsConflicts(pref, opts) {
+  // don't silently override user-provided indexing options
+  if (setsIndexOptions(opts) && setsSecondaryRead(pref)) {
+    throwReadPreferenceError();
+  }
+
+  // if user has not explicitly set any auto-indexing options,
+  // we can silently default them all to false
+  else {
+    return defaultIndexOptsToFalse(opts);
+  }
+}
+
+function setsIndexOptions(opts) {
+  const configIdx = opts.config && opts.config.autoIndex;
+  const { autoCreate, autoIndex, useCreateIndex } = opts;
+  return !!(configIdx || autoCreate || autoIndex || useCreateIndex);
+}
+
+function setsSecondaryRead(prefString) {
+  return !!(prefString === 'secondary' || prefString === 'secondaryPreferred');
+}
+
+function getUriReadPreference(connectionString) {
+  const exp = /(?:&|\?)readPreference=(\w+)(?:&|$)/;
+  const match = exp.exec(connectionString);
+  return match ? match[1] : null;
+}
+
+function defaultIndexOptsToFalse(opts) {
+  opts.config = { autoIndex: false };
+  opts.autoCreate = false;
+  opts.autoIndex = false;
+  opts.useCreateIndex = false;
+  return opts;
+}
+
+function throwReadPreferenceError() {
+  throw new MongooseError(
+    'MongoDB prohibits index creation on connections that read from ' +
+            'non-primary replicas.  Connections that set "readPreference" to "secondary" or ' +
+            '"secondaryPreferred" may not opt-in to the following connection options: ' +
+            'autoCreate, autoIndex, useCreateIndex'
+  );
+}
+
+module.exports = processConnectionOptions;


### PR DESCRIPTION
**Summary**
Implements sensible defaults discussed in #9374 if connection readPreference is 'secondary'  or 'preferSecondary'.  If readPreference will be set to 'nearest' or 'primaryPreferred', it warns but otherwise behaves as before.
**Examples**
Several tests added for Mongoose.prototype.connect and Mongoose.prototype.createConnection.