### PR TITLE
Add SchemaType `set` breaking change in v6 migration guide

### DIFF
--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -333,25 +333,24 @@ If you set `timestamps: true`, Mongoose will now make the `createdAt` property `
 
 <h3 id="schematype-set-parameters"><a href="#schematype-set-parameters">SchemaType `set` parameters</a></h3>
 
-SchemaType `set` parameters now use `priorValue` as the second parameter instead of `self`.
+Mongoose now calls setter functions with `priorValue` as the 2nd parameter, rather than `schemaType` in Mongoose 5.
 
-In v5.x schema types setters received the second parameter `self`, which is the schemaType itself.
-in v6.x schema types setters receive `priorValue` as the second parameter, and `self` as the third parameter. We should add this to the migration guide.
 
-```ts
+```js
 const userSchema = new Schema({
   name: {
     type: String,
-    // in v5.x, the second parameter was `self`
-    set: (val, self) => {
-      return self.cast(val.toLowerCase());
-    },
-    // in v6.x, add a second parameter `priorValue`
-    set: (val, priorValue, self) => {
-      return self.cast(val.toLowerCase());
-    }
+    trimStart: true,
+    set: trimStartSetter
   }
 });
+
+// in v5.x the parameters were (value, schemaType), in v6.x the parameters are (value, priorValue, schemaType).
+function trimStartSetter(val, priorValue, schemaType) {
+  if (schemaType.options.trimStart && typeof val === 'string') {
+    return val.trimStart();
+  }
+}
 
 const User = mongoose.model('User', userSchema);
 

--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -35,6 +35,7 @@ If you're still on Mongoose 4.x, please read the [Mongoose 4.x to 5.x migration 
 * [Immutable `createdAt`](#immutable-createdat)
 * [Removed Validator `isAsync`](#removed-validator-isasync)
 * [Removed `safe`](#removed-safe)
+* [SchemaType `set` parameters now use `priorValue` as the second parameter instead of `self`](#schematype-set-parameters)
 * [TypeScript changes](#typescript-changes)
 
 <h3 id="version-requirements"><a href="#version-requirements">Version Requirements</a></h3>
@@ -330,6 +331,33 @@ If you set `timestamps: true`, Mongoose will now make the `createdAt` property `
 
 `safe` is no longer an option for schemas, queries, or `save()`. Use `writeConcern` instead.
 
+<h3 id="schematype-set-parameters"><a href="#schematype-set-parameters">SchemaType `set` parameters</a></h3>
+
+SchemaType `set` parameters now use `priorValue` as the second parameter instead of `self`.
+
+In v5.x schema types setters received the second parameter `self`, which is the schemaType itself.
+in v6.x schema types setters receive `priorValue` as the second parameter, and `self` as the third parameter. We should add this to the migration guide.
+
+```ts
+const userSchema = new Schema({
+  name: {
+    type: String,
+    // in v5.x, the second parameter was `self`
+    set: (val, self) => {
+      return self.cast(val.toLowerCase());
+    },
+    // in v6.x, add a second parameter `priorValue`
+    set: (val, priorValue, self) => {
+      return self.cast(val.toLowerCase());
+    }
+  }
+});
+
+const User = mongoose.model('User', userSchema);
+
+const user = new User({ name: 'Robert Martin' });
+console.log(user.name); // 'robert martin'
+```
 ## TypeScript changes
 
 The `Schema` class now takes 3 generic params instead of 4. The 3rd generic param, `SchemaDefinitionType`, is now the same as the 1st generic param `DocType`. Replace `new Schema<UserDocument, UserModel, User>(schemaDefinition)` with `new Schema<UserDocument, UserModel>(schemaDefinition)`

--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -350,6 +350,7 @@ function trimStartSetter(val, priorValue, schemaType) {
   if (schemaType.options.trimStart && typeof val === 'string') {
     return val.trimStart();
   }
+  return val;
 }
 
 const User = mongoose.model('User', userSchema);
@@ -357,6 +358,7 @@ const User = mongoose.model('User', userSchema);
 const user = new User({ name: 'Robert Martin' });
 console.log(user.name); // 'robert martin'
 ```
+
 ## TypeScript changes
 
 The `Schema` class now takes 3 generic params instead of 4. The 3rd generic param, `SchemaDefinitionType`, is now the same as the 1st generic param `DocType`. Replace `new Schema<UserDocument, UserModel, User>(schemaDefinition)` with `new Schema<UserDocument, UserModel>(schemaDefinition)`

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -610,7 +610,7 @@ SchemaType.prototype.transform = function(fn) {
  *
  * Setters are also passed a second argument, the schematype on which the setter was defined. This allows for tailored behavior based on options passed in the schema.
  *
- *     function inspector (val, schematype) {
+ *     function inspector (val, priorValue, schematype) {
  *       if (schematype.options.required) {
  *         return schematype.path + ' is required';
  *       } else {
@@ -697,7 +697,7 @@ SchemaType.prototype.set = function(fn) {
  *
  * Getters are also passed a second argument, the schematype on which the getter was defined. This allows for tailored behavior based on options passed in the schema.
  *
- *     function inspector (val, schematype) {
+ *     function inspector (val, priorValue, schematype) {
  *       if (schematype.options.required) {
  *         return schematype.path + ' is required';
  *       } else {


### PR DESCRIPTION
fixes #10921 