### PR TITLE
Address gh-11515, improve in-practice runtime to insert clean boolean data, and improve source code readability

### DIFF
--- a/lib/cast/boolean.js
+++ b/lib/cast/boolean.js
@@ -14,6 +14,11 @@ const CastError = require('../error/cast');
  */
 
 module.exports = function castBoolean(value, path) {
+  // Relevant test files: schematype.cast.test.js and schematype.test.js and schema.boolean.test.js
+  // David Xie: speed up in-practice runtime for clean input (user always pass a boolean-typed value in), as creating an object takes "large amount of "time
+  if (typeof value === 'boolean') {
+    return value;
+  }
   if (module.exports.convertToTrue.has(value)) {
     return true;
   }

--- a/lib/error/serverSelection.js
+++ b/lib/error/serverSelection.js
@@ -12,13 +12,13 @@ const isSSLError = require('../helpers/topology/isSSLError');
 /*!
  * ignore
  */
-
-const atlasMessage = 'Could not connect to any servers in your MongoDB Atlas cluster. ' +
+// David Xie: making variable names more self-evident, and change the MongoDB Atlas URL due to a 30* redirect on old URL
+const atlasErrMsg = 'Could not connect to any servers in your MongoDB Atlas cluster. ' +
   'One common reason is that you\'re trying to access the database from ' +
   'an IP that isn\'t whitelisted. Make sure your current IP address is on your Atlas ' +
-  'cluster\'s IP whitelist: https://docs.atlas.mongodb.com/security-whitelist/';
+  'cluster\'s IP whitelist: https://docs.atlas.mongodb.com/security/ip-access-list/';
 
-const sslMessage = 'Mongoose is connecting with SSL enabled, but the server is ' +
+const sslErrMsg = 'Mongoose is connecting with SSL enabled, but the server is ' +
   'not accepting SSL connections. Please ensure that the MongoDB server you are ' +
   'connecting to is configured to accept SSL connections. Learn more: ' +
   'https://mongoosejs.com/docs/tutorials/ssl.html';
@@ -34,13 +34,13 @@ class MongooseServerSelectionError extends MongooseError {
     // Special message for a case that is likely due to IP whitelisting issues.
     const isAtlasWhitelistError = isAtlas(reason) &&
       allServersUnknown(reason) &&
-      err.message.indexOf('bad auth') === -1 &&
-      err.message.indexOf('Authentication failed') === -1;
+      !err.message.includes('bad auth') && // David Xie: using String.includes() is more self-evident (compared to String.indexOf() === -1)
+      !err.message.includes('Authentication failed');
 
     if (isAtlasWhitelistError) {
-      this.message = atlasMessage;
+      this.message = atlasErrMsg;
     } else if (isSSLError(reason)) {
-      this.message = sslMessage;
+      this.message = sslErrMsg;
     } else {
       this.message = err.message;
     }

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -112,10 +112,6 @@ function clone(obj, options, isArrayChild) {
 }
 module.exports = clone;
 
-/*!
- * ignore
- */
-
 function cloneObject(obj, options, isArrayChild) {
   const minimize = options && options.minimize;
   const ret = {};

--- a/lib/helpers/pluralize.js
+++ b/lib/helpers/pluralize.js
@@ -6,31 +6,36 @@ module.exports = pluralize;
  * Pluralization rules.
  */
 
+// David Xie: rebase pluralization rules from pluralize.js committed on Oct 6, 2021
+// License of pluralize.js: MIT License
+// Commit: https://github.com/plurals/pluralize/blob/36f03cd2d573fa6d23e12e1529fa4627e2af74b4/pluralize.js
+
 exports.pluralization = [
-  [/(m)an$/gi, '$1en'],
-  [/(pe)rson$/gi, '$1ople'],
-  [/(child)$/gi, '$1ren'],
-  [/^(ox)$/gi, '$1en'],
-  [/(ax|test)is$/gi, '$1es'],
-  [/(octop|vir)us$/gi, '$1i'],
-  [/(alias|status)$/gi, '$1es'],
-  [/(bu)s$/gi, '$1ses'],
-  [/(buffal|tomat|potat)o$/gi, '$1oes'],
-  [/([ti])um$/gi, '$1a'],
-  [/sis$/gi, 'ses'],
-  [/(?:([^f])fe|([lr])f)$/gi, '$1$2ves'],
-  [/(hive)$/gi, '$1s'],
-  [/([^aeiouy]|qu)y$/gi, '$1ies'],
-  [/(x|ch|ss|sh)$/gi, '$1es'],
-  [/(matr|vert|ind)ix|ex$/gi, '$1ices'],
-  [/([m|l])ouse$/gi, '$1ice'],
-  [/(kn|w|l)ife$/gi, '$1ives'],
-  [/(quiz)$/gi, '$1zes'],
-  [/^goose$/i, 'geese'],
-  [/s$/gi, 's'],
-  [/([^a-z])$/, '$1'],
-  [/$/gi, 's']
-];
+  [/s?$/i, 's'],
+  [/([^aeiou]ese)$/i, '$1'],
+  [/(ax|test)is$/i, '$1es'],
+  [/(alias|[^aou]us|t[lm]as|gas|ris)$/i, '$1es'],
+  [/(e[mn]u)s?$/i, '$1s'],
+  [/([^l]ias|[aeiou]las|[ejzr]as|[iu]am)$/i, '$1'],
+  [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i'],
+  [/(alumn|alg|vertebr)(?:a|ae)$/i, '$1ae'],
+  [/(seraph|cherub)(?:im)?$/i, '$1im'],
+  [/(her|at|gr)o$/i, '$1oes'],
+  [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|automat|quor)(?:a|um)$/i, '$1a'],
+  [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)(?:a|on)$/i, '$1a'],
+  [/sis$/i, 'ses'],
+  [/(?:(kni|wi|li)fe|(ar|l|ea|eo|oa|hoo)f)$/i, '$1$2ves'],
+  [/([^aeiouy]|qu)y$/i, '$1ies'],
+  [/([^ch][ieo][ln])ey$/i, '$1ies'],
+  [/(x|ch|ss|sh|zz)$/i, '$1es'],
+  [/(matr|cod|mur|sil|vert|ind|append)(?:ix|ex)$/i, '$1ices'],
+  [/\b((?:tit)?m|l)(?:ice|ouse)$/i, '$1ice'],
+  [/(pe)(?:rson|ople)$/i, '$1ople'],
+  [/(child)(?:ren)?$/i, '$1ren'],
+  [/eaux$/i, '$0'],
+  [/m[ae]n$/i, 'men'],
+  ['thou', 'you']
+].reverse(); // pluralize.js lists pluralization rules in the reverse order
 const rules = exports.pluralization;
 
 /**
@@ -41,33 +46,109 @@ const rules = exports.pluralization;
  */
 
 exports.uncountables = [
+  // Singular words with no plurals.
+  'adulthood',
   'advice',
-  'energy',
-  'excretion',
-  'digestion',
+  'agenda',
+  'aid',
+  'aircraft',
+  'alcohol',
+  'ammo',
+  'analytics',
+  'anime',
+  'athletics',
+  'audio',
+  'bison',
+  'blood',
+  'bream',
+  'buffalo',
+  'butter',
+  'carp',
+  'cash',
+  'chassis',
+  'chess',
+  'clothing',
+  'cod',
+  'commerce',
   'cooperation',
-  'health',
-  'justice',
-  'labour',
-  'machinery',
+  'corps',
+  'debris',
+  'diabetes',
+  'digestion',
+  'elk',
+  'energy',
   'equipment',
-  'information',
-  'pollution',
-  'sewage',
-  'paper',
-  'money',
-  'species',
-  'series',
-  'rain',
-  'rice',
-  'fish',
-  'sheep',
-  'moose',
-  'deer',
-  'news',
+  'excretion',
   'expertise',
-  'status',
-  'media'
+  'firmware',
+  'flounder',
+  'fun',
+  'gallows',
+  'garbage',
+  'graffiti',
+  'hardware',
+  'headquarters',
+  'health',
+  'herpes',
+  'highjinks',
+  'homework',
+  'housework',
+  'information',
+  'jeans',
+  'justice',
+  'kudos',
+  'labour',
+  'literature',
+  'machinery',
+  'mackerel',
+  'mail',
+  'media',
+  'mews',
+  'moose',
+  'music',
+  'mud',
+  'manga',
+  'news',
+  'only',
+  'personnel',
+  'pike',
+  'plankton',
+  'pliers',
+  'police',
+  'pollution',
+  'premises',
+  'rain',
+  'research',
+  'rice',
+  'salmon',
+  'scissors',
+  'series',
+  'sewage',
+  'shambles',
+  'shrimp',
+  'software',
+  'staff',
+  'swine',
+  'tennis',
+  'traffic',
+  'transportation',
+  'trout',
+  'tuna',
+  'wealth',
+  'welfare',
+  'whiting',
+  'wildebeest',
+  'wildlife',
+  'you',
+  /pok[eé]mon$/i,
+  // Regexes.
+  /[^aeiou]ese$/i, // "chinese", "japanese"
+  /deer$/i, // "deer", "reindeer"
+  /fish$/i, // "fish", "blowfish", "angelfish"
+  /measles$/i,
+  /o[iu]s$/i, // "carnivorous"
+  /pox$/i, // "chickpox", "smallpox"
+  /sheep$/i
 ];
 const uncountables = exports.uncountables;
 
@@ -79,7 +160,20 @@ const uncountables = exports.uncountables;
  * @api private
  */
 
+// David Xie: rebase rules from pluralize.js
+// Test file: test/helpers/pluralize.test.js
 function pluralize(str) {
+  // Support regex singular rules (aids rebasing from pluralize.js files)
+  const uncountablesLocal = new Set();
+  function parseUncountables(word) {
+    if (typeof word === 'string') {
+      uncountablesLocal.add(word.toLowerCase());
+      return;
+    }
+    rules.unshift([word, '$0']);
+  }
+  uncountables.forEach((word) => parseUncountables(word));
+
   let found;
   str = str.toLowerCase();
   if (!~uncountables.indexOf(str)) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -305,28 +305,19 @@ Schema.prototype.paths;
 Schema.prototype.tree;
 
 /**
- * Returns a deep copy of the schema
- *
- * ####Example:
- *
- *     const schema = new Schema({ name: String });
- *     const clone = schema.clone();
- *     clone === schema; // false
- *     clone.path('name'); // SchemaString { ... }
- *
  * @return {Schema} the cloned schema
  * @api public
  * @memberOf Schema
  * @instance
  */
 
-Schema.prototype.clone = function() {
-  const s = this._clone();
+Schema.prototype.clone = function schemaDeepCopy() {
+  const s = this._clone(); // clone === schema returns false
 
   // Bubble up `init` for backwards compat
-  s.on('init', v => this.emit('init', v));
+  schema.on('init', v => this.emit('init', v));
 
-  return s;
+  return schema;
 };
 
 /*!

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -333,45 +333,69 @@ Schema.prototype.clone = function() {
  * ignore
  */
 
+// Related test file: test/schema.test.js
 Schema.prototype._clone = function _clone(Constructor) {
   Constructor = Constructor || (this.base == null ? Schema : this.base.Schema);
-
   const s = new Constructor({}, this._userProvidedOptions);
-  s.base = this.base;
-  s.obj = this.obj;
-  s.options = utils.clone(this.options);
-  s.callQueue = this.callQueue.map(function(f) { return f; });
-  s.methods = utils.clone(this.methods);
-  s.methodOptions = utils.clone(this.methodOptions);
-  s.statics = utils.clone(this.statics);
-  s.query = utils.clone(this.query);
-  s.plugins = Array.prototype.slice.call(this.plugins);
-  s._indexes = utils.clone(this._indexes);
+
+  // David Xie: simplify repeated use of similar syntaxes
+  const directAssignmentKeys = ['base', 'obj', '$globalPluginsApplied', '$isRootDiscriminator', '$implicitlyCreated', '$id'];
+  directAssignmentKeys.forEach((element) => {
+    s[element] = this[element]; // Example: s.base = this.base;
+  });
+
+  const keysToUtilClone = ['options', 'methods', 'methodOptions', 'statics', 'query', '_indexes',
+    'tree', 'paths', 'nested', 'subpaths', 'singleNestedPaths',
+    'virtuals'];
+  keysToUtilClone.forEach((element) => {
+    s[element] = utils.clone(this[element]); // Example: s.options = utils.clone(this.options);
+  });
+
+  const arrayDeepCopy = ['callQueue', 'plugins', 'mapPaths'];
+  // ECMAScript2018 way to deep copy an array, using spread operator
+  arrayDeepCopy.forEach((element) => {
+    s[element] = [...this[element]]; // Example: s.callQueue = [...this.callQueue];
+  });
+
+  // s.base = this.base;
+  // s.obj = this.obj;
+  // s.options = utils.clone(this.options);
+  // s.callQueue = this.callQueue.map(function(f) { return f; }); // Refactored to arrayDeepCopy
+  // s.methods = utils.clone(this.methods);
+  // s.methodOptions = utils.clone(this.methodOptions);
+  // s.statics = utils.clone(this.statics);
+  // s.query = utils.clone(this.query);
+  // s.plugins = Array.prototype.slice.call(this.plugins); // Refactored to arrayDeepCopy
+  // s._indexes = utils.clone(this._indexes);
   s.s.hooks = this.s.hooks.clone();
 
-  s.tree = utils.clone(this.tree);
-  s.paths = utils.clone(this.paths);
-  s.nested = utils.clone(this.nested);
-  s.subpaths = utils.clone(this.subpaths);
-  s.singleNestedPaths = utils.clone(this.singleNestedPaths);
+  // s.tree = utils.clone(this.tree);
+  // s.paths = utils.clone(this.paths);
+  // s.nested = utils.clone(this.nested);
+  // s.subpaths = utils.clone(this.subpaths);
+  // s.singleNestedPaths = utils.clone(this.singleNestedPaths);
   s.childSchemas = gatherChildSchemas(s);
 
-  s.virtuals = utils.clone(this.virtuals);
-  s.$globalPluginsApplied = this.$globalPluginsApplied;
-  s.$isRootDiscriminator = this.$isRootDiscriminator;
-  s.$implicitlyCreated = this.$implicitlyCreated;
+  // s.virtuals = utils.clone(this.virtuals);
+  // s.$globalPluginsApplied = this.$globalPluginsApplied;
+  // s.$isRootDiscriminator = this.$isRootDiscriminator;
+  // s.$implicitlyCreated = this.$implicitlyCreated;
   s.$id = ++id;
-  s.$originalSchemaId = this.$id;
-  s.mapPaths = [].concat(this.mapPaths);
+  // s.$originalSchemaId = this.$id;
+  // s.mapPaths = [].concat(this.mapPaths); // Refactored to arrayDeepCopy
 
   if (this.discriminatorMapping != null) {
-    s.discriminatorMapping = Object.assign({}, this.discriminatorMapping);
+    // ECMAScript2018 way to copy an object, using spread operator instead of Object.assign({}, sourceObj);
+    s.discriminatorMapping = { ... this.discriminatorMapping };
+    // s.discriminatorMapping = Object.assign({}, this.discriminatorMapping);
   }
   if (this.discriminators != null) {
-    s.discriminators = Object.assign({}, this.discriminators);
+    s.discriminators = { ... this.discriminators };
+    // s.discriminators = Object.assign({}, this.discriminators);
   }
 
-  s.aliases = Object.assign({}, this.aliases);
+  s.aliases = { ... this.aliases };
+  // s.aliases = Object.assign({}, this.aliases);
 
   return s;
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -312,7 +312,7 @@ Schema.prototype.tree;
  */
 
 Schema.prototype.clone = function schemaDeepCopy() {
-  const s = this._clone(); // clone === schema returns false
+  const schema = this._clone(); // clone === schema returns false
 
   // Bubble up `init` for backwards compat
   schema.on('init', v => this.emit('init', v));

--- a/test/helpers/pluralize.test.js
+++ b/test/helpers/pluralize.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const pluralize = require('../../lib/helpers/pluralize');
+
+// David Xie: test pluralization rules (re: gh-11515)
+// https://github.com/Automattic/mongoose/issues/11515
+
+// six => sixes
+// sex => sexes
+// vertex => vertices
+// Index => indices (David Xie's fix)
+describe('pluralize.js testings', function() {
+  it('Pluralize words', function(done) {
+    const original = ['six', 'sex', 'vertex', 'Index'];
+    const plurals = original.map((element) => pluralize(element));
+    const expected = ['sixes', 'sexes', 'vertices', 'indices'];
+    assert.deepStrictEqual(plurals, expected);
+    done();
+  });
+});

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -23,11 +23,11 @@ const schema = new Schema({
 describe('model', function() {
   describe('create()', function() {
     let db;
-    let B;
+    let testModel;
 
     before(function() {
       db = start();
-      B = db.model('Test', schema);
+      testModel = db.model('Test', schema);
     });
 
     after(async function() {
@@ -35,7 +35,7 @@ describe('model', function() {
     });
 
     it('accepts an array and returns an array', async function() {
-      const posts = await B.create([{ title: 'hi' }, { title: 'bye' }]);
+      const posts = await testModel.create([{ title: 'hi' }, { title: 'bye' }]);
 
       assert.ok(posts instanceof Array);
       assert.equal(posts.length, 2);
@@ -49,7 +49,7 @@ describe('model', function() {
     });
 
     it('fires callback when passed 0 docs', function(done) {
-      B.create(function(err, a) {
+      testModel.create(function(err, a) {
         assert.ifError(err);
         assert.ok(!a);
         done();
@@ -57,7 +57,7 @@ describe('model', function() {
     });
 
     it('fires callback when empty array passed', function(done) {
-      B.create([], function(err, a) {
+      testModel.create([], function(err, a) {
         assert.ifError(err);
         assert.deepEqual(a, []);
         done();
@@ -65,15 +65,15 @@ describe('model', function() {
     });
 
     it('supports passing options', async function() {
-      const docs = await B.create([{}], { validateBeforeSave: false });
+      const docs = await testModel.create([{}], { validateBeforeSave: false });
 
       assert.ok(Array.isArray(docs));
       assert.equal(docs.length, 1);
     });
 
     it('returns a promise', function() {
-      const p = B.create({ title: 'returns promise' });
-      assert.ok(p instanceof mongoose.Promise);
+      const returnPromise = testModel.create({ title: 'returns promise' });
+      assert.ok(returnPromise instanceof mongoose.Promise);
     });
 
     it('creates in parallel', async function() {
@@ -123,13 +123,13 @@ describe('model', function() {
 
     describe('callback is optional', function() {
       it('with one doc', async function() {
-        const doc = await B.create({ title: 'optional callback' });
+        const doc = await testModel.create({ title: 'optional callback' });
 
         assert.equal(doc.title, 'optional callback');
       });
 
       it('with more than one doc', async function() {
-        const docs = await B.create({ title: 'optional callback 2' }, { title: 'orient expressions' });
+        const docs = await testModel.create({ title: 'optional callback 2' }, { title: 'orient expressions' });
 
         assert.equal(docs.length, 2);
         const doc1 = docs[0];
@@ -139,7 +139,7 @@ describe('model', function() {
       });
 
       it('with array of docs', async function() {
-        const docs = await B.create([{ title: 'optional callback3' }, { title: '3' }]);
+        const docs = await testModel.create([{ title: 'optional callback3' }, { title: '3' }]);
 
         assert.ok(docs instanceof Array);
         assert.equal(docs.length, 2);
@@ -150,15 +150,15 @@ describe('model', function() {
       });
 
       it('and should reject promise on error', async function() {
-        const p = B.create({ title: 'optional callback 4' });
-        const doc = await p;
+        const callback = testModel.create({ title: 'optional callback 4' });
+        const doc = await callback;
 
-        const err = await B.create({ _id: doc._id }).then(() => null, err => err);
+        const err = await testModel.create({ _id: doc._id }).then(() => null, err => err);
         assert(err);
       });
 
       it('if callback is falsy, will ignore it (gh-5061)', async function() {
-        const doc = await B.create({ title: 'test' }, null);
+        const doc = await testModel.create({ title: 'test' }, null);
 
         assert.equal(doc.title, 'test');
       });
@@ -172,7 +172,7 @@ describe('model', function() {
       });
 
       it('treats undefined first arg as doc rather than callback (gh-9765)', function() {
-        return B.create(void 0).
+        return testModel.create(void 0).
           then(function(doc) {
             assert.ok(doc);
             assert.ok(doc._id);

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -30,6 +30,7 @@ describe('schematype', function() {
       assert.strictEqual(true, m3.b);
       done();
     });
+    // David Xie: add new test suite below
     it('should cast truthy strings & numbers to true', function(done) {
       // Check whether a truthy String value can be casted to true
       const s4 = new Schema({ b: { type: Boolean, default: 'yes' } });
@@ -44,6 +45,7 @@ describe('schematype', function() {
       assert.strictEqual(true, m5.b);
       done();
     });
+    // David Xie: add new test suite below
     it('should throw an error for values that can\'t be casted to a boolean value (without custom boolean casting declaration)', async function() {
       const s6 = new Schema({ b: Boolean });
       const M6 = mongoose.model('Test6', s6);

--- a/test/schema.boolean.test.js
+++ b/test/schema.boolean.test.js
@@ -30,5 +30,31 @@ describe('schematype', function() {
       assert.strictEqual(true, m3.b);
       done();
     });
+    it('should cast truthy strings & numbers to true', function(done) {
+      // Check whether a truthy String value can be casted to true
+      const s4 = new Schema({ b: { type: Boolean, default: 'yes' } });
+      const M4 = mongoose.model('Test4', s4);
+      // Check whether a truthy number can be casted to true
+      const s5 = new Schema({ b: { type: Boolean, default: 1 } });
+      const M5 = mongoose.model('Test5', s5);
+
+      const m4 = new M4();
+      assert.strictEqual(true, m4.b);
+      const m5 = new M5();
+      assert.strictEqual(true, m5.b);
+      done();
+    });
+    it('should throw an error for values that can\'t be casted to a boolean value (without custom boolean casting declaration)', async function() {
+      const s6 = new Schema({ b: Boolean });
+      const M6 = mongoose.model('Test6', s6);
+      let threw = false;
+      try {
+        const newRow = new M6({ b: 'sí' });
+        await newRow.save();
+      } catch (error) {
+        threw = true;
+      }
+      assert.ok(threw);
+    });
   });
 });


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory.

**Summary**

Solves gh-11515 (https://github.com/Automattic/mongoose/issues/11515) pluralization concern by rebasing from pluralize.js module (MIT license, [commit](https://github.com/plurals/pluralize/blob/36f03cd2d573fa6d23e12e1529fa4627e2af74b4/pluralize.js)), along with test suite.

Improved in-practice runtime to insert clean boolean data by skipping Set creations if the input is a boolean-typed value.

Extracted similar operations in `Schema._clone()` function to declutter the code.

`test/model.create.test.js`: renamed variables

`lib/helpers/clone.js`: removed confusing comment

`lib/schema.js`: fixed variable name and changed function name for better readability

**Examples**

Added tests for the improved pluralization (gh-11515) code.

Added tests that validates casting values to boolean.


