### PR TITLE
fix(index.d.ts): add a missing type for discriminator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -782,6 +782,7 @@ declare module 'mongoose' {
 
     /** Adds a discriminator type. */
     discriminator<D extends Document>(name: string, schema: Schema, value?: string): Model<D>;
+    discriminator<T extends Document, U extends Model<T, TQueryHelpers>, TQueryHelpers = {}>(name: string, schema: Schema<T, U>, value?: string): U;
 
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct(field: string, filter?: FilterQuery<T>, callback?: (err: any, count: number) => void): QueryWithHelpers<Array<any>, T, TQueryHelpers>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -782,7 +782,7 @@ declare module 'mongoose' {
 
     /** Adds a discriminator type. */
     discriminator<D extends Document>(name: string, schema: Schema, value?: string): Model<D>;
-    discriminator<T extends Document, U extends Model<T, TQueryHelpers>, TQueryHelpers = {}>(name: string, schema: Schema<T, U>, value?: string): U;
+    discriminator<T extends Document, U extends Model>(name: string, schema: Schema<T, U>, value?: string): U;
 
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct(field: string, filter?: FilterQuery<T>, callback?: (err: any, count: number) => void): QueryWithHelpers<Array<any>, T, TQueryHelpers>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -782,7 +782,7 @@ declare module 'mongoose' {
 
     /** Adds a discriminator type. */
     discriminator<D extends Document>(name: string, schema: Schema, value?: string): Model<D>;
-    discriminator<T extends Document, U extends Model>(name: string, schema: Schema<T, U>, value?: string): U;
+    discriminator<T extends Document, U extends Model<T>>(name: string, schema: Schema<T, U>, value?: string): U;
 
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct(field: string, filter?: FilterQuery<T>, callback?: (err: any, count: number) => void): QueryWithHelpers<Array<any>, T, TQueryHelpers>;


### PR DESCRIPTION
**Summary**

It adds a missing type for discriminator.

**Examples**

This commit will make the following code works in TS:
```Typescript
Image.discriminator<ImageChildDoc, ImageChildModel>('ImageChild', imageChildSchema);
```
