### PR TITLE
check that schema type is an object when setting isUnderneathDocArray

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -777,12 +777,18 @@ Schema.prototype.path = function(path, obj) {
 
   if (schemaType.$isMongooseDocumentArray) {
     for (const key of Object.keys(schemaType.schema.paths)) {
-      this.subpaths[path + '.' + key] = schemaType.schema.paths[key];
-      schemaType.schema.paths[key].$isUnderneathDocArray = true;
+      const _schemaType = schemaType.schema.paths[key];
+      this.subpaths[path + '.' + key] = _schemaType;
+      if (typeof _schemaType === 'object' && _schemaType != null) {
+        _schemaType.$isUnderneathDocArray = true;
+      }
     }
     for (const key of Object.keys(schemaType.schema.subpaths)) {
-      this.subpaths[path + '.' + key] = schemaType.schema.subpaths[key];
-      schemaType.schema.subpaths[key].$isUnderneathDocArray = true;
+      const _schemaType = schemaType.schema.subpaths[key];
+      this.subpaths[path + '.' + key] = _schemaType;
+      if (typeof _schemaType === 'object' && _schemaType != null) {
+        _schemaType.$isUnderneathDocArray = true;
+      }
     }
     for (const key of Object.keys(schemaType.schema.singleNestedPaths)) {
       const _schemaType = schemaType.schema.singleNestedPaths[key];


### PR DESCRIPTION
**Summary**
Originally mentioned here:
https://github.com/Automattic/mongoose/issues/10193 which was (at least partially for us) fixed by @vkarpov15 

When checking if `isUnderneathDocArray` should be true for a given schema the root object of a sub document can be just 'nested' and so it throws an error: "Cannot create property '$isUnderneathDocArray' on string 'nested'".

This fix just slightly extends the work of @vkarpov15 by adding his fix to `schemaType.schema.paths` and `schemaType.schema.subpaths` in addition to `schemaType.schema.singleNestedPaths`.

More recently mentioned here:
https://github.com/Automattic/mongoose/issues/10357

**Examples**
Slightly modified version @IslandRhythms  example (removed need to connect to db since this happens on schema compilation):
```
const mongoose = require('mongoose');
const Schema = mongoose.Schema;

const OutputSchema = new Schema({
      1: { left: { type: String }},
});

const AslSchema = new Schema({
  output: { type: OutputSchema }
});

const SessionSchema = new Schema({
  asls: { type: [AslSchema] }
});

const BlockSchema = new Schema({
  sessions: { type: [SessionSchema]  }
});

const Test = mongoose.model('Test', BlockSchema);

async function test() {
    await Test.validate({sessions: {asls: [{output: {1: {left: 'Test'}}}]}});
}

test();
```
