### PR TITLE
fix(types): avoid adding non-existent properties from model constructor for typegoose

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
       ],
       "rules": {
         "@typescript-eslint/triple-slash-reference": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
         "spaced-comment": [
           "error",
           "always",

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -197,3 +197,44 @@ function autoTypedDocument() {
   expectType<ReturnType<AutoTypedSchemaType['methods']['instanceFn']>>(new AutoTypedModel().instanceFn());
 
 }
+
+async function gh11960() {
+  type DocumentType<T> = Document<any> & T;
+  type SubDocumentType<T> = DocumentType<T> & Types.Subdocument;
+  type ArraySubDocumentType<T> = DocumentType<T> & Types.ArraySubdocument;
+
+  interface Nested {
+    dummy?: string;
+  }
+
+  interface Parent {
+    username?: string;
+    map?: Map<string, string>;
+    nested?: SubDocumentType<Nested>;
+    nestedArray?: ArraySubDocumentType<Nested>[];
+  }
+
+  const NestedSchema = new Schema({
+    dummy: { type: String }
+  });
+
+  const ParentSchema = new Schema({
+    username: { type: String },
+    map: { type: Map, of: String },
+    nested: { type: NestedSchema },
+    nestedArray: [{ type: NestedSchema }]
+  });
+
+  const ParentModel = model<DocumentType<Parent>>('Parent', ParentSchema);
+
+  const doc = new ParentModel({
+    username: 'user1',
+    map: { key1: 'value1', key2: 'value2' },
+    nested: { dummy: 'hello' },
+    nestedArray: [{ dummy: 'hello again' }]
+  });
+
+  expectType<Map<string, string> | undefined>(doc.map);
+  doc.nested!.parent();
+
+}

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -192,8 +192,6 @@ function autoTypedDocument() {
   expectType<AutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
   expectType<AutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
   expectType<AutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
-  expectType<number>(AutoTypeModelInstance.unExistProperty);
-  expectType<number>(AutoTypeModelInstance.description);
 
   // Document-Methods-tests
   expectType<ReturnType<AutoTypedSchemaType['methods']['instanceFn']>>(new AutoTypedModel().instanceFn());

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -119,7 +119,7 @@ declare module 'mongoose' {
     AcceptsDiscriminator,
     IndexManager,
     SessionStarter {
-    new <DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<MergeType<T, DocType>, TMethodsAndOverrides, TVirtuals> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
+    new <DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides, TVirtuals> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
     aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
     aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;


### PR DESCRIPTION
Fix #11960

Please take a look @mohammad0-0ahmad

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In #11563, it looks like the model constructor pulls types from the parameter to the model constructor, which is very wrong. @hasezoey reported that this also causes issues for Typegoose.

The tests in `document.test.ts#L195-L196` are also wrong, `unExistProperty` shouldn't be defined on the document instance. See the below script:

```javascript
const mongoose = require('mongoose');

void async function main() {
  await mongoose.connect('mongodb://localhost:27017');

  const Test = mongoose.model('Test', mongoose.Schema({ name: String }));
  const doc = new Test({ name: 'test', unExistProperty: 1 });
  console.log(doc);
  console.log(doc.name); // 'test'
  console.log(doc.unExistProperty); // undefined

  await mongoose.disconnect();
}();
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
