### PR TITLE
Remove double determiners in connections docs.

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -247,7 +247,7 @@ connection may emit.
 
 When you're connecting to a single MongoDB server (a "standalone"), Mongoose will emit 'disconnected' if it gets
 disconnected from the standalone server, and 'connected' if it successfully connects to the standalone. In a
-replica set, Mongoose will emit 'disconnected' if it loses connectivity to the replica set primary, and 'connected' if it manages to reconnect to a the replica set primary.
+replica set, Mongoose will emit 'disconnected' if it loses connectivity to the replica set primary, and 'connected' if it manages to reconnect to the replica set primary.
 
 <h3 id="keepAlive"><a href="#keepAlive">A note about keepAlive</a></h3>
 


### PR DESCRIPTION
Minimal grammar fix.
'reconnect to a the replica' -> 'reconnect to the replica'

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

Fixes grammar in sentence.

**Examples**

doc change
