### PR TITLE
lint: remove unnecessary 'eslint-disable' comments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,6 @@ declare module 'mongoose' {
    * Mongoose constructor. The exports object of the `mongoose` module is an instance of this
    * class. Most apps will only use this one instance.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-types
   export const Mongoose: new (options?: object | null) => typeof mongoose;
 
   /**
@@ -626,12 +625,10 @@ declare module 'mongoose' {
   type EnforceDocument<T, TMethods> = T extends Document ? T : T & Document<any, any, T> & TMethods;
 
   export const Model: Model<any>;
-  // eslint-disable-next-line no-undef
   interface Model<T, TQueryHelpers = {}, TMethods = {}> extends NodeJS.EventEmitter, AcceptsDiscriminator {
     new(doc?: T | any): EnforceDocument<T, TMethods>;
 
     aggregate<R = any>(pipeline?: any[]): Aggregate<Array<R>>;
-    // eslint-disable-next-line @typescript-eslint/ban-types
     aggregate<R = any>(pipeline: any[], cb: Function): Promise<Array<R>>;
 
     /** Base Mongoose instance the model uses. */
@@ -722,7 +719,6 @@ declare module 'mongoose' {
      * Event emitter that reports any errors that occurred. Useful for global error
      * handling.
      */
-    // eslint-disable-next-line no-undef
     events: NodeJS.EventEmitter;
 
     /**
@@ -802,7 +798,6 @@ declare module 'mongoose' {
     watch(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream;
 
     /** Adds a `$where` clause to this query */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     $where(argument: string | Function): QueryWithHelpers<Array<EnforceDocument<T, TMethods>>, EnforceDocument<T, TMethods>, TQueryHelpers, T>;
 
     /** Registered discriminators for this model. */
@@ -998,7 +993,6 @@ declare module 'mongoose' {
   }
 
   interface MapReduceOptions<T, Key, Val> {
-    // eslint-disable-next-line @typescript-eslint/ban-types
     map: Function | string;
     reduce: (key: Key, vals: T[]) => Val;
     /** query filter object. */
@@ -1152,11 +1146,9 @@ declare module 'mongoose' {
      * [statics](http://mongoosejs.com/docs/guide.html#statics), and
      * [methods](http://mongoosejs.com/docs/guide.html#methods).
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     loadClass(model: Function, onlyVirtuals?: boolean): this;
 
     /** Adds an instance method to documents constructed from Models compiled from this schema. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     method(name: string, fn: (this: EnforceDocument<DocType, TInstanceMethods>, ...args: any[]) => any, opts?: any): this;
     method(obj: { [name: string]: (this: EnforceDocument<DocType, TInstanceMethods>, ...args: any[]) => any }): this;
 
@@ -1227,9 +1219,7 @@ declare module 'mongoose' {
     set(path: string, value: any, _tags?: any): this;
 
     /** Adds static "class" methods to Models compiled from this schema. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     static(name: string, fn: (this: M, ...args: any[]) => any): this;
-    // eslint-disable-next-line @typescript-eslint/ban-types
     static(obj: { [name: string]: (this: M, ...args: any[]) => any }): this;
 
     /** Object of currently defined statics on this schema. */
@@ -1452,7 +1442,6 @@ declare module 'mongoose' {
     alias?: string;
 
     /** Function or object describing how to validate this schematype. See [validation docs](https://mongoosejs.com/docs/validation.html). */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     validate?: RegExp | [RegExp, string] | Function | [Function, string] | ValidateOpts<T> | ValidateOpts<T>[];
 
     /** Allows overriding casting logic for this individual path. If a string, the given string overwrites Mongoose's default cast error message. */
@@ -1548,7 +1537,6 @@ declare module 'mongoose' {
     _id?: boolean;
 
     /** If set, specifies the type of this map's values. Mongoose will cast this map's values to the given type. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     of?: Function | SchemaDefinitionProperty<any>;
 
     /** If true, uses Mongoose's default `_id` settings. Only allowed for ObjectIds */
@@ -1975,7 +1963,6 @@ declare module 'mongoose' {
     // @todo: this doesn't seem right
     exec(callback?: (err: CallbackError, result: ResultType) => void): Promise<ResultType> | any;
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     $where(argument: string | Function): QueryWithHelpers<DocType[], DocType, THelpers, RawDocType>;
 
     /** Specifies an `$all` query condition. When called with one argument, the most recent path passed to `where()` is used. */
@@ -2054,9 +2041,7 @@ declare module 'mongoose' {
     distinct(field: string, filter?: FilterQuery<DocType>, callback?: (err: CallbackError, count: number) => void): QueryWithHelpers<Array<any>, DocType, THelpers, RawDocType>;
 
     /** Specifies a `$elemMatch` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     elemMatch(val: Function | any): this;
-    // eslint-disable-next-line @typescript-eslint/ban-types
     elemMatch(path: string, val: Function | any): this;
 
     /**
@@ -2443,7 +2428,6 @@ declare module 'mongoose' {
 
   type actualPrimitives = string | boolean | number | bigint | symbol | null | undefined;
   type TreatAsPrimitives = actualPrimitives |
-      // eslint-disable-next-line no-undef
     NativeDate | RegExp | symbol | Error | BigInt | Types.ObjectId;
 
   type LeanType<T> =
@@ -2694,7 +2678,6 @@ declare module 'mongoose' {
     constructor(path: string, options?: any, instance?: string);
 
     /** Get/set the function used to cast arbitrary values to this type. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     static cast(caster?: Function | boolean): Function;
 
     static checkRequired(checkRequired?: (v: any) => boolean): (v: any) => boolean;
@@ -2715,7 +2698,6 @@ declare module 'mongoose' {
     default(val: any): any;
 
     /** Adds a getter to this schematype. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     get(fn: Function): this;
 
     /**
@@ -2743,7 +2725,6 @@ declare module 'mongoose' {
     select(val: boolean): this;
 
     /** Adds a setter to this schematype. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     set(fn: Function): this;
 
     /** Declares a sparse index. */
@@ -2759,7 +2740,6 @@ declare module 'mongoose' {
     unique(bool: boolean): this;
 
     /** Adds validator(s) for this document path. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     validate(obj: RegExp | Function | any, errorMsg?: string,
       type?: string): this;
   }

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -451,7 +451,7 @@ SchemaArray.prototype._castForPopulate = function _castForPopulate(value, doc) {
  */
 
 SchemaArray.prototype.discriminator = function(name, schema) {
-  let arr = this; // eslint-disable-line consistent-this
+  let arr = this;
   while (arr.$isMongooseArray && !arr.$isMongooseDocumentArray) {
     arr = arr.casterConstructor;
     if (arr == null || typeof arr === 'function') {

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -397,7 +397,7 @@ EmbeddedDocument.prototype.ownerDocument = function() {
 
 EmbeddedDocument.prototype.$__fullPath = function(path) {
   if (!this.$__.fullPath) {
-    let parent = this; // eslint-disable-line consistent-this
+    let parent = this;
     if (!parent[documentArrayParent]) {
       return path;
     }

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -39,7 +39,6 @@ schema.post<ITest>('save', function() {
   console.log(this.name);
 });
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 schema.post<ITest>('save', function(err: Error, res: ITest, next: Function) {
   console.log(this.name, err.stack);
 });


### PR DESCRIPTION
**Summary**
ESLint doesn't throw errors or warnings after removing these comments. Some of the rules have already been globally disabled.