### PR TITLE
Indicate index won't be created when not buffering

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -75,7 +75,7 @@ creates collections if you use the [`autoCreate` option](/docs/guide.html#autoCr
 If you disable buffering, you should also disable the `autoCreate`
 option and use [`createCollection()`](/docs/api/model.html#model_Model.createCollection)
 to create [capped collections](/docs/guide.html#capped) or
-[collections with collations](/docs/guide.html#collation).
+[collections with collations](/docs/guide.html#collation). In addition, if you diable buffering, you should disable the [`autoIndex` option](https://mongoosejs.com/docs/guide.html#autoIndex) and use [`createIndexes()`](https://mongoosejs.com/docs/api.html#model_Model.createIndexes) to create indices.
 
 ```javascript
 const schema = new Schema({
@@ -83,13 +83,15 @@ const schema = new Schema({
 }, {
   capped: { size: 1024 },
   bufferCommands: false,
-  autoCreate: false // disable `autoCreate` since `bufferCommands` is false
+  autoCreate: false, // disable `autoCreate` since `bufferCommands` is false
+  autoIndex: false // disable `autoIndex` since `bufferCommands` is false
 });
 
 const Model = mongoose.model('Test', schema);
 // Explicitly create the collection before using it
 // so the collection is capped.
 await Model.createCollection();
+await Model.createIndexes();
 ```
 
 <h3 id="error-handling"><a href="#error-handling">Error Handling</a></h3>


### PR DESCRIPTION
Updates documentation to show the caveat of turning off buffering.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Mongoose doesn't create indexes automatically when buffering is turned off. Possible reason for https://github.com/Automattic/mongoose/issues/10631

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```javascript
const mongoose = require('mongoose');
const {Schema} = mongoose;

const testSchema = new Schema({
    name: String,
    age: Number,
    weight: Number,
    height: Number,
    birthday: String
});

testSchema.index({age: 1}, {unique: true});
testSchema.index({ name: 1, weight: 1});
testSchema.index({ name: 1, birthday: 1}, {unique: true});
testSchema.index({ name: 1, height: 1});

testSchema.index({'$**': 'text'}, { name: 'textIndex'});

const Test = mongoose.model('Test', testSchema, 'test');

async function test() {
    await mongoose.connect('mongodb://localhost:27017/test', {
        useNewUrlParser: true,
        useUnifiedTopology: true,
        bufferCommands: false
      });
      await mongoose.connection.dropDatabase();
      await Test.init();
    console.log(await Test.listIndexes());
}

test();
```
Example is taken from @IslandRhythms' https://github.com/Automattic/mongoose/issues/10631#issuecomment-914371481