### PR TITLE
docs(model.estimatedDocumentCount): add `await` into example to get value from the Query

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2259,7 +2259,7 @@ Model.findOne = function findOne(conditions, projection, options, callback) {
  *
  * ####Example:
  *
- *     const numAdventures = Adventure.estimatedDocumentCount();
+ *     const numAdventures = await Adventure.estimatedDocumentCount();
  *
  * @param {Object} [options]
  * @param {Function} [callback]


### PR DESCRIPTION
**Summary**

When doing copy/paste of the example
```
const numAdventures = Adventure.estimatedDocumentCount();
```

there is no expected numeric value assigned to the `numAdventures`. By adding `await` there will be one.

https://mongoosejs.com/docs/api.html#model_Model.estimatedDocumentCount