### PR TITLE
fix: Discriminator generic type not being passed to schema 

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -3,7 +3,7 @@ declare module 'mongoose' {
 
   export interface AcceptsDiscriminator {
     /** Adds a discriminator type. */
-    discriminator<D>(name: string | number, schema: Schema, value?: string | number | ObjectId): Model<D>;
+    discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<D>;
     discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
   }
 


### PR DESCRIPTION
-- Fix schema type passed to discriminator method not extending Document

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

A model created from a discriminator does not have types for the "document" (save, find, etc) as the original model does

**Examples**

```typescript
# Old
const ClickedLinkEvent = Event.discriminator('ClickedLink', new mongoose.Schema({ url: String }, options));
ClickedLinkEvent.save() // save has type any

# New
ClickedLinkEvent.save() // save has the type from Document['save']
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
