### PR TITLE
fix(types): Model / Document definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ declare module 'mongoose' {
     collection?: string,
     skipInit?: boolean
   ): U;
+  export function model<T, TQueryHelpers = {}, TMethods = {}, TSchemaDefinitionType = T>(name: string, schema?: Schema<any>, collection?: string, skipInit?: boolean): Model<T, TQueryHelpers, TMethods, TSchemaDefinitionType>;
 
   /** Returns an array of model names created on this instance of Mongoose. */
   export function modelNames(): Array<string>;
@@ -712,7 +713,7 @@ declare module 'mongoose' {
     discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
   }
 
-  type AnyKeys<T> = { [P in keyof T]?: T[P] | any };
+  type AnyKeys<T> = { [P in keyof T]: T[P] | any };
   interface AnyObject { [k: string]: any }
 
   type Require_id<T> = T extends { _id?: any } ? (T & { _id: T['_id'] }) : (T & { _id: Types.ObjectId });
@@ -726,8 +727,8 @@ declare module 'mongoose' {
   }
 
   export const Model: Model<any>;
-  interface Model<T, TQueryHelpers = {}, TMethods = {}> extends NodeJS.EventEmitter, AcceptsDiscriminator {
-    new(doc?: AnyKeys<T> & AnyObject): EnforceDocument<T, TMethods>;
+  interface Model<T, TQueryHelpers = {}, TMethods = {}, TSchemaDefinitionType = T> extends NodeJS.EventEmitter, AcceptsDiscriminator {
+    new(doc?: AnyKeys<TSchemaDefinitionType> & AnyObject): EnforceDocument<T, TMethods>;
 
     aggregate<R = any>(pipeline?: any[], options?: Record<string, unknown>): Aggregate<Array<R>>;
     aggregate<R = any>(pipeline: any[], cb: Function): Promise<Array<R>>;


### PR DESCRIPTION
This PR allow a model to understand document vs a doc type


Given the following setup

```
interface Event {
  name: string
  code?: string
}

const EventSchema = new Schema<Event>(
  {
    name: { type: String, required: true },
    code: { type: String },
  }
)

export const EventModel = model<Event>('Event', EventSchema)
```

Attempting to create the model with the following
```
  const event = new EventModel({code: '1234'})
```

Will not give us a type error, and it should as we are missing `name` from the event model. The fix in this PR to `AnyKeys` will cause this to report properly and inform the user they are missing `name`. I am not sure why `AnyKeys` was turning everything optional prior to this.

**However to continue;** 
The resulting `event` is properly an `Event` but this is incorrect as it is missing the `id`, `_id`  and `__v` fields that are automatically applied to every document. So my suggestion, for those that want full type completion with the actual ID's of their models is to adjust `index.d.ts` as I have here and then setup the following.

```
interface Event {
  name: string
  code?: string
}

// first `any` here in Document would allow for `id` typing as well!
export type EventDocument = Document<any, any, Event> & Event

const EventSchema = new Schema<Event>(
  {
    name: { type: String, required: true},
    code: { type: String },
  }
)

export const EventModel = model<EventDocument, {}, {}, Event>(
  'Event',
  EventSchema,
)```

This will allow `new EventModel(def)` to confirm `def` adheres to the `Event` interface as well as returning an `EventDocument` instead of an `Event` when doing various the various query operations (`find`, `findOne`, `findById`, etc) giving the user full document typing with `_id`, `id` and `__v` as they are actually there to work with. 

This is essential for projects that are just letting Mongo deal with ObjectIDs for unique identifiers. This also is only an enhancement as "normally" users will pass the `Event` interface in like the following

```
export const EventModel = model<Event>('Event', EventSchema)
```

Which then everything will work as normal including type checking for `Event` when creating a new `EventModel`. They simply will not get `id`. `_id` and `__v` in there code completion for `event`. Which maybe they are cool with 🤷‍♂️ .

The only issue this presents is for users that extend Document with their interfaces. like this

```
interface Event extends Document {}
```

This seems like a poor practice in general as now we have no way to know what are actual Schema properties and what are just document properties. Document also adds a ton of methods and crap we don't want. So when you go to create a new `EventModel` you could actually pass in document properties not knowing which belong to which. 

Going the route of something like PR suggests will allow us to keep separation between `DocType` and a `Document` and get real code completion and error checking all the way through creation and querying.

