### PR TITLE
 Support removing fields from projections

### DIFF
--- a/lib/helpers/projection/isSubpath.js
+++ b/lib/helpers/projection/isSubpath.js
@@ -9,15 +9,5 @@
  */
 
 module.exports = function isSubpath(path1, path2) {
-  const path1Parts = path1.split('.');
-  const path2Parts = path2.split('.');
-  for (let i = 0; i < Math.min(path1Parts.length, path2Parts.length); ++i) {
-    // If any path parts don't match, then path1 is not a subpath of path2
-    if (path1Parts[i] !== path2Parts[i]) {
-      return false;
-    }
-  }
-  // If all corresponding parts match, but path1 has more parts than path2, then path1 is not a subpath of path2
-  // e.g. "a.b" is not a subpath of "a.b.c"
-  return path1Parts.length <= path2Parts.length;
+  return path1 === path2 || path2.startsWith(path1 + '.');
 };

--- a/lib/helpers/projection/isSubpath.js
+++ b/lib/helpers/projection/isSubpath.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/*!
+ * Determines if `path2` is a subpath of or equal to `path1`
+ *
+ * @param {string} path1
+ * @param {string} path2
+ * @return {Boolean}
+ */
+
+module.exports = function isSubpath(path1, path2) {
+  const path1Parts = path1.split('.');
+  const path2Parts = path2.split('.');
+  for (let i = 0; i < Math.min(path1Parts.length, path2Parts.length); ++i) {
+    // If any path parts don't match, then path1 is not a subpath of path2
+    if (path1Parts[i] !== path2Parts[i]) {
+      return false;
+    }
+  }
+  // If all corresponding parts match, but path1 has more parts than path2, then path1 is not a subpath of path2
+  // e.g. "a.b" is not a subpath of "a.b.c"
+  return path1Parts.length <= path2Parts.length;
+};

--- a/lib/query.js
+++ b/lib/query.js
@@ -999,6 +999,10 @@ Query.prototype.projection = function(arg) {
  *     query.select({ a: 1, b: 1 });
  *     query.select({ c: 0, d: 0 });
  *
+ *     Additional calls to select can override the previous selection:
+ *     query.select({ a: 1, b: 1 }).select({ b: 0 }); // selection is now { a: 1 }
+ *     query.select({ a: 0, b: 0 }).select({ b: 1 }); // selection is now { a: 0 }
+ *
  *
  * @method select
  * @memberOf Query

--- a/lib/query.js
+++ b/lib/query.js
@@ -25,6 +25,7 @@ const helpers = require('./queryhelpers');
 const immediate = require('./helpers/immediate');
 const isExclusive = require('./helpers/projection/isExclusive');
 const isInclusive = require('./helpers/projection/isInclusive');
+const isSubpath = require('./helpers/projection/isSubpath');
 const mquery = require('mquery');
 const parseProjection = require('./helpers/projection/parseProjection');
 const removeUnusedArrayFilters = require('./helpers/update/removeUnusedArrayFilters');
@@ -1029,17 +1030,50 @@ Query.prototype.select = function select() {
     sanitizeProjection = this._mongooseOptions.sanitizeProjection;
   }
 
+  function sanitizeValue(value) {
+    return typeof value === 'string' && sanitizeProjection ? value = 1 : value;
+  }
+
   arg = parseProjection(arg);
 
   if (utils.isObject(arg)) {
-    const keys = Object.keys(arg);
-    for (let i = 0; i < keys.length; ++i) {
-      let value = arg[keys[i]];
-      if (typeof value === 'string' && sanitizeProjection) {
-        value = 1;
+    if (this.selectedInclusively()) {
+      Object.entries(arg).forEach(([key, value]) => {
+        if (value) {
+          // Add the field to the projection
+          fields[key] = userProvidedFields[key] = sanitizeValue(value);
+        } else {
+          // Remove the field from the projection
+          Object.keys(userProvidedFields).forEach(field => {
+            if (isSubpath(key, field)) {
+              delete fields[field];
+              delete userProvidedFields[field];
+            }
+          });
+        }
+      });
+    } else if (this.selectedExclusively()) {
+      Object.entries(arg).forEach(([key, value]) => {
+        if (!value) {
+          // Add the field to the projection
+          fields[key] = userProvidedFields[key] = sanitizeValue(value);
+        } else {
+          // Remove the field from the projection
+          Object.keys(userProvidedFields).forEach(field => {
+            if (isSubpath(key, field)) {
+              delete fields[field];
+              delete userProvidedFields[field];
+            }
+          });
+        }
+      });
+    } else {
+      const keys = Object.keys(arg);
+      for (let i = 0; i < keys.length; ++i) {
+        const value = arg[keys[i]];
+        fields[keys[i]] = sanitizeValue(value);
+        userProvidedFields[keys[i]] = sanitizeValue(value);
       }
-      fields[keys[i]] = value;
-      userProvidedFields[keys[i]] = value;
     }
     return this;
   }

--- a/test/helpers/projection.test.js
+++ b/test/helpers/projection.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require('assert');
+const isSubpath = require('../../lib/helpers/projection/isSubpath');
+
+describe('isSubpath', function() {
+  it('handles single-part paths', function(done) {
+    assert.equal(isSubpath('a', 'a'), true);
+    assert.equal(isSubpath('a', 'b'), false);
+
+    done();
+  });
+
+  it('handles multi-part paths', function(done) {
+    assert.equal(isSubpath('a.b.c', 'a.b.c'), true);
+    assert.equal(isSubpath('a.c.b', 'a.b.c'), false);
+    assert.equal(isSubpath('a', 'a.b.c'), true);
+    assert.equal(isSubpath('a.b.c', 'a'), false);
+
+    done();
+  });
+});

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -89,10 +89,40 @@ describe('Query', function() {
       assert.deepEqual(query._fields, { a: 1 });
       query.select('b');
       assert.deepEqual(query._fields, { a: 1, b: 1 });
-      query.select({ c: 0 });
-      assert.deepEqual(query._fields, { a: 1, b: 1, c: 0 });
-      query.select('-d');
-      assert.deepEqual(query._fields, { a: 1, b: 1, c: 0, d: 0 });
+      query.select({ c: 1 });
+      assert.deepEqual(query._fields, { a: 1, b: 1, c: 1 });
+      query.select('d');
+      assert.deepEqual(query._fields, { a: 1, b: 1, c: 1, d: 1 });
+      done();
+    });
+
+    it('should remove existing fields from inclusive projection', function(done) {
+      const query = new Query({});
+      query.select({
+        a: 1,
+        b: 1,
+        c: 1,
+        'parent1.child1': 1,
+        'parent1.child2': 1,
+        'parent2.child1': 1,
+        'parent2.child2': 1
+      }).select({ b: 0, d: 1, 'c.child': 0, parent1: 0, 'parent2.child1': 0 });
+      assert.deepEqual(query._fields, { a: 1, c: 1, d: 1, 'parent2.child2': 1 });
+      done();
+    });
+
+    it('should remove existing fields from exclusive projection', function(done) {
+      const query = new Query({});
+      query.select({
+        a: 0,
+        b: 0,
+        c: 0,
+        'parent1.child1': 0,
+        'parent1.child2': 0,
+        'parent2.child1': 0,
+        'parent2.child2': 0
+      }).select({ b: 1, d: 0, 'c.child': 1, parent1: 1, 'parent2.child1': 1 });
+      assert.deepEqual(query._fields, { a: 0, c: 0, d: 0, 'parent2.child2': 0 });
       done();
     });
   });


### PR DESCRIPTION
Closes #10628, including new documentation.

**Summary**

This PR allows you to remove fields from a projection that have previously been added. `query.select({ a: 1, b: 1 }).select({ b: 0 })` now produces the valid projection `{ a: 1 }` instead of the invalid projection `{ a: 1, b: 0 }`.

**Examples**

Check out the tests.