### PR TITLE
fix: accepts uppercase values in mongoose.isValidObjectId

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -960,7 +960,7 @@ Mongoose.prototype.isValidObjectId = function(v) {
       if (typeof v === 'string' && v.length === 12) {
         return true;
       }
-      if (typeof v === 'string' && v.length === 24 && /^[a-f0-9]*$/.test(v)) {
+      if (typeof v === 'string' && /^[0-9A-Fa-f]{24}$/.test(v)) {
         return true;
       }
       return false;
@@ -974,7 +974,7 @@ Mongoose.prototype.isValidObjectId = function(v) {
   if (typeof v === 'string' && v.length === 12) {
     return true;
   }
-  if (typeof v === 'string' && v.length === 24 && /^[a-f0-9]*$/.test(v)) {
+  if (typeof v === 'string' && /^[0-9A-Fa-f]{24}$/.test(v)) {
     return true;
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -688,6 +688,8 @@ describe('mongoose module:', function() {
 
   it('isValidObjectId (gh-3823)', function() {
     assert.ok(mongoose.isValidObjectId('0123456789ab'));
+    assert.ok(mongoose.isValidObjectId('5f5c2d56f6e911019ec2acdc'));
+    assert.ok(mongoose.isValidObjectId('608DE01F32B6A93BBA314159'));
     assert.ok(mongoose.isValidObjectId(new mongoose.Types.ObjectId()));
     assert.ok(!mongoose.isValidObjectId(6));
   });


### PR DESCRIPTION
### Summary

ObjectId are case-insensitives in MongoDB as long as the value is hexadecimal.

`mongoose.isValidObjectId` function should consider uppercase ObjectId as valid.

### Example

Adding the two following assertions to the test suite:
```js
assert.ok(mongoose.isValidObjectId('5f5c2d56f6e911019ec2acdc')); // passing before and after change
assert.ok(mongoose.isValidObjectId('608DE01F32B6A93BBA314159')); // passing only after change
```