### PR TITLE
impr: better esm support, no necessity for setting allowSyntheticDefaultImports and esModuleInterop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,9 @@
+import events = require('events');
+import mongodb = require('mongodb');
+import mongoose = require('mongoose');
+import stream = require('stream');
+
 declare module 'mongoose' {
-  import events = require('events');
-  import mongodb = require('mongodb');
-  import mongoose = require('mongoose');
-  import stream = require('stream');
 
   export enum ConnectionStates {
     disconnected = 0,
@@ -3483,3 +3484,5 @@ declare module 'mongoose' {
   /* for ts-mongoose */
   class mquery {}
 }
+
+export default mongoose;

--- a/index.js
+++ b/index.js
@@ -6,4 +6,8 @@
 
 'use strict';
 
-module.exports = require('./lib/');
+const mongoose = require('./lib/');
+
+module.exports = mongoose;
+module.exports.default = mongoose;
+module.exports.mongoose = mongoose;

--- a/test/esm.test.js
+++ b/test/esm.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const mongoose = require('../');
+const assert = require('assert');
+
+describe('esm:', function() {
+  it('should have default export', function() {
+    assert.deepEqual(mongoose, mongoose.default);
+  });
+  it('should have mongoose export', function() {
+    assert.deepEqual(mongoose, mongoose.mongoose);
+  });
+});

--- a/test/typescript/esm.ts
+++ b/test/typescript/esm.ts
@@ -1,0 +1,3 @@
+import mongoose from 'mongoose';
+
+mongoose.pluralize(null);

--- a/test/typescript/main.test.js
+++ b/test/typescript/main.test.js
@@ -7,6 +7,12 @@ const tsconfig = require('./tsconfig.json');
 describe('typescript syntax', function() {
   this.timeout(60000);
 
+  it('esm', function() {
+    const errors = runTest('esm.ts');
+    printTSErrors(errors);
+    assert.equal(errors.length, 0);
+  });
+
   it('base', function() {
     const errors = runTest('base.ts');
     printTSErrors(errors);

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true
+    "esModuleInterop": false
   },
-  "esModuleInterop": true,
   "outDir": "test/dist",
   "strictNullChecks": true,
   "include": [


### PR DESCRIPTION
This PR improves the esm support. 

you can now import mongoose in typescript with
```typescript
import mongoose from "mongoose";
```
without being forced to set esModuleInterop or allowSyntheticDefaultImports to true.

I tested it with those settings set to true, and it doesnt break. So backwards compatibility, that means somebody set those settings to true in his existing project, is given. 