### PR TITLE
fix(typescript): `aggregate.sort()` accepts a string but also `{ field: 'asc'|'ascending'|'desc'|'descending' }`

### DIFF
--- a/test/types/aggregate.test.ts
+++ b/test/types/aggregate.test.ts
@@ -1,4 +1,5 @@
 import { Schema, model, Document, Types } from 'mongoose';
+import { expectType } from 'tsd';
 
 const schema: Schema = new Schema({ name: { type: 'String' } });
 
@@ -30,4 +31,14 @@ async function run() {
   for await (const obj of Test.aggregate<ITest>()) {
     obj.name;
   }
+
+  // Aggregate.prototype.sort()
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort('-name'));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 1 }));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: -1 }));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 'asc' }));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 'ascending' }));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 'desc' }));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 'descending' }));
+  expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: { $meta: 'textScore' } }));
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2790,7 +2790,7 @@ declare module 'mongoose' {
     skip(num: number): this;
 
     /** Appends a new $sort operator to this aggregate pipeline. */
-    sort(arg: PipelineStage.Sort['$sort']): this;
+    sort(arg: string | PipelineStage.Sort['$sort']): this;
 
     /** Provides promise for aggregate. */
     then: Promise<R>['then'];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2500,7 +2500,7 @@ declare module 'mongoose' {
     $each: Type;
   };
 
-  type SortValues = -1 | 1 | 'asc' | 'desc';
+  type SortValues = -1 | 1 | 'asc' | 'ascending' | 'desc' | 'descending';
 
   type ArrayOperator<Type> = {
     $each: Type;
@@ -2790,7 +2790,7 @@ declare module 'mongoose' {
     skip(num: number): this;
 
     /** Appends a new $sort operator to this aggregate pipeline. */
-    sort(arg: string | PipelineStage.Sort['$sort']): this;
+    sort(arg: string | Record<string, SortValues> | PipelineStage.Sort['$sort']): this;
 
     /** Provides promise for aggregate. */
     then: Promise<R>['then'];


### PR DESCRIPTION
When using TypeScript, calling `model.aggregate().sort("-name")` generates the following error:

```
Argument of type 'string' is not assignable to parameter of type 'Record<string, 1 | -1 | { $meta: "textScore"; }>'
```

This PR also adds support for mongoose sort keywords: `asc`, `ascending`, `desc` and `descending` (according to the [current implementation](https://github.com/Automattic/mongoose/blob/18cb0bed7256784701d7b75e160707895a0e50db/lib/aggregate.js#L573) and  the mongoose docs).
