### PR TITLE
Update depopulate documentation for document.js

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4146,7 +4146,7 @@ Document.prototype.populated = function(path, val, options) {
  *       console.log(doc.author); // '5144cf8050f071d979c118a7'
  *     })
  *
- * If the path was not populated, this is a no-op.
+ * If the path was not provided, then all populated fields are returned to their unpopulated state.
  *
  * @param {String} path
  * @return {Document} this


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

**Summary**

Currently the documentation indicates that if a path for depopulate(path) is not provided, then it's a no-op. This is absolutely not true -- in fact, all fields are depopulated. This change fixes the documentation issue.

**Examples**

E.g., depopulate() is not a no-op, it depopulates all populated virtuals.