### PR TITLE
chore: update declarations for schema options

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -264,3 +264,15 @@ function gh10789() {
     }
   });
 }
+
+function gh11439() {
+  type Book = {
+    collection: string
+  }
+
+  const bookSchema = new Schema<Book>({
+    collection: String
+  }, {
+    supressReservedKeysWarning: true
+  });
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1607,6 +1607,13 @@ declare module 'mongoose' {
      * field names by setting timestamps.createdAt and timestamps.updatedAt.
      */
     timestamps?: boolean | SchemaTimestampsConfig;
+
+    /**
+     * Using `save`, `isNew`, and other Mongoose reserved names as schema path names now triggers a warning, not an error. 
+     * You can suppress the warning by setting { supressReservedKeysWarning: true } schema options. Keep in mind that this 
+     * can break plugins that rely on these reserved names.
+     */
+     supressReservedKeysWarning?: boolean
   }
 
   interface SchemaTimestampsConfig {


### PR DESCRIPTION
Added declaration for the `supressReservedKeysWarning`  schema property.

**Summary**

This PR adds a declaration for the `suppressReservedKeysWarning` schema option added in version 6.