### PR TITLE
Impr: export and refactor types of PreMiddlewareFunction, PreSaveMiddlewareFunction, PostMiddlewareFunction, ErrorHandlingMiddlewareFunction

### DIFF
--- a/test/types/middleware.test.ts
+++ b/test/types/middleware.test.ts
@@ -1,9 +1,18 @@
-import { Schema, model, Model, Document, SaveOptions, Query, Aggregate, HydratedDocument } from 'mongoose';
+import { Schema, model, Model, Document, SaveOptions, Query, Aggregate, HydratedDocument, PreSaveMiddlewareFunction } from 'mongoose';
 import { expectError, expectType } from 'tsd';
 
 interface ITest extends Document {
   name?: string;
 }
+
+const preMiddlewareFn: PreSaveMiddlewareFunction<Document> = function(next, opts) {
+  this.$markValid('name');
+  if (opts.session) {
+    next();
+  } else {
+    next(new Error('Operation must be in Session.'));
+  }
+};
 
 const schema: Schema<ITest> = new Schema<ITest>({ name: { type: 'String' } });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1092,10 +1092,10 @@ declare module 'mongoose' {
   type IndexDirection = 1 | -1 | '2d' | '2dsphere' | 'geoHaystack' | 'hashed' | 'text';
   type IndexDefinition = Record<string, IndexDirection>;
 
-  type PreMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void) => void | Promise<void>;
-  type PreSaveMiddlewareFunction<T> = (this: T, next: (err?: CallbackError) => void, opts: SaveOptions) => void | Promise<void>;
-  type PostMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, res: ResType, next: (err?: CallbackError) => void) => void | Promise<void>;
-  type ErrorHandlingMiddlewareFunction<ThisType, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: (err?: CallbackError) => void) => void;
+  export type PreMiddlewareFunction<ThisType = any> = (this: ThisType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void>;
+  export type PreSaveMiddlewareFunction<ThisType = any> = (this: ThisType, next: CallbackWithoutResultAndOptionalError, opts: SaveOptions) => void | Promise<void>;
+  export type PostMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, res: ResType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void>;
+  export type ErrorHandlingMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: CallbackWithoutResultAndOptionalError) => void;
 
   class Schema<DocType = any, M = Model<DocType, any, any, any>, TInstanceMethods = any, TQueryHelpers = any> extends events.EventEmitter {
     /**
@@ -2942,6 +2942,7 @@ declare module 'mongoose' {
   type Callback<T = any> = (error: CallbackError, result: T) => void;
 
   type CallbackWithoutResult = (error: CallbackError) => void;
+  type CallbackWithoutResultAndOptionalError = (error?: CallbackError) => void;
 
   /* for ts-mongoose */
   class mquery {}


### PR DESCRIPTION
If I understood #11449 correctly, the ability to type the hook function is not given, because the types are not exposed.

