### PR TITLE
Query.prototype.transform documentation fix, resolves #11093

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4444,7 +4444,7 @@ function _update(query, op, filter, doc, options, callback) {
  * Runs a function `fn` and treats the return value of `fn` as the new value
  * for the query to resolve to.
  *
- * Any functions you pass to `map()` will run **after** any post hooks.
+ * Any functions you pass to `transform()` will run **after** any post hooks.
  *
  * ####Example:
  *
@@ -4456,7 +4456,7 @@ function _update(query, op, filter, doc, options, callback) {
  *         Object.assign(res, { loadedAt: new Date() });
  *     });
  *
- * @method map
+ * @method transform
  * @memberOf Query
  * @instance
  * @param {Function} fn function to run to transform the query result


### PR DESCRIPTION
**Summary**
`Query.prototype.transform` documentation changed. An old method name `map` was replaced with `transform`.
Resolves #11093
