### PR TITLE
Fixed typo in document.js

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3632,7 +3632,7 @@ Document.prototype.$toObject = function(options, json) {
  * If you pass a transform in `toObject()` options, Mongoose will apply the transform
  * to [subdocuments](/docs/subdocs.html) in addition to the top-level document.
  * Similarly, `transform: false` skips transforms for all subdocuments.
- * Note that this is behavior is different for transforms defined in the schema:
+ * Note that this behavior is different for transforms defined in the schema:
  * if you define a transform in `schema.options.toObject.transform`, that transform
  * will **not** apply to subdocuments.
  *


### PR DESCRIPTION
**Summary**

Fixed small typo in `Document.prototype.toObject()` api docs.

**Examples**

