### PR TITLE
feat(mongoose): add `setDriver()` function to allow overwriting `driver` in a more consistent way

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,13 +7,13 @@
 const ChangeStream = require('./cursor/ChangeStream');
 const EventEmitter = require('events').EventEmitter;
 const Schema = require('./schema');
-const Collection = require('./driver').get().Collection;
 const STATES = require('./connectionstate');
 const MongooseError = require('./error/index');
 const SyncIndexesError = require('./error/syncIndexes');
 const PromiseProvider = require('./promise_provider');
 const ServerSelectionError = require('./error/serverSelection');
 const applyPlugins = require('./helpers/schema/applyPlugins');
+const driver = require('./driver');
 const promiseOrCallback = require('./helpers/promiseOrCallback');
 const get = require('./helpers/get');
 const immediate = require('./helpers/immediate');
@@ -1026,6 +1026,7 @@ Connection.prototype.collection = function(name, options) {
   };
   options = Object.assign({}, defaultOptions, options ? utils.clone(options) : {});
   options.$wasForceClosed = this.$wasForceClosed;
+  const Collection = driver.get().Collection;
   if (!(name in this.collections)) {
     this.collections[name] = new Collection(name, this, options);
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1026,7 +1026,7 @@ Connection.prototype.collection = function(name, options) {
   };
   options = Object.assign({}, defaultOptions, options ? utils.clone(options) : {});
   options.$wasForceClosed = this.$wasForceClosed;
-  const Collection = driver.get().Collection;
+  const Collection = this.base && this.base.__driver ? this.base.__driver.Collection : driver.get().Collection;
   if (!(name in this.collections)) {
     this.collections[name] = new Collection(name, this, options);
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -6,20 +6,10 @@
 
 let driver = null;
 
-const _mongooseInstances = [];
-module.exports._mongooseInstances = _mongooseInstances;
-
 module.exports.get = function() {
   return driver;
 };
 
 module.exports.set = function(v) {
   driver = v;
-
-  for (const mongoose of _mongooseInstances) {
-    const Connection = driver.getConnection();
-    mongoose.Connection = Connection;
-    mongoose.connections = [new Connection(mongoose)];
-    mongoose.Collection = driver.Collection;
-  }
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -6,10 +6,20 @@
 
 let driver = null;
 
+const _mongooseInstances = [];
+module.exports._mongooseInstances = _mongooseInstances;
+
 module.exports.get = function() {
   return driver;
 };
 
 module.exports.set = function(v) {
   driver = v;
+
+  for (const mongoose of _mongooseInstances) {
+    const Connection = driver.getConnection();
+    mongoose.Connection = Connection;
+    mongoose.connections = [new Connection(mongoose)];
+    mongoose.Collection = driver.Collection;
+  }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -507,7 +507,6 @@ Mongoose.prototype.pluralize = function(fn) {
  */
 
 Mongoose.prototype.model = function(name, schema, collection, options) {
-
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
   if (typeof schema === 'string') {
@@ -786,7 +785,6 @@ Object.defineProperty(Mongoose.prototype, 'Collection', {
  * @method Connection
  * @api public
  */
-
 
 Object.defineProperty(Mongoose.prototype, 'Connection', {
   get: function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ const shardingPlugin = require('./plugins/sharding');
 const trusted = require('./helpers/query/trusted').trusted;
 const sanitizeFilter = require('./helpers/query/sanitizeFilter');
 const isBsonType = require('./helpers/isBsonType');
+const MongooseError = require('./error/mongooseError');
 
 const defaultMongooseSymbol = Symbol.for('mongoose:default');
 
@@ -62,6 +63,7 @@ function Mongoose(options) {
   this.connections = [];
   this.models = {};
   this.events = new EventEmitter();
+  this.__driver = driver.get();
   // default global options
   this.options = Object.assign({
     pluralization: true,
@@ -70,7 +72,6 @@ function Mongoose(options) {
   }, options);
   const conn = this.createConnection(); // default connection
   conn.models = this.models;
-  driver._mongooseInstances.push(this);
 
   if (this.options.pluralization) {
     this._pluralize = legacyPluralize;
@@ -136,12 +137,42 @@ Mongoose.prototype.ConnectionStates = STATES;
  * uses to communicate with the database. A driver is a Mongoose-specific interface that defines functions
  * like `find()`.
  *
+ * @deprecated
  * @memberOf Mongoose
  * @property driver
  * @api public
  */
 
 Mongoose.prototype.driver = driver;
+
+/**
+ * Overwrites the current driver used by this Mongoose instance. A driver is a
+ * Mongoose-specific interface that defines functions like `find()`.
+ *
+ * @memberOf Mongoose
+ * @method setDriver
+ * @api public
+ */
+
+Mongoose.prototype.setDriver = function setDriver(driver) {
+  const _mongoose = this instanceof Mongoose ? this : mongoose;
+
+  if (_mongoose.__driver === driver) {
+    return;
+  }
+
+  if (_mongoose.connections && _mongoose.connections.find(conn => conn.readyState !== STATES.disconnected)) {
+    const msg = 'Cannot modify Mongoose driver if a connection is already open. ' +
+      'Call `mongoose.disconnect()` before modifying the driver';
+    throw new MongooseError(msg);
+  }
+  _mongoose.__driver = driver;
+
+  const Connection = driver.getConnection();
+  _mongoose.connections = [new Connection(_mongoose)];
+
+  return _mongoose;
+};
 
 /**
  * Sets mongoose options
@@ -276,7 +307,7 @@ Mongoose.prototype.get = Mongoose.prototype.set;
 Mongoose.prototype.createConnection = function(uri, options, callback) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
-  const Connection = driver.get().getConnection();
+  const Connection = _mongoose.__driver.getConnection();
   const conn = new Connection(_mongoose);
   if (typeof options === 'function') {
     callback = options;
@@ -689,7 +720,7 @@ Mongoose.prototype.__defineGetter__('connection', function() {
 });
 
 Mongoose.prototype.__defineSetter__('connection', function(v) {
-  if (v instanceof Connection) {
+  if (v instanceof this.__driver.getConnection()) {
     this.connections[0] = v;
     this.models = v.models;
   }
@@ -718,18 +749,6 @@ Mongoose.prototype.__defineSetter__('connection', function(v) {
 
 Mongoose.prototype.connections;
 
-/*!
- * Connection
- */
-
-const Connection = driver.get().getConnection();
-
-/*!
- * Collection
- */
-
-const Collection = driver.get().Collection;
-
 /**
  * The Mongoose Aggregate constructor
  *
@@ -746,7 +765,14 @@ Mongoose.prototype.Aggregate = Aggregate;
  * @api public
  */
 
-Mongoose.prototype.Collection = Collection;
+Object.defineProperty(Mongoose.prototype, 'Collection', {
+  get: function() {
+    return this.__driver.Collection;
+  },
+  set: function(Collection) {
+    this.__driver.Collection = Collection;
+  }
+});
 
 /**
  * The Mongoose [Connection](#connection_Connection) constructor
@@ -757,7 +783,19 @@ Mongoose.prototype.Collection = Collection;
  * @api public
  */
 
-Mongoose.prototype.Connection = Connection;
+
+Object.defineProperty(Mongoose.prototype, 'Connection', {
+  get: function() {
+    return this.__driver.getConnection();
+  },
+  set: function(Connection) {
+    if (Connection === this.__driver.getConnection()) {
+      return;
+    }
+
+    this.__driver.getConnection = () => Connection;
+  }
+});
 
 /**
  * The Mongoose version

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ function Mongoose(options) {
   }, options);
   const conn = this.createConnection(); // default connection
   conn.models = this.models;
+  driver._mongooseInstances.push(this);
 
   if (this.options.pluralization) {
     this._pluralize = legacyPluralize;
@@ -275,6 +276,7 @@ Mongoose.prototype.get = Mongoose.prototype.set;
 Mongoose.prototype.createConnection = function(uri, options, callback) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
+  const Connection = driver.get().getConnection();
   const conn = new Connection(_mongoose);
   if (typeof options === 'function') {
     callback = options;

--- a/lib/query.js
+++ b/lib/query.js
@@ -124,7 +124,10 @@ function Query(conditions, options, model, collection) {
   }
 
   // inherit mquery
-  mquery.call(this, this.mongooseCollection, options);
+  mquery.call(this, null, options);
+  if (collection) {
+    this.collection(collection);
+  }
 
   if (conditions) {
     this.find(conditions);

--- a/lib/query.js
+++ b/lib/query.js
@@ -2197,7 +2197,6 @@ function _castArrayFilters(query) {
  * @api private
  */
 Query.prototype._find = wrapThunk(function(callback) {
-
   this._castConditions();
 
   if (this.error() != null) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -935,6 +935,9 @@ exports.getOption = function(name) {
   const sources = Array.prototype.slice.call(arguments, 1);
 
   for (const source of sources) {
+    if (source == null) {
+      continue;
+    }
     if (source[name] != null) {
       return source[name];
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,7 @@ const start = require('./common');
 const assert = require('assert');
 const random = require('./util').random;
 const stream = require('stream');
+const { EventEmitter } = require('events');
 
 const collection = 'blogposts_' + random();
 
@@ -1042,6 +1043,47 @@ describe('mongoose module:', function() {
         // Assert
         assert.equal(userSchema.path('createdAt').options.immutable, false);
       });
+    });
+  });
+
+  describe('custom drivers', function() {
+    it('can set custom driver (gh-11900)', async function() {
+      const m = new mongoose.Mongoose();
+
+      class Collection {
+        findOne(filter, options, cb) {
+          cb(null, { answer: 42 });
+        }
+      }
+      class Connection extends EventEmitter {
+        constructor(base) {
+          super();
+          this.base = base;
+          this.models = {};
+        }
+
+        collection() {
+          return new Collection();
+        }
+
+        openUri(uri, opts, callback) {
+          this.readyState = mongoose.ConnectionStates.connected;
+          callback();
+        }
+      }
+      const driver = {
+        Collection,
+        getConnection: () => Connection
+      };
+
+      m.setDriver(driver);
+
+      await m.connect();
+
+      const Test = m.model('Test', m.Schema({ answer: Number }));
+
+      const res = await Test.findOne();
+      assert.deepEqual(res.toObject(), { answer: 42 });
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,6 +72,12 @@ declare module 'mongoose' {
   /** Returns an array of model names created on this instance of Mongoose. */
   export function modelNames(): Array<string>;
 
+  /**
+   * Overwrites the current driver used by this Mongoose instance. A driver is a
+   * Mongoose-specific interface that defines functions like `find()`.
+   */
+  export function setDriver(driver: any): Mongoose;
+
   /** The node-mongodb-native driver Mongoose uses. */
   export const mongo: typeof mongodb;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now overwriting the Mongoose driver is a bit messy, because 1) `Connection` and `Collection` aren't changed when you do `mongoose.driver.set()`, and 2) driver is always global, so no way to have 2 Mongoose instances with the same driver in the same process.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

You can now do `mongoose.setDriver()` without any extra work to use a different driver.

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
