### PR TITLE
perf: improve typescript type checking performance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2494,9 +2494,9 @@ declare module 'mongoose' {
     ? mongodb.Condition<T[P]>
     : mongodb.Condition<T[P] | string>;
   } &
-    mongodb.RootQuerySelector<T>;
+    mongodb.RootQuerySelector<DocumentDefinition<T>>;
 
-  export type FilterQuery<T> = _FilterQuery<DocumentDefinition<T>>;
+  export type FilterQuery<T> = _FilterQuery<T>;
 
   type NumericTypes = number | mongodb.Decimal128 | mongodb.Double | mongodb.Int32 | mongodb.Long;
 


### PR DESCRIPTION
**Summary**

Related #10349 

You can use the repro at https://github.com/andreialecu/repro-mongoose-slow-ts

Output of `yarn tsc --extendedDiagnostics`.

Before:
```
Identifiers:                 82983
Symbols:                    128042
Types:                       42997
Instantiations:             291774
Memory used:               148795K
Assignability cache size:    13123
Identity cache size:             3
Subtype cache size:              0
Strict subtype cache size:       0
I/O Read time:               0.02s
Parse time:                  0.39s
ResolveModule time:          0.03s
ResolveTypeReference time:   0.00s
Program time:                0.45s
Bind time:                   0.19s
Check time:                  1.21s
transformTime time:          0.00s
commentTime time:            0.00s
I/O Write time:              0.00s
printTime time:              0.01s
Emit time:                   0.01s
Total time:                  1.87s
✨  Done in 2.37s.
```

After:
```
Identifiers:                 82983
Symbols:                     98359
Types:                       23540
Instantiations:             153096
Memory used:               133310K
Assignability cache size:     7426
Identity cache size:             1
Subtype cache size:              0
Strict subtype cache size:       0
I/O Read time:               0.02s
Parse time:                  0.38s
ResolveModule time:          0.02s
ResolveTypeReference time:   0.00s
Program time:                0.44s
Bind time:                   0.19s
Check time:                  0.76s
transformTime time:          0.00s
commentTime time:            0.00s
I/O Write time:              0.00s
printTime time:              0.01s
Emit time:                   0.01s
Total time:                  1.40s
✨  Done in 1.62s.
```

Notice a huge decrease in `types` and `instantiations`, and also in `Check time`.

I'm not sure if this is the right change, but there was some overlap with `_AllowStringsForIds` being used by `DocumentDefinition` doing most of the same work as `_FilterQuery` is doing. That seems unnecessary and the `DocumentDefinition<T>` seems like could be applied to just a specific part of the type.

This doesn't seem to break anything in my code base, and I got most of the speed back.