### PR TITLE
Fixes #10072

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1166,8 +1166,8 @@ declare module 'mongoose' {
     pre<T extends Query<any, any> = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err: CallbackError) => void) => void): this;
     pre<T extends Aggregate<any> = Aggregate<any>>(method: 'aggregate' | RegExp, fn: (this: T, next: (err: CallbackError) => void) => void): this;
     pre<T extends Aggregate<any> = Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err: CallbackError) => void) => void): this;
-    pre<T extends Model<DocType> = M>(method: 'insertMany' | RegExp, fn: (this: T, next: (err: CallbackError) => void) => void): this;
-    pre<T extends Model<DocType> = M>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err: CallbackError) => void) => void): this;
+    pre<T extends Model<DocType> = M>(method: 'insertMany' | RegExp, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void): this;
+    pre<T extends Model<DocType> = M>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void): this;
 
     /** Object of currently defined query helpers on this schema. */
     query: { [name: string]: <T extends QueryWithHelpers<any, DocType, ExtractQueryHelpers<M>> = QueryWithHelpers<any, DocType, ExtractQueryHelpers<M>>>(this: T, ...args: any[]) => any };

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -39,4 +39,27 @@ schema.post<ITest>('save', function(err: Error, res: ITest, next: Function) {
   console.log(this.name, err.stack);
 });
 
+schema.pre<Model<ITest>>('insertMany', function() {
+  return Promise.resolve(this.name);
+});
+
+schema.pre<Model<ITest>>('insertMany', { document: false, query: false }, function() {
+  console.log(this.name);
+});
+
+schema.pre<Model<ITest>>('insertMany', function(next) {
+  console.log(this.name);
+  next();
+});
+
+schema.pre<Model<ITest>>('insertMany', function(next, doc: ITest) {
+  console.log(this.name, doc);
+  next();
+});
+
+schema.pre<Model<ITest>>('insertMany', function(next, docs: Array<ITest>) {
+  console.log(this.name, docs);
+  next();
+});
+
 const Test = model<ITest>('Test', schema);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

Current typescript method declarations for `insertMany` pre-hook misses parameters passed to original `insertMany` method

**Examples**

Following code
```typescript
schema.pre<Model<ITest>>("insertMany", function (this, next, docs) {
  console.log(docs);
});
```
produce compilation error:
```
error TS2345: Argument of type '(this: any, next: any, docs: any) => void' is not assignable to parameter of type '(this: Model<ITest, {}>, next: (err: NativeError) => void) => void
```
