### PR TITLE
fix: query object types on schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1161,7 +1161,7 @@ declare module 'mongoose' {
     pre<T extends Model<DocType> = M>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err: CallbackError) => void) => void): this;
 
     /** Object of currently defined query helpers on this schema. */
-    query: { [name: string]: (this: M, ...args: any[]) => any };
+    query: { [name: string]: <T extends Query<any, DocType, any>>(this: T, ...args: any[]) => T };
 
     /** Adds a method call to the queue. */
     queue(name: string, args: any[]): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1161,7 +1161,7 @@ declare module 'mongoose' {
     pre<T extends Model<DocType> = M>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err: CallbackError) => void) => void): this;
 
     /** Object of currently defined query helpers on this schema. */
-    query: { [name: string]: <T extends Query<any, DocType, any>>(this: T, ...args: any[]) => T };
+    query: { [name: string]: <T extends Query<any, any, any> = Query<any, any, any>>(this: T, ...args: any[]) => any };
 
     /** Adds a method call to the queue. */
     queue(name: string, args: any[]): this;


### PR DESCRIPTION
**Summary**

The `query` field on the Schema class is typed incorrectly. It types `this` as the Model type, whereas it should actually be the Query type.

Only thing I'm not sure about is if query functions always return another query, or if they can return other values. Let me know if I need to change anything!

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
