### PR TITLE
Fix findByIdAndUpdate behavior with undefined id

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2621,6 +2621,10 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  *     A.findByIdAndUpdate()                     // returns Query
  *
  * ####Note:
+ * 
+ * If id is undefined and update is specified, an error will be thrown.
+ * 
+ * ####Note:
  *
  * All top level update keys which are not `atomic` operation names are treated as set operations:
  *
@@ -2676,6 +2680,9 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
       throw new TypeError(msg);
     }
     return this.findOneAndUpdate({ _id: id }, undefined);
+  } else if (id === undefined) {
+    const msg = 'Model.findByIdAndUpdate(): id cannot be undefined if update is specified.\n';
+    throw new TypeError(msg);
   }
 
   // if a model is passed in instead of an id

--- a/lib/model.js
+++ b/lib/model.js
@@ -2680,8 +2680,8 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
       throw new TypeError(msg);
     }
     return this.findOneAndUpdate({ _id: id }, undefined);
-  } else if (id === undefined) {
-    const msg = 'Model.findByIdAndUpdate(): id cannot be undefined if update is specified.\n';
+  } else if (arguments.length > 1 && id === undefined) {
+    const msg = 'Model.findByIdAndUpdate(): id cannot be undefined if update is specified.';
     throw new TypeError(msg);
   }
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -316,6 +316,22 @@ describe('model: populate:', function() {
       });
   });
 
+  it ('fail on undefined id update', function(done) {
+    const BlogPost = db.model('BlogPost', blogPostSchema);
+
+    BlogPost.create(
+      { title: 'woot' },
+      function(err, post) {
+        assert.ifError(err);
+
+        BlogPost.
+          findByIdAndUpdate(undefined, { $set: { _creator: {} } }, function(err) {
+            assert.ok(err);
+            done();
+          });
+      });
+  })
+
   it('across DBs', function(done) {
     const db = start();
     const db2 = db.useDb('mongoose_test2');

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -318,20 +318,12 @@ describe('model: populate:', function() {
       });
   });
 
-  it('fail on undefined id update', function(done) {
+  it('fail on undefined id update', function() {
     const BlogPost = db.model('BlogPost', blogPostSchema);
 
-    BlogPost.create(
-      { title: 'woot' },
-      function(err, post) {
-        assert.ifError(err);
-
-        BlogPost.
-          findByIdAndUpdate(undefined, { $set: { _creator: {} } }, function(err) {
-            assert.ok(err);
-            done();
-          });
-      });
+    assert.throws(function() {
+      BlogPost.findByIdAndUpdate(undefined, { $set: { _creator: {} } });
+    }, /id cannot be undefined/);
   })
 
   it('across DBs', function(done) {

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -308,15 +308,17 @@ describe('model: populate:', function() {
       function(err, post) {
         assert.ifError(err);
 
-        BlogPost.
-          findByIdAndUpdate(post._id, { $set: { _creator: {} } }, function(err) {
-            assert.ok(err);
-            done();
-          });
+        assert.throws(function() {
+          BlogPost.
+            findByIdAndUpdate(post._id, { $set: { _creator: {} } }, function(err) {
+              assert.ok(err);
+              done();
+            });
+        });
       });
   });
 
-  it ('fail on undefined id update', function(done) {
+  it('fail on undefined id update', function(done) {
     const BlogPost = db.model('BlogPost', blogPostSchema);
 
     BlogPost.create(

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -308,13 +308,11 @@ describe('model: populate:', function() {
       function(err, post) {
         assert.ifError(err);
 
-        assert.throws(function() {
-          BlogPost.
-            findByIdAndUpdate(post._id, { $set: { _creator: {} } }, function(err) {
-              assert.ok(err);
-              done();
-            });
-        });
+        BlogPost.
+          findByIdAndUpdate(post._id, { $set: { _creator: {} } }, function(err) {
+            assert.ok(err);
+            done();
+          });
       });
   });
 


### PR DESCRIPTION
**Summary**

findByIdAndUpdate should not work with an undefined id, if an update is specified. Resolves #10964

**Examples**

I added a test to demonstrate this change.
