### PR TITLE
ts: strictly typed query cursor async iterator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2368,6 +2368,8 @@ declare module 'mongoose' {
     T;
 
   class QueryCursor<DocType extends Document> extends stream.Readable {
+    [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
+
     /**
      * Adds a [cursor flag](http://mongodb.github.io/node-mongodb-native/2.2/api/Cursor.html#addCursorFlag).
      * Useful for setting the `noCursorTimeout` and `tailable` flags.


### PR DESCRIPTION
Closes #10252

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

This PR implements #10252 

**Examples**

Currently, the following TypeScript code compiles, with the bug in the code:
```
import { Schema, model } from "mongoose";
interface Test {
  test: string;
}
const schema = new Schema<Test>({
  test: { type: String, required: true },
});
const TestModel = model<Test>("Test", schema);
async function main() {
  const cursor = TestModel.find({}).cursor();
  for await (const test of cursor) {
    console.log(test.tedt); // intentional bug
  }
}
main()
```
The proposed change makes the above not compile