### PR TITLE
Make LeanDocument work with PopulatedDoc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2438,12 +2438,17 @@ declare module 'mongoose' {
   type LeanArray<T extends unknown[]> = T extends unknown[][] ? LeanArray<T[number]>[] : LeanType<T[number]>[];
 
   export type _LeanDocument<T> = {
-    [K in keyof T]:
-    0 extends (1 & T[K]) ? T[K] : // any
-    T[K] extends unknown[] ? LeanArray<T[K]> : // Array
-    T[K] extends Document ? LeanDocument<T[K]> : // Subdocument
-    T[K];
+    [K in keyof T]: LeanDocumentElement<T[K]>;
   };
+
+  // Keep this a separate type, to ensure that T is a naked type.
+  // This way, the conditional type is distributive over union types.
+  // This is required for PopulatedDoc.
+  type LeanDocumentElement<T> =
+    0 extends (1 & T) ? T : // any
+    T extends unknown[] ? LeanArray<T> : // Array
+    T extends Document ? LeanDocument<T> : // Subdocument
+    T;
 
   export type LeanDocument<T> = Omit<_LeanDocument<T>, Exclude<keyof Document, '_id' | 'id' | '__v'> | '$isSingleNested'>;
 

--- a/test/typescript/main.test.js
+++ b/test/typescript/main.test.js
@@ -198,7 +198,8 @@ describe('typescript syntax', function() {
     if (process.env.D && errors.length) {
       console.log(errors);
     }
-    assert.equal(errors.length, 0);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].messageText.includes('Property \'save\' does not exist'), errors[0].messageText);
   });
 
   it('generics', function() {

--- a/test/typescript/populate.ts
+++ b/test/typescript/populate.ts
@@ -1,4 +1,6 @@
 import { Schema, model, Document, PopulatedDoc } from 'mongoose';
+// Use the mongodb ObjectId to make instanceof calls possible
+import { ObjectId } from "mongodb";
 
 interface Child {
   name: string;
@@ -8,7 +10,7 @@ const childSchema: Schema = new Schema({ name: String });
 const ChildModel = model<Child>('Child', childSchema);
 
 interface Parent {
-  child?: PopulatedDoc<Child & Document>,
+  child?: PopulatedDoc<Child & Document<ObjectId>>,
   name?: string
 }
 
@@ -17,8 +19,21 @@ const ParentModel = model<Parent>('Parent', new Schema({
   name: String
 }));
 
-ParentModel.findOne({}).populate('child').orFail().then((doc: Parent) => {
-  useChildDoc(doc.child);
+ParentModel.findOne({}).populate('child').orFail().then((doc: Parent & Document) => {
+  const child = doc.child;
+  if (child == null || child instanceof ObjectId) {
+    throw new Error('should be populated');
+  } else {
+    useChildDoc(child);
+  }
+  const lean = doc.toObject();
+  const leanChild = lean.child;
+  if (leanChild == null || leanChild instanceof ObjectId) {
+    throw new Error('should be populated');
+  } else {
+    const name = leanChild.name;
+    leanChild.save();
+  }
 });
 
 function useChildDoc(child: Child): void {


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
When we call `toObject()` on a populated document, it also modifies the subdocuments. The type signature of `LeanDocument` does not reflect this change. The reason is that `(ObjectId | Document)` does not extend `Document`, so `LeanDocument` ignores it. This PR modifies the definition of LeanDocument, so it becomes distributive over union types.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
```typescript
import { PopulatedDoc, Document } from "mongoose";
import { ObjectId } from "mongodb";
interface Child {
  name: string;
}
interface Parent {
  child?: PopulatedDoc<Child & Document<ObjectId>>,
}
const parent : Parent & Document = {} as Document; // just for type check
const leanChild = parent.toObject().child;
if (leanChild != null && !(leanChild instanceof ObjectId)) {
  leanChild.save(); // works, but should not work
}
```

**Test case**
The attached test case imports everything from the "mongoose" package (not the local development files), so I think it will not see the changes and shold fail. I did not modify the import as other tests use the same pattern. Also, I used the `ObjectId` from the "mongodb" package, to make `instanceof` type inference possible.