### PR TITLE
chore: remove uuid-parse, upgrade uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "semver": "5.5.0",
     "serve-handler": "6.1.3",
     "typescript": "4.5.3",
-    "uuid": "2.0.3",
-    "uuid-parse": "1.0.0",
+    "uuid": "^8.3.2",
     "webpack": "4.44.1"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "semver": "5.5.0",
     "serve-handler": "6.1.3",
     "typescript": "4.5.3",
-    "uuid": "^8.3.2",
+    "uuid": "8.3.2",
     "webpack": "4.44.1"
   },
   "directories": {

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1958,8 +1958,6 @@ describe('model: findOneAndUpdate:', function() {
     });
 
     it('avoids edge case with middleware cloning buffers (gh-5702)', function(done) {
-      const uuidParse = require('uuid');
-
       function toUUID(string) {
         if (!string) {
           return null;

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1958,7 +1958,7 @@ describe('model: findOneAndUpdate:', function() {
     });
 
     it('avoids edge case with middleware cloning buffers (gh-5702)', function(done) {
-      const uuidParse = require('uuid-parse');
+      const uuidParse = require('uuid');
 
       function toUUID(string) {
         if (!string) {
@@ -1967,7 +1967,7 @@ describe('model: findOneAndUpdate:', function() {
         if (Buffer.isBuffer(string) || Buffer.isBuffer(string.buffer)) {
           return string;
         }
-        const buffer = uuidParse.parse(string);
+        const buffer = uuid.parse(string);
         return new mongoose.Types.Buffer(buffer).toObject(0x04);
       }
 
@@ -1975,7 +1975,7 @@ describe('model: findOneAndUpdate:', function() {
         if (!buffer || buffer.length !== 16) {
           return null;
         }
-        return uuidParse.unparse(buffer);
+        return uuid.stringify(buffer);
       }
 
       const UserSchema = new mongoose.Schema({
@@ -2022,7 +2022,7 @@ describe('model: findOneAndUpdate:', function() {
         this.skip();
       }
 
-      const uuidParse = require('uuid-parse');
+      const uuid = require('uuid');
       function toUUID(string) {
         if (!string) {
           return null;
@@ -2030,7 +2030,7 @@ describe('model: findOneAndUpdate:', function() {
         if (Buffer.isBuffer(string) || Buffer.isBuffer(string.buffer)) {
           return string;
         }
-        const buffer = uuidParse.parse(string);
+        const buffer = uuid.parse(string);
         return new mongoose.Types.Buffer(buffer).toObject(0x04);
       }
 


### PR DESCRIPTION
uuid reports some Math.random sec-vuln. So upgraded it and used the builtin parse from 8.3 uuid to replace the not maintained uuid-parse package. 

Reduce Supply Chain Attack Risks.