### PR TITLE
Update index.d.ts -> Add missing constructor typing for VersionError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3088,6 +3088,8 @@ declare module 'mongoose' {
       name: 'VersionError';
       version: number;
       modifiedPaths: Array<string>;
+      
+      constructor(doc: Document, currentVersion: number, modifiedPaths: Array<string>);
     }
   }
 


### PR DESCRIPTION
Adds missing constructor typing for VersionError as it extends Error it wrongfully expects to receive a string as a parameter (not 3 parameters)

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Adds missing constructor typing for VersionError as it extends Error it wrongfully expects to receive a string as a parameter (not 3 parameters)

**Examples**

```
// this gives the following error: Expected 1 arguments, but got 3. ts(2554)
const error = new VersionError({}, 2, ['a', 'b']);
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
