### PR TITLE
allow QueryOptions populate parameter type PopulateOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1079,7 +1079,7 @@ declare module 'mongoose' {
     omitUndefined?: boolean;
     overwrite?: boolean;
     overwriteDiscriminatorKey?: boolean;
-    populate?: string;
+    populate?: string | string[] | PopulateOptions | PopulateOptions[];
     projection?: any;
     /**
      * if true, returns the raw result from the MongoDB driver

--- a/test/typescript/queries.ts
+++ b/test/typescript/queries.ts
@@ -1,13 +1,18 @@
-import { Schema, model, Document, Types, Query, Model, QueryWithHelpers } from 'mongoose';
+import { Schema, model, Document, Types, Query, Model, QueryWithHelpers, PopulatedDoc } from 'mongoose';
+import { ObjectId } from 'mongodb';
 
 interface QueryHelpers {
   _byName(this: QueryWithHelpers<any, ITest, QueryHelpers>, name: string): QueryWithHelpers<Array<ITest>, ITest, QueryHelpers>;
   byName(name: string): QueryWithHelpers<Array<ITest>, ITest, QueryHelpers>;
 }
 
+const childSchema: Schema = new Schema({ name: String });
+const ChildModel = model<Child>('Child', childSchema);
+
 const schema: Schema<ITest, Model<ITest, QueryHelpers>> = new Schema({
   name: { type: 'String' },
   tags: [String],
+  child: { type: 'ObjectId', ref: 'Child' },
   docs: [{ _id: 'ObjectId', id: Number, tags: [String] }],
   endDate: Date
 });
@@ -21,6 +26,9 @@ schema.query.byName = function(name: string): QueryWithHelpers<any, ITest> {
   return this._byName(name);
 };
 
+interface Child {
+  name: string;
+}
 interface ISubdoc extends Document {
   myId?: Types.ObjectId;
   id?: number;
@@ -31,12 +39,15 @@ interface ITest extends Document {
   name?: string;
   age?: number;
   parent?: Types.ObjectId;
+  child?: PopulatedDoc<Child & Document<ObjectId>>,
   tags?: string[];
   docs?: ISubdoc[];
   endDate?: Date;
 }
 
 const Test = model<ITest, Model<ITest, QueryHelpers>>('Test', schema);
+
+Test.find({}, {}, {populate:{path:"child", model:ChildModel, match:true}}).exec().then((res: Array<ITest>) => console.log(res))
 
 Test.find().byName('test').byName('test2').orFail().exec().then(console.log);
 


### PR DESCRIPTION
**Summary**
Mongoose 5.10.x version `QueryOptions` method populate property type allow to use `string`, `ModelPopulateOptions`. This make it easy to develop generic mongoose crud operation. I checked and realized after mongoose version 5.10.x some method is changed. I changed to populate property type for adapt new version.  


**Examples**
Mongoose 5.10.x index.d.ts :
```ts
interface QueryFindBaseOptions {
        /** Sets a default collation for every query and aggregation. */
        collation?: CollationOptions;
        explain?: any;
        lean?: boolean;
        populate?: string | ModelPopulateOptions;
        /** like select, it determines which fields to return */
        projection?: any;
        /** use client session for transaction */
        session?: ClientSession;
    }
```
Mongoose 5.13.7 index.d.ts :
```ts
  interface QueryOptions {
    arrayFilters?: { [key: string]: any }[];
    batchSize?: number;
    collation?: mongodb.CollationDocument;
    comment?: any;
    context?: string;
    explain?: any;
    fields?: any | string;
    hint?: any;
    /**
     * If truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document.
     */
    lean?: boolean | any;
    limit?: number;
    maxTimeMS?: number;
    maxscan?: number;
    multi?: boolean;
    multipleCastError?: boolean;
    /**
     * By default, `findOneAndUpdate()` returns the document as it was **before**
     * `update` was applied. If you set `new: true`, `findOneAndUpdate()` will
     * instead give you the object after `update` was applied.
     */
    new?: boolean;
    omitUndefined?: boolean;
    overwrite?: boolean;
    overwriteDiscriminatorKey?: boolean;
    populate?: string | string[] | PopulateOptions | PopulateOptions[];
    projection?: any;
    /**
     * if true, returns the raw result from the MongoDB driver
     */
    rawResult?: boolean;
    readPreference?: mongodb.ReadPreferenceMode;
    /**
     * An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
     */
    returnOriginal?: boolean;
    /**
     * Another alias for the `new` option. `returnOriginal` is deprecated so this should be used.
     */
    returnDocument?: string;
    runValidators?: boolean;
    sanitizeProjection?: boolean;
    /** The session associated with this query. */
    session?: mongodb.ClientSession;
    setDefaultsOnInsert?: boolean;
    skip?: number;
    snapshot?: any;
    sort?: any;
    /** overwrites the schema's strict mode option */
    strict?: boolean | string;
    tailable?: number;
    /**
     * If set to `false` and schema-level timestamps are enabled,
     * skip timestamps for this update. Note that this allows you to overwrite
     * timestamps. Does nothing if schema-level timestamps are not set.
     */
    timestamps?: boolean;
    upsert?: boolean;
    useFindAndModify?: boolean;
    writeConcern?: any;
  }
```

I changed populate method   : 
```ts
// Before : 
populate: string
// After:
populate?: string | string[] | PopulateOptions | PopulateOptions[];
```

Through of this change We can use the find method as in the 5.10.x version: 
`find(FilterQuery<T>, projection ,options?: {populate:{path:"<relation path>, model:<relation db schema>"}})` .