### PR TITLE
Amending Model.translateAliases to observe non-aliased sub schemas

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1876,6 +1876,7 @@ Model.translateAliases = function translateAliases(fields) {
         // Alias found,
         translated.push(alias);
       } else {
+        alias = name;
         // Alias not found, so treat as un-aliased key
         translated.push(name);
       }

--- a/test/model.translateAliases.test.js
+++ b/test/model.translateAliases.test.js
@@ -18,6 +18,7 @@ describe('model translate aliases', function() {
 
     const Character = mongoose.model('Character', new mongoose.Schema({
       d: { type: Syntax, alias: 'dot' },
+      noAlias: { type: Syntax },
       name: { type: String, alias: '名' },
       bio: {
         age: { type: Number, alias: '年齢' }
@@ -29,6 +30,7 @@ describe('model translate aliases', function() {
       Character.translateAliases({
         _id: '1',
         名: 'Stark',
+        'noAlias.syntax': 'NoAliasSyntax',
         年齢: 30,
         'dot.syntax': 'DotSyntax',
         $and: [{ $or: [{ 名: 'Stark' }, { 年齢: 30 }] }, { 'dot.syntax': 'DotSyntax' }]
@@ -38,6 +40,7 @@ describe('model translate aliases', function() {
         name: 'Stark',
         _id: '1',
         'bio.age': 30,
+        'noAlias.s': 'NoAliasSyntax',
         'd.s': 'DotSyntax',
         $and: [{ $or: [{ name: 'Stark' }, { 'bio.age': 30 }] }, { 'd.s': 'DotSyntax' }]
       }
@@ -49,14 +52,16 @@ describe('model translate aliases', function() {
         ['_id', '1'],
         ['名', 'Stark'],
         ['年齢', 30],
-        ['dot.syntax', 'DotSyntax']
+        ['dot.syntax', 'DotSyntax'],
+        ['noAlias.syntax', 'NoAliasSyntax']
       ])),
       // How translated aliases suppose to look like
       new Map([
         ['name', 'Stark'],
         ['_id', '1'],
         ['bio.age', 30],
-        ['d.s', 'DotSyntax']
+        ['d.s', 'DotSyntax'],
+        ['noAlias.s', 'NoAliasSyntax']
       ])
     );
   });


### PR DESCRIPTION
**Summary**

A fix for issue #10770. `translateAliases` wouldn't pick up nested sub-schemas if the key it just observed wasn't an alias itself.

**Examples**

I amended the translateAliases test case to include an example of the behaviour and made sure it failed before and passed afterwards.
