### PR TITLE
fix: Model.findOneAndReplace docs

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2861,8 +2861,10 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
 
   if (arguments.length === 1 && typeof filter === 'function') {
     const msg = 'Model.findOneAndReplace(): First argument must not be a function.\n\n'
-        + '  ' + this.modelName + '.findOneAndReplace(conditions, callback)\n'
-        + '  ' + this.modelName + '.findOneAndReplace(conditions)\n'
+        + '  ' + this.modelName + '.findOneAndReplace(filter, replacement, options, callback)\n'
+        + '  ' + this.modelName + '.findOneAndReplace(filter, replacement, callback)\n'
+        + '  ' + this.modelName + '.findOneAndReplace(filter, replacement)\n'
+        + '  ' + this.modelName + '.findOneAndReplace(filter, callback)\n'
         + '  ' + this.modelName + '.findOneAndReplace()\n';
     throw new TypeError(msg);
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -2836,11 +2836,11 @@ Model.findByIdAndDelete = function(id, options, callback) {
  *
  * ####Examples:
  *
- *     A.findOneAndReplace(conditions, options, callback) // executes
- *     A.findOneAndReplace(conditions, options)  // return Query
- *     A.findOneAndReplace(conditions, callback) // executes
- *     A.findOneAndReplace(conditions) // returns Query
- *     A.findOneAndReplace()           // returns Query
+ *     A.findOneAndReplace(filter, replacement, options, callback) // executes
+ *     A.findOneAndReplace(filter, replacement, options)  // return Query
+ *     A.findOneAndReplace(filter, replacement, callback) // executes
+ *     A.findOneAndReplace(filter, replacement) // returns Query
+ *     A.findOneAndReplace()                    // returns Query
  *
  * @param {Object} filter Replace the first document that matches this filter
  * @param {Object} [replacement] Replace with this document


### PR DESCRIPTION
**Summary**
The `Model.findOneAndReplace` examples had the wrong params passed to them.
`conditions` instead of `filter` and `replacement`.

**Example**
```javascript
A.findOneAndReplace(conditions)
```

When in reality it should be:
```javascript
A.findOneAndReplace(filter, replacement)
```