### PR TITLE
Fix ObjectId `instanceof` checks

### DIFF
--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -9,6 +9,7 @@ const SchemaType = require('../schematype');
 const castObjectId = require('../cast/objectid');
 const getConstructorName = require('../helpers/getConstructorName');
 const oid = require('../types/objectid');
+const isBsonType = require('../helpers/isBsonType');
 const utils = require('../utils');
 
 const CastError = SchemaType.CastError;
@@ -113,7 +114,7 @@ ObjectId.prototype.auto = function(turnOn) {
  * ignore
  */
 
-ObjectId._checkRequired = v => v instanceof oid;
+ObjectId._checkRequired = v => isBsonType(v, 'ObjectID');
 
 /*!
  * ignore
@@ -161,7 +162,7 @@ ObjectId.cast = function cast(caster) {
  */
 
 ObjectId._defaultCaster = v => {
-  if (!(v instanceof oid)) {
+  if (!(isBsonType(v, 'ObjectID'))) {
     throw new Error(v + ' is not an instance of ObjectId');
   }
   return v;
@@ -221,7 +222,7 @@ ObjectId.prototype.checkRequired = function checkRequired(value, doc) {
  */
 
 ObjectId.prototype.cast = function(value, doc, init) {
-  if (!(value instanceof oid) && SchemaType._isRef(this, value, doc, init)) {
+  if (!(isBsonType(value, 'ObjectID')) && SchemaType._isRef(this, value, doc, init)) {
     // wait! we may need to cast this to a document
     if ((getConstructorName(value) || '').toLowerCase() === 'objectid') {
       return new oid(value.toHexString());


### PR DESCRIPTION
**Summary**

PR #11841 changed a whole bunch of checks for `instanceof ObjectId` to
use the `isBsonType()` function instead. Unfortunately some were missed
in the `./lib/schema/objectid.js` file.

Convert the remaining `instanceof` checks in `objectid.js` to use the
`isBsonType()` check instead so that all `ObjectId`s created from any
`bson` modules should validate/cast properly.

This was found because my nested document with required ObjectIds
started failing validation when I loaded the documents from JSON files
in my tests using `bson.EJSON` after the release of 6.3.4 -> 6.3.5.

**Examples**

This test when run in a project that depends on `mongoose` and `bson`
will fail before this fix and work afterward.

```js
const mongoose = require('mongoose');
const { EJSON } = require('bson');

describe('validation of required ObjectId type', () => {
  it('should be able to insert documents that correspond to the schema', async () => {
    const TestDocumentSchema = new mongoose.Schema({
      name: {
        type: mongoose.Schema.Types.String,
        required: true,
      },
      owner: {
        type: mongoose.Schema.Types.ObjectId,
        default: () => mongoose.Types.ObjectId(),
        required: true,
      },
    });

    const TestDocumentModel = mongoose.model(
      'TestDocument',
      TestDocumentSchema,
    );

    const result = await TestDocumentModel.insertMany([
      EJSON.parse(
        EJSON.stringify({
          name: 'Document 1',
          owner: new mongoose.Types.ObjectId(),
        }),
      ),
      EJSON.parse(EJSON.stringify({ name: 'document 2' })),
    ]);

    expect(result).not.toBeNull();
  });
});
```
