### PR TITLE
disable debug option in virtuals unit test

### DIFF
--- a/test/docs/virtuals.test.js
+++ b/test/docs/virtuals.test.js
@@ -133,7 +133,6 @@ describe('Virtuals', function() {
     // acquit:ignore:end
     // Will **not** find any results, because `domain` is not stored in
     // MongoDB.
-    mongoose.set('debug', true);
     const doc = await User.findOne({ domain: 'gmail.com' }, null, { strictQuery: false });
     doc; // undefined
     // acquit:ignore:start


### PR DESCRIPTION
Unnecessary output of the mongo operations when running unit tests, because I guess somebody forgot to remove the debug option. 