### PR TITLE
gh-10275

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3119,7 +3119,7 @@ Document.prototype.$__getArrayPathsToValidate = function() {
 
 Document.prototype.$getAllSubdocs = function $getAllSubdocs() {
   DocumentArray || (DocumentArray = require('./types/documentarray'));
-  Embedded = Embedded || require('./types/embedded');
+  Embedded || (Embedded = require('./types/embedded'));
 
   function docReducer(doc, seed, path) {
     let val = doc;
@@ -3154,17 +3154,18 @@ Document.prototype.$getAllSubdocs = function $getAllSubdocs() {
         }
       });
     } else if (val instanceof Document && val.$__isNested) {
-      seed = Object.keys(val).reduce(function(seed, path) {
-        return docReducer(val, seed, path);
-      }, seed);
+      for (const key of Object.keys(val)) {
+        docReducer(val, seed, key);
+      }
     }
     return seed;
   }
 
-  const _this = this;
-  const subDocs = Object.keys(this._doc).reduce(function(seed, path) {
-    return docReducer(_this, seed, path);
-  }, []);
+  const subDocs = [];
+  const keys = Object.keys(this._doc);
+  for (const key of keys) {
+    docReducer(this, subDocs, key);
+  }
 
   return subDocs;
 };

--- a/lib/helpers/document/compile.js
+++ b/lib/helpers/document/compile.js
@@ -49,108 +49,116 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
   prefix = prefix || '';
 
   if (subprops) {
+    const nested = Object.create(Document.prototype, {
+      $__: { writable: true, enumerable: false, value: void 0 },
+      isNew: { writable: true, enumerable: false, value: true },
+      errors: { writable: true, enumerable: false, value: void 0 },
+      $locals: { writable: true, enumerable: false, value: {} },
+      $op: { writable: true, enumerable: false, value: null },
+      _doc: { writable: true, enumerable: false, value: void 0 },
+      schema: { writable: true, enumerable: false, value: void 0, configurable: true },
+      $__schema: { writable: true, enumerable: false, value: void 0 },
+      documentSchemaSymbol: { writable: true, enumerable: false, value: void 0 }
+    });
+
+    Object.defineProperty(nested, 'toObject', {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: function() {
+        return utils.clone(this.get(path, null, {
+          virtuals: get(this, 'schema.options.toObject.virtuals', null)
+        }));
+      }
+    });
+
+    Object.defineProperty(nested, '$__get', {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: function() {
+        return this.get(path, null, {
+          virtuals: get(this, 'schema.options.toObject.virtuals', null)
+        });
+      }
+    });
+
+    Object.defineProperty(nested, 'toJSON', {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: function() {
+        return this.get(path, null, {
+          virtuals: get(this, 'schema.options.toJSON.virtuals', null)
+        });
+      }
+    });
+
+    Object.defineProperty(nested, '$__isNested', {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: true
+    });
+
+    const _isEmptyOptions = Object.freeze({
+      minimize: true,
+      virtuals: false,
+      getters: false,
+      transform: false
+    });
+    Object.defineProperty(nested, '$isEmpty', {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: function() {
+        return Object.keys(this.get(path, null, _isEmptyOptions) || {}).length === 0;
+      }
+    });
+
+    Object.defineProperty(nested, '$__parent', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: void 0
+    });
+
+    compile(subprops, nested, path, options);
+    const _compiledSubprops = Object.keys(subprops);
+
     Object.defineProperty(prototype, prop, {
       enumerable: true,
       configurable: true,
       get: function() {
-        const _this = this;
         if (!this.$__.getters) {
           this.$__.getters = {};
         }
 
         if (!this.$__.getters[path]) {
-          const nested = Object.create(Document.prototype, getOwnPropertyDescriptors(this));
+          nested.$__ = this.$__;
+          nested.isNew = this.isNew;
+          nested.errors = this.errors;
+          nested.$locals = this.$locals;
+          nested.$op = this.$op;
+          nested._doc = this._doc;
 
+          nested.$__schema = nested[documentSchemaSymbol] = prototype.schema;
+          if (!subprops.hasOwnProperty('schema')) {
+            nested.schema = prototype.schema;
+          }
+          nested.$__parent = this;
           // save scope for nested getters/setters
           if (!prefix) {
             nested.$__[scopeSymbol] = this;
           }
           nested.$__.nestedPath = path;
 
-          Object.defineProperty(nested, 'schema', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: prototype.schema
-          });
+          // Added extra subprops between compilation and access? Add them.
+          // This allows adding virtuals after compiling the schema (re: #10275)
+          if (Object.keys(subprops).length !== _compiledSubprops.length) {
+            compile(subprops, nested, path, options);
+          }
 
-          Object.defineProperty(nested, '$__schema', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: prototype.schema
-          });
-
-          Object.defineProperty(nested, documentSchemaSymbol, {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: prototype.schema
-          });
-
-          Object.defineProperty(nested, 'toObject', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: function() {
-              return utils.clone(_this.get(path, null, {
-                virtuals: get(this, 'schema.options.toObject.virtuals', null)
-              }));
-            }
-          });
-
-          Object.defineProperty(nested, '$__get', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: function() {
-              return _this.get(path, null, {
-                virtuals: get(this, 'schema.options.toObject.virtuals', null)
-              });
-            }
-          });
-
-          Object.defineProperty(nested, 'toJSON', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: function() {
-              return _this.get(path, null, {
-                virtuals: get(_this, 'schema.options.toJSON.virtuals', null)
-              });
-            }
-          });
-
-          Object.defineProperty(nested, '$__isNested', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: true
-          });
-
-          const _isEmptyOptions = Object.freeze({
-            minimize: true,
-            virtuals: false,
-            getters: false,
-            transform: false
-          });
-          Object.defineProperty(nested, '$isEmpty', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: function() {
-              return Object.keys(this.get(path, null, _isEmptyOptions) || {}).length === 0;
-            }
-          });
-
-          Object.defineProperty(nested, '$__parent', {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            value: this
-          });
-
-          compile(subprops, nested, path, options);
           this.$__.getters[path] = nested;
         }
 
@@ -180,32 +188,4 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
       }
     });
   }
-}
-
-// gets descriptors for all properties of `object`
-// makes all properties non-enumerable to match previous behavior to #2211
-function getOwnPropertyDescriptors(object) {
-  const result = {};
-
-  Object.getOwnPropertyNames(object).forEach(function(key) {
-    result[key] = Object.getOwnPropertyDescriptor(object, key);
-    // Assume these are schema paths, ignore them re: #5470
-    if (result[key].get) {
-      delete result[key];
-      return;
-    }
-    result[key].enumerable = [
-      'isNew',
-      '$__',
-      'errors',
-      '_doc',
-      '$locals',
-      '$op',
-      '__parentArray',
-      '__index',
-      '$isDocumentArrayElement'
-    ].indexOf(key) === -1;
-  });
-
-  return result;
 }


### PR DESCRIPTION
I'm going to open and close this PR immediately because unfortunately I don't think going in this direction is going to work. Here's why:

The problem is that `$getAllSubdocs()` triggers every single nested path's getter, and nested path getters currently use `Object.defineProperty()` to correctly create a fake nested property object that looks like a Mongoose document, but looks like a normal object when you call `Object.keys()`.

The approach in this diff _almost_ works. The idea is to move the work of compiling a nested property object up to compile time rather than runtime. But the problem is that every instance of a model has the same nested property instance, which is why the test for #9105 fails: `assert.ok(fromDb.nested.updatedAt > doc.nested.updatedAt)` fails because `fromDb.nested` is the same object as `doc.nested`, even though `fromDb` and `doc` are separate objects.

The other workaround would be to create a `NestedProperty()` class. But the problem there is [enumerability](https://masteringjs.io/tutorials/fundamentals/enumerable). Even if the property is not enumerable on the base class, it becomes enumerable once you set it.

```javascript
function MyClass() {
  this.test = 42;
}

MyClass.prototype = new Object();

Object.defineProperty(MyClass.prototype, 'test', {
  enumerable: false,
  writable: true,
  value: 1
});

const obj = new MyClass();
// ['test']
console.log(Object.keys(obj));
```

[Symbols](https://masteringjs.io/tutorials/fundamentals/symbol) are a potential workaround, but we've run into quite a few issues with symbols due to users having multiple versions of Mongoose installed, and those issues are very hard to debug.

I think this performance impact is enough to justify promoting #7408 (making nested paths into schematypes rather than a separate concept). There's a lot of issues that pop up related to the quirks of nested paths, like #1766, #3896, #1174, and more.