### PR TITLE
fix(index.d.ts) treat _id like other fields in $project

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3115,7 +3115,7 @@ declare module 'mongoose' {
 
     export interface Project {
       /** [`$project` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/project/) */
-      $project: { _id?: 0 | false; [field: string]: any } | {_id: 1 | true}
+      $project: { [field: string]: any }
     }
 
     export interface Redact {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3115,7 +3115,7 @@ declare module 'mongoose' {
 
     export interface Project {
       /** [`$project` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/project/) */
-      $project: { _id?: 0 | false; [field: string]: any }
+      $project: { _id?: 0 | false; [field: string]: any } | {_id: 1 | true}
     }
 
     export interface Redact {


### PR DESCRIPTION
Fix #11088 
Fix #11099

Changed type to
```
$project: { _id?: 0 | false; [field: string]: any } | {_id: 1 | true}
```

:heavy_check_mark:  OK
```
{
  $project: {
    _id: 1,
  }
}
```

:heavy_check_mark:  OK
```
{
  $project: {
    _id: 0,
    someField: 1
  }
}
```

:x: Error
```
{
  $project: {
    _id: 1,
    someField: 1
  }
}
```
