### PR TITLE
Mark Model.update and Model.remove as deprecated

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1942,7 +1942,7 @@ Model.translateAliases = function translateAliases(fields) {
  * To remove just the first document that matches `conditions`, set the `single`
  * option to true.
  *
- * This method is deprecated. See [Deprecation Warnings](./deprecations.html#remove) for details.
+ * This method is deprecated. See [Deprecation Warnings](../deprecations.html#remove) for details.
  *
  * ####Example:
  *
@@ -3755,7 +3755,7 @@ Model.hydrate = function(obj, projection) {
  *
  * - `update()`
  *
- * This method is deprecated. See [Deprecation Warnings](./deprecations.html#update) for details.
+ * This method is deprecated. See [Deprecation Warnings](../deprecations.html#update) for details.
  *
  * ####Examples:
  *

--- a/lib/model.js
+++ b/lib/model.js
@@ -1942,6 +1942,8 @@ Model.translateAliases = function translateAliases(fields) {
  * To remove just the first document that matches `conditions`, set the `single`
  * option to true.
  *
+ * This method is deprecated. See [Deprecation Warnings](./deprecations.html#remove) for details.
+ *
  * ####Example:
  *
  *     const res = await Character.remove({ name: 'Eddard Stark' });
@@ -1953,6 +1955,7 @@ Model.translateAliases = function translateAliases(fields) {
  * are involved. Because no Mongoose documents are involved, Mongoose does
  * not execute [document middleware](/docs/middleware.html#types-of-middleware).
  *
+ * @deprecated
  * @param {Object} conditions
  * @param {Object} [options]
  * @param {Session} [options.session=null] the [session](https://docs.mongodb.com/manual/reference/server-sessions/) associated with this operation.
@@ -3752,6 +3755,8 @@ Model.hydrate = function(obj, projection) {
  *
  * - `update()`
  *
+ * This method is deprecated. See [Deprecation Warnings](./deprecations.html#update) for details.
+ *
  * ####Examples:
  *
  *     MyModel.update({ age: { $gt: 18 } }, { oldEnough: true }, fn);
@@ -3799,6 +3804,7 @@ Model.hydrate = function(obj, projection) {
  *
  * Be careful to not use an existing model instance for the update clause (this won't work and can cause weird behavior like infinite loops). Also, ensure that the update clause does not have an _id property, which causes Mongo to return a "Mod on _id not allowed" error.
  *
+ * @deprecated
  * @see strict http://mongoosejs.com/docs/guide.html#strict
  * @see response http://docs.mongodb.org/v2.6/reference/command/update/#output
  * @param {Object} filter


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
`Model.update()` and `Model.remove()` provoke deprecation warnings on the console output. Details can be found on the official [Deprecation Warnings](https://mongoosejs.com/docs/deprecations.html) page.

This PR marks `Model.update()` and `Model.remove()` as deprecated.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
Using `Model.update()` or `Model.remove()` result in deprecation warnings like these:
```
(node:5345) [MONGODB DRIVER] Warning: collection.update is deprecated. Use updateOne, updateMany, or bulkWrite instead.
    at emitWarning (/[...]/node_modules/mongodb/lib/utils.js:1109:20)
    at Object.emitWarningOnce (/[...]/node_modules/mongodb/lib/utils.js:1122:16)
    at Collection.update (/[...]/node_modules/mongodb/lib/collection.js:457:17)
    at NativeCollection.<computed> [as update] (/[...]/node_modules/mongoose/lib/drivers/node-mongodb-native/collection.js:200:33)
    at NodeCollection.update (/[...]/node_modules/mquery/lib/collection/node.js:64:19)
    at model.Query._updateThunk (/[...]/node_modules/mongoose/lib/query.js:3979:23)
    at model.Query.<anonymous> (/[...]/node_modules/mongoose/lib/query.js:4017:23)
    at model.Query._wrappedThunk [as _execUpdate] (/[...]/node_modules/mongoose/lib/helpers/query/wrapThunk.js:27:8)
    at /[...]/node_modules/kareem/index.js:370:33
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
```
```
(node:5345) [MONGODB DRIVER] Warning: collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.
    at emitWarning (/[...]/node_modules/mongodb/lib/utils.js:1109:20)
    at Object.emitWarningOnce (/[...]/node_modules/mongodb/lib/utils.js:1122:16)
    at Collection.remove (/[...]/node_modules/mongodb/lib/collection.js:472:17)
    at NativeCollection.<computed> [as remove] (/[...]/node_modules/mongoose/lib/drivers/node-mongodb-native/collection.js:200:33)
    at NodeCollection.remove (/[...]/node_modules/mquery/lib/collection/node.js:112:19)
    at model.Query.Query.remove (/[...]/node_modules/mquery/lib/mquery.js:2566:20)
    at model.Query.<anonymous> (/[...]/node_modules/mongoose/lib/query.js:2884:28)
    at model.Query._wrappedThunk [as _remove] (/[...]/node_modules/mongoose/lib/helpers/query/wrapThunk.js:27:8)
    at /[...]/node_modules/kareem/index.js:370:33
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
```

