### PR TITLE
types: improve lastErrorObject typing for rawResults

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -265,3 +265,14 @@ async function gh11306(): Promise<void> {
   expectType<any[]>(await MyModel.distinct('name'));
   expectType<string[]>(await MyModel.distinct<string>('name'));
 }
+
+async function gh11602(): Promise<void> {
+  const updateResult = await Model.findOneAndUpdate(query, { $inc: { occurence: 1 } }, {
+    upsert: true,
+    returnDocument: 'after',
+    rawResult: true
+  });
+  expectError(updateResult.lastErrorObject?.modifiedCount);
+  expectType<boolean | undefined>(updateResult.lastErrorObject?.updatedExisting);
+  expectType<ObjectId | undefined>(updateResult.lastErrorObject?.upserted);
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -248,7 +248,11 @@ declare module 'mongoose' {
 
   interface ModifyResult<T> {
     value: Require_id<T> | null;
-    lastErrorObject?: mongodb.Document;
+    /** see https://www.mongodb.com/docs/manual/reference/command/findAndModify/#lasterrorobject */
+    lastErrorObject?: {
+      updatedExisting?: boolean;
+      upserted?: mongodb.ObjectId;
+    };
     ok: 0 | 1;
   }
 


### PR DESCRIPTION
**Summary**

This improves the type for lastErrorObject, this helps to use the correct values as there is for example no modifiedCount or other things that a simple updateOne returns.

**Examples**

```ts
// findOneAndUpdate with rawResult: true
const result = Model.findOneAndUpdate(query, { $inc: { occurence: 1 } },  { upsert: true, returnDocument: 'after', rawResult: true });

// should work
updateResult.lastErrorObject?.upserted
// should throw error
updateResult.lastErrorObject?.modifiedCount
```