### PR TITLE
fix(index.d.ts): add boolean type for transform option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1219,7 +1219,7 @@ declare module 'mongoose' {
     /** remove empty objects (defaults to true) */
     minimize?: boolean;
     /** if set, mongoose will call this function to allow you to transform the returned object */
-    transform?: (doc: any, ret: any, options: any) => any;
+    transform?: boolean | ((doc: any, ret: any, options: any) => any);
     /** if true, replace any conventionally populated paths with the original id in the output. Has no affect on virtual populated paths. */
     depopulate?: boolean;
     /** if false, exclude the version key (`__v` by default) from the output */


### PR DESCRIPTION
In docs is clearly state that the default value for `toJSON()` and `toObject()` options is `{ transform: true, flattenDecimals: true }`. Also, it's possible to use `{ transform: false }` to stop document transformation.