### PR TITLE
Models should follow the schema (Please god I want this for my sanity)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -619,7 +619,7 @@ declare module 'mongoose' {
   export const Model: Model<any>;
   // eslint-disable-next-line no-undef
   interface Model<T, TQueryHelpers = {}, TMethods = {}> extends NodeJS.EventEmitter, AcceptsDiscriminator {
-    new(doc?: T | any): EnforceDocument<T, TMethods>;
+    new(doc?: T): EnforceDocument<T, TMethods>;
 
     aggregate<R = any>(pipeline?: any[]): Aggregate<Array<R>>;
     // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
**Summary**

See, when I create a model, there is never a time where I ever have to create a model for a schema that isn't defined. This is basically to make it so that you NEED a proper document for the proper schema.
Thats it

**Examples**

```ts
new MyModel({must be a schema})
```
