### PR TITLE
optimize size of browser bundle, use buffer v.5.7.1 package to match buffer package of mongodb in browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-loader": "8.2.5",
     "benchmark": "2.1.4",
     "bluebird": "3.7.2",
-    "buffer": "^5.7.1",
+    "buffer": "^5.6.0",
     "cheerio": "1.0.0-rc.10",
     "crypto-browserify": "3.12.0",
     "dox": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-loader": "8.2.5",
     "benchmark": "2.1.4",
     "bluebird": "3.7.2",
+    "buffer": "^5.7.1",
     "cheerio": "1.0.0-rc.10",
     "crypto-browserify": "3.12.0",
     "dox": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-loader": "8.2.5",
     "benchmark": "2.1.4",
     "bluebird": "3.7.2",
-    "buffer": "6.0.3",
     "cheerio": "1.0.0-rc.10",
     "crypto-browserify": "3.12.0",
     "dox": "0.3.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,6 @@ const webpackConfig = {
       }
     ]
   },
-
   resolve: {
     alias: {
       'bn.js': require.resolve('bn.js')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,9 +34,12 @@ const webpackConfig = {
   },
 
   resolve: {
+    alias: {
+      'bn.js': require.resolve('bn.js')
+    },
     fallback: {
       assert: require.resolve('assert-browserify'),
-      buffer: require.resolve('buffer/'),
+      buffer: require.resolve('buffer'),
       crypto: require.resolve('crypto-browserify'),
       stream: require.resolve('stream-browserify')
     }


### PR DESCRIPTION
- use buffer v.5.7.1 as a devDependency so that the version matches the buffer package from mongodb.
- use alias in webpack on bn.js to reduce redundancy, saving about 260 kb

before:
![Screenshot from 2022-05-03 23-10-04](https://user-images.githubusercontent.com/5059100/166567851-32047bd2-a7e3-4e39-9f08-4db2624f4fce.png)

after:
![Screenshot from 2022-05-03 23-09-48](https://user-images.githubusercontent.com/5059100/166567889-855104c9-f6ae-4a7f-94d7-946fb461a654.png)

before:1048 kb
after: 781 kb