### PR TITLE
Conflict with connect-mongo 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "db"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "mongodb": "4.5.0",
+  },
   "dependencies": {
     "bson": "^4.6.2",
     "kareem": "2.3.5",
-    "mongodb": "4.5.0",
     "mpath": "0.9.0",
     "mquery": "4.0.3",
     "ms": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "mongodb": "4.5.0",
+    "mongodb": "4.5.0"
   },
   "dependencies": {
     "bson": "^4.6.2",


### PR DESCRIPTION
When executing the following:
```
const app = express();
const mongoPromise = mongoose.connect(MONGODB_URL)
    .then(m => m.connection.getClient());
app.use(session({
    secret: SOMESECRET,
    saveUninitialized: false,
    resave: false,
    store: MongoStore.create({
        clientPromise: mongoPromise, // <-- ERROR OCCURS HERE
    }),
}));
```

I get the following error:
```
Type 'Promise<import("C:/.../node_modules/mongoose/node_modules/mongodb/mongodb").MongoClient>' is not assignable to type 'Promise<import("C:/.../node_modules/mongodb/mongodb").MongoClient>'.
  Type 'import("C:/.../node_modules/mongoose/node_modules/mongodb/mongodb").MongoClient' is not assignable to type 'import("C:/.../node_modules/mongodb/mongodb").MongoClient'.
    The types of 'options.autoEncrypter' are incompatible between these types.
      Type 'import("C:/.../node_modules/mongoose/node_modules/mongodb/mongodb").AutoEncrypter | undefined' is not assignable to type 'import("C:/.../node_modules/mongodb/mongodb").AutoEncrypter | undefined'.ts(2322)
MongoStore.d.ts(14, 5): The expected type comes from property 'clientPromise' which is declared here on type 'ConnectMongoOptions'
```

I resolved this by simply adding a `peerDependency` for `mongodb v4.5.0` in the `package.json` file.