### PR TITLE
Fix Event Listeners to comply with (new v3 & v4) MongoDB Driver API changes

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -929,7 +929,7 @@ function _setClient(conn, client, options, dbName) {
         }
       });
 
-      db.on('close', function() {
+      client.on('close', function() {
         const type = get(db, 's.topology.s.description.type', '');
         if (type !== 'ReplicaSetWithPrimary') {
           // Implicitly emits 'disconnected'
@@ -945,7 +945,7 @@ function _setClient(conn, client, options, dbName) {
   });
 
   if (!options.useUnifiedTopology) {
-    db.on('reconnect', function() {
+    client.on('reconnect', function() {
       _handleReconnect();
     });
 
@@ -965,7 +965,7 @@ function _setClient(conn, client, options, dbName) {
     });
   }
   if (!options.useUnifiedTopology) {
-    db.on('close', function() {
+    client.on('close', function() {
       // Implicitly emits 'disconnected'
       conn.readyState = STATES.disconnected;
     });
@@ -984,7 +984,7 @@ function _setClient(conn, client, options, dbName) {
       }
     });
 
-    db.on('timeout', function() {
+    client.on('timeout', function() {
       conn.emit('timeout');
     });
   }


### PR DESCRIPTION
Listening to events on the DB object is deprecated in v3.x and will be unsupported in v4 of the mongodb drivers. Adjusted remaining listeneers to use the DB client object, as per the MongoDB Driver API docs

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

resolving https://github.com/Automattic/mongoose/issues/9930

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
