### PR TITLE
fix(connection): fix promise chaining for openUri

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -858,7 +858,7 @@ Connection.prototype.openUri = function(uri, options, callback) {
   this.then = function(resolve, reject) {
     return this.$initialConnection.then(() => {
       if (typeof resolve === 'function') {
-        resolve(_this);
+        return resolve(_this);
       }
     }, reject);
   };


### PR DESCRIPTION
**Summary**

When a user calls openUri and attaches more than one callback to its return value with 'then' method, it should be able to pass the result of the first callback to the second one. Currently, openUri always pass 'undefined' to the second callback, making it behave differently from a regular promise. This is unlikely to be an expected behaviour.

To fix it, modify openUri to propagate the return value of the user-provided callback to the 'then' method of the promise.

**Examples**

```javascript
const mongoose = require('mongoose')

mongoose.createConnection('mongodb://localhost:27017/test', {
  useNewUrlParser: true,
  useUnifiedTopology: true,
}).then((conn) => {
  console.log('callback 1', typeof conn);
  return 2;
}).then((x) => {
  console.log('callback 2', x);
  return 3;
}).then((x) => {
  console.log('callback 3', x);
  return 4;
}).catch((err) => {
  console.log('error', err);
})
```

Current behaviour:
```
callback 1 object
callback 2 undefined
callback 3 3
```

Expected behaviour:
```
callback 1 object
callback 2 2
callback 3 3
```

