### PR TITLE
Add `MongooseOptions` interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module 'mongoose' {
    * Mongoose constructor. The exports object of the `mongoose` module is an instance of this
    * class. Most apps will only use this one instance.
    */
-  export const Mongoose: new (options?: object | null) => typeof mongoose;
+  export const Mongoose: new (options?: MongooseOptions | null) => typeof mongoose;
 
   /**
    * The Mongoose Number [SchemaType](/docs/schematypes.html). Used for
@@ -92,7 +92,7 @@ declare module 'mongoose' {
   export function disconnect(cb: (err: CallbackError) => void): void;
 
   /** Gets mongoose options */
-  export function get(key: string): any;
+  export function get<K extends keyof MongooseOptions>(key: K): MongooseOptions[K];
 
   /**
    * Returns true if Mongoose can cast the given value to an ObjectId, or
@@ -128,7 +128,7 @@ declare module 'mongoose' {
   export function pluralize(fn?: ((str: string) => string) | null): ((str: string) => string) | null;
 
   /** Sets mongoose options */
-  export function set(key: string, value: any): void;
+  export function set<K extends keyof MongooseOptions>(key: K, value: MongooseOptions[K]): typeof mongoose;
 
   /**
    * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
@@ -144,6 +144,135 @@ declare module 'mongoose' {
   export type CastError = Error.CastError;
 
   type Mongoose = typeof mongoose;
+
+  interface MongooseOptions {
+    /** true by default. Set to false to skip applying global plugins to child schemas */
+    applyPluginsToChildSchemas?: boolean;
+
+    /**
+     * false by default. Set to true to apply global plugins to discriminator schemas.
+     * This typically isn't necessary because plugins are applied to the base schema and
+     * discriminators copy all middleware, methods, statics, and properties from the base schema.
+     */
+    applyPluginsToDiscriminators?: boolean;
+
+    /**
+     * Set to `true` to make Mongoose call` Model.createCollection()` automatically when you
+     * create a model with `mongoose.model()` or `conn.model()`. This is useful for testing
+     * transactions, change streams, and other features that require the collection to exist.
+     */
+    autoCreate?: boolean;
+
+    /**
+     * true by default. Set to false to disable automatic index creation
+     * for all models associated with this Mongoose instance.
+     */
+    autoIndex?: boolean;
+
+    /** enable/disable mongoose's buffering mechanism for all connections and models */
+    bufferCommands?: boolean;
+
+    bufferTimeoutMS?: number;
+
+    /** false by default. Set to `true` to `clone()` all schemas before compiling into a model. */
+    cloneSchemas?: boolean;
+
+    /**
+     * If `true`, prints the operations mongoose sends to MongoDB to the console.
+     * If a writable stream is passed, it will log to that stream, without colorization.
+     * If a callback function is passed, it will receive the collection name, the method
+     * name, then all arguments passed to the method. For example, if you wanted to
+     * replicate the default logging, you could output from the callback
+     * `Mongoose: ${collectionName}.${methodName}(${methodArgs.join(', ')})`.
+     */
+    debug?:
+      | boolean
+      | { color?: boolean; shell?: boolean }
+      | WritableStream
+      | ((collectionName: string, methodName: string, ...methodArgs: any[]) => void);
+
+    /** If set, attaches [maxTimeMS](https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/) to every query */
+    maxTimeMS?: number;
+
+    /**
+     * true by default. Mongoose adds a getter to MongoDB ObjectId's called `_id` that
+     * returns `this` for convenience with populate. Set this to false to remove the getter.
+     */
+    objectIdGetter?: boolean;
+
+    /**
+     * Set to `true` to default to overwriting models with the same name when calling
+     * `mongoose.model()`, as opposed to throwing an `OverwriteModelError`.
+     */
+    overwriteModels?: boolean;
+
+    /**
+     * If `false`, changes the default `returnOriginal` option to `findOneAndUpdate()`,
+     * `findByIdAndUpdate`, and `findOneAndReplace()` to false. This is equivalent to
+     * setting the `new` option to `true` for `findOneAndX()` calls by default. Read our
+     * `findOneAndUpdate()` [tutorial](https://mongoosejs.com/docs/tutorials/findoneandupdate.html)
+     * for more information.
+     */
+    returnOriginal?: boolean;
+
+    /**
+     * false by default. Set to true to enable [update validators](
+     * https://mongoosejs.com/docs/validation.html#update-validators
+     * ) for all validators by default.
+     */
+    runValidators?: boolean;
+
+    sanitizeProjection?: boolean;
+
+    /**
+     * true by default. Set to false to opt out of Mongoose adding all fields that you `populate()`
+     * to your `select()`. The schema-level option `selectPopulatedPaths` overwrites this one.
+     */
+    selectPopulatedPaths?: boolean;
+
+    setDefaultsOnInsert?: boolean;
+
+    /** true by default, may be `false`, `true`, or `'throw'`. Sets the default strict mode for schemas. */
+    strict?: boolean | 'throw';
+
+    /**
+     * false by default, may be `false`, `true`, or `'throw'`. Sets the default
+     * [strictQuery](https://mongoosejs.com/docs/guide.html#strictQuery) mode for schemas.
+     */
+    strictQuery?: boolean | 'throw';
+
+    /**
+     * `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to
+     * `toJSON()`, for determining how Mongoose documents get serialized by `JSON.stringify()`
+     */
+    toJSON?: ToObjectOptions;
+
+    /** `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to `toObject()` */
+    toObject?: ToObjectOptions;
+
+    /** true by default, may be `false` or `true`. Sets the default typePojoToMixed for schemas. */
+    typePojoToMixed?: boolean;
+
+    /**
+     * false by default. Set to `true` to make Mongoose's default index build use `createIndex()`
+     * instead of `ensureIndex()` to avoid deprecation warnings from the MongoDB driver.
+     */
+    useCreateIndex?: boolean;
+
+    /**
+     * true by default. Set to `false` to make `findOneAndUpdate()` and `findOneAndRemove()`
+     * use native `findOneAndUpdate()` rather than `findAndModify()`.
+     */
+    useFindAndModify?: boolean;
+
+    /** false by default. Set to `true` to make all connections set the `useNewUrlParser` option by default */
+    useNewUrlParser?: boolean;
+
+    usePushEach?: boolean;
+
+    /** false by default. Set to `true` to make all connections set the `useUnifiedTopology` option by default */
+    useUnifiedTopology?: boolean;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface ClientSession extends mongodb.ClientSession { }


### PR DESCRIPTION
**Summary**
Added `MongooseOptions` interface and adjusted `Mongoose` constructor, `Mongoose#get` and `Mongoose#set` types.

**Examples**
![Screenshot from 2021-07-19 20-14-47](https://user-images.githubusercontent.com/66492727/126239442-59e5f594-e599-4860-8618-0b40072e19e4.png)
![Screenshot from 2021-07-19 20-17-06](https://user-images.githubusercontent.com/66492727/126239447-06becfea-7695-40ab-8cb3-81670014c7f4.png)
![Screenshot from 2021-07-19 20-17-33](https://user-images.githubusercontent.com/66492727/126239453-d9467983-70d4-47b9-8072-6c4fc4f1e234.png)

