### PR TITLE
chore(deps-dev): bump marked from 2.1.3 to 4.0.12

### DIFF
--- a/docs/search.js
+++ b/docs/search.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const pug = require('pug');
 const mongoose = require('../');
 
-const markdown = require('marked');
+const { marked: markdown } = require('marked');
 const highlight = require('highlight.js');
 markdown.setOptions({
   highlight: function(code) {
@@ -47,7 +47,7 @@ for (const filename of files) {
     }
   } else if (file.markdown) {
     let text = fs.readFileSync(filename, 'utf8');
-    text = markdown(text);
+    text = markdown.parse(text);
 
     const content = new Content({
       title: file.title,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "highlight.js": "9.18.3",
     "lodash.isequal": "4.5.0",
     "lodash.isequalwith": "4.4.0",
-    "marked": "2.1.3",
+    "marked": "4.0.12",
     "mocha": "9.2.2",
     "moment": "2.x",
     "mongodb-memory-server": "^8.3.0",

--- a/website.js
+++ b/website.js
@@ -24,7 +24,7 @@ try {
 
 require('acquit-ignore')();
 
-const markdown = require('marked');
+const { marked: markdown } = require('marked');
 const highlight = require('highlight.js');
 const renderer = {
   heading: function(text, level, raw, slugger) {
@@ -154,12 +154,12 @@ function pugify(filename, options, newfile) {
 
   options.marked = markdown;
   options.markedCode = function(v) {
-    return markdown('```javascript\n' + v + '\n```');
+    return markdown.parse('```javascript\n' + v + '\n```');
   };
   options.filename = filename;
   options.filters = {
     markdown: function(block) {
-      return markdown(block);
+      return markdown.parse(block);
     }
   };
 


### PR DESCRIPTION
This fixes the breaking changes in [v3](https://github.com/markedjs/marked/releases?page=3#:~:text=tokens%20(%232166)%20(bc400ac)-,BREAKING%20CHANGES,-Drop%20support%20for) (Node 10 support dropped), and [v4](https://github.com/markedjs/marked/releases/tag/v4.0.0), `const { marked } = require('marked')` instead of `const marked = require('marked');`