### PR TITLE
chore: upgrade to mongodb driver 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "^4.2.2",
     "kareem": "2.3.2",
-    "mongodb": "4.1.1",
+    "mongodb": "^4.1.2",
     "mpath": "0.8.4",
     "mquery": "4.0.0",
     "ms": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "^4.2.2",
     "kareem": "2.3.2",
-    "mongodb": "^4.1.2",
+    "mongodb": "4.1.2",
     "mpath": "0.8.4",
     "mquery": "4.0.0",
     "ms": "2.1.2",


### PR DESCRIPTION
And support working with other minor versions.

**Summary**

If the including package has both mongoose and mongodb installed with different versions, it leads to errors on build.

**Examples**

```
myfile.ts(40,31): error TS2345: Argument of type 'import("node_modules/mongoose/node_modules/mongodb/mongodb").ChangeStream<any>' is not assignable to parameter of type 'import("node_modules/mongodb/mongodb").ChangeStream<any>'.
  The types of 'options.session.clientOptions.autoEncrypter' are incompatible between these types.
```