### PR TITLE
updated array push type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1970,10 +1970,10 @@ declare module 'mongoose' {
       isMongooseArray: true;
 
       /** Pushes items to the array non-atomically. */
-      nonAtomicPush(...args: any[]): number;
+      nonAtomicPush(...args: T[]): number;
 
       /** Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking. */
-      push(...args: any[]): number;
+      push(...args: T[]): number;
 
       /**
        * Pulls items from the array atomically. Equality is determined by casting

--- a/index.d.ts
+++ b/index.d.ts
@@ -2022,6 +2022,8 @@ declare module 'mongoose' {
 
       /** Searches array items for the first document with a matching _id. */
       id(id: any): T | null;
+
+      push(...args: any[]): number;
     }
 
     class EmbeddedDocument extends Document {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1904,7 +1904,7 @@ declare module 'mongoose' {
 
         /** Sets a maximum number validator. */
         max(value: number, message: string): this;
-\
+
         /** Sets a minimum number validator. */
         min(value: number, message: string): this;
       }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2023,7 +2023,7 @@ declare module 'mongoose' {
       /** Searches array items for the first document with a matching _id. */
       id(id: any): T | null;
 
-      push(...args: Array<AnyKeys<T> & AnyObject>): number;
+      push(...args: (AnyKeys<T> & AnyObject)[]): number;
     }
 
     class EmbeddedDocument extends Document {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1904,7 +1904,7 @@ declare module 'mongoose' {
 
         /** Sets a maximum number validator. */
         max(value: number, message: string): this;
-
+\
         /** Sets a minimum number validator. */
         min(value: number, message: string): this;
       }
@@ -1957,7 +1957,6 @@ declare module 'mongoose' {
   }
 
   namespace Types {
-	type OmitDocumentTypes<T> = T extends Document ? Omit<T, keyof Document> : T
     class Array<T> extends global.Array<T> {
       /** Pops the array atomically at most one time per document `save()`. */
       $pop(): T;
@@ -1974,7 +1973,7 @@ declare module 'mongoose' {
       nonAtomicPush(...args: Array<AnyKeys<T> & AnyObject>): number;
 
       /** Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking. */
-      push(...args: T[]): number;
+      push(...args: (AnyKeys<T> & AnyObject)[]): number;
 
       /**
        * Pulls items from the array atomically. Equality is determined by casting

--- a/index.d.ts
+++ b/index.d.ts
@@ -1970,10 +1970,10 @@ declare module 'mongoose' {
       isMongooseArray: true;
 
       /** Pushes items to the array non-atomically. */
-      nonAtomicPush(...args: Array<AnyKeys<T> & AnyObject>): number;
+      nonAtomicPush(...args: any[]): number;
 
       /** Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking. */
-      push(...args: Array<AnyKeys<T> & AnyObject>): number;
+      push(...args: any[]): number;
 
       /**
        * Pulls items from the array atomically. Equality is determined by casting
@@ -2023,7 +2023,7 @@ declare module 'mongoose' {
       /** Searches array items for the first document with a matching _id. */
       id(id: any): T | null;
 
-      push(...args: Omit<T, keyof Document>[]): number;
+      push(...args: Array<AnyKeys<T> & AnyObject>): number;
     }
 
     class EmbeddedDocument extends Document {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1957,6 +1957,7 @@ declare module 'mongoose' {
   }
 
   namespace Types {
+	type OmitDocumentTypes<T> = T extends Document ? Omit<T, keyof Document> : T
     class Array<T> extends global.Array<T> {
       /** Pops the array atomically at most one time per document `save()`. */
       $pop(): T;
@@ -2023,7 +2024,7 @@ declare module 'mongoose' {
       /** Searches array items for the first document with a matching _id. */
       id(id: any): T | null;
 
-      push(...args: any[]): number;
+      push(...args: Omit<T, keyof Document>[]): number;
     }
 
     class EmbeddedDocument extends Document {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1971,7 +1971,7 @@ declare module 'mongoose' {
       isMongooseArray: true;
 
       /** Pushes items to the array non-atomically. */
-      nonAtomicPush(...args: T[]): number;
+      nonAtomicPush(...args: Array<AnyKeys<T> & AnyObject>): number;
 
       /** Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking. */
       push(...args: T[]): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1973,7 +1973,7 @@ declare module 'mongoose' {
       nonAtomicPush(...args: Array<AnyKeys<T> & AnyObject>): number;
 
       /** Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking. */
-      push(...args: (AnyKeys<T> & AnyObject)[]): number;
+      push(...args: Array<AnyKeys<T> & AnyObject>): number;
 
       /**
        * Pulls items from the array atomically. Equality is determined by casting


### PR DESCRIPTION
**Summary**

Array Push Type accepts the T type parameter, it was any

**Examples**

```ts
//typescript
const x = [1,2,3];
x.push('x') // error

//mongoose array
const x = [1,2,3];
x.push('x') // ok
```
```ts
//mongoose array
const x = [ { a: 1 }, { a: 2 } ];
x.push('x') // ok
x.push({ a: 3 }) // no intellisense

```

