### PR TITLE
Better for service discovery

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1359,7 +1359,7 @@ Connection.prototype.setClient = function setClient(client) {
   if (!(client instanceof mongodb.MongoClient)) {
     throw new MongooseError('Must call `setClient()` with an instance of MongoClient');
   }
-  if (this.client != null || this.readyState !== STATES.disconnected) {
+  if (this.readyState !== STATES.disconnected) {
     throw new MongooseError('Cannot call `setClient()` on a connection that is already connected.');
   }
   if (client.topology == null) {


### PR DESCRIPTION
For some situation, the mongo server host is dynamic and we need to create a new mongodb client when the current client is disconnected, so it's much better if we can call `setClient` multiple times.

```js
const createMongoClient = async () => {

  const host = await service.discover('mongodb.host');

  const uri = `mongodb://${host.uri}/test`;

  const mongoClient: MongoClient = await MongoClient.connect(uri, {
    autoReconnect: false,
  });

  client.setClient(mongoClient);

  client.once('disconnected', async () => {
    mongoClient.close();

    // @ts-ignore   we need to get rid of this
    client.client = null;

    while(true) {
      await sleep(3 * 1e3);
      try {
        if (client.readyState === mongoose.STATES.disconnected) {
          await createMongoClient();
        }  
        break;
      } catch (err) {
        console.error(err);
      }
    }        
  });
}

await createMongoClient();

``` 