### PR TITLE
Feature: Infer schema type automatically.

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -143,9 +143,18 @@ We may also define our own custom document instance methods.
 
 ```javascript
 // define a schema
-const animalSchema = new Schema({ name: String, type: String });
+const animalSchema = new Schema({ name: String, type: String },
+{
+  // Assign a function to the "methods" object of our animalSchema through schema options.
+  // this approach support auto typed instance methods then no need to create separate TS types. 
+  methods:{
+    findSimilarTypes(cb){
+      return mongoose.model('Animal').find({ type: this.type }, cb);
+    }
+  }
+});
 
-// assign a function to the "methods" object of our animalSchema
+// Or, assign a function to the "methods" object of our animalSchema
 animalSchema.methods.findSimilarTypes = function(cb) {
   return mongoose.model('Animal').find({ type: this.type }, cb);
 };
@@ -169,14 +178,28 @@ dog.findSimilarTypes((err, dogs) => {
 
 <h3 id="statics"><a href="#statics">Statics</a></h3>
 
-You can also add static functions to your model. There are two equivalent
+You can also add static functions to your model. There are three equivalent
 ways to add a static:
 
+- Add a function property to schema constructor second argument `statics`
 - Add a function property to `schema.statics`
 - Call the [`Schema#static()` function](/docs/api.html#schema_Schema-static)
 
 ```javascript
-// Assign a function to the "statics" object of our animalSchema
+
+// define a schema
+const animalSchema = new Schema({ name: String, type: String },
+{
+  // Assign a function to the "statics" object of our animalSchema through schema options.
+  // this approach support auto typed static methods then no need to create separate TS types. 
+  statics:{
+    findByName(name){
+      return this.find({ name: new RegExp(name, 'i') });
+    }
+  }
+});
+
+// Or, Assign a function to the "statics" object of our animalSchema
 animalSchema.statics.findByName = function(name) {
   return this.find({ name: new RegExp(name, 'i') });
 };
@@ -197,6 +220,20 @@ but for mongoose queries. Query helper methods let you extend mongoose's
 [chainable query builder API](./queries.html).
 
 ```javascript
+
+// define a schema
+const animalSchema = new Schema({ name: String, type: String },
+{
+  // Assign a function to the "query" object of our animalSchema through schema options.
+  // this approach support auto typed query helpers methods then no need to create separate TS types. 
+  statics:{
+    byName(name){
+      return this.where({ name: new RegExp(name, 'i') })
+    }
+  }
+});
+
+// Or, Assign a function to the "query" object of our animalSchema
 animalSchema.query.byName = function(name) {
   return this.where({ name: new RegExp(name, 'i') })
 };
@@ -409,6 +446,7 @@ Valid options:
 - [read](#read)
 - [writeConcern](#writeConcern)
 - [shardKey](#shardKey)
+- [statics](#statics)
 - [strict](#strict)
 - [strictQuery](#strictQuery)
 - [toJSON](#toJSON)
@@ -423,6 +461,8 @@ Valid options:
 - [skipVersioning](#skipVersioning)
 - [timestamps](#timestamps)
 - [storeSubdocValidationError](#storeSubdocValidationError)
+- [methods](#methods)
+- [query](#query-helpers)
 
 <h3 id="autoIndex"><a href="#autoIndex">option: autoIndex</a></h3>
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -146,7 +146,7 @@ We may also define our own custom document instance methods.
 const animalSchema = new Schema({ name: String, type: String },
 {
   // Assign a function to the "methods" object of our animalSchema through schema options.
-  // this approach support auto typed instance methods then no need to create separate TS types. 
+  // By following this approach, there is no need to create a separate TS type to define the type of the instance functions.
   methods:{
     findSimilarTypes(cb){
       return mongoose.model('Animal').find({ type: this.type }, cb);
@@ -181,7 +181,7 @@ dog.findSimilarTypes((err, dogs) => {
 You can also add static functions to your model. There are three equivalent
 ways to add a static:
 
-- Add a function property to schema constructor second argument `statics`
+- Add a function property to the second argument of the schema-constructor (`statics`)
 - Add a function property to `schema.statics`
 - Call the [`Schema#static()` function](/docs/api.html#schema_Schema-static)
 
@@ -191,7 +191,7 @@ ways to add a static:
 const animalSchema = new Schema({ name: String, type: String },
 {
   // Assign a function to the "statics" object of our animalSchema through schema options.
-  // this approach support auto typed static methods then no need to create separate TS types. 
+  // By following this approach, there is no need to create a separate TS type to define the type of the statics functions. 
   statics:{
     findByName(name){
       return this.find({ name: new RegExp(name, 'i') });
@@ -225,8 +225,8 @@ but for mongoose queries. Query helper methods let you extend mongoose's
 const animalSchema = new Schema({ name: String, type: String },
 {
   // Assign a function to the "query" object of our animalSchema through schema options.
-  // this approach support auto typed query helpers methods then no need to create separate TS types. 
-  statics:{
+  // By following this approach, there is no need to create a separate TS type to define the type of the query functions. 
+  query:{
     byName(name){
       return this.where({ name: new RegExp(name, 'i') })
     }

--- a/docs/typescript/query-helpers.md
+++ b/docs/typescript/query-helpers.md
@@ -14,7 +14,7 @@ var Project = mongoose.model('Project', ProjectSchema);
 Project.find().where('stars').gt(1000).byName('mongoose');
 ```
 
-In TypeScript, Mongoose does support manually typed & auto typed Query Helpers.
+In TypeScript, Mongoose does support manually typed and automatically typed Query Helpers.
 
 1- Manually typed:
 Mongoose's `Model` takes 3 generic parameters:
@@ -64,7 +64,7 @@ async function run(): Promise<void> {
 ```
 
 2- Automatically typed:
-Mongoose does support auto typed Query Helpers that it is supplied in schema options.
+Mongoose does support auto typed Query Helpers that it are supplied in schema options.
 Query Helpers functions can be defined as following:
 
 ```typescript

--- a/docs/typescript/query-helpers.md
+++ b/docs/typescript/query-helpers.md
@@ -14,7 +14,10 @@ var Project = mongoose.model('Project', ProjectSchema);
 Project.find().where('stars').gt(1000).byName('mongoose');
 ```
 
-In TypeScript, Mongoose's `Model` takes 3 generic parameters:
+In TypeScript, Mongoose does support manually typed & auto typed Query Helpers.
+
+1- Manually typed:
+Mongoose's `Model` takes 3 generic parameters:
 
 1. The `DocType`
 2. a `TQueryHelpers` type
@@ -55,6 +58,34 @@ run().catch(err => console.log(err));
 async function run(): Promise<void> {
   await connect('mongodb://localhost:27017/test');
   
+  // Equivalent to `ProjectModel.find({ stars: { $gt: 1000 }, name: 'mongoose' })`
+  await ProjectModel.find().where('stars').gt(1000).byName('mongoose');
+}
+```
+
+2- Automatically typed:
+Mongoose V6.3.2 does support auto typed Query Helpers that it is supplied in schema options.
+Query Helpers functions can be defined as following:
+
+```typescript
+import { Schema, model } from 'mongoose';
+
+  const schema = new Schema({
+    name: { type: String, required: true },
+    stars: { type: Number, required: true }
+  }, {
+    query: {
+      byName(name) {
+        return this.find({ name: name });
+      }
+    }
+  });
+
+  const ProjectModel = model(
+    'Project',
+    schema
+  );
+
   // Equivalent to `ProjectModel.find({ stars: { $gt: 1000 }, name: 'mongoose' })`
   await ProjectModel.find().where('stars').gt(1000).byName('mongoose');
 }

--- a/docs/typescript/query-helpers.md
+++ b/docs/typescript/query-helpers.md
@@ -64,7 +64,7 @@ async function run(): Promise<void> {
 ```
 
 2- Automatically typed:
-Mongoose V6.3.2 does support auto typed Query Helpers that it is supplied in schema options.
+Mongoose does support auto typed Query Helpers that it is supplied in schema options.
 Query Helpers functions can be defined as following:
 
 ```typescript

--- a/docs/typescript/schemas.md
+++ b/docs/typescript/schemas.md
@@ -8,7 +8,7 @@ Mongoose released new TS utility `InferSchemaType` that helps to get the type of
 `Until mongoose V6.3.1:`
 
 ```typescript
-import { Schema } from "mongoose";
+import { Schema } from 'mongoose';
 
 // Document interface
 interface User {
@@ -21,14 +21,14 @@ interface User {
 const schema = new Schema<User>({
   name: { type: String, required: true },
   email: { type: String, required: true },
-  avatar: String,
+  avatar: String
 });
 ```
 
 `another approach:`
 
 ```typescript
-import { Schema, InferSchemaType } from "mongoose";
+import { Schema, InferSchemaType } from 'mongoose';
 
 // Document interface
 // No needs to define TS interface any more.
@@ -42,7 +42,7 @@ import { Schema, InferSchemaType } from "mongoose";
 const schema = new Schema({
   name: { type: String, required: true },
   email: { type: String, required: true },
-  avatar: String,
+  avatar: String
 });
 
 type User = InferSchemaType<typeof schema>;
@@ -86,7 +86,7 @@ Mongoose wraps `DocType` in a Mongoose document for cases like the `this` parame
 For example:
 
 ```typescript
-schema.pre("save", function (): void {
+schema.pre('save', function (): void {
   console.log(this.name); // TypeScript knows that `this` is a `mongoose.Document & User` by default
 });
 ```
@@ -104,7 +104,7 @@ Mongoose checks to make sure that every path in your schema is defined in your d
 For example, the below code will fail to compile because `emaill` is a path in the schema, but not in the `DocType` interface.
 
 ```typescript
-import { Schema, Model } from "mongoose";
+import { Schema, Model } from 'mongoose';
 
 interface User {
   name: string;
@@ -117,7 +117,7 @@ interface User {
 const schema = new Schema<User>({
   name: { type: String, required: true },
   emaill: { type: String, required: true },
-  avatar: String,
+  avatar: String
 });
 ```
 
@@ -125,7 +125,7 @@ However, Mongoose does **not** check for paths that exist in the document interf
 For example, the below code compiles.
 
 ```typescript
-import { Schema, Model } from "mongoose";
+import { Schema, Model } from 'mongoose';
 
 interface User {
   name: string;
@@ -148,7 +148,7 @@ This is because Mongoose has numerous features that add paths to your schema tha
 When you define an array in a document interface, we recommend using Mongoose's `Types.Array` type for primitive arrays or `Types.DocumentArray` for arrays of documents.
 
 ```typescript
-import { Schema, Model, Types } from "mongoose";
+import { Schema, Model, Types } from 'mongoose';
 
 interface BlogPost {
   _id: Types.ObjectId;
@@ -173,5 +173,5 @@ If you use `Types.DocumentArray` in the above case, you'll be able to `push()` a
 ```typescript
 const user = new User({ blogPosts: [] });
 
-user.blogPosts.push({ title: "test" }); // Would not work if you did `blogPosts: BlogPost[]`
+user.blogPosts.push({ title: 'test' }); // Would not work if you did `blogPosts: BlogPost[]`
 ```

--- a/docs/typescript/schemas.md
+++ b/docs/typescript/schemas.md
@@ -1,10 +1,14 @@
 # Schemas in TypeScript
 
 Mongoose [schemas](/docs/guide.html) are how you tell Mongoose what your documents look like.
-Mongoose schemas are separate from TypeScript interfaces, so you need to define both a _document interface_ and a _schema_.
+Mongoose schemas are separate from TypeScript interfaces, so you need to define both a _document interface_ and a _schema_ until V6.3.1.
+Mongoose supports auto typed schemas in V6.3.2 so you don't need to define a typescript interface anymore but you still able to do so.
+Mongoose released as well in V6.3.2 new TS utility `InferSchemaType` that helps to get the type of the auto typed schema document if it's needed.
+
+`Until mongoose V6.3.1:`
 
 ```typescript
-import { Schema } from 'mongoose';
+import { Schema } from "mongoose";
 
 // Document interface
 interface User {
@@ -17,8 +21,39 @@ interface User {
 const schema = new Schema<User>({
   name: { type: String, required: true },
   email: { type: String, required: true },
-  avatar: String
+  avatar: String,
 });
+```
+
+`In mongoose V6.3.2:`
+
+```typescript
+import { Schema, InferSchemaType } from "mongoose";
+
+// Document interface
+// No needs to define TS interface any more.
+// interface User {
+//   name: string;
+//   email: string;
+//   avatar?: string;
+// }
+
+// Schema
+const schema = new Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true },
+  avatar: String,
+});
+
+type User = InferSchemaType<typeof schema>;
+// This will become: 
+// type User = {
+//   name: string;
+//   email: string;
+//   avatar?: string;
+// }
+
+
 ```
 
 By default, Mongoose does **not** check if your document interface lines up with your schema.
@@ -51,7 +86,7 @@ Mongoose wraps `DocType` in a Mongoose document for cases like the `this` parame
 For example:
 
 ```typescript
-schema.pre('save', function(): void {
+schema.pre("save", function (): void {
   console.log(this.name); // TypeScript knows that `this` is a `mongoose.Document & User` by default
 });
 ```
@@ -69,7 +104,7 @@ Mongoose checks to make sure that every path in your schema is defined in your d
 For example, the below code will fail to compile because `emaill` is a path in the schema, but not in the `DocType` interface.
 
 ```typescript
-import { Schema, Model } from 'mongoose';
+import { Schema, Model } from "mongoose";
 
 interface User {
   name: string;
@@ -82,7 +117,7 @@ interface User {
 const schema = new Schema<User>({
   name: { type: String, required: true },
   emaill: { type: String, required: true },
-  avatar: String
+  avatar: String,
 });
 ```
 
@@ -90,7 +125,7 @@ However, Mongoose does **not** check for paths that exist in the document interf
 For example, the below code compiles.
 
 ```typescript
-import { Schema, Model } from 'mongoose';
+import { Schema, Model } from "mongoose";
 
 interface User {
   name: string;
@@ -102,7 +137,7 @@ interface User {
 const schema = new Schema<User, Model<User>>({
   name: { type: String, required: true },
   email: { type: String, required: true },
-  avatar: String
+  avatar: String,
 });
 ```
 
@@ -113,7 +148,7 @@ This is because Mongoose has numerous features that add paths to your schema tha
 When you define an array in a document interface, we recommend using Mongoose's `Types.Array` type for primitive arrays or `Types.DocumentArray` for arrays of documents.
 
 ```typescript
-import { Schema, Model, Types } from 'mongoose';
+import { Schema, Model, Types } from "mongoose";
 
 interface BlogPost {
   _id: Types.ObjectId;
@@ -121,13 +156,13 @@ interface BlogPost {
 }
 
 interface User {
-  tags: Types.Array<string>,
-  blogPosts: Types.DocumentArray<BlogPost>
+  tags: Types.Array<string>;
+  blogPosts: Types.DocumentArray<BlogPost>;
 }
 
 const schema = new Schema<User, Model<User>>({
   tags: [String],
-  blogPosts: [{ title: String }]
+  blogPosts: [{ title: String }],
 });
 ```
 
@@ -138,5 +173,5 @@ If you use `Types.DocumentArray` in the above case, you'll be able to `push()` a
 ```typescript
 const user = new User({ blogPosts: [] });
 
-user.blogPosts.push({ title: 'test' }); // Would not work if you did `blogPosts: BlogPost[]`
+user.blogPosts.push({ title: "test" }); // Would not work if you did `blogPosts: BlogPost[]`
 ```

--- a/docs/typescript/schemas.md
+++ b/docs/typescript/schemas.md
@@ -2,8 +2,8 @@
 
 Mongoose [schemas](/docs/guide.html) are how you tell Mongoose what your documents look like.
 Mongoose schemas are separate from TypeScript interfaces, so you need to define both a _document interface_ and a _schema_ until V6.3.1.
-Mongoose supports auto typed schemas in V6.3.2 so you don't need to define a typescript interface anymore but you still able to do so.
-Mongoose released as well in V6.3.2 new TS utility `InferSchemaType` that helps to get the type of the auto typed schema document if it's needed.
+Mongoose supports auto typed schemas now so you don't need to define a typescript interface anymore but you still able to do so.
+Mongoose released new TS utility `InferSchemaType` that helps to get the type of the auto typed schema document if it's needed.
 
 `Until mongoose V6.3.1:`
 
@@ -25,7 +25,7 @@ const schema = new Schema<User>({
 });
 ```
 
-`In mongoose V6.3.2:`
+`another approach:`
 
 ```typescript
 import { Schema, InferSchemaType } from "mongoose";

--- a/docs/typescript/schemas.md
+++ b/docs/typescript/schemas.md
@@ -2,8 +2,8 @@
 
 Mongoose [schemas](/docs/guide.html) are how you tell Mongoose what your documents look like.
 Mongoose schemas are separate from TypeScript interfaces, so you need to define both a _document interface_ and a _schema_ until V6.3.1.
-Mongoose supports auto typed schemas now so you don't need to define a typescript interface anymore but you still able to do so.
-Mongoose released new TS utility `InferSchemaType` that helps to get the type of the auto typed schema document if it's needed.
+Mongoose supports auto typed schemas so you don't need to define additional typescript interface anymore but you are still able to do so.
+Mongoose provides a `InferSchemaType`, which infers the type of the auto typed schema document when needed.
 
 `Until mongoose V6.3.1:`
 
@@ -31,7 +31,7 @@ const schema = new Schema<User>({
 import { Schema, InferSchemaType } from 'mongoose';
 
 // Document interface
-// No needs to define TS interface any more.
+// No need to define TS interface any more.
 // interface User {
 //   name: string;
 //   email: string;
@@ -46,7 +46,7 @@ const schema = new Schema({
 });
 
 type User = InferSchemaType<typeof schema>;
-// This will become: 
+// InferSchemaType will determine the type as follows: 
 // type User = {
 //   name: string;
 //   email: string;

--- a/docs/typescript/statics-and-methods.md
+++ b/docs/typescript/statics-and-methods.md
@@ -65,6 +65,27 @@ const User = model<IUser, UserModel>('User', schema);
 const answer: number = User.myStaticMethod(); // 42
 ```
 
+Mongoose does support auto typed static functions now that it is supplied in schema options.
+Statics functions can be defined as following:
+
+```typescript
+import { Schema, model } from 'mongoose';
+
+const schema = new Schema(
+  { name: String },
+  {
+    statics: {
+      myStaticMethod() {
+        return 42;
+      },
+    },
+  }
+);
+
+const User = model('User', schema);
+
+const answer = User.myStaticMethod(); // 42
+```
 ## Both Methods and Statics
 
 Below is how you can define a model that has both methods and statics.

--- a/docs/typescript/statics.md
+++ b/docs/typescript/statics.md
@@ -24,7 +24,7 @@ const User = model<IUser, UserModel>("User", schema);
 const answer: number = User.myStaticMethod(); // 42
 ```
 
-Mongoose V6.3.2 does support auto typed static functions that it is supplied in schema options.
+Mongoose does support auto typed static functions that it is supplied in schema options.
 Statics functions can be defined as following:
 
 ```typescript

--- a/docs/typescript/statics.md
+++ b/docs/typescript/statics.md
@@ -24,8 +24,8 @@ const User = model<IUser, UserModel>('User', schema);
 const answer: number = User.myStaticMethod(); // 42
 ```
 
-Mongoose does support auto typed static functions that it is supplied in schema options.
-Statics functions can be defined as following:
+Mongoose does support auto typed static functions that it are supplied in schema options.
+Static functions can be defined by:
 
 ```typescript
 import { Schema, model } from 'mongoose';

--- a/docs/typescript/statics.md
+++ b/docs/typescript/statics.md
@@ -4,7 +4,7 @@ Mongoose [models](/docs/models.html) do **not** have an explicit generic paramet
 If your model has statics, we recommend creating an interface that [extends](https://www.typescriptlang.org/docs/handbook/interfaces.html) Mongoose's `Model` interface as shown below.
 
 ```typescript
-import { Model, Schema, model } from "mongoose";
+import { Model, Schema, model } from 'mongoose';
 
 interface IUser {
   name: string;
@@ -15,11 +15,11 @@ interface UserModel extends Model<IUser> {
 }
 
 const schema = new Schema<IUser, UserModel>({ name: String });
-schema.static("myStaticMethod", function myStaticMethod() {
+schema.static('myStaticMethod', function myStaticMethod() {
   return 42;
 });
 
-const User = model<IUser, UserModel>("User", schema);
+const User = model<IUser, UserModel>('User', schema);
 
 const answer: number = User.myStaticMethod(); // 42
 ```
@@ -28,7 +28,7 @@ Mongoose does support auto typed static functions that it is supplied in schema 
 Statics functions can be defined as following:
 
 ```typescript
-import { Schema, model } from "mongoose";
+import { Schema, model } from 'mongoose';
 
 const schema = new Schema(
   { name: String },
@@ -41,7 +41,7 @@ const schema = new Schema(
   }
 );
 
-const User = model("User", schema);
+const User = model('User', schema);
 
 const answer = User.myStaticMethod(); // 42
 ```

--- a/docs/typescript/statics.md
+++ b/docs/typescript/statics.md
@@ -1,0 +1,47 @@
+# Statics in TypeScript
+
+Mongoose [models](/docs/models.html) do **not** have an explicit generic parameter for [statics](/docs/guide.html#statics).
+If your model has statics, we recommend creating an interface that [extends](https://www.typescriptlang.org/docs/handbook/interfaces.html) Mongoose's `Model` interface as shown below.
+
+```typescript
+import { Model, Schema, model } from "mongoose";
+
+interface IUser {
+  name: string;
+}
+
+interface UserModel extends Model<IUser> {
+  myStaticMethod(): number;
+}
+
+const schema = new Schema<IUser, UserModel>({ name: String });
+schema.static("myStaticMethod", function myStaticMethod() {
+  return 42;
+});
+
+const User = model<IUser, UserModel>("User", schema);
+
+const answer: number = User.myStaticMethod(); // 42
+```
+
+Mongoose V6.3.2 does support auto typed static functions that it is supplied in schema options.
+Statics functions can be defined as following:
+
+```typescript
+import { Schema, model } from "mongoose";
+
+const schema = new Schema(
+  { name: String },
+  {
+    statics: {
+      myStaticMethod() {
+        return 42;
+      },
+    },
+  }
+);
+
+const User = model("User", schema);
+
+const answer = User.myStaticMethod(); // 42
+```

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -107,7 +107,7 @@ function Schema(obj, options) {
   this.inherits = {};
   this.callQueue = [];
   this._indexes = [];
-  this.methods = {};
+  this.methods = (options && options.methods) || {};
   this.methodOptions = {};
   this.statics = (options && options.statics) || {};
   this.tree = {};

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -109,7 +109,7 @@ function Schema(obj, options) {
   this._indexes = [];
   this.methods = {};
   this.methodOptions = {};
-  this.statics = {};
+  this.statics = (options && options.statics) || {};
   this.tree = {};
   this.query = {};
   this.childSchemas = [];

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -111,7 +111,7 @@ function Schema(obj, options) {
   this.methodOptions = {};
   this.statics = (options && options.statics) || {};
   this.tree = {};
-  this.query = {};
+  this.query = (options && options.query) || {};
   this.childSchemas = [];
   this.plugins = [];
   // For internal debugging. Do not use this to try to save a schema in MDB.

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11456,8 +11456,8 @@ describe('document', function() {
   });
 });
 
-describe('Check if instance functions that is supplied in schema option is availabe (m0_0a)', function() {
-  it('should give an instance function back rather than undefined', function M0_0aModelJS() {
+describe('Check if instance functions that is supplied in schema option is availabe', function() {
+  it('should give an instance function back rather than undefined', function ModelJS() {
     const testSchema = new mongoose.Schema({}, { methods: { instanceFn() { return 'Returned from DocumentInstanceFn'; } } });
     const TestModel = mongoose.model('TestModel', testSchema);
     const TestDocument = new TestModel({});

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11455,3 +11455,12 @@ describe('document', function() {
     assert.ok(baz.populated('bar'));
   });
 });
+
+describe('Check if instance functions that is supplied in schema option is availabe (m0_0a)', function() {
+  it('should give an instance function back rather than undefined', function M0_0aModelJS() {
+    const testSchema = new mongoose.Schema({}, { methods: { instanceFn() { return 'Returned from DocumentInstanceFn'; } } });
+    const TestModel = mongoose.model('TestModel', testSchema);
+    const TestDocument = new TestModel({});
+    assert.equal(TestDocument.instanceFn(), 'Returned from DocumentInstanceFn');
+  });
+});

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11456,7 +11456,7 @@ describe('document', function() {
   });
 });
 
-describe('Check if instance functions that is supplied in schema option is availabe', function() {
+describe('Check if instance function that is supplied in schema option is availabe', function() {
   it('should give an instance function back rather than undefined', function ModelJS() {
     const testSchema = new mongoose.Schema({}, { methods: { instanceFn() { return 'Returned from DocumentInstanceFn'; } } });
     const TestModel = mongoose.model('TestModel', testSchema);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8505,8 +8505,8 @@ describe('Model', function() {
   });
 });
 
-describe('Check if statics functions that is supplied in schema option is availabe (m0_0a)', function() {
-  it('should give a static function back rather than undefined', function M0_0aModelJS() {
+describe('Check if statics functions that is supplied in schema option is availabe', function() {
+  it('should give a static function back rather than undefined', function ModelJS() {
     const testSchema = new mongoose.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
     const TestModel = mongoose.model('TestModel', testSchema);
     assert.equal(TestModel.staticFn(), 'Returned from staticFn');

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8505,6 +8505,13 @@ describe('Model', function() {
   });
 });
 
+describe('Check if statics functions that is supplied in schema option is availabe (m0_0a)', function() {
+  it('should give a static function back rather than undefined', function M0_0aModelJS() {
+    const testSchema = new mongoose.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
+    const TestModel = mongoose.model('TestModel', testSchema);
+    assert.equal(TestModel.staticFn(), 'Returned from staticFn');
+  });
+});
 
 
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8505,7 +8505,7 @@ describe('Model', function() {
   });
 });
 
-describe('Check if statics function that is supplied in schema option is availabe', function() {
+describe('Check if static function that is supplied in schema option is available', function() {
   it('should give a static function back rather than undefined', function ModelJS() {
     const testSchema = new mongoose.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
     const TestModel = mongoose.model('TestModel', testSchema);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8505,7 +8505,7 @@ describe('Model', function() {
   });
 });
 
-describe('Check if statics functions that is supplied in schema option is availabe', function() {
+describe('Check if statics function that is supplied in schema option is availabe', function() {
   it('should give a static function back rather than undefined', function ModelJS() {
     const testSchema = new mongoose.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
     const TestModel = mongoose.model('TestModel', testSchema);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3964,7 +3964,6 @@ describe('Query', function() {
   });
 
   it('should return query helper supplied in schema options query property instead of undefined', function(done) {
-
     const Model = db.model('Test', new Schema({
       userName: {
         type: String,
@@ -3979,7 +3978,9 @@ describe('Query', function() {
     }));
 
     Model.create({ userName: 'test' }, function(error) {
-      assert.ifError(error);
+      if (error instanceof Error) {
+        return done(error);
+      }
       Model.find().byUserName('test').exec(function(error, docs) {
         if (error instanceof Error) {
           return done(error);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3962,4 +3962,31 @@ describe('Query', function() {
     assert.equal(result.length, 1);
     assert.equal(result[0].name, '@foo.com');
   });
+
+  it('should return query helper supplied in schema options query property instead of undefined', function(done) {
+
+    const Model = db.model('Test', new Schema({
+      userName: {
+        type: String,
+        required: [true, 'userName is required']
+      }
+    }, {
+      query: {
+        byUserName(userName) {
+          return this.where({ userName });
+        }
+      }
+    }));
+
+    Model.create({ userName: 'test' }, function(error) {
+      assert.ifError(error);
+      Model.find().byUserName('test').exec(function(error, docs) {
+        assert.ifError(error);
+        assert.equal(docs.length, 1);
+        assert.equal(docs[0].userName, 'test');
+        done();
+      });
+    });
+  });
+
 });

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3981,7 +3981,9 @@ describe('Query', function() {
     Model.create({ userName: 'test' }, function(error) {
       assert.ifError(error);
       Model.find().byUserName('test').exec(function(error, docs) {
-        assert.ifError(error);
+        if (error instanceof Error) {
+          return done(error);
+        }
         assert.equal(docs.length, 1);
         assert.equal(docs[0].userName, 'test');
         done();

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -9,7 +9,7 @@ interface ITest extends Document {
 
 const Test = model<ITest>('Test', schema);
 
-Test.create({ _id: '0'.repeat(24), name: 'test' }).then((doc: ITest) => console.log(doc.name));
+Test.create({ _id: new Types.ObjectId('0'.repeat(24)), name: 'test' }).then((doc: ITest) => console.log(doc.name));
 
 Test.create([{ name: 'test' }], { validateBeforeSave: false }).then((docs: ITest[]) => console.log(docs[0].name));
 

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -3,7 +3,7 @@ import { Schema, model, Document, Types } from 'mongoose';
 const schema: Schema = new Schema({ name: { type: 'String' } });
 
 interface ITest extends Document {
-  _id?: Types.ObjectId;
+  _id?: Types.ObjectId | string;
   name?: string;
 }
 

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -3,7 +3,7 @@ import { Schema, model, Document, Types } from 'mongoose';
 const schema: Schema = new Schema({ name: { type: 'String' } });
 
 interface ITest extends Document {
-  _id?: Types.ObjectId | string;
+  _id?: Types.ObjectId;
   name?: string;
 }
 

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -1,25 +1,187 @@
-import { Schema, model, Document, Types } from 'mongoose';
+import { Schema, model, Types, CallbackError } from 'mongoose';
+import { expectError, expectType } from 'tsd';
 
 const schema: Schema = new Schema({ name: { type: 'String' } });
 
-interface ITest extends Document {
+interface ITest {
   _id?: Types.ObjectId;
   name?: string;
 }
 
 const Test = model<ITest>('Test', schema);
 
-Test.create({ _id: new Types.ObjectId('0'.repeat(24)), name: 'test' }).then((doc: ITest) => console.log(doc.name));
+Test.create({ _id: '000000000000000000000000', name: 'test' }).then(doc => {
+  expectType<Types.ObjectId>(doc._id);
+  expectType<string>(doc.name);
+  expectType<boolean>(doc.isNew);
+});
 
-Test.create([{ name: 'test' }], { validateBeforeSave: false }).then((docs: ITest[]) => console.log(docs[0].name));
+Test.create({ _id: new Types.ObjectId('000000000000000000000000'), name: 'test' }).then((doc) => {
+  expectType<Types.ObjectId>(doc._id);
+  expectType<string>(doc.name);
+  expectType<boolean>(doc.isNew);
+});
 
-Test.create({ name: 'test' }, { name: 'test2' }).then((docs: ITest[]) => console.log(docs[0].name));
+Test.create([{ name: 'test' }], { validateBeforeSave: false }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
 
-Test.insertMany({ name: 'test' }).then((docs: ITest[]) => console.log(docs[0].name));
+Test.create({ name: 'test' }, { name: 'test2' }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<Types.ObjectId>(docs[1]._id);
+  expectType<string>(docs[1].name);
+});
 
-Test.create([{ name: 'test' }], { validateBeforeSave: true }).then((docs: ITest[]) => console.log(docs[0].name));
+Test.create([{ name: 'test' }], { validateBeforeSave: true }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+});
 
-(async() => {
+
+Test.insertMany({ name: 'test' }, {}, (err, docs) => {
+  expectType<CallbackError>(err);
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }, { lean: true }, (err, docs) => {
+  expectType<CallbackError>(err);
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectError(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }, (err, docs) => {
+  expectType<CallbackError>(err);
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }, {}, (err, docs) => {
+  expectType<CallbackError>(err);
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany([{ name: 'test' }], { rawResult: true }, (err, result) => {
+  expectType<CallbackError>(err);
+  expectType<boolean>(result.acknowledged);
+  expectType<number>(result.insertedCount);
+  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+});
+
+Test.insertMany([{ name: 'test' }], { rawResult: true }, (err, result) => {
+  expectType<CallbackError>(err);
+  expectType<boolean>(result.acknowledged);
+  expectType<number>(result.insertedCount);
+  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+});
+
+Test.insertMany([{ name: 'test' }], { lean: true }, (err, docs) => {
+  expectType<CallbackError>(err);
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectError(docs[0].isNew);
+});
+
+Test.insertMany([{ name: 'test' }], (err, docs) => {
+  expectType<CallbackError>(err);
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ _id: '000000000000000000000000', name: 'test' }, (err, docs) => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ _id: new Types.ObjectId('000000000000000000000000')}, (err, docs) => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string | undefined>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }, {}).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }, { lean: true }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectError(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ name: 'test' }, {}).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany([{ name: 'test' }], { rawResult: true }).then(result => {
+  expectType<boolean>(result.acknowledged);
+  expectType<number>(result.insertedCount);
+  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+});
+
+Test.insertMany([{ name: 'test' }], { rawResult: true }).then(result => {
+  expectType<boolean>(result.acknowledged);
+  expectType<number>(result.insertedCount);
+  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+});
+
+Test.insertMany([{ name: 'test' }], { lean: true }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectError(docs[0].isNew);
+});
+
+Test.insertMany([{ name: 'test' }], { lean: false }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string | undefined>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany([{ name: 'test' }], { }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string | undefined>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany([{ name: 'test' }]).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ _id: '000000000000000000000000', name: 'test' }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+Test.insertMany({ _id: new Types.ObjectId('000000000000000000000000'), name: 'test' }).then(docs => {
+  expectType<Types.ObjectId>(docs[0]._id);
+  expectType<string>(docs[0].name);
+  expectType<boolean>(docs[0].isNew);
+});
+
+(async () => {
   const [t1] = await Test.create([{ name: 'test' }]);
   const [t2, t3, t4] = await Test.create({ name: 'test' }, { name: 'test' }, { name: 'test' });
   (await Test.create([{ name: 'test' }]))[0];

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -73,14 +73,14 @@ Test.insertMany([{ name: 'test' }], { rawResult: true }, (err, result) => {
   expectType<CallbackError>(err);
   expectType<boolean>(result.acknowledged);
   expectType<number>(result.insertedCount);
-  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+  expectType<{ [key: number]: Types.ObjectId; }>(result.insertedIds);
 });
 
 Test.insertMany([{ name: 'test' }], { rawResult: true }, (err, result) => {
   expectType<CallbackError>(err);
   expectType<boolean>(result.acknowledged);
   expectType<number>(result.insertedCount);
-  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+  expectType<{ [key: number]: Types.ObjectId; }>(result.insertedIds);
 });
 
 Test.insertMany([{ name: 'test' }], { lean: true }, (err, docs) => {
@@ -103,7 +103,7 @@ Test.insertMany({ _id: '000000000000000000000000', name: 'test' }, (err, docs) =
   expectType<boolean>(docs[0].isNew);
 });
 
-Test.insertMany({ _id: new Types.ObjectId('000000000000000000000000')}, (err, docs) => {
+Test.insertMany({ _id: new Types.ObjectId('000000000000000000000000') }, (err, docs) => {
   expectType<Types.ObjectId>(docs[0]._id);
   expectType<string | undefined>(docs[0].name);
   expectType<boolean>(docs[0].isNew);
@@ -136,13 +136,13 @@ Test.insertMany({ name: 'test' }, {}).then(docs => {
 Test.insertMany([{ name: 'test' }], { rawResult: true }).then(result => {
   expectType<boolean>(result.acknowledged);
   expectType<number>(result.insertedCount);
-  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+  expectType<{ [key: number]: Types.ObjectId; }>(result.insertedIds);
 });
 
 Test.insertMany([{ name: 'test' }], { rawResult: true }).then(result => {
   expectType<boolean>(result.acknowledged);
   expectType<number>(result.insertedCount);
-  expectType<{[key: number]: Types.ObjectId;}>(result.insertedIds)
+  expectType<{ [key: number]: Types.ObjectId; }>(result.insertedIds);
 });
 
 Test.insertMany([{ name: 'test' }], { lean: true }).then(docs => {
@@ -181,7 +181,7 @@ Test.insertMany({ _id: new Types.ObjectId('000000000000000000000000'), name: 'te
   expectType<boolean>(docs[0].isNew);
 });
 
-(async () => {
+(async() => {
   const [t1] = await Test.create([{ name: 'test' }]);
   const [t2, t3, t4] = await Test.create({ name: 'test' }, { name: 'test' }, { name: 'test' });
   (await Test.create([{ name: 'test' }]))[0];

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -1,5 +1,7 @@
 import { Schema, model, Model, Document, Types } from 'mongoose';
-import { expectError, expectType } from 'tsd';
+import { expectAssignable, expectError, expectType } from 'tsd';
+import { m0_0aModel } from './models.test';
+import { M0_0aAutoTypedSchemaType } from './schema.test';
 
 const Drink = model('Drink', new Schema({
   name: String
@@ -52,15 +54,16 @@ void async function run() {
   test.validateSync({ pathsToSkip: ['name', 'age'] });
   test.validateSync({ pathsToSkip: 'name age' });
   test.validateSync({ pathsToSkip: 'name age', blub: 1 });
-  expectType<Promise<ITest & { _id: any; }>>(test.save());
-  expectType<Promise<ITest & { _id: any; }>>(test.save({}));
+  const x = test.save();
+  expectAssignable<Promise<ITest & { _id: any; }>>(test.save());
+  expectAssignable<Promise<ITest & { _id: any; }>>(test.save({}));
   expectType<void>(test.save({}, (err, doc) => {
     expectType<Error | null>(err);
-    expectType<ITest & { _id: any; }>(doc);
+    expectAssignable<ITest & { _id: any; }>(doc);
   }));
   expectType<void>(test.save((err, doc) => {
     expectType<Error | null>(err);
-    expectType<ITest & { _id: any; }>(doc);
+    expectAssignable<ITest & { _id: any; }>(doc);
   }));
 })();
 
@@ -180,4 +183,22 @@ function gh11435() {
 async function gh11598() {
   const doc = await Test.findOne().orFail();
   doc.populate('favoritDrink', undefined, model('temp', new Schema()));
+}
+
+async function m0_0aDocument() {
+  const AutoTypeModel = await m0_0aModel();
+  const AutoTypeModelInstance = new AutoTypeModel({ unExistProperty: 1, description: 2 });
+
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
+  expectType<M0_0aAutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
+  expectType<M0_0aAutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
+  expectType<number>(AutoTypeModelInstance.unExistProperty);
+  expectType<number>(AutoTypeModelInstance.description);
+
+  /* -------------------------------------------------------------------------- */
+  /*                        Document-Instance-Methods-tests                     */
+  /* -------------------------------------------------------------------------- */
+
+  expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(AutoTypeModelInstance.instanceFn());
+
 }

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -186,8 +186,8 @@ async function gh11598() {
 }
 
 async function m0_0aDocument() {
-  const AutoTypeModel = await m0_0aModel();
-  const AutoTypeModelInstance = new AutoTypeModel({ unExistProperty: 1, description: 2 });
+  const AutoTypedModel = await m0_0aModel();
+  const AutoTypeModelInstance = new AutoTypedModel({ unExistProperty: 1, description: 2 });
 
   expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
   expectType<M0_0aAutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
@@ -196,7 +196,7 @@ async function m0_0aDocument() {
   expectType<number>(AutoTypeModelInstance.description);
 
   /* -------------------------------------------------------------------------- */
-  /*                        Document-Instance-Methods-tests                     */
+  /*                           Document-Methods-tests                           */
   /* -------------------------------------------------------------------------- */
 
   expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(AutoTypeModelInstance.instanceFn());

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -199,6 +199,6 @@ function m0_0aDocument() {
   /*                           Document-Methods-tests                           */
   /* -------------------------------------------------------------------------- */
 
-  expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(AutoTypeModelInstance.instanceFn());
+  expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(new AutoTypedModel().instanceFn());
 
 }

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -1,7 +1,7 @@
 import { Schema, model, Model, Document, Types } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { autoTypedModel } from './models.test';
-import { M0_0aAutoTypedSchemaType } from './schema.test';
+import { AutoTypedSchemaType } from './schema.test';
 
 const Drink = model('Drink', new Schema({
   name: String
@@ -185,20 +185,17 @@ async function gh11598() {
   doc.populate('favoritDrink', undefined, model('temp', new Schema()));
 }
 
-function m0_0aDocument() {
+function autoTypedDocument() {
   const AutoTypedModel = autoTypedModel();
   const AutoTypeModelInstance = new AutoTypedModel({ unExistProperty: 1, description: 2 });
 
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
-  expectType<M0_0aAutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
-  expectType<M0_0aAutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
+  expectType<AutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
+  expectType<AutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
+  expectType<AutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
   expectType<number>(AutoTypeModelInstance.unExistProperty);
   expectType<number>(AutoTypeModelInstance.description);
 
-  /* -------------------------------------------------------------------------- */
-  /*                           Document-Methods-tests                           */
-  /* -------------------------------------------------------------------------- */
-
-  expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(new AutoTypedModel().instanceFn());
+  // Document-Methods-tests
+  expectType<ReturnType<AutoTypedSchemaType['methods']['instanceFn']>>(new AutoTypedModel().instanceFn());
 
 }

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -1,6 +1,6 @@
 import { Schema, model, Model, Document, Types } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
-import { m0_0aModel } from './models.test';
+import { autoTypedModel } from './models.test';
 import { M0_0aAutoTypedSchemaType } from './schema.test';
 
 const Drink = model('Drink', new Schema({
@@ -185,8 +185,8 @@ async function gh11598() {
   doc.populate('favoritDrink', undefined, model('temp', new Schema()));
 }
 
-async function m0_0aDocument() {
-  const AutoTypedModel = await m0_0aModel();
+function m0_0aDocument() {
+  const AutoTypedModel = autoTypedModel();
   const AutoTypeModelInstance = new AutoTypedModel({ unExistProperty: 1, description: 2 });
 
   expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -263,21 +263,5 @@ export async function m0_0aModel() {
 
   expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypeModel.staticFn());
 
-  /* -------------------------------------------------------------------------- */
-  /*                                Instance-tests                              */
-  /* -------------------------------------------------------------------------- */
-
-  const AutoTypeModelInstance = new AutoTypeModel({});
-
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
-  expectType<M0_0aAutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
-  expectType<M0_0aAutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
-
-  /* -------------------------------------------------------------------------- */
-  /*                        Document-Instance-Methods-tests                     */
-  /* -------------------------------------------------------------------------- */
-
-  expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(AutoTypeModelInstance.instanceFn());
-
   return AutoTypeModel;
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -247,5 +247,17 @@ export async function m0_0aModel() {
 
   expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypeModel.staticFn());
 
+  /* -------------------------------------------------------------------------- */
+  /*                                Instance-Test                               */
+  /* -------------------------------------------------------------------------- */
+
+  const AutoTypeModelInstance = new AutoTypeModel({});
+
+  /* -------------------------------------------------------------------------- */
+  /*                          Document-Instance-Methods                         */
+  /* -------------------------------------------------------------------------- */
+
+  expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(AutoTypeModelInstance.instanceFn());
+
   return AutoTypeModel;
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,5 +1,6 @@
 import { Schema, Document, Model, Types, connection, model } from 'mongoose';
-import { expectError } from 'tsd';
+import { expectError, expectType } from 'tsd';
+import { M0_0aAutoTypedSchemaType, m0_0aSchema } from './schema.test';
 
 function conventionalSyntax(): void {
   interface ITest extends Document {
@@ -234,4 +235,17 @@ function bulkWrite() {
     }
   ];
   M.bulkWrite(ops);
+}
+
+export async function m0_0aModel() {
+  const AutoTypeSchema = m0_0aSchema();
+  const AutoTypeModel = model('AutoTypeModel', AutoTypeSchema);
+
+  /* -------------------------------------------------------------------------- */
+  /*                        Model-statics-functions-test                        */
+  /* -------------------------------------------------------------------------- */
+
+  expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypeModel.staticFn());
+
+  return AutoTypeModel;
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,6 +1,6 @@
 import { Schema, Document, Model, Types, connection, model } from 'mongoose';
 import { expectError, expectType } from 'tsd';
-import { M0_0aAutoTypedSchemaType, autoTypedSchema } from './schema.test';
+import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
 
 function conventionalSyntax(): void {
   interface ITest extends Document {
@@ -242,31 +242,26 @@ export function autoTypedModel() {
   const AutoTypedModel = model('AutoTypeModel', AutoTypedSchema);
 
   (async() => {
-  /* -------------------------------------------------------------------------- */
-  /*                            Model-functions-test                            */
-  /* -------------------------------------------------------------------------- */
+  // Model-functions-test
   // Create should works with arbitrary objects.
     const randomObject = await AutoTypedModel.create({ unExistKey: 'unExistKey', description: 'st' });
     expectType<string>(randomObject.unExistKey);
-    expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(randomObject.userName);
+    expectType<AutoTypedSchemaType['schema']['userName']>(randomObject.userName);
 
     const testDoc1 = await AutoTypedModel.create({ userName: 'M0_0a' });
-    expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
-    expectType<M0_0aAutoTypedSchemaType['schema']['description']>(testDoc1.description);
+    expectType<AutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
+    expectType<AutoTypedSchemaType['schema']['description']>(testDoc1.description);
 
     const testDoc2 = await AutoTypedModel.insertMany([{ userName: 'M0_0a' }]);
-    expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
-    expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
+    expectType<AutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
+    expectType<AutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
 
     const testDoc3 = await AutoTypedModel.findOne({ userName: 'M0_0a' });
-    expectType<M0_0aAutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
-    expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
+    expectType<AutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
+    expectType<AutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
 
-    /* -------------------------------------------------------------------------- */
-    /*                      Model-statics-functions-test                          */
-    /* -------------------------------------------------------------------------- */
-
-    expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypedModel.staticFn());
+    // Model-statics-functions-test
+    expectType<ReturnType<AutoTypedSchemaType['statics']['staticFn']>>(AutoTypedModel.staticFn());
 
   })();
   return AutoTypedModel;

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,6 +1,6 @@
 import { Schema, Document, Model, Types, connection, model } from 'mongoose';
 import { expectError, expectType } from 'tsd';
-import { M0_0aAutoTypedSchemaType, m0_0aSchema } from './schema.test';
+import { M0_0aAutoTypedSchemaType, autoTypedSchema } from './schema.test';
 
 function conventionalSyntax(): void {
   interface ITest extends Document {
@@ -237,35 +237,37 @@ function bulkWrite() {
   M.bulkWrite(ops);
 }
 
-export async function m0_0aModel() {
-  const AutoTypeSchema = m0_0aSchema();
-  const AutoTypeModel = model('AutoTypeModel', AutoTypeSchema);
+export function autoTypedModel() {
+  const AutoTypedSchema = autoTypedSchema();
+  const AutoTypedModel = model('AutoTypeModel', AutoTypedSchema);
 
+  (async() => {
   /* -------------------------------------------------------------------------- */
   /*                            Model-functions-test                            */
   /* -------------------------------------------------------------------------- */
   // Create should works with arbitrary objects.
-  const randomObject = await AutoTypeModel.create({ unExistKey: 'unExistKey', description: 'st' });
-  expectType<string>(randomObject.unExistKey);
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(randomObject.userName);
+    const randomObject = await AutoTypedModel.create({ unExistKey: 'unExistKey', description: 'st' });
+    expectType<string>(randomObject.unExistKey);
+    expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(randomObject.userName);
 
-  const testDoc1 = await AutoTypeModel.create({ userName: 'M0_0a' });
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
-  expectType<M0_0aAutoTypedSchemaType['schema']['description']>(testDoc1.description);
+    const testDoc1 = await AutoTypedModel.create({ userName: 'M0_0a' });
+    expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
+    expectType<M0_0aAutoTypedSchemaType['schema']['description']>(testDoc1.description);
 
-  const testDoc2 = await AutoTypeModel.insertMany([{ userName: 'M0_0a' }]);
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
-  expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
+    const testDoc2 = await AutoTypedModel.insertMany([{ userName: 'M0_0a' }]);
+    expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
+    expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
 
-  const testDoc3 = await AutoTypeModel.findOne({ userName: 'M0_0a' });
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
-  expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
+    const testDoc3 = await AutoTypedModel.findOne({ userName: 'M0_0a' });
+    expectType<M0_0aAutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
+    expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
 
-  /* -------------------------------------------------------------------------- */
-  /*                      Model-statics-functions-test                          */
-  /* -------------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------------- */
+    /*                      Model-statics-functions-test                          */
+    /* -------------------------------------------------------------------------- */
 
-  expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypeModel.staticFn());
+    expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypedModel.staticFn());
 
-  return AutoTypeModel;
+  })();
+  return AutoTypedModel;
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -253,6 +253,10 @@ export async function m0_0aModel() {
   expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
   expectType<M0_0aAutoTypedSchemaType['schema']['description']>(testDoc1.description);
 
+  const testDoc2 = await AutoTypeModel.findOne({ userName: 'M0_0a' });
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName'] | undefined>(testDoc2?.userName);
+  expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc2?.description);
+
   /* -------------------------------------------------------------------------- */
   /*                      Model-statics-functions-test                          */
   /* -------------------------------------------------------------------------- */

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -253,9 +253,13 @@ export async function m0_0aModel() {
   expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
   expectType<M0_0aAutoTypedSchemaType['schema']['description']>(testDoc1.description);
 
-  const testDoc2 = await AutoTypeModel.findOne({ userName: 'M0_0a' });
-  expectType<M0_0aAutoTypedSchemaType['schema']['userName'] | undefined>(testDoc2?.userName);
-  expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc2?.description);
+  const testDoc2 = await AutoTypeModel.insertMany([{ userName: 'M0_0a' }]);
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
+  expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
+
+  const testDoc3 = await AutoTypeModel.findOne({ userName: 'M0_0a' });
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
+  expectType<M0_0aAutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
 
   /* -------------------------------------------------------------------------- */
   /*                      Model-statics-functions-test                          */

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -242,19 +242,35 @@ export async function m0_0aModel() {
   const AutoTypeModel = model('AutoTypeModel', AutoTypeSchema);
 
   /* -------------------------------------------------------------------------- */
-  /*                        Model-statics-functions-test                        */
+  /*                            Model-functions-test                            */
+  /* -------------------------------------------------------------------------- */
+  // Create should works with arbitrary objects.
+  const randomObject = await AutoTypeModel.create({ unExistKey: 'unExistKey', description: 'st' });
+  expectType<string>(randomObject.unExistKey);
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(randomObject.userName);
+
+  const testDoc1 = await AutoTypeModel.create({ userName: 'M0_0a' });
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
+  expectType<M0_0aAutoTypedSchemaType['schema']['description']>(testDoc1.description);
+
+  /* -------------------------------------------------------------------------- */
+  /*                      Model-statics-functions-test                          */
   /* -------------------------------------------------------------------------- */
 
   expectType<ReturnType<M0_0aAutoTypedSchemaType['statics']['staticFn']>>(AutoTypeModel.staticFn());
 
   /* -------------------------------------------------------------------------- */
-  /*                                Instance-Test                               */
+  /*                                Instance-tests                              */
   /* -------------------------------------------------------------------------- */
 
   const AutoTypeModelInstance = new AutoTypeModel({});
 
+  expectType<M0_0aAutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
+  expectType<M0_0aAutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
+  expectType<M0_0aAutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
+
   /* -------------------------------------------------------------------------- */
-  /*                          Document-Instance-Methods                         */
+  /*                        Document-Instance-Methods-tests                     */
   /* -------------------------------------------------------------------------- */
 
   expectType<ReturnType<M0_0aAutoTypedSchemaType['methods']['instanceFn']>>(AutoTypeModelInstance.instanceFn());

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -72,6 +72,7 @@ const Story = model<IStory>('Story', storySchema);
 
   await story.populate('author');
   await story.populate({ path: 'fans' });
+  await story.populate({ path: 'fans', model: Person });
   await story.populate(['author']);
   await story.populate([{ path: 'fans' }]);
   await story.populate(['author', { path: 'fans' }]);

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -2,7 +2,7 @@ import { HydratedDocument, Schema, model, Document, Types, Query, Model, QueryWi
 import { ObjectId } from 'mongodb';
 import { expectError, expectType } from 'tsd';
 import { autoTypedModel } from './models.test';
-import { M0_0aAutoTypedSchemaType } from './schema.test';
+import { AutoTypedSchemaType } from './schema.test';
 
 interface QueryHelpers {
   _byName(this: QueryWithHelpers<any, ITest, QueryHelpers>, name: string): QueryWithHelpers<Array<ITest>, ITest, QueryHelpers>;

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -1,6 +1,8 @@
 import { HydratedDocument, Schema, model, Document, Types, Query, Model, QueryWithHelpers, PopulatedDoc, FilterQuery, UpdateQuery } from 'mongoose';
 import { ObjectId } from 'mongodb';
 import { expectError, expectType } from 'tsd';
+import { autoTypedModel } from './models.test';
+import { M0_0aAutoTypedSchemaType } from './schema.test';
 
 interface QueryHelpers {
   _byName(this: QueryWithHelpers<any, ITest, QueryHelpers>, name: string): QueryWithHelpers<Array<ITest>, ITest, QueryHelpers>;
@@ -286,4 +288,9 @@ async function gh11602(): Promise<void> {
   expectError(updateResult.lastErrorObject?.modifiedCount);
   expectType<boolean | undefined>(updateResult.lastErrorObject?.updatedExisting);
   expectType<ObjectId | undefined>(updateResult.lastErrorObject?.upserted);
+}
+
+function autoTypedQuery() {
+  const AutoTypedModel = autoTypedModel();
+  expectType<M0_0aAutoTypedSchemaType['query']['byUserName']>(AutoTypedModel.find().byUserName);
 }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -292,5 +292,6 @@ async function gh11602(): Promise<void> {
 
 function autoTypedQuery() {
   const AutoTypedModel = autoTypedModel();
-  expectType<M0_0aAutoTypedSchemaType['query']['byUserName']>(AutoTypedModel.find().byUserName);
+  const query = AutoTypedModel.find();
+  expectType<typeof query>(AutoTypedModel.find().byUserName(''));
 }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -163,10 +163,10 @@ function testGenericQuery(): void {
 
 function eachAsync(): void {
   Test.find().cursor().eachAsync((doc) => {
-    expectType<(ITest & { _id: any; })>(doc);
+    expectType<(ITest & { _id: Types.ObjectId; })>(doc);
   });
   Test.find().cursor().eachAsync((docs) => {
-    expectType<(ITest & { _id: any; })[]>(docs);
+    expectType<(ITest & { _id: Types.ObjectId; })[]>(docs);
   }, { batchSize: 2 });
 }
 

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -376,6 +376,9 @@ export function autoTypedSchema() {
     array3?: any[];
     array4?: any[];
     array5?: any[];
+    decimal1?: Schema.Types.Decimal128;
+    decimal2?: Schema.Types.Decimal128;
+    decimal3?: Schema.Types.Decimal128;
   };
 
   const TestSchema = new Schema({
@@ -412,7 +415,10 @@ export function autoTypedSchema() {
     array2: Array,
     array3: [Schema.Types.Mixed],
     array4: [{}],
-    array5: []
+    array5: [],
+    decimal1: Schema.Types.Decimal128,
+    decimal2: 'Decimal128',
+    decimal3: 'decimal128'
   });
 
   type InferredTestSchemaType = InferSchemaType<typeof TestSchema>;

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,5 +1,6 @@
 import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query, HydratedDocument } from 'mongoose';
 import { expectType, expectError, expectAssignable } from 'tsd';
+import { IsTAny } from '../../types/inferschematype';
 
 enum Genre {
   Action,
@@ -371,6 +372,10 @@ export function autoTypedSchema() {
     customSchema?: Int8;
     map1?: Map<string, string>;
     map2?: Map<string, number>;
+    array1?: string[];
+    array2?: Schema.Types.Mixed[];
+    array3?: Schema.Types.Mixed[];
+    array4?: Schema.Types.Mixed[];
   };
 
   const TestSchema = new Schema({
@@ -402,7 +407,11 @@ export function autoTypedSchema() {
     objectId3: 'objectId',
     customSchema: Int8,
     map1: { type: Map, of: String },
-    map2: { type: Map, of: Number }
+    map2: { type: Map, of: Number },
+    array1: { type: [String] },
+    array2: { type: Array },
+    array3: { type: [Schema.Types.Mixed] },
+    array4: { type: [{}] }
   });
 
   type InferredTestSchemaType = InferSchemaType<typeof TestSchema>;

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -461,6 +461,7 @@ export function autoTypedSchema() {
     },
     query: {
       byUserName(userName) {
+        expectType<Query<unknown, unknown>>(this);
         return this.where({ userName });
       }
     }
@@ -492,7 +493,4 @@ export type M0_0aAutoTypedSchemaType = {
   methods: {
     instanceFn: () => 'Returned from DocumentInstanceFn'
   },
-  query: {
-    byUserName: <T extends Query<unknown, unknown>>(this: T, userName: any) => T
-  }
 };

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,4 +1,4 @@
-import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType } from 'mongoose';
+import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query } from 'mongoose';
 import { expectType, expectError } from 'tsd';
 
 enum Genre {
@@ -319,73 +319,8 @@ function gh10900(): void {
     menuStatus: { type: Schema.Types.Mixed, default: {} }
   });
 }
-export type M0_0aAutoTypedSchemaType = {
-  schema: {
-    userName: string;
-    description?: string;
-    nested?: {
-      age: number;
-      hobby?: string
-    },
-    favoritDrink?: 'Tea' | 'Coffee',
-    favoritColorMode: 'dark' | 'light'
-  }
-  , statics: {
-    staticFn: () => 'Returned from staticFn'
-  },
-  methods: {
-    instanceFn: () => 'Returned from DocumentInstanceFn'
-  }
-};
 
-export function m0_0aSchema() {
-  const AutoTypedSchema = new Schema({
-    userName: {
-      type: String,
-      required: [true, 'userName is required']
-    },
-    description: String,
-    nested: new Schema({
-      age: {
-        type: Number,
-        required: true
-      },
-      hobby: {
-        type: String,
-        required: false
-      }
-    }),
-    favoritDrink: {
-      type: String,
-      enum: ['Coffee', 'Tea']
-    },
-    favoritColorMode: {
-      type: String,
-      enum: {
-        values: ['dark', 'light'],
-        message: '{VALUE} is not supported'
-      },
-      required: true
-    }
-  }, {
-    statics: {
-      staticFn() {
-        return 'Returned from staticFn';
-      }
-    },
-    methods: {
-      instanceFn() {
-        return 'Returned from DocumentInstanceFn';
-      }
-    }
-  });
-
-  type InferredSchemaType = InferSchemaType<typeof AutoTypedSchema>;
-
-  expectType<M0_0aAutoTypedSchemaType['schema']>({} as InferredSchemaType);
-
-  expectError<M0_0aAutoTypedSchemaType['schema'] & { doesNotExist: boolean; }>({} as InferredSchemaType);
-
+export function autoTypedSchema() {
   // Test auto schema type obtaining with all possible path types.
 
   class Int8 extends SchemaType {
@@ -485,5 +420,79 @@ export function m0_0aSchema() {
 
   expectType<string>({} as InferSchemaType<typeof SchemaWithCustomTypeKey>['name']);
 
+  const AutoTypedSchema = new Schema({
+    userName: {
+      type: String,
+      required: [true, 'userName is required']
+    },
+    description: String,
+    nested: new Schema({
+      age: {
+        type: Number,
+        required: true
+      },
+      hobby: {
+        type: String,
+        required: false
+      }
+    }),
+    favoritDrink: {
+      type: String,
+      enum: ['Coffee', 'Tea']
+    },
+    favoritColorMode: {
+      type: String,
+      enum: {
+        values: ['dark', 'light'],
+        message: '{VALUE} is not supported'
+      },
+      required: true
+    }
+  }, {
+    statics: {
+      staticFn() {
+        return 'Returned from staticFn';
+      }
+    },
+    methods: {
+      instanceFn() {
+        return 'Returned from DocumentInstanceFn';
+      }
+    },
+    query: {
+      byUserName(userName) {
+        return this.where({ userName });
+      }
+    }
+  });
+
+  type InferredSchemaType = InferSchemaType<typeof AutoTypedSchema>;
+
+  expectType<M0_0aAutoTypedSchemaType['schema']>({} as InferredSchemaType);
+
+  expectError<M0_0aAutoTypedSchemaType['schema'] & { doesNotExist: boolean; }>({} as InferredSchemaType);
+
   return AutoTypedSchema;
 }
+
+export type M0_0aAutoTypedSchemaType = {
+  schema: {
+    userName: string;
+    description?: string;
+    nested?: {
+      age: number;
+      hobby?: string
+    },
+    favoritDrink?: 'Tea' | 'Coffee',
+    favoritColorMode: 'dark' | 'light'
+  }
+  , statics: {
+    staticFn: () => 'Returned from staticFn'
+  },
+  methods: {
+    instanceFn: () => 'Returned from DocumentInstanceFn'
+  },
+  query: {
+    byUserName: <T extends Query<unknown, unknown>>(this: T, userName: any) => T
+  }
+};

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -362,9 +362,9 @@ export function autoTypedSchema() {
     boolean2?: boolean;
     boolean3?: boolean;
     boolean4?: boolean;
-    mixed1?: Schema.Types.Mixed;
-    mixed2?: Schema.Types.Mixed;
-    mixed3?: Schema.Types.Mixed;
+    mixed1?: any;
+    mixed2?: any;
+    mixed3?: any;
     objectId1?: Schema.Types.ObjectId;
     objectId2?: Schema.Types.ObjectId;
     objectId3?: Schema.Types.ObjectId;
@@ -372,10 +372,10 @@ export function autoTypedSchema() {
     map1?: Map<string, string>;
     map2?: Map<string, number>;
     array1?: string[];
-    array2?: Schema.Types.Mixed[];
-    array3?: Schema.Types.Mixed[];
-    array4?: Schema.Types.Mixed[];
-    array5?: Schema.Types.Mixed[];
+    array2?: any[];
+    array3?: any[];
+    array4?: any[];
+    array5?: any[];
   };
 
   const TestSchema = new Schema({

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -469,6 +469,7 @@ export function m0_0aSchema() {
   type InferredTestSchemaType = InferSchemaType<typeof TestSchema>;
 
   expectType<TestSchemaType>({} as InferredTestSchemaType);
+
   const SchemaWithCustomTypeKey = new Schema({
     name: {
       customKTypeKey: String,

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,4 +1,4 @@
-import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query } from 'mongoose';
+import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query, HydratedDocument } from 'mongoose';
 import { expectType, expectError, expectAssignable } from 'tsd';
 
 enum Genre {
@@ -457,7 +457,7 @@ export function autoTypedSchema() {
     },
     methods: {
       instanceFn() {
-        expectAssignable<Document<any, any, M0_0aAutoTypedSchemaType['schema']>>(this);
+        expectType<HydratedDocument<M0_0aAutoTypedSchemaType['schema']>>(this);
         return 'Returned from DocumentInstanceFn' as const;
       }
     },

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,5 +1,5 @@
 import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query } from 'mongoose';
-import { expectType, expectError, expectAssignable, expectNotAssignable } from 'tsd';
+import { expectType, expectError, expectAssignable } from 'tsd';
 
 enum Genre {
   Action,
@@ -451,19 +451,19 @@ export function autoTypedSchema() {
   }, {
     statics: {
       staticFn() {
-        expectAssignable<Model<any>>(this);
+        expectType<Model<M0_0aAutoTypedSchemaType['schema']>>(this);
         return 'Returned from staticFn' as const;
       }
     },
     methods: {
       instanceFn() {
-        expectAssignable<Document>(this);
+        expectAssignable<Document<any, any, M0_0aAutoTypedSchemaType['schema']>>(this);
         return 'Returned from DocumentInstanceFn' as const;
       }
     },
     query: {
       byUserName(userName) {
-        expectAssignable<Query<unknown, unknown>>(this);
+        expectAssignable<Query<unknown, M0_0aAutoTypedSchemaType['schema']>>(this);
         return this.where({ userName });
       }
     }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -369,10 +369,14 @@ export function m0_0aSchema() {
     }
   }, {
     statics: {
-      staticFn() { return 'Returned from staticFn'; }
+      staticFn() {
+        return 'Returned from staticFn';
+      }
     },
     methods: {
-      instanceFn() { return 'Returned from DocumentInstanceFn'; }
+      instanceFn() {
+        return 'Returned from DocumentInstanceFn';
+      }
     }
   });
 

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -367,6 +367,10 @@ export function m0_0aSchema() {
       },
       required: true
     }
+  }, {
+    statics: {
+      staticFn() { return 'Returned from staticFn'; }
+    }
   });
 
   type InferredSchemaType = InferSchemaType<typeof AutoTypedSchema>;

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -461,19 +461,19 @@ export function autoTypedSchema() {
   }, {
     statics: {
       staticFn() {
-        expectType<Model<M0_0aAutoTypedSchemaType['schema']>>(this);
+        expectType<Model<AutoTypedSchemaType['schema']>>(this);
         return 'Returned from staticFn' as const;
       }
     },
     methods: {
       instanceFn() {
-        expectType<HydratedDocument<M0_0aAutoTypedSchemaType['schema']>>(this);
+        expectType<HydratedDocument<AutoTypedSchemaType['schema']>>(this);
         return 'Returned from DocumentInstanceFn' as const;
       }
     },
     query: {
       byUserName(userName) {
-        expectAssignable<Query<unknown, M0_0aAutoTypedSchemaType['schema']>>(this);
+        expectAssignable<Query<unknown, AutoTypedSchemaType['schema']>>(this);
         return this.where({ userName });
       }
     }
@@ -481,14 +481,14 @@ export function autoTypedSchema() {
 
   type InferredSchemaType = InferSchemaType<typeof AutoTypedSchema>;
 
-  expectType<M0_0aAutoTypedSchemaType['schema']>({} as InferredSchemaType);
+  expectType<AutoTypedSchemaType['schema']>({} as InferredSchemaType);
 
-  expectError<M0_0aAutoTypedSchemaType['schema'] & { doesNotExist: boolean; }>({} as InferredSchemaType);
+  expectError<AutoTypedSchemaType['schema'] & { doesNotExist: boolean; }>({} as InferredSchemaType);
 
   return AutoTypedSchema;
 }
 
-export type M0_0aAutoTypedSchemaType = {
+export type AutoTypedSchemaType = {
   schema: {
     userName: string;
     description?: string;

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,5 +1,5 @@
-import { Schema, Document, SchemaDefinition, Model, Types } from 'mongoose';
-import { expectType, expectNotType, expectError } from 'tsd';
+import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType } from 'mongoose';
+import { expectType, expectError } from 'tsd';
 
 enum Genre {
   Action,
@@ -318,4 +318,150 @@ function gh10900(): void {
   const patientSchema = new Schema<IUserProp>({
     menuStatus: { type: Schema.Types.Mixed, default: {} }
   });
+}
+export type M0_0aAutoTypedSchemaType = {
+  schema: {
+    userName: string;
+    description?: string;
+    nested?: {
+      age: number;
+      hobby?: string
+    },
+    favoritDrink?: 'Tea' | 'Coffee',
+    favoritColorMode: 'dark' | 'light'
+  }
+  , statics: {
+    staticFn: () => 'Returned from staticFn'
+  },
+  methods: {
+    instanceFn: () => 'Returned from DocumentInstanceFn'
+  }
+};
+
+export function m0_0aSchema() {
+  const AutoTypedSchema = new Schema({
+    userName: {
+      type: String,
+      required: [true, 'userName is required']
+    },
+    description: String,
+    nested: new Schema({
+      age: {
+        type: Number,
+        required: true
+      },
+      hobby: {
+        type: String,
+        required: false
+      }
+    }),
+    favoritDrink: {
+      type: String,
+      enum: ['Coffee', 'Tea']
+    },
+    favoritColorMode: {
+      type: String,
+      enum: {
+        values: ['dark', 'light'],
+        message: '{VALUE} is not supported'
+      },
+      required: true
+    }
+  });
+
+  type InferredSchemaType = InferSchemaType<typeof AutoTypedSchema>;
+
+  expectType<M0_0aAutoTypedSchemaType['schema']>({} as InferredSchemaType);
+
+  expectError<M0_0aAutoTypedSchemaType['schema'] & { doesNotExist: boolean; }>({} as InferredSchemaType);
+
+  // Test auto schema type obtaining with all possible path types.
+
+  class Int8 extends SchemaType {
+    constructor(key, options) {
+      super(key, options, 'Int8');
+    }
+    cast(val) {
+      let _val = Number(val);
+      if (isNaN(_val)) {
+        throw new Error('Int8: ' + val + ' is not a number');
+      }
+      _val = Math.round(_val);
+      if (_val < -0x80 || _val > 0x7F) {
+        throw new Error('Int8: ' + val +
+          ' is outside of the range of valid 8-bit ints');
+      }
+      return _val;
+    }
+  }
+
+  type TestSchemaType = {
+    string1?: string;
+    string2?: string;
+    string3?: string;
+    string4?: string;
+    number1?: number;
+    number2?: number;
+    number3?: number;
+    number4?: number;
+    date1?: Date;
+    date2?: Date;
+    date3?: Date;
+    date4?: Date;
+    buffer1?: Buffer;
+    buffer2?: Buffer;
+    buffer3?: Buffer;
+    buffer4?: Buffer;
+    boolean1?: boolean;
+    boolean2?: boolean;
+    boolean3?: boolean;
+    boolean4?: boolean;
+    mixed1?: Schema.Types.Mixed;
+    mixed2?: Schema.Types.Mixed;
+    mixed3?: Schema.Types.Mixed;
+    objectId1?: Schema.Types.ObjectId;
+    objectId2?: Schema.Types.ObjectId;
+    objectId3?: Schema.Types.ObjectId;
+    customSchema?: Int8;
+    map1?: Map<string, string>;
+    map2?: Map<string, number>;
+  };
+
+  const TestSchema = new Schema({
+    string1: String,
+    string2: 'String',
+    string3: 'string',
+    string4: Schema.Types.String,
+    number1: Number,
+    number2: 'Number',
+    number3: 'number',
+    number4: Schema.Types.Number,
+    date1: Date,
+    date2: 'Date',
+    date3: 'date',
+    date4: Schema.Types.Date,
+    buffer1: Buffer,
+    buffer2: 'Buffer',
+    buffer3: 'buffer',
+    buffer4: Schema.Types.Buffer,
+    boolean1: Boolean,
+    boolean2: 'Boolean',
+    boolean3: 'boolean',
+    boolean4: Schema.Types.Boolean,
+    mixed1: Object,
+    mixed2: {},
+    mixed3: Schema.Types.Mixed,
+    objectId1: Schema.Types.ObjectId,
+    objectId2: 'ObjectId',
+    objectId3: 'objectId',
+    customSchema: Int8,
+    map1: { type: Map, of: String },
+    map2: { type: Map, of: Number }
+  });
+
+  type InferredTestSchemaType = InferSchemaType<typeof TestSchema>;
+
+  expectType<TestSchemaType>({} as InferredTestSchemaType);
+
+  return AutoTypedSchema;
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -370,6 +370,9 @@ export function m0_0aSchema() {
   }, {
     statics: {
       staticFn() { return 'Returned from staticFn'; }
+    },
+    methods: {
+      instanceFn() { return 'Returned from DocumentInstanceFn'; }
     }
   });
 

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -462,6 +462,16 @@ export function m0_0aSchema() {
   type InferredTestSchemaType = InferSchemaType<typeof TestSchema>;
 
   expectType<TestSchemaType>({} as InferredTestSchemaType);
+  const SchemaWithCustomTypeKey = new Schema({
+    name: {
+      customKTypeKey: String,
+      required: true
+    }
+  }, {
+    typeKey: 'customKTypeKey'
+  });
+
+  expectType<string>({} as InferSchemaType<typeof SchemaWithCustomTypeKey>['name']);
 
   return AutoTypedSchema;
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,6 +1,5 @@
 import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query, HydratedDocument } from 'mongoose';
 import { expectType, expectError, expectAssignable } from 'tsd';
-import { IsTAny } from '../../types/inferschematype';
 
 enum Genre {
   Action,
@@ -376,6 +375,7 @@ export function autoTypedSchema() {
     array2?: Schema.Types.Mixed[];
     array3?: Schema.Types.Mixed[];
     array4?: Schema.Types.Mixed[];
+    array5?: Schema.Types.Mixed[];
   };
 
   const TestSchema = new Schema({
@@ -408,10 +408,11 @@ export function autoTypedSchema() {
     customSchema: Int8,
     map1: { type: Map, of: String },
     map2: { type: Map, of: Number },
-    array1: { type: [String] },
-    array2: { type: Array },
-    array3: { type: [Schema.Types.Mixed] },
-    array4: { type: [{}] }
+    array1: [String],
+    array2: Array,
+    array3: [Schema.Types.Mixed],
+    array4: [{}],
+    array5: []
   });
 
   type InferredTestSchemaType = InferSchemaType<typeof TestSchema>;

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,5 +1,5 @@
 import { Schema, Document, SchemaDefinition, Model, Types, InferSchemaType, SchemaType, Query } from 'mongoose';
-import { expectType, expectError } from 'tsd';
+import { expectType, expectError, expectAssignable, expectNotAssignable } from 'tsd';
 
 enum Genre {
   Action,
@@ -451,17 +451,19 @@ export function autoTypedSchema() {
   }, {
     statics: {
       staticFn() {
-        return 'Returned from staticFn';
+        expectAssignable<Model<any>>(this);
+        return 'Returned from staticFn' as const;
       }
     },
     methods: {
       instanceFn() {
-        return 'Returned from DocumentInstanceFn';
+        expectAssignable<Document>(this);
+        return 'Returned from DocumentInstanceFn' as const;
       }
     },
     query: {
       byUserName(userName) {
-        expectType<Query<unknown, unknown>>(this);
+        expectAssignable<Query<unknown, unknown>>(this);
         return this.where({ userName });
       }
     }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -472,11 +472,11 @@ export function m0_0aSchema() {
 
   const SchemaWithCustomTypeKey = new Schema({
     name: {
-      customKTypeKey: String,
+      customTypeKey: String,
       required: true
     }
   }, {
-    typeKey: 'customKTypeKey'
+    typeKey: 'customTypeKey'
   });
 
   expectType<string>({} as InferSchemaType<typeof SchemaWithCustomTypeKey>['name']);

--- a/test/types/utility.test.ts
+++ b/test/types/utility.test.ts
@@ -1,0 +1,13 @@
+import { MergeType } from 'mongoose';
+import { expectType } from 'tsd';
+
+type A = { a: string, c: number};
+type B = { a: number, b: string };
+
+expectType<string>({} as MergeType<B, A>["a"]);
+expectType<string>({} as MergeType<B, A>["b"]);
+expectType<number>({} as MergeType<B, A>["c"]);
+
+expectType<number>({} as MergeType<A, B>["a"]);
+expectType<string>({} as MergeType<A, B>["b"]);
+expectType<number>({} as MergeType<A, B>["c"]);

--- a/test/types/utility.test.ts
+++ b/test/types/utility.test.ts
@@ -1,13 +1,13 @@
 import { MergeType } from 'mongoose';
 import { expectType } from 'tsd';
 
-type A = { a: string, c: number};
+type A = { a: string, c: number };
 type B = { a: number, b: string };
 
-expectType<string>({} as MergeType<B, A>["a"]);
-expectType<string>({} as MergeType<B, A>["b"]);
-expectType<number>({} as MergeType<B, A>["c"]);
+expectType<string>({} as MergeType<B, A>['a']);
+expectType<string>({} as MergeType<B, A>['b']);
+expectType<number>({} as MergeType<B, A>['c']);
 
-expectType<number>({} as MergeType<A, B>["a"]);
-expectType<string>({} as MergeType<A, B>["b"]);
-expectType<number>({} as MergeType<A, B>["c"]);
+expectType<number>({} as MergeType<A, B>['a']);
+expectType<string>({} as MergeType<A, B>['b']);
+expectType<number>({} as MergeType<A, B>['c']);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "strictNullChecks": true,
     "paths": {
       "mongoose" : ["./types/index.d.ts"]

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -193,8 +193,8 @@ declare module 'mongoose' {
     /** Populates document references. */
     populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<this & Paths>;
     populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[], callback: Callback<this & Paths>): void;
-    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<unknown>, match?: AnyObject, options?: PopulateOptions): Promise<this & Paths>;
-    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<unknown>, match?: AnyObject, options?: PopulateOptions, callback?: Callback<this & Paths>): void;
+    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions): Promise<this & Paths>;
+    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions, callback?: Callback<this & Paths>): void;
 
     /** Gets _id(s) used during population of the given `path`. If the path was not populated, returns `undefined`. */
     populated(path: string): any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,7 +130,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>>, options?: SchemaOptions);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,7 +130,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey>);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TStaticMethods>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,7 +62,7 @@ declare module 'mongoose' {
   /* ! ignore */
   export type CompileModelOptions = { overwriteModels?: boolean, connection?: Connection };
 
-  export function model<T, U = unknown, TQueryHelpers = {}, TSchema = any>(
+  export function model<T, U = unknown, TQueryHelpers = {}, TSchema = unknown>(
     name: string,
     schema?: TSchema,
     collection?: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,8 +94,6 @@ declare module 'mongoose' {
     [k: string]: any
   }
 
-  export type FlexibleObject<T extends {}> = { [P in keyof (T & Omit<any, keyof T>)]?: P extends keyof T ? T[P] : any };
-
   export type Require_id<T> = T extends { _id?: any } ? (T & { _id: T['_id'] }) : (T & { _id: Types.ObjectId });
 
   export type HydratedDocument<DocType, TMethodsAndOverrides = {}, TVirtuals = {}> = DocType extends Document ? Require_id<DocType> : (Document<unknown, any, DocType> & Require_id<DocType> & TVirtuals & TMethodsAndOverrides);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -67,7 +67,7 @@ declare module 'mongoose' {
     schema?: TSchema,
     collection?: string,
     options?: CompileModelOptions
-  ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema>;
+  ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
   export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
 
@@ -101,7 +101,15 @@ declare module 'mongoose' {
     [k: string]: any
   }
 
-  export type Require_id<T> = T extends { _id?: any } ? (T & { _id: T['_id'] }) : (T & { _id: Types.ObjectId });
+  export type Require_id<T> = T extends { _id?: infer U } 
+    ? U extends any
+      ? (T & { _id: Types.ObjectId })
+      : T &  Required<{ _id: U }>
+    : T & { _id: Types.ObjectId };
+  
+  export type RequireOnlyTypedId<T> = T extends { _id?: infer U; } 
+  ? Required<{ _id: U }>
+  : { _id: Types.ObjectId };
 
   export type HydratedDocument<DocType, TMethodsAndOverrides = {}, TVirtuals = {}> = DocType extends Document ? Require_id<DocType> : (Document<unknown, any, DocType> & Require_id<DocType> & TVirtuals & TMethodsAndOverrides);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -131,7 +131,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TInstanceMethods, TQueryHelpers, TStaticMethods>);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, DocType, TInstanceMethods, TQueryHelpers, TStaticMethods>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,7 +69,7 @@ declare module 'mongoose' {
     options?: CompileModelOptions
   ): U extends Model<any>
     ? U
-    : Model<T & InferSchemaType<TSchema>, TQueryHelpers, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema>;
+    : Model<T & InferSchemaType<TSchema>, TQueryHelpers & ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema>;
 
   /** Returns an array of model names created on this instance of Mongoose. */
   export function modelNames(): Array<string>;
@@ -131,7 +131,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TStaticMethods, TInstanceMethods>);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TStaticMethods, TInstanceMethods, TQueryHelpers>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,13 +62,14 @@ declare module 'mongoose' {
   /* ! ignore */
   export type CompileModelOptions = { overwriteModels?: boolean, connection?: Connection };
 
-  export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
-  export function model<T, U, TQueryHelpers = {}>(
+  export function model<T, U = unknown, TQueryHelpers = {}, TSchema = any>(
     name: string,
-    schema?: Schema<T, U, {}, TQueryHelpers>,
+    schema?: TSchema,
     collection?: string,
     options?: CompileModelOptions
-  ): U;
+  ): U extends Model<any>
+    ? U
+    : Model<T & InferSchemaType<TSchema>, TQueryHelpers, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema>;
 
   /** Returns an array of model names created on this instance of Mongoose. */
   export function modelNames(): Array<string>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -93,6 +93,9 @@ declare module 'mongoose' {
   export interface AnyObject {
     [k: string]: any
   }
+
+  export type FlexibleObject<T extends {}> = { [P in keyof (T & Omit<any, keyof T>)]?: P extends keyof T ? T[P] : any };
+
   export type Require_id<T> = T extends { _id?: any } ? (T & { _id: T['_id'] }) : (T & { _id: Types.ObjectId });
 
   export type HydratedDocument<DocType, TMethodsAndOverrides = {}, TVirtuals = {}> = DocType extends Document ? Require_id<DocType> : (Document<unknown, any, DocType> & Require_id<DocType> & TVirtuals & TMethodsAndOverrides);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,14 +62,21 @@ declare module 'mongoose' {
   /* ! ignore */
   export type CompileModelOptions = { overwriteModels?: boolean, connection?: Connection };
 
-  export function model<T, U = unknown, TQueryHelpers = {}, TSchema = unknown>(
+  export function model<TSchema extends Schema = any>(
     name: string,
     schema?: TSchema,
     collection?: string,
     options?: CompileModelOptions
-  ): U extends Model<any>
-    ? U
-    : Model<T & InferSchemaType<TSchema>, TQueryHelpers & ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema>;
+  ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema>;
+
+  export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
+
+  export function model<T, U, TQueryHelpers = {}>(
+    name: string,
+    schema?: Schema<T, any, TQueryHelpers>,
+    collection?: string,
+    options?: CompileModelOptions
+  ): U;
 
   /** Returns an array of model names created on this instance of Mongoose. */
   export function modelNames(): Array<string>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -124,9 +124,9 @@ declare module 'mongoose' {
   }
 
   export class Schema<EnforcedDocType = any, M = Model<EnforcedDocType, any, any, any>, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = any,
+    TStaticMethods = {},
     TPathTypeKey extends TypeKeyBaseType = DefaultTypeKey,
-    DocType extends ObtainDocumentType<DocType, EnforcedDocType, TPathTypeKey> = ObtainDocumentType<any, EnforcedDocType, TPathTypeKey>,
-    TStaticMethods = {}>
+    DocType extends ObtainDocumentType<DocType, EnforcedDocType, TPathTypeKey> = ObtainDocumentType<any, EnforcedDocType, TPathTypeKey>>
     extends events.EventEmitter {
     /**
      * Create a new schema

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,7 +130,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,7 @@
 /// <reference path="./types.d.ts" />
 /// <reference path="./utility.d.ts" />
 /// <reference path="./validation.d.ts" />
+/// <reference path="./inferschematype.d.ts" />
 
 declare class NativeDate extends global.Date { }
 
@@ -120,14 +121,18 @@ declare module 'mongoose' {
     useProjection?: boolean;
   }
 
-  export class Schema<DocType = any, M = Model<DocType, any, any, any>, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = any> extends events.EventEmitter {
+  export class Schema<EnforcedDocType = any, M = Model<EnforcedDocType, any, any, any>, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = any,
+    TPathTypeKey extends TypeKeyBaseType = DefaultTypeKey,
+    DocType extends ObtainDocumentType<DocType, EnforcedDocType, TPathTypeKey> = ObtainDocumentType<any, EnforcedDocType, TPathTypeKey>,
+    TStaticMethods = {}>
+    extends events.EventEmitter {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<DocType>>, options?: SchemaOptions);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>>, options?: SchemaOptions);
 
     /** Adds key path / schema type pairs to this schema. */
-    add(obj: SchemaDefinition<SchemaDefinitionType<DocType>> | Schema, prefix?: string): this;
+    add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;
 
     /**
      * Array of child schemas (from document arrays and single nested subdocs)
@@ -180,7 +185,7 @@ declare module 'mongoose' {
     methods: { [F in keyof TInstanceMethods]: TInstanceMethods[F] } & AnyObject;
 
     /** The original object passed to the schema constructor */
-    obj: SchemaDefinition<SchemaDefinitionType<DocType>>;
+    obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>>;
 
     /** Gets/sets schema paths. */
     path<ResultType extends SchemaType = SchemaType>(path: string): ResultType;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -131,7 +131,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TStaticMethods, TInstanceMethods, TQueryHelpers>);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TInstanceMethods, TQueryHelpers, TStaticMethods>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,7 +130,7 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TStaticMethods>);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<TPathTypeKey, TStaticMethods, TInstanceMethods>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -101,15 +101,15 @@ declare module 'mongoose' {
     [k: string]: any
   }
 
-  export type Require_id<T> = T extends { _id?: infer U } 
+  export type Require_id<T> = T extends { _id?: infer U }
     ? U extends any
       ? (T & { _id: Types.ObjectId })
-      : T &  Required<{ _id: U }>
+      : T & Required<{ _id: U }>
     : T & { _id: Types.ObjectId };
-  
-  export type RequireOnlyTypedId<T> = T extends { _id?: infer U; } 
-  ? Required<{ _id: U }>
-  : { _id: Types.ObjectId };
+
+  export type RequireOnlyTypedId<T> = T extends { _id?: infer U; }
+    ? Required<{ _id: U }>
+    : { _id: Types.ObjectId };
 
   export type HydratedDocument<DocType, TMethodsAndOverrides = {}, TVirtuals = {}> = DocType extends Document ? Require_id<DocType> : (Document<unknown, any, DocType> & Require_id<DocType> & TVirtuals & TMethodsAndOverrides);
 

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -32,9 +32,18 @@ declare module 'mongoose' {
    * @param {TSchema} TSchema A generic of schema type instance.
    * @param {alias} alias Targeted generic alias.
    */
-  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TPathTypeKey' | 'DocType' | 'TStaticMethods'> =
-    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TPathTypeKey, infer DocType, infer TStaticMethods>
-      ? { EnforcedDocType: EnforcedDocType, M: M, TInstanceMethods: TInstanceMethods, TQueryHelpers: TQueryHelpers, TVirtuals: TVirtuals, TPathTypeKey: TPathTypeKey, DocType: DocType, TStaticMethods: TStaticMethods }[alias]
+  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TPathTypeKey' | 'DocType'> =
+    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TStaticMethods, infer TPathTypeKey, infer DocType>
+      ? {
+        EnforcedDocType: EnforcedDocType;
+        M: M;
+        TInstanceMethods: TInstanceMethods;
+        TQueryHelpers: TQueryHelpers;
+        TVirtuals: TVirtuals;
+        TStaticMethods: TStaticMethods;
+        TPathTypeKey: TPathTypeKey;
+        DocType: DocType;
+      }[alias]
       : unknown;
 }
 /**

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -52,9 +52,18 @@ declare module 'mongoose' {
  * @param {T} T A generic type to be checked.
  * @returns true if {@link T} is Record OR false if {@link T} is of any type.
  */
-type IsItRecordAndNotAny<T> = IsTAny<T> extends true ? false : T extends Record<any, any> ? true : false;
+type IsItRecordAndNotAny<T> = IfEquals<T, any, false, T extends Record<any, any> ? true : false>;
 
-type IsTAny<T> = keyof any extends keyof T ? (unknown extends T ? true : false) : false;
+/**
+ * @summary Checks if two types are identical.
+ * @param {T} T The first type to be compared with {@link U}.
+ * @param {U} U The seconde type to be compared with {@link T}.
+ * @param {Y} Y A type to be returned if {@link T} &  {@link U} are identical.
+ * @param {N} N A type to be returned if {@link T} &  {@link U} are not identical.
+ */
+type IfEquals<T, U, Y = true, N = false> =
+    (<G>() => G extends T ? 1 : 0) extends
+    (<G>() => G extends U ? 1 : 0) ? Y : N;
 
 /**
  * @summary Required path base type.
@@ -131,8 +140,7 @@ type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (
  * @returns Number, "Number" or "number" will be resolved to string type.
  */
 type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueType> = {}> =
-  IsTAny<PathValueType> extends true ? Schema.Types.Mixed:
-    PathValueType extends (infer Item)[] ? ResolvePathType<Item>[] :
+    PathValueType extends (infer Item)[] ? IfEquals<Item, never, Schema.Types.Mixed, ResolvePathType<Item>>[] :
       PathValueType extends StringConstructor | 'string' | 'String' | typeof Schema.Types.String ? PathEnumOrString<Options['enum']> :
         PathValueType extends NumberConstructor | 'number' | 'Number' | typeof Schema.Types.Number ? number :
           PathValueType extends DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date ? Date :

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -11,7 +11,7 @@ declare module 'mongoose' {
   type ObtainDocumentType<DocDefinition, EnforcedDocType = any, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
     IsItRecordAndNotAny<EnforcedDocType> extends true ? EnforcedDocType : {
       [K in keyof (RequiredPaths<DocDefinition> &
-        OptionalPaths<DocDefinition>)]: ObtainDocumentPathType<DocDefinition[K], TypeKey>;
+      OptionalPaths<DocDefinition>)]: ObtainDocumentPathType<DocDefinition[K], TypeKey>;
     };
 
   /**
@@ -32,10 +32,10 @@ declare module 'mongoose' {
    * @param {TSchema} TSchema A generic of schema type instance.
    * @param {alias} alias Targeted generic alias.
    */
-  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TPathTypeKey' |'DocType' | 'TStaticMethods'> =
-    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TPathTypeKey, infer DocType, infer TStaticMethods>
-    ? { EnforcedDocType: EnforcedDocType, M: M, TInstanceMethods: TInstanceMethods, TQueryHelpers: TQueryHelpers, TPathTypeKey:TPathTypeKey, DocType: DocType, TStaticMethods: TStaticMethods }[alias]
-    : unknown;
+  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TPathTypeKey' | 'DocType' | 'TStaticMethods'> =
+    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TPathTypeKey, infer DocType, infer TStaticMethods>
+      ? { EnforcedDocType: EnforcedDocType, M: M, TInstanceMethods: TInstanceMethods, TQueryHelpers: TQueryHelpers, TVirtuals: TVirtuals, TPathTypeKey: TPathTypeKey, DocType: DocType, TStaticMethods: TStaticMethods }[alias]
+      : unknown;
 }
 /**
  * @summary Checks if a type is "Record" or "any".
@@ -49,14 +49,14 @@ type IsItRecordAndNotAny<T> = T extends any[] ? false : T extends Record<any, an
  * @summary Required path base type.
  * @description It helps to check whereas if a path is required OR optional.
  */
-type RequiredPathBaseType = { required: true | [true, string | undefined] }
+type RequiredPathBaseType = { required: true | [true, string | undefined] };
 
 /**
  * @summary Path base type defined by using TypeKey
  * @description It helps to check if a path is defined by TypeKey OR not.
  * @param {TypeKey} TypeKey A literal string refers to path type property key.
  */
-type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in TypeKey]: any }
+type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in TypeKey]: any };
 
 /**
  * @summary A Utility to obtain schema's required path keys.
@@ -103,8 +103,8 @@ type OptionalPaths<T> = {
 type ObtainDocumentPathType<PathValueType, TypeKey extends TypeKeyBaseType> = PathValueType extends Schema<any>
   ? InferSchemaType<PathValueType>
   : ResolvePathType<
-    PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
-    PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {}
+  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
+  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {}
   >;
 
 /**
@@ -121,14 +121,14 @@ type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (
  */
 type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueType> = {}> =
 PathValueType extends (infer Item)[] ? ResolvePathType<Item>[] :
-PathValueType extends StringConstructor | 'string' | 'String' | typeof Schema.Types.String ? PathEnumOrString<Options['enum']> :
-PathValueType extends NumberConstructor | 'number' | 'Number' | typeof Schema.Types.Number ? number :
-PathValueType extends DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date ? Date :
-PathValueType extends BufferConstructor | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
-PathValueType extends BooleanConstructor | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean ? boolean :
-PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Schema.Types.ObjectId :
-PathValueType extends ObjectConstructor | typeof Schema.Types.Mixed ? Schema.Types.Mixed :
-keyof PathValueType extends never ? Schema.Types.Mixed :
-PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
-PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
-unknown
+  PathValueType extends StringConstructor | 'string' | 'String' | typeof Schema.Types.String ? PathEnumOrString<Options['enum']> :
+    PathValueType extends NumberConstructor | 'number' | 'Number' | typeof Schema.Types.Number ? number :
+      PathValueType extends DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date ? Date :
+        PathValueType extends BufferConstructor | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
+          PathValueType extends BooleanConstructor | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean ? boolean :
+            PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Schema.Types.ObjectId :
+              PathValueType extends ObjectConstructor | typeof Schema.Types.Mixed ? Schema.Types.Mixed :
+                keyof PathValueType extends never ? Schema.Types.Mixed :
+                  PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
+                    PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+                      unknown;

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -1,0 +1,134 @@
+import { Schema, InferSchemaType, SchemaType, SchemaTypeOptions, TypeKeyBaseType } from 'mongoose';
+
+declare module 'mongoose' {
+  /**
+   * @summary Obtains document schema type.
+   * @description Obtains document schema type from document Definition OR returns enforced schema type if it's provided.
+   * @param {DocDefinition} DocDefinition A generic equals to the type of document definition "provided in as first parameter in Schema constructor".
+   * @param {EnforcedDocType} EnforcedDocType A generic type enforced by user "provided before schema constructor".
+   * @param {TypeKey} TypeKey A generic of literal string type.
+   */
+  type ObtainDocumentType<DocDefinition, EnforcedDocType = any, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
+    IsItRecordAndNotAny<EnforcedDocType> extends true ? EnforcedDocType : {
+      [K in keyof (RequiredPaths<DocDefinition> &
+        OptionalPaths<DocDefinition>)]: ObtainDocumentPathType<DocDefinition[K], TypeKey>;
+    };
+
+  /**
+   * @summary Obtains document schema type from Schema instance.
+   * @param {SchemaType} SchemaType A generic of schema type instance.
+   * @example
+   * const userSchema = new Schema({userName:String});
+   * type UserType = InferSchemaType<typeof userSchema>;
+   * // result
+   * type UserType = {userName?: string}
+   */
+  type InferSchemaType<SchemaType> = SchemaType extends Schema<infer DocType>
+    ? IsItRecordAndNotAny<DocType> extends true ? DocType : ObtainSchemaGeneric<SchemaType, 'DocType'>
+    : unknown;
+
+  /**
+   * @summary Obtains schema Generic type by using generic alias.
+   * @param {TSchema} TSchema A generic of schema type instance.
+   * @param {alias} alias Targeted generic alias.
+   */
+  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TPathTypeKey' |'DocType' | 'TStaticMethods'> =
+    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TPathTypeKey, infer DocType, infer TStaticMethods>
+    ? { EnforcedDocType: EnforcedDocType, M: M, TInstanceMethods: TInstanceMethods, TQueryHelpers: TQueryHelpers, TPathTypeKey:TPathTypeKey, DocType: DocType, TStaticMethods: TStaticMethods }[alias]
+    : unknown;
+}
+/**
+ * @summary Checks if a type is "Record" or "any".
+ * @description It Helps to check if user has provided schema type "EnforcedDocType"
+ * @param {T} T A generic type to be checked.
+ * @returns true if {@link T} is Record OR false if {@link T} is of any type.
+ */
+type IsItRecordAndNotAny<T> = T extends any[] ? false : T extends Record<any, any> ? true : false;
+
+/**
+ * @summary Required path base type.
+ * @description It helps to check whereas if a path is required OR optional.
+ */
+type RequiredPathBaseType = { required: true | [true, string | undefined] }
+
+/**
+ * @summary Path base type defined by using TypeKey
+ * @description It helps to check if a path is defined by TypeKey OR not.
+ * @param {TypeKey} TypeKey A literal string refers to path type property key.
+ */
+type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in TypeKey]: any }
+
+/**
+ * @summary A Utility to obtain schema's required path keys.
+ * @param {T} T A generic refers to document definition.
+ * @returns required paths keys of document definition.
+ */
+type RequiredPathKeys<T> = {
+  [K in keyof T]: T[K] extends RequiredPathBaseType ? K : never;
+}[keyof T];
+
+/**
+ * @summary A Utility to obtain schema's required paths.
+ * @param {T} T A generic refers to document definition.
+ * @returns a record contains required paths with the corresponding type.
+ */
+type RequiredPaths<T> = {
+  [K in RequiredPathKeys<T>]: T[K];
+};
+
+/**
+ * @summary A Utility to obtain schema's optional path keys.
+ * @param {T} T A generic refers to document definition.
+ * @returns optional paths keys of document definition.
+ */
+type OptionalPathKeys<T> = {
+  [K in keyof T]: T[K] extends RequiredPathBaseType ? never : K;
+}[keyof T];
+
+/**
+ * @summary A Utility to obtain schema's optional paths.
+ * @param {T} T A generic refers to document definition.
+ * @returns a record contains optional paths with the corresponding type.
+ */
+type OptionalPaths<T> = {
+  [K in OptionalPathKeys<T>]?: T[K];
+};
+
+/**
+ * @summary Obtains schema Path type.
+ * @description Obtains Path type by calling {@link ResolvePathType} OR by calling {@link InferSchemaType} if path of schema type.
+ * @param {PathValueType} PathValueType Document definition path type.
+ * @param {TypeKey} TypeKey A generic refers to document definition.
+ */
+type ObtainDocumentPathType<PathValueType, TypeKey extends TypeKeyBaseType> = PathValueType extends Schema<any>
+  ? InferSchemaType<PathValueType>
+  : ResolvePathType<
+    PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
+    PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {}
+  >;
+
+/**
+ * @param {T} T A generic refers to string path enums.
+ * @returns Path enum values type as literal strings or string.
+ */
+type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (infer E)[] ? E : T extends { values: any } ? PathEnumOrString<T['values']> : string;
+
+/**
+ * @summary Resolve path type by returning the corresponding type.
+ * @param {PathValueType} PathValueType Document definition path type.
+ * @param {Options} Options Document definition path options except path type.
+ * @returns Number, "Number" or "number" will be resolved to string type.
+ */
+type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueType> = {}> =
+PathValueType extends (infer Item)[] ? ResolvePathType<Item>[] :
+PathValueType extends StringConstructor | 'string' | 'String' | typeof Schema.Types.String ? PathEnumOrString<Options['enum']> :
+PathValueType extends NumberConstructor | 'number' | 'Number' | typeof Schema.Types.Number ? number :
+PathValueType extends DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date ? Date :
+PathValueType extends BufferConstructor | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
+PathValueType extends BooleanConstructor | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean ? boolean :
+PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Schema.Types.ObjectId :
+PathValueType extends ObjectConstructor | typeof Schema.Types.Mixed ? Schema.Types.Mixed :
+keyof PathValueType extends never ? Schema.Types.Mixed :
+PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
+PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+unknown

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -23,9 +23,7 @@ declare module 'mongoose' {
    * // result
    * type UserType = {userName?: string}
    */
-  type InferSchemaType<SchemaType> = SchemaType extends Schema<infer EnforcedDocType>
-    ? IsItRecordAndNotAny<EnforcedDocType> extends true ? EnforcedDocType : ObtainSchemaGeneric<SchemaType, 'DocType'>
-    : unknown;
+  type InferSchemaType<SchemaType> = ObtainSchemaGeneric<SchemaType, 'DocType'> ;
 
   /**
    * @summary Obtains schema Generic type by using generic alias.
@@ -84,7 +82,7 @@ type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in Typ
  * @returns required paths keys of document definition.
  */
 type RequiredPathKeys<T> = {
-  [K in keyof T]: T[K] extends RequiredPathBaseType ? K : never;
+  [K in keyof T]: T[K] extends RequiredPathBaseType ? IfEquals<T[K], any, never, K> : never;
 }[keyof T];
 
 /**
@@ -140,16 +138,17 @@ type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (
  * @returns Number, "Number" or "number" will be resolved to string type.
  */
 type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueType> = {}> =
-    PathValueType extends (infer Item)[] ? IfEquals<Item, never, Schema.Types.Mixed, ResolvePathType<Item>>[] :
-      PathValueType extends StringConstructor | 'string' | 'String' | typeof Schema.Types.String ? PathEnumOrString<Options['enum']> :
-        PathValueType extends NumberConstructor | 'number' | 'Number' | typeof Schema.Types.Number ? number :
-          PathValueType extends DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date ? Date :
-            PathValueType extends BufferConstructor | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
-              PathValueType extends BooleanConstructor | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean ? boolean :
-                PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Schema.Types.ObjectId :
-                  PathValueType extends ObjectConstructor | typeof Schema.Types.Mixed ? Schema.Types.Mixed :
-                    PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
-                      PathValueType extends ArrayConstructor ? Schema.Types.Mixed[] :
-                        keyof PathValueType extends keyof {} ? Schema.Types.Mixed :
+  PathValueType extends (infer Item)[] ? IfEquals<Item, never, any, ResolvePathType<Item>>[] :
+    PathValueType extends StringConstructor | 'string' | 'String' | typeof Schema.Types.String ? PathEnumOrString<Options['enum']> :
+      PathValueType extends NumberConstructor | 'number' | 'Number' | typeof Schema.Types.Number ? number :
+        PathValueType extends DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date ? Date :
+          PathValueType extends BufferConstructor | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
+            PathValueType extends BooleanConstructor | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean ? boolean :
+              PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Schema.Types.ObjectId :
+                PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
+                  PathValueType extends ArrayConstructor ? any[] :
+                    PathValueType extends typeof Schema.Types.Mixed ? any:
+                      IfEquals<PathValueType, ObjectConstructor> extends true ? any:
+                        IfEquals<PathValueType, {}> extends true ? any:
                           PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
                             unknown;

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -145,10 +145,11 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
           PathValueType extends BufferConstructor | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
             PathValueType extends BooleanConstructor | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean ? boolean :
               PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Schema.Types.ObjectId :
-                PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
-                  PathValueType extends ArrayConstructor ? any[] :
-                    PathValueType extends typeof Schema.Types.Mixed ? any:
-                      IfEquals<PathValueType, ObjectConstructor> extends true ? any:
-                        IfEquals<PathValueType, {}> extends true ? any:
-                          PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
-                            unknown;
+                PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 ? Schema.Types.Decimal128 :
+                  PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
+                    PathValueType extends ArrayConstructor ? any[] :
+                      PathValueType extends typeof Schema.Types.Mixed ? any:
+                        IfEquals<PathValueType, ObjectConstructor> extends true ? any:
+                          IfEquals<PathValueType, {}> extends true ? any:
+                            PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+                              unknown;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -114,7 +114,7 @@ declare module 'mongoose' {
   }
 
   const Model: Model<any>;
-  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}> extends
+  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> extends
     NodeJS.EventEmitter,
     AcceptsDiscriminator,
     IndexManager,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -114,142 +114,143 @@ declare module 'mongoose' {
   }
 
   const Model: Model<any>;
-  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> extends
-    NodeJS.EventEmitter,
-    AcceptsDiscriminator,
-    IndexManager,
-    SessionStarter {
-    new <DocType = AnyKeys<T> & AnyObject>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
+  type Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any>=
+    NodeJS.EventEmitter &
+    AcceptsDiscriminator &
+    IndexManager &
+    SessionStarter &
+    ObtainSchemaGeneric<TSchema, 'TStaticMethods'> & {
+      new <DocType = AnyKeys<T> & AnyObject>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
 
-    aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
-    aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;
+      aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
+      aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;
 
-    /** Base Mongoose instance the model uses. */
-    base: Mongoose;
+      /** Base Mongoose instance the model uses. */
+      base: Mongoose;
 
-    /**
+      /**
      * If this is a discriminator model, `baseModelName` is the name of
      * the base model.
      */
-    baseModelName: string | undefined;
+      baseModelName: string | undefined;
 
-    /**
+      /**
      * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,
      * `deleteOne`, and/or `deleteMany` operations to the MongoDB server in one
      * command. This is faster than sending multiple independent operations (e.g.
      * if you use `create()`) because with `bulkWrite()` there is only one network
      * round trip to the MongoDB server.
      */
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, callback: Callback<mongodb.BulkWriteResult>): void;
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+      bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
+      bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, callback: Callback<mongodb.BulkWriteResult>): void;
+      bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
 
-    /**
+      /**
      * Sends multiple `save()` calls in a single `bulkWrite()`. This is faster than
      * sending multiple `save()` calls because with `bulkSave()` there is only one
      * network round trip to the MongoDB server.
      */
-    bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+      bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions): Promise<mongodb.BulkWriteResult>;
 
-    /** Collection the model uses. */
-    collection: Collection;
+      /** Collection the model uses. */
+      collection: Collection;
 
-    /** Creates a `count` query: counts the number of documents that match `filter`. */
-    count(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    count(filter: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      /** Creates a `count` query: counts the number of documents that match `filter`. */
+      count(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      count(filter: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
-    countDocuments(filter: FilterQuery<T>, options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
+      countDocuments(filter: FilterQuery<T>, options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /** Creates a new document or documents */
-    create(docs: (AnyKeys<T> | AnyObject)[], options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create(docs: (AnyKeys<T> | AnyObject)[], callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>): void;
-    create(doc: AnyKeys<T> | AnyObject): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-    create(doc: AnyKeys<T> | AnyObject, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
-    create<DocContents = AnyKeys<T>>(docs: DocContents[], options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(docs: DocContents[], callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>): void;
-    create<DocContents = AnyKeys<T>>(doc: DocContents): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-    create<DocContents = AnyKeys<T>>(...docs: DocContents[]): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(doc: DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
+      /** Creates a new document or documents */
+      create(docs: (AnyKeys<T> | AnyObject)[], options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+      create(docs: (AnyKeys<T> | AnyObject)[], callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>): void;
+      create(doc: AnyKeys<T> | AnyObject): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+      create(doc: AnyKeys<T> | AnyObject, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
+      create<DocContents = AnyKeys<T>>(docs: DocContents[], options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = AnyKeys<T>>(docs: DocContents[], callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>): void;
+      create<DocContents = AnyKeys<T>>(doc: DocContents): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+      create<DocContents = AnyKeys<T>>(...docs: DocContents[]): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = AnyKeys<T>>(doc: DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
 
-    /**
+      /**
      * Create the collection for this model. By default, if no indexes are specified,
      * mongoose will not create the collection for the model until any documents are
      * created. Use this method to create the collection explicitly.
      */
-    createCollection<T extends mongodb.Document>(options: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'> | null, callback: Callback<mongodb.Collection<T>>): void;
-    createCollection<T extends mongodb.Document>(callback: Callback<mongodb.Collection<T>>): void;
-    createCollection<T extends mongodb.Document>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
+      createCollection<T extends mongodb.Document>(options: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'> | null, callback: Callback<mongodb.Collection<T>>): void;
+      createCollection<T extends mongodb.Document>(callback: Callback<mongodb.Collection<T>>): void;
+      createCollection<T extends mongodb.Document>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
 
-    /** Connection the model uses. */
-    db: Connection;
+      /** Connection the model uses. */
+      db: Connection;
 
-    /**
+      /**
      * Deletes all of the documents that match `conditions` from the collection.
      * Behaves like `remove()`, but deletes all documents that match `conditions`
      * regardless of the `single` option.
      */
-    deleteMany(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    deleteMany(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    deleteMany(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      deleteMany(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      deleteMany(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      deleteMany(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /**
+      /**
      * Deletes the first document that matches `conditions` from the collection.
      * Behaves like `remove()`, but deletes at most one document regardless of the
      * `single` option.
      */
-    deleteOne(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    deleteOne(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    deleteOne(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      deleteOne(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      deleteOne(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      deleteOne(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /**
+      /**
      * Event emitter that reports any errors that occurred. Useful for global error
      * handling.
      */
-    events: NodeJS.EventEmitter;
+      events: NodeJS.EventEmitter;
 
-    /**
+      /**
      * Finds a single document by its _id field. `findById(id)` is almost*
      * equivalent to `findOne({ _id: id })`. If you want to query by a document's
      * `_id`, use `findById()` instead of `findOne()`.
      */
-    findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      id: any,
-      projection?: ProjectionType<T> | null,
-      options?: QueryOptions<T> | null,
-      callback?: Callback<ResultDoc | null>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-    findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      id: any,
-      projection?: ProjectionType<T> | null,
-      callback?: Callback<ResultDoc | null>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        id: any,
+        projection?: ProjectionType<T> | null,
+        options?: QueryOptions<T> | null,
+        callback?: Callback<ResultDoc | null>
+      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        id: any,
+        projection?: ProjectionType<T> | null,
+        callback?: Callback<ResultDoc | null>
+      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Finds one document. */
-    findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      projection?: ProjectionType<T> | null,
-      options?: QueryOptions<T> | null,
-      callback?: Callback<ResultDoc | null>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-    findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      projection?: ProjectionType<T> | null,
-      callback?: Callback<ResultDoc | null>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-    findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      callback?: Callback<ResultDoc | null>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Finds one document. */
+      findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        projection?: ProjectionType<T> | null,
+        options?: QueryOptions<T> | null,
+        callback?: Callback<ResultDoc | null>
+      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        projection?: ProjectionType<T> | null,
+        callback?: Callback<ResultDoc | null>
+      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        callback?: Callback<ResultDoc | null>
+      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /**
+      /**
      * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
      * The document returned has no paths marked as modified initially.
      */
-    hydrate(obj: any): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
+      hydrate(obj: any): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
 
-    /**
+      /**
      * This function is responsible for building [indexes](https://docs.mongodb.com/manual/indexes/),
      * unless [`autoIndex`](http://mongoosejs.com/docs/guide.html#autoIndex) is turned off.
      * Mongoose calls this function automatically when a model is created using
@@ -257,163 +258,163 @@ declare module 'mongoose' {
      * [`connection.model()`](/docs/api.html#connection_Connection-model), so you
      * don't need to call it.
      */
-    init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+      init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
-    /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
-    insertMany(docs: Array<AnyKeys<T> | AnyObject>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<T>>;
-    insertMany(docs: Array<AnyKeys<T> | AnyObject>, options?: InsertManyOptions): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
-    insertMany(doc: AnyKeys<T> | AnyObject, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<T>>;
-    insertMany(doc: AnyKeys<T> | AnyObject, options?: InsertManyOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    insertMany(doc: AnyKeys<T> | AnyObject, options?: InsertManyOptions, callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<T>>): void;
-    insertMany(docs: Array<AnyKeys<T> | AnyObject>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<T>>): void;
+      /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
+      insertMany(docs: Array<AnyKeys<T> | AnyObject>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<T>>;
+      insertMany(docs: Array<AnyKeys<T> | AnyObject>, options?: InsertManyOptions): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
+      insertMany(doc: AnyKeys<T> | AnyObject, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<T>>;
+      insertMany(doc: AnyKeys<T> | AnyObject, options?: InsertManyOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+      insertMany(doc: AnyKeys<T> | AnyObject, options?: InsertManyOptions, callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<T>>): void;
+      insertMany(docs: Array<AnyKeys<T> | AnyObject>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<T>>): void;
 
-    /** The name of the model */
-    modelName: string;
+      /** The name of the model */
+      modelName: string;
 
-    /** Populates document references. */
-    populate(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string,
-      callback?: Callback<(HydratedDocument<T, TMethodsAndOverrides, TVirtuals>)[]>): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
-    populate(doc: any, options: PopulateOptions | Array<PopulateOptions> | string,
-      callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+      /** Populates document references. */
+      populate(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string,
+        callback?: Callback<(HydratedDocument<T, TMethodsAndOverrides, TVirtuals>)[]>): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
+      populate(doc: any, options: PopulateOptions | Array<PopulateOptions> | string,
+        callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
 
-    /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
-    validate(callback?: CallbackWithoutResult): Promise<void>;
-    validate(optional: any, callback?: CallbackWithoutResult): Promise<void>;
-    validate(optional: any, pathsToValidate: PathsToValidate, callback?: CallbackWithoutResult): Promise<void>;
+      /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
+      validate(callback?: CallbackWithoutResult): Promise<void>;
+      validate(optional: any, callback?: CallbackWithoutResult): Promise<void>;
+      validate(optional: any, pathsToValidate: PathsToValidate, callback?: CallbackWithoutResult): Promise<void>;
 
-    /** Watches the underlying collection for changes using [MongoDB change streams](https://docs.mongodb.com/manual/changeStreams/). */
-    watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
+      /** Watches the underlying collection for changes using [MongoDB change streams](https://docs.mongodb.com/manual/changeStreams/). */
+      watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
 
-    /** Adds a `$where` clause to this query */
-    $where(argument: string | Function): QueryWithHelpers<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      /** Adds a `$where` clause to this query */
+      $where(argument: string | Function): QueryWithHelpers<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /** Registered discriminators for this model. */
-    discriminators: { [name: string]: Model<any> } | undefined;
+      /** Registered discriminators for this model. */
+      discriminators: { [name: string]: Model<any> } | undefined;
 
-    /** Translate any aliases fields/conditions so the final query or document object is pure */
-    translateAliases(raw: any): any;
+      /** Translate any aliases fields/conditions so the final query or document object is pure */
+      translateAliases(raw: any): any;
 
-    /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
-    distinct<ReturnType = any>(field: string, filter?: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<Array<ReturnType>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
+      distinct<ReturnType = any>(field: string, filter?: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<Array<ReturnType>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /** Creates a `estimatedDocumentCount` query: counts the number of documents in the collection. */
-    estimatedDocumentCount(options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      /** Creates a `estimatedDocumentCount` query: counts the number of documents in the collection. */
+      estimatedDocumentCount(options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /**
+      /**
      * Returns a document with its `_id` if at least one document exists in the database that matches
      * the given `filter`, and `null` otherwise.
      */
-    exists(filter: FilterQuery<T>, callback: Callback<Pick<Document<T>, '_id'> | null>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-    exists(filter: FilterQuery<T>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      exists(filter: FilterQuery<T>, callback: Callback<Pick<Document<T>, '_id'> | null>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+      exists(filter: FilterQuery<T>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-    /** Creates a `find` query: gets a list of documents that match `filter`. */
-    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter: FilterQuery<T>,
-      projection?: ProjectionType<T> | null,
-      callback?: Callback<ResultDoc[]>
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, projection?: ProjectionType<T> | null, options?: QueryOptions<T> | null, callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `find` query: gets a list of documents that match `filter`. */
+      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter: FilterQuery<T>,
+        projection?: ProjectionType<T> | null,
+        callback?: Callback<ResultDoc[]>
+      ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, projection?: ProjectionType<T> | null, options?: QueryOptions<T> | null, callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
-    findByIdAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
+      findByIdAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findByIdAndRemove` query, filtering by the given `_id`. */
-    findByIdAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findByIdAndRemove` query, filtering by the given `_id`. */
+      findByIdAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
-    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { rawResult: true }, callback?: (err: CallbackError, doc: any, res: any) => void): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
-    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, update?: UpdateQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, callback: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
+      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { rawResult: true }, callback?: (err: CallbackError, doc: any, res: any) => void): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
+      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, update?: UpdateQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, callback: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
-    findOneAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
+      findOneAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findOneAndRemove` query: atomically finds the given document and deletes it. */
-    findOneAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findOneAndRemove` query: atomically finds the given document and deletes it. */
+      findOneAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
-    findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
-    findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, replacement?: T | AnyObject, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
+      findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
+      findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, replacement?: T | AnyObject, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
-    findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter: FilterQuery<T>,
-      update: UpdateQuery<T>,
-      options: QueryOptions<T> & { rawResult: true },
-      callback?: (err: CallbackError, doc: any, res: any) => void
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter: FilterQuery<T>,
-      update: UpdateQuery<T>,
-      options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc,
-      callback?: (err: CallbackError, doc: ResultDoc, res: any) => void
-    ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
-    findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      update?: UpdateQuery<T>,
-      options?: QueryOptions<T> | null,
-      callback?: (err: CallbackError, doc: T | null, res: any) => void
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
+      findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter: FilterQuery<T>,
+        update: UpdateQuery<T>,
+        options: QueryOptions<T> & { rawResult: true },
+        callback?: (err: CallbackError, doc: any, res: any) => void
+      ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter: FilterQuery<T>,
+        update: UpdateQuery<T>,
+        options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc,
+        callback?: (err: CallbackError, doc: ResultDoc, res: any) => void
+      ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
+      findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        update?: UpdateQuery<T>,
+        options?: QueryOptions<T> | null,
+        callback?: (err: CallbackError, doc: T | null, res: any) => void
+      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-    geoSearch<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      options?: GeoSearchOptions,
-      callback?: Callback<Array<ResultDoc>>
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      geoSearch<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        options?: GeoSearchOptions,
+        callback?: Callback<Array<ResultDoc>>
+      ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
 
-    /** Executes a mapReduce command. */
-    mapReduce<Key, Value>(
-      o: MapReduceOptions<T, Key, Value>,
-      callback?: Callback
-    ): Promise<any>;
+      /** Executes a mapReduce command. */
+      mapReduce<Key, Value>(
+        o: MapReduceOptions<T, Key, Value>,
+        callback?: Callback
+      ): Promise<any>;
 
-    remove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: any, callback?: CallbackWithoutResult): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
+      remove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: any, callback?: CallbackWithoutResult): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
-    replaceOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      replacement?: T | AnyObject,
-      options?: QueryOptions<T> | null,
-      callback?: Callback
-    ): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
+      replaceOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        replacement?: T | AnyObject,
+        options?: QueryOptions<T> | null,
+        callback?: Callback
+      ): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
 
-    /** Schema the model uses. */
-    schema: Schema<T>;
+      /** Schema the model uses. */
+      schema: Schema<T>;
 
-    /**
+      /**
      * @deprecated use `updateOne` or `updateMany` instead.
      * Creates a `update` query: updates one or many documents that match `filter` with `update`, based on the `multi` option.
      */
-    update<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<T> | null,
-      callback?: Callback
-    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
+      update<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
+        options?: QueryOptions<T> | null,
+        callback?: Callback
+      ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
-    updateMany<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<T> | null,
-      callback?: Callback
-    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
+      updateMany<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
+        options?: QueryOptions<T> | null,
+        callback?: Callback
+      ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
-    updateOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      filter?: FilterQuery<T>,
-      update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<T> | null,
-      callback?: Callback
-    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
+      /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
+      updateOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+        filter?: FilterQuery<T>,
+        update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
+        options?: QueryOptions<T> | null,
+        callback?: Callback
+      ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
 
-    /** Creates a Query, applies the passed conditions, and returns the Query. */
-    where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(path: string, val?: any): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(obj: object): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-  }
+      /** Creates a Query, applies the passed conditions, and returns the Query. */
+      where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(path: string, val?: any): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(obj: object): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+      where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    };
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -114,13 +114,13 @@ declare module 'mongoose' {
   }
 
   const Model: Model<any>;
-  type Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any>=
+  type Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> =
     NodeJS.EventEmitter &
     AcceptsDiscriminator &
     IndexManager &
     SessionStarter &
     ObtainSchemaGeneric<TSchema, 'TStaticMethods'> & {
-      new <DocType = AnyKeys<T> & AnyObject>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
+      new<DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<UnpackedIntersection<T, DocType>, TMethodsAndOverrides, TVirtuals>;
 
       aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
       aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -120,7 +120,7 @@ declare module 'mongoose' {
     IndexManager &
     SessionStarter &
     ObtainSchemaGeneric<TSchema, 'TStaticMethods'> & {
-      new<DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<Omit<T, keyof DocType> & DocType, TMethodsAndOverrides, TVirtuals>;
+      new<DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<MergeBOntoA<T, DocType>, TMethodsAndOverrides, TVirtuals>;
 
       aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
       aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;
@@ -164,11 +164,11 @@ declare module 'mongoose' {
       countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
       /** Creates a new document or documents */
-      create<DocContents = T>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = T>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>): void;
-      create<DocContents = T>(doc: T | DocContents): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>;
-      create<DocContents = T>(...docs: Array<T | DocContents>): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = T>(doc: T | DocContents, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>): void;
+      create<DocContents = T>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = T>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>): void;
+      create<DocContents = T>(doc: DocContents | T): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>>;
+      create<DocContents = T>(...docs: Array<T | DocContents>): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = T>(doc: T | DocContents, callback: Callback<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>>): void;
 
       /**
      * Create the collection for this model. By default, if no indexes are specified,
@@ -257,12 +257,12 @@ declare module 'mongoose' {
       init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
       /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
-      insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<UnpackedIntersection<DocContents, T>>>;
-      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions): Promise<Array<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>>;
-      insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<UnpackedIntersection<DocContents, T>>>;
-      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
-      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions, callback?: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<UnpackedIntersection<DocContents, T>>>): void;
-      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<UnpackedIntersection<DocContents, T>>>): void;
+      insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<MergeBOntoA<T, DocContents>>>;
+      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions): Promise<Array<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>>>;
+      insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<MergeBOntoA<T, DocContents>>>;
+      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
+      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions, callback?: Callback<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<MergeBOntoA<T, DocContents>>>): void;
+      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<MergeBOntoA<T, DocContents>>>): void;
 
       /** The name of the model */
       modelName: string;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -120,7 +120,7 @@ declare module 'mongoose' {
     IndexManager &
     SessionStarter &
     ObtainSchemaGeneric<TSchema, 'TStaticMethods'> & {
-      new<DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<UnpackedIntersection<T, DocType>, TMethodsAndOverrides, TVirtuals>;
+      new<DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<Omit<T, keyof DocType> & DocType, TMethodsAndOverrides, TVirtuals>;
 
       aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
       aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -164,15 +164,11 @@ declare module 'mongoose' {
       countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
       /** Creates a new document or documents */
-      create(docs: (AnyKeys<T> | AnyObject)[], options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-      create(docs: (AnyKeys<T> | AnyObject)[], callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>): void;
-      create(doc: AnyKeys<T> | AnyObject): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-      create(doc: AnyKeys<T> | AnyObject, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
-      create<DocContents = AnyKeys<T>>(docs: DocContents[], options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = AnyKeys<T>>(docs: DocContents[], callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>): void;
-      create<DocContents = AnyKeys<T>>(doc: DocContents): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-      create<DocContents = AnyKeys<T>>(...docs: DocContents[]): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = AnyKeys<T>>(doc: DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
+      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>): void;
+      create<DocContents = FlexibleObject<T>>(doc: T | DocContents): Promise<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>>;
+      create<DocContents = FlexibleObject<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = FlexibleObject<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>>): void;
 
       /**
      * Create the collection for this model. By default, if no indexes are specified,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -114,303 +114,321 @@ declare module 'mongoose' {
   }
 
   const Model: Model<any>;
-  type Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> =
-    NodeJS.EventEmitter &
-    AcceptsDiscriminator &
-    IndexManager &
-    SessionStarter &
-    ObtainSchemaGeneric<TSchema, 'TStaticMethods'> & {
-      new<DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<MergeBOntoA<T, DocType>, TMethodsAndOverrides, TVirtuals>;
+  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> extends
+    NodeJS.EventEmitter,
+    AcceptsDiscriminator,
+    IndexManager,
+    SessionStarter {
+    new <DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<MergeType<T, DocType>, TMethodsAndOverrides, TVirtuals> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
-      aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
-      aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;
+    aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
+    aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;
 
-      /** Base Mongoose instance the model uses. */
-      base: Mongoose;
+    /** Base Mongoose instance the model uses. */
+    base: Mongoose;
 
-      /**
-     * If this is a discriminator model, `baseModelName` is the name of
-     * the base model.
-     */
-      baseModelName: string | undefined;
+    /**
+   * If this is a discriminator model, `baseModelName` is the name of
+   * the base model.
+   */
+    baseModelName: string | undefined;
 
-      /**
-     * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,
-     * `deleteOne`, and/or `deleteMany` operations to the MongoDB server in one
-     * command. This is faster than sending multiple independent operations (e.g.
-     * if you use `create()`) because with `bulkWrite()` there is only one network
-     * round trip to the MongoDB server.
-     */
-      bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
-      bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, callback: Callback<mongodb.BulkWriteResult>): void;
-      bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+    /**
+   * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,
+   * `deleteOne`, and/or `deleteMany` operations to the MongoDB server in one
+   * command. This is faster than sending multiple independent operations (e.g.
+   * if you use `create()`) because with `bulkWrite()` there is only one network
+   * round trip to the MongoDB server.
+   */
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, callback: Callback<mongodb.BulkWriteResult>): void;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
 
-      /**
-     * Sends multiple `save()` calls in a single `bulkWrite()`. This is faster than
-     * sending multiple `save()` calls because with `bulkSave()` there is only one
-     * network round trip to the MongoDB server.
-     */
-      bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+    /**
+   * Sends multiple `save()` calls in a single `bulkWrite()`. This is faster than
+   * sending multiple `save()` calls because with `bulkSave()` there is only one
+   * network round trip to the MongoDB server.
+   */
+    bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions): Promise<mongodb.BulkWriteResult>;
 
-      /** Collection the model uses. */
-      collection: Collection;
+    /** Collection the model uses. */
+    collection: Collection;
 
-      /** Creates a `count` query: counts the number of documents that match `filter`. */
-      count(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      count(filter: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /** Creates a `count` query: counts the number of documents that match `filter`. */
+    count(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    count(filter: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
-      countDocuments(filter: FilterQuery<T>, options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
+    countDocuments(filter: FilterQuery<T>, options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /** Creates a new document or documents */
-      create<DocContents = T>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = T>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>): void;
-      create<DocContents = T>(doc: DocContents | T): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>>;
-      create<DocContents = T>(...docs: Array<T | DocContents>): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = T>(doc: T | DocContents, callback: Callback<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>>): void;
+    /** Creates a new document or documents */
+    create<DocContents = T>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>[]>;
+    create<DocContents = T>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>[]>): void;
+    create<DocContents = T>(doc: DocContents | T): Promise<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>;
+    create<DocContents = T>(...docs: Array<T | DocContents>): Promise<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>[]>;
+    create<DocContents = T>(doc: T | DocContents, callback: Callback<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>): void;
 
-      /**
-     * Create the collection for this model. By default, if no indexes are specified,
-     * mongoose will not create the collection for the model until any documents are
-     * created. Use this method to create the collection explicitly.
-     */
-      createCollection<T extends mongodb.Document>(options: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'> | null, callback: Callback<mongodb.Collection<T>>): void;
-      createCollection<T extends mongodb.Document>(callback: Callback<mongodb.Collection<T>>): void;
-      createCollection<T extends mongodb.Document>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
+    /**
+   * Create the collection for this model. By default, if no indexes are specified,
+   * mongoose will not create the collection for the model until any documents are
+   * created. Use this method to create the collection explicitly.
+   */
+    createCollection<T extends mongodb.Document>(options: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'> | null, callback: Callback<mongodb.Collection<T>>): void;
+    createCollection<T extends mongodb.Document>(callback: Callback<mongodb.Collection<T>>): void;
+    createCollection<T extends mongodb.Document>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
 
-      /** Connection the model uses. */
-      db: Connection;
+    /** Connection the model uses. */
+    db: Connection;
 
-      /**
-     * Deletes all of the documents that match `conditions` from the collection.
-     * Behaves like `remove()`, but deletes all documents that match `conditions`
-     * regardless of the `single` option.
-     */
-      deleteMany(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      deleteMany(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      deleteMany(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /**
+   * Deletes all of the documents that match `conditions` from the collection.
+   * Behaves like `remove()`, but deletes all documents that match `conditions`
+   * regardless of the `single` option.
+   */
+    deleteMany(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    deleteMany(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    deleteMany(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /**
-     * Deletes the first document that matches `conditions` from the collection.
-     * Behaves like `remove()`, but deletes at most one document regardless of the
-     * `single` option.
-     */
-      deleteOne(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      deleteOne(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      deleteOne(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /**
+   * Deletes the first document that matches `conditions` from the collection.
+   * Behaves like `remove()`, but deletes at most one document regardless of the
+   * `single` option.
+   */
+    deleteOne(filter?: FilterQuery<T>, options?: QueryOptions<T>, callback?: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    deleteOne(filter: FilterQuery<T>, callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    deleteOne(callback: CallbackWithoutResult): QueryWithHelpers<mongodb.DeleteResult, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /**
-     * Event emitter that reports any errors that occurred. Useful for global error
-     * handling.
-     */
-      events: NodeJS.EventEmitter;
+    /**
+   * Event emitter that reports any errors that occurred. Useful for global error
+   * handling.
+   */
+    events: NodeJS.EventEmitter;
 
-      /**
-     * Finds a single document by its _id field. `findById(id)` is almost*
-     * equivalent to `findOne({ _id: id })`. If you want to query by a document's
-     * `_id`, use `findById()` instead of `findOne()`.
-     */
-      findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        id: any,
-        projection?: ProjectionType<T> | null,
-        options?: QueryOptions<T> | null,
-        callback?: Callback<ResultDoc | null>
-      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-      findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        id: any,
-        projection?: ProjectionType<T> | null,
-        callback?: Callback<ResultDoc | null>
-      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /**
+   * Finds a single document by its _id field. `findById(id)` is almost*
+   * equivalent to `findOne({ _id: id })`. If you want to query by a document's
+   * `_id`, use `findById()` instead of `findOne()`.
+   */
+    findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      id: any,
+      projection?: ProjectionType<T> | null,
+      options?: QueryOptions<T> | null,
+      callback?: Callback<ResultDoc | null>
+    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    findById<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      id: any,
+      projection?: ProjectionType<T> | null,
+      callback?: Callback<ResultDoc | null>
+    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Finds one document. */
-      findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        projection?: ProjectionType<T> | null,
-        options?: QueryOptions<T> | null,
-        callback?: Callback<ResultDoc | null>
-      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-      findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        projection?: ProjectionType<T> | null,
-        callback?: Callback<ResultDoc | null>
-      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-      findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        callback?: Callback<ResultDoc | null>
-      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Finds one document. */
+    findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      projection?: ProjectionType<T> | null,
+      options?: QueryOptions<T> | null,
+      callback?: Callback<ResultDoc | null>
+    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      projection?: ProjectionType<T> | null,
+      callback?: Callback<ResultDoc | null>
+    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    findOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      callback?: Callback<ResultDoc | null>
+    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /**
-     * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
-     * The document returned has no paths marked as modified initially.
-     */
-      hydrate(obj: any): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
+    /**
+   * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
+   * The document returned has no paths marked as modified initially.
+   */
+    hydrate(obj: any): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;
 
-      /**
-     * This function is responsible for building [indexes](https://docs.mongodb.com/manual/indexes/),
-     * unless [`autoIndex`](http://mongoosejs.com/docs/guide.html#autoIndex) is turned off.
-     * Mongoose calls this function automatically when a model is created using
-     * [`mongoose.model()`](/docs/api.html#mongoose_Mongoose-model) or
-     * [`connection.model()`](/docs/api.html#connection_Connection-model), so you
-     * don't need to call it.
-     */
-      init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+    /**
+   * This function is responsible for building [indexes](https://docs.mongodb.com/manual/indexes/),
+   * unless [`autoIndex`](http://mongoosejs.com/docs/guide.html#autoIndex) is turned off.
+   * Mongoose calls this function automatically when a model is created using
+   * [`mongoose.model()`](/docs/api.html#mongoose_Mongoose-model) or
+   * [`connection.model()`](/docs/api.html#connection_Connection-model), so you
+   * don't need to call it.
+   */
+    init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
-      /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
-      insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<MergeBOntoA<T, DocContents>>>;
-      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions): Promise<Array<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>>>;
-      insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<MergeBOntoA<T, DocContents>>>;
-      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions): Promise<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
-      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions, callback?: Callback<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<MergeBOntoA<T, DocContents>>>): void;
-      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<MergeBOntoA<T, DocContents>, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<MergeBOntoA<T, DocContents>>>): void;
+    /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }, callback: Callback<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>): void;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true; }, callback: Callback<mongodb.InsertManyResult<T>>): void;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }, callback: Callback<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>): void;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true; }, callback: Callback<mongodb.InsertManyResult<T>>): void;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean?: false | undefined }, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
+    insertMany<DocContents = T>(doc: DocContents, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
 
-      /** The name of the model */
-      modelName: string;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true; }): Promise<mongodb.InsertManyResult<T>>;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true; }): Promise<mongodb.InsertManyResult<T>>;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>;
+    insertMany<DocContents = T>(doc: DocContents): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>;
 
-      /** Populates document references. */
-      populate(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string,
-        callback?: Callback<(HydratedDocument<T, TMethodsAndOverrides, TVirtuals>)[]>): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
-      populate(doc: any, options: PopulateOptions | Array<PopulateOptions> | string,
-        callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+    /** The name of the model */
+    modelName: string;
+
+    /** Populates document references. */
+    populate(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string,
+      callback?: Callback<(HydratedDocument<T, TMethodsAndOverrides, TVirtuals>)[]>): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
+    populate(doc: any, options: PopulateOptions | Array<PopulateOptions> | string,
+      callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
 
-      /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
-      validate(callback?: CallbackWithoutResult): Promise<void>;
-      validate(optional: any, callback?: CallbackWithoutResult): Promise<void>;
-      validate(optional: any, pathsToValidate: PathsToValidate, callback?: CallbackWithoutResult): Promise<void>;
+    /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
+    validate(callback?: CallbackWithoutResult): Promise<void>;
+    validate(optional: any, callback?: CallbackWithoutResult): Promise<void>;
+    validate(optional: any, pathsToValidate: PathsToValidate, callback?: CallbackWithoutResult): Promise<void>;
 
-      /** Watches the underlying collection for changes using [MongoDB change streams](https://docs.mongodb.com/manual/changeStreams/). */
-      watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
+    /** Watches the underlying collection for changes using [MongoDB change streams](https://docs.mongodb.com/manual/changeStreams/). */
+    watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
 
-      /** Adds a `$where` clause to this query */
-      $where(argument: string | Function): QueryWithHelpers<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /** Adds a `$where` clause to this query */
+    $where(argument: string | Function): QueryWithHelpers<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /** Registered discriminators for this model. */
-      discriminators: { [name: string]: Model<any> } | undefined;
+    /** Registered discriminators for this model. */
+    discriminators: { [name: string]: Model<any> } | undefined;
 
-      /** Translate any aliases fields/conditions so the final query or document object is pure */
-      translateAliases(raw: any): any;
+    /** Translate any aliases fields/conditions so the final query or document object is pure */
+    translateAliases(raw: any): any;
 
-      /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
-      distinct<ReturnType = any>(field: string, filter?: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<Array<ReturnType>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
+    distinct<ReturnType = any>(field: string, filter?: FilterQuery<T>, callback?: Callback<number>): QueryWithHelpers<Array<ReturnType>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /** Creates a `estimatedDocumentCount` query: counts the number of documents in the collection. */
-      estimatedDocumentCount(options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /** Creates a `estimatedDocumentCount` query: counts the number of documents in the collection. */
+    estimatedDocumentCount(options?: QueryOptions<T>, callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /**
-     * Returns a document with its `_id` if at least one document exists in the database that matches
-     * the given `filter`, and `null` otherwise.
-     */
-      exists(filter: FilterQuery<T>, callback: Callback<Pick<Document<T>, '_id'> | null>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
-      exists(filter: FilterQuery<T>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    /**
+   * Returns a document with its `_id` if at least one document exists in the database that matches
+   * the given `filter`, and `null` otherwise.
+   */
+    exists(filter: FilterQuery<T>, callback: Callback<Pick<Document<T>, '_id'> | null>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
+    exists(filter: FilterQuery<T>): QueryWithHelpers<Pick<Document<T>, '_id'> | null, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
-      /** Creates a `find` query: gets a list of documents that match `filter`. */
-      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter: FilterQuery<T>,
-        projection?: ProjectionType<T> | null,
-        callback?: Callback<ResultDoc[]>
-      ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, projection?: ProjectionType<T> | null, options?: QueryOptions<T> | null, callback?: Callback<ResultDoc[]>): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `find` query: gets a list of documents that match `filter`. */
+    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter: FilterQuery<T>,
+      projection: ProjectionType<T> | null,
+      options: QueryOptions<T> | null,
+      callback?: Callback<ResultDoc[]>
+    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter: FilterQuery<T>,
+      projection: ProjectionType<T> | null,
+      callback?: Callback<ResultDoc[]>
+    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter: FilterQuery<T>,
+      callback?: Callback<ResultDoc[]>
+    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      callback?: Callback<ResultDoc[]>
+    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
-      findByIdAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
+    findByIdAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findByIdAndRemove` query, filtering by the given `_id`. */
-      findByIdAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findByIdAndRemove` query, filtering by the given `_id`. */
+    findByIdAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
-      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { rawResult: true }, callback?: (err: CallbackError, doc: any, res: any) => void): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
-      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, update?: UpdateQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
-      findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, callback: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
+    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { rawResult: true }, callback?: (err: CallbackError, doc: any, res: any) => void): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
+    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id?: mongodb.ObjectId | any, update?: UpdateQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    findByIdAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(id: mongodb.ObjectId | any, update: UpdateQuery<T>, callback: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
-      findOneAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
+    findOneAndDelete<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findOneAndRemove` query: atomically finds the given document and deletes it. */
-      findOneAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findOneAndRemove` query: atomically finds the given document and deletes it. */
+    findOneAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
-      findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
-      findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, replacement?: T | AnyObject, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
+    findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
+    findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, replacement?: T | AnyObject, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
-      findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter: FilterQuery<T>,
-        update: UpdateQuery<T>,
-        options: QueryOptions<T> & { rawResult: true },
-        callback?: (err: CallbackError, doc: any, res: any) => void
-      ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter: FilterQuery<T>,
-        update: UpdateQuery<T>,
-        options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc,
-        callback?: (err: CallbackError, doc: ResultDoc, res: any) => void
-      ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
-      findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        update?: UpdateQuery<T>,
-        options?: QueryOptions<T> | null,
-        callback?: (err: CallbackError, doc: T | null, res: any) => void
-      ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
+    findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter: FilterQuery<T>,
+      update: UpdateQuery<T>,
+      options: QueryOptions<T> & { rawResult: true },
+      callback?: (err: CallbackError, doc: any, res: any) => void
+    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter: FilterQuery<T>,
+      update: UpdateQuery<T>,
+      options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc,
+      callback?: (err: CallbackError, doc: ResultDoc, res: any) => void
+    ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
+    findOneAndUpdate<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      update?: UpdateQuery<T>,
+      options?: QueryOptions<T> | null,
+      callback?: (err: CallbackError, doc: T | null, res: any) => void
+    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
-      geoSearch<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        options?: GeoSearchOptions,
-        callback?: Callback<Array<ResultDoc>>
-      ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    geoSearch<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      options?: GeoSearchOptions,
+      callback?: Callback<Array<ResultDoc>>
+    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
 
-      /** Executes a mapReduce command. */
-      mapReduce<Key, Value>(
-        o: MapReduceOptions<T, Key, Value>,
-        callback?: Callback
-      ): Promise<any>;
+    /** Executes a mapReduce command. */
+    mapReduce<Key, Value>(
+      o: MapReduceOptions<T, Key, Value>,
+      callback?: Callback
+    ): Promise<any>;
 
-      remove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: any, callback?: CallbackWithoutResult): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
+    remove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: any, callback?: CallbackWithoutResult): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
-      replaceOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        replacement?: T | AnyObject,
-        options?: QueryOptions<T> | null,
-        callback?: Callback
-      ): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
+    replaceOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      replacement?: T | AnyObject,
+      options?: QueryOptions<T> | null,
+      callback?: Callback
+    ): QueryWithHelpers<any, ResultDoc, TQueryHelpers, T>;
 
-      /** Schema the model uses. */
-      schema: Schema<T>;
+    /** Schema the model uses. */
+    schema: Schema<T>;
 
-      /**
-     * @deprecated use `updateOne` or `updateMany` instead.
-     * Creates a `update` query: updates one or many documents that match `filter` with `update`, based on the `multi` option.
-     */
-      update<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
-        options?: QueryOptions<T> | null,
-        callback?: Callback
-      ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
+    /**
+   * @deprecated use `updateOne` or `updateMany` instead.
+   * Creates a `update` query: updates one or many documents that match `filter` with `update`, based on the `multi` option.
+   */
+    update<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
+      options?: QueryOptions<T> | null,
+      callback?: Callback
+    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
-      updateMany<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
-        options?: QueryOptions<T> | null,
-        callback?: Callback
-      ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
+    updateMany<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
+      options?: QueryOptions<T> | null,
+      callback?: Callback
+    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
-      updateOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-        filter?: FilterQuery<T>,
-        update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
-        options?: QueryOptions<T> | null,
-        callback?: Callback
-      ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
+    /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
+    updateOne<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
+      filter?: FilterQuery<T>,
+      update?: UpdateQuery<T> | UpdateWithAggregationPipeline,
+      options?: QueryOptions<T> | null,
+      callback?: Callback
+    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, T>;
 
-      /** Creates a Query, applies the passed conditions, and returns the Query. */
-      where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(path: string, val?: any): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(obj: object): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-      where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
-    };
+    /** Creates a Query, applies the passed conditions, and returns the Query. */
+    where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(path: string, val?: any): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(obj: object): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+    where<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
+  }
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -164,11 +164,11 @@ declare module 'mongoose' {
       countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
       /** Creates a new document or documents */
-      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>): void;
-      create<DocContents = FlexibleObject<T>>(doc: T | DocContents): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>;
-      create<DocContents = FlexibleObject<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = FlexibleObject<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>): void;
+      create<DocContents = T>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = T>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>): void;
+      create<DocContents = T>(doc: T | DocContents): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>;
+      create<DocContents = T>(...docs: Array<T | DocContents>): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = T>(doc: T | DocContents, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>): void;
 
       /**
      * Create the collection for this model. By default, if no indexes are specified,
@@ -257,12 +257,12 @@ declare module 'mongoose' {
       init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
       /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
-      insertMany(docs: Array<AnyKeys<T> | AnyObject>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<T>>;
-      insertMany(docs: Array<AnyKeys<T> | AnyObject>, options?: InsertManyOptions): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
-      insertMany(doc: AnyKeys<T> | AnyObject, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<T>>;
-      insertMany(doc: AnyKeys<T> | AnyObject, options?: InsertManyOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-      insertMany(doc: AnyKeys<T> | AnyObject, options?: InsertManyOptions, callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<T>>): void;
-      insertMany(docs: Array<AnyKeys<T> | AnyObject>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<T>>): void;
+      insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<UnpackedIntersection<DocContents, T>>>;
+      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions): Promise<Array<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>>;
+      insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true }): Promise<InsertManyResult<UnpackedIntersection<DocContents, T>>>;
+      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
+      insertMany<DocContents = T>(doc: DocContents, options?: InsertManyOptions, callback?: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[] | InsertManyResult<UnpackedIntersection<DocContents, T>>>): void;
+      insertMany<DocContents = T>(docs: Array<DocContents | T>, options?: InsertManyOptions, callback?: Callback<Array<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>> | InsertManyResult<UnpackedIntersection<DocContents, T>>>): void;
 
       /** The name of the model */
       modelName: string;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -164,11 +164,11 @@ declare module 'mongoose' {
       countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
       /** Creates a new document or documents */
-      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>): void;
-      create<DocContents = FlexibleObject<T>>(doc: T | DocContents): Promise<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>>;
-      create<DocContents = FlexibleObject<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>[]>;
-      create<DocContents = FlexibleObject<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<UnpackedIntersection<T, DocContents>, TMethodsAndOverrides, TVirtuals>>): void;
+      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = FlexibleObject<T>>(docs: Array<T | DocContents>, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>): void;
+      create<DocContents = FlexibleObject<T>>(doc: T | DocContents): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>;
+      create<DocContents = FlexibleObject<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>[]>;
+      create<DocContents = FlexibleObject<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<UnpackedIntersection<DocContents, T>, TMethodsAndOverrides, TVirtuals>>): void;
 
       /**
      * Create the collection for this model. By default, if no indexes are specified,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -1,7 +1,7 @@
 declare module 'mongoose' {
   import mongodb = require('mongodb');
 
-  type ApplyBasicQueryCasting<T> = T | T[] | any;
+  export type ApplyBasicQueryCasting<T, defaultT = T | T[] | {}> = T extends any[] ? T[0] & defaultT: defaultT;
   type Condition<T> = ApplyBasicQueryCasting<T> | QuerySelector<ApplyBasicQueryCasting<T>>;
 
   type _FilterQuery<T> = {

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, StaticMethods = {}, InstanceMethods = {}, QueryHelpers = {}> {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, InstanceMethods = {}, QueryHelpers = {}, StaticMethods = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -191,12 +191,12 @@ declare module 'mongoose' {
     /**
      * Model Statics methods.
      */
-    statics?: StaticMethods,
+    statics?: Record<any, <T extends Model<any>>(this: T, ...args: any) => unknown> | StaticMethods,
 
     /**
      * Document instance methods.
      */
-    methods?: InstanceMethods,
+    methods?: Record<any, <T extends Document>(this: T, ...args: any) => unknown> | InstanceMethods,
 
     /**
      * Query helper functions

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, StaticMethods = {}, InstanceMethods = {}> {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, StaticMethods = {}, InstanceMethods = {}, QueryHelpers = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable
@@ -197,5 +197,10 @@ declare module 'mongoose' {
      * Document instance methods.
      */
     methods?: InstanceMethods,
+
+    /**
+     * Query helper functions
+     */
+    query?: Record<any, <T extends Query<unknown, unknown>>(this: T, ...args: any) => T> | QueryHelpers,
   }
 }

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type'
-  interface SchemaOptions {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable
@@ -139,7 +139,7 @@ declare module 'mongoose' {
      * type declaration. However, for applications like geoJSON, the 'type' property is important. If you want to
      * control which key mongoose uses to find type declarations, set the 'typeKey' schema option.
      */
-    typeKey?: string;
+    typeKey?: PathTypeKey;
 
     /**
      * By default, documents are automatically validated before they are saved to the database. This is to

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, DocType = unknown, InstanceMethods = {}, QueryHelpers = {}, StaticMethods = {}> {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, DocType = unknown, InstanceMethods = {}, QueryHelpers = {}, StaticMethods = {}, virtuals = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable
@@ -191,12 +191,12 @@ declare module 'mongoose' {
     /**
      * Model Statics methods.
      */
-    statics?: Record<any, <T extends Model<DocType>>(this: T, ...args: any) => unknown> | StaticMethods,
+    statics?: Record<any, (this: Model<DocType>, ...args: any) => unknown> | StaticMethods,
 
     /**
      * Document instance methods.
      */
-    methods?: Record<any, <T extends Document<any, any, DocType>>(this: T, ...args: any) => unknown> | InstanceMethods,
+    methods?: Record<any, (this: HydratedDocument<DocType>, ...args: any) => unknown> | InstanceMethods,
 
     /**
      * Query helper functions

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, StaticMethods = {}> {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, StaticMethods = {}, InstanceMethods = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable
@@ -192,5 +192,10 @@ declare module 'mongoose' {
      * Model Statics methods.
      */
     statics?: StaticMethods,
+
+    /**
+     * Document instance methods.
+     */
+    methods?: InstanceMethods,
   }
 }

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -7,6 +7,9 @@ declare module 'mongoose' {
     currentTime?: () => (NativeDate | number);
   }
 
+  type TypeKeyBaseType = string;
+
+  type DefaultTypeKey = 'type'
   interface SchemaOptions {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, InstanceMethods = {}, QueryHelpers = {}, StaticMethods = {}> {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, DocType = unknown, InstanceMethods = {}, QueryHelpers = {}, StaticMethods = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable
@@ -191,16 +191,16 @@ declare module 'mongoose' {
     /**
      * Model Statics methods.
      */
-    statics?: Record<any, <T extends Model<any>>(this: T, ...args: any) => unknown> | StaticMethods,
+    statics?: Record<any, <T extends Model<DocType>>(this: T, ...args: any) => unknown> | StaticMethods,
 
     /**
      * Document instance methods.
      */
-    methods?: Record<any, <T extends Document>(this: T, ...args: any) => unknown> | InstanceMethods,
+    methods?: Record<any, <T extends Document<any, any, DocType>>(this: T, ...args: any) => unknown> | InstanceMethods,
 
     /**
      * Query helper functions
      */
-    query?: Record<any, <T extends QueryWithHelpers<unknown, unknown>>(this: T, ...args: any) => T> | QueryHelpers,
+    query?: Record<any, <T extends QueryWithHelpers<unknown, DocType>>(this: T, ...args: any) => T> | QueryHelpers,
   }
 }

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -9,8 +9,8 @@ declare module 'mongoose' {
 
   type TypeKeyBaseType = string;
 
-  type DefaultTypeKey = 'type'
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey> {
+  type DefaultTypeKey = 'type';
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, StaticMethods = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable
@@ -186,6 +186,11 @@ declare module 'mongoose' {
      * You can suppress the warning by setting { supressReservedKeysWarning: true } schema options. Keep in mind that this
      * can break plugins that rely on these reserved names.
      */
-    supressReservedKeysWarning?: boolean
+    supressReservedKeysWarning?: boolean,
+
+    /**
+     * Model Statics methods.
+     */
+    statics?: StaticMethods,
   }
 }

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -201,6 +201,6 @@ declare module 'mongoose' {
     /**
      * Query helper functions
      */
-    query?: Record<any, <T extends Query<unknown, unknown>>(this: T, ...args: any) => T> | QueryHelpers,
+    query?: Record<any, <T extends QueryWithHelpers<unknown, unknown>>(this: T, ...args: any) => T> | QueryHelpers,
   }
 }

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -7,10 +7,9 @@ declare module 'mongoose' {
   type UnpackedIntersection<T, U> = T extends null ? null : T extends (infer A)[]
     ? (Omit<A, keyof U> & U)[]
     : keyof U extends never
-      ? T
-      : Omit<T, keyof U> & U;
+    ? T
+    : Omit<T, keyof U> & U;
 
-  type MergeBOntoA<A, B> = Omit<A, keyof B> & B;
-
+  type MergeType<A extends Record<number | string, any>, B extends Record<number | string, any>> = Omit<A, keyof B> & B;
 
 }

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -10,4 +10,7 @@ declare module 'mongoose' {
       ? T
       : Omit<T, keyof U> & U;
 
+  type MergeBOntoA<A, B> = Omit<A, keyof B> & B;
+
+
 }

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -7,8 +7,8 @@ declare module 'mongoose' {
   type UnpackedIntersection<T, U> = T extends null ? null : T extends (infer A)[]
     ? (Omit<A, keyof U> & U)[]
     : keyof U extends never
-    ? T
-    : Omit<T, keyof U> & U;
+      ? T
+      : Omit<T, keyof U> & U;
 
   type MergeType<A extends Record<number | string, any>, B extends Record<number | string, any>> = Omit<A, keyof B> & B;
 


### PR DESCRIPTION
# Tasks to be implemented :
- [x] Infer schema type automatically from document definition.
- [x] Provide TS utility to be able to extract schema type from schema instance to be able to reuse the type as separated type "InferSchemaType".
- [x] Improve Model.create function type to show schema properties in suggestions dialog.
- [x]  Adding "statics"  property in schema options  to support auto type inference for model statics methods.
- [x]  Adding "methods"  property in schema options  to support auto type inference for document instance methods.
- [x] Support custom type key "typeKey" to inference schema type.
- [x] Improve Model new function "document constructor" type to show schema properties in suggestions dialog.
- [x] Improve Model.insertMany function type to show schema properties in suggestions dialog.
- [x]  Adding "query"  property in schema options  to support auto type inference for query helpers methods.

# Status:
- [x]  Ready to review.
- [x]  Docs is updated.
- [x]  Ready to merge.

Do you have any suggestions or ideas to be implemented in this PR, please leave a comment :slightly_smiling_face:

### Get it early:
You can install mongoose including this feature by running:
```shell
 npm i Automattic/mongoose#pull/11563/head
```
# Screenshots :
- Auto schema type inference & create function:

![Untitled](https://user-images.githubusercontent.com/50488054/159979456-cc6c84ba-8355-4ad1-8aec-a5ce57bfcd86.png)

- InferSchemaType utility & supporting custom type key:

![Untitled](https://user-images.githubusercontent.com/50488054/160260913-ef67a983-5751-4fbe-befa-f54728890ee4.png)
