### PR TITLE
fix(model): `insertedDocs` may contain docs that weren't inserted

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3343,8 +3343,24 @@ Model.$__insertMany = function(arr, options, callback) {
 
         // `insertedDocs` is a Mongoose-specific property
         const erroredIndexes = new Set(get(error, 'writeErrors', []).map(err => err.index));
+
+        let firstErroredIndex = -1;
         error.insertedDocs = docAttributes.
-          filter((doc, i) => !erroredIndexes.has(i)).
+          filter((doc, i) => {
+            const isErrored = erroredIndexes.has(i);
+
+            if (ordered) {
+              if (firstErroredIndex > -1) {
+                return i < firstErroredIndex;
+              }
+
+              if (isErrored) {
+                firstErroredIndex = i;
+              }
+            }
+
+            return !isErrored;
+          }).
           map(function setIsNewForInsertedDoc(doc) {
             doc.$__reset();
             _setIsNew(doc, false);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4774,6 +4774,31 @@ describe('Model', function() {
       });
     });
 
+    it('insertMany() returns only inserted docs with `ordered = true`', function() {
+      const schema = new Schema({
+        name: { type: String, required: true, unique: true }
+      });
+      const Movie = db.model('Movie', schema);
+
+      const arr = [
+        { name: 'The Phantom Menace' },
+        { name: 'The Empire Strikes Back' },
+        { name: 'The Phantom Menace' },
+        { name: 'Jingle All The Way' }
+      ];
+      const opts = { ordered: true };
+      return co(function*() {
+        yield Movie.init();
+        const err = yield Movie.insertMany(arr, opts).then(() => err, err => err);
+        assert.ok(err);
+        assert.ok(err.insertedDocs);
+
+        assert.equal(err.insertedDocs.length, 2);
+        assert.strictEqual(err.insertedDocs[0].name, 'The Phantom Menace');
+        assert.strictEqual(err.insertedDocs[1].name, 'The Empire Strikes Back');
+      });
+    });
+
     it('insertMany() validation error with ordered true and rawResult true when all documents are invalid', function(done) {
       const schema = new Schema({
         name: { type: String, required: true }


### PR DESCRIPTION
Fixes the bug when `insertedDocs` property may contain docs that were not actually inserted. It only happens when `Model.insertMany()` called with `ordered: true` option. 

Example:

```js
const mongoose = require('mongoose');
const Test = mongoose.model('Test', new mongoose.Schema({ _id: { type: String } }), 'tests');

Test.insertMany(
  [
    { _id: 'test_id' },
    { _id: 'test_id_2' },
    { _id: 'test_id' },
    { _id: 'test_id_3' }
  ],

  { ordered: true }
).catch(error => {
  console.log(error.insertedDocs);

  // =>
  //
  // [
  //   { _id: 'test_id', __v: 0 },
  //   { _id: 'test_id_2', __v: 0 },
  //   { _id: 'test_id_3', __v: 0 }
  // ]

  // mongo$ > db.tests.find()
  //
  // { "_id" : "test_id", "__v" : 0 }
  // { "_id" : "test_id_2", "__v" : 0 }
});
```