### PR TITLE
Upgrade mongodb dep to 3.6.5 to eliminate inside circular dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/mongodb": "^3.5.27",
     "bson": "^1.1.4",
     "kareem": "2.3.2",
-    "mongodb": "3.6.4",
+    "mongodb": "3.6.5",
     "mongoose-legacy-pluralize": "1.0.2",
     "mpath": "0.8.3",
     "mquery": "3.2.4",


### PR DESCRIPTION
**Summary**

I was using `mongoose@5.12.0` and was getting this warning on start-up:

```bash
(node:21965) Warning: Accessing non-existent property 'MongoError' of module exports inside circular dependency
``` 

Some research led me to this: https://stackoverflow.com/questions/66049860/cannot-connect-to-mongodb-because-of-wrong-uri/66102270#66102270

Basically `mongodb`, one of this package dependencies, had this bug on 3.6.4. 

2 days ago `mongodb@3.6.5` was released and seems to fix this bug. Hence I am opening a PR to bump the version.
