### PR TITLE
ci: add test for ubuntu-20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,20 @@ on:
     push:
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         node: [12, 14, 16]
-    name: Node ${{ matrix.node }}
+        os: [ubuntu-18.04, ubuntu-20.04]
+        include:
+          - os: ubuntu-18.04
+            mongo-os: ubuntu1804
+            mongo: 4.0.2
+          - os: ubuntu-20.04
+            mongo-os: ubuntu2004
+            mongo: 5.0.2
+    name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongo }}
     steps:
       - uses: actions/checkout@v2
 
@@ -22,16 +30,16 @@ jobs:
 
       - name: Setup
         run: |
-          wget -q http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.2.tgz
-          tar xf mongodb-linux-x86_64-ubuntu1804-4.0.2.tgz
+          wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}.tgz
+          tar xf mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}.tgz
           mkdir -p ./data/db/27017 ./data/db/27000
           printf "\n--timeout 8000" >> ./test/mocha.opts
-          ./mongodb-linux-x86_64-ubuntu1804-4.0.2/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
+          ./mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
           sleep 2
           mongod --version
           mkdir ./test/typescript/node_modules
           ln -s `pwd` ./test/typescript/node_modules/mongoose
-          echo `pwd`/mongodb-linux-x86_64-ubuntu1804-4.0.2/bin >> $GITHUB_PATH
+          echo `pwd`/mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}/bin >> $GITHUB_PATH
 
       - run: npm test
 


### PR DESCRIPTION
**Summary**
Adds test for latest Ubuntu LTS, while preserving 4.0 (which has built binaries up to 18.04). 
Can add other versions if/when necessary. 