### PR TITLE
chore: remove chalk as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-loader": "8.1.0",
     "benchmark": "2.1.4",
     "bluebird": "3.7.2",
-    "chalk": "4.1.2",
     "cheerio": "1.0.0-rc.5",
     "dox": "0.3.1",
     "eslint": "8.5.0",

--- a/test/shard.test.js
+++ b/test/shard.test.js
@@ -9,10 +9,11 @@ const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 
 const uri = process.env.MONGOOSE_SHARD_TEST_URI;
+const redColorEscapeCharacter = '\x1b[31m';
 
 if (!uri) {
   console.log([
-    '\x1b[31m',
+    redColorEscapeCharacter,
     'You\'re not testing shards!',
     'Please set the MONGOOSE_SHARD_TEST_URI env variable.',
     'e.g: `mongodb://localhost:27017/database',

--- a/test/shard.test.js
+++ b/test/shard.test.js
@@ -12,11 +12,11 @@ const uri = process.env.MONGOOSE_SHARD_TEST_URI;
 
 if (!uri) {
   console.log([
-      '\x1b[31m',
-      'You\'re not testing shards!',
-      'Please set the MONGOOSE_SHARD_TEST_URI env variable.',
-      'e.g: `mongodb://localhost:27017/database',
-      'Sharding must already be enabled on your database'
+    '\x1b[31m',
+    'You\'re not testing shards!',
+    'Please set the MONGOOSE_SHARD_TEST_URI env variable.',
+    'e.g: `mongodb://localhost:27017/database',
+    'Sharding must already be enabled on your database'
   ].join('\n'));
 
   return;

--- a/test/shard.test.js
+++ b/test/shard.test.js
@@ -3,7 +3,6 @@
 const start = require('./common');
 
 const assert = require('assert');
-const chalk = require('chalk');
 const random = require('./util').random;
 
 const mongoose = start.mongoose;
@@ -12,14 +11,13 @@ const Schema = mongoose.Schema;
 const uri = process.env.MONGOOSE_SHARD_TEST_URI;
 
 if (!uri) {
-  console.log(
-    chalk.red(
-      '\n', 'You\'re not testing shards!',
-      '\n', 'Please set the MONGOOSE_SHARD_TEST_URI env variable.', '\n',
-      'e.g: `mongodb://localhost:27017/database', '\n',
+  console.log([
+      '\x1b[31m',
+      'You\'re not testing shards!',
+      'Please set the MONGOOSE_SHARD_TEST_URI env variable.',
+      'e.g: `mongodb://localhost:27017/database',
       'Sharding must already be enabled on your database'
-    )
-  );
+  ].join('\n'));
 
   return;
 }


### PR DESCRIPTION
We use chalk only in one place: To write in red, that we dont run the sharding tests. We just need to use the correct escape character, which can be easily googled, to write in red color. 

Reduces the potential risk of a supply chain attack. 