### PR TITLE
chore: remove node 5 upgrade npm from workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Upgrade Node 5 npm
-        run: npm install -g npm@3
-        if: ${{ matrix.node == 5 }}
-
       - run: npm install
 
       - name: Setup


### PR DESCRIPTION
This PR removes the step "Upgrade Node 5 npm" from GItHub workflows, shouldn't be necessary anymore since we're not using node 5 anymore.