### PR TITLE
Fix: Broken Link

### DIFF
--- a/lib/types/array/ArrayWrapper.js
+++ b/lib/types/array/ArrayWrapper.js
@@ -554,7 +554,7 @@ class ArrayWrapper extends Array {
   /**
    * Pulls items from the array atomically. Equality is determined by casting
    * the provided value to an embedded document and comparing using
-   * [the `Document.equals()` function.](./api.html#document_Document-equals)
+   * [the `Document.equals()` function.](/docs/api.html#document_Document-equals)
    *
    * ####Examples:
    *


### PR DESCRIPTION
Hyperlink for `Document.equals()` on this page: https://mongoosejs.com/docs/api/array.html#mongoosearray_MongooseArray-pull leads to (https://mongoosejs.com/docs/api/api.html#document_Document-equals) which is a 404 not found page.

The pull request intends to fix the broken link.