### PR TITLE
Another fix for #11709 Typescript doc exemple for query helpers does not seem to work

### DIFF
--- a/docs/typescript/query-helpers.md
+++ b/docs/typescript/query-helpers.md
@@ -31,8 +31,9 @@ interface Project {
   stars: number;
 }
 
+type ProjectDocumentType = Document<any, any, Project> & Project;
 type ProjectModelType = Model<Project, ProjectQueryHelpers>;
-type ProjectQueryType = Query<any, Document<Project>, ProjectQueryHelpers> & ProjectQueryHelpers;
+type ProjectQueryType = Query<any, ProjectDocumentType, ProjectQueryHelpers> & ProjectQueryHelpers;
 
 // Query helpers should return `Query<any, Document<DocType>, ProjectQueryHelpers> & ProjectQueryHelpers`
 // to enable chaining.

--- a/docs/typescript/query-helpers.md
+++ b/docs/typescript/query-helpers.md
@@ -32,17 +32,19 @@ interface Project {
 }
 
 type ProjectModelType = Model<Project, ProjectQueryHelpers>;
-// Query helpers should return `Query<any, Document<DocType>> & ProjectQueryHelpers`
+type ProjectQueryType = Query<any, Document<Project>, ProjectQueryHelpers> & ProjectQueryHelpers;
+
+// Query helpers should return `Query<any, Document<DocType>, ProjectQueryHelpers> & ProjectQueryHelpers`
 // to enable chaining.
 interface ProjectQueryHelpers {
-  byName(name: string): Query<any, Document<Project>> & ProjectQueryHelpers;
+  byName(name: string): ProjectQueryType;
 }
 
-const schema = new Schema<Project, ProjectModelType, {}, ProjectQueryHelpers>({
+const schema = new Schema<Project, ProjectModelType, {}, ProjectQueryType>({
   name: { type: String, required: true },
   stars: { type: Number, required: true }
 });
-schema.query.byName = function(name): Query<any, Document<Project>> & ProjectQueryHelpers {
+schema.query.byName = function(name): ProjectQueryType {
   return this.find({ name: name });
 };
 


### PR DESCRIPTION
The fix provided in #11709 didn't solve `TS2339: Property 'find' does not exist on type '{}'.`

When i copy paste the code raw the problem still happens.

I modifed by adding the third class type `THelpers` in the Query template. I hope the problem isn't me.

