### PR TITLE
Enhance docs section linking

### DIFF
--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -15,9 +15,11 @@ a {
   color: #0971B2;
 }
 
+h1 a::before,
 h2 a::before,
 h3 a::before,
-h4 a::before {
+h4 a::before,
+a.anchor::before {
   position: absolute;
   left: 22px;
   margin-top: 4px;
@@ -33,12 +35,15 @@ h4 a::before {
   opacity: 0;
 }
 
+h1 a:hover::before,
 h2 a:hover::before,
 h3 a:hover::before,
-h4 a:hover::before {
+h4 a:hover::before,
+a.anchor:hover::before {
   opacity: 1;
 }
 
+h1 a,
 h2 a,
 h3 a,
 h4 a {

--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -15,34 +15,34 @@ a {
   color: #0971B2;
 }
 
-h2 a {
-  color: #000;
-}
-
-h2:hover::before {
+h2 a::before,
+h3 a::before,
+h4 a::before {
   position: absolute;
   left: 22px;
   margin-top: 4px;
   background-image: url('/docs/images/link_64x64.png');
   background-size: contain;
+  background-repeat: no-repeat;
   height: 1em;
-  width: 1em;
+  /* Any width that will be over the size of the icon and overlap the link to keep the hover state will work */
+  width: 2em;
   content: ' ';
+
+  /* Hide it when not hover */
+  opacity: 0;
 }
 
-h3 a {
+h2 a:hover::before,
+h3 a:hover::before,
+h4 a:hover::before {
+  opacity: 1;
+}
+
+h2 a,
+h3 a,
+h4 a {
   color: #000;
-}
-
-h3:hover::before {
-  position: absolute;
-  left: 22px;
-  margin-top: 4px;
-  background-image: url('/docs/images/link_64x64.png');
-  background-size: contain;
-  height: 1em;
-  width: 1em;
-  content: ' ';
 }
 
 code {

--- a/docs/discriminators.md
+++ b/docs/discriminators.md
@@ -1,6 +1,6 @@
 ## Discriminators
 
-### [The `model.discriminator()` function](#the-modeldiscriminator-function)
+### The `model.discriminator()` function
 
 Discriminators are a schema inheritance mechanism. They enable
 you to have multiple models with overlapping schemas on top of the
@@ -18,7 +18,7 @@ is the union of the base schema and the discriminator schema.
 [require:The `model.discriminator\(\)` function]
 ```
 
-### [Discriminators save to the Event model's collection](#discriminators-save-to-the-event-models-collection)
+### Discriminators save to the Event model's collection
 
 Suppose you created another discriminator to track events where
 a new user registered. These `SignedUpEvent` instances will be
@@ -29,7 +29,7 @@ instances.
 [require:Discriminators save to the Event model's collection]
 ```
 
-### [Discriminator keys](discriminator-keys)
+### Discriminator keys
 
 The way mongoose tells the difference between the different
 discriminator models is by the 'discriminator key', which is

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,7 @@ hr {
 
 <hr id="unique-doesnt-work" />
 
-<a href="#unique-doesnt-work">**Q**</a>. I declared a schema property as `unique` but I can still save duplicates. What gives?
+<a class="anchor" href="#unique-doesnt-work">**Q**</a>. I declared a schema property as `unique` but I can still save duplicates. What gives?
 
 **A**. Mongoose doesn't handle `unique` on its own: `{ name: { type: String, unique: true } }`
 is just a shorthand for creating a [MongoDB unique index on `name`](https://docs.mongodb.com/manual/core/index-unique/).
@@ -64,7 +64,7 @@ convenient for development and documentation, but mongoose is *not* an index man
 
 <hr id="nested-properties" />
 
-<a href="#nested-properties">**Q**</a>. When I have a nested property in a schema, mongoose adds empty objects by default. Why?
+<a class="anchor" href="#nested-properties">**Q**</a>. When I have a nested property in a schema, mongoose adds empty objects by default. Why?
 
 ```javascript
 const schema = new mongoose.Schema({
@@ -94,7 +94,7 @@ is undefined on the underlying [POJO](./guide.html#minimize).
 
 <hr id="destructured-imports" />
 
-<a href="#destructured-imports">**Q**</a>. When I use named imports like `import { set } from 'mongoose'`, I
+<a class="anchor" href="#destructured-imports">**Q**</a>. When I use named imports like `import { set } from 'mongoose'`, I
     get a `TypeError`. What causes this issue and how can I fix it?
 
 **A**. The only import syntax Mongoose supports is `import mongoose from 'mongoose'`.
@@ -119,7 +119,7 @@ foo(); // "undefined"
 
 <hr id="arrow-functions" />
 
-<a href="#arrow-functions">**Q**</a>. I'm using an arrow function for a [virtual](./guide.html#virtuals), [middleware](./middleware.html), [getter](./api.html#schematype_SchemaType-get)/[setter](./api.html#schematype_SchemaType-set), or [method](./guide.html#methods) and the value of `this` is wrong.
+<a class="anchor" href="#arrow-functions">**Q**</a>. I'm using an arrow function for a [virtual](./guide.html#virtuals), [middleware](./middleware.html), [getter](./api.html#schematype_SchemaType-get)/[setter](./api.html#schematype_SchemaType-set), or [method](./guide.html#methods) and the value of `this` is wrong.
 
 **A**. Arrow functions [handle the `this` keyword much differently than conventional functions](https://masteringjs.io/tutorials/fundamentals/arrow#why-not-arrow-functions).
 Mongoose getters/setters depend on `this` to give you access to the document that you're writing to, but this functionality does not work with arrow functions. Do **not** use arrow functions for mongoose getters/setters unless do not intend to access the document in the getter/setter.
@@ -149,7 +149,7 @@ schema.virtual('virtualWithArrow').get(() => {
 
 <hr id="type-key">
 
-<a href="#type-key">**Q**</a>. I have an embedded property named `type` like this:
+<a class="anchor" href="#type-key">**Q**</a>. I have an embedded property named `type` like this:
 
 ```javascript
 const holdingSchema = new Schema({
@@ -193,7 +193,7 @@ const holdingSchema = new Schema({
 
 <hr id="populate_sort_order" />
 
-<a href="#populate_sort_order">**Q**</a>. I'm populating a nested property under an array like the below code:
+<a class="anchor" href="#populate_sort_order">**Q**</a>. I'm populating a nested property under an array like the below code:
 
 ```javascript
 new Schema({
@@ -209,7 +209,7 @@ new Schema({
 
 <hr id="model_functions_hanging" />
 
-<a href="#model_functions_hanging">**Q**</a>. All function calls on my models hang, what am I doing wrong?
+<a class="anchor" href="#model_functions_hanging">**Q**</a>. All function calls on my models hang, what am I doing wrong?
 
 **A**. By default, mongoose will buffer your function calls until it can
 connect to MongoDB. Read the [buffering section of the connection docs](./connections.html#buffering)
@@ -217,7 +217,7 @@ for more information.
 
 <hr id="enable_debugging" />
 
-<a href="#enable_debugging">**Q**</a>. How can I enable debugging?
+<a class="anchor" href="#enable_debugging">**Q**</a>. How can I enable debugging?
 
 **A**. Set the `debug` option:
 
@@ -236,7 +236,7 @@ For more debugging options (streams, callbacks), see the ['debug' option under `
 
 <hr id="callback_never_executes" />
 
-<a href="#callback_never_executes">**Q**</a>. My `save()` callback never executes. What am I doing wrong?
+<a class="anchor" href="#callback_never_executes">**Q**</a>. My `save()` callback never executes. What am I doing wrong?
 
 **A**. All `collection` actions (insert, remove, queries, etc.) are queued
 until Mongoose successfully connects to MongoDB. It is likely you haven't called Mongoose's
@@ -262,14 +262,14 @@ mongoose.set('bufferTimeoutMS', 500);
 
 <hr id="creating_connections" />
 
-<a href="#creating_connections">**Q**</a>. Should I create/destroy a new connection for each database operation?
+<a class="anchor" href="#creating_connections">**Q**</a>. Should I create/destroy a new connection for each database operation?
 
 **A**. No. Open your connection when your application starts up and leave
 it open until the application shuts down.
 
 <hr id="overwrite-model-error" />
 
-<a href="#overwrite-model-error">**Q**</a>. Why do I get "OverwriteModelError: Cannot overwrite .. model once
+<a class="anchor" href="#overwrite-model-error">**Q**</a>. Why do I get "OverwriteModelError: Cannot overwrite .. model once
 compiled" when I use nodemon / a testing framework?
 
 **A**. `mongoose.model('ModelName', schema)` requires 'ModelName' to be
@@ -294,7 +294,7 @@ const Kitten = connection.model('Kitten', kittySchema);
 
 <hr id="array-defaults" />
 
-<a href="#array-defaults">**Q**</a>. How can I change mongoose's default behavior of initializing an array path to an empty array so that I can require real data on document creation?
+<a class="anchor" href="#array-defaults">**Q**</a>. How can I change mongoose's default behavior of initializing an array path to an empty array so that I can require real data on document creation?
 
 **A**. You can set the default of the array to a function that returns `undefined`.
 
@@ -309,7 +309,7 @@ const CollectionSchema = new Schema({
 
 <hr id="initialize-array-path-null" />
     
-<a href="#initialize-array-path-null">**Q**</a>. How can I initialize an array path to `null`?
+<a class="anchor" href="#initialize-array-path-null">**Q**</a>. How can I initialize an array path to `null`?
 
 **A**. You can set the default of the array to a function that returns `null`.
 
@@ -324,7 +324,7 @@ const CollectionSchema = new Schema({
 
 <hr id="aggregate-casting" />
 
-<a href="#aggregate-casting">**Q**</a>. Why does my aggregate $match fail to return the document that my find query returns when working with dates?
+<a class="anchor" href="#aggregate-casting">**Q**</a>. Why does my aggregate $match fail to return the document that my find query returns when working with dates?
 
 **A**. Mongoose does not cast aggregation pipeline stages because with $project,
 $group, etc. the type of a property may change during the aggregation. If you want
@@ -333,7 +333,7 @@ that you're passing in a valid date.
 
 <hr id="date_changes" />
 
-<a href="#date_changes">**Q**</a>. Why don't in-place modifications to date objects
+<a class="anchor" href="#date_changes">**Q**</a>. Why don't in-place modifications to date objects
 (e.g. `date.setMonth(1);`) get saved?
 
 ```javascript
@@ -357,7 +357,7 @@ doc.save(); // Works
 
 <hr id="parallel_saves" />
 
-<a href="#parallel_saves">**Q**</a>. Why does calling `save()` multiple times on the same document in parallel only let
+<a class="anchor" href="#parallel_saves">**Q**</a>. Why does calling `save()` multiple times on the same document in parallel only let
 the first save call succeed and return ParallelSaveErrors for the rest?
 
 **A**. Due to the asynchronous nature of validation and middleware in general, calling
@@ -366,20 +366,20 @@ validating, and then subsequently invalidating the same path.
 
 <hr id="objectid-validation" />
 
-<a href="#objectid-validation">**Q**</a>. Why is **any** 12 character string successfully cast to an ObjectId?
+<a class="anchor" href="#objectid-validation">**Q**</a>. Why is **any** 12 character string successfully cast to an ObjectId?
 
 **A**. Technically, any 12 character string is a valid [ObjectId](https://docs.mongodb.com/manual/reference/bson-types/#objectid).
 Consider using a regex like `/^[a-f0-9]{24}$/` to test whether a string is exactly 24 hex characters.
 
 <hr id="map-keys-strings" />
 
-<a href="#map-keys-strings">**Q**</a>. Why do keys in Mongoose Maps have to be strings?
+<a class="anchor" href="#map-keys-strings">**Q**</a>. Why do keys in Mongoose Maps have to be strings?
 
 **A**. Because the Map eventually gets stored in MongoDB where the keys must be strings.
 
 <hr id="limit-vs-perDocumentLimit" />
 
-<a href="#limit-vs-perDocumentLimit">**Q**</a>. I am using `Model.find(...).populate(...)` with the `limit` option, but getting fewer results than the limit. What gives?
+<a class="anchor" href="#limit-vs-perDocumentLimit">**Q**</a>. I am using `Model.find(...).populate(...)` with the `limit` option, but getting fewer results than the limit. What gives?
 
 **A**. In order to avoid executing a separate query for each document returned from the `find` query, Mongoose
 instead queries using (numDocuments * limit) as the limit. If you need the correct limit, you should use the
@@ -388,7 +388,7 @@ mind that populate() will execute a separate query for each document.
 
 <hr id="duplicate-query" />
 
-<a href="#duplicate-query">**Q**</a>. My query/update seems to execute twice. Why is this happening?
+<a class="anchor" href="#duplicate-query">**Q**</a>. My query/update seems to execute twice. Why is this happening?
 
 **A**. The most common cause of duplicate queries is **mixing callbacks and promises with queries**.
 That's because passing a callback to a query function, like `find()` or `updateOne()`,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1221,7 +1221,7 @@ console.log(schema.virtuals); // { myVirtual: VirtualType { ... } }
 Schemas are also [pluggable](./plugins.html) which allows us to package up reusable features into
 plugins that can be shared with the community or just between your projects.
 
-<h3 id="further-reading">Further Reading</h3>
+<h3 id="further-reading"><a href="further-reading">Further Reading</a></h3>
 
 Here's an [alternative introduction to Mongoose schemas](https://masteringjs.io/tutorials/mongoose/schema).
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -19,7 +19,7 @@ on the schema level and is useful for writing [plugins](./plugins.html).
   <li><a href="#synchronous">Synchronous Hooks</a></li>
 </ul>
 
-### [Types of Middleware](#types-of-middleware)
+### Types of Middleware
 
 Mongoose has 4 types
 of middleware: document middleware, model middleware, aggregate middleware, and query middleware.

--- a/docs/models.md
+++ b/docs/models.md
@@ -31,7 +31,7 @@ in the database.
 you've added everything you want to `schema`, including hooks,
 before calling `.model()`!
 
-### [Constructing Documents](#constructing-documents)
+### Constructing Documents
 
 An instance of a model is called a [document](./documents.html). Creating
 them and saving to the database is easy.
@@ -73,7 +73,7 @@ const connection = mongoose.createConnection('mongodb://localhost:27017/test');
 const Tank = connection.model('Tank', yourSchema);
 ```
 
-### [Querying](#querying)
+### Querying
 
 Finding documents is easy with Mongoose, which supports the [rich](http://www.mongodb.org/display/DOCS/Advanced+Queries) query syntax of MongoDB. Documents can be retrieved using a `model`'s [find](./api.html#model_Model.find), [findById](./api.html#model_Model.findById), [findOne](./api.html#model_Model.findOne), or [where](./api.html#model_Model.where) static methods.
 
@@ -83,7 +83,7 @@ Tank.find({ size: 'small' }).where('createdDate').gt(oneYearAgo).exec(callback);
 
 See the chapter on [queries](./queries.html) for more details on how to use the [Query](./api.html#query-js) api.
 
-### [Deleting](#deleting)
+### Deleting
 
 Models have static `deleteOne()` and `deleteMany()` functions
 for removing all documents matching the given `filter`.
@@ -95,7 +95,7 @@ Tank.deleteOne({ size: 'large' }, function (err) {
 });
 ```
 
-### [Updating](#updating)
+### Updating
 
 Each `model` has its own `update` method for modifying documents in the
 database without returning them to your application. See the
@@ -112,7 +112,7 @@ _If you want to update a single document in the db and return it to your
 application, use [findOneAndUpdate](./api.html#model_Model.findOneAndUpdate)
 instead._
 
-### [Change Streams](#change-streams)
+### Change Streams
 
 _New in MongoDB 3.6.0 and Mongoose 5.0.0_
 
@@ -154,10 +154,10 @@ The output from the above [async function](http://thecodebarbarian.com/80-20-gui
 
 You can read more about [change streams in mongoose in this blog post](http://thecodebarbarian.com/a-nodejs-perspective-on-mongodb-36-change-streams.html#change-streams-in-mongoose).
 
-### [Yet more](#yet-more)
+### Yet more
 
 The [API docs](./api.html#model_Model) cover many additional methods available like [count](./api.html#model_Model.count), [mapReduce](./api.html#model_Model.mapReduce), [aggregate](./api.html#model_Model.aggregate), and [more](./api.html#model_Model.findOneAndRemove).
 
-### [Next Up](#next-up)
+### Next Up
 
 Now that we've covered `Models`, let's take a look at [Documents](/docs/documents.html).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -107,7 +107,7 @@ Mongoose. Here's a couple:
 
 You can find a full list of officially supported plugins on [Mongoose's plugins search site](https://plugins.mongoosejs.io/).
 
-### [Community!](#community)
+### Community!
 
 Not only can you re-use schema functionality in your own projects, but you
 also reap the benefits of the Mongoose community as well. Any plugin

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -35,7 +35,7 @@ A query also has a `.then()` function, and thus can be used as a promise.
   <li><a href="#versus-aggregation">Versus Aggregation</a></li>
 </ul>
 
-### [Executing](#executing)
+### Executing
 
 When executing a query with a `callback` function, you specify your query as a JSON document. The JSON document's syntax is the same as the [MongoDB shell](http://docs.mongodb.org/manual/tutorial/query-documents/).
 

--- a/docs/subdocs.md
+++ b/docs/subdocs.md
@@ -33,7 +33,7 @@ a group of fields (e.g. dateRange.fromDate <= dateRange.toDate).
   <li><a href="#altsyntaxsingle">Alternate declaration syntax for single subdocuments</a></li>
 </ul>
 
-### [What is a Subdocument?](#what-is-a-subdocument)
+### What is a Subdocument?
 
 Subdocuments are similar to normal documents. Nested schemas can have
 [middleware](./middleware.html), [custom validation logic](./validation.html),
@@ -106,7 +106,7 @@ parentSchema.pre('save', function(next) {
 });
 ```
 
-### [Subdocuments versus Nested Paths](#subdocuments-versus-nested-paths)
+### Subdocuments versus Nested Paths
 
 In Mongoose, nested paths are subtly different from subdocuments.
 For example, below are two schemas: one with `child` as a subdocument,
@@ -145,7 +145,7 @@ console.log(doc2.child); // Prints 'MongooseDocument { undefined }'
 doc2.child.name = 'test'; // Works
 ```
 
-### [Subdocument Defaults](#subdocument-defaults)
+### Subdocument Defaults
 
 Subdocument paths are undefined by default, and Mongoose does
 not apply subdocument defaults unless you set the subdocument
@@ -205,7 +205,7 @@ const doc = new Subdoc();
 doc.child; // { age: 0 }
 ```
 
-### [Finding a Subdocument](#finding-a-subdocument)
+### Finding a Subdocument
 
 Each subdocument has an `_id` by default. Mongoose document arrays have a
 special [id](./api.html#types_documentarray_MongooseDocumentArray-id) method
@@ -214,7 +214,7 @@ for searching a document array to find a document with a given `_id`.
 const doc = parent.children.id(_id);
 ```
 
-### [Adding Subdocs to Arrays](#adding-subdocs-to-arrays)
+### Adding Subdocs to Arrays
 
 MongooseArray methods such as
 [push](./api.html#mongoosearray_MongooseArray-push),
@@ -245,7 +245,7 @@ method of MongooseArrays.
 const newdoc = parent.children.create({ name: 'Aaron' });
 ```
 
-### [Removing Subdocs](#removing-subdocs)
+### Removing Subdocs
 
 Each subdocument has it's own
 [remove](./api.html#types_embedded_EmbeddedDocument-remove) method. For

--- a/docs/tutorials/findoneandupdate.md
+++ b/docs/tutorials/findoneandupdate.md
@@ -7,7 +7,7 @@ The [`findOneAndUpdate()` function in Mongoose](/docs/api.html#query_Query-findO
 * [Upsert](#upsert)
 * [The `rawResult` Option](#raw-result)
 
-<h2 id="getting-started">Getting Started</h2>
+## Getting Started
 
 As the name implies, `findOneAndUpdate()` finds the first document that matches a given `filter`, applies an `update`, and returns the document. By default, `findOneAndUpdate()` returns the document as it was **before** `update` was applied.
 
@@ -32,7 +32,7 @@ which has the same option.
 [require:Tutorial.*findOneAndUpdate.*returnOriginal option]
 ```
 
-<h2 id="atomic-updates">Atomic Updates</h2>
+## Atomic Updates
 
 With the exception of an [unindexed upsert](https://docs.mongodb.com/manual/reference/method/db.collection.findAndModify/#upsert-with-unique-index), [`findOneAndUpdate()` is atomic](https://docs.mongodb.com/manual/core/write-operations-atomicity/#atomicity). That means you can assume the document doesn't change between when MongoDB finds the document and when it updates the document, _unless_ you're doing an [upsert](#upsert).
 
@@ -42,7 +42,7 @@ For example, if you're using `save()` to update a document, the document can cha
 [require:Tutorial.*findOneAndUpdate.*save race condition]
 ```
 
-<h2 id="upsert">Upsert</h2>
+## Upsert
 
 Using the `upsert` option, you can use `findOneAndUpdate()` as a find-and-[upsert](https://docs.mongodb.com/manual/reference/method/db.collection.update/#db.collection.update) operation. An upsert behaves like a normal `findOneAndUpdate()` if it finds a document that matches `filter`. But, if no document matches `filter`, MongoDB will insert one by combining `filter` and `update` as shown below.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4,7 +4,7 @@ Mongoose introduced [officially supported TypeScript bindings in v5.11.0](https:
 Mongoose's `index.d.ts` file supports a wide variety of syntaxes and strives to be compatible with `@types/mongoose` where possible.
 This guide describes Mongoose's recommended approach to working with Mongoose in TypeScript.
 
-### [Creating Your First Document](#creating-your-first-document)
+### Creating Your First Document
 
 To get started with Mongoose in TypeScript, you need to: 
 
@@ -53,7 +53,7 @@ async function run(): Promise<void> {
 You as the developer are responsible for ensuring that your document interface lines up with your Mongoose schema.
 For example, Mongoose won't report an error if `email` is `required` in your Mongoose schema but optional in your document interface.
 
-### [Using `extends Document`](#using-extends-document)
+### Using `extends Document`
 
 Alternatively, your document interface can extend Mongoose's `Document` class.
 Many Mongoose TypeScript codebases use the below approach.
@@ -74,7 +74,7 @@ Using `extends Document` makes it difficult for Mongoose to infer which properti
 We recommend your document interface contain the properties defined in your schema and line up with what your documents look like in MongoDB.
 Although you can add [instance methods](/docs/guide.html#methods) to your document interface, we do not recommend doing so.
 
-### [Using Custom Bindings](#using-custom-bindings)
+### Using Custom Bindings
 
 If Mongoose's built-in `index.d.ts` file does not work for you, you can remove it in a postinstall script in your `package.json` as shown below.
 However, before you do, please [open an issue on Mongoose's GitHub page](https://github.com/Automattic/mongoose/issues/new) and describe the issue you're experiencing.

--- a/docs/typescript/schemas.md
+++ b/docs/typescript/schemas.md
@@ -24,7 +24,7 @@ const schema = new Schema<User>({
 By default, Mongoose does **not** check if your document interface lines up with your schema.
 For example, the above code won't throw an error if `email` is optional in the document interface, but `required` in `schema`.
 
-## [Generic parameters](#generic-parameters)
+## Generic parameters
 
 The Mongoose `Schema` class in TypeScript has 3 [generic parameters](https://www.typescriptlang.org/docs/handbook/2/generics.html):
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -15,7 +15,7 @@ Before we get into the specifics of validation syntax, please keep the following
 [require:Validation$]
 ```
 
-### [Built-in Validators](#built-in-validators)
+### Built-in Validators
 
 Mongoose has several built-in validators.
 
@@ -29,7 +29,7 @@ Each of the validator links above provide more information about how to enable t
 [require:Built-in Validators]
 ```
 
-### [Custom Error Messages](#custom-error-messages)
+### Custom Error Messages
 
 You can configure the error message for individual validators in your schema. There are two equivalent
 ways to set the validator error message:
@@ -44,7 +44,7 @@ Mongoose replaces `{VALUE}` with the value being validated.
 [require:Custom Error Messages]
 ```
 
-### [The `unique` Option is Not a Validator](#the-unique-option-is-not-a-validator)
+### The `unique` Option is Not a Validator
 
 A common gotcha for beginners is that the `unique` option for schemas
 is *not* a validator. It's a convenient helper for building [MongoDB unique indexes](https://docs.mongodb.com/manual/core/index-unique/).
@@ -54,7 +54,7 @@ See the [FAQ](/docs/faq.html) for more information.
 [require:The `unique` Option is Not a Validator]
 ```
 
-### [Custom Validators](#custom-validators)
+### Custom Validators
 
 If the built-in validators aren't enough, you can define custom validators
 to suit your needs.
@@ -67,7 +67,7 @@ You can find detailed instructions on how to do this in the
 [require:Custom Validators]
 ```
 
-### [Async Custom Validators](#async-custom-validators)
+### Async Custom Validators
 
 Custom validators can also be asynchronous. If your validator function
 returns a promise (like an `async` function), mongoose will wait for that
@@ -78,7 +78,7 @@ the value `false`, Mongoose will consider that a validation error.
 [require:Async Custom Validators]
 ```
 
-### [Validation Errors](#validation-errors)
+### Validation Errors
 
 Errors returned after failed validation contain an `errors` object
 whose values are `ValidatorError` objects. Each
@@ -92,7 +92,7 @@ thrown.
 [require:Validation Errors]
 ```
 
-### [Cast Errors](#cast-errors)
+### Cast Errors
 
 Before running validators, Mongoose attempts to coerce values to the
 correct type. This process is called _casting_ the document. If
@@ -107,7 +107,7 @@ fails. That means your custom validators may assume `v` is `null`,
 [require:Cast Errors]
 ```
 
-### [Required Validators On Nested Objects](#required-validators-on-nested-objects)
+### Required Validators On Nested Objects
 
 Defining validators on nested objects in mongoose is tricky, because
 nested objects are not fully fledged paths.
@@ -116,7 +116,7 @@ nested objects are not fully fledged paths.
 [require:Required Validators On Nested Objects]
 ```
 
-### [Update Validators](#update-validators)
+### Update Validators
 
 In the above examples, you learned about document validation. Mongoose also
 supports validation for [`update()`](/docs/api.html#query_Query-update),
@@ -135,7 +135,7 @@ caveats.
 [require:Update Validators$]
 ```
 
-### [Update Validators and `this`](#update-validators-and-this)
+### Update Validators and `this`
 
 There are a couple of key differences between update validators and
 document validators. In the color validation function above, `this` refers
@@ -148,7 +148,7 @@ not defined.
 [require:Update Validators and `this`]
 ```
 
-### [The `context` option](#the-context-option)
+### The `context` option
 
 The `context` option lets you set the value of `this` in update validators
 to the underlying query.
@@ -157,7 +157,7 @@ to the underlying query.
 [require:The `context` option]
 ```
 
-### [Update Validators Only Run On Updated Paths](#update-validators-only-run-on-updated-paths)
+### Update Validators Only Run On Updated Paths
 
 The other key difference is that update validators only run on the paths
 specified in the update. For instance, in the below example, because
@@ -171,7 +171,7 @@ you try to explicitly `$unset` the key.
 [require:Update Validators Only Run On Updated Paths]
 ```
 
-### [Update Validators Only Run For Some Operations](#update-validators-only-run-for-some-operations)
+### Update Validators Only Run For Some Operations
 
 One final detail worth noting: update validators **only** run on the
 following update operators:

--- a/website.js
+++ b/website.js
@@ -16,11 +16,22 @@ require('acquit-ignore')();
 
 const markdown = require('marked');
 const highlight = require('highlight.js');
+const renderer = {
+  heading: function(text, level, raw, slugger) {
+    const slug = slugger.slug(raw);
+    return `<h${level} id="${slug}">
+      <a href="#${slug}">
+        ${text}
+      </a>
+    </h${level}>\n`;
+  }
+};
 markdown.setOptions({
   highlight: function(code) {
     return highlight.highlight('JavaScript', code).value;
   }
 });
+markdown.use({ renderer });
 
 const tests = [
   ...acquit.parse(fs.readFileSync('./test/geojson.test.js').toString()),


### PR DESCRIPTION
Using marked's built-in slugify function ensures the links would not be broken.

Manual links are still supported, e.g.
```
   <h3 id="order"><a href="#order">Save/Validate Hooks</a></h3>
```

However note that this syntax doesn't work (didn't work previously either)
```
   ### [Save/Validate Hooks](#order)
```

Also makes the CSS better:
* You can hover any part of the link + the "hidden" side where the icon appears
* Handles h4, h1 and FAQ

Removes as much as possible "manual" links, but some remain (mostly HTML ones I believe, didn't want to check each one that it wouldn't break a link)