### PR TITLE
fix typo (compatability → compatibility)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2787,7 +2787,7 @@ declare module 'mongoose' {
 
   /** Deprecated types for backwards compatibility. */
 
-  /** Alias for QueryOptions for backwards compatability. */
+  /** Alias for QueryOptions for backwards compatibility. */
   type ModelUpdateOptions = QueryOptions;
 
   type DocumentQuery<ResultType, DocType extends Document, THelpers = {}> = Query<ResultType, DocType, THelpers>;


### PR DESCRIPTION
**Summary**

Fixed typo.

`compatability → compatibility`

