### PR TITLE
chore: replace object-sizeof with native v8.serialize(...).length

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "mocha": "9.1.3",
     "moment": "2.x",
     "mongodb-memory-server": "^8.2.0",
-    "object-sizeof": "1.3.0",
     "pug": "3.0.2",
     "q": "1.5.1",
     "rimraf": "2.6.3",

--- a/test/docs/lean.test.js
+++ b/test/docs/lean.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const { serialize } = require('v8');
+const v8Serialize = require('v8').serialize;
 const start = require('../common');
 
 // This file is in `es-next` because it uses async/await for convenience
@@ -32,13 +32,16 @@ describe('Lean Tutorial', function() {
     // To enable the `lean` option for a query, use the `lean()` function.
     const leanDoc = await MyModel.findOne().lean();
 
+    v8Serialize(normalDoc).length; // approximately 300
+    v8Serialize(leanDoc).length; // 32, more than 10x smaller!
+
     // In case you were wondering, the JSON form of a Mongoose doc is the same
     // as the POJO. This additional memory only affects how much memory your
     // Node.js process uses, not how much data is sent over the network.
     JSON.stringify(normalDoc).length === JSON.stringify(leanDoc.length); // true
     // acquit:ignore:start
-    assert.ok(serialize(normalDoc).length >= 300 && serialize(normalDoc).length <= 800, serialize(normalDoc).length);
-    assert.equal(serialize(leanDoc).length, 32);
+    assert.ok(v8Serialize(normalDoc).length >= 300 && v8Serialize(normalDoc).length <= 800, v8Serialize(normalDoc).length);
+    assert.equal(v8Serialize(leanDoc).length, 32);
     assert.equal(JSON.stringify(normalDoc).length, JSON.stringify(leanDoc).length);
     // acquit:ignore:end
   });

--- a/test/docs/lean.test.js
+++ b/test/docs/lean.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { serialize } = require('v8');
 const start = require('../common');
 
 // This file is in `es-next` because it uses async/await for convenience
@@ -27,23 +28,17 @@ describe('Lean Tutorial', function() {
 
     await MyModel.create({ name: 'test' });
 
-    // Module that estimates the size of an object in memory
-    const sizeof = require('object-sizeof');
-
     const normalDoc = await MyModel.findOne();
     // To enable the `lean` option for a query, use the `lean()` function.
     const leanDoc = await MyModel.findOne().lean();
-
-    sizeof(normalDoc); // approximately 600
-    sizeof(leanDoc); // 36, more than 10x smaller!
 
     // In case you were wondering, the JSON form of a Mongoose doc is the same
     // as the POJO. This additional memory only affects how much memory your
     // Node.js process uses, not how much data is sent over the network.
     JSON.stringify(normalDoc).length === JSON.stringify(leanDoc.length); // true
     // acquit:ignore:start
-    assert.ok(sizeof(normalDoc) >= 400 && sizeof(normalDoc) <= 800, sizeof(normalDoc));
-    assert.equal(sizeof(leanDoc), 36);
+    assert.ok(serialize(normalDoc).length >= 300 && serialize(normalDoc).length <= 800, serialize(normalDoc).length);
+    assert.equal(serialize(leanDoc).length, 32);
     assert.equal(JSON.stringify(normalDoc).length, JSON.stringify(leanDoc).length);
     // acquit:ignore:end
   });


### PR DESCRIPTION
object-sizeof is an unnecessary dependency, which does not even return the correct memory footprint of a variable in v8/node. To determine the correct size of a variable, we can use the serialize method of v8 and use the length property of the Buffer to determine the actual size of the variable, when stored in v8.