### PR TITLE
Define `IndexOptions` in terms of `mongodb.IndexOptions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1732,12 +1732,8 @@ declare module 'mongoose' {
     RawId extends RefType = (PopulatedType extends { _id?: RefType; } ? NonNullable<PopulatedType['_id']> : mongoose.Types.ObjectId) | undefined
     > = PopulatedType | RawId;
 
-  interface IndexOptions {
-    background?: boolean,
+  interface IndexOptions extends mongodb.IndexOptions {
     expires?: number | string
-    sparse?: boolean,
-    type?: string,
-    unique?: boolean
   }
 
   interface ValidatorProps {


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The current `IndexOptions` definition is missing some mongo-allowed properties, like `partialFilterExpression`.  Since mongoose simply passes the value along (after handling the added `expires` property), the type should be defined in the same way: as a simple extension to the mongo `IndexOptions` type.


**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
This allows the following to work properly (in Typescript)

```ts
import mongoose from "mongoose";

export const schema = new mongoose.Schema({ whatever: String, useWhatever: Boolean });

schema.index({ whatever: 1 }, { partialFilterExpression: { useWhatever: true } });
```