### PR TITLE
chore(eslint): include tools, website.js and benchmarks to eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,11 +4,8 @@
     ],
     "ignorePatterns": [
         "docs",
-        "tools",
         "dist",
-        "website.js",
-        "test/files/*",
-        "benchmarks"
+        "test/files/*"
     ],
     "overrides": [
         {


### PR DESCRIPTION
This PR includes the following files/folders to be automatically linted. Is there a reason to not want to lint those?
* website.js
* benchmarks
* tools