### PR TITLE
fix: add missing timeseries expiration handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           tar xf mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}.tgz
           mkdir -p ./data/db/27017 ./data/db/27000
           printf "\n--timeout 8000" >> ./test/mocha.opts
-          ./mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}/bin/mongod --fork --dbpath ./data/db/27017 --syslog --port 27017
+          ./mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
           sleep 2
           mongod --version
           echo `pwd`/mongodb-linux-x86_64-${{ matrix.mongo-os }}-${{ matrix.mongo }}/bin >> $GITHUB_PATH

--- a/lib/model.js
+++ b/lib/model.js
@@ -1375,6 +1375,12 @@ Model.createCollection = function createCollection(options, callback) {
   this.schema.options.timeseries;
   if (timeseries != null) {
     options = Object.assign({ timeseries }, options);
+    if (this.schema.options.expireAfterSeconds) {
+      options.expireAfterSeconds = this.schema.options.expireAfterSeconds;
+    } else if (this.schema.options.expires) {
+      options.expires = this.schema.options.expires;
+      utils.expires(options);
+    }
   }
 
   callback = this.$handleCallbackError(callback);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1375,9 +1375,13 @@ Model.createCollection = function createCollection(options, callback) {
   this.schema.options.timeseries;
   if (timeseries != null) {
     options = Object.assign({ timeseries }, options);
-    if (this.schema.options.expireAfterSeconds) {
+    if (options.expireAfterSeconds != null) {
+      // do nothing
+    } else if (options.expires != null) {
+      utils.expires(options);
+    } else if (this.schema.options.expireAfterSeconds != null) {
       options.expireAfterSeconds = this.schema.options.expireAfterSeconds;
-    } else if (this.schema.options.expires) {
+    } else if (this.schema.options.expires != null) {
       options.expires = this.schema.options.expires;
       utils.expires(options);
     }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6902,6 +6902,99 @@ describe('Model', function() {
       await Test.collection.drop().catch(() => {});
     });
 
+    it('createCollection() respects enforces expires (gh-11229)', async function() {
+      this.timeout(10000);
+      const version = await start.mongodVersion();
+      if (version[0] < 5) {
+        this.skip();
+        return;
+      }
+
+      const schema = Schema({ name: String, timestamp: Date, metadata: Object }, {
+        timeseries: {
+          timeField: 'timestamp',
+          metaField: 'metadata',
+          granularity: 'hours'
+        },
+        autoCreate: false,
+        expires: '5 seconds'
+      });
+
+      const Test = db.model('Test', schema);
+
+      await Test.collection.drop().catch(() => {});
+      await Test.createCollection();
+
+      await Test.insertMany([
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T00:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T04:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T16:00:00.000Z'),
+          temp: 16
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T20:00:00.000Z'),
+          temp: 15
+        }, {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T00:00:00.000Z'),
+          temp: 13
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T04:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T16:00:00.000Z'),
+          temp: 17
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T20:00:00.000Z'),
+          temp: 12
+        }
+      ]);
+
+      const beforeExpirationCount = await Test.count({});
+      assert.ok(beforeExpirationCount === 12);
+      await new Promise(resolve => setTimeout(resolve, 6000));
+      const afterExpirationCount = await Test.count({});
+      assert.ok(afterExpirationCount === 0);
+      await Test.collection.drop().catch(() => {});
+    });
+
     it('createCollection() handles NamespaceExists errors (gh-9447)', async function() {
       const userSchema = new Schema({ name: String });
       const Model = db.model('User', userSchema);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6809,7 +6809,191 @@ describe('Model', function() {
       await Test.collection.drop().catch(() => {});
     });
 
-    it('createCollection() respects enforces expireAfterSeconds (gh-11229)', async function() {
+    it('createCollection() enforces expireAfterSeconds (gh-11229)', async function() {
+      this.timeout(10000);
+      const version = await start.mongodVersion();
+      if (version[0] < 5) {
+        this.skip();
+        return;
+      }
+
+      const schema = Schema({ name: String, timestamp: Date, metadata: Object }, {
+        timeseries: {
+          timeField: 'timestamp',
+          metaField: 'metadata',
+          granularity: 'hours'
+        },
+        autoCreate: false
+      });
+
+      const Test = db.model('TestGH11229Var1', schema);
+
+      await Test.collection.drop().catch(() => {});
+      await Test.createCollection({ expireAfterSeconds: 5 });
+
+      await Test.insertMany([
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T00:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T04:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T16:00:00.000Z'),
+          temp: 16
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T20:00:00.000Z'),
+          temp: 15
+        }, {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T00:00:00.000Z'),
+          temp: 13
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T04:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T16:00:00.000Z'),
+          temp: 17
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T20:00:00.000Z'),
+          temp: 12
+        }
+      ]);
+
+      const beforeExpirationCount = await Test.count({});
+      assert.ok(beforeExpirationCount === 12);
+      await new Promise(resolve => setTimeout(resolve, 6000));
+      const afterExpirationCount = await Test.count({});
+      assert.ok(afterExpirationCount === 0);
+      await Test.collection.drop().catch(() => {});
+    });
+
+    it('createCollection() enforces expires (gh-11229)', async function() {
+      this.timeout(10000);
+      const version = await start.mongodVersion();
+      if (version[0] < 5) {
+        this.skip();
+        return;
+      }
+
+      const schema = Schema({ name: String, timestamp: Date, metadata: Object }, {
+        timeseries: {
+          timeField: 'timestamp',
+          metaField: 'metadata',
+          granularity: 'hours'
+        },
+        autoCreate: false
+      });
+
+      const Test = db.model('TestGH11229Var2', schema);
+
+      await Test.collection.drop().catch(() => {});
+      await Test.createCollection({ expires: '5 seconds' });
+
+      await Test.insertMany([
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T00:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T04:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T16:00:00.000Z'),
+          temp: 16
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T20:00:00.000Z'),
+          temp: 15
+        }, {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T00:00:00.000Z'),
+          temp: 13
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T04:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T16:00:00.000Z'),
+          temp: 17
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T20:00:00.000Z'),
+          temp: 12
+        }
+      ]);
+
+      const beforeExpirationCount = await Test.count({});
+      assert.ok(beforeExpirationCount === 12);
+      await new Promise(resolve => setTimeout(resolve, 6000));
+      const afterExpirationCount = await Test.count({});
+      assert.ok(afterExpirationCount === 0);
+      await Test.collection.drop().catch(() => {});
+    });
+
+    it('createCollection() enforces expireAfterSeconds when set by Schema (gh-11229)', async function() {
       this.timeout(10000);
       const version = await start.mongodVersion();
       if (version[0] < 5) {
@@ -6827,7 +7011,7 @@ describe('Model', function() {
         expireAfterSeconds: 5
       });
 
-      const Test = db.model('Test', schema);
+      const Test = db.model('TestGH11229Var3', schema);
 
       await Test.collection.drop().catch(() => {});
       await Test.createCollection();
@@ -6902,7 +7086,7 @@ describe('Model', function() {
       await Test.collection.drop().catch(() => {});
     });
 
-    it('createCollection() respects enforces expires (gh-11229)', async function() {
+    it('createCollection() enforces expires when set by Schema (gh-11229)', async function() {
       this.timeout(10000);
       const version = await start.mongodVersion();
       if (version[0] < 5) {
@@ -6920,7 +7104,7 @@ describe('Model', function() {
         expires: '5 seconds'
       });
 
-      const Test = db.model('Test', schema);
+      const Test = db.model('TestGH11229Var4', schema);
 
       await Test.collection.drop().catch(() => {});
       await Test.createCollection();

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6809,6 +6809,99 @@ describe('Model', function() {
       await Test.collection.drop().catch(() => {});
     });
 
+    it('createCollection() respects enforces expireAfterSeconds (gh-11229)', async function() {
+      this.timeout(10000);
+      const version = await start.mongodVersion();
+      if (version[0] < 5) {
+        this.skip();
+        return;
+      }
+
+      const schema = Schema({ name: String, timestamp: Date, metadata: Object }, {
+        timeseries: {
+          timeField: 'timestamp',
+          metaField: 'metadata',
+          granularity: 'hours'
+        },
+        autoCreate: false,
+        expireAfterSeconds: 5
+      });
+
+      const Test = db.model('Test', schema);
+
+      await Test.collection.drop().catch(() => {});
+      await Test.createCollection();
+
+      await Test.insertMany([
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T00:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T04:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T16:00:00.000Z'),
+          temp: 16
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-18T20:00:00.000Z'),
+          temp: 15
+        }, {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T00:00:00.000Z'),
+          temp: 13
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T04:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T08:00:00.000Z'),
+          temp: 11
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T12:00:00.000Z'),
+          temp: 12
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T16:00:00.000Z'),
+          temp: 17
+        },
+        {
+          metadata: { sensorId: 5578, type: 'temperature' },
+          timestamp: new Date('2021-05-19T20:00:00.000Z'),
+          temp: 12
+        }
+      ]);
+
+      const beforeExpirationCount = await Test.count({});
+      assert.ok(beforeExpirationCount === 12);
+      await new Promise(resolve => setTimeout(resolve, 6000));
+      const afterExpirationCount = await Test.count({});
+      assert.ok(afterExpirationCount === 0);
+      await Test.collection.drop().catch(() => {});
+    });
+
     it('createCollection() handles NamespaceExists errors (gh-9447)', async function() {
       const userSchema = new Schema({ name: String });
       const Model = db.model('User', userSchema);

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -206,3 +206,7 @@ function inheritance() {
     }
   }
 }
+
+Project.createCollection({ expires: '5 seconds' });
+Project.createCollection({ expireAfterSeconds: 5 });
+expectError(Project.createCollection({ expireAfterSeconds: '5 seconds' }));

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -287,3 +287,8 @@ function gh11448() {
 
   userSchema.pick<Pick<IUser, 'age'>>(['age']);
 }
+
+// timeSeries
+new Schema({}, { expires: '5 seconds' });
+expectError(new Schema({}, { expireAfterSeconds: '5 seconds' }));
+new Schema({}, { expireAfterSeconds: 5 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -659,8 +659,8 @@ declare module 'mongoose' {
      * mongoose will not create the collection for the model until any documents are
      * created. Use this method to create the collection explicitly.
      */
-    createCollection<T>(options?: mongodb.CreateCollectionOptions): Promise<mongodb.Collection<T>>;
-    createCollection<T>(options: mongodb.CreateCollectionOptions | null, callback: Callback<mongodb.Collection<T>>): void;
+    createCollection<T>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
+    createCollection<T>(options: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'> | null, callback: Callback<mongodb.Collection<T>>): void;
 
     /**
      * Similar to `ensureIndexes()`, except for it uses the [`createIndex`](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#createIndex)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1301,6 +1301,12 @@ declare module 'mongoose' {
     /** The timeseries option to use when creating the model's collection. */
     timeseries?: mongodb.TimeSeriesCollectionOptions;
 
+    /** The number of seconds after which a document in a timeseries collection expires. */
+    expireAfterSeconds?: number;
+
+    /** The time after which a document in a timeseries collection expires. */
+    expires?: number | string;
+
     /**
      * Mongoose by default produces a collection name by passing the model name to the utils.toCollectionName
      * method. This method pluralizes the name. Set this option if you need a different name for your collection.


### PR DESCRIPTION
Resolves #11229 

Didnt know if I should just add expiresAfterSeconds which does only pass through the value to createCollection or like we do it in indexes with expires where we also handle date strings. So I implemented both. Removing is easier than adding.

Added unit test