### PR TITLE
fix(types): remove discriminator type requirement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -618,8 +618,8 @@ declare module 'mongoose' {
 
   interface AcceptsDiscriminator {
     /** Adds a discriminator type. */
-    discriminator<D extends Document>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<D>;
-    discriminator<T extends Document, U extends Model<T>>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
+    discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<D>;
+    discriminator<T, U extends Model<T>>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
   }
 
   interface AnyObject { [k: string]: any }
@@ -1703,8 +1703,8 @@ declare module 'mongoose' {
 
         static options: { castNonArrays: boolean; };
 
-        discriminator<D extends Document>(name: string | number, schema: Schema<D>, value?: string): Model<D>;
-        discriminator<T extends Document, U extends Model<T>>(name: string | number, schema: Schema<T, U>, value?: string): U;
+        discriminator<D>(name: string | number, schema: Schema<D>, value?: string): Model<D>;
+        discriminator<T, U extends Model<T>>(name: string | number, schema: Schema<T, U>, value?: string): U;
 
         /**
          * Adds an enum validator if this is an array of strings or numbers. Equivalent to
@@ -1760,8 +1760,8 @@ declare module 'mongoose' {
 
         static options: { castNonArrays: boolean; };
 
-        discriminator<D extends Document>(name: string | number, schema: Schema<D>, value?: string): Model<D>;
-        discriminator<T extends Document, U extends Model<T>>(name: string | number, schema: Schema<T, U>, value?: string): U;
+        discriminator<D>(name: string | number, schema: Schema<D>, value?: string): Model<D>;
+        discriminator<T, U extends Model<T>>(name: string | number, schema: Schema<T, U>, value?: string): U;
 
         /** The schema used for documents in this array */
         schema: Schema;


### PR DESCRIPTION
**Summary**

As described in the issue #10421, the `.discriminator` function is yielding an error when trying to use an interface that doesn't extends `Document`.
Since Model enforces Document when needed, the discriminator type parameter doesn't need to extend it.

Fixes #10421

**Examples**

```typescript
import { Model, model, Schema } from 'mongoose';

const options = { discriminatorKey: 'kind' };
interface IEvent {
  time: Date;
  kind: string;
}

const eventSchema = new Schema<IEvent, Model<IEvent>>({ time: Date }, options);
const Event = model<IEvent, Model<IEvent>>('Event', eventSchema);

interface IClickedLinkEvent extends IEvent {
  url: string;
}

// ClickedLinkEvent is a special type of Event that has
// a URL.
const ClickedLinkEvent = Event.discriminator<
  IClickedLinkEvent, // <-- no more error here
  Model<IClickedLinkEvent>
>('ClickedLink', new Schema({ url: String }, options));
```
