### PR TITLE
fix: Add generic to plugin schema definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1123,7 +1123,7 @@ declare module 'mongoose' {
     pathType(path: string): string;
 
     /** Registers a plugin for this schema. */
-    plugin(fn: (schema: Schema, opts?: any) => void, opts?: any): this;
+    plugin(fn: (schema: Schema<DocType, Model<DocType>, SchemaDefinitionType>, opts?: any) => void, opts?: any): this;
 
     /** Defines a post hook for the model. */
     post<T extends Document = DocType>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, fn: (this: T, res: any, next: (err?: CallbackError) => void) => void): this;


### PR DESCRIPTION
**Summary**

Update the typescript definition for `plugin()` on Schema to add generic support. Currently, the plugin() complains when trying to add a plugin with custom Document/Model definitions.

**Examples**
```
const myDocumentSchema = new Schema<MyDocument, MyModel>({ name: String });

export default function myPlugin(mySchema: Schema<MyDocument, MyModel>): void {
    mySchema.add({
        plugin: Boolean
    })
}

myDocumentSchema.plugin(myPlugin); // <-- this does not work since Schema in plugin does not support generics
```



