### PR TITLE
fix(index.d.ts): fix typings in Merge stage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3099,7 +3099,7 @@ declare module 'mongoose' {
         into: string | { db: string; coll: string }
         on?: string | string[]
         let?: Record<string, any>
-        whenMatched?: 'replace' | 'keepExisting' | 'merge' | 'fail' | 'pipeline'
+        whenMatched?: 'replace' | 'keepExisting' | 'merge' | 'fail' | Extract<PipelineStage, PipelineStage.AddFields | PipelineStage.Set | PipelineStage.Project | PipelineStage.Unset | PipelineStage.ReplaceRoot | PipelineStage.ReplaceWith>[]
         whenNotMatched?: 'insert' | 'discard' | 'fail'
       }
     }


### PR DESCRIPTION
Fixes #11109.
Thanks to @gabrie-allaigre

Correctly assign types of whenMatched case according to official docs:
https://docs.mongodb.com/manual/reference/operator/aggregation/merge/