### PR TITLE
documentation:fixed internal document link.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -904,7 +904,7 @@ Mongoose.prototype.PromiseProvider = PromiseProvider;
 Mongoose.prototype.Model = Model;
 
 /**
- * The Mongoose [Document](/api/document.html) constructor.
+ * The Mongoose [Document](/docs/api.html#Document) constructor.
  *
  * @method Document
  * @api public


### PR DESCRIPTION

```Bug

What is the current behavior?
When visiting the documentation under https://mongoosejs.com/docs/api.html#mongoose_Mongoose-Document (via first Google hit to api.html and then clicking on the Mongoose.prototype.Document() link), a click on the Document link there leads to https://mongoosejs.com/api/document.html which returns a 404 when it should probably link to https://mongoosejs.com/docs/api.html#Document .

If the current behavior is a bug, please provide the steps to reproduce.
Stated above.

What is the expected behavior?
It should probably link to https://mongoosejs.com/docs/api.html#Document .
'''
