### PR TITLE
Add strictPopulate type to PopulateOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -709,6 +709,8 @@ declare module 'mongoose' {
     model?: string | Model<any>;
     /** optional query options like sort, limit, etc */
     options?: any;
+    /** optional boolean, set to `false` to allow populating paths that aren't in the schema */
+    strictPopulate?: boolean;
     /** deep populate */
     populate?: string | PopulateOptions | (string | PopulateOptions)[];
     /**


### PR DESCRIPTION
Added strictPopulate to PopulateOptions, otherwise given option can't be used in TS projects when enforcing types.

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
When using populate in mongoose 6, the types for populate options might've been overlooked. ```PopulateOptions``` interface is missing `strictPopulate` prop, so I added one, with description from the doc. Otherwise I can't use populate with given option.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
```
await DocumentModel.findById('some_id')
  .populate({
    match: { somePath: { $ne: undefined } } 
    path: 'somePath',
    strictPopulate: false
  })
```
Previously this was not allowed in typescript dev environment due to enforcing of types, and a type error was thrown.
Now I added the respective type and all works.


***For future reference***
It seems that the `options?: any` seems to be unnecessary and wrongfully referring to _`options.options`_. But when we look at the current codebase with `strictPopulate` for example, then the value will be taken from `options.strictPopulate`, not _`options.options.strictPopulate`_. 

TL;DR I'd suggest removing the `options?: any` from the `PopulateOptions` entirely and replace it with the specific options (i.e. strictPopulate, like in this PR)