### PR TITLE
fix(index.d.ts): Allow model creation with instance methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1248,7 +1248,7 @@ declare module 'mongoose' {
   type PostMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, res: ResType, next: (err?: CallbackError) => void) => void | Promise<void>;
   type ErrorHandlingMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: (err?: CallbackError) => void) => void;
 
-  class Schema<DocType = any, M = Model<DocType, any, any, any>, TInstanceMethods = {}> extends events.EventEmitter {
+  class Schema<DocType = any, M = Model<DocType, any, any, any>, TInstanceMethods = any> extends events.EventEmitter {
     /**
      * Create a new schema
      */


### PR DESCRIPTION
**Summary**

When using mongoose w/ typescript it's not possible to create models w/ instance methods.


**Examples**

https://github.com/Automattic/mongoose/issues/10358#issuecomment-861779692

```ts
import { Schema, Model, createConnection } from 'mongoose'

interface ITestModel {
    name: string
}
interface InstanceMethods {
    iMethod1: (param1: string) => string
    iMethod2: (param1: string) => string
}
interface TestModel extends Model<ITestModel, {}, InstanceMethods> {
    sMethod1: (param1: string) => string
    sMethod2: (param1: string) => string
}
const ModelSchema = new Schema<ITestModel, TestModel, undefined, InstanceMethods>({ // <-- add `InstanceMethods` here
    name: String
})

ModelSchema.statics.sMethod1 = function() {
    this.sMethod2('test')
}
ModelSchema.statics.sMethod2 = function() {}

ModelSchema.methods.iMethod1 = function() {
    this.iMethod2("test")
}
ModelSchema.methods.iMethod2 = function() {
}

// create lazy connection object to connect later
const connection = createConnection()

export const TestModelCompiled = connection.model<ITestModel, TestModel>("testModel", ModelSchema)

const modelInstance = new TestModelCompiled()

modelInstance.iMethod1('test')

TestModelCompiled.sMethod1('test')
```

However due to the change made in this commit: https://github.com/Automattic/mongoose/commit/fefebb35065f7d85850b77656484d538aa4d612d

The above mentioned code won't compile. The error occurs on this line:
`export const TestModelCompiled = connection.model<ITestModel, TestModel>("testModel", ModelSchema)`

Output in VSCode (v1.62.2):
```
No overload matches this call.
  Overload 1 of 3, '(name: string, schema?: Schema<ITestModel, TestModel, {}, {}>, collection?: string, skipInit?: boolean): TestModel', gave the following error.
    Argument of type 'Schema<ITestModel, TestModel, undefined, InstanceMethods>' is not assignable to parameter of type 'Schema<ITestModel, TestModel, {}, {}>'.
      Type '{}' is missing the following properties from type 'InstanceMethods': iMethod1, iMethod2
  Overload 2 of 3, '(name: string, schema?: Schema<any, Model<any, any, any>, undefined, {}>, collection?: string, skipInit?: boolean): TestModel', gave the following error.
    Argument of type 'Schema<ITestModel, TestModel, undefined, InstanceMethods>' is not assignable to parameter of type 'Schema<any, Model<any, any, any>, undefined, {}>'.
      Type '{}' is not assignable to type 'InstanceMethods'.ts(2769)
const ModelSchema: Schema<ITestModel, TestModel, undefined, InstanceMethods>
```
