### PR TITLE
chore: upgrade to mongodb driver 4.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "^4.2.2",
     "kareem": "2.3.2",
-    "mongodb": "4.1.3",
+    "mongodb": "4.1.4",
     "mpath": "0.8.4",
     "mquery": "4.0.0",
     "ms": "2.1.2",


### PR DESCRIPTION
**Summary**

Required to build with TypeScript 4.5 (mongodb/node-mongodb-native#3004)