### PR TITLE
Fix ts types for query set

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2442,7 +2442,7 @@ declare module 'mongoose' {
      * This is useful for query middleware so you can add an update regardless
      * of whether you use `updateOne()`, `updateMany()`, `findOneAndUpdate()`, etc.
      */
-    set(path: string | Record<string, unknown>, value: any): this;
+    set(path: string | Record<string, unknown>, value?: any): this;
 
     /** Sets query options. Some options only make sense for certain operations. */
     setOptions(options: QueryOptions, overwrite?: boolean): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2442,7 +2442,7 @@ declare module 'mongoose' {
      * This is useful for query middleware so you can add an update regardless
      * of whether you use `updateOne()`, `updateMany()`, `findOneAndUpdate()`, etc.
      */
-    set(path: string, value: any): this;
+    set(path: string | Record<string, unknown>, value: any): this;
 
     /** Sets query options. Some options only make sense for certain operations. */
     setOptions(options: QueryOptions, overwrite?: boolean): this;


### PR DESCRIPTION
**Summary**

The Query `set` method does not function properly in TypeScript projects. It currently only supports, the `string, value` implementation, but not the `object` only implementation. See https://github.com/Automattic/mongoose/blob/5.x/lib/query.js#L1835-L1848 for reference.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

```ts
// Does not work
Model.updateOne({ id }).set({ name: 'new' });

// Works
Model.updateOne({ id }).set('name', 'new');
```
