### PR TITLE
fix(index): export ConnectionStates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,15 @@ Mongoose.prototype.cast = cast;
 Mongoose.prototype.STATES = STATES;
 
 /**
+ * Expose connection states for user-land
+ *
+ * @memberOf Mongoose
+ * @property ConnectionStates
+ * @api public
+ */
+Mongoose.prototype.ConnectionStates = STATES;
+
+ /**
  * Object with `get()` and `set()` containing the underlying driver this Mongoose instance
  * uses to communicate with the database. A driver is a Mongoose-specific interface that defines functions
  * like `find()`.

--- a/test/typescript/global.ts
+++ b/test/typescript/global.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const m: mongoose.Mongoose = new mongoose.Mongoose();
 
 m.STATES.connected;
+m.ConnectionStates.connected;
 
 m.connect('mongodb://localhost:27017/test').then(() => {
   console.log('Connected!');


### PR DESCRIPTION
**Summary**
It is declared as an enum in ts definitions, but did not really work.

**Examples**
This code passes ts compilation, but crashes on runtime:

```typescript
import { Connection, ConnectionStates } from 'mongoose';
// ...
return (this.connection.readyState !== ConnectionStates.connected);
```