### PR TITLE
fix(type): add caster for SchemaType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2948,6 +2948,9 @@ declare module 'mongoose' {
     /** String representation of what type this is, like 'ObjectID' or 'Number' */
     instance: string;
 
+    /** The caster instance associated with this schematype (for embedded). */
+    caster?: SchemaType;
+
     /** The options this SchemaType was instantiated with */
     options: AnyObject;
 


### PR DESCRIPTION
**Summary**

Adds caster in type definition.

According to this issue https://github.com/Automattic/mongoose/issues/10418, no concrete use case was found for adding `caster` in type definition files:

> If there's a reason for them to be user facing I'm happy to add them to the TS bindings.

I actually found use case for plugins and introspection tools. I saw two examples in two different repositories (see examples below)

**Examples**

- https://github.com/ForestAdmin/forest-express-mongoose/blob/0bad7998b624d32a410464040001fa3f386ef49b/src/adapters/mongoose.js#L140-L143
- https://github.com/selego/mongoose-elastic/blob/dd318091230f1a10938347ebc5d0d8ea44e5bb6f/src/index.ts#L235-L240

It's my first contribution to mongoose, let me know if I can improve my PR.