### PR TITLE
impr: aggregate unwind

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -139,7 +139,7 @@ Aggregate.prototype.model = function(model) {
 Aggregate.prototype.append = function() {
   const args = (arguments.length === 1 && Array.isArray(arguments[0]))
     ? arguments[0]
-    : [...arguments];
+    : Array.from(arguments);
 
   if (!args.every(isOperator)) {
     throw new Error('Arguments must be aggregate pipeline operators');
@@ -371,15 +371,15 @@ Aggregate.prototype.near = function(arg) {
  */
 
 Aggregate.prototype.unwind = function() {
-  const args = [...arguments];
+  const args = Array.from(arguments);
 
   const res = [];
   for (const arg of args) {
-    if (arg && typeof arg === 'object') {
+    if (typeof arg === 'object' && arg !== null) {
       res.push({ $unwind: arg });
     } else if (typeof arg === 'string') {
       res.push({
-        $unwind: (arg && arg.startsWith('$')) ? arg : '$' + arg
+        $unwind: arg[0] === '$' ? arg : '$' + arg
       });
     } else {
       throw new Error('Invalid arg "' + arg + '" to unwind(), ' +
@@ -465,7 +465,7 @@ Aggregate.prototype.sortByCount = function(arg) {
     return this.append({ $sortByCount: arg });
   } else if (typeof arg === 'string') {
     return this.append({
-      $sortByCount: (arg && arg.startsWith('$')) ? arg : '$' + arg
+      $sortByCount: (arg && arg[0] === '$') ? arg : '$' + arg
     });
   } else {
     throw new TypeError('Invalid arg "' + arg + '" to sortByCount(), ' +


### PR DESCRIPTION
- Array.from is faster for Iterators, like arguments
- added check if provided argument is not null
- replace startswith with faster single character check