### PR TITLE
fix 10850 by removing two properties from the `dbIndex.key` and assigning whats left to `const weight` with `dbIndex.weights`

### DIFF
--- a/lib/helpers/indexes/isIndexEqual.js
+++ b/lib/helpers/indexes/isIndexEqual.js
@@ -2,7 +2,7 @@
 
 const get = require('../get');
 const utils = require('../../utils');
-
+const _ = require('lodash')
 /**
  * Given a Mongoose index definition (key + options objects) and a MongoDB server
  * index definition, determine if the two indexes are equal.
@@ -28,7 +28,9 @@ module.exports = function isIndexEqual(key, options, dbIndex) {
   //   textIndexVersion: 3
   // }
   if (dbIndex.textIndexVersion != null) {
-    const weights = dbIndex.weights;
+    delete dbIndex.key._fts;
+    delete dbIndex.key._ftsx;
+    const weights = { ...dbIndex.weights, ...dbIndex.key };
     if (Object.keys(weights).length !== Object.keys(key).length) {
       return false;
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1429,6 +1429,9 @@ Model.diffIndexes = function diffIndexes(options, callback) {
   return this.db.base._promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
     this.listIndexes((err, indexes) => {
+      if (indexes === undefined) {
+        indexes = [];
+      }
       const schemaIndexes = this.schema.indexes();
       // Iterate through the indexes created in mongodb and
       // compare against the indexes in the schema.

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6231,6 +6231,19 @@ describe('Model', function() {
       assert.strictEqual(indexes[1].background, false);
     });
 
+    it('should not drop a text index on .syncIndexes() call (gh-10850)', async function() {
+      const collation = { collation: { locale: 'simple' } };
+      const someSchema = new Schema({
+        title: String,
+        author: String
+      });
+      someSchema.index({ title: 1, author: 'text' }, collation);
+      const M = db.model('Some', someSchema);
+      await M.init();
+      await M.syncIndexes();
+      assert(await M.syncIndexes(), []);
+    });
+
     it('using `new db.model()()` (gh-6698)', function(done) {
       db.model('Test', new Schema({
         name: String
@@ -7557,6 +7570,8 @@ describe('Model', function() {
     assert.ok(!test.name);
 
   });
+
+  
 });
 
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
