### PR TITLE
feat(populate): support `ref` on subdocuments

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -170,7 +170,7 @@ module.exports = function assignVals(o) {
     }
     if (docs[i].$__) {
       o.allOptions.options[populateModelSymbol] = o.allOptions.model;
-      docs[i].$populated(_path, o.allIds[i], o.allOptions.options);
+      docs[i].$populated(_path, o.unpopulatedValues[i], o.allOptions.options);
 
       if (valueToSet instanceof Map && !valueToSet.$isMongooseMap) {
         valueToSet = new MongooseMap(valueToSet, _path, docs[i], docs[i].schema.path(_path).$__schemaType);

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -75,6 +75,23 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     let normalizedRefPath = null;
     let schemaOptions = null;
 
+    if (schema != null && schema.instance === 'Embedded' && schema.options.ref) {
+      const data = {
+        localField: options.path + '._id',
+        foreignField: '_id'
+      };
+      let normalizedRef;
+      if (typeof schema.options.ref === 'function' && !schema.options.ref[modelSymbol]) {
+        normalizedRef = schema.options.ref.call(doc, doc);
+      } else {
+        normalizedRef = schema.options.ref;
+      }
+      const unpopulatedValue = get(doc, options.path);
+      const id = get(unpopulatedValue, ['_id']);
+      addModelNamesToMap(model, map, available, [normalizedRef], options, data, id, doc, schemaOptions, unpopulatedValue);
+      continue;
+    }
+
     if (Array.isArray(schema)) {
       const schemasArray = schema;
       for (const _schema of schemasArray) {
@@ -444,10 +461,15 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
  * ignore
  */
 
-function addModelNamesToMap(model, map, available, modelNames, options, data, ret, doc, schemaOptions) {
+function addModelNamesToMap(model, map, available, modelNames, options, data, ret, doc, schemaOptions, unpopulatedValue) {
   // `PopulateOptions#connection`: if the model is passed as a string, the
   // connection matters because different connections have different models.
   const connection = options.connection != null ? options.connection : model.db;
+
+  unpopulatedValue = unpopulatedValue === void 0 ? ret : unpopulatedValue;
+  if (Array.isArray(unpopulatedValue)) {
+    unpopulatedValue = [].concat(unpopulatedValue);
+  }
 
   if (modelNames == null) {
     return;
@@ -510,6 +532,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
         docs: [doc],
         ids: [ids],
         allIds: [ret],
+        unpopulatedValues: [unpopulatedValue],
         localField: new Set([data.localField]),
         foreignField: new Set([data.foreignField]),
         justOne: data.justOne,
@@ -525,6 +548,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
       available[modelName].docs.push(doc);
       available[modelName].ids.push(ids);
       available[modelName].allIds.push(ret);
+      available[modelName].unpopulatedValues.push(unpopulatedValue);
       if (data.hasMatchFunction) {
         available[modelName].match.push(data.match);
       }

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -78,17 +78,14 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     if (schema != null && schema.instance === 'Embedded' && schema.options.ref) {
       const data = {
         localField: options.path + '._id',
-        foreignField: '_id'
+        foreignField: '_id',
+        justOne: true
       };
-      let normalizedRef;
-      if (typeof schema.options.ref === 'function' && !schema.options.ref[modelSymbol]) {
-        normalizedRef = schema.options.ref.call(doc, doc);
-      } else {
-        normalizedRef = schema.options.ref;
-      }
-      const unpopulatedValue = get(doc, options.path);
-      const id = get(unpopulatedValue, ['_id']);
-      addModelNamesToMap(model, map, available, [normalizedRef], options, data, id, doc, schemaOptions, unpopulatedValue);
+      const res = _getModelNames(doc, schema, modelNameFromQuery, model);
+
+      const unpopulatedValue = mpath.get(options.path, doc);
+      const id = mpath.get('_id', unpopulatedValue);
+      addModelNamesToMap(model, map, available, res.modelNames, options, data, id, doc, schemaOptions, unpopulatedValue);
       continue;
     }
 
@@ -200,7 +197,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     let isRefPath = false;
     let justOne = null;
 
-    if (schema && schema.caster) {
+    if (schema && schema.instance === 'Array') {
       schema = schema.caster;
     }
     if (schema && schema.$isSchemaMap) {
@@ -473,7 +470,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
 
   unpopulatedValue = unpopulatedValue === void 0 ? ret : unpopulatedValue;
   if (Array.isArray(unpopulatedValue)) {
-    unpopulatedValue = [].concat(unpopulatedValue);
+    unpopulatedValue = utils.cloneArrays(unpopulatedValue);
   }
 
   if (modelNames == null) {
@@ -584,6 +581,8 @@ function _getLocalFieldValues(doc, localField, model, options, virtual, schema) 
     localFieldPathType.schema;
   const localFieldGetters = localFieldPath && localFieldPath.getters ?
     localFieldPath.getters : [];
+
+  localField = localFieldPath != null && localFieldPath.instance === 'Embedded' ? localField + '._id' : localField;
 
   const _populateOptions = get(options, 'options', {});
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -4709,6 +4709,7 @@ function _assign(model, vals, mod, assignmentOpts) {
     // If virtual, make sure to not mutate original field
     rawIds: mod.isVirtual ? allIds : mod.allIds,
     allIds: allIds,
+    unpopulatedValues: mod.unpopulatedValues,
     foreignField: mod.foreignField,
     rawDocs: rawDocs,
     rawOrder: rawOrder,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -182,6 +182,18 @@ exports.promiseOrCallback = promiseOrCallback;
  * ignore
  */
 
+exports.cloneArrays = function cloneArrays(arr) {
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return arr.map(el => exports.cloneArrays(el));
+};
+
+/*!
+ * ignore
+ */
+
 exports.omit = function omit(obj, keys) {
   if (keys == null) {
     return Object.assign({}, obj);

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -10447,4 +10447,34 @@ describe('model: populate:', function() {
     const doc = await BlogPost.findOne().populate('author');
     assert.equal(doc.author.email, 'test@gmail.com');
   });
+
+  it('supports ref on subdocuments (gh-10856)', async function() {
+    const userSchema = Schema({ _id: Number, name: String, email: String });
+    const blogPostSchema = Schema({
+      title: String,
+      author: {
+        type: new Schema({ _id: Number, name: String }),
+        ref: 'User'
+      }
+    });
+
+    const User = db.model('User', userSchema);
+    const BlogPost = db.model('BlogPost', blogPostSchema);
+
+    await User.create({ _id: 1, name: 'John Smith', email: 'test@gmail.com' });
+    await BlogPost.create({ title: 'Introduction to Mongoose', author: { _id: 1, name: 'John Smith' } });
+
+    const doc = await BlogPost.findOne().populate('author');
+    assert.equal(doc.author.email, 'test@gmail.com');
+    assert.equal(doc.toObject().author.email, 'test@gmail.com');
+
+    doc.depopulate();
+    assert.equal(doc.author.name, 'John Smith');
+
+    doc.author.name = 'John Smythe';
+    await doc.save();
+
+    const fromDb = await BlogPost.findById(doc);
+    assert.equal(fromDb.author.name, 'John Smythe');
+  });
 });


### PR DESCRIPTION
Re: #10856

**Summary**

From the discussion of #10856, we want to support populating partially denormalized subdocuments. 

```javascript
    const blogPostSchema = Schema({
      title: String,
      author: {
        // Denormalize `_id` and `name` from User, but if you `populate('author')`, you should get the other properties
        type: new Schema({ _id: Number, name: String }),
        ref: 'User'
      }
    });
```

PR is a little rougher than I'd like, I would still like to improve a couple of things: a `cloneArrays()` function for the `if (Array.isArray(unpopulatedValue)) { ... }` case to handle deep arrays, make this less of an edge case in `getModelsMapForPopulate()`, and make sure this still works with arrays that contain subdocuments. But enough to review the general idea.

One key issue/design decision: if you `populate('author')` on a blog post, `author` will be a fully fledged populated document, **not** a subdocument. This means that updating `doc.author.name = 'foo'; await doc.save();` will not update `author.name` unless you depopulate. We can make this work in the future, but might be a bit too tricky for this PR.

@adamreisnz we'd like to hear your thoughts as well

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
