### PR TITLE
feat: add `skipMiddlewareFunction()` and `overwriteMiddlewareResult()` for skipping and modifying middleware results

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ require('./driver').set(require('./drivers/node-mongodb-native'));
 
 const Document = require('./document');
 const EventEmitter = require('events').EventEmitter;
+const Kareem = require('kareem');
 const Schema = require('./schema');
 const SchemaType = require('./schematype');
 const SchemaTypes = require('./schema/index');
@@ -1184,6 +1185,43 @@ Mongoose.prototype.trusted = trusted;
 Mongoose.prototype._promiseOrCallback = function(callback, fn, ee) {
   return promiseOrCallback(callback, fn, ee, this.Promise);
 };
+
+/**
+ * Use this function in `pre()` middleware to skip calling the wrapped function.
+ *
+ * ####Example:
+ *
+ *     schema.pre('save', function() {
+ *       // Will skip executing `save()`, but will execute post hooks as if
+ *       // `save()` had executed with the result `{ matchedCount: 0 }`
+ *       return mongoose.skipMiddlewareFunction({ matchedCount: 0 });
+ *     });
+ *
+ * @method skipMiddlewareFunction
+ * @param {any} result
+ * @api public
+ */
+
+Mongoose.prototype.skipMiddlewareFunction = Kareem.skipWrappedFunction;
+
+/**
+ * Use this function in `post()` middleware to replace the result
+ *
+ * ####Example:
+ *
+ *     schema.post('find', function(res) {
+ *       // Normally you have to modify `res` in place. But with
+ *       // `overwriteMiddlewarResult()`, you can make `find()` return a
+ *       // completely different value.
+ *       return mongoose.overwriteMiddlewareResult(res.filter(doc => !doc.isDeleted));
+ *     });
+ *
+ * @method overwriteMiddlewareResult
+ * @param {any} result
+ * @api public
+ */
+
+Mongoose.prototype.overwriteMiddlewareResult = Kareem.overwriteResult;
 
 /*!
  * The exports object is an instance of Mongoose.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^4.6.2",
-    "kareem": "2.3.5",
+    "kareem": "2.4.0",
     "mongodb": "4.7.0",
     "mpath": "0.9.0",
     "mquery": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^4.6.2",
-    "kareem": "2.4.0",
+    "kareem": "2.4.1",
     "mongodb": "4.7.0",
     "mpath": "0.9.0",
     "mquery": "4.0.3",


### PR DESCRIPTION
Fix #11426
Fix #8393

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now there's no way to overwrite the result of a function in a `post()` hook. For example, there's no way to use `filter()` to modify a `find()` result in a `post('find')` hook.

There's also no way to "cancel" an operation in a pre hook without throwing an error. Which is inconvenient, because there are some use cases where it would be great to skip executing the underlying function (local caching, memorizing results, etc.)

This PR adds `overwriteMiddlewareResult()` for the former, and `skipMiddlewareFunction()` for the latter, from https://github.com/vkarpov15/kareem/pull/30 .

@AbdelrahmanHafez @Uzlopak what do you think about the naming and overall idea?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

See tests

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
