### PR TITLE
fix: make bulkWrite can work with `timestamps: false`

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -20,7 +20,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
       const model = decideModelByObject(originalModel, op['insertOne']['document']);
 
       const doc = new model(op['insertOne']['document']);
-      if (doc.initializeTimestamps) {
+      if (model.schema.options.timestamps) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {
@@ -147,7 +147,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
 
       // set `skipId`, otherwise we get "_id field cannot be changed"
       const doc = new model(op['replaceOne']['replacement'], strict, true);
-      if (doc.initializeTimestamps) {
+      if (model.schema.options.timestamps) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {

--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -20,7 +20,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
       const model = decideModelByObject(originalModel, op['insertOne']['document']);
 
       const doc = new model(op['insertOne']['document']);
-      if (model.schema.options.timestamps != null) {
+      if (doc.initializeTimestamps) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {
@@ -147,7 +147,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
 
       // set `skipId`, otherwise we get "_id field cannot be changed"
       const doc = new model(op['replaceOne']['replacement'], strict, true);
-      if (model.schema.options.timestamps != null) {
+      if (doc.initializeTimestamps) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5780,6 +5780,35 @@ describe('Model', function() {
           assert.equal(people[3].age, 30);
         });
       });
+
+      it('insertOne and replaceOne should not throw an error when set `timestamps: false` in schmea', function() {
+        const schema = new Schema({ name: String }, { timestamps: false });
+        const Model = db.model('Test', schema);
+
+        return co(function*() {
+          yield Model.create({ name: 'test' });
+
+          yield Model.bulkWrite([
+            {
+              insertOne: {
+                document: { name: 'insertOne-test' }
+              }
+            },
+            {
+              replaceOne: {
+                filter: { name: 'test' },
+                replacement: { name: 'replaceOne-test' }
+              }
+            }
+          ]);
+
+          for (const name of ['insertOne-test', 'replaceOne-test']) {
+            const doc = yield Model.findOne({ name });
+            assert.strictEqual(doc.createdAt, undefined);
+            assert.strictEqual(doc.updatedAt, undefined);
+          }
+        });
+      });
     });
 
     it('insertMany with Decimal (gh-5190)', function(done) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5781,7 +5781,7 @@ describe('Model', function() {
         });
       });
 
-      it('insertOne and replaceOne should not throw an error when set `timestamps: false` in schmea', function() {
+      it('insertOne and replaceOne should not throw an error when set `timestamps: false` in schmea (gh-10048)', function() {
         const schema = new Schema({ name: String }, { timestamps: false });
         const Model = db.model('Test', schema);
 


### PR DESCRIPTION
**Summary**

bulkWrite use `if (model.schema.options.timestamps != null)` to check that it should run `initializeTimestamps()` or not, so it will got error when set `timestamps: false` in schema.
I saw `Model.$__insertMany` use `if (doc.initializeTimestamps)` to check, so I make bulkWrite use the same condition to fix issue.

**Examples**

#10048 

