### PR TITLE
 Redundant null check on object #11223

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -73,7 +73,7 @@ const specialProperties = utils.specialProperties;
  */
 
 function Document(obj, fields, skipId, options) {
-  if (typeof skipId === 'object' && skipId != null) {
+  if (skipId != null && typeof skipId === 'object') {
     options = skipId;
     skipId = options.skipId;
   }


### PR DESCRIPTION
**Summary**
Fixed redundant null check on `skipId` variable at [this line](https://github.com/Automattic/mongoose/blob/master/lib/document.js#L76), by performing null check on mentioned variable before performing type check.

Resolves #11223 