### PR TITLE
fix _id field of PipelineStage.Group

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3054,8 +3054,8 @@ declare module 'mongoose' {
 
     export interface Group {
       /** [`$group` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/group) */
-      $group: { _id: null | any } | {
-        _id: null | any
+      $group: { _id: any } | {
+        _id: any
         [key: string]: { [op in AccumulatorOperator]?: any }
       }
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3055,6 +3055,7 @@ declare module 'mongoose' {
     export interface Group {
       /** [`$group` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/group) */
       $group: { _id: null | any } | {
+        _id: null | any
         [key: string]: { [op in AccumulatorOperator]?: any }
       }
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3054,9 +3054,9 @@ declare module 'mongoose' {
 
     export interface Group {
       /** [`$group` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/group) */
-      $group: {
+      $group: { _id: null | any } | {
         [key: string]: { [op in AccumulatorOperator]?: any }
-      } & { _id: null | { [op in AccumulatorOperator]?: any } | any}
+      }
     }
 
     export interface IndexStats {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3055,9 +3055,8 @@ declare module 'mongoose' {
     export interface Group {
       /** [`$group` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/group) */
       $group: {
-        _id: any
         [key: string]: { [op in AccumulatorOperator]?: any }
-      }
+      } & { _id: null | { [op in AccumulatorOperator]?: any } | any}
     }
 
     export interface IndexStats {


### PR DESCRIPTION
This PR fixes the PipelineStage.Group

_id can be set to null, which is not covered by the type definition as it wants to enforce AccumulatorOperators. 
