### PR TITLE
perf: improve performance of parentPaths

### DIFF
--- a/lib/helpers/path/parentPaths.js
+++ b/lib/helpers/path/parentPaths.js
@@ -1,16 +1,18 @@
 'use strict';
 
+const dotRE = /\./g;
 module.exports = function parentPaths(path) {
   if (path.indexOf('.') === -1) {
     return [path];
   }
-  let pos = path.indexOf('.');
-  const ret = [];
-  let i = 0;
-  while (pos !== -1) {
-    ret[i++] = (path.substring(0, pos));
-    pos = path.indexOf('.', pos + 1);
+  const pieces = path.split(dotRE);
+  const len = pieces.length;
+  const ret = new Array(len);
+  let cur = '';
+  for (let i = 0; i < len; ++i) {
+    cur += (cur.length !== 0) ? '.' + pieces[i] : pieces[i];
+    ret[i] = cur;
   }
-  ret[i] = path.substring(0);
+
   return ret;
 };

--- a/lib/helpers/path/parentPaths.js
+++ b/lib/helpers/path/parentPaths.js
@@ -1,13 +1,16 @@
 'use strict';
 
 module.exports = function parentPaths(path) {
-  const pieces = path.split('.');
-  let cur = '';
-  const ret = [];
-  for (let i = 0; i < pieces.length; ++i) {
-    cur += (cur.length > 0 ? '.' : '') + pieces[i];
-    ret.push(cur);
+  if (path.indexOf('.') === -1) {
+    return [path];
   }
-
+  let pos = path.indexOf('.')
+  const ret = [];
+  let i = 0;
+  while (pos !== -1) {
+    ret[i++] = (path.substring(0, pos));
+    pos = path.indexOf('.', pos + 1);
+  }
+  ret[i] = path.substring(0);
   return ret;
 };

--- a/lib/helpers/path/parentPaths.js
+++ b/lib/helpers/path/parentPaths.js
@@ -4,7 +4,7 @@ module.exports = function parentPaths(path) {
   if (path.indexOf('.') === -1) {
     return [path];
   }
-  let pos = path.indexOf('.')
+  let pos = path.indexOf('.');
   const ret = [];
   let i = 0;
   while (pos !== -1) {

--- a/test/helpers/parentPaths.test.js
+++ b/test/helpers/parentPaths.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require('assert');
+const parentPaths = require('../../lib/helpers/path/parentPaths');
+
+describe('parentPaths', function () {
+  it('first', function () {
+    assert.deepEqual(parentPaths('first'), ['first']);
+  });
+  it('first.second', function () {
+    assert.deepEqual(parentPaths('first.second'), ['first', 'first.second']);
+  });
+  it('first.', function () {
+    assert.deepEqual(parentPaths('first.'), ['first', 'first.']);
+  });
+});

--- a/test/helpers/parentPaths.test.js
+++ b/test/helpers/parentPaths.test.js
@@ -3,14 +3,14 @@
 const assert = require('assert');
 const parentPaths = require('../../lib/helpers/path/parentPaths');
 
-describe('parentPaths', function () {
-  it('first', function () {
+describe('parentPaths', function() {
+  it('first', function() {
     assert.deepEqual(parentPaths('first'), ['first']);
   });
-  it('first.second', function () {
+  it('first.second', function() {
     assert.deepEqual(parentPaths('first.second'), ['first', 'first.second']);
   });
-  it('first.', function () {
+  it('first.', function() {
     assert.deepEqual(parentPaths('first.'), ['first', 'first.']);
   });
 });


### PR DESCRIPTION
My Benchmark for optimizing parentPaths.

var0 = old
var1 = new

```
first
var0 x 6,011,762 ops/sec ±0.76% (90 runs sampled)
var1 x 122,339,355 ops/sec ±0.96% (95 runs sampled)
first.second
var0 x 5,210,949 ops/sec ±0.42% (91 runs sampled)
var1 x 7,159,684 ops/sec ±0.96% (90 runs sampled)
first.second.third
var0 x 4,773,409 ops/sec ±0.29% (93 runs sampled)
var1 x 5,326,110 ops/sec ±0.78% (92 runs sampled)
first.second.third.fourth.fifth
var0 x 4,134,150 ops/sec ±0.60% (91 runs sampled)
var1 x 3,836,214 ops/sec ±0.78% (92 runs sampled)
a.b.c.d.e.f
var0 x 3,665,917 ops/sec ±0.35% (94 runs sampled)
var1 x 3,452,551 ops/sec ±1.22% (90 runs sampled)
```

```
'use strict';

const Bench = require('benchmark');
const { expect } = require('chai');

function parentPathsVar0(path) {
  const pieces = path.split('.');
  let cur = '';
  const ret = [];
  for (let i = 0; i < pieces.length; ++i) {
    cur += (cur.length > 0 ? '.' : '') + pieces[i];
    ret.push(cur);
  }

  return ret;
};
const dotRE = /\./g
function parentPathsVar1(path) {
  if (path.indexOf('.') === -1) {
    return [path];
  }
  const pieces = path.split(dotRE);
  const len = pieces.length;
  const ret = new Array(len);
  let cur = '';
  for (let i = 0; i < len; ++i) {
    cur += (cur.length !== 0) ?  '.' + pieces[i] : pieces[i];
    ret[i] = cur;
  }

  return ret;
};

const validate = (value, expected) => {
  expect(parentPathsVar0(value), "var0").to.be.eql(expected);
  expect(parentPathsVar1(value), "var1").to.be.eql(expected);
}

validate('first', ['first']);
validate('first.second', ['first', 'first.second']);
validate('', ['']);

const bench = (value) => {
  console.log(value)
  new Bench.Suite()
    .add('var0', function () {
      parentPathsVar0(value);
    })
    .add('var1', function () {
      parentPathsVar1(value);
    })
    .on('cycle', function (e) {
      const s = String(e.target);
      console.log(s);
    })
    .run();
}


bench("first");
bench("first.second");
bench("first.second.third");
bench("first.second.third.fourth.fifth");
bench("a.b.c.d.e.f");
```

