### PR TITLE
remove obsolete code after upgrading to bson4

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -36,14 +36,6 @@ module.exports = function cast(schema, obj, options, context) {
     return obj;
   }
 
-  // bson 1.x has the unfortunate tendency to remove filters that have a top-level
-  // `_bsontype` property. But we should still allow ObjectIds because
-  // `Collection#find()` has a special case to support `find(objectid)`.
-  // Should remove this when we upgrade to bson 4.x. See gh-8222, gh-8268
-  if (obj.hasOwnProperty('_bsontype') && obj._bsontype !== 'ObjectID') {
-    delete obj._bsontype;
-  }
-
   if (schema != null && schema.discriminators != null && obj[schema.options.discriminatorKey] != null) {
     schema = getSchemaDiscriminatorByValue(schema, obj[schema.options.discriminatorKey]) || schema;
   }


### PR DESCRIPTION
There was a remark to remove a code block if we upgraded to bson4....