### PR TITLE
fix: Discriminator generic type not being passed to schema

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -3,7 +3,7 @@ declare module 'mongoose' {
 
   export interface AcceptsDiscriminator<B> {
     /** Adds a discriminator type. */
-    discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<B & D>;
+    discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<Omit<B, keyof D> & D>;
     discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
   }
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -1,9 +1,9 @@
 declare module 'mongoose' {
   import mongodb = require('mongodb');
 
-  export interface AcceptsDiscriminator {
+  export interface AcceptsDiscriminator<B> {
     /** Adds a discriminator type. */
-    discriminator<D>(name: string | number, schema: Schema, value?: string | number | ObjectId): Model<D>;
+    discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<B & D>;
     discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
   }
 
@@ -116,7 +116,7 @@ declare module 'mongoose' {
   const Model: Model<any>;
   interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}> extends
     NodeJS.EventEmitter,
-    AcceptsDiscriminator,
+    AcceptsDiscriminator<T>,
     IndexManager,
     SessionStarter {
     new <DocType = AnyKeys<T> & AnyObject>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides, TVirtuals>;

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -279,7 +279,7 @@ declare module 'mongoose' {
         discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<Omit<B, keyof D> & D>;
 
         /** The schematype embedded in this array */
-        caster?: SchemaType;
+        caster?: SchemaType<B>;
 
         /**
          * Adds an enum validator if this is an array of strings or numbers. Equivalent to
@@ -339,7 +339,7 @@ declare module 'mongoose' {
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
 
         /** The schema used for documents in this array */
-        schema: Schema;
+        schema: Schema<B>;
 
         /** The constructor used for subdocuments in this array */
         caster?: typeof Types.Subdocument;
@@ -382,7 +382,7 @@ declare module 'mongoose' {
         static schemaName: string;
 
         /** The document's schema */
-        schema: Schema;
+        schema: Schema<B>;
 
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
         discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<Omit<B, keyof D> & D>;

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -269,14 +269,14 @@ declare module 'mongoose' {
 
   namespace Schema {
     namespace Types {
-      class Array extends SchemaType implements AcceptsDiscriminator {
+      class Array<B = any> extends SchemaType<B> implements AcceptsDiscriminator<B> {
         /** This schema type's name, to defend against minifiers that mangle function names. */
         static schemaName: 'Array';
 
         static options: { castNonArrays: boolean; };
 
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
-        discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
+        discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<Omit<B, keyof D> & D>;
 
         /** The schematype embedded in this array */
         caster?: SchemaType;
@@ -329,13 +329,13 @@ declare module 'mongoose' {
         static schemaName: 'Decimal128';
       }
 
-      class DocumentArray extends SchemaType implements AcceptsDiscriminator {
+      class DocumentArray<B = any> extends SchemaType<B> implements AcceptsDiscriminator<B> {
         /** This schema type's name, to defend against minifiers that mangle function names. */
         static schemaName: 'DocumentArray';
 
         static options: { castNonArrays: boolean; };
 
-        discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
+        discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<Omit<B, keyof D> & D>;
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
 
         /** The schema used for documents in this array */
@@ -377,7 +377,7 @@ declare module 'mongoose' {
         auto(turnOn: boolean): this;
       }
 
-      class Subdocument extends SchemaType implements AcceptsDiscriminator {
+      class Subdocument<B = any> extends SchemaType<B> implements AcceptsDiscriminator<B> {
         /** This schema type's name, to defend against minifiers that mangle function names. */
         static schemaName: string;
 
@@ -385,7 +385,7 @@ declare module 'mongoose' {
         schema: Schema;
 
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
-        discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
+        discriminator<D>(name: string | number, schema: Schema<D>, value?: string | number | ObjectId): Model<Omit<B, keyof D> & D>;
       }
 
       class String extends SchemaType {


### PR DESCRIPTION
-- Fix instance created from model returned from discriminator having type 'any'
-- Fix model created from discriminator not inheriting the properties from the base model

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A model created from a discriminator does not have types for the "document" (save, find, etc) as the original model does and does not inherit the properties from the base model
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**


```typescript
type EventSchema = {
    time: Date
}
const eventSchema = new mongoose.Schema<EventSchema>({ time: Date }, options);
const Event = mongoose.model('Event', eventSchema);

type ClickedLinkEventSchema = {
    url: string
}
const clickedLinkEventSchema = new mongoose.Schema<ClickedLinkEventSchema>({ url: String }, options)
const ClickedLinkEvent = Event.discriminator('ClickedLink', clickedLinkEventSchema);
const clickedLinkEvent = new ClickedLinkEvent({
    time: new Date(),
    url: 'https://mongoosejs.com/',
});

# Old
clickedLinkEvent.time  // time has type any
clickedLinkEvent.save() // save has type any

# New
clickedLinkEvent.time  // time has type Date
clickedLinkEvent.save() // save has the type from Document['save']
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
This is a remake of #11897 with fixed branch name and commits