### PR TITLE
fix: typo in methods/index.js

### DIFF
--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -149,7 +149,7 @@ const methods = {
    *
    * #### NOTE:
    *
-   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
+   * _Calling this multiple times on an array before saving sends the same command as calling it once._
    * _This update is implemented using the MongoDB [$pop](https://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
    *
    *      doc.array = [1,2,3];


### PR DESCRIPTION
mulitple -> multiple

