### PR TITLE
Added note about `_id` propery by MongoDB

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -100,6 +100,9 @@ To do so, we pass it into `mongoose.model(modelName, schema)`:
 
 <h3 id="_id"><a href="#_id">Ids</a></h3>
 
+>MongoDB(on which Mongoose runs) adds `_id` property to each document.
+>Here, for better understanding of user we have mentioned it as Mongoose.
+
 By default, Mongoose adds an `_id` property to your schemas.
 
 ```javascript


### PR DESCRIPTION
In Docs explain that  adding  `_id` property to document is default feature of Mongoose.
This might confuse the beginners about whether MongoDB adds its to the document or Mongoose does?
Hence added a note so the beginners will not get confused.
