### PR TITLE
fix typo: preferences

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1034,7 +1034,7 @@ Query.prototype.select = function select() {
  *     // read from secondaries with matching tags
  *     new Query().read('s', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }])
  *
- * Read more about how to use read preferrences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
+ * Read more about how to use read preferences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
  *
  * @method read
  * @memberOf Query


### PR DESCRIPTION
Fixes a small documentation typo for the function Query.prototype.read

before: preferrences 

after: preferences