### PR TITLE
documentation: fixed broken link

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -904,7 +904,7 @@ Mongoose.prototype.PromiseProvider = PromiseProvider;
 Mongoose.prototype.Model = Model;
 
 /**
- * The Mongoose [Document](/api/document.html) constructor.
+ * The Mongoose [Document](/docs/api.html#Document) constructor.
  *
  * @method Document
  * @api public


### PR DESCRIPTION
Solved the issue #11089 . Now the `Mongoose.prototype.Document()` Document link points to the  https://mongoosejs.com/docs/api.html#Document