### PR TITLE
fix: Model.save does not store fields set with select:false in schema-level

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -11,5 +11,5 @@ exports.internalToObjectOptions = {
   _skipDepopulateTopLevel: true,
   depopulate: true,
   flattenDecimals: false,
-  useProjection: false,
+  useProjection: false
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -10,5 +10,6 @@ exports.internalToObjectOptions = {
   getters: false,
   _skipDepopulateTopLevel: true,
   depopulate: true,
-  flattenDecimals: false
+  flattenDecimals: false,
+  useProjection: false,
 };


### PR DESCRIPTION
**Summary**

This fixes issue #10100 by adding `useProjection: false` into `internalToObjectOptions` variable in "/lib/option.js" file so that when calling `Model.save()`, it would save all the fields, including the fields set `select: false` in schema-level.

**Examples**

Model.save() should store all the fields.
```js
const User = mongoose.model('users', new Schema({
  username: { type: String, required: true },
  password: { type: String, required: true, select: false },  // hidden by default
}, {
  toObject: {
    useProjection: true,  // to enable projection in schema-level
  },
}));

const user = new User({ username: 'testuser', password: 'password' });
await user.save();    // this should do users.insertOne({_id: ObjectId("xxx"), username: 'testuser', password: 'password', __v: 0});
```