### PR TITLE
Export a Separate Type for PipelineStage Types Allowed in Facet Aggregation Sub-Pipelines

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3022,11 +3022,10 @@ declare module 'mongoose' {
 
     export interface Facet {
       /** [`$facet` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/facet/) */
-      $facet: Record<
-        string,
-        Exclude<PipelineStage, PipelineStage.CollStats | PipelineStage.Facet | PipelineStage.GeoNear | PipelineStage.IndexStats | PipelineStage.Out | PipelineStage.Merge | PipelineStage.PlanCacheStats>[]
-      >
+      $facet: Record<string, FacetPipelineStep[]>
     }
+
+    export type FacetPipelineStep = Exclude<PipelineStage, PipelineStage.CollStats | PipelineStage.Facet | PipelineStage.GeoNear | PipelineStage.IndexStats | PipelineStage.Out | PipelineStage.Merge | PipelineStage.PlanCacheStats>
 
     export interface GeoNear {
       /** [`$geoNear` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/) */

--- a/index.d.ts
+++ b/index.d.ts
@@ -3022,10 +3022,10 @@ declare module 'mongoose' {
 
     export interface Facet {
       /** [`$facet` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/facet/) */
-      $facet: Record<string, FacetPipelineStep[]>
+      $facet: Record<string, FacetPipelineStage[]>
     }
 
-    export type FacetPipelineStep = Exclude<PipelineStage, PipelineStage.CollStats | PipelineStage.Facet | PipelineStage.GeoNear | PipelineStage.IndexStats | PipelineStage.Out | PipelineStage.Merge | PipelineStage.PlanCacheStats>
+    export type FacetPipelineStage = Exclude<PipelineStage, PipelineStage.CollStats | PipelineStage.Facet | PipelineStage.GeoNear | PipelineStage.IndexStats | PipelineStage.Out | PipelineStage.Merge | PipelineStage.PlanCacheStats>
 
     export interface GeoNear {
       /** [`$geoNear` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/) */


### PR DESCRIPTION
**Summary**

This is a typescript type-only change.

Currently, the type definition for each sub-pipeline within a `{ $facet: ... }` aggregation pipeline stage is baked in to the overall definition of the Facet stage. 

We've got a situation where we'd like to pass these sub-pipeline arrays around, ideally in a type-safe way. Currently, that requires a bit of boilerplate to keep typescript happy; with this change, we should just be able to say, for example:

```ts
import * as mongoose from "mongoose";

export function Query(resultsFacet: mongoose.FacetPipelineStage[]) {
  return db.myCollection.aggregate([{
    $facet: { results: resultsFacet },
  }]);
}
```

Happy to change the name of this type if `FacetPipelineStage` doesn't make sense. 

Thank you for the great project 😀 