### PR TITLE
fix(index.d.ts): make pipeline property from $unionWith an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3177,7 +3177,7 @@ declare module 'mongoose' {
       /** [`$unionWith` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/unionWith/) */
       $unionWith:
         | string
-        | { coll: string; pipeline?: Exclude<PipelineStage, PipelineStage.Out | PipelineStage.Merge> }
+        | { coll: string; pipeline?: Exclude<PipelineStage, PipelineStage.Out | PipelineStage.Merge>[] }
     }
 
     export interface Unset {


### PR DESCRIPTION
**Summary**

The code below is generating a error:
```
const data = model.aggregate([
  {
    $match: {
      somevalue: "string"
    }
  },
  {
    $unionWith: {
      coll: "some.collection",
      pipeline: [
        {
          $match: {
            someField: "someValue"
          }
        }
      ]
    }
  }
]);
```

Error:
```
Type '{ $match: { someField: string; }; }[]' is not assignable to type 'AddFields | Bucket | BucketAuto | CollStats | Count | Facet | GeoNear | GraphLookup | Group | ... 20 more ... | undefined'.
  Property '$unwind' is missing in type '{ $match: { someField: string; }; }[]' but required in type 'Unwind'.ts(2322)
```

Currently, the `pipeline` property is not an array.

More info here: #11069