### PR TITLE
Add migration to 6.x in Migration Guides section

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -42,6 +42,7 @@ integrating Mongoose with external tools and frameworks.
 
 ### Migration Guides
 
+* [Mongoose 5.x to 6.x](/docs/migrating_to_6.html)
 * [Mongoose 4.x to 5.x](/docs/migrating_to_5.html)
 * [Mongoose 3.x to 4.x](/docs/migration.html)
 


### PR DESCRIPTION
The 6.x migration guide is currently missing in the section as can be seen [here](https://mongoosejs.com/docs/guides.html).

I just added the link in.