### PR TITLE
improve performance of cast$expr

### DIFF
--- a/lib/cast/number.js
+++ b/lib/cast/number.js
@@ -3,12 +3,11 @@
 const assert = require('assert');
 
 /*!
- * Given a value, cast it to a number, or throw a `CastError` if the value
+ * Given a value, cast it to a number, or throw an `Error` if the value
  * cannot be casted. `null` and `undefined` are considered valid.
  *
  * @param {Any} value
- * @param {String} [path] optional the path to set on the CastError
- * @return {Boolean|null|undefined}
+ * @return {Number}
  * @throws {Error} if `value` is not one of the allowed values
  * @api private
  */

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -68,7 +68,7 @@ const dateOperators = new Set([
 ]);
 
 module.exports = function cast$expr(val, schema, strictQuery) {
-  if (typeof val !== 'object' || val == null) {
+  if (typeof val !== 'object' || val === null) {
     throw new Error('`$expr` must be an object');
   }
 
@@ -123,10 +123,8 @@ function _castExpression(val, schema, strictQuery) {
 
 function _omitUndefined(val) {
   const keys = Object.keys(val);
-  for (const key of keys) {
-    if (val[key] === void 0) {
-      delete val[key];
-    }
+  for (let i = 0, len = keys.length; i < len; ++i) {
+    (val[keys[i]] === void 0) && delete val[keys[i]];
   }
 }
 
@@ -144,15 +142,14 @@ function castNumberOperator(val) {
 }
 
 function castIn(val, schema, strictQuery) {
-  let search = val[0];
-  let path = val[1];
+  const path = val[1];
   if (!isPath(path)) {
     return val;
   }
+  const search = val[0];
 
-  path = path.slice(1);
-  const schematype = schema.path(path);
-  if (schematype == null) {
+  const schematype = schema.path(path.slice(1));
+  if (schematype === null) {
     if (strictQuery === false) {
       return val;
     } else if (strictQuery === 'throw') {
@@ -166,12 +163,10 @@ function castIn(val, schema, strictQuery) {
     throw new Error('Path must be an array for $in');
   }
 
-  if (schematype.$isMongooseDocumentArray) {
-    search = schematype.$embeddedSchemaType.cast(search);
-  } else {
-    search = schematype.caster.cast(search);
-  }
-  return [search, val[1]];
+  return [
+    schematype.$isMongooseDocumentArray ? schematype.$embeddedSchemaType.cast(search) : schematype.caster.cast(search),
+    path
+  ];
 }
 
 // { $op: [<number>, <number>] }
@@ -268,14 +263,14 @@ function castComparison(val, schema, strictQuery) {
 }
 
 function isPath(val) {
-  return typeof val === 'string' && val.startsWith('$');
+  return typeof val === 'string' && val[0] === '$';
 }
 
 function isLiteral(val) {
-  if (typeof val === 'string' && val.startsWith('$')) {
+  if (typeof val === 'string' && val[0] === '$') {
     return false;
   }
-  if (typeof val === 'object' && val != null && Object.keys(val).find(key => key.startsWith('$'))) {
+  if (typeof val === 'object' && val !== null && Object.keys(val).find(key => key[0] === '$')) {
     // The `$literal` expression can make an object a literal
     // https://docs.mongodb.com/manual/reference/operator/aggregation/literal/#mongodb-expression-exp.-literal
     return val.$literal != null;


### PR DESCRIPTION
Dont know if this is improving the overall performance, but should I improved some parts.

omitUndefined is now about 5 - 10 % faster
isPath is now about 40 % faster.

Benchmarks and their result:

```javascript
'use strict';

const Benchmark = require('benchmark');


function omitUndefinedVar1(val) {
  const keys = Object.keys(val);
  for (const key of keys) {
    if (val[key] === void 0) {
      delete val[key];
    }
  }
}

function omitUndefinedVar2(val) {
  const keys = Object.keys(val);
  for (let i = 0, len = keys.length; i < len; ++i) {
    (val[keys[i]] === void 0) && delete val[keys[i]];
  }
}

new Benchmark.Suite()
.add('var1 valid', function () {
  const a = omitUndefinedVar1({
    a: undefined,
    b: null,
    c: undefined,
    d: 'a',
    fa: 234,
    ferfe:234234,
    adcverg:234234
  })
})
.add('var1 valid2', function () {
  const a = omitUndefinedVar1({
    d: 'a',
    fa: 234,
    ferfe:234234,
    adcverg:234234
  })
})
  .add('var2 valid', function () {
    const a = omitUndefinedVar2({
      a: undefined,
      b: null,
      c: undefined,
      d: 'a',
      fa: 234,
      ferfe:234234,
      adcverg:234234
    })
  })
  .add('var2 valid2', function () {
    const a = omitUndefinedVar2({
      d: 'a',
      fa: 234,
      ferfe:234234,
      adcverg:234234
    })
  })
  .on('cycle', function (evt) {
    if (process.env.MONGOOSE_DEV || process.env.PULL_REQUEST) {
      console.log(String(evt.target));
    }
  })
  .run();
process.memoryUsage();

// --trace-opt --trace-deopt --trace-bailout

```
MONGOOSE_DEV=1 node omitUndefined.js 
var1 valid x 1,925,657 ops/sec ±0.56% (93 runs sampled)
var1 valid2 x 19,595,175 ops/sec ±2.95% (90 runs sampled)
var2 valid x 2,026,454 ops/sec ±0.30% (95 runs sampled)
var2 valid2 x 21,847,207 ops/sec ±0.43% (90 runs sampled)


```javascript
'use strict';

const Benchmark = require('benchmark');

function isPathVar1(val) {
  return typeof val === 'string' && val.startsWith('$');
}
function isPathVar2(val) {
  return typeof val === 'string' && val[0] === '$';
}
function isPathVar3(val) {
  return typeof val === 'string' && val.charCodeAt(0) === 36;
}
function isPathVar4(val) {
  return typeof val === 'string' && val.charCodeAt() === 36;
}
function isPathVar5(val) {
  return typeof val === 'string' && val.charAt() === '$';
}
new Benchmark.Suite()
  .add('var1 valid', function () {
    const a = isPathVar1('$aasdasdf')
  })
  .add('var1 invalid', function () {
    const a = isPathVar1('aasdasdf')
  })
  .add('var2 valid', function () {
    const a = isPathVar2('$aasdasdf')
  })
  .add('var2 invalid', function () {
    const a = isPathVar2('aasdasdf')
  })
  .add('var3 valid', function () {
    const a = isPathVar3('$aasdasdf')
  })
  .add('var3 invalid', function () {
    const a = isPathVar3('aasdasdf')
  })
  .add('var4 valid', function () {
    const a = isPathVar4('$aasdasdf')
  })
  .add('var4 invalid', function () {
    const a = isPathVar4('aasdasdf')
  })
  .add('var5 valid', function () {
    const a = isPathVar5('$aasdasdf')
  })
  .add('var5 invalid', function () {
    const a = isPathVar5('aasdasdf')
  })
  .on('cycle', function (evt) {
    if (process.env.MONGOOSE_DEV || process.env.PULL_REQUEST) {
      console.log(String(evt.target));
    }
  })
  .run();
process.memoryUsage();

// --trace-opt --trace-deopt --trace-bailout

```

MONGOOSE_DEV=1 node isPath.js 
var1 valid x 894,729,315 ops/sec ±2.38% (85 runs sampled)
var1 invalid x 901,086,157 ops/sec ±2.30% (84 runs sampled)
var2 valid x 1,373,966,160 ops/sec ±0.21% (95 runs sampled)
var2 invalid x 1,376,078,120 ops/sec ±0.13% (93 runs sampled)
var3 valid x 914,513,098 ops/sec ±2.31% (86 runs sampled)
var3 invalid x 902,081,446 ops/sec ±2.33% (85 runs sampled)
var4 valid x 906,717,792 ops/sec ±2.29% (84 runs sampled)
var4 invalid x 914,859,437 ops/sec ±2.32% (86 runs sampled)
var5 valid x 523,148,950 ops/sec ±6.62% (87 runs sampled)
var5 invalid x 136,384,194 ops/sec ±3.14% (84 runs sampled)

Variant 2 is the chosen one. We should not use startsWith when we only want to check if the first character is a specific one.