### PR TITLE
remove npm script for symlinking mongoose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
           sleep 2
           mongod --version
           echo `pwd`/mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}/bin >> $GITHUB_PATH
-      - run: npm run sym-link-mongoose
       - run: npm test
 
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,6 @@ If you have a question about Mongoose (not a bug report) please post it to eithe
 ### Running the tests
 - Open a terminal and navigate to the root of the project
 - execute `npm install` to install the necessary dependencies
-- execute `npm run sym-link-mongoose` to create a symlink so typescript tests can run. 
 - execute `npm run mongo` to start a MongoDB instance on port 27017. This step is optional, if you have already a database running on port 27017. To spin up a specific mongo version, you can do it by executing `npm run mongo -- {version}`. E.g. you want to spin up a mongo 4.2.2 server, you execute `npm run mongo -- 4.2.2`
 - execute `npm test` to run the tests (we're using [mocha](http://mochajs.org/))
   - or to execute a single test `npm test -- -g 'some regexp that matches the test description'`

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "mongo": "node ./tools/repl.js",
     "test": "mocha --exit ./test/*.test.js",
     "test-tsd": "tsd",
-    "sym-link-mongoose": "npm link && npm link mongoose",
     "tdd": "mocha ./test/*.test.js ./test/typescript/main.test.js --inspect --watch --recursive --watch-files ./**/*.js",
     "test-coverage": "nyc --reporter=html --reporter=text npm test"
   },


### PR DESCRIPTION
This is a PR following the tsd PR. We don't need to symlink any more, yeah!