### PR TITLE
perf: improve validation sync and async by replacing forEach with classic for loops

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2853,19 +2853,21 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
   }
   const validating = {};
 
-  paths.forEach(function(path) {
+  for (let i = 0, len = paths.length; i < len; ++i) {
+    const path = paths[i];
+
     if (validating[path]) {
-      return;
+      continue;
     }
 
     validating[path] = true;
 
     const p = _this.$__schema.path(path);
     if (!p) {
-      return;
+      continue;
     }
     if (!_this.$isValid(path)) {
-      return;
+      continue;
     }
 
     const val = _this.$__getValue(path);
@@ -2879,11 +2881,11 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
         p.$isArraySubdocument ||
         p.$isMongooseDocumentArray;
       if (isSubdoc && err instanceof ValidationError) {
-        return;
+        continue;
       }
       _this.invalidate(path, err, undefined, true);
     }
-  });
+  }
 
   const err = _this.$__.validationError;
   _this.$__.validationError = undefined;

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1250,10 +1250,10 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     return fn(null);
   }
 
-  const _this = this;
-  validators.forEach(function(v) {
+  for (let i = 0, len = validators.length; i < len; ++i) {
+    const v = validators[i];
     if (err) {
-      return;
+      break;
     }
 
     const validator = v.validator;
@@ -1265,16 +1265,16 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
 
     if (validator instanceof RegExp) {
       validate(validator.test(value), validatorProperties);
-      return;
+      continue;
     }
 
     if (typeof validator !== 'function') {
-      return;
+      continue;
     }
 
-    if (value === undefined && validator !== _this.requiredValidator) {
+    if (value === undefined && validator !== this.requiredValidator) {
       validate(true, validatorProperties);
-      return;
+      continue;
     }
 
     try {
@@ -1303,8 +1303,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     } else {
       validate(ok, validatorProperties);
     }
-
-  });
+  }
 
   function validate(ok, validatorProperties) {
     if (err) {


### PR DESCRIPTION
It is basically replacing the forEach with classic for loop

before
```
MONGOOSE_DEV=1 node validate
invalid x 23,482 ops/sec ±3.63% (89 runs sampled)
valid x 75,238 ops/sec ±0.58% (91 runs sampled)
```

after
```
MONGOOSE_DEV=1 node validate
invalid x 27,460 ops/sec ±0.91% (89 runs sampled)
valid x 76,128 ops/sec ±0.69% (93 runs sampled)
```