### PR TITLE
perf: improve perf of key order

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1052,7 +1052,6 @@ Document.prototype.$set = function $set(path, val, type, options) {
   const merge = options.merge;
   const adhoc = type && type !== true;
   const constructing = type === true;
-  const typeKey = this.$__schema.options.typeKey;
   let adhocs;
   let keys;
   let i = 0;

--- a/lib/document.js
+++ b/lib/document.js
@@ -1154,14 +1154,15 @@ Document.prototype.$set = function $set(path, val, type, options) {
       }
     }
 
-    // Ensure all properties are in correct order by deleting and recreating every property.
-    for (const key of Object.keys(this.$__schema.tree)) {
-      if (this._doc.hasOwnProperty(key)) {
-        const val = this._doc[key];
-        delete this._doc[key];
-        this._doc[key] = val;
-      }
+    // Ensure all properties are in correct order
+    const orderedDoc = {};
+    const orderedKeys = Object.keys(this.$__schema.tree);
+    for (let i = 0, len = orderedKeys.length; i < len; ++i) {
+      (key = orderedKeys[i]) &&
+      (this._doc.hasOwnProperty(key)) &&
+      (orderedDoc[key] = undefined);
     }
+    this._doc = Object.assign(orderedDoc, this._doc);
 
     return this;
   }

--- a/lib/document.js
+++ b/lib/document.js
@@ -1386,6 +1386,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
     }
 
     let popOpts;
+    const typeKey = this.$__schema.options.typeKey;
     if (schema.options &&
         Array.isArray(schema.options[typeKey]) &&
         schema.options[typeKey].length &&


### PR DESCRIPTION
I actually dont understand why the key ordre is so important. Nevertheless, this implementatoin is faster.

without reordering:
MONGOOSE_DEV=1 node create.js 
CheckItem x 201,161 ops/sec ±1.00% (92 runs sampled)
Board x 182 ops/sec ±0.82% (83 runs sampled)

before:
 MONGOOSE_DEV=1 node create.js 
CheckItem x 170,092 ops/sec ±1.35% (90 runs sampled)
Board x 168 ops/sec ±1.22% (80 runs sampled)

after:
MONGOOSE_DEV=1 node create.js 
CheckItem x 195,166 ops/sec ±0.41% (96 runs sampled)
Board x 174 ops/sec ±1.29% (80 runs sampled)

So we get pretty close to the non-ordered object.