### PR TITLE
fix(types): add clone to query

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2129,6 +2129,9 @@ declare module 'mongoose' {
     circle(area: any): this;
     circle(path: string, area: any): this;
 
+    /** Make a copy of this query so you can re-execute it. */
+    clone(): this;
+
     /** Adds a collation to this op (MongoDB 3.4 and up) */
     collation(value: mongodb.CollationOptions): this;
 


### PR DESCRIPTION
**Summary**

This adds the [clone](https://github.com/Automattic/mongoose/blob/da1f4bdc8e7fceb248c07287ea76131c9e011616/lib/query.js#L242) method to the typings for `Query` as it was missing.

**Examples**

```ts
Model.find().clone()
```
Typescript Error: `Property 'clone' does not exist on type 'Query<any, any, {}, any>'`

[All tests passed.](https://github.com/asportnoy/mongoose/actions/runs/1401455220)