### PR TITLE
perf: improve isAsyncFunction

### DIFF
--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -2,7 +2,7 @@
 
 const { inspect } = require('util');
 
-const primitiveTypes = new Set(['number', 'string', 'bigint', 'boolean', 'symbol']);
+const primitiveTypes = new Set(['undefined', 'number', 'string', 'bigint', 'boolean', 'symbol']);
 const isAsyncFunctionCache = new WeakMap();
 
 module.exports = function isAsyncFunction(v) {

--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -2,10 +2,13 @@
 
 const { inspect } = require('util');
 
-module.exports = function isAsyncFunction(v) {
-  if (typeof v !== 'function') {
-    return;
-  }
+const isAsyncFunctionCache = new WeakMap();
 
-  return inspect(v).startsWith('[AsyncFunction:');
+module.exports = function isAsyncFunction(v) {
+  if (isAsyncFunctionCache.has(v)) {
+    return isAsyncFunctionCache.get(v);
+  }
+  const result = typeof v === 'function' && inspect(v).indexOf('[AsyncFunction:') === 0 || false;
+  isAsyncFunctionCache.set(v, result);
+  return result;
 };

--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -2,9 +2,13 @@
 
 const { inspect } = require('util');
 
+const primitiveTypes = new Set(['number', 'string', 'bigint', 'boolean', 'symbol']);
 const isAsyncFunctionCache = new WeakMap();
 
 module.exports = function isAsyncFunction(v) {
+  if (primitiveTypes.has(v)) {
+    return false;
+  }
   if (isAsyncFunctionCache.has(v)) {
     return isAsyncFunctionCache.get(v);
   }

--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -6,7 +6,7 @@ const primitiveTypes = new Set(['number', 'string', 'bigint', 'boolean', 'symbol
 const isAsyncFunctionCache = new WeakMap();
 
 module.exports = function isAsyncFunction(v) {
-  if (primitiveTypes.has(v)) {
+  if (primitiveTypes.has(typeof v)) {
     return false;
   }
   if (isAsyncFunctionCache.has(v)) {

--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -1,18 +1,11 @@
 'use strict';
 
-const { inspect } = require('util');
-
 const primitiveTypes = new Set(['undefined', 'number', 'string', 'bigint', 'boolean', 'symbol']);
-const isAsyncFunctionCache = new WeakMap();
+const asyncFunctionPrototype = Object.getPrototypeOf(async function() {});
 
 module.exports = function isAsyncFunction(v) {
   if (primitiveTypes.has(typeof v)) {
     return false;
   }
-  if (isAsyncFunctionCache.has(v)) {
-    return isAsyncFunctionCache.get(v);
-  }
-  const result = typeof v === 'function' && inspect(v).indexOf('[AsyncFunction:') === 0 || false;
-  isAsyncFunctionCache.set(v, result);
-  return result;
+  return Object.getPrototypeOf(v) === asyncFunctionPrototype;
 };

--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const primitiveTypes = new Set(['undefined', 'number', 'string', 'bigint', 'boolean', 'symbol']);
 const asyncFunctionPrototype = Object.getPrototypeOf(async function() {});
 
 module.exports = function isAsyncFunction(v) {
-  if (primitiveTypes.has(typeof v)) {
-    return false;
-  }
-  return Object.getPrototypeOf(v) === asyncFunctionPrototype;
+  return (
+    typeof v === 'function' &&
+    Object.getPrototypeOf(v) === asyncFunctionPrototype
+  );
 };

--- a/test/helpers/isAsyncFunction.test.js
+++ b/test/helpers/isAsyncFunction.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('assert');
+const isAsyncFunction = require('../../lib/helpers/isAsyncFunction');
+
+describe('isAsyncFunction', function() {
+  it('should return false for non-functions', () => {
+    assert.ok(!isAsyncFunction('a'));
+    assert.ok(!isAsyncFunction(1));
+    assert.ok(!isAsyncFunction(1n));
+    assert.ok(!isAsyncFunction({}));
+    assert.ok(!isAsyncFunction(new Date()));
+    assert.ok(!isAsyncFunction([]));
+    assert.ok(!isAsyncFunction(true));
+  });
+  it('should return false for sync function', () => {
+    assert.ok(!isAsyncFunction(function syncFunction() { return 'a';}));
+  });
+  it('should return true for async function', () => {
+    assert.ok(isAsyncFunction(async function asyncFunction() { return 'a';}));
+  });
+  it('should return false for sync function returning a Promise', () => {
+    assert.ok(!isAsyncFunction(function promiseReturningFunction() { return Promise.resolve('a');}));
+  });
+});


### PR DESCRIPTION
I was playing around and realized that isAsyncFunction is using utils.inspect and startsWitht. So I tested the benchmark/validate and got

```
MONGOOSE_DEV=1 node validate
invalid x 24,186 ops/sec ±0.62% (92 runs sampled)
valid x 76,020 ops/sec ±0.59% (92 runs sampled)
```

So I replaced startsWith with indexOf which is about 10 times faster than startsWith and benchmarked again:

```
MONGOOSE_DEV=1 node validate
invalid x 24,283 ops/sec ±3.05% (94 runs sampled)
valid x 76,428 ops/sec ±0.50% (95 runs sampled)
```

No performance gain, despite we know that indexOf is about 10 x faster indicates that we have a different bottleneck, utils.inspect.

So I thought: Ok, there is a call to utils.inspect which is basically stringifying the function to just check if the string begins with `[AsyncFunction:`

So I was like: We get non-primitive values for the isAsyncFunction-check. So I can use a WeakMap to cache the information if it is an async Function or not. And then I benchmarked again:

```
MONGOOSE_DEV=1 node validate
invalid x 27,056 ops/sec ±0.67% (91 runs sampled)
valid x 104,265 ops/sec ±0.66% (93 runs sampled)
``` 

Nice gain. 

To make sure, that dont get an Error when passing a primitive type, I added a check if we pass a primitive type and benched again:

```
MONGOOSE_DEV=1 node validate
invalid x 27,390 ops/sec ±0.51% (93 runs sampled)
valid x 104,177 ops/sec ±0.70% (95 runs sampled)
```

To compare how close we are if we are basically skipping the check, as the benchmark is not using async functions, i patched isAsyncFunction to return false.

```
MONGOOSE_DEV=1 node validate
invalid x 26,246 ops/sec ±0.83% (90 runs sampled)
valid x 107,461 ops/sec ±0.77% (91 runs sampled)
```

So with this PR we are avoiding the bottleneck very good.

So from 76k to 104k is not bad.. Also compared to #11298 where we started with 46k in mongoose 6.1.10 for the valid path, this means we basically doubled our performance for validate from mongoose 6.2.0.