### PR TITLE
chore: remove semver from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "pug": "3.0.2",
     "q": "1.5.1",
     "rimraf": "2.6.3",
-    "semver": "5.5.0",
     "serve-handler": "6.1.3",
     "typescript": "4.5.3",
     "uuid": "2.0.3",

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -53,14 +53,21 @@ function setupData(db, callback) {
  *
  * @param {String} semver, `3.4`, specify minimum compatible mongod version
  * @param {Object} ctx, `this`, so that mocha tests can be skipped
- * @return {Void}
+ * @return {Promise.<void>}
  */
 async function onlyTestAtOrAbove(semver, ctx) {
+  const versions = {
+    '3.4' : [3, 4],
+    '3.6' : [3, 6]
+  }
+
+  if (semver.length !== 3 || Object.keys(versions).indexOf(semver) === -1) {
+    throw new TypeError('onlyTestAtOrAbove expects either ' + Object.keys(versions).join(', ') + ' as first parameter.');
+  }
+
   const version = await start.mongodVersion();
 
-  const desired = semver.split('.').map(function(s) {
-    return parseInt(s);
-  });
+  const desired = versions[semver];
 
   const meetsMinimum = version[0] > desired[0] || (version[0] === desired[0] && version[1] >= desired[1]);
 

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -53,7 +53,7 @@ function setupData(db, callback) {
  *
  * @param {String} semver, `3.4`, specify minimum compatible mongod version
  * @param {Object} ctx, `this`, so that mocha tests can be skipped
- * @return {Promise.<void>}
+ * @return {Promise<void>}
  */
 async function onlyTestAtOrAbove(semver, ctx) {
   const versions = {

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -57,9 +57,9 @@ function setupData(db, callback) {
  */
 async function onlyTestAtOrAbove(semver, ctx) {
   const versions = {
-    '3.4' : [3, 4],
-    '3.6' : [3, 6]
-  }
+    3.4: [3, 4],
+    3.6: [3, 6]
+  };
 
   if (semver.length !== 3 || Object.keys(versions).indexOf(semver) === -1) {
     throw new TypeError('onlyTestAtOrAbove expects either ' + Object.keys(versions).join(', ') + ' as first parameter.');


### PR DESCRIPTION
We did not use semver. I took the chance to make the onlyTestAtOrAbove-method more readable (well in my opinion atleast ;). 