### PR TITLE
fix: make `doValidate()` on document array elements run validation on the whole subdoc

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2484,7 +2484,7 @@ function _getPathsToValidate(doc) {
       const fullPathToSubdoc = subdoc.$__fullPathWithIndexes();
 
       for (const p of paths) {
-        if (p === null || p.startsWith(fullPathToSubdoc + '.')) {
+        if (p == null || p.startsWith(fullPathToSubdoc + '.')) {
           paths.delete(p);
         }
       }
@@ -2507,7 +2507,7 @@ function _getPathsToValidate(doc) {
 
     if (_pathType.$isMongooseDocumentArray) {
       for (const p of paths) {
-        if (p === null || p.startsWith(_pathType.path + '.')) {
+        if (p == null || p.startsWith(_pathType.path + '.')) {
           paths.delete(p);
         }
       }

--- a/lib/document.js
+++ b/lib/document.js
@@ -2505,6 +2505,14 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
+    if (_pathType.$isMongooseDocumentArray) {
+      for (const p of paths) {
+        if (p === null || p.startsWith(_pathType.path + '.')) {
+          paths.delete(p);
+        }
+      }
+    }
+
     // Optimization: if primitive path with no validators, or array of primitives
     // with no validators, skip validating this path entirely.
     if (!_pathType.caster && _pathType.validators.length === 0) {
@@ -3143,8 +3151,7 @@ Document.prototype.$__reset = function reset() {
       if (subdoc.$isDocumentArrayElement) {
         if (!resetArrays.has(subdoc.parentArray())) {
           const array = subdoc.parentArray();
-          // Mark path to array as init for gh-6818
-          this.$__.activePaths.init(fullPathWithIndexes.replace(/\.\d+$/, '').slice(-subdoc.$basePath - 1));
+          this.$__.activePaths.clearPath(fullPathWithIndexes.replace(/\.\d+$/, '').slice(-subdoc.$basePath - 1));
           array[arrayAtomicsBackupSymbol] = array[arrayAtomicsSymbol];
           array[arrayAtomicsSymbol] = {};
 
@@ -3152,7 +3159,7 @@ Document.prototype.$__reset = function reset() {
         }
       } else {
         if (subdoc.$parent() === this) {
-          this.$__.activePaths.init(subdoc.$basePath);
+          this.$__.activePaths.clearPath(subdoc.$basePath);
         } else if (subdoc.$parent() != null && subdoc.$parent().$isSubdocument) {
           // If map path underneath subdocument, may end up with a case where
           // map path is modified but parent still needs to be reset. See gh-10295

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -135,7 +135,6 @@ module.exports = function(query, schema, castedDoc, options, callback) {
                 err.path = updates[i];
                 validationErrors.push(err);
               }
-              return callback(null);
             }
 
             return callback(null);

--- a/lib/helpers/updateValidators.js
+++ b/lib/helpers/updateValidators.js
@@ -125,26 +125,20 @@ module.exports = function(query, schema, castedDoc, options, callback) {
         validatorsToExecute.push(function(callback) {
           schemaPath.doValidate(v, function(err) {
             if (err) {
-              err.path = updates[i];
-              validationErrors.push(err);
+              if (err.errors) {
+                for (const key of Object.keys(err.errors)) {
+                  const _err = err.errors[key];
+                  _err.path = updates[i] + '.' + key;
+                  validationErrors.push(_err);
+                }
+              } else {
+                err.path = updates[i];
+                validationErrors.push(err);
+              }
               return callback(null);
             }
 
-            v.validate(function(err) {
-              if (err) {
-                if (err.errors) {
-                  for (const key of Object.keys(err.errors)) {
-                    const _err = err.errors[key];
-                    _err.path = updates[i] + '.' + key;
-                    validationErrors.push(_err);
-                  }
-                } else {
-                  err.path = updates[i];
-                  validationErrors.push(err);
-                }
-              }
-              callback(null);
-            });
+            return callback(null);
           }, context, { updateValidator: true });
         });
       } else {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4281,7 +4281,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
 
     for (const path of paths) {
       const schemaType = schema.path(path);
-      if (!schemaType || !schemaType.$isMongooseArray) {
+      if (!schemaType || !schemaType.$isMongooseArray || schemaType.$isMongooseDocumentArray) {
         continue;
       }
 

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -10,6 +10,7 @@ const EventEmitter = require('events').EventEmitter;
 const SchemaDocumentArrayOptions =
   require('../options/SchemaDocumentArrayOptions');
 const SchemaType = require('../schematype');
+const SubdocumentPath = require('./SubdocumentPath');
 const discriminator = require('../helpers/model/discriminator');
 const handleIdOption = require('../helpers/schema/handleIdOption');
 const handleSpreadDoc = require('../helpers/document/handleSpreadDoc');
@@ -75,6 +76,7 @@ function DocumentArrayPath(key, schema, options, schemaOptions) {
   this.$embeddedSchemaType.cast = function(value, doc, init) {
     return parentSchemaType.cast(value, doc, init)[0];
   };
+  this.$embeddedSchemaType.doValidate = SubdocumentPath.prototype.doValidate;
   this.$embeddedSchemaType.$isMongooseDocumentArrayElement = true;
   this.$embeddedSchemaType.caster = this.Constructor;
   this.$embeddedSchemaType.schema = this.schema;

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -76,7 +76,15 @@ function DocumentArrayPath(key, schema, options, schemaOptions) {
   this.$embeddedSchemaType.cast = function(value, doc, init) {
     return parentSchemaType.cast(value, doc, init)[0];
   };
-  this.$embeddedSchemaType.doValidate = SubdocumentPath.prototype.doValidate;
+  this.$embeddedSchemaType.doValidate = function(value, fn, scope, options) {
+    const Constructor = getConstructor(this.caster, value);
+
+    if (value && !(value instanceof Constructor)) {
+      value = new Constructor(value, scope, null, null, options && options.index != null ? options.index : null);
+    }
+
+    return SubdocumentPath.prototype.doValidate.call(this, value, fn, scope, options);
+  };
   this.$embeddedSchemaType.$isMongooseDocumentArrayElement = true;
   this.$embeddedSchemaType.caster = this.Constructor;
   this.$embeddedSchemaType.schema = this.schema;

--- a/lib/statemachine.js
+++ b/lib/statemachine.js
@@ -96,6 +96,19 @@ StateMachine.prototype.clear = function clear(state) {
 };
 
 /*!
+ * ignore
+ */
+
+StateMachine.prototype.clearPath = function clearPath(path) {
+  const state = this.paths[path];
+  if (!state) {
+    return;
+  }
+  delete this.paths[path];
+  delete this.states[state][path];
+};
+
+/*!
  * Checks to see if at least one path is in the states passed in via `arguments`
  * e.g., this.some('required', 'inited')
  *

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -8346,7 +8346,6 @@ describe('document', function() {
     });
     const Organization = db.model('Test', organizationSchema);
 
-
     const org = new Organization();
     org.set('name', 'MongoDB');
 

--- a/test/schema.documentarray.test.js
+++ b/test/schema.documentarray.test.js
@@ -126,4 +126,30 @@ describe('schema.documentarray', function() {
     const value = testSchema.path('comments').getDefault();
     assert.strictEqual(value, null);
   });
+
+  it('doValidate() validates entire subdocument (gh-11770)', async function() {
+    mongoose.deleteModel(/Test/);
+
+    const testSchema = new Schema({
+      comments: [{
+        text: {
+          type: String,
+          required: true
+        }
+      }]
+    });
+    const TestModel = mongoose.model('Test', testSchema);
+    const testDoc = new TestModel();
+
+    const err = await new Promise((resolve, reject) => {
+      testSchema.path('comments').$embeddedSchemaType.doValidate({}, err => {
+        if (err != null) {
+          return reject(err);
+        }
+        resolve();
+      }, testDoc.comments, { index: 1 });
+    }).then(() => null, err => err);
+    assert.equal(err.name, 'ValidationError');
+    assert.equal(err.message, 'Validation failed: text: Path `text` is required.');
+  });
 });


### PR DESCRIPTION
Fix #11770

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In #11770 I made a note that we leave subdocuments in `init` state after `save()` to work around some issues like #6818. That is technically incorrect, because `init` should only be used for paths that are loaded from the database. The underlying issue comes down to the fact that array subdocument paths' `doValidate()` function doesn't run validation on paths in the document.

In this PR, I made it so that the embedded schema type in document arrays have a `doValidate()` that is the same as `SubdocumentPath`'s. In order to support this change, needed to fix a couple of places where we relied on the old behavior in update validators and `Model.validate()`.

Future work: make array subdocument paths a separate class, and make primitive arrays also validate all their subpaths when calling `doValidate()`.

We should probably put this change in 6.4, or hold off until after 6.4 It is a fairly sizable change of Mongoose internals, and while our tests do all pass, I'd like to be cautious with this one.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
