### PR TITLE
fix(types): ConnectOptions definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,10 @@ declare module 'mongoose' {
     autoIndex?: boolean;
     /** Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection. */
     autoCreate?: boolean;
+    /** Set to `true` to use new [url parser behind the flag](https://mongoosejs.com/docs/deprecations.html#the-usenewurlparser-option). */
+    useNewUrlParser?: boolean;
+    /** Set to `true` to opt in to [using the new topology engine](https://mongoosejs.com/docs/deprecations.html#useunifiedtopology). */
+    useUnifiedTopology?: boolean;
   }
 
   class Connection extends events.EventEmitter {


### PR DESCRIPTION
**Summary**

The following options from the documentation (https://mongoosejs.com/docs/deprecations.html) were missing on the `ConnectOptions` type:
* `useNewUrlParser`
* `useUnifiedTopology`

They have to be added to the index.d.ts, to work properly, in accordance with the current documentation. If they are not needed, then the documentation must be updated.

**Examples**

When I use the following code, I get the compilation errors in typescript:
```typescript
mongoose.connect(connectionString, {
  useNewUrlParser: true,
  useUnifiedTopology: true,
});
```

The error has the following message:
```
error TS2769: No overload matches this call.
  Overload 1 of 3, '(uri: string, callback: CallbackWithoutResult): void', gave the following error.
    Argument of type '{ useNewUrlParser: boolean; useUnifiedTopology: boolean; }' is not assignable to parameter of type 'CallbackWithoutResult'.
      Object literal may only specify known properties, and 'useNewUrlParser' does not exist in type 'CallbackWithoutResult'.
  Overload 2 of 3, '(uri: string, options?: ConnectOptions): Promise<typeof import("mongoose")>', gave the following error.
    Argument of type '{ useNewUrlParser: boolean; useUnifiedTopology: boolean; }' is not assignable to parameter of type 'ConnectOptions'.
      Object literal may only specify known properties, and 'useNewUrlParser' does not exist in type 'ConnectOptions'.
```

After the proposed fix, the errors are gone.