### PR TITLE
[Types] Re-add the possibility to pass undefined for projection in Model.find

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'bson';
-import { Schema, Document, Model, connection, model, Types } from 'mongoose';
+import { Schema, Document, Model, connection, model, Types, CallbackError } from 'mongoose';
 import { expectError, expectType } from 'tsd';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
 
@@ -198,6 +198,39 @@ Project.exists({ name: 'Hello' }).then(result => {
 Project.exists({ name: 'Hello' }, (err, result) => {
   result?._id;
 });
+
+function find() {
+  // no args
+  Project.find();
+
+  // just filter
+  Project.find({});
+  Project.find({ name: 'Hello' });
+
+  // just callback
+  Project.find((error: CallbackError, result: IProject[]) => console.log(error, result));
+
+  // filter + projection
+  Project.find({}, undefined);
+  Project.find({}, null);
+  Project.find({}, { name: 1 });
+  Project.find({}, { name: 1 });
+  Project.find({}, { name: 1 });
+
+  // filter + callback
+  Project.find({}, (error: CallbackError, result: IProject[]) => console.log(error, result));
+  Project.find({ name: 'Hello' }, (error: CallbackError, result: IProject[]) => console.log(error, result));
+
+  // filter + projection + options
+  Project.find({}, undefined, { limit: 5 });
+  Project.find({}, null, { limit: 5 });
+  Project.find({}, { name: 1 }, { limit: 5 });
+
+  // filter + projection + options + callback
+  Project.find({}, undefined, { limit: 5 }, (error: CallbackError, result: IProject[]) => console.log(error, result));
+  Project.find({}, null, { limit: 5 }, (error: CallbackError, result: IProject[]) => console.log(error, result));
+  Project.find({}, { name: 1 }, { limit: 5 }, (error: CallbackError, result: IProject[]) => console.log(error, result));
+}
 
 function inheritance() {
   class InteractsWithDatabase extends Model {

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -214,8 +214,7 @@ function find() {
   Project.find({}, undefined);
   Project.find({}, null);
   Project.find({}, { name: 1 });
-  Project.find({}, { name: 1 });
-  Project.find({}, { name: 1 });
+  Project.find({}, { name: 0 });
 
   // filter + callback
   Project.find({}, (error: CallbackError, result: IProject[]) => console.log(error, result));

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -315,21 +315,21 @@ declare module 'mongoose' {
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
       filter: FilterQuery<T>,
-      projection: ProjectionType<T> | null,
-      options: QueryOptions<T> | null,
-      callback?: Callback<ResultDoc[]>
+      projection?: ProjectionType<T> | null | undefined,
+      options?: QueryOptions<T> | null | undefined,
+      callback?: Callback<ResultDoc[]> | undefined
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
     find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
       filter: FilterQuery<T>,
-      projection: ProjectionType<T> | null,
-      callback?: Callback<ResultDoc[]>
+      projection?: ProjectionType<T> | null | undefined,
+      callback?: Callback<ResultDoc[]> | undefined
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
     find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
       filter: FilterQuery<T>,
-      callback?: Callback<ResultDoc[]>
+      callback?: Callback<ResultDoc[]> | undefined
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
     find<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(
-      callback?: Callback<ResultDoc[]>
+      callback?: Callback<ResultDoc[]> | undefined
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, T>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */


### PR DESCRIPTION
**Summary**

This re-adds the possibility to pass `undefined` as projection to the `find` method of models.

**Examples**

```ts
  Project.find({}, undefined, { limit: 5 });
```
(see the added tests for more details)