### PR TITLE
fix(document): fix ObjectId conversion for external schemas

### DIFF
--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -71,14 +71,12 @@ function clone(obj, options, isArrayChild) {
         return new objConstructor(+obj);
       case 'RegExp':
         return cloneRegExp(obj);
+      case 'ObjectId':
+        return new ObjectId(obj.id);
       default:
         // ignore
         break;
     }
-  }
-
-  if (obj instanceof ObjectId) {
-    return new ObjectId(obj.id);
   }
 
   if (isBsonType(obj, 'Decimal128')) {

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -78,6 +78,10 @@ function clone(obj, options, isArrayChild) {
         break;
     }
   }
+  
+  if (obj instanceof ObjectId) {
+    return new ObjectId(obj.id);
+  }
 
   if (isBsonType(obj, 'Decimal128')) {
     if (options && options.flattenDecimals) {

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -75,9 +75,8 @@ function clone(obj, options, isArrayChild) {
       case 'ObjectId':
         if (obj._bsonType === 'ObjectID') {
           return new ObjectId(obj.id);
-        } else {
-          break;
         }
+        break;
       default:
         // ignore
         break;

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -71,8 +71,13 @@ function clone(obj, options, isArrayChild) {
         return new objConstructor(+obj);
       case 'RegExp':
         return cloneRegExp(obj);
+        // instanceof is not enough for schemas defined in another package
       case 'ObjectId':
-        return new ObjectId(obj.id);
+        if (obj._bsonType === "ObjectID") {
+          return new ObjectId(obj.id);
+        } else {
+          break;
+        }
       default:
         // ignore
         break;

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -71,19 +71,13 @@ function clone(obj, options, isArrayChild) {
         return new objConstructor(+obj);
       case 'RegExp':
         return cloneRegExp(obj);
-        // instanceof is not enough for schemas defined in another package
-      case 'ObjectId':
-        if (obj._bsonType === 'ObjectID') {
-          return new ObjectId(obj.id);
-        }
-        break;
       default:
         // ignore
         break;
     }
   }
 
-  if (obj instanceof ObjectId) {
+  if (isBsonType(obj, 'ObjectID')) {
     return new ObjectId(obj.id);
   }
 

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -78,7 +78,7 @@ function clone(obj, options, isArrayChild) {
         break;
     }
   }
-  
+
   if (obj instanceof ObjectId) {
     return new ObjectId(obj.id);
   }

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -73,7 +73,7 @@ function clone(obj, options, isArrayChild) {
         return cloneRegExp(obj);
         // instanceof is not enough for schemas defined in another package
       case 'ObjectId':
-        if (obj._bsonType === "ObjectID") {
+        if (obj._bsonType === 'ObjectID') {
           return new ObjectId(obj.id);
         } else {
           break;

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -5,8 +5,7 @@
  */
 
 const Binary = require('../driver').get().Binary;
-const Decimal128 = require('../types/decimal128');
-const ObjectId = require('../types/objectid');
+const isBsonType = require('./isBsonType');
 const isMongooseObject = require('./isMongooseObject');
 
 exports.flatten = flatten;
@@ -99,9 +98,9 @@ function shouldFlatten(val) {
   return val &&
     typeof val === 'object' &&
     !(val instanceof Date) &&
-    !(val instanceof ObjectId) &&
+    !isBsonType(val, 'ObjectID') &&
     (!Array.isArray(val) || val.length !== 0) &&
     !(val instanceof Buffer) &&
-    !(val instanceof Decimal128) &&
+    !isBsonType(val, 'Decimal128') &&
     !(val instanceof Binary);
 }

--- a/lib/helpers/discriminator/areDiscriminatorValuesEqual.js
+++ b/lib/helpers/discriminator/areDiscriminatorValuesEqual.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ObjectId = require('../../types/objectid');
+const isBsonType = require('../isBsonType');
 
 module.exports = function areDiscriminatorValuesEqual(a, b) {
   if (typeof a === 'string' && typeof b === 'string') {
@@ -9,7 +9,7 @@ module.exports = function areDiscriminatorValuesEqual(a, b) {
   if (typeof a === 'number' && typeof b === 'number') {
     return a === b;
   }
-  if (a instanceof ObjectId && b instanceof ObjectId) {
+  if (isBsonType(a, 'ObjectID') && isBsonType(b, 'ObjectID')) {
     return a.toString() === b.toString();
   }
   return false;

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -6,9 +6,9 @@
 
 const SchemaType = require('../schematype');
 const CastError = SchemaType.CastError;
-const Decimal128Type = require('../types/decimal128');
 const castDecimal128 = require('../cast/decimal128');
 const utils = require('../utils');
+const isBsonType = require('../helpers/isBsonType');
 
 /**
  * Decimal128 SchemaType constructor.
@@ -105,7 +105,7 @@ Decimal128.cast = function cast(caster) {
  */
 
 Decimal128._defaultCaster = v => {
-  if (v != null && !(v instanceof Decimal128Type)) {
+  if (v != null && !isBsonType(v, 'Decimal128')) {
     throw new Error();
   }
   return v;
@@ -115,7 +115,7 @@ Decimal128._defaultCaster = v => {
  * ignore
  */
 
-Decimal128._checkRequired = v => v instanceof Decimal128Type;
+Decimal128._checkRequired = v => isBsonType(v, 'Decimal128');
 
 /**
  * Override the function the required validator uses to check whether a string
@@ -164,7 +164,7 @@ Decimal128.prototype.checkRequired = function checkRequired(value, doc) {
 
 Decimal128.prototype.cast = function(value, doc, init) {
   if (SchemaType._isRef(this, value, doc, init)) {
-    if (value instanceof Decimal128Type) {
+    if (isBsonType(value, 'Decimal128')) {
       return value;
     }
 

--- a/lib/types/DocumentArray/methods/index.js
+++ b/lib/types/DocumentArray/methods/index.js
@@ -2,11 +2,11 @@
 
 const ArrayMethods = require('../../array/methods');
 const Document = require('../../../document');
-const ObjectId = require('../../objectid');
 const castObjectId = require('../../../cast/objectid');
 const getDiscriminatorByValue = require('../../../helpers/discriminator/getDiscriminatorByValue');
 const internalToObjectOptions = require('../../../options').internalToObjectOptions;
 const utils = require('../../../utils');
+const isBsonType = require('../../../helpers/isBsonType');
 
 const arrayParentSymbol = require('../../../helpers/symbols').arrayParentSymbol;
 const arrayPathSymbol = require('../../../helpers/symbols').arrayPathSymbol;
@@ -66,7 +66,7 @@ const methods = {
     // only objects are permitted so we can safely assume that
     // non-objects are to be interpreted as _id
     if (Buffer.isBuffer(value) ||
-        value instanceof ObjectId || !utils.isObject(value)) {
+        isBsonType(value, 'ObjectID') || !utils.isObject(value)) {
       value = { _id: value };
     }
 
@@ -134,7 +134,7 @@ const methods = {
         if (sid == _id._id) {
           return val;
         }
-      } else if (!(id instanceof ObjectId) && !(_id instanceof ObjectId)) {
+      } else if (!isBsonType(id, 'ObjectID') && !isBsonType(_id, 'ObjectID')) {
         if (id == _id || utils.deepEqual(id, _id)) {
           return val;
         }

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -3,10 +3,10 @@
 const Document = require('../../../document');
 const ArraySubdocument = require('../../ArraySubdocument');
 const MongooseError = require('../../../error/mongooseError');
-const ObjectId = require('../../objectid');
 const cleanModifiedSubpaths = require('../../../helpers/document/cleanModifiedSubpaths');
 const internalToObjectOptions = require('../../../options').internalToObjectOptions;
 const utils = require('../../../utils');
+const isBsonType = require('../../../helpers/isBsonType');
 
 const arrayAtomicsSymbol = require('../../../helpers/symbols').arrayAtomicsSymbol;
 const arrayParentSymbol = require('../../../helpers/symbols').arrayParentSymbol;
@@ -227,7 +227,7 @@ const methods = {
       // only objects are permitted so we can safely assume that
       // non-objects are to be interpreted as _id
       if (Buffer.isBuffer(value) ||
-          value instanceof ObjectId || !utils.isObject(value)) {
+          isBsonType(value, 'ObjectID') || !utils.isObject(value)) {
         value = { _id: value };
       }
 
@@ -469,7 +469,7 @@ const methods = {
    */
 
   indexOf(obj, fromIndex) {
-    if (obj instanceof ObjectId) {
+    if (isBsonType(obj, 'ObjectID')) {
       obj = obj.toString();
     }
 

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const Mixed = require('../schema/mixed');
-const ObjectId = require('./objectid');
 const clone = require('../helpers/clone');
 const deepEqual = require('../utils').deepEqual;
 const getConstructorName = require('../helpers/getConstructorName');
 const handleSpreadDoc = require('../helpers/document/handleSpreadDoc');
 const util = require('util');
 const specialProperties = require('../helpers/specialProperties');
+const isBsonType = require('../helpers/isBsonType');
 
 const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
@@ -43,7 +43,7 @@ class MongooseMap extends Map {
   }
 
   get(key, options) {
-    if (key instanceof ObjectId) {
+    if (isBsonType(key, 'ObjectID')) {
       key = key.toString();
     }
 
@@ -55,7 +55,7 @@ class MongooseMap extends Map {
   }
 
   set(key, value) {
-    if (key instanceof ObjectId) {
+    if (isBsonType(key, 'ObjectID')) {
       key = key.toString();
     }
 
@@ -117,7 +117,7 @@ class MongooseMap extends Map {
   }
 
   delete(key) {
-    if (key instanceof ObjectId) {
+    if (isBsonType(key, 'ObjectID')) {
       key = key.toString();
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,6 @@
 
 const ms = require('ms');
 const mpath = require('mpath');
-const Decimal = require('./types/decimal128');
 const ObjectId = require('./types/objectid');
 const PopulateOptions = require('./options/PopulateOptions');
 const clone = require('./helpers/clone');
@@ -307,7 +306,7 @@ exports.merge = function merge(to, from, options, path) {
             to[key] = from[key].clone();
           }
           continue;
-        } else if (from[key] instanceof ObjectId) {
+        } else if (isBsonType(from[key], 'ObjectID')) {
           to[key] = new ObjectId(from[key]);
           continue;
         }
@@ -481,7 +480,7 @@ exports.tick = function tick(callback) {
  */
 
 exports.isMongooseType = function(v) {
-  return v instanceof ObjectId || v instanceof Decimal || v instanceof Buffer;
+  return isBsonType(v, 'ObjectID') || isBsonType(v, 'Decimal128') || v instanceof Buffer;
 };
 
 exports.isMongooseObject = isMongooseObject;
@@ -795,7 +794,7 @@ exports.array.unique = function(arr) {
       }
       ret.push(item);
       primitives.add(item);
-    } else if (item instanceof ObjectId) {
+    } else if (isBsonType(item, 'ObjectID')) {
       if (ids.has(item.toString())) {
         continue;
       }


### PR DESCRIPTION
**Summary**

When dealing with external schemas, i.e. a mongoose schema created inside another module, `instanceOf` may not work.

This results in the value of ObjectIds in the schema being converted to strings when saving to the database.

**Examples**

I have a monorepo project with pnpm. One module `lib` contains a schema, which I use to create a model in my program. 

Both my program and the imported `lib` module have the same `bson`, `mongoose` and `mongodb` versions.