### PR TITLE
fix: Fixed incorrect type definition for Query's .map function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2290,7 +2290,7 @@ declare module 'mongoose' {
      * Runs a function `fn` and treats the return value of `fn` as the new value
      * for the query to resolve to.
      */
-    map<MappedType>(fn: (doc: DocType) => MappedType): QueryWithHelpers<ResultType extends unknown[] ? MappedType[] : MappedType, DocType, THelpers, RawDocType>;
+    map<MappedType>(fn: (doc: ResultType) => MappedType): QueryWithHelpers<MappedType, DocType, THelpers, RawDocType>;
 
     /** Specifies an `$maxDistance` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     maxDistance(val: number): this;


### PR DESCRIPTION
**Summary**

The type definition for the Query.map() function is incorrect. As an example, it does not understand that a `Model.find()` returns an array nor "pass the mapped value foward" in a correct way

**Examples**

Old:
```typescript
Model.find().map(v => v) // v has type `DocType`
```

New:
```typescript
Model.find().map(v => v) // v has type `DocType[]`
```

Old:
```typescript
Trade.findOne().map(v => v._id).map(w => w) // w has type `DocType`
```

New:
```typescript
Trade.findOne().map(v => v._id).map(w => w) // w has type `ObjectId`
```