### PR TITLE
Added Document.prototype.parent to type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -543,6 +543,12 @@ declare module 'mongoose' {
     overwrite(obj: DocumentDefinition<this>): this;
 
     /**
+     * If this document is a subdocument or populated document, returns the 
+     * document's parent. Returns undefined otherwise.
+     */
+    parent(): Document | undefined;
+
+    /**
      * Populates document references, executing the `callback` when complete.
      * If you want to use promises instead, use this function with
      * [`execPopulate()`](#document_Document-execPopulate).

--- a/index.d.ts
+++ b/index.d.ts
@@ -546,7 +546,7 @@ declare module 'mongoose' {
      * If this document is a subdocument or populated document, returns the 
      * document's parent. Returns undefined otherwise.
      */
-    parent(): Document | undefined;
+    $parent(): Document | undefined;
 
     /**
      * Populates document references, executing the `callback` when complete.
@@ -1827,6 +1827,9 @@ declare module 'mongoose' {
 
       /** Returns this sub-documents parent document. */
       parent(): Document;
+      
+      /** Returns this sub-documents parent document. */
+      $parent(): Document;
 
       /** Returns this sub-documents parent array. */
       parentArray(): DocumentArray<Document>;
@@ -1861,6 +1864,9 @@ declare module 'mongoose' {
 
       /** Returns this sub-documents parent document. */
       parent(): Document;
+      
+      /** Returns this sub-documents parent document. */
+      $parent(): Document;
     }
   }
 


### PR DESCRIPTION
**Summary**

The type declaration file was missing `Document.prototype.parent()` this is a method as can be seen here 

https://github.com/Automattic/mongoose/blob/80245edf5aeab304411681035f7f4153dbd2b692/lib/document.js#L3725

It is reflected in the docs [here](https://mongoosejs.com/docs/api/document.html#document_Document-parent).

I just added: the definition, and the description from the documentation. Made sure to put it in alphabetical order with the rest.

**Note**

You still need to keep the type declarations for `EmbeddedDocument.prototype.parent()` and `Subdocument.prototype.parent()` because they narrow the return type from `Document | undefined` to `Document`.
