### PR TITLE
fix(types): improve helpers typings

### DIFF
--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -20,14 +20,13 @@ declare module 'mongoose' {
    * of an ObjectId.
    */
   function isObjectIdOrHexString(v: mongodb.ObjectId): true;
-  function isObjectIdOrHexString(v: string): boolean;
+  function isObjectIdOrHexString(v: mongodb.ObjectId | string): boolean;
   function isObjectIdOrHexString(v: any): false;
 
   /**
    * Returns true if Mongoose can cast the given value to an ObjectId, or
    * false otherwise.
    */
-  function isValidObjectId(v: mongodb.ObjectId): true;
-  function isValidObjectId(v: Types.ObjectId): true;
+  function isValidObjectId(v: mongodb.ObjectId | Types.ObjectId): true;
   function isValidObjectId(v: any): boolean;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
A simple typescript definition fix.

**Rationale**

`isObjectIdOrHexString` in the `any` position is used by typescript, resulting in a `false` when passed arguments of type `mongodb.ObjectId | string` - and typescript or typescript-eslint will complain in certain circumstances, such unreachable code. Similar with isValidObjectId

**Examples**

