### PR TITLE
check for all flags in a regex deepequal

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,7 +84,8 @@ exports.deepEqual = function deepEqual(a, b) {
         a.global === b.global &&
         a.dotAll === b.dotAll &&
         a.unicode === b.unicode &&
-        a.sticky === b.sticky;
+        a.sticky === b.sticky &&
+        a.hasIndices === b.hasIndices;
   }
 
   if (a == null || b == null) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,7 +81,10 @@ exports.deepEqual = function deepEqual(a, b) {
     return a.source === b.source &&
         a.ignoreCase === b.ignoreCase &&
         a.multiline === b.multiline &&
-        a.global === b.global;
+        a.global === b.global &&
+        a.dotAll === b.dotAll &&
+        a.unicode === b.unicode &&
+        a.sticky === b.sticky;
   }
 
   if (a == null || b == null) {


### PR DESCRIPTION
This PR modifies the deepEqual check in mongoose. It checks a regex for all 6 flags of a Regex.

As it is more strict, it could be breaking(?)