### PR TITLE
fix: add missing asyncInterator to Query type def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1850,6 +1850,13 @@ declare module 'mongoose' {
   class Query<ResultType, DocType extends Document, THelpers = {}> {
     _mongooseOptions: MongooseQueryOptions;
 
+    /**
+     * Returns a wrapper around a [mongodb driver cursor](http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html).
+     * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
+     * This is equivalent to calling `.cursor()` with no arguments.
+     */
+    [Symbol.asyncIterator]: QueryCursor<DocType>;
+
     /** Executes the query */
     exec(): Promise<ResultType>;
     exec(callback?: (err: CallbackError, res: ResultType) => void): void;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

Fixes #10093. According to [documentation](https://mongoosejs.com/docs/queries.html#streaming), a `Query` instance has an async iterator (which is in fact the `.cursor()`'s async iterator). This pull request makes it possible in Typescript.

**Examples**
Now it is possible to do the following in Typescript:
```
for await (const doc of Person.find()) {
  console.log(doc); // Prints documents one at a time
}
```
