### PR TITLE
Follow-up fix of TS index signature definition for Group type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3058,7 +3058,7 @@ declare module 'mongoose' {
 
     export interface Group {
       /** [`$group` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/group) */
-      $group: { _id: any } | { _id: any; [key: string]: { [op in AccumulatorOperator]?: any } }
+      $group: { _id: any } | { [key: string]: { [op in AccumulatorOperator]?: any } }
     }
 
     export interface IndexStats {


### PR DESCRIPTION
**Summary**
This PR is the follow-up PR for: #11059 and for #11124 
All explicitly defined keys should always follow the type defined at the index signature. So having `any` as a type for `_id` was just a hidden error.
Even more, `_id` as a key in the member of union type was redundant.
