### PR TITLE
fix(index.d.ts): More precise type for Schema.clone()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1257,7 +1257,7 @@ declare module 'mongoose' {
     childSchemas: { schema: Schema, model: any }[];
 
     /** Returns a copy of this schema */
-    clone(): Schema;
+    clone(): this;
 
     /** Object containing discriminators defined on this schema */
     discriminators?: { [name: string]: Schema };


### PR DESCRIPTION
**Summary**

Currently, `schema.clone()` returns a generic `Schema`, without using typing info already available on `schema`.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
