### PR TITLE
Sync indexes global option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -167,6 +167,7 @@ Mongoose.prototype.driver = driver;
  * - 'strict': true by default, may be `false`, `true`, or `'throw'`. Sets the default strict mode for schemas.
  * - 'strictQuery': same value as 'strict' by default (`true`), may be `false`, `true`, or `'throw'`. Sets the default [strictQuery](/docs/guide.html#strictQuery) mode for schemas.
  * - 'selectPopulatedPaths': true by default. Set to false to opt out of Mongoose adding all fields that you `populate()` to your `select()`. The schema-level option `selectPopulatedPaths` overwrites this one.
+ * - 'syncIndexes': false by default. Set to true to run syncIndexes on every model.
  * - 'maxTimeMS': If set, attaches [maxTimeMS](https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/) to every query
  * - 'autoIndex': true by default. Set to false to disable automatic index creation for all models associated with this Mongoose instance.
  * - 'autoCreate': Set to `true` to make Mongoose call [`Model.createCollection()`](/docs/api/model.html#model_Model.createCollection) automatically when you create a model with `mongoose.model()` or `conn.model()`. This is useful for testing transactions, change streams, and other features that require the collection to exist.

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,8 @@ function Mongoose(options) {
   this.options = Object.assign({
     pluralization: true,
     autoIndex: true,
-    autoCreate: true
+    autoCreate: true,
+    syncIndexes: false
   }, options);
   const conn = this.createConnection(); // default connection
   conn.models = this.models;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1275,6 +1275,9 @@ Model.init = function init(callback) {
   const _createCollection = autoCreate ?
     cb => this.createCollection({}, cb) :
     cb => cb();
+  const _syncIndexes = syncIndexes ?
+    cb => this.syncIndexes({}, cb) :
+    cb => cb();
 
   this.$init = new Promise((resolve, reject) => {
     _createCollection(error => {
@@ -1288,7 +1291,12 @@ Model.init = function init(callback) {
           resolve(this);
         });
       } else {
-        this.syncIndexes();
+        _syncIndexes(error => {
+          if (error) {
+            return reject(error);
+          }
+          resolve(this);
+        })
       }
     });
   });

--- a/lib/model.js
+++ b/lib/model.js
@@ -1267,6 +1267,7 @@ Model.init = function init(callback) {
     this.schema.options, this.db.config, this.db.base.options);
   const autoCreate = utils.getOption('autoCreate',
     this.schema.options, this.db.config, this.db.base.options);
+  const syncIndexes = utils.getOption('syncIndexes', this.schema.options, this.db.config, this.db.base.options);
 
   const _ensureIndexes = autoIndex ?
     cb => this.ensureIndexes({ _automatic: true }, cb) :
@@ -1279,13 +1280,16 @@ Model.init = function init(callback) {
     _createCollection(error => {
       if (error) {
         return reject(error);
+      } else if (!syncIndexes) {
+        _ensureIndexes(error => {
+          if (error) {
+            return reject(error);
+          }
+          resolve(this);
+        });
+      } else {
+        this.syncIndexes();
       }
-      _ensureIndexes(error => {
-        if (error) {
-          return reject(error);
-        }
-        resolve(this);
-      });
     });
   });
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1408,7 +1408,6 @@ Model.createCollection = function createCollection(options, callback) {
  */
 
 Model.syncIndexes = function syncIndexes(options, callback) {
-  console.log('sync Indexes');
   _checkContext(this, 'syncIndexes');
 
   callback = this.$handleCallbackError(callback);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1292,6 +1292,7 @@ Model.init = function init(callback) {
         });
       } else {
         _syncIndexes(error => {
+          console.log('_syncIndexes')
           if (error) {
             return reject(error);
           }
@@ -1408,6 +1409,7 @@ Model.createCollection = function createCollection(options, callback) {
  */
 
 Model.syncIndexes = function syncIndexes(options, callback) {
+  console.log('sync Indexes');
   _checkContext(this, 'syncIndexes');
 
   callback = this.$handleCallbackError(callback);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1292,12 +1292,11 @@ Model.init = function init(callback) {
         });
       } else {
         _syncIndexes(error => {
-          console.log('_syncIndexes')
           if (error) {
             return reject(error);
           }
           resolve(this);
-        })
+        });
       }
     });
   });

--- a/lib/validoptions.js
+++ b/lib/validoptions.js
@@ -26,6 +26,7 @@ const VALID_OPTIONS = Object.freeze([
   'strict',
   'strictPopulate',
   'strictQuery',
+  'syncIndexes',
   'toJSON',
   'toObject'
 ]);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -879,7 +879,8 @@ describe('mongoose module:', function() {
       const Indexes = await syncFalse.listIndexes();
       assert.equal(Indexes.length, 2);
       await syncFalse.collection.createIndex({ name: 1 });
-      await m.deleteModel('Sync');
+      // await m.deleteModel('Sync');
+      delete m.connection.models['Sync'];
       m.set('syncIndexes', true);
       const syncSchema = new m.Schema({ nickname: { type: String, index: true } });
       const syncTrue = db.model('Sync', syncSchema, 'Sync');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -866,5 +866,18 @@ describe('mongoose module:', function() {
       const m = new mongoose.Mongoose();
       assert.deepEqual(await m.syncIndexes(), {});
     });
+    it('Allows a syncIndexes global option (gh-11030)', async function() {
+      const m = new mongoose.Mongoose();
+      m.set('syncIndexes', true);
+
+      const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
+
+      const schema = new m.Schema({
+        title: String,
+      });
+
+      const Movie = db.model('Movie', schema);
+
+    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -872,23 +872,22 @@ describe('mongoose module:', function() {
       m.set('debug', true);
       const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
       const schema = new m.Schema({
-        title: String
+        title: {type: String, index: true}
       });
-      const syncFalse = db.model('Sync', schema, 'Sync');
-      await syncFalse.collection.createIndex({ title: 1 });
-      await syncFalse.init();
+      const syncFalse = db.model('NoSync', schema, 'NoSync');
       const Indexes = await syncFalse.listIndexes();
       console.log(Indexes);
       assert.equal(Indexes.length, 2);
-      await db.connection.db.dropCollection('Sync');
+      syncFalse.collection.drop();
+      mongoose.connection.models = {};
       m.set('syncIndexes', true);
-      const syncTrue = db.model('Sync', schema, 'Sync');
-      await syncTrue.collection.createIndex({ title: 1 });
-      await syncTrue.init();
+      const syncSchema = new m.Schema({ name: String });
+      m.connection.db.collection('Sync').createIndex({name: 1});
+      const syncTrue = db.model('Sync', syncSchema, 'Sync');
       const Index = await syncTrue.listIndexes();
       console.log(Index);
-      assert.equal(Index.length, 1);
-      await db.connection.db.dropCollection('Sync');
+
+      
       // https://thecodebarbarian.com/whats-new-in-mongoose-5-2-syncindexes
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -872,14 +872,14 @@ describe('mongoose module:', function() {
       m.set('debug', true);
       const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
       const schema = new m.Schema({
-        title: {type: String, index: true}
+        title: { type: String, index: true }
       });
       const syncFalse = db.model('Sync', schema, 'Sync');
       await syncFalse.init();
       const Indexes = await syncFalse.listIndexes();
       console.log(Indexes);
       assert.equal(Indexes.length, 2);
-      await syncFalse.collection.createIndex({name: 1});
+      await syncFalse.collection.createIndex({ name: 1 });
       delete m.connection.models['Sync'];
       m.set('syncIndexes', true);
       const syncSchema = new m.Schema({ title: String });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -874,21 +874,20 @@ describe('mongoose module:', function() {
       const schema = new m.Schema({
         title: {type: String, index: true}
       });
-      const syncFalse = db.model('NoSync', schema, 'NoSync');
+      const syncFalse = db.model('Sync', schema, 'Sync');
+      await syncFalse.init();
       const Indexes = await syncFalse.listIndexes();
       console.log(Indexes);
       assert.equal(Indexes.length, 2);
-      syncFalse.collection.drop();
-      mongoose.connection.models = {};
+      await syncFalse.collection.createIndex({name: 1});
+      delete m.connection.models['Sync'];
       m.set('syncIndexes', true);
-      const syncSchema = new m.Schema({ name: String });
-      m.connection.db.collection('Sync').createIndex({name: 1});
+      const syncSchema = new m.Schema({ title: String });
       const syncTrue = db.model('Sync', syncSchema, 'Sync');
+      await syncTrue.init();
       const Index = await syncTrue.listIndexes();
       console.log(Index);
-
-      
-      // https://thecodebarbarian.com/whats-new-in-mongoose-5-2-syncindexes
+      assert.equal(Index.length, 1);
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -870,22 +870,41 @@ describe('mongoose module:', function() {
       const m = new mongoose.Mongoose();
 
       const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
+
+      m.set('syncIndexes', true);
+
+      const initialSchema = new m.Schema({ location: { type: String, index: true } });
+      const initialModel = db.model('Sync', initialSchema, 'Sync');
+      await initialModel.init();
+      const initialIndexes = await initialModel.listIndexes();
+
+      assert.equal(initialIndexes.length, 2);
+
+      await m.deleteModel('Sync');
+
+      m.set('syncIndexes', false);
+
       const schema = new m.Schema({
         title: { type: String, index: true }
       });
       const syncFalse = db.model('Sync', schema, 'Sync');
-      await syncFalse.collection.dropIndexes();
       await syncFalse.init();
       const Indexes = await syncFalse.listIndexes();
-      assert.equal(Indexes.length, 2);
+
+      assert.equal(Indexes.length, 3);
+
       await syncFalse.collection.createIndex({ name: 1 });
       await m.deleteModel('Sync');
+
       m.set('syncIndexes', true);
+
       const syncSchema = new m.Schema({ nickname: { type: String, index: true } });
       const syncTrue = db.model('Sync', syncSchema, 'Sync');
       await syncTrue.init();
       const Index = await syncTrue.listIndexes();
+
       assert.equal(Index[0].name, '_id_');
+
       assert.equal(Index.length, 2);
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -868,16 +868,22 @@ describe('mongoose module:', function() {
     });
     it('Allows a syncIndexes global option (gh-11030)', async function() {
       const m = new mongoose.Mongoose();
-      m.set('syncIndexes', true);
 
+      m.set('debug', true);
       const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
 
       const schema = new m.Schema({
-        title: String,
+        title: String
       });
-
-      const Movie = db.model('Movie', schema);
-
+      const syncFalse = db.model('Movie', schema);
+      await syncFalse.collection.createIndex({ title: 1 });
+      let indexes = await syncFalse.listIndexes();
+      assert.equal(indexes.length, 2);
+      m.set('syncIndexes', true);
+      const syncTrue = db.model('Sync', schema);
+      await syncTrue.collection.createIndex({ title: 1 });
+      indexes = await syncTrue.listIndexes();
+      assert.equal(indexes.length, 1);
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -879,8 +879,7 @@ describe('mongoose module:', function() {
       const Indexes = await syncFalse.listIndexes();
       assert.equal(Indexes.length, 2);
       await syncFalse.collection.createIndex({ name: 1 });
-      // await m.deleteModel('Sync');
-      delete m.connection.models['Sync'];
+      await m.deleteModel('Sync');
       m.set('syncIndexes', true);
       const syncSchema = new m.Schema({ nickname: { type: String, index: true } });
       const syncTrue = db.model('Sync', syncSchema, 'Sync');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -869,25 +869,24 @@ describe('mongoose module:', function() {
     it('Allows a syncIndexes global option (gh-11030)', async function() {
       const m = new mongoose.Mongoose();
 
-      m.set('debug', true);
       const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
       const schema = new m.Schema({
         title: { type: String, index: true }
       });
       const syncFalse = db.model('Sync', schema, 'Sync');
+      await syncFalse.collection.dropIndexes();
       await syncFalse.init();
       const Indexes = await syncFalse.listIndexes();
-      console.log(Indexes);
       assert.equal(Indexes.length, 2);
       await syncFalse.collection.createIndex({ name: 1 });
-      delete m.connection.models['Sync'];
+      await m.deleteModel('Sync');
       m.set('syncIndexes', true);
-      const syncSchema = new m.Schema({ title: String });
+      const syncSchema = new m.Schema({ nickname: {type: String, index: true} });
       const syncTrue = db.model('Sync', syncSchema, 'Sync');
       await syncTrue.init();
       const Index = await syncTrue.listIndexes();
-      console.log(Index);
-      assert.equal(Index.length, 1);
+      assert.equal(Index[0].name, '_id_');
+      assert.equal(Index.length, 2);
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -871,19 +871,25 @@ describe('mongoose module:', function() {
 
       m.set('debug', true);
       const db = await m.connect('mongodb://localhost:27017/mongoose_test_11030');
-
       const schema = new m.Schema({
         title: String
       });
-      const syncFalse = db.model('Movie', schema);
+      const syncFalse = db.model('Sync', schema, 'Sync');
       await syncFalse.collection.createIndex({ title: 1 });
-      let indexes = await syncFalse.listIndexes();
-      assert.equal(indexes.length, 2);
+      await syncFalse.init();
+      const Indexes = await syncFalse.listIndexes();
+      console.log(Indexes);
+      assert.equal(Indexes.length, 2);
+      await db.connection.db.dropCollection('Sync');
       m.set('syncIndexes', true);
-      const syncTrue = db.model('Sync', schema);
+      const syncTrue = db.model('Sync', schema, 'Sync');
       await syncTrue.collection.createIndex({ title: 1 });
-      indexes = await syncTrue.listIndexes();
-      assert.equal(indexes.length, 1);
+      await syncTrue.init();
+      const Index = await syncTrue.listIndexes();
+      console.log(Index);
+      assert.equal(Index.length, 1);
+      await db.connection.db.dropCollection('Sync');
+      // https://thecodebarbarian.com/whats-new-in-mongoose-5-2-syncindexes
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -881,7 +881,7 @@ describe('mongoose module:', function() {
       await syncFalse.collection.createIndex({ name: 1 });
       await m.deleteModel('Sync');
       m.set('syncIndexes', true);
-      const syncSchema = new m.Schema({ nickname: {type: String, index: true} });
+      const syncSchema = new m.Schema({ nickname: { type: String, index: true } });
       const syncTrue = db.model('Sync', syncSchema, 'Sync');
       await syncTrue.init();
       const Index = await syncTrue.listIndexes();


### PR DESCRIPTION
Why can't I do `await Model.listIndexes().length` off the rip but instead have to save it to a variable? Just curious.
