### PR TITLE
fix(types): Allow sorting by text score

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -579,7 +579,7 @@ declare module 'mongoose' {
     snapshot(val?: boolean): this;
 
     /** Sets the sort order. If an object is passed, values allowed are `asc`, `desc`, `ascending`, `descending`, `1`, and `-1`. */
-    sort(arg?: string | { [key: string]: SortOrder } | { score: { $meta: 'textScore' } } | undefined | null): this;
+    sort(arg?: string | { [key: string]: SortOrder } | { [key: string]: { $meta: 'textScore' } } | undefined | null): this;
 
     /** Sets the tailable option (for use with capped collections). */
     tailable(bool?: boolean, opts?: {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -579,7 +579,7 @@ declare module 'mongoose' {
     snapshot(val?: boolean): this;
 
     /** Sets the sort order. If an object is passed, values allowed are `asc`, `desc`, `ascending`, `descending`, `1`, and `-1`. */
-    sort(arg?: string | { [key: string]: SortOrder } | undefined | null): this;
+    sort(arg?: string | { [key: string]: SortOrder } | { score: { $meta: 'textScore' } } | undefined | null): this;
 
     /** Sets the tailable option (for use with capped collections). */
     tailable(bool?: boolean, opts?: {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -579,7 +579,7 @@ declare module 'mongoose' {
     snapshot(val?: boolean): this;
 
     /** Sets the sort order. If an object is passed, values allowed are `asc`, `desc`, `ascending`, `descending`, `1`, and `-1`. */
-    sort(arg?: string | { [key: string]: SortOrder } | { [key: string]: { $meta: 'textScore' } } | undefined | null): this;
+    sort(arg?: string | { [key: string]: SortOrder | { $meta: 'textScore' } } | undefined | null): this;
 
     /** Sets the tailable option (for use with capped collections). */
     tailable(bool?: boolean, opts?: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Sorting by text score is a special case. See https://www.mongodb.com/docs/manual/reference/method/cursor.sort/#text-score-metadata-sort

This fixes a type error caused by 6.3.5

**Examples**

This code fails with 6.3.5:

```ts
const cities = await InseeCity.find({ $text: { $search: req.query.query as string } })
    .sort({ score: { $meta: "textScore" } })
```

It used to work