### PR TITLE
fix Node.js 17.5 compatibility

### DIFF
--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -137,11 +137,15 @@ if (Symbol.asyncIterator != null) {
  * @method map
  */
 
-AggregationCursor.prototype.map = function(fn) {
-  this._transforms.push(fn);
-  return this;
-};
-
+Object.defineProperty(AggregationCursor.prototype, 'map', {
+  value: function(fn) {
+    this._transforms.push(fn);
+    return this;
+  },
+  enumerable: false,
+  configurable: true,
+  writable: false
+});
 /*!
  * Marks this cursor as errored
  */

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -141,10 +141,15 @@ QueryCursor.prototype._read = function() {
  * @method map
  */
 
-QueryCursor.prototype.map = function(fn) {
-  this._transforms.push(fn);
-  return this;
-};
+Object.defineProperty(QueryCursor.prototype, 'map', {
+    value: function(fn) {
+        this._transforms.push(fn);
+        return this;
+    },
+    enumerable: false,
+    configurable: true,
+    writable: false
+});
 
 /*!
  * Marks this cursor as errored

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -142,13 +142,13 @@ QueryCursor.prototype._read = function() {
  */
 
 Object.defineProperty(QueryCursor.prototype, 'map', {
-    value: function(fn) {
-        this._transforms.push(fn);
-        return this;
-    },
-    enumerable: false,
-    configurable: true,
-    writable: false
+  value: function(fn) {
+    this._transforms.push(fn);
+    return this;
+  },
+  enumerable: false,
+  configurable: true,
+  writable: false
 });
 
 /*!


### PR DESCRIPTION
The tc39 async iterator helpers spec adds `.map` to async iterators and Node added support for that.

As part of spec compliance Node uses defineProperty to add these properties.

This PR fixes setting `.map` in Mongoose over the property.

As a side note: it might make sense for Mongoose to deprecate `.map` since it's mutative which makes it named the same but with a different behavior from the tc39 iterator helpers proposal `.map`


Fixes: https://github.com/Automattic/mongoose/issues/11377