### PR TITLE
chore: fix automated replicaset tests in CI/CD pipeline

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5189,7 +5189,7 @@ describe('Model', function() {
         it('watch() before connecting (gh-5964)', async function() {
           const db = start();
 
-          const MyModel = db.model('Test', new Schema({ name: String }));
+          const MyModel = db.model('Test5964', new Schema({ name: String }));
 
           // Synchronous, before connection happens
           const changeStream = MyModel.watch();


### PR DESCRIPTION
I guess the collection name results some interference with the replicaset tests. Maybe the collection is after running all the normal unit tests full with data, resulting that it takes more then 10 seconds. 

I merge this, if the test pass, as it is not a massive change.