### PR TITLE
use node 18 instead of node 17 in CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16, 17]
+        node: [12, 14, 16, 18]
         os: [ubuntu-18.04, ubuntu-20.04]
         include:
           - os: ubuntu-18.04


### PR DESCRIPTION
node 18 is out, node 17 is history. time to change the CI/CD platform matrix for node