### PR TITLE
fix(document): make array assignment trigger isModified: true

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2057,21 +2057,34 @@ Document.prototype[documentModifiedPaths] = Document.prototype.modifiedPaths;
 
 Document.prototype.isModified = function(paths, modifiedPaths) {
   if (!paths) {
-    return this.$__.activePaths.some('modify');
+    return this.$__.activePaths.some('modify') || this.$__.activePaths.some('init');
   }
   if (!Array.isArray(paths)) {
     paths = paths.split(' ');
   }
   const modified = modifiedPaths || this[documentModifiedPaths]();
   const directModifiedPaths = Object.keys(this.$__.activePaths.states.modify);
+  const directInitializedPaths = Object.keys(this.$__.activePaths.states.init);
   const isModifiedChild = paths.some((path) => !!~modified.indexOf(path));
+  if (isModifiedChild) {
+    return isModifiedChild;
+  }
+  const isSomePathModified = doPathsIntersect(paths, directModifiedPaths);
+  if (isSomePathModified) {
+    return isSomePathModified;
+  }
 
-  return isModifiedChild || paths.some(function(path) {
-    return directModifiedPaths.some(function(mod) {
-      return mod === path || path.startsWith(mod + '.');
+  const isSomePathInitialized = doPathsIntersect(paths, directInitializedPaths);
+  return isSomePathInitialized;
+};
+
+function doPathsIntersect(sourcePaths, targetPaths) {
+  return sourcePaths.some(function(sourcePath) {
+    return targetPaths.some(function(targetPath) {
+      return targetPath === sourcePath || sourcePath.startsWith(targetPath + '.');
     });
   });
-};
+}
 
 Document.prototype.$isModified = Document.prototype.isModified;
 
@@ -2157,7 +2170,7 @@ Document.prototype.$isDeleted = function(val) {
 
 Document.prototype.isDirectModified = function(path) {
   if (path == null) {
-    return this.$__.activePaths.some('modify');
+    return this.$__.activePaths.some('modify') || this.$__.activePaths.some('init');
   }
 
   if (typeof path === 'string' && path.indexOf(' ') === -1) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -2064,9 +2064,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
   }
   const modified = modifiedPaths || this[documentModifiedPaths]();
   const directModifiedPaths = Object.keys(this.$__.activePaths.states.modify);
-  const isModifiedChild = paths.some(function(path) {
-    return !!~modified.indexOf(path);
-  });
+  const isModifiedChild = paths.some((path) => !!~modified.indexOf(path));
 
   return isModifiedChild || paths.some(function(path) {
     return directModifiedPaths.some(function(mod) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -2056,24 +2056,23 @@ Document.prototype[documentModifiedPaths] = Document.prototype.modifiedPaths;
  */
 
 Document.prototype.isModified = function(paths, modifiedPaths) {
-  if (paths) {
-    if (!Array.isArray(paths)) {
-      paths = paths.split(' ');
-    }
-    const modified = modifiedPaths || this[documentModifiedPaths]();
-    const directModifiedPaths = Object.keys(this.$__.activePaths.states.modify);
-    const isModifiedChild = paths.some(function(path) {
-      return !!~modified.indexOf(path);
-    });
-
-    return isModifiedChild || paths.some(function(path) {
-      return directModifiedPaths.some(function(mod) {
-        return mod === path || path.startsWith(mod + '.');
-      });
-    });
+  if (!paths) {
+    return this.$__.activePaths.some('modify');
   }
+  if (!Array.isArray(paths)) {
+    paths = paths.split(' ');
+  }
+  const modified = modifiedPaths || this[documentModifiedPaths]();
+  const directModifiedPaths = Object.keys(this.$__.activePaths.states.modify);
+  const isModifiedChild = paths.some(function(path) {
+    return !!~modified.indexOf(path);
+  });
 
-  return this.$__.activePaths.some('modify');
+  return isModifiedChild || paths.some(function(path) {
+    return directModifiedPaths.some(function(mod) {
+      return mod === path || path.startsWith(mod + '.');
+    });
+  });
 };
 
 Document.prototype.$isModified = Document.prototype.isModified;

--- a/lib/document.js
+++ b/lib/document.js
@@ -2057,34 +2057,21 @@ Document.prototype[documentModifiedPaths] = Document.prototype.modifiedPaths;
 
 Document.prototype.isModified = function(paths, modifiedPaths) {
   if (!paths) {
-    return this.$__.activePaths.some('modify') || this.$__.activePaths.some('init');
+    return this.$__.activePaths.some('modify');
   }
   if (!Array.isArray(paths)) {
     paths = paths.split(' ');
   }
   const modified = modifiedPaths || this[documentModifiedPaths]();
   const directModifiedPaths = Object.keys(this.$__.activePaths.states.modify);
-  const directInitializedPaths = Object.keys(this.$__.activePaths.states.init);
   const isModifiedChild = paths.some((path) => !!~modified.indexOf(path));
-  if (isModifiedChild) {
-    return isModifiedChild;
-  }
-  const isSomePathModified = doPathsIntersect(paths, directModifiedPaths);
-  if (isSomePathModified) {
-    return isSomePathModified;
-  }
 
-  const isSomePathInitialized = doPathsIntersect(paths, directInitializedPaths);
-  return isSomePathInitialized;
-};
-
-function doPathsIntersect(sourcePaths, targetPaths) {
-  return sourcePaths.some(function(sourcePath) {
-    return targetPaths.some(function(targetPath) {
-      return targetPath === sourcePath || sourcePath.startsWith(targetPath + '.');
+  return isModifiedChild || paths.some(function(path) {
+    return directModifiedPaths.some(function(mod) {
+      return mod === path || path.startsWith(mod + '.');
     });
   });
-}
+};
 
 Document.prototype.$isModified = Document.prototype.isModified;
 
@@ -2170,7 +2157,7 @@ Document.prototype.$isDeleted = function(val) {
 
 Document.prototype.isDirectModified = function(path) {
   if (path == null) {
-    return this.$__.activePaths.some('modify') || this.$__.activePaths.some('init');
+    return this.$__.activePaths.some('modify');
   }
 
   if (typeof path === 'string' && path.indexOf(' ') === -1) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -10973,14 +10973,15 @@ describe('document', function() {
     });
     const Order = db.model('Order', orderSchema);
 
-    const order = await Order.create({ cumulativeConsumption: [{ unit: 'bar', value: 42 }] });
-
-    order.cumulativeConsumption = [{ unit: 'bar', value: 42 }];
+    const createdOrder = await Order.create({ cumulativeConsumption: [{ unit: 'bar', value: 42 }] });
+    const order = await Order.findOne({ _id: createdOrder._id });
+    order.cumulativeConsumption = [{ value: 42, unit: 'bar' }];
     order.cumulativeConsumption[0].value = 43;
 
     const documentIsModified = order.isModified();
     const pathisModified = order.isModified('cumulativeConsumption');
 
+    assert.ok(order.$__delta());
     assert.equal(documentIsModified, true);
     assert.equal(pathisModified, true);
   });

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -10962,4 +10962,26 @@ describe('document', function() {
     await new Test(doc).save();
 
   });
+
+  it('Document#isModified() marks document as modified correctly when `_id` is false (gh-11172)', async() => {
+    const orderSchema = new Schema({
+      cumulativeConsumption: [{
+        _id: false,
+        unit: String,
+        value: Number
+      }]
+    });
+    const Order = db.model('Order', orderSchema);
+
+    const order = await Order.create({ cumulativeConsumption: [{ unit: 'bar', value: 42 }] });
+
+    order.cumulativeConsumption = [{ unit: 'bar', value: 42 }];
+    order.cumulativeConsumption[0].value = 43;
+
+    const documentIsModified = order.isModified();
+    const pathisModified = order.isModified('cumulativeConsumption');
+
+    assert.equal(documentIsModified, true);
+    assert.equal(pathisModified, true);
+  });
 });


### PR DESCRIPTION
re #11172

Marking a path as `isModified` when its state is `init` breaks other test cases,

The issue here is as follows:
```js
const productSchema = new Schema({ _id: false, price: Number });
const orderSchema = new Schema({ products: [productsSchema] });

const order = new Order({ products: [{ price: 42 }] });
// mongoose can't detect this change, assuming that's because it compares with `assert.equals(...)`
// since there is no `_id` in both cases , an array with an object { price: 42 } is the same.
order.products = [{ price: 42 }];
order.products[0].price = 10; // mongoose can't detect this change either
```

@vkarpov15 I'm assuming here that the issue would be solved if we can make the line `order.products = [{ price: 42 }]` change the state of `products` to `modify`.

Can you point me in the right direction on where that change might be?