### PR TITLE
perf: Improve type checking performance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1232,7 +1232,7 @@ declare module 'mongoose' {
   type PostMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, res: ResType, next: (err?: CallbackError) => void) => void | Promise<void>;
   type ErrorHandlingMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: (err?: CallbackError) => void) => void;
 
-  class Schema<DocType = Document, M extends Model<DocType, any, any> = Model<any, any, any>, SchemaDefinitionType = undefined, TInstanceMethods = ExtractMethods<M>> extends events.EventEmitter {
+ class Schema<DocType = Document, M = Model<any, any, any>, SchemaDefinitionType = undefined, TInstanceMethods = any> extends events.EventEmitter {
     /**
      * Create a new schema
      */


### PR DESCRIPTION
### Extends #10515
**Summary**
**Visual Studio code intellicode lags due to the declared Schema Type**
 for testing the speed of the intellicode i used a simple typescript command as `npm run tsc -- --extendedDiagnostics`
**Steps to reproduce**
- clone the repository at : [repro script](https://github.com/perenSHERE/mongoose-repro-intellicode-javascript)
- run  `npm i`
- then run `npm run tsc -- --extendedDiagnostics`
**Results (Before):**
![image](https://user-images.githubusercontent.com/73697546/128019674-14f2144f-b962-4b75-ab90-585ad1710c04.png)
- apply the changes in the **Pull Request**
**Results (After):**
![image](https://user-images.githubusercontent.com/73697546/128019935-e97743e5-7ce9-4ed9-bdba-66244ce9aa81.png)

> This gives me back the snappy intellicode and also doesn't effect the types that much 
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
**Examples**
Before applying the changes in the Pull Request.

https://user-images.githubusercontent.com/73697546/128023769-6fbb0137-c845-48fc-9372-b9a207fbbcbe.mp4

After applying the changes in the Pull Request.

https://user-images.githubusercontent.com/73697546/128024398-76fbeca4-2971-4b62-bff9-6f545c84a71e.mp4



<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->