### PR TITLE
🎨 isValidObjectId: remove this reference of Types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -956,7 +956,7 @@ Mongoose.prototype.ObjectId = SchemaTypes.ObjectId;
 
 Mongoose.prototype.isValidObjectId = function(v) {
   try {
-    new this.Types.ObjectId(v);
+    new Types.ObjectId(v);
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
**Summary**

As in last mongoose release v6.1.9 we have updated the function definition of `isValidObjectId`. It is breaking for the developers who use this function directly to validate ObjectId.
Because its using `Types` from `Mongoose` object's `this` reference.
We can avoid that and can have same results. So developer can use `isValidObjectId` function as provided in example below

**Example**

````javascript
const { isValidObjectId } = require('mongoose');
if (isValidObjectId(id)) {
    ...
}
`````