### PR TITLE
fix(types): change index "weights" to be more explicit

### DIFF
--- a/types/indexes.d.ts
+++ b/types/indexes.d.ts
@@ -93,6 +93,6 @@ declare module 'mongoose' {
      * ```
      */
     expires?: number | string;
-    weights?: Record<string | number, number>;
+    weights?: Record<string, number>;
   }
 }

--- a/types/indexes.d.ts
+++ b/types/indexes.d.ts
@@ -93,6 +93,6 @@ declare module 'mongoose' {
      * ```
      */
     expires?: number | string;
-    weights?: AnyObject;
+    weights?: Record<string | number, number>;
   }
 }


### PR DESCRIPTION
**Summary**

Currently the types for index option `weights` was defined as `AnyObject` which allows only string keys and any value type, but with this change `string | number` keys are allowed (i dont know if indexes support this, please review) and explicitly set the value type to `number`, because that is the only type mongodb accepts (from what i know)

**Examples**

```ts
sch.index({ field1: 1 }, { weights: { field1: 10 } });
```
