### PR TITLE
fix: 🐛 Types of Connection.deleteModel()

### DIFF
--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -72,7 +72,7 @@ declare module 'mongoose' {
        * use this function to clean up any models you created in your tests to
        * prevent OverwriteModelErrors.
        */
-    deleteModel(name: string): this;
+    deleteModel(name: string | RegExp): this;
 
     /**
        * Helper for `dropCollection()`. Will delete the given collection, including


### PR DESCRIPTION
The documentation and the code of Connection.deleteModel() tells, that
it accepts a string and a RegExp. So, the types should accept a RegExp
as well.

**Summary**

At the moment `moongoose.connection.deleteModel(/.+/)` is not working in the test code in one of my typescript repositories, because of a type error. The javascript code of `deleteModel` tells, that a RegExp is accepted, but the current types only allow a string as parameter. My current workaround is `mongoose.connection.deleteModel(<string><unknown>/.+/)`, what is not ideal in my opinion.

**Examples**

The following line should work in typescript as well:

`mongoose.connection.deleteModel(/.+/)`