### PR TITLE
fix createdAt set condition

### DIFF
--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -49,7 +49,7 @@ module.exports = function setupTimestamps(schema, timestamps) {
       (this.ownerDocument ? this.ownerDocument() : this).constructor.base.now();
     const auto_id = this._id && this._id.auto;
 
-    if (!skipCreatedAt && createdAt && !this.get(createdAt) && this.$__isSelected(createdAt)) {
+    if (!skipCreatedAt && createdAt && !this.$__getValue(createdAt) && this.$__isSelected(createdAt)) {
       this.$set(createdAt, auto_id ? this._id.getTimestamp() : defaultTimestamp);
     }
 

--- a/test/timestamps.test.js
+++ b/test/timestamps.test.js
@@ -782,6 +782,30 @@ describe('timestamps', function() {
     assert.equal(doc.updatedAt, 42);
   });
 
+  it('timestamps with custom timestamp using getter method (gh-3957)', async function() {
+    const now = Date.now();
+    const schema = Schema({
+      createdAt: {
+        type: Schema.Types.Number,
+        get: (createdAt) => new Date(createdAt * 1000),
+      },
+      updatedAt: {
+        type: Schema.Types.Number,
+        get: (updatedAt) => new Date(updatedAt * 1000),
+      },
+      name: String
+    }, {
+      timestamps: { currentTime: () => Math.floor(now / 1000) }
+    });
+    const Model = db.model('Test', schema);
+    const doc = await Model.create({ name: 'test' });
+
+    assert.equal(typeof doc.createdAt, 'object');
+    assert.equal(typeof doc.updatedAt, 'object');
+    assert.equal(Math.floor(doc.createdAt.getTime() / 1000), Math.floor(now / 1000));
+    assert.equal(Math.floor(doc.updatedAt.getTime() / 1000), Math.floor(now / 1000));
+  });
+
   it('shouldnt bump updatedAt in single nested subdocs that are not modified (gh-9357)', async function() {
     const nestedSchema = Schema({
       nestedA: { type: String },


### PR DESCRIPTION

**Summary**

If I set schema like the code below, then it won't pass the condition of 
L56 at `mongoose/lib/helpers/timestamps/setupTimestamps.js`

so I changed `!this.get(createdAt)` into `!this.$__getValue(createdAt)`to set proper timestamps.

```
const schema = Schema({
      createdAt: {
        type: Schema.Types.Number,
        get: (createdAt) => new Date(createdAt * 1000),
      },
      updatedAt: {
        type: Schema.Types.Number,
        get: (updatedAt) => new Date(updatedAt * 1000),
      },
      name: String
    }, {
      timestamps: { currentTime: () => Math.floor(now / 1000) }
    });
```
