### PR TITLE
chore: Drop Node 12 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
         os: [ubuntu-18.04, ubuntu-20.04]
         include:
           - os: ubuntu-18.04

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "main": "./index.js",
   "types": "./types/index.d.ts",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "bugs": {
     "url": "https://github.com/Automattic/mongoose/issues/new"


### PR DESCRIPTION
Node 12 is EOL. We should remove support for it.

Do we have somewhere documented, which versions we support?