### PR TITLE
remove typescript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "devDependencies": {
     "@babel/core": "7.10.5",
     "@babel/preset-env": "7.10.4",
-    "@typescript-eslint/eslint-plugin": "5.8.0",
-    "@typescript-eslint/parser": "5.8.0",
+    "@typescript-eslint/eslint-plugin": "5.11.0",
+    "@typescript-eslint/parser": "5.11.0",
     "acquit": "1.x",
     "acquit-ignore": "0.1.x",
     "acquit-require": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "rimraf": "2.6.3",
     "serve-handler": "6.1.3",
     "tsd": "0.19.1",
-    "typescript": "4.5.3",
     "uuid": "8.3.2",
     "webpack": "4.44.1"
   },


### PR DESCRIPTION
We dont need typescript as devDependency anymore as it is a dependency of tsd.