### PR TITLE
Bug/types/update query

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,5 +1,5 @@
-import { Schema, Document, Model, Types, connection, model } from 'mongoose';
-import { expectError } from 'tsd';
+import { UpdateQuery, Schema, Document, Model, Types, connection, model } from 'mongoose';
+import { expectError, expectType } from 'tsd';
 
 function conventionalSyntax(): void {
   interface ITest extends Document {
@@ -210,3 +210,17 @@ function inheritance() {
 Project.createCollection({ expires: '5 seconds' });
 Project.createCollection({ expireAfterSeconds: 5 });
 expectError(Project.createCollection({ expireAfterSeconds: '5 seconds' }));
+
+
+function update() {
+  interface IUser {
+    name:string;
+    age:number;
+    isActive:boolean;
+  }
+  const update: UpdateQuery<IUser> = {};
+
+  expectType<string>(update.name);
+  expectType<number>(update.age);
+  expectType<boolean>(update.isActive);
+}

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -214,9 +214,9 @@ expectError(Project.createCollection({ expireAfterSeconds: '5 seconds' }));
 
 function update() {
   interface IUser {
-    name:string;
-    age:number;
-    isActive:boolean;
+    name: string;
+    age: number;
+    isActive: boolean;
   }
   const update: UpdateQuery<IUser> = {};
 

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -220,7 +220,7 @@ function update() {
   }
   const update: UpdateQuery<IUser> = {};
 
-  expectType<string>(update.name);
-  expectType<number>(update.age);
-  expectType<boolean>(update.isActive);
+  expectType<string | undefined>(update.name);
+  expectType<number | undefined>(update.age);
+  expectType<boolean | undefined>(update.isActive);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2058,7 +2058,7 @@ declare module 'mongoose' {
    * { age: 30 }
    * ```
    */
-  export type UpdateQuery<T> = _UpdateQuery<_UpdateQueryDef<T>>['$set'] & _UpdateQuery<_UpdateQueryDef<T>> & AnyObject;
+  export type UpdateQuery<T> = Partial<T> & _UpdateQuery<_UpdateQueryDef<T>> & AnyObject;
 
   export type DocumentDefinition<T> = {
     [K in keyof Omit<T, Exclude<keyof Document, '_id' | 'id' | '__v'>>]:

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2058,7 +2058,7 @@ declare module 'mongoose' {
    * { age: 30 }
    * ```
    */
-  export type UpdateQuery<T> = _UpdateQuery<_UpdateQueryDef<T>> & AnyObject;
+  export type UpdateQuery<T> = _UpdateQuery<_UpdateQueryDef<T>>['$set'] & _UpdateQuery<_UpdateQueryDef<T>> & AnyObject;
 
   export type DocumentDefinition<T> = {
     [K in keyof Omit<T, Exclude<keyof Document, '_id' | 'id' | '__v'>>]:


### PR DESCRIPTION
Currently, we can do the following in JavaScript:
```ts
const userSchema = new Schema({ name: String });
const User = mongoose.model('User', userSchema);

await User.updateOne({}, { name: 'Sam' });
```

But TypeScript doesn't know that the second parameter to `updateOne` can take `name` as a top level property.
It would, however, understand the types if we use `$set`:
```ts
// provides inteliisense support
await User.updateOne({}, { $set: { name: 'Sam' } });

// does not provide intellisense support
await User.updateOne({}, { name: 'Sam' });
```

I managed to make it read the properties from the interface, but another bug seems to be that it converts all types to `any` instead of the type defined on the schema.