### PR TITLE
Remove duplicate "path" in comment.

### DIFF
--- a/lib/options/SchemaTypeOptions.js
+++ b/lib/options/SchemaTypeOptions.js
@@ -82,7 +82,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'cast', opts);
 
 /**
  * If true, attach a required validator to this path, which ensures this path
- * path cannot be set to a nullish value. If a function, Mongoose calls the
+ * cannot be set to a nullish value. If a function, Mongoose calls the
  * function and only checks for nullish values if the function returns a truthy value.
  *
  * @api public


### PR DESCRIPTION
**Summary**

This is a ridiculous PR and I'm sorry for wasting your time. I haven't worked with upstream repos before.  While teaching myself MongoDB I was reading the docs and saw the duplicated "path" in the docs.  I decided to figure out how to fork, update, and PR back into the original repo.  Once I got as far as this PR I was going to just delete my repo and forget about it, but I decided what the heck...

**Examples**

This is a documentation comment "fix" only.
