### PR TITLE
types: Fix return type of `projection` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2403,7 +2403,7 @@ declare module 'mongoose' {
     populate<Paths = {}>(options: PopulateOptions | Array<PopulateOptions>): QueryWithHelpers<UnpackedIntersection<ResultType, Paths>, DocType, THelpers, RawDocType>;
 
     /** Get/set the current projection (AKA fields). Pass `null` to remove the current projection. */
-    projection(fields?: any | null): any;
+    projection(fields?: any | null): this;
 
     /** Determines the MongoDB nodes from which to read. */
     read(pref: string | mongodb.ReadPreferenceMode, tags?: any[]): this;


### PR DESCRIPTION
**Summary**

`Query.projection` should return `this` for correct completion while method chaining.

Introduced here: https://github.com/Automattic/mongoose/commit/d7aaa5568330e2dcadde7ae6847bff1522f3ae4e
