### PR TITLE
Fix typo in populate docs

### DIFF
--- a/docs/populate.md
+++ b/docs/populate.md
@@ -667,7 +667,7 @@ let authors = await Author.
 
 authors = await Author.
   find({}).
-  // Works, foreign field `band` is selected
+  // Works, foreign field `author` is selected
   populate({ path: 'posts', select: 'title author' }).
   exec();
 ```


### PR DESCRIPTION
Docs mistakenly reference foreign field "band" but the foreign field in the example is "author" 