### PR TITLE
add unionWith method to aggregate

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2870,6 +2870,9 @@ declare module 'mongoose' {
      */
     sortByCount(arg: string | any): this;
 
+    /** Appends new $unionWith operator to this aggregate pipeline. */
+    unionWith(options: any): this;
+
     /** Appends new custom $unwind operator(s) to this aggregate pipeline. */
     unwind(...args: any[]): this;
   }

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -594,6 +594,23 @@ Aggregate.prototype.sort = function(arg) {
 };
 
 /**
+ * Appends new $unionWith operator to this aggregate pipeline.
+ *
+ * ####Examples:
+ *
+ *     aggregate.unionWith({ coll: 'users', pipeline: [ { $match: { _id: 1 } } ] });
+ *
+ * @see $unionWith https://docs.mongodb.com/manual/reference/operator/aggregation/unionWith
+ * @param {Object} options to $unionWith query as described in the above link
+ * @return {Aggregate}* @api public
+ */
+
+Aggregate.prototype.unionWith = function(options) {
+  return this.append({ $unionWith: options });
+};
+
+
+/**
  * Sets the readPreference option for the aggregation query.
  *
  * ####Example:

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -342,6 +342,25 @@ describe('aggregate: ', function() {
     });
   });
 
+  describe('unionWith', function () {
+    it('works', function () {
+      const aggregate = new Aggregate();
+      const obj = {
+        coll: 'users',
+        pipeline: [
+          {
+            $match: {_id: 1}
+          }
+        ]
+      };
+
+      aggregate.unionWith(obj);
+
+      assert.equal(aggregate._pipeline.length, 1);
+      assert.deepEqual(aggregate._pipeline[0].$unionWith, obj);
+    });
+  });
+
   describe('sample', function() {
     it('works', function() {
       const aggregate = new Aggregate();


### PR DESCRIPTION
MongoDB 4.4 introduces new $unionWith aggregation operator to union the results of multiple different queries into one result set. The documentation can be find [here](https://docs.mongodb.com/manual/reference/operator/aggregation/unionWith).

This PR offers this new pipeline operator as a chaining method to Aggregate.

Working Example:
```js

model.aggregate()
  .unionWith({
    coll: 'users',
    pipeline: [
      {
        $match: {_id: 1}
      }
    ]
  })

