### PR TITLE
Improve Connection Typings

### DIFF
--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -1,26 +1,91 @@
-import { createConnection, Schema, Connection } from 'mongoose';
+import { createConnection, Schema, Collection, Connection, ConnectionSyncIndexesResult, Model } from 'mongoose';
+import * as mongodb from 'mongodb';
+import { expectError, expectType } from 'tsd';
+
+expectType<Connection>(createConnection());
+expectType<Connection>(createConnection('mongodb://localhost:27017/test'));
+expectType<Connection>(createConnection('mongodb://localhost:27017/test', { appName: 'mongoose' }));
+expectType<void>(createConnection('mongodb://localhost:27017/test', { appName: 'mongoose' }, (err, res) => (expectType<Connection>(res))));
 
 const conn = createConnection();
 
-conn.model('Test', new Schema({ name: { type: String } }));
+expectType<Model<{ name: string }, any, any, any>>(conn.model('Test', new Schema<{ name: string }>({ name: { type: String } })));
+expectType<Model<{ name: string }>>(conn.model<{ name: string }>('Test', new Schema({ name: { type: String } })));
 
-conn.openUri('mongodb://localhost:27017/test').then(() => console.log('Connected!'));
+expectType<Promise<Connection>>(conn.openUri('mongodb://localhost:27017/test'));
+expectType<Promise<Connection>>(conn.openUri('mongodb://localhost:27017/test', { bufferCommands: true }));
+expectType<Connection>(conn.openUri('mongodb://localhost:27017/test', { bufferCommands: true }, (err, value) => { expectType<Connection>(value); }));
 
-createConnection('mongodb://localhost:27017/test').asPromise().then((conn: Connection) => {
-  conn.host;
-});
+conn.readyState === 0;
+conn.readyState === 99;
 
-createConnection('mongodb://localhost:27017/test').close();
+expectError(conn.readyState = 0);
 
-conn.db.collection('Test').findOne({ name: String }).then(doc => console.log(doc));
-conn.collection('Test').findOne({ name: String }).then(doc => console.log(doc));
-conn.syncIndexes({ continueOnError: true }).then(result => {
-  result['User'].forEach((index) => {
-    index.includes('name');
-  });
-  result['Order'].message;
-  result['Order'].code;
-});
-conn.syncIndexes({ continueOnError: false, background: true }).then().catch(err => {
-  err.errors['Order'].code;
-});
+expectType<Connection>(new Connection());
+expectType<Promise<Connection>>(new Connection().asPromise());
+
+expectType<Promise<mongodb.Collection<{ [key: string]: any }>>>(conn.createCollection('some'));
+expectType<void>(conn.createCollection('some', (err, res) => {
+  expectType<mongodb.Collection<{ [key: string]: any }>>(res);
+}));
+
+expectType<Promise<void>>(conn.dropCollection('some'));
+expectType<void>(conn.dropCollection('some', () => {
+  // do nothing
+}));
+
+expectError(conn.deleteModel());
+expectType<Connection>(conn.deleteModel('something'));
+
+expectType<Array<string>>(conn.modelNames());
+
+expectType<Promise<void>>(createConnection('mongodb://localhost:27017/test').close());
+expectType<Promise<void>>(createConnection('mongodb://localhost:27017/test').close(true));
+expectType<void>(createConnection('mongodb://localhost:27017/test').close(() => {
+  // do nothing.
+}));
+expectType<void>(createConnection('mongodb://localhost:27017/test').close(true, () => {
+  // do nothing.
+}));
+expectType<void>(createConnection('mongodb://localhost:27017/test').close(false, () => {
+  // do nothing.
+}));
+
+expectType<mongodb.Db>(conn.db);
+
+expectType<mongodb.MongoClient>(conn.getClient());
+expectType<Connection>(conn.setClient(new mongodb.MongoClient('mongodb://localhost:27017/test')));
+
+expectType<Promise<string>>(conn.transaction<string>(async(res) => {
+  expectType<mongodb.ClientSession>(res);
+  return 'a';
+}));
+
+expectError(conn.user = 'invalid');
+expectError(conn.pass = 'invalid');
+expectError(conn.host = 'invalid');
+expectError(conn.port = 'invalid');
+
+expectType<Collection>(conn.collection('test'));
+expectType<mongodb.Collection>(conn.db.collection('test'));
+
+expectType<Promise<mongodb.ClientSession>>(conn.startSession());
+expectType<Promise<mongodb.ClientSession>>(conn.startSession({ causalConsistency: true }));
+expectType<void>(conn.startSession((err, res) => { expectType<mongodb.ClientSession>(res); }));
+expectType<void>(conn.startSession(undefined, (err, res) => { expectType<mongodb.ClientSession>(res); }));
+expectType<void>(conn.startSession(null, (err, res) => { expectType<mongodb.ClientSession>(res); }));
+expectType<void>(conn.startSession({}, (err, res) => { expectType<mongodb.ClientSession>(res); }));
+
+expectType<Promise<ConnectionSyncIndexesResult>>(conn.syncIndexes());
+expectType<Promise<ConnectionSyncIndexesResult>>(conn.syncIndexes({ continueOnError: true }));
+expectType<Promise<ConnectionSyncIndexesResult>>(conn.syncIndexes({ background: true }));
+
+expectType<void>(conn.syncIndexes(undefined, (err, value) => { expectType<ConnectionSyncIndexesResult>(value); }));
+expectType<void>(conn.syncIndexes(null, (err, value) => { expectType<ConnectionSyncIndexesResult>(value); }));
+expectType<void>(conn.syncIndexes({ continueOnError: true }, (err, value) => { expectType<ConnectionSyncIndexesResult>(value); }));
+expectType<void>(conn.syncIndexes({ background: true }, (err, value) => { expectType<ConnectionSyncIndexesResult>(value); }));
+
+expectType<Connection>(conn.useDb('test'));
+expectType<Connection>(conn.useDb('test', {}));
+expectType<Connection>(conn.useDb('test', { noListener: true }));
+expectType<Connection>(conn.useDb('test', { useCache: true }));

--- a/types/Connection.d.ts
+++ b/types/Connection.d.ts
@@ -60,32 +60,32 @@ declare module 'mongoose' {
       readonly db: mongodb.Db;
 
       /**
-         * Helper for `createCollection()`. Will explicitly create the given collection
-         * with specified options. Used to create [capped collections](https://docs.mongodb.com/manual/core/capped-collections/)
-         * and [views](https://docs.mongodb.com/manual/core/views/) from mongoose.
-         */
+       * Helper for `createCollection()`. Will explicitly create the given collection
+       * with specified options. Used to create [capped collections](https://docs.mongodb.com/manual/core/capped-collections/)
+       * and [views](https://docs.mongodb.com/manual/core/views/) from mongoose.
+       */
       createCollection<T extends AnyObject = AnyObject>(name: string, options: mongodb.CreateCollectionOptions, callback: Callback<mongodb.Collection<T>>): void;
       createCollection<T extends AnyObject = AnyObject>(name: string, callback: Callback<mongodb.Collection<T>>): void;
       createCollection<T extends AnyObject = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Promise<mongodb.Collection<T>>;
 
       /**
-         * Removes the model named `name` from this connection, if it exists. You can
-         * use this function to clean up any models you created in your tests to
-         * prevent OverwriteModelErrors.
-         */
+       * Removes the model named `name` from this connection, if it exists. You can
+       * use this function to clean up any models you created in your tests to
+       * prevent OverwriteModelErrors.
+       */
       deleteModel(name: string): this;
 
       /**
-         * Helper for `dropCollection()`. Will delete the given collection, including
-         * all documents and indexes.
-         */
+       * Helper for `dropCollection()`. Will delete the given collection, including
+       * all documents and indexes.
+       */
       dropCollection(collection: string, cb: CallbackWithoutResult): void;
       dropCollection(collection: string): Promise<void>;
 
       /**
-         * Helper for `dropDatabase()`. Deletes the given database, including all
-         * collections, documents, and indexes.
-         */
+       * Helper for `dropDatabase()`. Deletes the given database, including all
+       * collections, documents, and indexes.
+       */
       dropDatabase(cb: CallbackWithoutResult): void;
       dropDatabase(): Promise<void>;
 
@@ -93,28 +93,28 @@ declare module 'mongoose' {
       get(key: string): any;
 
       /**
-         * Returns the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
-         * that this connection uses to talk to MongoDB.
-         */
+       * Returns the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+       * that this connection uses to talk to MongoDB.
+       */
       getClient(): mongodb.MongoClient;
 
       /**
-         * The host name portion of the URI. If multiple hosts, such as a replica set,
-         * this will contain the first host name in the URI
-         */
+       * The host name portion of the URI. If multiple hosts, such as a replica set,
+       * this will contain the first host name in the URI
+       */
       readonly host: string;
 
       /**
-         * A number identifier for this connection. Used for debugging when
-         * you have [multiple connections](/docs/connections.html#multiple_connections).
-         */
+       * A number identifier for this connection. Used for debugging when
+       * you have [multiple connections](/docs/connections.html#multiple_connections).
+       */
       readonly id: number;
 
       /**
-         * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing
-         * a map from model names to models. Contains all models that have been
-         * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).
-         */
+       * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing
+       * a map from model names to models. Contains all models that have been
+       * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).
+       */
       readonly models: Readonly<{ [index: string]: Model<any> }>;
 
       /** Defines or retrieves a model. */
@@ -141,9 +141,9 @@ declare module 'mongoose' {
       readonly pass: string;
 
       /**
-         * The port portion of the URI. If multiple hosts, such as a replica set,
-         * this will contain the port from the first host name in the URI.
-         */
+       * The port portion of the URI. If multiple hosts, such as a replica set,
+       * this will contain the port from the first host name in the URI.
+       */
       readonly port: number;
 
       /** Declares a plugin executed on all schemas you pass to `conn.model()` */
@@ -153,50 +153,50 @@ declare module 'mongoose' {
       plugins: Array<any>;
 
       /**
-         * Connection ready state
-         *
-         * - 0 = disconnected
-         * - 1 = connected
-         * - 2 = connecting
-         * - 3 = disconnecting
-         * - 99 = uninitialized
-         */
+       * Connection ready state
+       *
+       * - 0 = disconnected
+       * - 1 = connected
+       * - 2 = connecting
+       * - 3 = disconnecting
+       * - 99 = uninitialized
+       */
       readonly readyState: ConnectionStates;
 
       /** Sets the value of the option `key`. */
       set(key: string, value: any): any;
 
       /**
-         * Set the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
-         * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
-         * reuse it.
-         */
+       * Set the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+       * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
+       * reuse it.
+       */
       setClient(client: mongodb.MongoClient): this;
 
       /**
-         * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
-         * for benefits like causal consistency, [retryable writes](https://docs.mongodb.com/manual/core/retryable-writes/),
-         * and [transactions](http://thecodebarbarian.com/a-node-js-perspective-on-mongodb-4-transactions.html).
-         */
+       * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
+       * for benefits like causal consistency, [retryable writes](https://docs.mongodb.com/manual/core/retryable-writes/),
+       * and [transactions](http://thecodebarbarian.com/a-node-js-perspective-on-mongodb-4-transactions.html).
+       */
       startSession(options: mongodb.ClientSessionOptions | undefined | null, callback: Callback<mongodb.ClientSession>): void;
       startSession(callback: Callback<mongodb.ClientSession>): void;
       startSession(options?: mongodb.ClientSessionOptions): Promise<mongodb.ClientSession>;
 
       /**
-         * Makes the indexes in MongoDB match the indexes defined in every model's
-         * schema. This function will drop any indexes that are not defined in
-         * the model's schema except the `_id` index, and build any indexes that
-         * are in your schema but not in MongoDB.
-         */
+       * Makes the indexes in MongoDB match the indexes defined in every model's
+       * schema. This function will drop any indexes that are not defined in
+       * the model's schema except the `_id` index, and build any indexes that
+       * are in your schema but not in MongoDB.
+       */
       syncIndexes(options: SyncIndexesOptions | undefined | null, callback: Callback<ConnectionSyncIndexesResult>): void;
       syncIndexes(options?: SyncIndexesOptions): Promise<ConnectionSyncIndexesResult>;
 
       /**
-         * _Requires MongoDB >= 3.6.0._ Executes the wrapped async function
-         * in a transaction. Mongoose will commit the transaction if the
-         * async function executes successfully and attempt to retry if
-         * there was a retryable error.
-         */
+       * _Requires MongoDB >= 3.6.0._ Executes the wrapped async function
+       * in a transaction. Mongoose will commit the transaction if the
+       * async function executes successfully and attempt to retry if
+       * there was a retryable error.
+       */
       transaction<U = any>(fn: (session: mongodb.ClientSession) => Promise<U>): Promise<U>;
 
       /** Switches to a different database using the same connection pool. */

--- a/types/Connection.d.ts
+++ b/types/Connection.d.ts
@@ -1,0 +1,201 @@
+import mongodb = require('mongodb');
+import events = require('events');
+
+declare module 'mongoose' {
+
+    export enum ConnectionStates {
+        disconnected = 0,
+        connected = 1,
+        connecting = 2,
+        disconnecting = 3,
+        uninitialized = 99,
+    }
+
+    /** Expose connection states for user-land */
+    export const STATES: typeof ConnectionStates;
+
+    interface ConnectOptions extends mongodb.MongoClientOptions {
+        /** Set to false to [disable buffering](http://mongoosejs.com/docs/faq.html#callback_never_executes) on all models associated with this connection. */
+        bufferCommands?: boolean;
+        /** The name of the database you want to use. If not provided, Mongoose uses the database name from connection string. */
+        dbName?: string;
+        /** username for authentication, equivalent to `options.auth.user`. Maintained for backwards compatibility. */
+        user?: string;
+        /** password for authentication, equivalent to `options.auth.password`. Maintained for backwards compatibility. */
+        pass?: string;
+        /** Set to false to disable automatic index creation for all models associated with this connection. */
+        autoIndex?: boolean;
+        /** Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection. */
+        autoCreate?: boolean;
+    }
+
+    class Connection extends events.EventEmitter {
+        /** Returns a promise that resolves when this connection successfully connects to MongoDB */
+        asPromise(): Promise<this>;
+
+        /** Closes the connection */
+        close(callback: CallbackWithoutResult): void;
+        close(force: boolean, callback: CallbackWithoutResult): void;
+        close(force?: boolean): Promise<void>;
+
+        /** Retrieves a collection, creating it if not cached. */
+        collection<T = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Collection<T>;
+
+        /** A hash of the collections associated with this connection */
+        collections: { [index: string]: Collection };
+
+        /** A hash of the global options that are associated with this connection */
+        config: any;
+
+        /** The mongodb.Db instance, set when the connection is opened */
+        db: mongodb.Db;
+
+        /**
+         * Helper for `createCollection()`. Will explicitly create the given collection
+         * with specified options. Used to create [capped collections](https://docs.mongodb.com/manual/core/capped-collections/)
+         * and [views](https://docs.mongodb.com/manual/core/views/) from mongoose.
+         */
+        createCollection<T = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Promise<mongodb.Collection<T>>;
+        createCollection<T = AnyObject>(name: string, cb: Callback<mongodb.Collection<T>>): void;
+        createCollection<T = AnyObject>(name: string, options: mongodb.CreateCollectionOptions, cb?: Callback<mongodb.Collection<T>>): Promise<mongodb.Collection<T>>;
+
+        /**
+         * Removes the model named `name` from this connection, if it exists. You can
+         * use this function to clean up any models you created in your tests to
+         * prevent OverwriteModelErrors.
+         */
+        deleteModel(name: string): this;
+
+        /**
+         * Helper for `dropCollection()`. Will delete the given collection, including
+         * all documents and indexes.
+         */
+        dropCollection(collection: string): Promise<void>;
+        dropCollection(collection: string, cb: CallbackWithoutResult): void;
+
+        /**
+         * Helper for `dropDatabase()`. Deletes the given database, including all
+         * collections, documents, and indexes.
+         */
+        dropDatabase(): Promise<void>;
+        dropDatabase(cb: CallbackWithoutResult): void;
+
+        /** Gets the value of the option `key`. Equivalent to `conn.options[key]` */
+        get(key: string): any;
+
+        /**
+         * Returns the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+         * that this connection uses to talk to MongoDB.
+         */
+        getClient(): mongodb.MongoClient;
+
+        /**
+         * The host name portion of the URI. If multiple hosts, such as a replica set,
+         * this will contain the first host name in the URI
+         */
+        host: string;
+
+        /**
+         * A number identifier for this connection. Used for debugging when
+         * you have [multiple connections](/docs/connections.html#multiple_connections).
+         */
+        id: number;
+
+        /**
+         * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing
+         * a map from model names to models. Contains all models that have been
+         * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).
+         */
+        models: { [index: string]: Model<any> };
+
+        /** Defines or retrieves a model. */
+        model<T>(name: string, schema?: Schema<any>, collection?: string, options?: CompileModelOptions): Model<T>;
+        model<T, U, TQueryHelpers = {}>(
+            name: string,
+            schema?: Schema<T, U, TQueryHelpers>,
+            collection?: string,
+            options?: CompileModelOptions
+        ): U;
+
+        /** Returns an array of model names created on this connection. */
+        modelNames(): Array<string>;
+
+        /** The name of the database this connection points to. */
+        name: string;
+
+        /** Opens the connection with a URI using `MongoClient.connect()`. */
+        openUri(uri: string, options?: ConnectOptions): Promise<Connection>;
+        openUri(uri: string, callback: (err: CallbackError, conn?: Connection) => void): Connection;
+        openUri(uri: string, options: ConnectOptions, callback: (err: CallbackError, conn?: Connection) => void): Connection;
+
+        /** The password specified in the URI */
+        pass: string;
+
+        /**
+         * The port portion of the URI. If multiple hosts, such as a replica set,
+         * this will contain the port from the first host name in the URI.
+         */
+        port: number;
+
+        /** Declares a plugin executed on all schemas you pass to `conn.model()` */
+        plugin(fn: (schema: Schema, opts?: any) => void, opts?: any): Connection;
+
+        /** The plugins that will be applied to all models created on this connection. */
+        plugins: Array<any>;
+
+        /**
+         * Connection ready state
+         *
+         * - 0 = disconnected
+         * - 1 = connected
+         * - 2 = connecting
+         * - 3 = disconnecting
+         */
+        readyState: number;
+
+        /** Sets the value of the option `key`. Equivalent to `conn.options[key] = val` */
+        set(key: string, value: any): any;
+
+        /**
+         * Set the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+         * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
+         * reuse it.
+         */
+        setClient(client: mongodb.MongoClient): this;
+
+        /**
+         * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
+         * for benefits like causal consistency, [retryable writes](https://docs.mongodb.com/manual/core/retryable-writes/),
+         * and [transactions](http://thecodebarbarian.com/a-node-js-perspective-on-mongodb-4-transactions.html).
+         */
+        startSession(options?: mongodb.ClientSessionOptions): Promise<mongodb.ClientSession>;
+        startSession(options: mongodb.ClientSessionOptions, cb: Callback<mongodb.ClientSession>): void;
+
+        /**
+         * Makes the indexes in MongoDB match the indexes defined in every model's
+         * schema. This function will drop any indexes that are not defined in
+         * the model's schema except the `_id` index, and build any indexes that
+         * are in your schema but not in MongoDB.
+         */
+        syncIndexes(options?: SyncIndexesOptions): Promise<ConnectionSyncIndexesResult>;
+        syncIndexes(options: SyncIndexesOptions | null, callback: Callback<ConnectionSyncIndexesResult>): void;
+
+        /**
+         * _Requires MongoDB >= 3.6.0._ Executes the wrapped async function
+         * in a transaction. Mongoose will commit the transaction if the
+         * async function executes successfully and attempt to retry if
+         * there was a retryable error.
+         */
+        transaction(fn: (session: mongodb.ClientSession) => Promise<any>): Promise<any>;
+
+        /** Switches to a different database using the same connection pool. */
+        useDb(name: string, options?: { useCache?: boolean, noListener?: boolean }): Connection;
+
+        /** The username specified in the URI */
+        user: string;
+
+        /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model.watch). */
+        watch<ResultType = any>(pipeline?: Array<any>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
+    }
+
+}

--- a/types/Connection.d.ts
+++ b/types/Connection.d.ts
@@ -79,14 +79,14 @@ declare module 'mongoose' {
        * Helper for `dropCollection()`. Will delete the given collection, including
        * all documents and indexes.
        */
-      dropCollection(collection: string, cb: CallbackWithoutResult): void;
+      dropCollection(collection: string, callback: CallbackWithoutResult): void;
       dropCollection(collection: string): Promise<void>;
 
       /**
        * Helper for `dropDatabase()`. Deletes the given database, including all
        * collections, documents, and indexes.
        */
-      dropDatabase(cb: CallbackWithoutResult): void;
+      dropDatabase(callback: CallbackWithoutResult): void;
       dropDatabase(): Promise<void>;
 
       /** Gets the value of the option `key`. */

--- a/types/Connection.d.ts
+++ b/types/Connection.d.ts
@@ -3,6 +3,15 @@ import events = require('events');
 
 declare module 'mongoose' {
 
+    /**
+     * Connection ready state
+     *
+     * - 0 = disconnected
+     * - 1 = connected
+     * - 2 = connecting
+     * - 3 = disconnecting
+     * - 99 = uninitialized
+     */
     export enum ConnectionStates {
         disconnected = 0,
         connected = 1,
@@ -30,172 +39,174 @@ declare module 'mongoose' {
     }
 
     class Connection extends events.EventEmitter {
-        /** Returns a promise that resolves when this connection successfully connects to MongoDB */
-        asPromise(): Promise<this>;
+      /** Returns a promise that resolves when this connection successfully connects to MongoDB */
+      asPromise(): Promise<this>;
 
-        /** Closes the connection */
-        close(callback: CallbackWithoutResult): void;
-        close(force: boolean, callback: CallbackWithoutResult): void;
-        close(force?: boolean): Promise<void>;
+      /** Closes the connection */
+      close(force: boolean, callback: CallbackWithoutResult): void;
+      close(callback: CallbackWithoutResult): void;
+      close(force?: boolean): Promise<void>;
 
-        /** Retrieves a collection, creating it if not cached. */
-        collection<T = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Collection<T>;
+      /** Retrieves a collection, creating it if not cached. */
+      collection<T extends AnyObject = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Collection<T>;
 
-        /** A hash of the collections associated with this connection */
-        collections: { [index: string]: Collection };
+      /** A hash of the collections associated with this connection */
+      readonly collections: { [index: string]: Collection };
 
-        /** A hash of the global options that are associated with this connection */
-        config: any;
+      /** A hash of the global options that are associated with this connection */
+      readonly config: any;
 
-        /** The mongodb.Db instance, set when the connection is opened */
-        db: mongodb.Db;
+      /** The mongodb.Db instance, set when the connection is opened */
+      readonly db: mongodb.Db;
 
-        /**
+      /**
          * Helper for `createCollection()`. Will explicitly create the given collection
          * with specified options. Used to create [capped collections](https://docs.mongodb.com/manual/core/capped-collections/)
          * and [views](https://docs.mongodb.com/manual/core/views/) from mongoose.
          */
-        createCollection<T = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Promise<mongodb.Collection<T>>;
-        createCollection<T = AnyObject>(name: string, cb: Callback<mongodb.Collection<T>>): void;
-        createCollection<T = AnyObject>(name: string, options: mongodb.CreateCollectionOptions, cb?: Callback<mongodb.Collection<T>>): Promise<mongodb.Collection<T>>;
+      createCollection<T extends AnyObject = AnyObject>(name: string, options: mongodb.CreateCollectionOptions, callback: Callback<mongodb.Collection<T>>): void;
+      createCollection<T extends AnyObject = AnyObject>(name: string, callback: Callback<mongodb.Collection<T>>): void;
+      createCollection<T extends AnyObject = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Promise<mongodb.Collection<T>>;
 
-        /**
+      /**
          * Removes the model named `name` from this connection, if it exists. You can
          * use this function to clean up any models you created in your tests to
          * prevent OverwriteModelErrors.
          */
-        deleteModel(name: string): this;
+      deleteModel(name: string): this;
 
-        /**
+      /**
          * Helper for `dropCollection()`. Will delete the given collection, including
          * all documents and indexes.
          */
-        dropCollection(collection: string): Promise<void>;
-        dropCollection(collection: string, cb: CallbackWithoutResult): void;
+      dropCollection(collection: string, cb: CallbackWithoutResult): void;
+      dropCollection(collection: string): Promise<void>;
 
-        /**
+      /**
          * Helper for `dropDatabase()`. Deletes the given database, including all
          * collections, documents, and indexes.
          */
-        dropDatabase(): Promise<void>;
-        dropDatabase(cb: CallbackWithoutResult): void;
+      dropDatabase(cb: CallbackWithoutResult): void;
+      dropDatabase(): Promise<void>;
 
-        /** Gets the value of the option `key`. Equivalent to `conn.options[key]` */
-        get(key: string): any;
+      /** Gets the value of the option `key`. */
+      get(key: string): any;
 
-        /**
+      /**
          * Returns the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
          * that this connection uses to talk to MongoDB.
          */
-        getClient(): mongodb.MongoClient;
+      getClient(): mongodb.MongoClient;
 
-        /**
+      /**
          * The host name portion of the URI. If multiple hosts, such as a replica set,
          * this will contain the first host name in the URI
          */
-        host: string;
+      readonly host: string;
 
-        /**
+      /**
          * A number identifier for this connection. Used for debugging when
          * you have [multiple connections](/docs/connections.html#multiple_connections).
          */
-        id: number;
+      readonly id: number;
 
-        /**
+      /**
          * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing
          * a map from model names to models. Contains all models that have been
          * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).
          */
-        models: { [index: string]: Model<any> };
+      readonly models: Readonly<{ [index: string]: Model<any> }>;
 
-        /** Defines or retrieves a model. */
-        model<T>(name: string, schema?: Schema<any>, collection?: string, options?: CompileModelOptions): Model<T>;
-        model<T, U, TQueryHelpers = {}>(
+      /** Defines or retrieves a model. */
+      model<T, U, TQueryHelpers = {}>(
             name: string,
             schema?: Schema<T, U, TQueryHelpers>,
             collection?: string,
             options?: CompileModelOptions
         ): U;
+      model<T>(name: string, schema?: Schema<T>, collection?: string, options?: CompileModelOptions): Model<T>;
 
-        /** Returns an array of model names created on this connection. */
-        modelNames(): Array<string>;
+      /** Returns an array of model names created on this connection. */
+      modelNames(): Array<string>;
 
-        /** The name of the database this connection points to. */
-        name: string;
+      /** The name of the database this connection points to. */
+      readonly name: string;
 
-        /** Opens the connection with a URI using `MongoClient.connect()`. */
-        openUri(uri: string, options?: ConnectOptions): Promise<Connection>;
-        openUri(uri: string, callback: (err: CallbackError, conn?: Connection) => void): Connection;
-        openUri(uri: string, options: ConnectOptions, callback: (err: CallbackError, conn?: Connection) => void): Connection;
+      /** Opens the connection with a URI using `MongoClient.connect()`. */
+      openUri(uri: string, options: ConnectOptions, callback: Callback<Connection>): Connection;
+      openUri(uri: string, callback: Callback<Connection>): Connection;
+      openUri(uri: string, options?: ConnectOptions): Promise<Connection>;
 
-        /** The password specified in the URI */
-        pass: string;
+      /** The password specified in the URI */
+      readonly pass: string;
 
-        /**
+      /**
          * The port portion of the URI. If multiple hosts, such as a replica set,
          * this will contain the port from the first host name in the URI.
          */
-        port: number;
+      readonly port: number;
 
-        /** Declares a plugin executed on all schemas you pass to `conn.model()` */
-        plugin(fn: (schema: Schema, opts?: any) => void, opts?: any): Connection;
+      /** Declares a plugin executed on all schemas you pass to `conn.model()` */
+      plugin<S extends Schema = Schema, O = AnyObject>(fn: (schema: S, opts?: any) => void, opts?: O): Connection;
 
-        /** The plugins that will be applied to all models created on this connection. */
-        plugins: Array<any>;
+      /** The plugins that will be applied to all models created on this connection. */
+      plugins: Array<any>;
 
-        /**
+      /**
          * Connection ready state
          *
          * - 0 = disconnected
          * - 1 = connected
          * - 2 = connecting
          * - 3 = disconnecting
+         * - 99 = uninitialized
          */
-        readyState: number;
+      readonly readyState: ConnectionStates;
 
-        /** Sets the value of the option `key`. Equivalent to `conn.options[key] = val` */
-        set(key: string, value: any): any;
+      /** Sets the value of the option `key`. */
+      set(key: string, value: any): any;
 
-        /**
+      /**
          * Set the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
          * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
          * reuse it.
          */
-        setClient(client: mongodb.MongoClient): this;
+      setClient(client: mongodb.MongoClient): this;
 
-        /**
+      /**
          * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
          * for benefits like causal consistency, [retryable writes](https://docs.mongodb.com/manual/core/retryable-writes/),
          * and [transactions](http://thecodebarbarian.com/a-node-js-perspective-on-mongodb-4-transactions.html).
          */
-        startSession(options?: mongodb.ClientSessionOptions): Promise<mongodb.ClientSession>;
-        startSession(options: mongodb.ClientSessionOptions, cb: Callback<mongodb.ClientSession>): void;
+      startSession(options: mongodb.ClientSessionOptions | undefined | null, callback: Callback<mongodb.ClientSession>): void;
+      startSession(callback: Callback<mongodb.ClientSession>): void;
+      startSession(options?: mongodb.ClientSessionOptions): Promise<mongodb.ClientSession>;
 
-        /**
+      /**
          * Makes the indexes in MongoDB match the indexes defined in every model's
          * schema. This function will drop any indexes that are not defined in
          * the model's schema except the `_id` index, and build any indexes that
          * are in your schema but not in MongoDB.
          */
-        syncIndexes(options?: SyncIndexesOptions): Promise<ConnectionSyncIndexesResult>;
-        syncIndexes(options: SyncIndexesOptions | null, callback: Callback<ConnectionSyncIndexesResult>): void;
+      syncIndexes(options: SyncIndexesOptions | undefined | null, callback: Callback<ConnectionSyncIndexesResult>): void;
+      syncIndexes(options?: SyncIndexesOptions): Promise<ConnectionSyncIndexesResult>;
 
-        /**
+      /**
          * _Requires MongoDB >= 3.6.0._ Executes the wrapped async function
          * in a transaction. Mongoose will commit the transaction if the
          * async function executes successfully and attempt to retry if
          * there was a retryable error.
          */
-        transaction(fn: (session: mongodb.ClientSession) => Promise<any>): Promise<any>;
+      transaction<U = any>(fn: (session: mongodb.ClientSession) => Promise<U>): Promise<U>;
 
-        /** Switches to a different database using the same connection pool. */
-        useDb(name: string, options?: { useCache?: boolean, noListener?: boolean }): Connection;
+      /** Switches to a different database using the same connection pool. */
+      useDb(name: string, options?: { useCache?: boolean, noListener?: boolean }): Connection;
 
-        /** The username specified in the URI */
-        user: string;
+      /** The username specified in the URI */
+      readonly user: string;
 
-        /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model.watch). */
-        watch<ResultType = any>(pipeline?: Array<any>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
+      /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model.watch). */
+      watch<ResultType = any>(pipeline?: Array<any>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
     }
 
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="./PipelineStage.d.ts" />
+/// <reference path="./Connection.d.ts" />
 
 import events = require('events');
 import mongodb = require('mongodb');
@@ -6,14 +7,6 @@ import mongoose = require('mongoose');
 import stream = require('stream');
 
 declare module 'mongoose' {
-
-  export enum ConnectionStates {
-    disconnected = 0,
-    connected = 1,
-    connecting = 2,
-    disconnecting = 3,
-    uninitialized = 99,
-  }
 
   class NativeDate extends global.Date {}
 
@@ -62,9 +55,6 @@ declare module 'mongoose' {
 
   /** The various Mongoose SchemaTypes. */
   export const SchemaTypes: typeof Schema.Types;
-
-  /** Expose connection states for user-land */
-  export const STATES: typeof ConnectionStates;
 
   /** Opens Mongoose's default connection to MongoDB, see [connections docs](https://mongoosejs.com/docs/connections.html) */
   export function connect(uri: string, options: ConnectOptions, callback: CallbackWithoutResult): void;
@@ -286,190 +276,6 @@ declare module 'mongoose' {
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface ClientSession extends mongodb.ClientSession { }
-
-  interface ConnectOptions extends mongodb.MongoClientOptions {
-    /** Set to false to [disable buffering](http://mongoosejs.com/docs/faq.html#callback_never_executes) on all models associated with this connection. */
-    bufferCommands?: boolean;
-    /** The name of the database you want to use. If not provided, Mongoose uses the database name from connection string. */
-    dbName?: string;
-    /** username for authentication, equivalent to `options.auth.user`. Maintained for backwards compatibility. */
-    user?: string;
-    /** password for authentication, equivalent to `options.auth.password`. Maintained for backwards compatibility. */
-    pass?: string;
-    /** Set to false to disable automatic index creation for all models associated with this connection. */
-    autoIndex?: boolean;
-    /** Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection. */
-    autoCreate?: boolean;
-  }
-
-  class Connection extends events.EventEmitter {
-    /** Returns a promise that resolves when this connection successfully connects to MongoDB */
-    asPromise(): Promise<this>;
-
-    /** Closes the connection */
-    close(callback: CallbackWithoutResult): void;
-    close(force: boolean, callback: CallbackWithoutResult): void;
-    close(force?: boolean): Promise<void>;
-
-    /** Retrieves a collection, creating it if not cached. */
-    collection<T = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Collection<T>;
-
-    /** A hash of the collections associated with this connection */
-    collections: { [index: string]: Collection };
-
-    /** A hash of the global options that are associated with this connection */
-    config: any;
-
-    /** The mongodb.Db instance, set when the connection is opened */
-    db: mongodb.Db;
-
-    /**
-     * Helper for `createCollection()`. Will explicitly create the given collection
-     * with specified options. Used to create [capped collections](https://docs.mongodb.com/manual/core/capped-collections/)
-     * and [views](https://docs.mongodb.com/manual/core/views/) from mongoose.
-     */
-    createCollection<T = AnyObject>(name: string, options?: mongodb.CreateCollectionOptions): Promise<mongodb.Collection<T>>;
-    createCollection<T = AnyObject>(name: string, cb: Callback<mongodb.Collection<T>>): void;
-    createCollection<T = AnyObject>(name: string, options: mongodb.CreateCollectionOptions, cb?: Callback<mongodb.Collection<T>>): Promise<mongodb.Collection<T>>;
-
-    /**
-     * Removes the model named `name` from this connection, if it exists. You can
-     * use this function to clean up any models you created in your tests to
-     * prevent OverwriteModelErrors.
-     */
-    deleteModel(name: string): this;
-
-    /**
-     * Helper for `dropCollection()`. Will delete the given collection, including
-     * all documents and indexes.
-     */
-    dropCollection(collection: string): Promise<void>;
-    dropCollection(collection: string, cb: CallbackWithoutResult): void;
-
-    /**
-     * Helper for `dropDatabase()`. Deletes the given database, including all
-     * collections, documents, and indexes.
-     */
-    dropDatabase(): Promise<void>;
-    dropDatabase(cb: CallbackWithoutResult): void;
-
-    /** Gets the value of the option `key`. Equivalent to `conn.options[key]` */
-    get(key: string): any;
-
-    /**
-     * Returns the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
-     * that this connection uses to talk to MongoDB.
-     */
-    getClient(): mongodb.MongoClient;
-
-    /**
-     * The host name portion of the URI. If multiple hosts, such as a replica set,
-     * this will contain the first host name in the URI
-     */
-    host: string;
-
-    /**
-     * A number identifier for this connection. Used for debugging when
-     * you have [multiple connections](/docs/connections.html#multiple_connections).
-     */
-    id: number;
-
-    /**
-     * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing
-     * a map from model names to models. Contains all models that have been
-     * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).
-     */
-    models: { [index: string]: Model<any> };
-
-    /** Defines or retrieves a model. */
-    model<T>(name: string, schema?: Schema<any>, collection?: string, options?: CompileModelOptions): Model<T>;
-    model<T, U, TQueryHelpers = {}>(
-      name: string,
-      schema?: Schema<T, U, TQueryHelpers>,
-      collection?: string,
-      options?: CompileModelOptions
-    ): U;
-
-    /** Returns an array of model names created on this connection. */
-    modelNames(): Array<string>;
-
-    /** The name of the database this connection points to. */
-    name: string;
-
-    /** Opens the connection with a URI using `MongoClient.connect()`. */
-    openUri(uri: string, options?: ConnectOptions): Promise<Connection>;
-    openUri(uri: string, callback: (err: CallbackError, conn?: Connection) => void): Connection;
-    openUri(uri: string, options: ConnectOptions, callback: (err: CallbackError, conn?: Connection) => void): Connection;
-
-    /** The password specified in the URI */
-    pass: string;
-
-    /**
-     * The port portion of the URI. If multiple hosts, such as a replica set,
-     * this will contain the port from the first host name in the URI.
-     */
-    port: number;
-
-    /** Declares a plugin executed on all schemas you pass to `conn.model()` */
-    plugin(fn: (schema: Schema, opts?: any) => void, opts?: any): Connection;
-
-    /** The plugins that will be applied to all models created on this connection. */
-    plugins: Array<any>;
-
-    /**
-     * Connection ready state
-     *
-     * - 0 = disconnected
-     * - 1 = connected
-     * - 2 = connecting
-     * - 3 = disconnecting
-     */
-    readyState: number;
-
-    /** Sets the value of the option `key`. Equivalent to `conn.options[key] = val` */
-    set(key: string, value: any): any;
-
-    /**
-     * Set the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
-     * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
-     * reuse it.
-     */
-    setClient(client: mongodb.MongoClient): this;
-
-    /**
-     * _Requires MongoDB >= 3.6.0._ Starts a [MongoDB session](https://docs.mongodb.com/manual/release-notes/3.6/#client-sessions)
-     * for benefits like causal consistency, [retryable writes](https://docs.mongodb.com/manual/core/retryable-writes/),
-     * and [transactions](http://thecodebarbarian.com/a-node-js-perspective-on-mongodb-4-transactions.html).
-     */
-    startSession(options?: mongodb.ClientSessionOptions): Promise<mongodb.ClientSession>;
-    startSession(options: mongodb.ClientSessionOptions, cb: Callback<mongodb.ClientSession>): void;
-
-    /**
-     * Makes the indexes in MongoDB match the indexes defined in every model's
-     * schema. This function will drop any indexes that are not defined in
-     * the model's schema except the `_id` index, and build any indexes that
-     * are in your schema but not in MongoDB.
-     */
-    syncIndexes(options?: SyncIndexesOptions): Promise<ConnectionSyncIndexesResult>;
-    syncIndexes(options: SyncIndexesOptions | null, callback: Callback<ConnectionSyncIndexesResult>): void;
-
-    /**
-     * _Requires MongoDB >= 3.6.0._ Executes the wrapped async function
-     * in a transaction. Mongoose will commit the transaction if the
-     * async function executes successfully and attempt to retry if
-     * there was a retryable error.
-     */
-    transaction(fn: (session: mongodb.ClientSession) => Promise<any>): Promise<any>;
-
-    /** Switches to a different database using the same connection pool. */
-    useDb(name: string, options?: { useCache?: boolean, noListener?: boolean }): Connection;
-
-    /** The username specified in the URI */
-    user: string;
-
-    /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model.watch). */
-    watch<ResultType = any>(pipeline?: Array<any>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
-  }
 
    /*
    * section collection.js

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,10 +89,11 @@ declare module 'mongoose' {
 
   /** An array containing all models associated with this Mongoose instance. */
   export const models: Models;
+
   /** Creates a Connection instance. */
+  export function createConnection(uri: string, options: ConnectOptions, callback: Callback<Connection>): void;
   export function createConnection(uri: string, options?: ConnectOptions): Connection;
   export function createConnection(): Connection;
-  export function createConnection(uri: string, options: ConnectOptions, callback: Callback<Connection>): void;
 
   /**
    * Removes the model named `name` from the default connection, if it exists.


### PR DESCRIPTION
This PR extracts the Connection Typings

With the first commit I extract the typings from Connection from index.d.ts into a new Connection.d.ts. 
With the second commit I do the actual improvements.

The order of the function overloads are according to Typescript Do's and Don'ts, so basically by most arity to least arity.
Attributes like pass, user, models etc. were set to readonly. nobody should use them directly for manipulating the internals of mongoose. If there is some reason to modify them, a developer should use the corresponding methods.

Just check the second commit to see relevant changes.

Also added typings tests.