### PR TITLE
remove include in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
       "allowSyntheticDefaultImports": true,
       "strictPropertyInitialization": false,
       "noImplicitAny": false,
+      "strictNullChecks": true,
       "module": "commonjs",
       "target": "ES2017"
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,5 @@
     "paths": {
       "mongoose" : ["./types/index.d.ts"]
     }
-  },
-  "include": ["types/*"]
+  }
 }


### PR DESCRIPTION
@mohammad0-0ahmad reported that with this [change](https://github.com/Automattic/mongoose/commit/5194756664665a6bc4ed5769d300f3a9d1e6f2c3)  the intellisense in vscode atleast in our typescript tests is broken. 

I dont understand why the include was done anyway. tsd is not using the configuration in tsconfig.json but from the tsc-configuration in package.json. 

Maybe @sandersn can give a clue why he added include instruction to tsconfig.json