### PR TITLE
fix(index.d.ts): SchemaDefinition conditional type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1205,7 +1205,7 @@ declare module 'mongoose' {
     SchemaDefinition<T> |
     SchemaDefinition<T>[];
 
-  type SchemaDefinition<T = undefined> = T extends undefined
+  type SchemaDefinition<T = undefined> = T extends DocumentDefinition<undefined>
     ? { [path: string]: SchemaDefinitionProperty; }
     : { [path in keyof T]?: SchemaDefinitionProperty<T[path]>; };
 


### PR DESCRIPTION
`SchemaDefinition` is receiving generic after computed
`DocumentDefinition`, so we can not check against
`undefined` here.

**Summary**

Attempt to fix an issue regarding to type hint for creating a schema definition.
Screenshot in current Version captured in VSCode 1.54.1 and TS 4.2.2:
![image](https://user-images.githubusercontent.com/7407146/110192031-bac26c80-7e66-11eb-854a-0121570815f2.png)

Note that the type of its first constructor param, it is an empty interface.
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
Fixed behaviour:
![image](https://user-images.githubusercontent.com/7407146/110192155-57850a00-7e67-11eb-8d6a-4fc9a3421613.png)

With this patch applied, the `SchemaDefinition` will check against `DocumentDefinition` rather than top-level type param (the third generic param of `Schema`). I think this change is backward-compliant as `SchemaDefinition` is not exported, nor used in other places. 

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, un
less you added a test. -->
