### PR TITLE
fix $search highlight path option type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3199,7 +3199,12 @@ declare module 'mongoose' {
       $search: {
         [key: string]: any
         index?: string
-        highlight?: { path: string; maxCharsToExamine?: number; maxNumPassages?: number }
+        highlight?: {
+        /** [`highlightPath` reference](https://docs.atlas.mongodb.com/atlas-search/path-construction/#multiple-field-search) */
+          path: string | string[] | { value: string, multi: string};
+          maxCharsToExamine?: number;
+          maxNumPassages?: number;
+        }
       }
     }
 


### PR DESCRIPTION
**Summary**

Fix this issue #11372 by adding all the possible types to highlight path ($search operator) following [MongoDB specs](https://docs.atlas.mongodb.com/atlas-search/highlighting/#std-label-highlight-ref)

**Examples**

Code provided in the issue is now working fine

```typescript
import {Model, model, Schema} from "mongoose";

interface IUser {
    name: string;
    firstName: string;
    search(query: string): any;
}

// 2. Create a Schema corresponding to the document interface.
const schema = new Schema<IUser>({
    firstName: { type: String, required: true },
    name: { type: String, required: true },

});

schema.static("search", function(this: Model<IUser>, query: string) {
    return this.aggregate([
        {
            $search: {
                highlight: {
                       path : ["name", "firstname"], // "name" works fine
                },
                index: "searchLucene",
                text: {
                    path: ["name", "firstname"],
                    query,
                },
            },
        },
        {
            $project: {
                firstName: 1,
                highlights: { $meta: "searchHighlights" },
                name: 1,
                score: { $meta: "searchScore" },
        }},

    ]);
});
// 3. Create a Model.
const UserModel = model<IUser>("User", schema);
```

Note that this code requires an search index to be created on the database to be run. 