### PR TITLE
Fix type for schema.index() to reflect actual mongoose API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1246,7 +1246,8 @@ declare module 'mongoose' {
   type ExtractQueryHelpers<M> = M extends Model<any, infer TQueryHelpers> ? TQueryHelpers : {};
   type ExtractMethods<M> = M extends Model<any, any, infer TMethods> ? TMethods : {};
 
-  type IndexDefinition<T> = { [K in keyof T]: 1 | -1; };
+  type IndexDirection = 1 | -1;
+  type IndexDefinition<T> = { [K in keyof T]: IndexDirection; };
 
   type PreMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void) => void | Promise<void>;
   type PreSaveMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void, opts: SaveOptions) => void | Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1246,6 +1246,8 @@ declare module 'mongoose' {
   type ExtractQueryHelpers<M> = M extends Model<any, infer TQueryHelpers> ? TQueryHelpers : {};
   type ExtractMethods<M> = M extends Model<any, any, infer TMethods> ? TMethods : {};
 
+  type IndexDefinition<T> = { [K in keyof T]: 1 | -1; };
+
   type PreMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void) => void | Promise<void>;
   type PreSaveMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void, opts: SaveOptions) => void | Promise<void>;
   type PostMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, res: ResType, next: (err?: CallbackError) => void) => void | Promise<void>;
@@ -1277,13 +1279,13 @@ declare module 'mongoose' {
     eachPath(fn: (path: string, type: SchemaType) => void): this;
 
     /** Defines an index (most likely compound) for this schema. */
-    index(fields: mongodb.IndexSpecification, options?: IndexOptions): this;
+    index(fields: IndexDefinition<SchemaDefinition<DocumentDefinition<SchemaDefinitionType>>>, options?: IndexOptions): this;
 
     /**
      * Returns a list of indexes that this schema declares, via `schema.index()`
      * or by `index: true` in a path's options.
      */
-    indexes(): Array<any>;
+    indexes(): Array<IndexDefinition<SchemaDefinition<DocumentDefinition<SchemaDefinitionType>>>>;
 
     /** Gets a schema option. */
     get<K extends keyof SchemaOptions>(key: K): SchemaOptions[K];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1246,9 +1246,9 @@ declare module 'mongoose' {
   type ExtractQueryHelpers<M> = M extends Model<any, infer TQueryHelpers> ? TQueryHelpers : {};
   type ExtractMethods<M> = M extends Model<any, any, infer TMethods> ? TMethods : {};
 
-  type IndexDirection = 1 | -1;
-  type IndexDefinition<T> = { [K in keyof T]: IndexDirection; };
-
+  type IndexDirection = 1 | -1 | '2d' | '2dsphere' | 'geoHaystack' | 'hashed' | 'text';
+  type IndexDefinition = Record<string, IndexDirection>;
+  
   type PreMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void) => void | Promise<void>;
   type PreSaveMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void, opts: SaveOptions) => void | Promise<void>;
   type PostMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, res: ResType, next: (err?: CallbackError) => void) => void | Promise<void>;
@@ -1280,13 +1280,13 @@ declare module 'mongoose' {
     eachPath(fn: (path: string, type: SchemaType) => void): this;
 
     /** Defines an index (most likely compound) for this schema. */
-    index(fields: IndexDefinition<SchemaDefinition<DocumentDefinition<SchemaDefinitionType>>>, options?: IndexOptions): this;
+    index(fields: IndexDefinition, options?: IndexOptions): this;
 
     /**
      * Returns a list of indexes that this schema declares, via `schema.index()`
      * or by `index: true` in a path's options.
      */
-    indexes(): Array<IndexDefinition<SchemaDefinition<DocumentDefinition<SchemaDefinitionType>>>>;
+    indexes(): Array<IndexDefinition>;
 
     /** Gets a schema option. */
     get<K extends keyof SchemaOptions>(key: K): SchemaOptions[K];


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

See issue #10561: the Typescript typings for `Schema.index()` were recently broken.  Commit 1c66cc972c90529bd0ffe8496e9de866b92a97fa broke the typing for `Schema.index()` by making `fields` look like mongo's `IndexSpecification`, when it's not: mongoose has its own idea about what the index specification looks like.  This not only undoes that breaking change, but adds additional type-safety so that only actual schema fields can be used in the index definition.

(I'm not 100% sure about the changed return value on `Schema.indexes()`... there may be prefixing and a `background` field added, as per https://github.com/Automattic/mongoose/blob/master/lib/helpers/schema/getIndexes.js.)

Fixes #10561.


**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

With this change, the following code (as Typescript): 
```ts
import mongoose from "mongoose";

export const schema = new mongoose.Schema({ whatever: String });

schema.index({ whatever: 1 });
```
will not cause an error.  Further, specifying an index of `{ whatever: 2 }` _**will**_ be an error, as only `1` and `-1` are now valid values for the index keys.  Also, `{ somethingElse: 1 }` will be an error as `somethingElse` is not defined as a schema field.

