### PR TITLE
chore: ignore infix-ops in eslint 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,7 @@
       "@typescript-eslint/object-curly-spacing": ["error", "always"],
       "@typescript-eslint/semi": "error",
       "@typescript-eslint/space-before-function-paren": ["error", "never"],
-      "@typescript-eslint/space-infix-ops": "error"
+      "@typescript-eslint/space-infix-ops": "off"
     }
   }],
   "plugins": [


### PR DESCRIPTION
Till https://github.com/typescript-eslint/typescript-eslint/pull/5135 gets released, turn off the infix-ops option of eslint. 