### PR TITLE
feat: support extending type for mongoose.models

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,8 +74,15 @@ declare module 'mongoose' {
   /** An array containing all connections associated with this Mongoose instance. */
   export const connections: Connection[];
 
+  /**
+   * Can be extended to explicitly type specific models.
+   */
+  interface Models {
+    [modelName: string]: Model<any>
+  }
+
   /** An array containing all models associated with this Mongoose instance. */
-  export const models: { [index: string]: Model<any> };
+  export const models: Models;
   /** Creates a Connection instance. */
   export function createConnection(uri: string, options?: ConnectOptions): Connection;
   export function createConnection(): Connection;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

Currently `mongoose.models` can not be explictly typed. So, `mongoose.models.Cat` will always have the type `Model<any>`.

This change enables users to explicitly type `mongoose.models`.

**Examples**

Create a file `mongoose.d.ts` in your codebase:

```ts
declare module 'mongoose' {
  interface Models {
    Cat: CatModel; // CatModel is something like `interface CatModel extends Model<CatDocument>`
  }
}
```

You the type for `mongoose.models.Cat` will be `CatModel`, type for `mongoose.models.Fish` will be `Model<any>`

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
