### PR TITLE
`.map`'s `ResultType` must be an array if used over an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2096,7 +2096,7 @@ declare module 'mongoose' {
      * Runs a function `fn` and treats the return value of `fn` as the new value
      * for the query to resolve to.
      */
-    map<MappedType>(fn: (doc: DocType) => MappedType): QueryWithHelpers<MappedType, DocType, THelpers>;
+    map<MappedType>(fn: (doc: DocType) => MappedType): QueryWithHelpers<ResultType extends unknown[] ? MappedType[] : MappedType, DocType, THelpers>;
 
     /** Specifies an `$maxDistance` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     maxDistance(val: number): this;


### PR DESCRIPTION
**Summary**
When using `.map()`, I noticed that the return type wasn't right.

```js
users.find().map((user) => user); // Query<UserDocument, UserDocument>
```

or it should be `Query<UserDocument[], UserDocument>`.

This PR fixes that issue while keeping non-array queries capable of using `.map()`.