### PR TITLE
fix(index.d.ts): fix `Document#populate()` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -642,15 +642,11 @@ declare module 'mongoose' {
      */
     $parent(): Document | undefined;
 
-    /**
-     * Populates document references.
-     */
-    populate(path: string | string[]): Promise<this>;
-    populate(path: string | string[], callback: Callback<this>): void;
+    /** Populates document references. */
+    populate(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<this>;
+    populate(path: string | PopulateOptions | (string | PopulateOptions)[], callback: Callback<this>): void;
     populate(path: string, names: string): Promise<this>;
     populate(path: string, names: string, callback: Callback<this>): void;
-    populate(opts: PopulateOptions | Array<PopulateOptions>): Promise<this>;
-    populate(opts: PopulateOptions | Array<PopulateOptions>, callback: Callback<this>): void;
 
     /** Gets _id(s) used during population of the given `path`. If the path was not populated, returns `undefined`. */
     populated(path: string): any;

--- a/test/typescript/populate.ts
+++ b/test/typescript/populate.ts
@@ -39,3 +39,39 @@ ParentModel.findOne({}).populate('child').orFail().then((doc: Parent & Document)
 function useChildDoc(child: Child): void {
   console.log(child.name.trim());
 }
+
+interface IPerson {
+  name?: string;
+  stories?: PopulatedDoc<IStory>[];
+}
+
+interface IStory {
+  title?: string;
+  author?: PopulatedDoc<IPerson>;
+  fans?: PopulatedDoc<IPerson>[];
+}
+
+const personSchema = new Schema<IPerson>({
+  name: String,
+  stories: [{ type: Schema.Types.ObjectId, ref: 'Story' }]
+});
+
+const storySchema = new Schema<IStory>({
+  title: String,
+  author: { type: Schema.Types.ObjectId, ref: 'Person' },
+  fans: [{ type: Schema.Types.ObjectId, ref: 'Person' }]
+});
+
+const Person = model<IPerson>('Person', personSchema);
+
+const Story = model<IStory>('Story', storySchema);
+
+(async() => {
+  const story = await Story.findOne().orFail();
+
+  await story.populate('author');
+  await story.populate({ path: 'fans' });
+  await story.populate(['author']);
+  await story.populate([{ path: 'fans' }]);
+  await story.populate(['author', { path: 'fans' }]);
+})();


### PR DESCRIPTION
**Summary**
According to [mongoose docs](https://mongoosejs.com/docs/api/document.html#document_Document-populate), `Document#populate()` receives, as the first argument, the path to populate or an options object or an array of paths and/or options objects.
However, in the following code, there is a TypeScript error:

```js
import { Schema, model } from 'mongoose';

const personSchema = new Schema({
  name: String,
  stories: [{ type: Schema.Types.ObjectId, ref: 'Story' }]
});

const storySchema = new Schema({
  title: String,
  author: { type: Schema.Types.ObjectId, ref: 'Person' },
  fans: [{ type: Schema.Types.ObjectId, ref: 'Person' }]
});

const Person = model('Person', personSchema);
const Story = model('Story', storySchema);

(async () => {
  const story = await Story.findOne().orFail(new Error('Story not found'));
  
  await story.populate(['author', { path: 'fans' }]); // This line is causing the error
})();
```

```
No overload matches this call.
  Overload 1 of 6, '(path: string | string[]): Promise<Document<any, any, unknown>>', gave the following error.
    Type '{ path: string; }' is not assignable to type 'string'.
  Overload 2 of 6, '(opts: PopulateOptions | PopulateOptions[]): Promise<Document<any, any, unknown>>', gave the following error.
    Type 'string' is not assignable to type 'PopulateOptions'.ts(2769)
```

This PR solves the problem, allowing us to provide an array mixing paths and option objects.

**Examples**
Now, all of these lines are valid:

```js
  await story.populate('author');
  await story.populate({ path: 'fans' });
  await story.populate(['author']);
  await story.populate([{ path: 'fans' }]);
  await story.populate(['author', { path: 'fans' }]);
```
