### PR TITLE
chore(deps-dev): upgrade highlight.js from 9.18.3 to 11.5.0

### DIFF
--- a/docs/3.0.x/docs/helpers/filters.js
+++ b/docs/3.0.x/docs/helpers/filters.js
@@ -7,13 +7,13 @@ module.exports = exports = function (jade) {
 
   jade.filters.js = function (str) {
     str = str.replace(/\\n/g, '\n');
-    var ret = hl.highlight('javascript', str).value;
+    var ret = hl.highlight(str, { language: 'javascript' }).value;
     var code = '<pre><code class="javascript">' + ret.replace(/\n/g, '\\n') + '</code></pre>';
     return code;
   }
 
   jade.filters.bash = function (str) {
-    var ret = hl.highlight('bash', str.replace(/\\n/g, '\n')).value;
+    var ret = hl.highlight(str.replace(/\\n/g, '\n'),{ language: 'bash' }).value;
     var code = '<pre><code class="bash">' + ret + '</code></pre>';
     return  code
   }

--- a/docs/3.0.x/docs/helpers/highlight.js
+++ b/docs/3.0.x/docs/helpers/highlight.js
@@ -4,7 +4,7 @@ var h = require('highlight.js')
 
 function hl (str) {
   str = str.replace(/\\n/g, '\n');
-  var ret = h.highlight('javascript', str).value;
+  var ret = h.highlight(str, { language: 'javascript' }).value;
   var code = '<pre><code class="javascript">' + ret+ '</code></pre>';
   return code;
 }

--- a/docs/3.1.x/docs/helpers/filters.js
+++ b/docs/3.1.x/docs/helpers/filters.js
@@ -7,13 +7,13 @@ module.exports = exports = function (jade) {
 
   jade.filters.js = function (str) {
     str = str.replace(/\\n/g, '\n');
-    var ret = hl.highlight('javascript', str).value;
+    var ret = hl.highlight(str, { language: 'javascript' }).value;
     var code = '<pre><code class="javascript">' + ret.replace(/\n/g, '\\n') + '</code></pre>';
     return code;
   }
 
   jade.filters.bash = function (str) {
-    var ret = hl.highlight('bash', str.replace(/\\n/g, '\n')).value;
+    var ret = hl.highlight(str.replace(/\\n/g, '\n'), { language:'bash' }).value;
     var code = '<pre><code class="bash">' + ret + '</code></pre>';
     return  code
   }

--- a/docs/3.1.x/docs/helpers/highlight.js
+++ b/docs/3.1.x/docs/helpers/highlight.js
@@ -4,7 +4,7 @@ var h = require('highlight.js')
 
 function hl (str) {
   str = str.replace(/\\n/g, '\n');
-  var ret = h.highlight('javascript', str).value;
+  var ret = h.highlight(str, { language: 'javascript' }).value;
   var code = '<pre><code class="javascript">' + ret+ '</code></pre>';
   return code;
 }

--- a/docs/3.1.x/docs/source/api.js
+++ b/docs/3.1.x/docs/source/api.js
@@ -207,7 +207,7 @@ function fix (str) {
     }
 
     return $1
-          + hl.highlight(code[1], code[2]).value.trim()
+          + hl.highlight(code[2], { language: code[1] }).value.trim()
           + $3;
   });
 }

--- a/docs/3.2.x/docs/helpers/filters.js
+++ b/docs/3.2.x/docs/helpers/filters.js
@@ -7,13 +7,13 @@ module.exports = exports = function (jade) {
 
   jade.filters.js = function (str) {
     str = str.replace(/\\n/g, '\n');
-    var ret = hl.highlight('javascript', str).value;
+    var ret = hl.highlight(str, { language: 'javascript' }).value;
     var code = '<pre><code class="javascript">' + ret.replace(/\n/g, '\\n') + '</code></pre>';
     return code;
   }
 
   jade.filters.bash = function (str) {
-    var ret = hl.highlight('bash', str.replace(/\\n/g, '\n')).value;
+    var ret = hl.highlight(str.replace(/\\n/g, '\n'), { language: 'bash' }).value;
     var code = '<pre><code class="bash">' + ret + '</code></pre>';
     return  code
   }

--- a/docs/3.2.x/docs/helpers/highlight.js
+++ b/docs/3.2.x/docs/helpers/highlight.js
@@ -4,7 +4,7 @@ var h = require('highlight.js')
 
 function hl (str) {
   str = str.replace(/\\n/g, '\n');
-  var ret = h.highlight('javascript', str).value;
+  var ret = h.highlight(str, { language: 'javascript' }).value;
   var code = '<pre><code class="javascript">' + ret+ '</code></pre>';
   return code;
 }

--- a/docs/3.2.x/docs/source/api.js
+++ b/docs/3.2.x/docs/source/api.js
@@ -207,7 +207,7 @@ function fix (str) {
     }
 
     return $1
-          + hl.highlight(code[1], code[2]).value.trim()
+          + hl.highlight(code[2], { language: code[1] }).value.trim()
           + $3;
   });
 }

--- a/docs/3.3.x/docs/helpers/filters.js
+++ b/docs/3.3.x/docs/helpers/filters.js
@@ -7,13 +7,13 @@ module.exports = exports = function (jade) {
 
   jade.filters.js = function (str) {
     str = str.replace(/\\n/g, '\n');
-    var ret = hl.highlight('javascript', str).value;
+    var ret = hl.highlight(str, { language: 'javascript' }).value;
     var code = '<pre><code class="javascript">' + ret.replace(/\n/g, '\\n') + '</code></pre>';
     return code;
   }
 
   jade.filters.bash = function (str) {
-    var ret = hl.highlight('bash', str.replace(/\\n/g, '\n')).value;
+    var ret = hl.highlight(str.replace(/\\n/g, '\n'), { language: 'bash' }).value;
     var code = '<pre><code class="bash">' + ret + '</code></pre>';
     return  code
   }

--- a/docs/3.3.x/docs/helpers/highlight.js
+++ b/docs/3.3.x/docs/helpers/highlight.js
@@ -4,7 +4,7 @@ var h = require('highlight.js')
 
 function hl (str) {
   str = str.replace(/\\n/g, '\n');
-  var ret = h.highlight('javascript', str).value;
+  var ret = h.highlight(str, { language: 'javascript' }).value;
   var code = '<pre><code class="javascript">' + ret+ '</code></pre>';
   return code;
 }

--- a/docs/3.3.x/docs/source/api.js
+++ b/docs/3.3.x/docs/source/api.js
@@ -207,7 +207,7 @@ function fix (str) {
     }
 
     return $1
-          + hl.highlight(code[1], code[2]).value.trim()
+          + hl.highlight(code[2], { language: code[1] }).value.trim()
           + $3;
   });
 }

--- a/docs/3.4.x/docs/helpers/filters.js
+++ b/docs/3.4.x/docs/helpers/filters.js
@@ -7,13 +7,13 @@ module.exports = exports = function (jade) {
 
   jade.filters.js = function (str) {
     str = str.replace(/\\n/g, '\n');
-    var ret = hl.highlight('javascript', str).value;
+    var ret = hl.highlight(str, { language: 'javascript' }).value;
     var code = '<pre><code class="javascript">' + ret.replace(/\n/g, '\\n') + '</code></pre>';
     return code;
   }
 
   jade.filters.bash = function (str) {
-    var ret = hl.highlight('bash', str.replace(/\\n/g, '\n')).value;
+    var ret = hl.highlight(str.replace(/\\n/g, '\n'), { language: 'bash' }).value;
     var code = '<pre><code class="bash">' + ret + '</code></pre>';
     return  code
   }

--- a/docs/3.4.x/docs/helpers/highlight.js
+++ b/docs/3.4.x/docs/helpers/highlight.js
@@ -4,7 +4,7 @@ var h = require('highlight.js')
 
 function hl (str) {
   str = str.replace(/\\n/g, '\n');
-  var ret = h.highlight('javascript', str).value;
+  var ret = h.highlight(str, { language: 'javascript' }).value;
   var code = '<pre><code class="javascript">' + ret+ '</code></pre>';
   return code;
 }

--- a/docs/3.4.x/docs/source/api.js
+++ b/docs/3.4.x/docs/source/api.js
@@ -207,7 +207,7 @@ function fix (str) {
     }
 
     return $1
-          + hl.highlight(code[1], code[2]).value.trim()
+          + hl.highlight(code[2], { language: code[1] }).value.trim()
           + $3;
   });
 }

--- a/docs/3.5.x/docs/helpers/filters.js
+++ b/docs/3.5.x/docs/helpers/filters.js
@@ -7,13 +7,13 @@ module.exports = exports = function (jade) {
 
   jade.filters.js = function (str) {
     str = str.replace(/\\n/g, '\n');
-    var ret = hl.highlight('javascript', str).value;
+    var ret = hl.highlight(str, { language: 'javascript' }).value;
     var code = '<pre><code class="javascript">' + ret.replace(/\n/g, '\\n') + '</code></pre>';
     return code;
   }
 
   jade.filters.bash = function (str) {
-    var ret = hl.highlight('bash', str.replace(/\\n/g, '\n')).value;
+    var ret = hl.highlight(str.replace(/\\n/g, '\n'), { language: 'bash' }).value;
     var code = '<pre><code class="bash">' + ret + '</code></pre>';
     return  code
   }

--- a/docs/3.5.x/docs/helpers/highlight.js
+++ b/docs/3.5.x/docs/helpers/highlight.js
@@ -4,7 +4,7 @@ var h = require('highlight.js')
 
 function hl (str) {
   str = str.replace(/\\n/g, '\n');
-  var ret = h.highlight('javascript', str).value;
+  var ret = h.highlight(str, { language: 'javascript' }).value;
   var code = '<pre><code class="javascript">' + ret+ '</code></pre>';
   return code;
 }

--- a/docs/3.5.x/docs/source/api.js
+++ b/docs/3.5.x/docs/source/api.js
@@ -208,7 +208,7 @@ function fix (str) {
     }
 
     return $1
-          + hl.highlight(code[1], code[2]).value.trim()
+          + hl.highlight(code[2], { language: code[1] }).value.trim()
           + $3;
   });
 }

--- a/docs/search.js
+++ b/docs/search.js
@@ -11,7 +11,7 @@ const markdown = require('marked');
 const highlight = require('highlight.js');
 markdown.setOptions({
   highlight: function(code) {
-    return highlight.highlight('JavaScript', code).value;
+    return highlight.highlight(code, { language: 'JavaScript' }).value;
   }
 });
 

--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -210,6 +210,6 @@ function highlight(str) {
       code[1] = 'javascript';
     }
 
-    return $1 + hl.highlight(code[1], code[2]).value.trim() + $3;
+    return $1 + hl.highlight(code[2], { language: code[1] }).value.trim() + $3;
   });
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dox": "0.3.1",
     "eslint": "8.11.0",
     "eslint-plugin-mocha-no-only": "1.1.1",
-    "highlight.js": "9.18.3",
+    "highlight.js": "11.5.0",
     "lodash.isequal": "4.5.0",
     "lodash.isequalwith": "4.4.0",
     "marked": "2.1.3",

--- a/website.js
+++ b/website.js
@@ -38,7 +38,7 @@ const renderer = {
 };
 markdown.setOptions({
   highlight: function(code) {
-    return highlight.highlight('JavaScript', code).value;
+    return highlight.highlight(code, { language: 'JavaScript' }).value;
   }
 });
 markdown.use({ renderer });


### PR DESCRIPTION
This PR fixes the breaking changes from upgrading to [v10](https://github.com/highlightjs/highlight.js/blob/main/VERSION_10_UPGRADE.md) and [v11](https://github.com/highlightjs/highlight.js/blob/main/VERSION_11_UPGRADE.md).

The only downside is IE11 support being dropped in v10 which I think is fine.

I also tested the rendering manually on my machine, and the docs highlighting is identical to the one in production.