### PR TITLE
Incorrect return value for UpdateOne

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -103,7 +103,7 @@ database without returning them to your application. See the
 
 ```javascript
 Tank.updateOne({ size: 'large' }, { name: 'T-90' }, function(err, res) {
-  // Updated at most one doc, `res.modifiedCount` contains the number
+  // Updated at most one doc, `res.nModified` contains the number
   // of docs that MongoDB updated
 });
 ```


### PR DESCRIPTION
The docs claim that the results from updateOne() contain an "modifiedCount" field identical to Mongo, but testing with Mongoose 5.12 shows that the actual field is named "nModified" instead.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
