### PR TITLE
add mongodb-memory-server to test easier locally. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mkdirp": "0.5.5",
     "mocha": "9.1.3",
     "moment": "2.x",
+    "mongodb-memory-server": "^8.2.0",
     "object-sizeof": "1.3.0",
     "pug": "3.0.2",
     "q": "1.5.1",
@@ -73,6 +74,7 @@
     "prepublishOnly": "npm run build-browser",
     "release": "git pull && git push origin master --tags && npm publish",
     "release-legacy": "git pull origin 5.x && git push origin 5.x --tags && npm publish --tag legacy",
+    "start:mongo:rs": "node ./tools/repl.js",
     "test": "mocha --exit ./test/*.test.js ./test/typescript/main.test.js",
     "tdd": "mocha ./test/*.test.js ./test/typescript/main.test.js --inspect --watch --recursive --watch-files ./**/*.js",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
@@ -240,6 +242,11 @@
       "mocha-no-only/mocha-no-only": [
         "error"
       ]
+    }
+  },
+  "config": {
+    "mongodbMemoryServer": {
+      "disablePostinstall": true
     }
   },
   "funding": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prepublishOnly": "npm run build-browser",
     "release": "git pull && git push origin master --tags && npm publish",
     "release-legacy": "git pull origin 5.x && git push origin 5.x --tags && npm publish --tag legacy",
-    "start:mongo:rs": "node ./tools/repl.js",
+    "mongo": "node ./tools/repl.js",
     "test": "mocha --exit ./test/*.test.js ./test/typescript/main.test.js",
     "tdd": "mocha ./test/*.test.js ./test/typescript/main.test.js --inspect --watch --recursive --watch-files ./**/*.js",
     "test-cov": "nyc --reporter=html --reporter=text npm test"

--- a/tools/repl.js
+++ b/tools/repl.js
@@ -10,6 +10,9 @@ async function run () {
 
   // Create new instance
   const replSet = new ReplSet({
+    binary: {
+      version: process.argv[3]
+    },
     instanceOpts: [
       // Set the expiry job in MongoDB to run every second
       { 

--- a/tools/repl.js
+++ b/tools/repl.js
@@ -6,31 +6,26 @@ run().catch(error => {
 });
 
 async function run () {
-  const ReplSet = require('mongodb-topology-manager').ReplSet;
+  const ReplSet = require('mongodb-memory-server').MongoMemoryReplSet;
 
   // Create new instance
-  const topology = new ReplSet('mongod', [{
-    // mongod process options
-    options: {
-      bind_ip: 'localhost', port: 31000, dbpath: `/data/db/31000`
-    }
-  }, {
-    // mongod process options
-    options: {
-      bind_ip: 'localhost', port: 31001, dbpath: `/data/db/31001`
-    }
-  }, {
-    // Type of node
-    arbiterOnly: true,
-    // mongod process options
-    options: {
-      bind_ip: 'localhost', port: 31002, dbpath: `/data/db/31002`
-    }
-  }], {
-    replSet: 'rs'
+  const replSet = new ReplSet({
+    instanceOpts: [
+      // Set the expiry job in MongoDB to run every second
+      { 
+        port: 27017,
+        args: ["--setParameter", "ttlMonitorSleepSecs=1"] },
+    ],
+    dbName: 'mongoose_test',
+    replSet: {
+      name: "rs0",
+      count: 2,
+      storageEngine: "wiredTiger",
+    },
   });
 
-  await topology.start();
-
-  console.log('done');
+  await replSet.start();
+  await replSet.waitUntilRunning();
+  console.log("MongoDB-ReplicaSet is now running.")
+  console.log(replSet.getUri("mongoose_test"));
 }


### PR DESCRIPTION
To run unit tests locally i added the option to start a mongodb-memory-server.

`npm run mongo` and voilá

if you want to run e.g. mongo 4.4.12 you would do 

`npm run mongo -- 4.4.12`