### PR TITLE
ts: fix query async iterator definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1876,7 +1876,7 @@ declare module 'mongoose' {
      * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
      * This is equivalent to calling `.cursor()` with no arguments.
      */
-    [Symbol.asyncIterator]: QueryCursor<DocType>;
+    [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
 
     /** Executes the query */
     exec(): Promise<ResultType>;


### PR DESCRIPTION
Fixes #10250

1. The async iterator is supposed to be a method and not a property;
2. According to underlying implementation, it returns an asyncIterator
   and not a query cursor.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

This PR addresses #10250

**Examples**

The following code now compiles:
```
import { Schema, model } from "mongoose";
interface Test {
  test: string;
}
const schema = new Schema<Test>({
  test: { type: String, required: true },
});
const TestModel = model<Test>("Test", schema);
async function main() {
  const query = TestModel.find({});
  for await (const test of query) {
    console.log(test);
  }
}
```