### PR TITLE
perf: use fast property access instead of get were possible

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -102,15 +102,18 @@ module.exports = function cast(schema, obj, options, context) {
           const pathFirstHalf = split.slice(0, j).join('.');
           const pathLastHalf = split.slice(j).join('.');
           const _schematype = schema.path(pathFirstHalf);
-          const discriminatorKey = get(_schematype, 'schema.options.discriminatorKey');
+          const discriminatorKey = _schematype &&
+            _schematype.schema &&
+            _schematype.schema.options &&
+            _schematype.schema.options.discriminatorKey;
 
           // gh-6027: if we haven't found the schematype but this path is
           // underneath an embedded discriminator and the embedded discriminator
           // key is in the query, use the embedded discriminator schema
           if (_schematype != null &&
-              get(_schematype, 'schema.discriminators') != null &&
-              discriminatorKey != null &&
-              pathLastHalf !== discriminatorKey) {
+            (_schematype.schema && _schematype.schema.discriminators) != null &&
+            discriminatorKey != null &&
+            pathLastHalf !== discriminatorKey) {
             const discriminatorVal = get(obj, pathFirstHalf + '.' + discriminatorKey);
             if (discriminatorVal != null) {
               schematype = _schematype.schema.discriminators[discriminatorVal].

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -837,9 +837,19 @@ function _setClient(conn, client, options, dbName) {
   const db = dbName != null ? client.db(dbName) : client.db();
   conn.db = db;
   conn.client = client;
-  conn.host = get(client, 's.options.hosts.0.host', void 0);
-  conn.port = get(client, 's.options.hosts.0.port', void 0);
-  conn.name = dbName != null ? dbName : get(client, 's.options.dbName', void 0);
+  conn.host = client &&
+    client.s &&
+    client.s.options &&
+    client.s.options.hosts &&
+    client.s.options.hosts[0] &&
+    client.s.options.hosts[0].host || void 0;
+  conn.port = client &&
+    client.s &&
+    client.s.options &&
+    client.s.options.hosts &&
+    client.s.options.hosts[0] &&
+    client.s.options.hosts[0].port || void 0;
+  conn.name = dbName != null ? dbName : client && client.s && client.s.options && client.s.options.dbName || void 0;
   conn._closeCalled = client._closeCalled;
 
   const _handleReconnect = () => {
@@ -855,7 +865,10 @@ function _setClient(conn, client, options, dbName) {
     }
   };
 
-  const type = get(client, 'topology.description.type', '');
+  const type = client &&
+  client.topology &&
+  client.topology.description &&
+  client.topology.description.type || '';
 
   if (type === 'Single') {
     client.on('serverDescriptionChanged', ev => {

--- a/lib/document.js
+++ b/lib/document.js
@@ -1119,7 +1119,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
     // `_skipMinimizeTopLevel` is because we may have deleted the top-level
     // nested key to ensure key order.
-    const _skipMinimizeTopLevel = get(options, '_skipMinimizeTopLevel', false);
+    const _skipMinimizeTopLevel = options._skipMinimizeTopLevel || false;
     if (len === 0 && _skipMinimizeTopLevel) {
       delete options._skipMinimizeTopLevel;
       if (val) {
@@ -2539,7 +2539,9 @@ function _getPathsToValidate(doc) {
         // To avoid potential performance issues, skip doc arrays whose children
         // are not required. `getPositionalPathType()` may be slow, so avoid
         // it unless we have a case of #6364
-        (!Array.isArray(_pathType) && _pathType.$isMongooseDocumentArray && !get(_pathType, 'schemaOptions.required'))) {
+        (!Array.isArray(_pathType) &&
+          _pathType.$isMongooseDocumentArray &&
+          !(_pathType && _pathType.schemaOptions && _pathType.schemaOptions.required))) {
       continue;
     }
 
@@ -2616,7 +2618,7 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
       (typeof options === 'object') &&
       ('validateModifiedOnly' in options);
 
-  const pathsToSkip = get(options, 'pathsToSkip', null);
+  const pathsToSkip = (options && options.pathsToSkip) || null;
 
   let shouldValidateModifiedOnly;
   if (hasValidateModifiedOnlyOption) {
@@ -3455,8 +3457,11 @@ Document.prototype.$toObject = function(options, json) {
   };
 
   const path = json ? 'toJSON' : 'toObject';
-  const baseOptions = get(this, 'constructor.base.options.' + path, {});
-  const schemaOptions = get(this, '$__schema.options', {});
+  const baseOptions = this.constructor &&
+  this.constructor.base &&
+  this.constructor.base.options &&
+  get(this.constructor.base.options, path) || {};
+  const schemaOptions = this.$__schema && this.$__schema.options || {};
   // merge base default options with Schema's set default options if available.
   // `clone` is necessary here because `utils.options` directly modifies the second input.
   defaultOptions = utils.options(defaultOptions, clone(baseOptions));
@@ -3503,7 +3508,7 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   const depopulate = options.depopulate ||
-    get(options, '_parentOptions.depopulate', false);
+    (options._parentOptions && options._parentOptions.depopulate || false);
   // _isNested will only be true if this is not the top level document, we
   // should never depopulate
   if (depopulate && options._isNested && this.$__.wasPopulated) {
@@ -3780,7 +3785,9 @@ function applyVirtuals(self, json, options, toObjectOptions) {
   let assignPath;
   let cur = self._doc;
   let v;
-  const aliases = get(toObjectOptions, 'aliases', true);
+  const aliases = typeof (toObjectOptions && toObjectOptions.aliases) === 'boolean'
+    ? toObjectOptions.aliases
+    : true;
 
   let virtualsToApply = null;
   if (Array.isArray(options.virtuals)) {
@@ -4317,7 +4324,7 @@ Document.prototype.depopulate = function(path) {
 
   let populatedIds;
   const virtualKeys = this.$$populatedVirtuals ? Object.keys(this.$$populatedVirtuals) : [];
-  const populated = get(this, '$__.populated', {});
+  const populated = this.$__ && this.$__.populated || {};
 
   if (arguments.length === 0) {
     // Depopulate all

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -8,7 +8,6 @@ const MongooseCollection = require('../../collection');
 const MongooseError = require('../../error/mongooseError');
 const Collection = require('mongodb').Collection;
 const ObjectId = require('./objectid');
-const get = require('../../helpers/get');
 const getConstructorName = require('../../helpers/getConstructorName');
 const stream = require('stream');
 const util = require('util');
@@ -76,7 +75,11 @@ function iter(i) {
     const collection = this.collection;
     const args = Array.from(arguments);
     const _this = this;
-    const debug = get(_this, 'conn.base.options.debug');
+    const debug = _this &&
+      _this.conn &&
+      _this.conn.base &&
+      _this.conn.base.options &&
+      _this.conn.base.options.debug;
     const lastArg = arguments[arguments.length - 1];
     const opId = new ObjectId();
 
@@ -84,7 +87,7 @@ function iter(i) {
     if (this.conn.$wasForceClosed) {
       const error = new MongooseError('Connection was force closed');
       if (args.length > 0 &&
-          typeof args[args.length - 1] === 'function') {
+        typeof args[args.length - 1] === 'function') {
         args[args.length - 1](error);
         return;
       } else {
@@ -368,7 +371,12 @@ function format(obj, sub, color, shell) {
           formatDate(x, key, shell);
         } else if (_constructorName === 'ClientSession') {
           x[key] = inspectable('ClientSession("' +
-            get(x[key], 'id.id.buffer', '').toString('hex') + '")');
+            (
+              x[key] &&
+              x[key].id &&
+              x[key].id.id &&
+              x[key].id.id.buffer || ''
+            ).toString('hex') + '")');
         } else if (Array.isArray(x[key])) {
           x[key] = x[key].map(map);
         } else if (error != null) {

--- a/lib/error/cast.js
+++ b/lib/error/cast.js
@@ -5,7 +5,6 @@
  */
 
 const MongooseError = require('./mongooseError');
-const get = require('../helpers/get');
 const util = require('util');
 
 /**
@@ -111,7 +110,9 @@ function getValueType(value) {
 }
 
 function getMessageFormat(schemaType) {
-  const messageFormat = get(schemaType, 'options.cast', null);
+  const messageFormat = schemaType &&
+  schemaType.options &&
+  schemaType.options.cast || null;
   if (typeof messageFormat === 'string') {
     return messageFormat;
   }

--- a/lib/helpers/document/compile.js
+++ b/lib/helpers/document/compile.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const documentSchemaSymbol = require('../../helpers/symbols').documentSchemaSymbol;
-const get = require('../../helpers/get');
 const internalToObjectOptions = require('../../options').internalToObjectOptions;
 const utils = require('../../utils');
 
@@ -93,7 +92,11 @@ function defineKey({ prop, subprops, prototype, prefix, options }) {
             writable: false,
             value: function() {
               return utils.clone(_this.get(path, null, {
-                virtuals: get(this, 'schema.options.toObject.virtuals', null)
+                virtuals: this &&
+                  this.schema &&
+                  this.schema.options &&
+                  this.schema.options.toObject &&
+                  this.schema.options.toObject.virtuals || null
               }));
             }
           });
@@ -104,7 +107,7 @@ function defineKey({ prop, subprops, prototype, prefix, options }) {
             writable: false,
             value: function() {
               return _this.get(path, null, {
-                virtuals: get(this, 'schema.options.toObject.virtuals', null)
+                virtuals: this && this.schema && this.schema.options && this.schema.options.toObject && this.schema.options.toObject.virtuals || null
               });
             }
           });
@@ -115,7 +118,7 @@ function defineKey({ prop, subprops, prototype, prefix, options }) {
             writable: false,
             value: function() {
               return _this.get(path, null, {
-                virtuals: get(_this, 'schema.options.toJSON.virtuals', null)
+                virtuals: this && this.schema && this.schema.options && this.schema.options.toJSON && this.schema.options.toJSON.virtuals || null
               });
             }
           });

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,6 @@ const Query = require('./query');
 const Model = require('./model');
 const applyPlugins = require('./helpers/schema/applyPlugins');
 const driver = require('./driver');
-const get = require('./helpers/get');
 const promiseOrCallback = require('./helpers/promiseOrCallback');
 const legacyPluralize = require('./helpers/pluralize');
 const utils = require('./utils');
@@ -632,10 +631,8 @@ Mongoose.prototype._applyPlugins = function(schema, options) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
   options = options || {};
-  options.applyPluginsToDiscriminators = get(_mongoose,
-    'options.applyPluginsToDiscriminators', false);
-  options.applyPluginsToChildSchemas = get(_mongoose,
-    'options.applyPluginsToChildSchemas', true);
+  options.applyPluginsToDiscriminators = _mongoose.options && _mongoose.options.applyPluginsToDiscriminators || false;
+  options.applyPluginsToChildSchemas = typeof (_mongoose.options && _mongoose.options.applyPluginsToDiscriminators) === 'boolean' ? _mongoose.options.applyPluginsToDiscriminators : true;
   applyPlugins(schema, _mongoose.plugins, options, '$globalPluginsApplied');
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -710,7 +710,7 @@ Model.prototype.$__delta = function() {
   where._id = this._doc._id;
   // If `_id` is an object, need to depopulate, but also need to be careful
   // because `_id` can technically be null (see gh-6406)
-  if (get(where, '_id.$__', null) != null) {
+  if ((where && where._id && where._id.$__ || null) != null) {
     where._id = where._id.toObject({ transform: false, depopulate: true });
   }
   for (; d < len; ++d) {
@@ -1159,7 +1159,7 @@ Model.discriminator = function(name, schema, options) {
 
   options = options || {};
   const value = utils.isPOJO(options) ? options.value : options;
-  const clone = get(options, 'clone', true);
+  const clone = typeof options.clone === 'boolean' ? options.clone : true;
 
   _checkContext(this, 'discriminator');
 
@@ -1354,15 +1354,24 @@ Model.createCollection = function createCollection(options, callback) {
     options = void 0;
   }
 
-  const schemaCollation = get(this, ['schema', 'options', 'collation'], null);
+  const schemaCollation = this &&
+  this.schema &&
+  this.schema.options &&
+  this.schema.options.collation || null;
   if (schemaCollation != null) {
     options = Object.assign({ collation: schemaCollation }, options);
   }
-  const capped = get(this, ['schema', 'options', 'capped']);
+  const capped = this &&
+  this.schema &&
+  this.schema.options &&
+   this.schema.options.capped;
   if (capped) {
     options = Object.assign({ capped: true }, capped, options);
   }
-  const timeseries = get(this, ['schema', 'options', 'timeseries']);
+  const timeseries = this &&
+  this.schema &&
+  this.schema.options &&
+  this.schema.options.timeseries;
   if (timeseries != null) {
     options = Object.assign({ timeseries }, options);
   }
@@ -2588,7 +2597,7 @@ Model.findOneAndUpdate = function(conditions, update, options, callback) {
  */
 
 function _decorateUpdateWithVersionKey(update, options, versionKey) {
-  if (!versionKey || !get(options, 'upsert', false)) {
+  if (!versionKey || !(options && options.upsert || false)) {
     return;
   }
 
@@ -3327,10 +3336,10 @@ Model.$__insertMany = function(arr, options, callback) {
   }
   callback = callback || utils.noop;
   options = options || {};
-  const limit = get(options, 'limit', 1000);
-  const rawResult = get(options, 'rawResult', false);
-  const ordered = get(options, 'ordered', true);
-  const lean = get(options, 'lean', false);
+  const limit = options.limit || 1000;
+  const rawResult = !!options.rawResult;
+  const ordered = typeof options.ordered === 'boolean' ? options.ordered : true;
+  const lean = !!options.lean;
 
   if (!Array.isArray(arr)) {
     arr = [arr];
@@ -3408,12 +3417,12 @@ Model.$__insertMany = function(arr, options, callback) {
         // `writeErrors` is a property reported by the MongoDB driver,
         // just not if there's only 1 error.
         if (error.writeErrors == null &&
-            get(error, 'result.result.writeErrors') != null) {
+           (error.result && error.result.result && error.result.result.writeErrors) != null) {
           error.writeErrors = error.result.result.writeErrors;
         }
 
         // `insertedDocs` is a Mongoose-specific property
-        const erroredIndexes = new Set(get(error, 'writeErrors', []).map(err => err.index));
+        const erroredIndexes = new Set((error && error.writeErrors || []).map(err => err.index));
 
         let firstErroredIndex = -1;
         error.insertedDocs = docAttributes.
@@ -3634,7 +3643,7 @@ Model.bulkSave = function(documents, options) {
     .then(() => documents.map(buildSuccessfulWriteHandlerPromise))
     .then(() => bulkWriteResultPromise)
     .catch((err) => {
-      if (!get(err, 'writeErrors.length')) {
+      if (!(err && err.writeErrors && err.writeErrors.length)) {
         throw err;
       }
       return Promise.all(
@@ -3979,7 +3988,7 @@ Model.updateOne = function updateOne(conditions, doc, options, callback) {
 Model.replaceOne = function replaceOne(conditions, doc, options, callback) {
   _checkContext(this, 'replaceOne');
 
-  const versionKey = get(this, 'schema.options.versionKey', null);
+  const versionKey = this && this.schema && this.schema.options && this.schema.options.versionKey || null;
   if (versionKey && !doc[versionKey]) {
     doc[versionKey] = 0;
   }
@@ -4004,7 +4013,10 @@ function _update(model, op, conditions, doc, options, callback) {
   }
   options = typeof options === 'function' ? options : utils.clone(options);
 
-  const versionKey = get(model, 'schema.options.versionKey', null);
+  const versionKey = model &&
+  model.schema &&
+  model.schema.options &&
+  model.schema.options.versionKey || null;
   _decorateUpdateWithVersionKey(doc, options, versionKey);
 
   return mq[op](conditions, doc, options, callback);
@@ -4183,7 +4195,7 @@ Model.mapReduce = function mapReduce(o, callback) {
 Model.aggregate = function aggregate(pipeline, options, callback) {
   _checkContext(this, 'aggregate');
 
-  if (arguments.length > 3 || get(pipeline, 'constructor.name') === 'Object') {
+  if (arguments.length > 3 || (pipeline && pipeline.constructor && pipeline.constructor.name) === 'Object') {
     throw new MongooseError('Mongoose 5.x disallows passing a spread of operators ' +
       'to `Model.aggregate()`. Instead of ' +
       '`Model.aggregate({ $match }, { $skip })`, do ' +
@@ -4506,7 +4518,10 @@ function populate(model, docs, options, callback) {
     ids = utils.array.unique(ids);
 
     const assignmentOpts = {};
-    assignmentOpts.sort = get(mod, 'options.options.sort', void 0);
+    assignmentOpts.sort = mod &&
+      mod.options &&
+      mod.options.options &&
+      mod.options.options.sort || void 0;
     assignmentOpts.excludeId = excludeIdReg.test(select) || (select && select._id === 0);
 
     if (ids.length === 0 || ids.every(utils.isNullOrUndefined)) {
@@ -4675,7 +4690,9 @@ function _assign(model, vals, mod, assignmentOpts) {
   const isVirtual = mod.isVirtual;
   const justOne = mod.justOne;
   let _val;
-  const lean = get(options, 'options.lean', false);
+  const lean = options &&
+    options.options &&
+    options.options.lean || false;
   const len = vals.length;
   const rawOrder = {};
   const rawDocs = {};

--- a/lib/query.js
+++ b/lib/query.js
@@ -18,7 +18,6 @@ const castArrayFilters = require('./helpers/update/castArrayFilters');
 const castNumber = require('./cast/number');
 const castUpdate = require('./helpers/query/castUpdate');
 const completeMany = require('./helpers/query/completeMany');
-const get = require('./helpers/get');
 const promiseOrCallback = require('./helpers/promiseOrCallback');
 const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminatorByValue');
 const hasDollarKeys = require('./helpers/query/hasDollarKeys');
@@ -110,7 +109,10 @@ function Query(conditions, options, model, collection) {
   // versions of MongoDB
   this.$useProjection = true;
 
-  const collation = get(this, 'schema.options.collation', null);
+  const collation = this &&
+    this.schema &&
+    this.schema.options &&
+    this.schema.options.collation || null;
   if (collation != null) {
     this.options.collation = collation;
   }
@@ -1911,7 +1913,10 @@ Query.prototype._optionsForExec = function(model) {
   // Apply schema-level `writeConcern` option
   applyWriteConcern(model.schema, options);
 
-  const readPreference = get(model, 'schema.options.read');
+  const readPreference = model &&
+  model.schema &&
+  model.schema.options &&
+  model.schema.options.read;
   if (!('readPreference' in options) && readPreference) {
     options.readPreference = readPreference;
   }
@@ -2184,7 +2189,7 @@ Query.prototype._find = wrapThunk(function(callback) {
   // Separate options to pass down to `completeMany()` in case we need to
   // set a session on the document
   const completeManyOptions = Object.assign({}, {
-    session: get(this, 'options.session', null)
+    session: this && this.options && this.options.session || null
   });
 
   const cb = (err, docs) => {
@@ -3332,8 +3337,11 @@ Query.prototype.findOneAndUpdate = function(criteria, doc, options, callback) {
     delete options.fields;
   }
 
-
-  const returnOriginal = get(this, 'model.base.options.returnOriginal');
+  const returnOriginal = this &&
+    this.model &&
+    this.model.base &&
+    this.model.base.options &&
+    this.model.base.options.returnOriginal;
   if (options.new == null && options.returnDocument == null && options.returnOriginal == null && returnOriginal != null) {
     options.returnOriginal = returnOriginal;
   }
@@ -3661,7 +3669,11 @@ Query.prototype.findOneAndReplace = function(filter, replacement, options, callb
 
   options = options || {};
 
-  const returnOriginal = get(this, 'model.base.options.returnOriginal');
+  const returnOriginal = this &&
+  this.model &&
+  this.model.base &&
+  this.model.base.options &&
+  this.model.base.options.returnOriginal;
   if (options.new == null && options.returnDocument == null && options.returnOriginal == null && returnOriginal != null) {
     options.returnOriginal = returnOriginal;
   }
@@ -4566,19 +4578,19 @@ Query.prototype.orFail = function(err) {
       case 'update':
       case 'updateMany':
       case 'updateOne':
-        if (get(res, 'modifiedCount') === 0) {
+        if (res && res.modifiedCount === 0) {
           throw _orFailError(err, this);
         }
         break;
       case 'findOneAndDelete':
       case 'findOneAndRemove':
-        if (get(res, 'lastErrorObject.n') === 0) {
+        if ((res && res.lastErrorObject && res.lastErrorObject.n) === 0) {
           throw _orFailError(err, this);
         }
         break;
       case 'findOneAndUpdate':
       case 'findOneAndReplace':
-        if (get(res, 'lastErrorObject.updatedExisting') === false) {
+        if ((res && res.lastErrorObject && res.lastErrorObject.updatedExisting) === false) {
           throw _orFailError(err, this);
         }
         break;
@@ -4946,11 +4958,11 @@ Query.prototype.populate = function() {
     const readPref = this.options.readPreference;
 
     for (const populateOptions of res) {
-      if (readConcern != null && get(populateOptions, 'options.readConcern') == null) {
+      if (readConcern != null && (populateOptions && populateOptions.options && populateOptions.options.readConcern) == null) {
         populateOptions.options = populateOptions.options || {};
         populateOptions.options.readConcern = readConcern;
       }
-      if (readPref != null && get(populateOptions, 'options.readPreference') == null) {
+      if (readPref != null && (populateOptions && populateOptions.options && populateOptions.options.readPreference) == null) {
         populateOptions.options = populateOptions.options || {};
         populateOptions.options.readPreference = readPref;
       }
@@ -4962,7 +4974,7 @@ Query.prototype.populate = function() {
   if (opts.lean != null) {
     const lean = opts.lean;
     for (const populateOptions of res) {
-      if (get(populateOptions, 'options.lean') == null) {
+      if ((populateOptions && populateOptions.options && populateOptions.options.lean) == null) {
         populateOptions.options = populateOptions.options || {};
         populateOptions.options.lean = lean;
       }

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -26,9 +26,9 @@ exports.preparePopulationOptions = function preparePopulationOptions(query, opti
 
   // lean options should trickle through all queries
   if (options.lean != null) {
-    pop.
-      filter(p => get(p, 'options.lean') == null).
-      forEach(makeLean(options.lean));
+    pop
+      .filter(p => (p && p.options && p.options.lean) == null)
+      .forEach(makeLean(options.lean));
   }
 
   pop.forEach(opts => {
@@ -53,12 +53,12 @@ exports.preparePopulationOptionsMQ = function preparePopulationOptionsMQ(query, 
 
   // lean options should trickle through all queries
   if (options.lean != null) {
-    pop.
-      filter(p => get(p, 'options.lean') == null).
-      forEach(makeLean(options.lean));
+    pop
+      .filter(p => (p && p.options && p.options.lean) == null)
+      .forEach(makeLean(options.lean));
   }
 
-  const session = get(query, 'options.session', null);
+  const session = query && query.options && query.options.session || null;
   if (session != null) {
     pop.forEach(path => {
       if (path.options == null) {
@@ -272,7 +272,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
     // Special case: if user has included a parent path of a discriminator key,
     // don't explicitly project in the discriminator key because that will
     // project out everything else under the parent path
-    if (!exclude && get(type, 'options.$skipDiscriminatorCheck', false)) {
+    if (!exclude && (type && type.options && type.options.$skipDiscriminatorCheck || false)) {
       let cur = '';
       for (let i = 0; i < pieces.length; ++i) {
         cur += (cur.length === 0 ? '' : '.') + pieces[i];
@@ -319,7 +319,7 @@ exports.handleDeleteWriteOpResult = function handleDeleteWriteOpResult(callback)
       return callback(error);
     }
     const mongooseResult = Object.assign({}, res.result);
-    if (get(res, 'result.n', null) != null) {
+    if ((res && res.result && res.result.n || null) != null) {
       mongooseResult.deletedCount = res.result.n;
     }
     if (res.deletedCount != null) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -425,7 +425,7 @@ Schema.prototype.pick = function(paths, options) {
 
 Schema.prototype.defaultOptions = function(options) {
   this._userProvidedOptions = options == null ? {} : utils.clone(options);
-  const baseOptions = get(this, 'base.options', {});
+  const baseOptions = this.base && this.base.options || {};
 
   const strict = 'strict' in baseOptions ? baseOptions.strict : true;
   options = utils.options({
@@ -519,7 +519,7 @@ Schema.prototype.add = function add(obj, prefix) {
     if (key === '_id' && val === false) {
       continue;
     }
-    if (val instanceof VirtualType || get(val, 'constructor.name', null) === 'VirtualType') {
+    if (val instanceof VirtualType || (val.constructor && val.constructor.name || null) === 'VirtualType') {
       this.virtual(val);
       continue;
     }

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -13,7 +13,6 @@ const $exists = require('./operators/exists');
 const castToNumber = require('./operators/helpers').castToNumber;
 const discriminator = require('../helpers/model/discriminator');
 const geospatial = require('./operators/geospatial');
-const get = require('../helpers/get');
 const getConstructor = require('../helpers/discriminator/getConstructor');
 const handleIdOption = require('../helpers/schema/handleIdOption');
 const internalToObjectOptions = require('../options').internalToObjectOptions;
@@ -164,7 +163,7 @@ SubdocumentPath.prototype.cast = function(val, doc, init, priorVal, options) {
   let subdoc;
 
   // Only pull relevant selected paths and pull out the base path
-  const parentSelected = get(doc, '$__.selected', {});
+  const parentSelected = doc && doc.$__ && doc.$__.selected || {};
   const path = this.path;
   const selected = Object.keys(parentSelected).reduce((obj, key) => {
     if (key.startsWith(path + '.')) {
@@ -301,7 +300,9 @@ SubdocumentPath.prototype.doValidateSync = function(value, scope, options) {
 SubdocumentPath.prototype.discriminator = function(name, schema, options) {
   options = options || {};
   const value = utils.isPOJO(options) ? options.value : options;
-  const clone = get(options, 'clone', true);
+  const clone = typeof options.clone === 'boolean'
+    ? options.clone
+    : true;
 
   if (schema.instanceOfSchema && clone) {
     schema = schema.clone();

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -13,7 +13,6 @@ const CastError = SchemaType.CastError;
 const Mixed = require('./mixed');
 const arrayDepth = require('../helpers/arrayDepth');
 const cast = require('../cast');
-const get = require('../helpers/get');
 const isOperator = require('../helpers/query/isOperator');
 const util = require('util');
 const utils = require('../utils');
@@ -236,7 +235,9 @@ SchemaArray.prototype.checkRequired = function checkRequired(value, doc) {
 SchemaArray.prototype.enum = function() {
   let arr = this;
   while (true) {
-    const instance = get(arr, 'caster.instance');
+    const instance = arr &&
+    arr.caster &&
+    arr.caster.instance;
     if (instance === 'Array') {
       arr = arr.caster;
       continue;
@@ -583,9 +584,15 @@ function cast$elemMatch(val) {
 
   // Is this an embedded discriminator and is the discriminator key set?
   // If so, use the discriminator schema. See gh-7449
-  const discriminatorKey = get(this,
-    'casterConstructor.schema.options.discriminatorKey');
-  const discriminators = get(this, 'casterConstructor.schema.discriminators', {});
+  const discriminatorKey = this &&
+    this.casterConstructor &&
+    this.casterConstructor.schema &&
+    this.casterConstructor.schema.options &&
+    this.casterConstructor.schema.options.discriminatorKey;
+  const discriminators = this &&
+  this.casterConstructor &&
+  this.casterConstructor.schema &&
+  this.casterConstructor.schema.discriminators || {};
   if (discriminatorKey != null &&
       val[discriminatorKey] != null &&
       discriminators[val[discriminatorKey]] != null) {

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -11,7 +11,6 @@ const SchemaDocumentArrayOptions =
   require('../options/SchemaDocumentArrayOptions');
 const SchemaType = require('../schematype');
 const discriminator = require('../helpers/model/discriminator');
-const get = require('../helpers/get');
 const handleIdOption = require('../helpers/schema/handleIdOption');
 const util = require('util');
 const utils = require('../utils');
@@ -68,7 +67,9 @@ function DocumentArrayPath(key, schema, options, schemaOptions) {
 
   const parentSchemaType = this;
   this.$embeddedSchemaType = new SchemaType(key + '.$', {
-    required: get(this, 'schemaOptions.required', false)
+    required: this &&
+      this.schemaOptions &&
+      this.schemaOptions.required || false
   });
   this.$embeddedSchemaType.cast = function(value, doc, init) {
     return parentSchemaType.cast(value, doc, init)[0];
@@ -173,7 +174,7 @@ DocumentArrayPath.prototype.discriminator = function(name, schema, options) {
 
   options = options || {};
   const tiedValue = utils.isPOJO(options) ? options.value : options;
-  const clone = get(options, 'clone', true);
+  const clone = typeof options.clone === 'boolean' ? options.clone : true;
 
   if (schema.instanceOfSchema && clone) {
     schema = schema.clone();

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -8,7 +8,6 @@ const MongooseError = require('./error/index');
 const SchemaTypeOptions = require('./options/SchemaTypeOptions');
 const $exists = require('./schema/operators/exists');
 const $type = require('./schema/operators/type');
-const get = require('./helpers/get');
 const handleImmutable = require('./helpers/schematype/handleImmutable');
 const isAsyncFunction = require('./helpers/isAsyncFunction');
 const immediate = require('./helpers/immediate');
@@ -1026,7 +1025,7 @@ SchemaType.prototype.required = function(required, message) {
   this.isRequired = true;
 
   this.requiredValidator = function(v) {
-    const cachedRequired = get(this, '$__.cachedRequired');
+    const cachedRequired = this && this.$__ && this.$__.cachedRequired;
 
     // no validation when this path wasn't selected in the query.
     if (cachedRequired != null && !this.$__isSelected(_this.path) && !this[documentIsModified](_this.path)) {

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -5,7 +5,6 @@ const ArraySubdocument = require('../../ArraySubdocument');
 const MongooseError = require('../../../error/mongooseError');
 const ObjectId = require('../../objectid');
 const cleanModifiedSubpaths = require('../../../helpers/document/cleanModifiedSubpaths');
-const get = require('../../../helpers/get');
 const internalToObjectOptions = require('../../../options').internalToObjectOptions;
 const utils = require('../../../utils');
 
@@ -660,7 +659,7 @@ const methods = {
     if (isOverwrite) {
       atomic.$each = values;
 
-      if (get(atomics, '$push.$each.length', 0) > 0 &&
+      if ((atomics.$push && atomics.$push.$each && atomics.$push.$each.length || 0) !== 0 &&
           atomics.$push.$position != atomic.$position) {
         throw new MongooseError('Cannot call `Array#push()` multiple times ' +
           'with different `$position`');
@@ -673,7 +672,7 @@ const methods = {
         ret = [].push.apply(arr, values);
       }
     } else {
-      if (get(atomics, '$push.$each.length', 0) > 0 &&
+      if ((atomics.$push && atomics.$push.$each && atomics.$push.$each.length || 0) !== 0 &&
           atomics.$push.$position != null) {
         throw new MongooseError('Cannot call `Array#push()` multiple times ' +
           'with different `$position`');
@@ -926,7 +925,7 @@ function _isAllSubdocs(docs, ref) {
 function _checkManualPopulation(arr, docs) {
   const ref = arr == null ?
     null :
-    get(arr[arraySchemaSymbol], 'caster.options.ref', null);
+    arr[arraySchemaSymbol] && arr[arraySchemaSymbol].caster && arr[arraySchemaSymbol].caster.options && arr[arraySchemaSymbol].caster.options.ref || null;
   if (arr.length === 0 &&
       docs.length !== 0) {
     if (_isAllSubdocs(docs, ref)) {

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -4,7 +4,6 @@ const Mixed = require('../schema/mixed');
 const ObjectId = require('./objectid');
 const clone = require('../helpers/clone');
 const deepEqual = require('../utils').deepEqual;
-const get = require('../helpers/get');
 const getConstructorName = require('../helpers/getConstructorName');
 const handleSpreadDoc = require('../helpers/document/handleSpreadDoc');
 const util = require('util');
@@ -131,7 +130,7 @@ class MongooseMap extends Map {
   }
 
   toObject(options) {
-    if (get(options, 'flattenMaps')) {
+    if (options && options.flattenMaps) {
       const ret = {};
       const keys = this.keys();
       for (const key of keys) {
@@ -148,7 +147,7 @@ class MongooseMap extends Map {
   }
 
   toJSON(options) {
-    if (get(options, 'flattenMaps', true)) {
+    if (typeof (options && options.flattenMaps) === 'boolean' ? options.flattenMaps : true) {
       const ret = {};
       const keys = this.keys();
       for (const key of keys) {


### PR DESCRIPTION
With this PR I replaced the get-method with fast property access were it is possible. I know that it looks not so sexy like the get call, but it has performance improvements as we dont need to split the path, traverse an array and stuff.

before:
$ MONGOOSE_DEV=1 node benchmarks/clone.js 
Simple x 140,319 ops/sec ±1.35% (92 runs sampled)
AllSchema x 23,986 ops/sec ±1.26% (90 runs sampled)

MONGOOSE_DEV=1 node benchmarks/validate.js 
invalid x 22,726 ops/sec ±0.62% (95 runs sampled)
valid x 61,786 ops/sec ±0.71% (93 runs sampled)

after
$ MONGOOSE_DEV=1 node benchmarks/clone.js 
Simple x 196,277 ops/sec ±0.72% (92 runs sampled)
AllSchema x 28,769 ops/sec ±0.41% (94 runs sampled)

$ MONGOOSE_DEV=1 node benchmarks/validate.js 
invalid x 23,488 ops/sec ±2.98% (95 runs sampled)
valid x 69,983 ops/sec ±1.05% (92 runs sampled

So atleast cloning is about 25 % faster.

We need more benchmarks imho... but hey. its something
