### PR TITLE
fix(typescript): id to be string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -487,7 +487,7 @@ declare module 'mongoose' {
     getChanges(): UpdateQuery<this>;
 
     /** The string version of this documents _id. */
-    id?: any;
+    id?: string;
 
     /** Signal that we desire an increment of this documents version. */
     increment(): this;


### PR DESCRIPTION
**Summary**

When documentation says that its the string version then its type should be string. Otherwise we would need to case the id to a string again, which feels unneccessary.

**Examples**

```typescript
const model = new Model({});
const id = model.id;

if (id === someOtherString) {
}
```