### PR TITLE
Restore  unpacked type and avoid distributive conditional types (#10767)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2480,11 +2480,11 @@ declare module 'mongoose' {
     $eq?: T;
     $gt?: T;
     $gte?: T;
-    $in?: T[];
+    $in?: [T] extends AnyArray<any> ? Unpacked<T>[] : T[];
     $lt?: T;
     $lte?: T;
     $ne?: T;
-    $nin?: T[];
+    $nin?: [T] extends AnyArray<any> ? Unpacked<T>[] : T[];
     // Logical
     $not?: T extends string ? QuerySelector<T> | RegExp : QuerySelector<T>;
     // Element

--- a/test/typescript/queries.ts
+++ b/test/typescript/queries.ts
@@ -161,3 +161,12 @@ function gh10757() {
 
   const test: FilterQuery<MyClass> = { status: { $in: [MyEnum.VALUE1, MyEnum.VALUE2] } };
 }
+
+function gh10857() {
+  type MyUnion = 'VALUE1'|'VALUE2';
+  interface MyClass {
+    status: MyUnion;
+  }
+  type MyClassDocument = MyClass & Document;
+  const test: FilterQuery<MyClass> = { status: { $in: ['VALUE1', 'VALUE2'] } };
+}


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

mongoose 6.0.9 has a typing error when dealing with union and enum in $in queries. It was incorrectly fixed in master, but the real problem was the "Distributive Conditional Types". IMHO, the correct fix is to disable the distribution


**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

See tests.
