### PR TITLE
Fix Schema's clone function typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1258,7 +1258,7 @@ declare module 'mongoose' {
     childSchemas: { schema: Schema, model: any }[];
 
     /** Returns a copy of this schema */
-    clone<T extends DocType = DocType>(): Schema<T>;
+    clone<T extends Schema<DocType> = this>(): T;
 
     /** Object containing discriminators defined on this schema */
     discriminators?: { [name: string]: Schema };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1258,7 +1258,7 @@ declare module 'mongoose' {
     childSchemas: { schema: Schema, model: any }[];
 
     /** Returns a copy of this schema */
-    clone<T extends Schema<DocType> = this>(): T;
+    clone<T = this>(): T;
 
     /** Object containing discriminators defined on this schema */
     discriminators?: { [name: string]: Schema };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1258,7 +1258,7 @@ declare module 'mongoose' {
     childSchemas: { schema: Schema, model: any }[];
 
     /** Returns a copy of this schema */
-    clone(): this;
+    clone<T extends DocType = DocType>(): Schema<T>;
 
     /** Object containing discriminators defined on this schema */
     discriminators?: { [name: string]: Schema };


### PR DESCRIPTION
**Summary**
The Schema's clone function does not preserve the typing (and on its best case, it loses the name of the type and just types the cloned schema as a nameless object)

**Examples**
Before:
clone returns an untyped schema (or at best it returns an object but the type name/interface/class is lost)

After:
clone returns a typed schema which can be the original type or a type that extends the base type (would work for type extending it with partial params)

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
