### PR TITLE
(quickstart) remove await for connection, not required as per #10610

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,14 +29,8 @@ connection to the `test` database on our locally running instance of MongoDB.
 // getting-started.js
 const mongoose = require('mongoose');
 
-main().catch(err => console.log(err));
-
-async function main() {
-  await mongoose.connect('mongodb://localhost:27017/test');
-}
+mongoose.connect('mongodb://localhost:27017/test');
 ```
-
-For brevity, let's assume that all following code is within the `main()` function.
 
 With Mongoose, everything is derived from a [Schema](/docs/guide.html).
 Let's get a reference to it and define our kittens.


### PR DESCRIPTION
As per https://github.com/Automattic/mongoose/issues/10610#issuecomment-906413825 await is not required anymore. It was only necessary as a temporary workaround of a bug in 6.0.1 which <s>was fixed in 6.0.2 here</s> https://github.com/Automattic/mongoose/commit/86f53ad99f1eab6fbf370ae544da88cbf9f4fb01 hasn't been fixed yet, see https://github.com/Automattic/mongoose/issues/10610#issuecomment-907060604