### PR TITLE
docs: fix default value of strictQuery

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ Mongoose.prototype.driver = driver;
  * - 'toObject': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toObject()`](/docs/api.html#document_Document-toObject)
  * - 'toJSON': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toJSON()`](/docs/api.html#document_Document-toJSON), for determining how Mongoose documents get serialized by `JSON.stringify()`
  * - 'strict': true by default, may be `false`, `true`, or `'throw'`. Sets the default strict mode for schemas.
- * - 'strictQuery': false by default, may be `false`, `true`, or `'throw'`. Sets the default [strictQuery](/docs/guide.html#strictQuery) mode for schemas.
+ * - 'strictQuery': same value as 'strict' by default (`true`), may be `false`, `true`, or `'throw'`. Sets the default [strictQuery](/docs/guide.html#strictQuery) mode for schemas.
  * - 'selectPopulatedPaths': true by default. Set to false to opt out of Mongoose adding all fields that you `populate()` to your `select()`. The schema-level option `selectPopulatedPaths` overwrites this one.
  * - 'maxTimeMS': If set, attaches [maxTimeMS](https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/) to every query
  * - 'autoIndex': true by default. Set to false to disable automatic index creation for all models associated with this Mongoose instance.


### PR DESCRIPTION
I think this is the right place to update the docs seen on https://mongoosejs.com/docs/api.html#mongoose_Mongoose-set
**Summary**

This small part of the docs is inaccurate, I believe. 

By default, strict is set to true, and strictQuery is set to the value of strict, so strictQuery is true by default. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
