### PR TITLE
perf: improve setDottedPath

### DIFF
--- a/lib/helpers/path/setDottedPath.js
+++ b/lib/helpers/path/setDottedPath.js
@@ -1,9 +1,14 @@
 'use strict';
 
 module.exports = function setDottedPath(obj, path, val) {
-  const parts = path.indexOf('.') === -1 ? [path] : path.split('.');
+  if (path.indexOf('.') === -1) {
+    obj[path] = val;
+    return;
+  }
+  const parts = path.split('.');
+  const last = parts.pop();
   let cur = obj;
-  for (const part of parts.slice(0, -1)) {
+  for (const part of parts) {
     if (cur[part] == null) {
       cur[part] = {};
     }
@@ -11,6 +16,5 @@ module.exports = function setDottedPath(obj, path, val) {
     cur = cur[part];
   }
 
-  const last = parts[parts.length - 1];
   cur[last] = val;
 };

--- a/test/helpers/setDottetPath.test.js
+++ b/test/helpers/setDottetPath.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('assert');
+const setDottedPath = require('../../lib/helpers/path/setDottedPath');
+
+describe('setDottedPath', function() {
+  it('setDottedPath root element', function() {
+    const obj = {
+      clearingInstituteName: 'Our local bank',
+      'transaction.receipt': 'I am a transaction receipt',
+      'transaction.authorizationCode': 'ABCDEF',
+      'transaction.acquirer.settlementDate': 'February 2021',
+      'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
+      nonExistentField: 'I should not be present'
+    };
+    setDottedPath(obj, 'authorizationResponse', '123456');
+    assert.deepEqual(obj, {
+      'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
+      'transaction.acquirer.settlementDate': 'February 2021',
+      'transaction.authorizationCode': 'ABCDEF',
+      'transaction.receipt': 'I am a transaction receipt',
+      authorizationResponse: '123456',
+      clearingInstituteName: 'Our local bank',
+      nonExistentField: 'I should not be present'
+    });
+  });
+  it('setDottedPath sub element', function() {
+    const obj = {
+      clearingInstituteName: 'Our local bank',
+      'transaction.receipt': 'I am a transaction receipt',
+      'transaction.authorizationCode': 'ABCDEF',
+      'transaction.acquirer.settlementDate': 'February 2021',
+      'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
+      nonExistentField: 'I should not be present'
+    };
+    setDottedPath(obj, 'authorizationResponse.stan', '123456');
+    assert.deepEqual(obj, {
+      'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
+      'transaction.acquirer.settlementDate': 'February 2021',
+      'transaction.authorizationCode': 'ABCDEF',
+      'transaction.receipt': 'I am a transaction receipt',
+      authorizationResponse: {
+        stan: '123456'
+      },
+      clearingInstituteName: 'Our local bank',
+      nonExistentField: 'I should not be present'
+    });
+  });
+});


### PR DESCRIPTION
Improve perf of setDottetPath

var0 = old
var1 = new

```
authorizationResponse
var0 x 30,093,641 ops/sec ±1.66% (86 runs sampled)
var1 x 123,402,415 ops/sec ±0.42% (95 runs sampled)
authorizationResponse.stan
var0 x 4,020,169 ops/sec ±0.43% (90 runs sampled)
var1 x 5,329,115 ops/sec ±0.50% (91 runs sampled)
```

benchmark:
```
'use strict';

const Bench = require('benchmark');
const { expect } = require('chai');

function setDottedPathVar0(obj, path, val) {
  const parts = path.indexOf('.') === -1 ? [path] : path.split('.');
  let cur = obj;
  for (const part of parts.slice(0, -1)) {
    if (cur[part] == null) {
      cur[part] = {};
    }

    cur = cur[part];
  }

  const last = parts[parts.length - 1];
  cur[last] = val;
};
function setDottedPathVar1(obj, path, val) {
  if (path.indexOf('.') === -1) {
    obj[path] = val;
    return;
  }
  const parts = path.split('.');
  const last = parts.pop();
  let cur = obj;
  for (const part of parts) {
    if (cur[part] == null) {
      cur[part] = {};
    }

    cur = cur[part];
  }

  cur[last] = val;
};

const validate = (path, value, expected) => {
  let obj = {
    clearingInstituteName: 'Our local bank',
    'transaction.receipt': 'I am a transaction receipt',
    'transaction.authorizationCode': 'ABCDEF',
    'transaction.acquirer.settlementDate': 'February 2021',
    'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
    nonExistentField: 'I should not be present'
  };
  setDottedPathVar0(obj, path, value);
  expect(obj, "var0").to.be.eql(expected);
  obj = {
    clearingInstituteName: 'Our local bank',
    'transaction.receipt': 'I am a transaction receipt',
    'transaction.authorizationCode': 'ABCDEF',
    'transaction.acquirer.settlementDate': 'February 2021',
    'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
    nonExistentField: 'I should not be present'
  };
  setDottedPathVar1(obj, path, value);
  expect(obj, "var1").to.be.eql(expected);
}

validate('authorizationResponse.stan', '123456', {
  clearingInstituteName: 'Our local bank',
  'transaction.receipt': 'I am a transaction receipt',
  'transaction.authorizationCode': 'ABCDEF',
  'transaction.acquirer.settlementDate': 'February 2021',
  'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
  nonExistentField: 'I should not be present',
  authorizationResponse: { stan: '123456' }
});
validate('authorizationResponse', '123456', {
  clearingInstituteName: 'Our local bank',
  'transaction.receipt': 'I am a transaction receipt',
  'transaction.authorizationCode': 'ABCDEF',
  'transaction.acquirer.settlementDate': 'February 2021',
  'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
  nonExistentField: 'I should not be present',
  authorizationResponse: '123456'
});
// validate('first.second', ['first', 'first.second']);
// validate('', ['']);

const bench = (path, value) => {
  console.log(path)
  new Bench.Suite()
    .add('var0', function () {

      const obj = {
        clearingInstituteName: 'Our local bank',
        'transaction.receipt': 'I am a transaction receipt',
        'transaction.authorizationCode': 'ABCDEF',
        'transaction.acquirer.settlementDate': 'February 2021',
        'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
        nonExistentField: 'I should not be present'
      };
      setDottedPathVar0(obj, path, value);
    })
    .add('var1', function () {

      const obj = {
        clearingInstituteName: 'Our local bank',
        'transaction.receipt': 'I am a transaction receipt',
        'transaction.authorizationCode': 'ABCDEF',
        'transaction.acquirer.settlementDate': 'February 2021',
        'sourceOfFunds.provided.card.issuer': 'Big bank corporation',
        nonExistentField: 'I should not be present'
      };
      setDottedPathVar1(obj, path, value);
    })
    .on('cycle', function (e) {
      const s = String(e.target);
      console.log(s);
    })
    .run();
}


bench('authorizationResponse', '123456');
bench('authorizationResponse.stan', '123456');
```