### PR TITLE
[gh-10902] Remove the logic for emit close, autodestroy will emit clo…

### DIFF
--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -36,7 +36,9 @@ const util = require('util');
  */
 
 function AggregationCursor(agg) {
-  Readable.call(this, { objectMode: true });
+  // set autoDestroy=true because on node 12 it's by default false
+  // gh-10902 need autoDestroy to destroy correctly and emit 'close' event
+  Readable.call(this, { autoDestroy: true, objectMode: true });
 
   this.cursor = null;
   this.agg = agg;
@@ -86,19 +88,6 @@ AggregationCursor.prototype._read = function() {
         if (error) {
           return _this.emit('error', error);
         }
-        setTimeout(function() {
-          // on node >= 14 streams close automatically (gh-8834)
-          const isNotClosedAutomatically = !_this.destroyed;
-          if (isNotClosedAutomatically) {
-            // call destroy method if exists to prevent emit twice 'close' by autoDestroy (gh-10876)
-            // @see https://nodejs.org/api/stream.html#stream_readable_destroy_error
-            if (_this.destroy) {
-              _this.destroy();
-            } else {
-              _this.emit('close');
-            }
-          }
-        }, 0);
       });
       return;
     }

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -34,7 +34,9 @@ const util = require('util');
  */
 
 function QueryCursor(query, options) {
-  Readable.call(this, { objectMode: true });
+  // set autoDestroy=true because on node 12 it's by default false
+  // gh-10902 need autoDestroy to destroy correctly and emit 'close' event
+  Readable.call(this, { autoDestroy: true, objectMode: true });
 
   this.cursor = null;
   this.query = query;
@@ -99,19 +101,6 @@ QueryCursor.prototype._read = function() {
         if (error) {
           return _this.emit('error', error);
         }
-        setTimeout(function() {
-          // on node >= 14 streams close automatically (gh-8834)
-          const isNotClosedAutomatically = !_this.destroyed;
-          if (isNotClosedAutomatically) {
-            // call destroy method if exists to prevent emit twice 'close' by autoDestroy (gh-10876)
-            // https://nodejs.org/api/stream.html#stream_readable_destroy_error
-            if (_this.destroy) {
-              _this.destroy();
-            } else {
-              _this.emit('close');
-            }
-          }
-        }, 0);
       });
       return;
     }

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -630,6 +630,88 @@ describe('QueryCursor', function() {
       });
   });
 
+  it('query cursor emit end event (gh-10902)', function(done) {
+    const User = db.model('User', new Schema({ name: String }));
+
+    User.create({ name: 'First' }, { name: 'Second' })
+      .then(() => {
+        const cursor = User.find({}).cursor();
+        cursor.on('data', () => {
+          cursor.pause();
+          setTimeout(() => cursor.resume(), 50);
+        });
+
+        let endEventTriggeredCount = 0;
+        cursor.on('end', () => endEventTriggeredCount++);
+
+        setTimeout(() => {
+          assert.equal(endEventTriggeredCount, 1);
+          done();
+        }, 200);
+      });
+  });
+
+  it('aggregate cursor emit end event (gh-10902)', function(done) {
+    const User = db.model('User', new Schema({ name: String }));
+
+    User.create({ name: 'First' }, { name: 'Second' })
+      .then(() => {
+        const cursor = User.aggregate([{ $match: {} }]).cursor();
+        cursor.on('data', () => {
+          cursor.pause();
+          setTimeout(() => cursor.resume(), 50);
+        });
+
+        let endEventTriggeredCount = 0;
+        cursor.on('end', () => endEventTriggeredCount++);
+
+        setTimeout(() => {
+          assert.equal(endEventTriggeredCount, 1);
+          done();
+        }, 200);
+      });
+  });
+
+  it('query cursor emit end event before close event (gh-10902)', function(done) {
+    const User = db.model('User', new Schema({ name: String }));
+
+    User.create({ name: 'First' }, { name: 'Second' })
+      .then(() => {
+        const cursor = User.find({}).cursor();
+        cursor.on('data', () => {
+          cursor.pause();
+          setTimeout(() => cursor.resume(), 50);
+        });
+
+        let endEventTriggeredCount = 0;
+        cursor.on('end', () => endEventTriggeredCount++);
+        cursor.on('close', () => {
+          assert.equal(endEventTriggeredCount, 1);
+          done();
+        });
+      });
+  });
+
+  it('aggregate cursor emit end event before close event (gh-10902)', function(done) {
+    const User = db.model('User', new Schema({ name: String }));
+
+    User.create({ name: 'First' }, { name: 'Second' })
+      .then(() => {
+        const cursor = User.aggregate([{ $match: {} }]).cursor();
+        cursor.on('data', () => {
+          cursor.pause();
+          setTimeout(() => cursor.resume(), 50);
+        });
+
+        let endEventTriggeredCount = 0;
+        cursor.on('end', () => endEventTriggeredCount++);
+        cursor.on('close', () => {
+          assert.equal(endEventTriggeredCount, 1);
+          done();
+        });
+      });
+  });
+
   it('passes document index as the second argument for query cursor (gh-8972)', async function() {
     const User = db.model('User', Schema({ order: Number }));
 


### PR DESCRIPTION
…se. Works only for node>=12.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**
The query/aggregate cursor should emit 'end' event and the 'end' event should be emitted before 'close' event.
It can be fixed using the auto destroy feature that exists in node >= 12.
I've added the autoDestroy=true for stream options because for node 12 this option is false by default.
This fix will work for node >= 12.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
