### PR TITLE
Fix: broken link in document.js

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -805,7 +805,7 @@ Document.prototype.updateOne = function updateOne(doc, options, callback) {
  *
  * ####Valid options:
  *
- *  - same as in [Model.replaceOne](#model_Model.replaceOne)
+ *  - same as in [Model.replaceOne](https://mongoosejs.com/docs/api/model.html#model_Model.replaceOne)
  *
  * @see Model.replaceOne #model_Model.replaceOne
  * @param {Object} doc


### PR DESCRIPTION
This links to an anchor, but the target is on a different page, so this link is broken.

I checked the other links to see how to link, but there are three different approaches used throughout the docs:

 - Relative links: `/docs/api/model.html#model_Model.replaceOne`
 - http links: `http://mongoosejs.com/docs/api/model.html#model_Model.replaceOne`
 - https links: `https://mongoosejs.com/docs/api/model.html#model_Model.replaceOne`

I opted for the https link (`https://mongoosejs.com/docs/api/model.html#model_Model.replaceOne`) since that seemed like the best choice to me.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
