### PR TITLE
Fix: Type of Connection.transaction()

### DIFF
--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -63,6 +63,10 @@ expectType<Promise<void>>(conn.transaction(async(res) => {
   expectType<mongodb.ClientSession>(res);
   return 'a';
 }));
+expectType<Promise<void>>(conn.transaction(async(res) => {
+  expectType<mongodb.ClientSession>(res);
+  return 'a';
+}, { readConcern: 'majority' }));
 
 expectError(conn.user = 'invalid');
 expectError(conn.pass = 'invalid');

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -196,7 +196,7 @@ declare module 'mongoose' {
        * async function executes successfully and attempt to retry if
        * there was a retryable error.
        */
-    transaction(fn: (session: mongodb.ClientSession) => Promise<any>): Promise<void>;
+    transaction(fn: (session: mongodb.ClientSession) => Promise<any>, options?: mongodb.TransactionOptions): Promise<void>;
 
     /** Switches to a different database using the same connection pool. */
     useDb(name: string, options?: { useCache?: boolean, noListener?: boolean }): Connection;


### PR DESCRIPTION
The documentation and code say it accepts "options" as a second parameter, but the type definition doesn't allow it.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The documentation lists [Connection.prototype.transaction()](https://mongoosejs.com/docs/api/connection.html#connection_Connection-transaction) as accepting an `options` parameter (and this [is indeed the case](https://github.com/Automattic/mongoose/blob/3b943b2a3f0d7a92e4ef22a7d4584859235c1d54/lib/connection.js#L468)), but the type definition doesn't allow it.
This is particularly problematic for using this function with [causally consistent sessions](https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency), given that the default read concern is `local`, because it prevents setting the `readConcern` at anything other than the client level.

**Examples**
The sample from the documentation:
```ts
await db.transaction(async function setRank(session) {
  doc.rank = 'Captain';
  await doc.save({ session });
  doc.isNew; // false

  // Throw an error to abort the transaction
  throw new Error('Oops!');
},{ readPreference: 'primary' }).catch(() => {});
```
will fail to transpire as Typescript, with the error `TS2554: Expected 1 arguments, but got 2.`