### PR TITLE
feat(types+document): add `$assertPopulated()` for working with manually populated paths in TypeScript

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4315,8 +4315,8 @@ Document.prototype.$populated = Document.prototype.populated;
  *
  *     const doc = await Model.findOne().populate('author');
  *
- *     doc.$assertPopulated('author'); // ok
- *     doc.$assertPopulated('other path');
+ *     doc.$assertPopulated('author'); // does not throw
+ *     doc.$assertPopulated('other path'); // throws an error
  *
  *
  * @param {String} path

--- a/lib/document.js
+++ b/lib/document.js
@@ -4319,7 +4319,7 @@ Document.prototype.$populated = Document.prototype.populated;
  *     doc.$assertPopulated('other path'); // throws an error
  *
  *
- * @param {String} path
+ * @param {String | Array<String>} path
  * @return {Document} this
  * @memberOf Document
  * @instance

--- a/lib/document.js
+++ b/lib/document.js
@@ -4251,10 +4251,10 @@ Document.prototype.$getPopulatedDocs = function $getPopulatedDocs() {
  *
  * #### Example:
  *
- *     Model.findOne().populate('author').exec(function (err, doc) {
- *       console.log(doc.author.name)         // Dr.Seuss
- *       console.log(doc.populated('author')) // '5144cf8050f071d979c118a7'
- *     })
+ *     const doc = await Model.findOne().populate('author');
+ *
+ *     console.log(doc.author.name); // Dr.Seuss
+ *     console.log(doc.populated('author')); // '5144cf8050f071d979c118a7'
  *
  * If the path was not populated, returns `undefined`.
  *
@@ -4307,6 +4307,37 @@ Document.prototype.populated = function(path, val, options) {
 };
 
 Document.prototype.$populated = Document.prototype.populated;
+
+/**
+ * Throws an error if a given path is not populated
+ *
+ * #### Example:
+ *
+ *     const doc = await Model.findOne().populate('author');
+ *
+ *     doc.$assertPopulated('author'); // ok
+ *     doc.$assertPopulated('other path');
+ *
+ *
+ * @param {String} path
+ * @return {Document} this
+ * @memberOf Document
+ * @instance
+ * @api public
+ */
+
+Document.prototype.$assertPopulated = function $assertPopulated(paths) {
+  if (Array.isArray(paths)) {
+    paths.forEach(path => this.$assertPopulated(path));
+    return this;
+  }
+
+  if (!this.$populated(paths)) {
+    throw new MongooseError(`Expected path "${paths}" to be populated`);
+  }
+
+  return this;
+};
 
 /**
  * Takes a populated field and returns it to its unpopulated state.

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -229,3 +229,30 @@ async function _11532() {
   expectType<string>(leanResult.child.name);
   expectError(leanResult?.__v);
 }
+
+function gh11758() {
+  interface NestedChild {
+    name: string
+    _id: Types.ObjectId
+  }
+  const nestedChildSchema: Schema = new Schema({ name: String });
+
+  interface Parent {
+    nestedChild: Types.ObjectId
+    name?: string
+  }
+
+  const ParentModel = model<Parent>('Parent', new Schema({
+    nestedChild: { type: Schema.Types.ObjectId, ref: 'NestedChild' },
+    name: String
+  }));
+
+  const NestedChildModel = model<NestedChild>('NestedChild', nestedChildSchema);
+
+  const parent = new ParentModel({
+    nestedChild: new NestedChildModel({ name: 'test' }),
+    name: 'Parent'
+  }).$assertPopulated<{ nestedChild: NestedChild }>('nestedChild');
+
+  expectType<string>(parent.nestedChild.name);
+}

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -19,6 +19,9 @@ declare module 'mongoose' {
     /** This documents __v. */
     __v?: any;
 
+    /** Assert that a given path or paths is populated. Throws an error if not populated. */
+    $assertPopulated<Paths = {}>(paths: string | string[]): Omit<this, keyof Paths> & Paths;
+
     /* Get all subdocs (by bfs) */
     $getAllSubdocs(): Document[];
 


### PR DESCRIPTION
Fix #11758

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Right now, if you instantiate a document with manually populated paths, there's no way to indicate that a path is manually populated as opposed to just an ObjectId.

```ts
const parent = new ParentModel({
    nestedChild: new NestedChildModel({ name: 'test' }),
    name: 'Parent'
})

parent.nestedChild; // always ObjectId, even if manually populated
```

With this PR, you can at least do:

```
const parent = new ParentModel({
    nestedChild: new NestedChildModel({ name: 'test' }),
    name: 'Parent'
}).$assertPopulated<{ nestedChild: NestedChild }>('nestedChild')

doc.nestedChild.name; // string
```

which will make TypeScript work correctly, and also correctly throw a runtime error if 'nestedChild' isn't populated. What do you think @AbdelrahmanHafez @Uzlopak ?

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
