### PR TITLE
Fix: Broken Link (#11337) +1

### DIFF
--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -538,7 +538,7 @@ const methods = {
   /**
    * Pulls items from the array atomically. Equality is determined by casting
    * the provided value to an embedded document and comparing using
-   * [the `Document.equals()` function.](./api.html#document_Document-equals)
+   * [the `Document.equals()` function.](/docs/api.html#document_Document-equals)
    *
    * ####Examples:
    *


### PR DESCRIPTION
The edit on Github button on this page: https://mongoosejs.com/docs/api/array.html#mongoosearray_MongooseArray-pull where I actually found the broken link #11337 is itself a broken link :|

I found another file with similar contents, not exactly sure which one corresponds to the actual website docs, so decided to modify this as well.