### PR TITLE
Fix: Mongoose slows down performance of VSCode (TSServer) by a lot #1…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module 'mongoose' {
    */
   export function isValidObjectId(v: any): boolean;
 
-  export function model<T>(name: string, schema?: Schema<T>, collection?: string, skipInit?: boolean): Model<T>;
+  export function model<T>(name: string, schema?: Schema<T> | Schema<T & Document>, collection?: string, skipInit?: boolean): Model<T>;
   export function model<T, U, TQueryHelpers = {}>(
     name: string,
     schema?: Schema<T, U, TQueryHelpers>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module 'mongoose' {
    */
   export function isValidObjectId(v: any): boolean;
 
-  export function model<T>(name: string, schema?: Schema<any>, collection?: string, skipInit?: boolean): Model<T>;
+  export function model<T>(name: string, schema?: Schema<T>, collection?: string, skipInit?: boolean): Model<T>;
   export function model<T, U, TQueryHelpers = {}>(
     name: string,
     schema?: Schema<T, U, TQueryHelpers>,


### PR DESCRIPTION
Addressing issue: Mongoose slows down performance of VSCode (TSServer) by a lot #10349 

Changing `Schema<any>` to `Schema<T>` in `model` seems to solve this problem. The other `model` overload already uses the generic in the schema parameter.

Examples:
Gists show two simple schemas based on the mongoose documentation: https://gist.github.com/traverse1984/ee57740a87374188851b30b4286a47fa

- When the schema has it's document type specified only, VSCode intellisense slows down for the whole project to around 3 seconds.
- When the schema has it's document type and model type specified, the issue does not arise.

Notes:
Without trying to get to grips with the entire set of mongoose typings, it seems that mismatched Schema/Model types cause the slowdown. I believe (but am not certain), that the `Schema<any>` in the function parameter was causing this to happen, despite the return type being correct. I noted that the Schema interface creates a model with 'any' types, but the defaults for the Model interface generics are {}.