### PR TITLE
Improve Document#populate documentation, tests

### DIFF
--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -282,7 +282,13 @@ However, Mongoose 6 does **not** buffer commands while a connection is disconnec
 
 <h3 id="removed-execpopulate"><a href="#removed-execpopulate">Removed `execPopulate()`</a></h3>
 
-`Document#populate()` now returns a promise. And is now no longer chainable. Replace `await doc.populate('path1').populate('path2').execPopulate()` with `await doc.populate(['path1', 'path2']);`
+`Document#populate()` now returns a promise and is now no longer chainable.
+
+* Replace `await doc.populate('path1').populate('path2').execPopulate();` with `await doc.populate(['path1', 'path2']);`
+* Replace `await doc.populate('path1', 'select1').populate('path2', 'select2').execPopulate();` with
+  ```
+  await doc.populate([{path: 'path1', select: 'select1'}, {path: 'path2', select: 'select2'}]);
+  ```
 
 <h3 id="create-with-empty-array"><a href="#create-with-empty-array">`create()` with Empty Array</a></h3>
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -4032,13 +4032,33 @@ Document.prototype.equals = function(doc) {
  *     doc.stories[0].title; // 'Casino Royale'
  *     doc.populated('fans'); // Array of ObjectIds
  *
+ *     await doc.populate('fans', '-email');
+ *     doc.fans[0].email // not populated
+ *
+ *     await doc.populate('author fans', '-email');
+ *     doc.author.email // not populated
+ *     doc.fans[0].email // not populated
+ *
+ * @param {String|Object|Array} path either the path to populate or an object specifying all parameters, or either an array of those
+ * @param {Object|String} [select] Field selection for the population query
+ * @param {Model} [model] The model you wish to use for population. If not specified, populate will look up the model by the name in the Schema's `ref` field.
+ * @param {Object} [match] Conditions for the population query
+ * @param {Object} [options] Options for the population query (sort, etc)
+ * @param {String} [options.path=null] The path to populate.
+ * @param {boolean} [options.retainNullValues=false] by default, Mongoose removes null and undefined values from populated arrays. Use this option to make `populate()` retain `null` and `undefined` array entries.
+ * @param {boolean} [options.getters=false] if true, Mongoose will call any getters defined on the `localField`. By default, Mongoose gets the raw value of `localField`. For example, you would need to set this option to `true` if you wanted to [add a `lowercase` getter to your `localField`](/docs/schematypes.html#schematype-options).
+ * @param {boolean} [options.clone=false] When you do `BlogPost.find().populate('author')`, blog posts with the same author will share 1 copy of an `author` doc. Enable this option to make Mongoose clone populated docs before assigning them.
+ * @param {Object|Function} [options.match=null] Add an additional filter to the populate query. Can be a filter object containing [MongoDB query syntax](https://docs.mongodb.com/manual/tutorial/query-documents/), or a function that returns a filter object.
+ * @param {Function} [options.transform=null] Function that Mongoose will call on every populated document that allows you to transform the populated document.
+ * @param {Object} [options.options=null] Additional options like `limit` and `lean`.
+ * @param {Function} [callback] Callback
+ * @see population ./populate.html
+ * @see Query#select #query_Query-select
  * @see Model.populate #model_Model.populate
- * @param {String|Object|Array} [path] The path to populate or an options object or array of paths and/or options objects.
- * @param {Function} [callback] When passed, population is invoked
- * @api public
- * @return {Promise|null} this
  * @memberOf Document
  * @instance
+ * @return {Promise|null}
+ * @api public
  */
 
 Document.prototype.populate = function populate() {

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -254,6 +254,48 @@ describe('document.populate', function() {
     });
   });
 
+  it('one path, model selection as second argument', async function() {
+    const b = await B.findById(post);
+
+    const creator_id = b._creator;
+
+    await b.populate('_creator', '-email');
+
+    assert.equal(String(b._creator._id), String(creator_id));
+
+    assert.ok(b.populated('_creator'));
+    assert.ok(!b._creator.email);
+    assert.ok(b._creator.age);
+  });
+
+  it('multiple paths, model selection as second argument', async function() {
+    const b = await B.findById(post);
+
+    await b.populate('_creator fans', '-email');
+
+    assert.ok(b.populated('_creator'));
+    assert.ok(!b._creator.email);
+    assert.ok(b._creator.age);
+
+    assert.ok(b.populated('fans'));
+    assert.ok(!b.fans[0].email);
+    assert.ok(b.fans[0].age);
+  });
+
+  it('multiple paths, mixed argument types', async function() {
+    const b = await B.findById(post);
+
+    await b.populate([{ path: '_creator', select: '-email' }, 'fans']);
+
+    assert.ok(b.populated('_creator'));
+    assert.ok(!b._creator.email);
+    assert.ok(b._creator.age);
+
+    assert.ok(b.populated('fans'));
+    assert.ok(b.fans[0].email);
+    assert.ok(b.fans[0].age);
+  });
+
   it('multiple paths, multiple options', async function() {
     const b = await B.findById(post);
 


### PR DESCRIPTION
When migrating to mongoose 6 I found that the new populate syntax for `Document#populate` was missing some documentation and it was hard to migrate without having a look at the code and guessing that the syntax was the same as `Query#populate`.

I'm not so familiar with documentation, but I copied the one from `Query#populate` which seems like an improvement.

Maybe a "sub-page" could describe what arguments `Query#populate, `Model#populate` and `Document#populate` accept in a single place instead of maintaining that in 3 different places, but I'll leave that up to you.

Also added a few tests to demonstrate the arguments I was adding do work.