### PR TITLE
Casting for `$expr` in queries

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -7,6 +7,7 @@
 const CastError = require('./error/cast');
 const StrictModeError = require('./error/strict');
 const Types = require('./schema/index');
+const cast$expr = require('./helpers/query/cast$expr');
 const castTextSearch = require('./schema/operators/text');
 const get = require('./helpers/get');
 const getConstructorName = require('./helpers/getConstructorName');
@@ -87,9 +88,7 @@ module.exports = function cast(schema, obj, options, context) {
 
       continue;
     } else if (path === '$expr') {
-      if (typeof val !== 'object' || val == null) {
-        throw new Error('`$expr` must be an object');
-      }
+      val = cast$expr(val, schema);
       continue;
     } else if (path === '$elemMatch') {
       val = cast(schema, val, options, context);

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -44,6 +44,16 @@ const arithmeticOperatorNumber = new Set([
   '$degreesToRadians',
   '$radiansToDegrees'
 ]);
+const dateOperators = new Set([
+  '$year',
+  '$month',
+  '$week',
+  '$dayOfMonth',
+  '$dayOfYear',
+  '$hour',
+  '$minute',
+  '$second'
+]);
 
 module.exports = function cast$expr(val, schema, strictQuery) {
   if (typeof val !== 'object' || val == null) {
@@ -60,9 +70,13 @@ function _castExpression(val, schema, strictQuery) {
   }
 
   if (val.$cond != null) {
-    val.$cond.if = _castExpression(val.$cond.if, schema, strictQuery);
-    val.$cond.then = _castExpression(val.$cond.then, schema, strictQuery);
-    val.$cond.else = _castExpression(val.$cond.else, schema, strictQuery);
+    if (Array.isArray(val.$cond)) {
+      val.$cond = val.$cond.map(expr => _castExpression(expr, schema, strictQuery));
+    } else {
+      val.$cond.if = _castExpression(val.$cond.if, schema, strictQuery);
+      val.$cond.then = _castExpression(val.$cond.then, schema, strictQuery);
+      val.$cond.else = _castExpression(val.$cond.else, schema, strictQuery);
+    }
   } else if (val.$ifNull != null) {
     val.$ifNull.map(v => _castExpression(v, schema, strictQuery));
   } else if (val.$switch != null) {
@@ -152,30 +166,11 @@ function castComparison(val, schema, strictQuery) {
       path = lhs.slice(1);
       schematype = schema.path(path);
     } else if (typeof lhs === 'object' && lhs != null) {
-      if (isPath(lhs.$year)) {
-        path = lhs.$year.slice(1) + '.$year';
-        caster = castNumber;
-      } else if (isPath(lhs.$month)) {
-        path = lhs.$month.slice(1) + '.$month';
-        caster = castNumber;
-      } else if (isPath(lhs.$week)) {
-        path = lhs.$week.slice(1) + '.$week';
-        caster = castNumber;
-      } else if (isPath(lhs.$dayOfMonth)) {
-        path = lhs.$dayOfMonth.slice(1) + '.$dayOfMonth';
-        caster = castNumber;
-      } else if (isPath(lhs.$dayOfYear)) {
-        path = lhs.$dayOfMonth.slice(1) + '.$dayOfYear';
-        caster = castNumber;
-      } else if (isPath(lhs.$hour)) {
-        path = lhs.$hour.slice(1) + '.$hour';
-        caster = castNumber;
-      } else if (isPath(lhs.$minute)) {
-        path = lhs.$minute.slice(1) + '.$minute';
-        caster = castNumber;
-      } else if (isPath(lhs.$second)) {
-        path = lhs.$second.slice(1) + '.$second';
-        caster = castNumber;
+      for (const key of Object.keys(lhs)) {
+        if (dateOperators.has(key) && isPath(lhs[key])) {
+          path = lhs[key].slice(1) + '.' + key;
+          caster = castNumber;
+        }
       }
     }
 
@@ -191,13 +186,13 @@ function castComparison(val, schema, strictQuery) {
         try {
           val[1] = { $literal: caster(val[1].$literal) };
         } catch (err) {
-          throw new CastError(caster.name.slice(4 /* 'cast'.length */), val[1], path + '.$literal');
+          throw new CastError(caster.name.replace(/^cast/, ''), val[1], path + '.$literal');
         }
       } else {
         try {
           val[1] = caster(val[1]);
         } catch (err) {
-          throw new CastError(caster.name.slice(4 /* 'cast'.length */), val[1], path);
+          throw new CastError(caster.name.replace(/^cast/, ''), val[1], path);
         }
       }
     } else if (path != null && strictQuery === true) {

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -7,6 +7,9 @@ const castNumber = require('../../cast/number');
 const booleanComparison = new Set(['$and', '$or', '$not']);
 const comparisonOperator = new Set(['$cmp', '$eq', '$lt', '$lte', '$gt', '$gte']);
 const arithmeticOperatorArray = new Set([
+  // avoid casting '$add' or '$subtract', because expressions can be either number or date,
+  // and we don't have a good way of inferring which arguments should be numbers and which should
+  // be dates.
   '$multiply',
   '$divide',
   '$log',
@@ -44,6 +47,11 @@ const arithmeticOperatorNumber = new Set([
   '$degreesToRadians',
   '$radiansToDegrees'
 ]);
+const arrayElementOperators = new Set([
+  '$arrayElemAt',
+  '$first',
+  '$last'
+]);
 const dateOperators = new Set([
   '$year',
   '$month',
@@ -52,7 +60,11 @@ const dateOperators = new Set([
   '$dayOfYear',
   '$hour',
   '$minute',
-  '$second'
+  '$second',
+  '$isoDayOfWeek',
+  '$isoWeekYear',
+  '$isoWeek',
+  '$millisecond'
 ]);
 
 module.exports = function cast$expr(val, schema, strictQuery) {
@@ -93,8 +105,15 @@ function _castExpression(val, schema, strictQuery) {
     } else if (arithmeticOperatorArray.has(key)) {
       val[key] = castArithmetic(val[key], schema, strictQuery);
     } else if (arithmeticOperatorNumber.has(key)) {
-      val[key] = castArithmeticSingle(val[key], schema, strictQuery);
+      val[key] = castNumberOperator(val[key], schema, strictQuery);
     }
+  }
+
+  if (val.$in) {
+    val.$in = castIn(val.$in, schema, strictQuery);
+  }
+  if (val.$size) {
+    val.$size = castNumberOperator(val.$size, schema, strictQuery);
   }
 
   _omitUndefined(val);
@@ -112,7 +131,7 @@ function _omitUndefined(val) {
 }
 
 // { $op: <number> }
-function castArithmeticSingle(val) {
+function castNumberOperator(val) {
   if (!isLiteral(val)) {
     return val;
   }
@@ -122,6 +141,37 @@ function castArithmeticSingle(val) {
   } catch (err) {
     throw new CastError('Number', val);
   }
+}
+
+function castIn(val, schema, strictQuery) {
+  let search = val[0];
+  let path = val[1];
+  if (!isPath(path)) {
+    return val;
+  }
+
+  path = path.slice(1);
+  const schematype = schema.path(path);
+  if (schematype == null) {
+    if (strictQuery === false) {
+      return val;
+    } else if (strictQuery === 'throw') {
+      throw new StrictModeError('$in');
+    }
+
+    return void 0;
+  }
+
+  if (!schematype.$isMongooseArray) {
+    throw new Error('Path must be an array for $in');
+  }
+
+  if (schematype.$isMongooseDocumentArray) {
+    search = schematype.$embeddedSchemaType.cast(search);
+  } else {
+    search = schematype.caster.cast(search);
+  }
+  return [search, val[1]];
 }
 
 // { $op: [<number>, <number>] }
@@ -170,6 +220,16 @@ function castComparison(val, schema, strictQuery) {
         if (dateOperators.has(key) && isPath(lhs[key])) {
           path = lhs[key].slice(1) + '.' + key;
           caster = castNumber;
+        } else if (arrayElementOperators.has(key) && isPath(lhs[key])) {
+          path = lhs[key].slice(1) + '.' + key;
+          schematype = schema.path(lhs[key].slice(1));
+          if (schematype != null) {
+            if (schematype.$isMongooseDocumentArray) {
+              schematype = schematype.$embeddedSchemaType;
+            } else if (schematype.$isMongooseArray) {
+              schematype = schematype.caster;
+            }
+          }
         }
       }
     }

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -4,6 +4,47 @@ const CastError = require('../../error/cast');
 const StrictModeError = require('../../error/strict');
 const castNumber = require('../../cast/number');
 
+const booleanComparison = new Set(['$and', '$or', '$not']);
+const comparisonOperator = new Set(['$cmp', '$eq', '$lt', '$lte', '$gt', '$gte']);
+const arithmeticOperatorArray = new Set([
+  '$multiply',
+  '$divide',
+  '$log',
+  '$mod',
+  '$trunc',
+  '$avg',
+  '$max',
+  '$min',
+  '$stdDevPop',
+  '$stdDevSamp',
+  '$sum'
+]);
+const arithmeticOperatorNumber = new Set([
+  '$abs',
+  '$exp',
+  '$ceil',
+  '$floor',
+  '$ln',
+  '$log10',
+  '$round',
+  '$sqrt',
+  '$sin',
+  '$cos',
+  '$tan',
+  '$asin',
+  '$acos',
+  '$atan',
+  '$atan2',
+  '$asinh',
+  '$acosh',
+  '$atanh',
+  '$sinh',
+  '$cosh',
+  '$tanh',
+  '$degreesToRadians',
+  '$radiansToDegrees'
+]);
+
 module.exports = function cast$expr(val, schema, strictQuery) {
   if (typeof val !== 'object' || val == null) {
     throw new Error('`$expr` must be an object');
@@ -18,43 +59,68 @@ function _castExpression(val, schema, strictQuery) {
     return val;
   }
 
-  if (val.$eq != null) {
-    val.$eq = castComparison(val.$eq, schema, strictQuery);
-    if (val.$eq === void 0) {
-      delete val.$eq;
+  if (val.$cond != null) {
+    val.$cond.if = _castExpression(val.$cond.if, schema, strictQuery);
+    val.$cond.then = _castExpression(val.$cond.then, schema, strictQuery);
+    val.$cond.else = _castExpression(val.$cond.else, schema, strictQuery);
+  } else if (val.$ifNull != null) {
+    val.$ifNull.map(v => _castExpression(v, schema, strictQuery));
+  } else if (val.$switch != null) {
+    val.branches.map(v => _castExpression(v, schema, strictQuery));
+    val.default = _castExpression(val.default, schema, strictQuery);
+  }
+
+  const keys = Object.keys(val);
+  for (const key of keys) {
+    if (booleanComparison.has(key)) {
+      val[key] = val[key].map(v => _castExpression(v, schema, strictQuery));
+    } else if (comparisonOperator.has(key)) {
+      val[key] = castComparison(val[key], schema, strictQuery);
+    } else if (arithmeticOperatorArray.has(key)) {
+      val[key] = castArithmetic(val[key], schema, strictQuery);
+    } else if (arithmeticOperatorNumber.has(key)) {
+      val[key] = castArithmeticSingle(val[key], schema, strictQuery);
     }
   }
-  if (val.$lt != null) {
-    val.$lt = castComparison(val.$lt, schema, strictQuery);
-    if (val.$lt === void 0) {
-      delete val.$lt;
-    }
-  }
-  if (val.$lte != null) {
-    val.$lte = castComparison(val.$lte, schema, strictQuery);
-    if (val.$lte === void 0) {
-      delete val.$lte;
-    }
-  }
-  if (val.$gte != null) {
-    val.$gte = castComparison(val.$gte, schema, strictQuery);
-    if (val.$gte === void 0) {
-      delete val.$gte;
-    }
-  }
-  if (val.$multiply != null) {
-    val.$multiply = castMath(val.$multiply, schema, strictQuery);
-    if (val.$multiply === void 0) {
-      delete val.$multiply;
-    }
-  }
+
+  _omitUndefined(val);
 
   return val;
 }
 
-function castMath(val) {
+function _omitUndefined(val) {
+  const keys = Object.keys(val);
+  for (const key of keys) {
+    if (val[key] === void 0) {
+      delete val[key];
+    }
+  }
+}
+
+// { $op: <number> }
+function castArithmeticSingle(val) {
+  if (!isLiteral(val)) {
+    return val;
+  }
+
+  try {
+    return castNumber(val);
+  } catch (err) {
+    throw new CastError('Number', val);
+  }
+}
+
+// { $op: [<number>, <number>] }
+function castArithmetic(val) {
   if (!Array.isArray(val)) {
-    throw new Error('Math operator must be an array');
+    if (!isLiteral(val)) {
+      return val;
+    }
+    try {
+      return castNumber(val);
+    } catch (err) {
+      throw new CastError('Number', val);
+    }
   }
 
   return val.map(v => {
@@ -64,23 +130,19 @@ function castMath(val) {
     try {
       return castNumber(v);
     } catch (err) {
-      throw new CastError('Number', v, '$multiiply');
+      throw new CastError('Number', v);
     }
   });
 }
 
+// { $op: [expression, expression] }
 function castComparison(val, schema, strictQuery) {
   if (!Array.isArray(val) || val.length !== 2) {
     throw new Error('Comparison operator must be an array of length 2');
   }
 
+  val[0] = _castExpression(val[0], schema, strictQuery);
   const lhs = val[0];
-
-  if (lhs.$cond != null) {
-    lhs.$cond.if = _castExpression(lhs.$cond.if, schema, strictQuery);
-    lhs.$cond.then = _castExpression(lhs.$cond.then, schema, strictQuery);
-    lhs.$cond.else = _castExpression(lhs.$cond.else, schema, strictQuery);
-  }
 
   if (isLiteral(val[1])) {
     let path = null;
@@ -117,19 +179,34 @@ function castComparison(val, schema, strictQuery) {
       }
     }
 
+    const is$literal = typeof val[1] === 'object' && val[1] != null && val[1].$literal != null;
     if (schematype != null) {
-      val[1] = schematype.cast(val[1]);
-    } else if (caster != null) {
-      try {
-        val[1] = caster(val[1]);
-      } catch (err) {
-        throw new CastError(caster.name.slice(4 /* 'cast'.length */), val[1], path);
+      if (is$literal) {
+        val[1] = { $literal: schematype.cast(val[1].$literal) };
+      } else {
+        val[1] = schematype.cast(val[1]);
       }
-    } else if (strictQuery === true) {
+    } else if (caster != null) {
+      if (is$literal) {
+        try {
+          val[1] = { $literal: caster(val[1].$literal) };
+        } catch (err) {
+          throw new CastError(caster.name.slice(4 /* 'cast'.length */), val[1], path + '.$literal');
+        }
+      } else {
+        try {
+          val[1] = caster(val[1]);
+        } catch (err) {
+          throw new CastError(caster.name.slice(4 /* 'cast'.length */), val[1], path);
+        }
+      }
+    } else if (path != null && strictQuery === true) {
       return void 0;
-    } else if (strictQuery === 'throw') {
+    } else if (path != null && strictQuery === 'throw') {
       throw new StrictModeError(path);
     }
+  } else {
+    val[1] = _castExpression(val[1]);
   }
 
   return val;
@@ -143,8 +220,10 @@ function isLiteral(val) {
   if (typeof val === 'string' && val.startsWith('$')) {
     return false;
   }
-  if (typeof val === 'object' && val != null && Object.keys(val).includes(key => key.startsWith('$'))) {
-    return false;
+  if (typeof val === 'object' && val != null && Object.keys(val).find(key => key.startsWith('$'))) {
+    // The `$literal` expression can make an object a literal
+    // https://docs.mongodb.com/manual/reference/operator/aggregation/literal/#mongodb-expression-exp.-literal
+    return val.$literal != null;
   }
   return true;
 }

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const CastError = require('../../error/cast');
+const StrictModeError = require('../../error/strict');
+const castNumber = require('../../cast/number');
+
+module.exports = function cast$expr(val, schema, strictQuery) {
+  if (typeof val !== 'object' || val == null) {
+    throw new Error('`$expr` must be an object');
+  }
+
+  return _castExpression(val, schema, strictQuery);
+};
+
+function _castExpression(val, schema, strictQuery) {
+  if (isPath(val)) {
+    // Assume path
+    return val;
+  }
+
+  if (val.$eq != null) {
+    val.$eq = castComparison(val.$eq, schema, strictQuery);
+    if (val.$eq === void 0) {
+      delete val.$eq;
+    }
+  }
+  if (val.$lt != null) {
+    val.$lt = castComparison(val.$lt, schema, strictQuery);
+    if (val.$lt === void 0) {
+      delete val.$lt;
+    }
+  }
+  if (val.$lte != null) {
+    val.$lte = castComparison(val.$lte, schema, strictQuery);
+    if (val.$lte === void 0) {
+      delete val.$lte;
+    }
+  }
+  if (val.$gte != null) {
+    val.$gte = castComparison(val.$gte, schema, strictQuery);
+    if (val.$gte === void 0) {
+      delete val.$gte;
+    }
+  }
+  if (val.$multiply != null) {
+    val.$multiply = castMath(val.$multiply, schema, strictQuery);
+    if (val.$multiply === void 0) {
+      delete val.$multiply;
+    }
+  }
+
+  return val;
+}
+
+function castMath(val) {
+  if (!Array.isArray(val)) {
+    throw new Error('Math operator must be an array');
+  }
+
+  return val.map(v => {
+    if (!isLiteral(v)) {
+      return v;
+    }
+    try {
+      return castNumber(v);
+    } catch (err) {
+      throw new CastError('Number', v, '$multiiply');
+    }
+  });
+}
+
+function castComparison(val, schema, strictQuery) {
+  if (!Array.isArray(val) || val.length !== 2) {
+    throw new Error('Comparison operator must be an array of length 2');
+  }
+
+  const lhs = val[0];
+
+  if (lhs.$cond != null) {
+    lhs.$cond.if = _castExpression(lhs.$cond.if, schema, strictQuery);
+    lhs.$cond.then = _castExpression(lhs.$cond.then, schema, strictQuery);
+    lhs.$cond.else = _castExpression(lhs.$cond.else, schema, strictQuery);
+  }
+
+  if (isLiteral(val[1])) {
+    let path = null;
+    let schematype = null;
+    let caster = null;
+    if (isPath(lhs)) {
+      path = lhs.slice(1);
+      schematype = schema.path(path);
+    } else if (typeof lhs === 'object' && lhs != null) {
+      if (isPath(lhs.$year)) {
+        path = lhs.$year.slice(1) + '.$year';
+        caster = castNumber;
+      } else if (isPath(lhs.$month)) {
+        path = lhs.$month.slice(1) + '.$month';
+        caster = castNumber;
+      } else if (isPath(lhs.$week)) {
+        path = lhs.$week.slice(1) + '.$week';
+        caster = castNumber;
+      } else if (isPath(lhs.$dayOfMonth)) {
+        path = lhs.$dayOfMonth.slice(1) + '.$dayOfMonth';
+        caster = castNumber;
+      } else if (isPath(lhs.$dayOfYear)) {
+        path = lhs.$dayOfMonth.slice(1) + '.$dayOfYear';
+        caster = castNumber;
+      } else if (isPath(lhs.$hour)) {
+        path = lhs.$hour.slice(1) + '.$hour';
+        caster = castNumber;
+      } else if (isPath(lhs.$minute)) {
+        path = lhs.$minute.slice(1) + '.$minute';
+        caster = castNumber;
+      } else if (isPath(lhs.$second)) {
+        path = lhs.$second.slice(1) + '.$second';
+        caster = castNumber;
+      }
+    }
+
+    if (schematype != null) {
+      val[1] = schematype.cast(val[1]);
+    } else if (caster != null) {
+      try {
+        val[1] = caster(val[1]);
+      } catch (err) {
+        throw new CastError(caster.name.slice(4 /* 'cast'.length */), val[1], path);
+      }
+    } else if (strictQuery === true) {
+      return void 0;
+    } else if (strictQuery === 'throw') {
+      throw new StrictModeError(path);
+    }
+  }
+
+  return val;
+}
+
+function isPath(val) {
+  return typeof val === 'string' && val.startsWith('$');
+}
+
+function isLiteral(val) {
+  if (typeof val === 'string' && val.startsWith('$')) {
+    return false;
+  }
+  if (typeof val === 'object' && val != null && Object.keys(val).includes(key => key.startsWith('$'))) {
+    return false;
+  }
+  return true;
+}

--- a/test/helpers/query.cast$expr.test.js
+++ b/test/helpers/query.cast$expr.test.js
@@ -11,8 +11,17 @@ describe('castexpr', function() {
     let res = cast$expr({ $eq: ['$date', '2021-06-01'] }, testSchema);
     assert.deepEqual(res, { $eq: ['$date', new Date('2021-06-01')] });
 
+    res = cast$expr({ $eq: [{ $year: '$date' }, 2021] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: [{ $year: '$date' }, 2021] });
+
     res = cast$expr({ $eq: [{ $year: '$date' }, '2021'] }, testSchema);
     assert.deepStrictEqual(res, { $eq: [{ $year: '$date' }, 2021] });
+
+    res = cast$expr({ $eq: [{ $year: '$date' }, { $literal: '2021' }] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: [{ $year: '$date' }, { $literal: 2021 }] });
+
+    res = cast$expr({ $eq: [{ $year: '$date' }, { $literal: '2021' }] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: [{ $year: '$date' }, { $literal: 2021 }] });
 
     res = cast$expr({ $gt: ['$spent', '$budget'] }, testSchema);
     assert.deepStrictEqual(res, { $gt: ['$spent', '$budget'] });
@@ -21,19 +30,19 @@ describe('castexpr', function() {
   it('casts conditions', function() {
     const testSchema = new Schema({ price: Number, qty: Number });
 
-    const discountedPrice = {
+    let discountedPrice = {
       $cond: {
-        if: { $gte: ['$qty', '100'] },
+        if: { $gte: ['$qty', { $floor: '100' }] },
         then: { $multiply: ['$price', '0.5'] },
         else: { $multiply: ['$price', '0.75'] }
       }
     };
-    const res = cast$expr({ $lt: [discountedPrice, 5] }, testSchema);
+    let res = cast$expr({ $lt: [discountedPrice, 5] }, testSchema);
     assert.deepStrictEqual(res, {
       $lt: [
         {
           $cond: {
-            if: { $gte: ['$qty', 100] },
+            if: { $gte: ['$qty', { $floor: 100 }] },
             then: { $multiply: ['$price', 0.5] },
             else: { $multiply: ['$price', 0.75] }
           }
@@ -41,5 +50,41 @@ describe('castexpr', function() {
         5
       ]
     });
+
+    discountedPrice = {
+      $cond: {
+        if: { $and: [{ $gte: ['$qty', { $floor: '100' }] }] },
+        then: { $multiply: ['$price', '0.5'] },
+        else: { $multiply: ['$price', '0.75'] }
+      }
+    };
+    res = cast$expr({ $lt: [discountedPrice, 5] }, testSchema);
+    assert.deepStrictEqual(res, {
+      $lt: [
+        {
+          $cond: {
+            if: { $and: [{ $gte: ['$qty', { $floor: 100 }] }] },
+            then: { $multiply: ['$price', 0.5] },
+            else: { $multiply: ['$price', 0.75] }
+          }
+        },
+        5
+      ]
+    });
+  });
+
+  it('casts boolean expressions', function() {
+    const testSchema = new Schema({ date: Date, spent: Number, budget: Number });
+
+    const res = cast$expr({ $and: [{ $eq: [{ $year: '$date' }, '2021'] }] }, testSchema);
+    assert.deepStrictEqual(res, { $and: [{ $eq: [{ $year: '$date' }, 2021] }] });
+  });
+
+  it('cast errors', function() {
+    const testSchema = new Schema({ date: Date, spent: Number, budget: Number });
+
+    assert.throws(() => {
+      cast$expr({ $eq: [{ $year: '$date' }, 'not a number'] }, testSchema);
+    }, /Cast to Number failed/);
   });
 });

--- a/test/helpers/query.cast$expr.test.js
+++ b/test/helpers/query.cast$expr.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { Schema } = require('../common').mongoose;
+const assert = require('assert');
+const cast$expr = require('../../lib/helpers/query/cast$expr');
+
+describe('castexpr', function() {
+  it('casts comparisons', function() {
+    const testSchema = new Schema({ date: Date, spent: Number, budget: Number });
+
+    let res = cast$expr({ $eq: ['$date', '2021-06-01'] }, testSchema);
+    assert.deepEqual(res, { $eq: ['$date', new Date('2021-06-01')] });
+
+    res = cast$expr({ $eq: [{ $year: '$date' }, '2021'] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: [{ $year: '$date' }, 2021] });
+
+    res = cast$expr({ $gt: ['$spent', '$budget'] }, testSchema);
+    assert.deepStrictEqual(res, { $gt: ['$spent', '$budget'] });
+  });
+
+  it('casts conditions', function() {
+    const testSchema = new Schema({ price: Number, qty: Number });
+
+    const discountedPrice = {
+      $cond: {
+        if: { $gte: ['$qty', '100'] },
+        then: { $multiply: ['$price', '0.5'] },
+        else: { $multiply: ['$price', '0.75'] }
+      }
+    };
+    const res = cast$expr({ $lt: [discountedPrice, 5] }, testSchema);
+    assert.deepStrictEqual(res, {
+      $lt: [
+        {
+          $cond: {
+            if: { $gte: ['$qty', 100] },
+            then: { $multiply: ['$price', 0.5] },
+            else: { $multiply: ['$price', 0.75] }
+          }
+        },
+        5
+      ]
+    });
+  });
+});


### PR DESCRIPTION
Mostly for comparisons, like `$eq`, etc. like in #10662 .

Missing support for a few things, like `$dateFromString` and similar operators, which we can add. But primarily wanted to support casting comparisons of paths and literals, which is what this PR does.