### PR TITLE
impr: hasDollarKeys

### DIFF
--- a/lib/helpers/query/hasDollarKeys.js
+++ b/lib/helpers/query/hasDollarKeys.js
@@ -4,16 +4,20 @@
  * ignore
  */
 
-module.exports = function(obj) {
-  if (obj == null || typeof obj !== 'object') {
+module.exports = function hasDollarKeys(obj) {
+
+  if (typeof obj !== 'object' || obj === null) {
     return false;
   }
+
   const keys = Object.keys(obj);
   const len = keys.length;
+
   for (let i = 0; i < len; ++i) {
-    if (keys[i].startsWith('$')) {
+    if (keys[i][0] === '$') {
       return true;
     }
   }
+
   return false;
 };


### PR DESCRIPTION
Small refactoring of hasDollarKeys
- added a name to the function
- the typecheck now uses !== instead of !=, as we just switched the conditions in the if-clause. So no implicit conversion of nullish values.
- uses direct character comparison instead of startsWith. 