### PR TITLE
test: 💍 Add missing test for type of Connection.deleteModel()

### DIFF
--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -38,6 +38,7 @@ expectType<void>(conn.dropCollection('some', () => {
 
 expectError(conn.deleteModel());
 expectType<Connection>(conn.deleteModel('something'));
+expectType<Connection>(conn.deleteModel(/.+/));
 
 expectType<Array<string>>(conn.modelNames());
 


### PR DESCRIPTION
Following the advice of github user Uzlopak to add a test, that
Connection.deleteModel is accepting a RegExp as well.


**Summary**

Yesterday, I have submitted a fix for the types of Connection.deleteModel(), because the javascript code accepts a RegExp and not just a string. The fix is already merged, but a reviewer asked me to add a test and gave me an advice how to do it.

**Examples**

This was exactly the advice how to add a test:

`expectType<Connection>(conn.deleteModel(/.+/));`