### PR TITLE
docs(document.js): fix link leading to old github pages site

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1818,7 +1818,7 @@ Document.prototype.$__path = function(path) {
 /**
  * Marks the path as having pending changes to write to the db.
  *
- * _Very helpful when using [Mixed](./schematypes.html#mixed) types._
+ * _Very helpful when using [Mixed](https://mongoosejs.com/docs/schematypes.html#mixed) types._
  *
  * ####Example:
  *


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

The link on the site for Mixed schema type, was linking me to the old github pages page, you might have another type of fix, but this is the fix I found

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
