### PR TITLE
fix(index.d.ts): add parameter type in merge

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2086,7 +2086,7 @@ declare module 'mongoose' {
     maxTimeMS(ms: number): this;
 
     /** Merges another Query or conditions object into this one. */
-    merge(source: Query<any, any>): this;
+    merge(source: Query<any, any> | FilterQuery<DocType>): this;
 
     /** Specifies a `$mod` condition, filters documents for documents whose `path` property is a number that is equal to `remainder` modulo `divisor`. */
     mod(val: Array<number>): this;


### PR DESCRIPTION
**Summary**

[In Mongoose 5.12.x official document](https://mongoosejs.com/docs/api/query.html#query_Query-merge), type of `source` parameter in `Query.prototype.merge()` is `Query | Object`.
So, I add `FilterQuery<DocType>` to `source` parameter type.

Please check it :)