### PR TITLE
Fix: simplify MergeType constraints

### DIFF
--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -10,6 +10,6 @@ declare module 'mongoose' {
       ? T
       : Omit<T, keyof U> & U;
 
-  type MergeType<A extends Record<number | string, any>, B extends Record<number | string, any>> = Omit<A, keyof B> & B;
+  type MergeType<A, B> = Omit<A, keyof B> & B;
 
 }


### PR DESCRIPTION
Fixes 16 errors in models.d.ts on Typescript 4.8 which is currently in beta. Typescript 4.8 forbids assignment of an unconstrained type
parameter to one that disallows `null` or `undefined`: https://github.com/microsoft/TypeScript/issues/49489

This is the minimal bug fix: `MergeType` now allows `null | undefined`, just like it does on shipping versions of Typescript. The result of `MergeType` can be unexpected when used with `undefined` or `SomeObjectType | undefined`, but this might not be a problem in practise.

There are two other possible fixes:

1. Constrain *lots* of types in models.d.ts to `Record<string | number, any>` -- that is, to forbid `null | undefined`. I don't know mongoose -- this might be a huge API break.
2. Make MergeType correctly handle `null` and `undefined`: it's pretty clear that `MergeType<A, null> === A` but I'm not sure whether `MergeType<A | undefined, B>` should be something like `(Omit<A, keyof B> & B) | undefined`.

**Summary**

Fixes Automattic/mongoose#11977 in a way that doesn't improve correctness, but doesn't break the API either.