### PR TITLE
fix(index.d.ts): separating _id property type from other $group properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3042,8 +3042,7 @@ declare module 'mongoose' {
 
     export interface Group {
       /** [`$group` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/group) */
-      $group: {
-        _id: any
+      $group: { _id: any } & {
         [key: string]: { [op in AccumulatorOperator]?: any }
       }
     }


### PR DESCRIPTION
As stated in TypeScript docs that string [index signatures enforce that all properties match their return type](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures). It's better to separate the `_id` to achieve [any valid expression type](https://docs.mongodb.com/manual/reference/operator/aggregation/group/#mongodb-pipeline-pipe.-group), instead of having all properties have the same type `{ [op in AccumulatorOperator]?: any }`