### PR TITLE
impr: isOperator

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1105,13 +1105,13 @@ if (Symbol.asyncIterator != null) {
  */
 
 function isOperator(obj) {
-  if (typeof obj !== 'object') {
+  if (typeof obj !== 'object' || obj === null) {
     return false;
   }
 
   const k = Object.keys(obj);
 
-  return k.length === 1 && k.some(key => { return key[0] === '$'; });
+  return k.length === 1 && k[0][0] === '$';
 }
 
 /*!

--- a/lib/helpers/query/isOperator.js
+++ b/lib/helpers/query/isOperator.js
@@ -7,5 +7,8 @@ const specialKeys = new Set([
 ]);
 
 module.exports = function isOperator(path) {
-  return path.startsWith('$') && !specialKeys.has(path);
+  return (
+    path[0] === '$' &&
+    !specialKeys.has(path)
+  );
 };


### PR DESCRIPTION
isOperator in aggregate used a .some() method to iterate over the only key in the array, so now it access it directly. Also added a null check for better safety...

the isOperator helper method used .startsWith method, which is slower than just checking the first character of the string. So I replaced it. 

It appears, the isOperator in aggregate and isOperator for queries have the same behaviour somehow, but the one for queries checks for the "special keys". Are those keys also special for the aggregation stage?