### PR TITLE
style: update carbon format

### DIFF
--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -76,6 +76,10 @@ pre code {
   text-transform: none;
 }
 
+.pure-menu {
+  padding-bottom: 180px;
+}
+
 .pure-menu-item {
   height: 28px;
   font-size: 12pt;
@@ -323,33 +327,77 @@ pre {
 
 /* CPM ads */
 
-.carbonad{
-  margin-top:0!important;
-  margin-bottom:-3rem!important
+.cpc-ad #carbonads * {
+  margin: initial;
+  padding: initial;
 }
 
-#carbonads {
-  position:fixed;
-  right: 0px;
-  bottom: 0px;
-  display:block;
-  width:160px;
-  padding:15px 15px 15px 150px;
-  overflow:hidden;
-  font-size:13px;
-  line-height:1.4;
-  text-align:left;
-  background-color: #fafafa;
+.cpc-ad #carbonads {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial,
+    sans-serif;
+    position: fixed;
+    bottom: 0;
 }
 
-@media (max-width: 1485px) {
-  #carbonads {
-    display: none !important;
-  }
+.cpc-ad #carbonads {
+  display: flex;
+  max-width: 250px;
+  background-color: hsl(0, 0%, 98%);
+  box-shadow: 0 1px 4px 1px hsla(0, 0%, 0%, 0.1);
+  z-index: 100;
 }
 
-#carbonads a{color:#333;text-decoration:none}
+.cpc-ad #carbonads a {
+  color: inherit;
+  text-decoration: none;
+}
 
-.carbon-img{float:left;margin-left:-145px}
+.cpc-ad #carbonads a:hover {
+  color: inherit;
+}
 
-.carbon-poweredby{display:block;color:#777!important}
+.cpc-ad #carbonads span {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+.cpc-ad #carbonads .carbon-wrap {
+  display: flex;
+}
+
+.cpc-ad #carbonads .carbon-img {
+  display: block;
+  line-height: 1;
+}
+
+.cpc-ad #carbonads .carbon-img img {
+  display: block;
+  width: 110px;
+  height: auto;
+}
+
+.cpc-ad #carbonads .carbon-text {
+  font-size: 11px;
+  padding: 10px;
+  margin-bottom: 16px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.cpc-ad #carbonads .carbon-poweredby {
+  display: block;
+  padding: 6px 8px;
+  background: #f1f1f2;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  font-size: 8px;
+  line-height: 1;
+  border-top-left-radius: 3px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -299,3 +299,100 @@ h2 a {
   position: relative;
   top: 5px;
 }
+
+/* Carbon Ads - Homepage */
+
+.carbon-home {
+    height: 100px;
+    margin: 3em 0;
+}
+
+.carbon-home #carbonads * {
+  margin: initial;
+  padding: initial;
+}
+
+.carbon-home #carbonads {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial,
+    sans-serif;
+    margin: 0 auto;
+}
+
+.carbon-home #carbonads {
+  display: flex;
+  max-width: 400px;
+  background-color: hsl(0, 0%, 98%);
+  box-shadow: 0 1px 4px 1px hsla(0, 0%, 0%, 0.1);
+  z-index: 100;
+}
+
+.carbon-home #carbonads a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.carbon-home #carbonads a:hover {
+  color: inherit;
+}
+
+.carbon-home #carbonads span {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+.carbon-home #carbonads .carbon-wrap {
+  display: flex;
+}
+
+.carbon-home #carbonads .carbon-img {
+  display: block;
+  margin: 0;
+  line-height: 1;
+}
+
+.carbon-home #carbonads .carbon-img img {
+  display: block;
+}
+
+.carbon-home #carbonads .carbon-text {
+  font-size: 13px;
+  padding: 10px;
+  margin-bottom: 16px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.carbon-home #carbonads .carbon-poweredby {
+  display: block;
+  padding: 6px 8px;
+  background: #f1f1f2;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  font-size: 8px;
+  line-height: 1;
+  border-top-left-radius: 3px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+/* Sponsors */
+
+.sponsors .sponsor {
+    max-height: 50px;
+    width: auto;
+    border: 0;
+}
+
+.sponsors > div {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.sponsors a {
+    margin: 2px;
+}

--- a/index.html
+++ b/index.html
@@ -17,37 +17,6 @@
   text-decoration: none;
 }
 
-.carbonad{
-  margin-top:0!important;
-  margin-bottom:-3rem!important
-}
-
-#carbonads {
-  position:fixed;
-  right: 0px;
-  bottom: 0px;
-  display:block;
-  width:200px;
-  padding:15px 15px 15px 160px;
-  overflow:hidden;
-  font-size:13px;
-  line-height:1.4;
-  text-align:left;
-  background-color: #fafafa;
-}
-
-@media (max-width: 1160px) {
-  #carbonads {
-    display: none !important;
-  }
-}
-
-#carbonads a{color:#333;text-decoration:none}
-
-.carbon-img{float:left;margin-left:-145px}
-
-.carbon-poweredby{display:block;color:#777!important}
-
 img.sponsor {
   margin-right: 10px;
   border: 1px dotted #dfdfdf;
@@ -69,7 +38,7 @@ query building, business logic hooks and more, out of the box.</p>
   <img src="/docs/images/tidelift.svg" />
   <span>Get Professionally Supported Mongoose</span>
 </a>
-</div><div class="carbon-ad"><script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=mongoosejscom" id="_carbonads_js"></script></div><h2 id="getting-started">Getting Started</h2>
+</div><div class="carbon-home"><script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=mongoosejscom" id="_carbonads_js"></script></div><h2 id="getting-started">Getting Started</h2>
 <ul>
 <li><a href="/docs/index.html">quick start guide</a></li>
 </ul>

--- a/index.pug
+++ b/index.pug
@@ -47,37 +47,6 @@ html(lang='en')
         text-decoration: none;
       }
 
-      .carbonad{
-        margin-top:0!important;
-        margin-bottom:-3rem!important
-      }
-
-      #carbonads {
-        position:fixed;
-        right: 0px;
-        bottom: 0px;
-        display:block;
-        width:200px;
-        padding:15px 15px 15px 160px;
-        overflow:hidden;
-        font-size:13px;
-        line-height:1.4;
-        text-align:left;
-        background-color: #fafafa;
-      }
-
-      @media (max-width: 1160px) {
-        #carbonads {
-          display: none !important;
-        }
-      }
-
-      #carbonads a{color:#333;text-decoration:none}
-
-      .carbon-img{float:left;margin-left:-145px}
-
-      .carbon-poweredby{display:block;color:#777!important}
-
       img.sponsor {
         margin-right: 10px;
         border: 1px dotted #dfdfdf;
@@ -139,7 +108,7 @@ html(lang='en')
             <span>Get Professionally Supported Mongoose</span>
           </a>
 
-        div.carbon-ad
+        div.carbon-home
           <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=mongoosejscom" id="_carbonads_js"></script>
 
         :markdown


### PR DESCRIPTION
**Summary**

Update the Carbon format on the homepage and documentation page so it's still visible in smaller viewport without using display: none. The CTR will affect the earnings, so this update will increase the ad revenue. I've also made some changes to how the sponsors are displayed:

- Remove border surrounding the image.
- Change to flex layout with margin between each image.
- Restrict the height to 50px to ensure they look sharper and aligned.

You can check out the screenshot for desktop, docs, and mobile here: https://dropover.cloud/fcb1e7