### PR TITLE
`continueOnError` option for `eachAsync()`

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -225,6 +225,8 @@ QueryCursor.prototype.next = function(callback) {
  * @param {Function} fn
  * @param {Object} [options]
  * @param {Number} [options.parallel] the number of promises to execute in parallel. Defaults to 1.
+ * @param {Number} [options.batchSize] if set, will call `fn()` with arrays of documents with length at most `batchSize`
+ * @param {Boolean} [options.continueOnError=false] if true, `eachAsync()` iterates through all docs even if `fn` throws an error. If false, `eachAsync()` throws an error immediately if the given function `fn()` throws an error.
  * @param {Function} [callback] executed when all docs have been processed
  * @return {Promise}
  * @api public

--- a/lib/error/eachAsyncMultiError.js
+++ b/lib/error/eachAsyncMultiError.js
@@ -8,10 +8,13 @@ const MongooseError = require('./');
 
 
 /**
- * The connection failed to reconnect and will never successfully reconnect to
- * MongoDB without manual intervention.
+ * If `eachAsync()` is called with `continueOnError: true`, there can be
+ * multiple errors. This error class contains an `errors` property, which
+ * contains an array of all errors that occurred in `eachAsync()`.
+ *
  * @api private
  */
+
 class EachAsyncMultiError extends MongooseError {
   /**
    * @param {String} connectionString

--- a/lib/error/eachAsyncMultiError.js
+++ b/lib/error/eachAsyncMultiError.js
@@ -1,0 +1,38 @@
+/*!
+ * Module dependencies.
+ */
+
+'use strict';
+
+const MongooseError = require('./');
+
+
+/**
+ * The connection failed to reconnect and will never successfully reconnect to
+ * MongoDB without manual intervention.
+ * @api private
+ */
+class EachAsyncMultiError extends MongooseError {
+  /**
+   * @param {String} connectionString
+   */
+  constructor(errors) {
+    let preview = errors.map(e => e.message).join(', ');
+    if (preview.length > 50) {
+      preview = preview.slice(0, 50) + '...';
+    }
+    super(`eachAsync() finished with ${errors.length} errors: ${preview}`);
+
+    this.errors = errors;
+  }
+}
+
+Object.defineProperty(EachAsyncMultiError.prototype, 'name', {
+  value: 'EachAsyncMultiError'
+});
+
+/*!
+ * exports
+ */
+
+module.exports = EachAsyncMultiError;

--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -26,7 +26,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
   const parallel = options.parallel || 1;
   const batchSize = options.batchSize;
   const continueOnError = options.continueOnError;
-  let aggregatedErrors = null;
+  const aggregatedErrors = [];
   const enqueue = asyncQueue();
 
   return promiseOrCallback(callback, cb => {
@@ -65,8 +65,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
         }
         if (err != null) {
           if (continueOnError) {
-            aggregatedErrors = aggregatedErrors || new EachAsyncMultiError([]);
-            aggregatedErrors.errors.push(err);
+            aggregatedErrors.push(err);
           } else {
             error = err;
             finalCallback(err);
@@ -76,7 +75,11 @@ module.exports = function eachAsync(next, fn, options, callback) {
         if (doc == null) {
           drained = true;
           if (handleResultsInProgress <= 0) {
-            finalCallback(aggregatedErrors);
+            const finalErr = continueOnError ?
+              createEachAsyncMultiError(aggregatedErrors) :
+              error;
+
+            finalCallback(finalErr);
           } else if (batchSize && documentsBatch.length) {
             handleNextResult(documentsBatch, currentDocumentIndex++, handleNextResultCallBack);
           }
@@ -110,15 +113,17 @@ module.exports = function eachAsync(next, fn, options, callback) {
           }
           if (err != null) {
             if (continueOnError) {
-              aggregatedErrors = aggregatedErrors || new EachAsyncMultiError([]);
-              aggregatedErrors.errors.push(err);
+              aggregatedErrors.push(err);
             } else {
               error = err;
               return finalCallback(err);
             }
           }
           if (drained && handleResultsInProgress <= 0) {
-            return finalCallback(aggregatedErrors);
+            const finalErr = continueOnError ?
+              createEachAsyncMultiError(aggregatedErrors) :
+              error;
+            return finalCallback(finalErr);
           }
 
           immediate(() => enqueue(fetch));
@@ -176,4 +181,12 @@ function asyncQueue() {
       inProgress = null;
     }
   }
+}
+
+function createEachAsyncMultiError(aggregatedErrors) {
+  if (aggregatedErrors.length === 0) {
+    return null;
+  }
+
+  return new EachAsyncMultiError(aggregatedErrors);
 }

--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -26,7 +26,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
   const parallel = options.parallel || 1;
   const batchSize = options.batchSize;
   const continueOnError = options.continueOnError;
-  const errors = [];
+  let aggregatedErrors = null;
   const enqueue = asyncQueue();
 
   return promiseOrCallback(callback, cb => {
@@ -64,15 +64,19 @@ module.exports = function eachAsync(next, fn, options, callback) {
           return done();
         }
         if (err != null) {
-          errors.push(err);
-          error = err;
-          finalCallback(err);
-          return done();
+          if (continueOnError) {
+            aggregatedErrors = aggregatedErrors || new EachAsyncMultiError([]);
+            aggregatedErrors.errors.push(err);
+          } else {
+            error = err;
+            finalCallback(err);
+            return done();
+          }
         }
         if (doc == null) {
           drained = true;
           if (handleResultsInProgress <= 0) {
-            finalCallback(null);
+            finalCallback(aggregatedErrors);
           } else if (batchSize && documentsBatch.length) {
             handleNextResult(documentsBatch, currentDocumentIndex++, handleNextResultCallBack);
           }
@@ -105,11 +109,16 @@ module.exports = function eachAsync(next, fn, options, callback) {
             --handleResultsInProgress;
           }
           if (err != null) {
-            error = err;
-            return finalCallback(err);
+            if (continueOnError) {
+              aggregatedErrors = aggregatedErrors || new EachAsyncMultiError([]);
+              aggregatedErrors.errors.push(err);
+            } else {
+              error = err;
+              return finalCallback(err);
+            }
           }
           if (drained && handleResultsInProgress <= 0) {
-            return finalCallback(null);
+            return finalCallback(aggregatedErrors);
           }
 
           immediate(() => enqueue(fetch));
@@ -121,11 +130,18 @@ module.exports = function eachAsync(next, fn, options, callback) {
   }
 
   function handleNextResult(doc, i, callback) {
-    const promise = fn(doc, i);
-    if (promise && typeof promise.then === 'function') {
-      promise.then(
+    let maybePromise;
+    try {
+      maybePromise = fn(doc, i);
+    } catch (err) {
+      return callback(err);
+    }
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise.then(
         function() { callback(null); },
-        function(error) { callback(error || new Error('`eachAsync()` promise rejected without error')); });
+        function(error) {
+          callback(error || new Error('`eachAsync()` promise rejected without error'));
+        });
     } else {
       callback(null);
     }

--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const EachAsyncMultiError = require('../../error/eachAsyncMultiError');
 const immediate = require('../immediate');
 const promiseOrCallback = require('../promiseOrCallback');
 
@@ -24,10 +25,11 @@ const promiseOrCallback = require('../promiseOrCallback');
 module.exports = function eachAsync(next, fn, options, callback) {
   const parallel = options.parallel || 1;
   const batchSize = options.batchSize;
+  const continueOnError = options.continueOnError;
+  const errors = [];
   const enqueue = asyncQueue();
 
   return promiseOrCallback(callback, cb => {
-
     if (batchSize != null) {
       if (typeof batchSize !== 'number') {
         throw new TypeError('batchSize must be a number');
@@ -62,6 +64,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
           return done();
         }
         if (err != null) {
+          errors.push(err);
           error = err;
           finalCallback(err);
           return done();

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -3,6 +3,12 @@ import stream = require('stream');
 declare module 'mongoose' {
   type CursorFlag = 'tailable' | 'oplogReplay' | 'noCursorTimeout' | 'awaitData' | 'partial';
 
+  interface EachAsyncOptions {
+    parallel?: number;
+    batchSize?: number;
+    continueOnError?: boolean;
+  }
+
   class Cursor<DocType = any, Options = never> extends stream.Readable {
     [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
 
@@ -25,10 +31,10 @@ declare module 'mongoose' {
      * will wait for the promise to resolve before iterating on to the next one.
      * Returns a promise that resolves when done.
      */
-    eachAsync(fn: (doc: DocType[]) => any, options: { parallel?: number, batchSize: number }, callback: CallbackWithoutResult): void;
-    eachAsync(fn: (doc: DocType) => any, options: { parallel?: number }, callback: CallbackWithoutResult): void;
-    eachAsync(fn: (doc: DocType[]) => any, options: { parallel?: number, batchSize: number }): Promise<void>;
-    eachAsync(fn: (doc: DocType) => any, options?: { parallel?: number }): Promise<void>;
+    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions, callback: CallbackWithoutResult): void;
+    eachAsync(fn: (doc: DocType) => any, options: EachAsyncOptions, callback: CallbackWithoutResult): void;
+    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions): Promise<void>;
+    eachAsync(fn: (doc: DocType) => any, options?: EachAsyncOptions): Promise<void>;
 
     /**
      * Registers a transform function which subsequently maps documents retrieved

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -31,9 +31,9 @@ declare module 'mongoose' {
      * will wait for the promise to resolve before iterating on to the next one.
      * Returns a promise that resolves when done.
      */
-    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions, callback: CallbackWithoutResult): void;
+    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions & { batchSize: number }, callback: CallbackWithoutResult): void;
     eachAsync(fn: (doc: DocType) => any, options: EachAsyncOptions, callback: CallbackWithoutResult): void;
-    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions): Promise<void>;
+    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions & { batchSize: number }): Promise<void>;
     eachAsync(fn: (doc: DocType) => any, options?: EachAsyncOptions): Promise<void>;
 
     /**


### PR DESCRIPTION
Fix #6355