### PR TITLE
Update guide.md

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -787,7 +787,7 @@ const mySchema = new Schema({ field: Number }, {
   strictQuery: false // Turn off strict mode for query filters
 });
 const MyModel = mongoose.model('Test', mySchema);
-// Mongoose will strip out `notInSchema: 1` because `strictQuery` is false
+// Mongoose will not strip out `notInSchema: 1` because `strictQuery` is false
 MyModel.find({ notInSchema: 1 });
 ```
 


### PR DESCRIPTION
Update example for `strictQuery` to indicate it will *not* remove fields not in schema when set to `false`.

**Summary**

The documentation currently states setting `strictQuery` to `false` will strip out fields in the filter that are not part of the Schema. This is the opposite of what setting `strictQuery` to `false` does.

**Examples**

```javascript
const mySchema = new Schema({ field: Number }, {
  strict: true,
  strictQuery: true
});
const MyModel = mongoose.model('Test', mySchema);
// Mongoose will strip out `notInSchema: 1` because `strictQuery` is true
MyModel.find({ notInSchema: 1 });
```

```javascript
const mySchema = new Schema({ field: Number }, {
  strict: true,
  strictQuery: false // Turn off strict mode for query filters
});
const MyModel = mongoose.model('Test', mySchema);
// Mongoose will not strip out `notInSchema: 1` because `strictQuery` is false
MyModel.find({ notInSchema: 1 });
```
