### PR TITLE
invalid  cast method for instance method of SchemaType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2535,8 +2535,8 @@ declare module 'mongoose' {
     /** Attaches a getter for all instances of this schema type. */
     static get(getter: (value: any) => any): void;
 
-    /** Get/set the function used to cast arbitrary values to this type. */
-    cast(caster: (v: any) => any): (v: any) => any;
+    /** Casts a value to it's schema type instance */
+    cast(value: any, doc: Document, init: boolean, prev?: any, options?: any): any;
 
     /** Sets a default value for this SchemaType. */
     default(val: any): any;


### PR DESCRIPTION
The current implementation is using the same signature for the static level `cast` and instance level `cast`.

However, the instance level `cast` is different.

The use of `any` is crucial here, to allow sub types to specify their narrowed types.
This is true as long as generics is not introduced to `SchemaType`