### PR TITLE
chore: upgrade mocha to 9.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash.isequalwith": "4.4.0",
     "marked": "2.1.3",
     "mkdirp": "0.5.5",
-    "mocha": "9.1.3",
+    "mocha": "9.2.0",
     "moment": "2.x",
     "mongodb-memory-server": "^8.2.0",
     "object-sizeof": "1.3.0",


### PR DESCRIPTION
mocha 9.1.3 throws a npm audit warning. Upgrading to mocha 9.2.0 resolves this issue. 