### PR TITLE
[gh-10875] Use stream destroy method on close to prevent emit 'close'…

### DIFF
--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -90,7 +90,13 @@ AggregationCursor.prototype._read = function() {
           // on node >= 14 streams close automatically (gh-8834)
           const isNotClosedAutomatically = !_this.destroyed;
           if (isNotClosedAutomatically) {
-            _this.emit('close');
+            // call destroy method if exists to prevent emit twice 'close' by autoDestroy (gh-10876)
+            // @see https://nodejs.org/api/stream.html#stream_readable_destroy_error
+            if (_this.destroy) {
+              _this.destroy();
+            } else {
+              _this.emit('close');
+            }
           }
         }, 0);
       });

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -103,7 +103,13 @@ QueryCursor.prototype._read = function() {
           // on node >= 14 streams close automatically (gh-8834)
           const isNotClosedAutomatically = !_this.destroyed;
           if (isNotClosedAutomatically) {
-            _this.emit('close');
+            // call destroy method if exists to prevent emit twice 'close' by autoDestroy (gh-10876)
+            // https://nodejs.org/api/stream.html#stream_readable_destroy_error
+            if (_this.destroy) {
+              _this.destroy();
+            } else {
+              _this.emit('close');
+            }
           }
         }, 0);
       });

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -589,6 +589,48 @@ describe('QueryCursor', function() {
     }, 20);
   });
 
+  it('closing query cursor emits `close` event only once with stream pause/resume (gh-10876)', function(done) {
+    const User = db.model('User', new Schema({ name: String }));
+
+    User.create({ name: 'First' }, { name: 'Second' })
+      .then(() => {
+        const cursor = User.find().cursor();
+        cursor.on('data', () => {
+          cursor.pause();
+          setTimeout(() => cursor.resume(), 50);
+        });
+
+        let closeEventTriggeredCount = 0;
+        cursor.on('close', () => closeEventTriggeredCount++);
+        setTimeout(() => {
+          assert.equal(closeEventTriggeredCount, 1);
+          done();
+        }, 200);
+      });
+  });
+
+  it('closing aggregation cursor emits `close` event only once with stream pause/resume (gh-10876)', function(done) {
+    const User = db.model('User', new Schema({ name: String }));
+
+    User.create({ name: 'First' }, { name: 'Second' })
+      .then(() => {
+        const cursor = User.aggregate([{ $match: {} }]).cursor();
+        cursor.on('data', () => {
+          cursor.pause();
+          setTimeout(() => cursor.resume(), 50);
+        });
+
+        let closeEventTriggeredCount = 0;
+        cursor.on('close', () => closeEventTriggeredCount++);
+
+
+        setTimeout(() => {
+          assert.equal(closeEventTriggeredCount, 1);
+          done();
+        }, 200);
+      });
+  });
+
   it('passes document index as the second argument for query cursor (gh-8972)', async function() {
     const User = db.model('User', Schema({ order: Number }));
 


### PR DESCRIPTION
… event twice

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
These changes fix the issue with twice emitted 'close' events. 
https://github.com/Automattic/mongoose/issues/10876

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
