### PR TITLE
Feature/ts lean missing doc fixes #11761 without killing LeanDocument

### DIFF
--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -188,3 +188,49 @@ async function getBaseDocumentTypeFromModel(): Promise<void> {
 
   const b = a.toJSON();
 }
+
+
+async function _11767() {
+  interface Question {
+    text: string;
+    answers: Types.Array<string>;
+    correct: number;
+  }
+  const QuestionSchema = new Schema<Question>({
+    text: String,
+    answers: [String],
+    correct: Number
+  });
+  interface Exam {
+    element: string;
+    dateTaken: Date;
+    questions: Types.DocumentArray<Question>;
+  }
+  const ExamSchema = new Schema<Exam>({
+    element: String,
+    dateTaken: Date,
+    questions: [QuestionSchema]
+  });
+
+  const ExamModel = model<Exam>('Exam', ExamSchema);
+
+  const examFound = await ExamModel.findOne().lean().exec();
+  if (!examFound) return;
+
+  // Had to comment some of these active checks out
+
+  // $pop shouldn't be there, because questions should no longer be a mongoose array
+  // expectError<Function>(examFound.questions.$pop);
+  // popoulated shouldn't be on the question doc because it shouldn't
+  // be a mongoose subdocument anymore
+  // expectError(examFound.questions[0]!.populated);
+  expectType<string[]>(examFound.questions[0].answers);
+
+  const examFound2 = await ExamModel.findOne().exec();
+  if (!examFound2) return;
+  const examFound2Obj = examFound2.toObject();
+
+  // expectError(examFound2Obj.questions.$pop);
+  // expectError(examFound2Obj.questions[0].populated);
+  expectType<string[]>(examFound2Obj.questions[0].answers);
+}

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -87,6 +87,18 @@ function gh10345() {
   })();
 }
 
+async function gh11761() {
+  const thingSchema = new Schema<{ name: string }>({
+    name: Schema.Types.String
+  });
+
+  const ThingModel = model('Thing', thingSchema);
+
+  const { _id, ...thing1 } = (await ThingModel.create({ name: 'thing1' })).toObject();
+
+  console.log({ _id, thing1 });
+}
+
 async function gh11118(): Promise<void> {
   interface User {
     name: string;

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -94,9 +94,23 @@ async function gh11761() {
 
   const ThingModel = model('Thing', thingSchema);
 
-  const { _id, ...thing1 } = (await ThingModel.create({ name: 'thing1' })).toObject();
+  {
+    // make sure _id has been added to the type
+    const { _id, ...thing1 } = (await ThingModel.create({ name: 'thing1' })).toObject();
+    expectType<Types.ObjectId>(_id);
 
-  console.log({ _id, thing1 });
+    console.log({ _id, thing1 });
+  }
+  // stretch goal, make sure lean works as well
+
+  const foundDoc = await ThingModel.findOne().lean().limit(1).exec();
+  {
+    if (!foundDoc) {
+      return; // Tell TS that it isn't null
+    }
+    const { _id, ...thing2 } = foundDoc;
+    expectType<Types.ObjectId>(foundDoc._id);
+  }
 }
 
 async function gh11118(): Promise<void> {

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -225,7 +225,7 @@ declare module 'mongoose' {
     toJSON<T = DocType>(options: ToObjectOptions & { flattenMaps: false }): LeanDocument<T>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
-    toObject<T = DocType>(options?: ToObjectOptions): LeanDocument<T>;
+    toObject<T = DocType>(options?: ToObjectOptions): Require_id<LeanDocument<T>>;
 
     /** Clears the modified state on the specified path. */
     unmarkModified(path: string): void;

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -221,11 +221,11 @@ declare module 'mongoose' {
     set(value: any): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
-    toJSON<T = DocType>(options?: ToObjectOptions & { flattenMaps?: true }): FlattenMaps<LeanDocument<T>>;
-    toJSON<T = DocType>(options: ToObjectOptions & { flattenMaps: false }): LeanDocument<T>;
+    toJSON<T = LeanDocument<DocType>>(options?: ToObjectOptions & { flattenMaps?: true }): FlattenMaps<T>;
+    toJSON<T = LeanDocument<DocType>>(options: ToObjectOptions & { flattenMaps: false }): T;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
-    toObject<T = DocType>(options?: ToObjectOptions): Require_id<LeanDocument<T>>;
+    toObject<T = LeanDocument<DocType>>(options?: ToObjectOptions): Require_id<T>;
 
     /** Clears the modified state on the specified path. */
     unmarkModified(path: string): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2272,8 +2272,8 @@ declare module 'mongoose' {
         T;
 
   export type LeanDocumentOrArrayWithRawType<T, RawDocType> = 0 extends (1 & T) ? T :
-    T extends unknown[] ? RawDocType[] :
-      T extends Document ? RawDocType :
+    T extends unknown[] ? LeanDocument<RawDocType>[] :
+      T extends Document ? LeanDocument<RawDocType> :
         T;
 
   export class SchemaType<T = any> {


### PR DESCRIPTION
**Summary**

Per #11761 `.toObject` doesn't add `_id` to the document if it is missing; this fixes that.

**Examples**

See unit tests in the code