### PR TITLE
Call markModified before setting changes in Array  and in DocumentArray methods

### DIFF
--- a/lib/types/DocumentArray/methods/index.js
+++ b/lib/types/DocumentArray/methods/index.js
@@ -311,8 +311,8 @@ const methods = {
       return this;
     }
     const value = methods._cast.call(this, val, i);
-    arr[i] = value;
     methods._markModified.call(this, i);
+    arr[i] = value;
     return this;
   },
 

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -414,9 +414,9 @@ const methods = {
       }
 
       if (!found) {
+        this._markModified();
         rawArray.push(v);
         this._registerAtomic('$addToSet', v);
-        this._markModified();
         [].push.call(added, v);
       }
     }, this);
@@ -510,9 +510,9 @@ const methods = {
 
   nonAtomicPush() {
     const values = [].map.call(arguments, this._mapCast, this);
+    this._markModified();
     const ret = [].push.apply(this, values);
     this._registerAtomic('$set', this);
-    this._markModified();
     return ret;
   },
 
@@ -530,9 +530,9 @@ const methods = {
    */
 
   pop() {
+    this._markModified();
     const ret = [].pop.call(this);
     this._registerAtomic('$set', this);
-    this._markModified();
     return ret;
   },
 
@@ -572,6 +572,7 @@ const methods = {
     const cur = this[arrayParentSymbol].get(this[arrayPathSymbol]);
     let i = cur.length;
     let mem;
+    this._markModified();
 
     while (i--) {
       mem = cur[i];
@@ -595,7 +596,6 @@ const methods = {
       this._registerAtomic('$pullAll', values);
     }
 
-    this._markModified();
 
     // Might have modified child paths and then pulled, like
     // `doc.children[1].name = 'test';` followed by
@@ -657,7 +657,7 @@ const methods = {
       undefined, { skipDocumentArrayCast: true });
     let ret;
     const atomics = this[arrayAtomicsSymbol];
-
+    this._markModified();
     if (isOverwrite) {
       atomic.$each = values;
 
@@ -684,7 +684,6 @@ const methods = {
     }
 
     this._registerAtomic('$push', atomic);
-    this._markModified();
     return ret;
   },
 
@@ -737,8 +736,8 @@ const methods = {
       return this;
     }
     const value = methods._cast.call(this, val, i);
-    arr[i] = value;
     methods._markModified.call(this, i);
+    arr[i] = value;
     return this;
   },
 
@@ -763,9 +762,9 @@ const methods = {
 
   shift() {
     const arr = utils.isMongooseArray(this) ? this.__array : this;
+    this._markModified();
     const ret = [].shift.call(arr);
     this._registerAtomic('$set', this);
-    this._markModified();
     return ret;
   },
 
@@ -890,9 +889,9 @@ const methods = {
     }
 
     const arr = utils.isMongooseArray(this) ? this.__array : this;
+    this._markModified();
     [].unshift.apply(arr, values);
     this._registerAtomic('$set', this);
-    this._markModified();
     return this.length;
   }
 };


### PR DESCRIPTION
@vkarpov15 is there any reason why in the `array` and `DocumentArray` methods we shouldn't call `markModified` before actually write the new value for the given path?

I understand that in order to mark something as modified we must have updated it before. However I do not know how we could keep track of the previous values when updating a single value from a nested array.

This pull request is motivated by this issue: https://github.com/Automattic/mongoose/issues/11644
In this comment there is detailed info and repro: https://github.com/Automattic/mongoose/issues/11644#issuecomment-1094891011

In this pull request, calling `markModified` before writing the new value for the given path, we can keep track of the changes when updating a single value of a nested array.

Example:
```javascript
const MONGO_URL = 'mongodb://localhost/mongoose-track-changes';
const mongoose = require('mongoose');
const changesTracker = require('./index');  // https://github.com/josegl/mongoose-track-changes/blob/main/index.js

const notificationSchema = mongoose.Schema({
  notify_to: [String],
});

const taskSchema = new mongoose.Schema({
  notification: notificationSchema,
  description: String,
});

taskSchema.plugin(changesTracker);

test('Mongoose-track-changes', async () => {
  await mongoose.connect(MONGO_URL);
  const taskModel = mongoose.model('Task', taskSchema);
  const task = taskModel({
    notification: {
      notify_to: new Array(3).fill(0).map((_, i) => `id${i}`),
    },
    description: 'test',
  });
  await task.save();
  const saved_task = await mongoose.models.Task.findOne({});
  saved_task.notification.notify_to[2] = 'id3';
});
```
Without the changes in this pull request, after using this plugin:
https://github.com/josegl/mongoose-track-changes
In the `task._changes` array will be only a single change, and it will be this:
```javascript
{path: '/notification/notify_to/2', old_value: 'id3'}
```
When the desired value is:
```javascript
{path: '/notification/notify_to/2', old_value: 'id2'}
```
With the changes applied by this PR, the value is exactly the desired value.

I would understand your hesitations to merge this PR because as I said before we can argue that semantically you cannot mark something as modified if it has not been modified yet. If so, what would be the best solution in order to keep track of a deltas array, no matter how a document is updated, I mean that we want to keep the changes if you use this syntax:
```javascript
myModel.set('any.path.you.want', 'new_value');
```
or this one:
```javascript
myModel.any.path.you.want = 'new_value';
```
In both cases we want to have the same deltas array:
```javascript
myModel._changes
// [{path: '/any/path/you/want', old_value: 'previous_value' || undefined /*if there was not a previous value*/}]
```