### PR TITLE
perf: remove regexp-clone

### DIFF
--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -1,7 +1,5 @@
 'use strict';
 
-
-const cloneRegExp = require('regexp-clone');
 const Decimal = require('../types/decimal128');
 const ObjectId = require('../types/objectid');
 const specialProperties = require('./specialProperties');
@@ -144,5 +142,13 @@ function cloneArray(arr, options) {
     ret.push(clone(item, options, true));
   }
 
+  return ret;
+}
+
+function cloneRegExp(regexp) {
+  const ret = new RegExp(regexp.source, regexp.flags);
+  if (typeof regexp.lastIndex === 'number') {
+    ret.lastIndex = regexp.lastIndex;
+  }
   return ret;
 }

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -146,7 +146,7 @@ function cloneArray(arr, options) {
 }
 
 function cloneRegExp(regexp) {
-  const ret = new RegExp(regexp);
+  const ret = new RegExp(regexp.source, regexp.flags);
 
   (typeof regexp.lastIndex === 'number') && (ret.lastIndex = regexp.lastIndex);
   return ret;

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -148,6 +148,8 @@ function cloneArray(arr, options) {
 function cloneRegExp(regexp) {
   const ret = new RegExp(regexp.source, regexp.flags);
 
-  (typeof regexp.lastIndex === 'number') && (ret.lastIndex = regexp.lastIndex);
+  if (ret.lastIndex !== regexp.lastIndex) {
+    ret.lastIndex = regexp.lastIndex;
+  }
   return ret;
 }

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -146,9 +146,8 @@ function cloneArray(arr, options) {
 }
 
 function cloneRegExp(regexp) {
-  const ret = new RegExp(regexp.source, regexp.flags);
-  if (typeof regexp.lastIndex === 'number') {
-    ret.lastIndex = regexp.lastIndex;
-  }
+  const ret = new RegExp(regexp);
+
+  (typeof regexp.lastIndex === 'number') && (ret.lastIndex = regexp.lastIndex);
   return ret;
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "mpath": "0.8.4",
     "mquery": "4.0.2",
     "ms": "2.1.2",
-    "regexp-clone": "1.0.0",
     "sift": "13.5.2"
   },
   "devDependencies": {

--- a/test/helpers/clone.test.js
+++ b/test/helpers/clone.test.js
@@ -148,9 +148,11 @@ describe('clone', () => {
 
     describe('constructor is RegExp', () => {
       it('return new equal date ', () => {
-        const base = new RegExp(/A-Z.*/);
+        const base = new RegExp(/A-Z.*/g);
+        base.lastIndex = 2;
         const cloned = clone(base);
         assert.deepStrictEqual(base, cloned);
+        assert.ok(base.lastIndex === cloned.lastIndex);
       });
     });
   });


### PR DESCRIPTION
Cloning an regexp does not need an external library.