### PR TITLE
refactor fix of github issue 11295

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -336,9 +336,10 @@ Model.prototype.$__handleSave = function(options, callback) {
         callback(null, ret);
       });
     } else {
+      const optimisticConcurrency = this.$__schema.options.optimisticConcurrency;
       const optionsWithCustomValues = Object.assign({}, options, saveOptions);
       const where = this.$__where();
-      if (this.$__schema.options.optimisticConcurrency) {
+      if (optimisticConcurrency) {
         const key = this.$__schema.options.versionKey;
         const val = this.$__getValue(key);
         if (val != null) {
@@ -347,13 +348,14 @@ Model.prototype.$__handleSave = function(options, callback) {
       }
       this.constructor.exists(where, optionsWithCustomValues).
         then((documentExists) => {
-          if (!documentExists) {
+          if (documentExists) {
+            const matchedCount = 1;
+            callback(null, { $where: where, matchedCount });
+          } else {
+            if (optimisticConcurrency) { this.$__.version = VERSION_INC; }
             const matchedCount = 0;
             return callback(null, { $where: where, matchedCount });
           }
-
-          const matchedCount = 1;
-          callback(null, { $where: where, matchedCount });
         }).
         catch(callback);
       return;
@@ -398,9 +400,8 @@ Model.prototype.$__save = function(options, callback) {
         }
       }
 
-      const versionBump = this.$__.version || this.$__schema.options.optimisticConcurrency;
       // was this an update that required a version bump?
-      if (versionBump && !this.$__.inserting) {
+      if (this.$__.version && !this.$__.inserting) {
         const doIncrement = VERSION_INC === (VERSION_INC & this.$__.version);
         this.$__.version = undefined;
         const key = this.$__schema.options.versionKey;


### PR DESCRIPTION
The original fix just fix the issue, but not telling people why.
`const versionBump = this.$__.version || this.$__schema.options.optimisticConcurrency;`

```javascript
```