### PR TITLE
style: add tsdoc to "IndexOptions#expires"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1710,6 +1710,26 @@ declare module 'mongoose' {
     > = PopulatedType | RawId;
 
   interface IndexOptions extends mongodb.CreateIndexesOptions {
+    /**
+     * `expires` utilizes the `ms` module from [guille](https://github.com/guille/) allowing us to use a friendlier syntax:
+     *
+     * @example
+     * ```js
+     * const schema = new Schema({ prop1: Date });
+     * 
+     * // expire in 24 hours
+     * schema.index({ prop1: 1 }, { expires: 60*60*24 })
+     * 
+     * // expire in 24 hours
+     * schema.index({ prop1: 1 }, { expires: '24h' })
+     * 
+     * // expire in 1.5 hours
+     * schema.index({ prop1: 1 }, { expires: '1.5h' })
+     * 
+     * // expire in 7 days
+     * schema.index({ prop1: 1 }, { expires: '7d' })
+     * ```
+     */
     expires?: number | string
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1716,16 +1716,16 @@ declare module 'mongoose' {
      * @example
      * ```js
      * const schema = new Schema({ prop1: Date });
-     * 
+     *
      * // expire in 24 hours
      * schema.index({ prop1: 1 }, { expires: 60*60*24 })
-     * 
+     *
      * // expire in 24 hours
      * schema.index({ prop1: 1 }, { expires: '24h' })
-     * 
+     *
      * // expire in 1.5 hours
      * schema.index({ prop1: 1 }, { expires: '1.5h' })
-     * 
+     *
      * // expire in 7 days
      * schema.index({ prop1: 1 }, { expires: '7d' })
      * ```


### PR DESCRIPTION
**Summary**

Add TSDoc to `IndexOptions#expires`

Examples adapted from 
https://github.com/Automattic/mongoose/blob/ec41d2222e4692169d15c6f0a968c71ed256fd56/lib/schema/date.js#L125-L142

Note: the tests failing should not have anything to do with this PR, because "only a comment is added" inside types