### PR TITLE
Extend types test for #11960

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -227,14 +227,17 @@ async function gh11960() {
 
   const ParentModel = model<DocumentType<Parent>>('Parent', ParentSchema);
 
-  const doc = new ParentModel({
-    username: 'user1',
-    map: { key1: 'value1', key2: 'value2' },
-    nested: { dummy: 'hello' },
-    nestedArray: [{ dummy: 'hello again' }]
-  });
+  {
+    const doc = new ParentModel({
+      username: 'user1',
+      map: { key1: 'value1', key2: 'value2' },
+      nested: { dummy: 'hello' },
+      nestedArray: [{ dummy: 'hello again' }]
+    });
 
-  expectType<Map<string, string> | undefined>(doc.map);
-  doc.nested!.parent();
-
+    expectType<Document<any, any, any> & Parent & { _id: Types.ObjectId }>(doc);
+    expectType<Map<string, string> | undefined>(doc.map);
+    doc.nested!.parent();
+    doc.nestedArray?.[0].parentArray();
+  }
 }

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -240,4 +240,18 @@ async function gh11960() {
     doc.nested!.parent();
     doc.nestedArray?.[0].parentArray();
   }
+
+  {
+    const doc = await ParentModel.create({
+      username: 'user1',
+      map: { key1: 'value1', key2: 'value2' },
+      nested: { dummy: 'hello' },
+      nestedArray: [{ dummy: 'hello again' }]
+    });
+
+    expectType<Document<any, any, any> & Parent & { _id: Types.ObjectId }>(doc);
+    expectType<Map<string, string> | undefined>(doc.map);
+    doc.nested!.parent();
+    doc.nestedArray?.[0].parentArray();
+  }
 }


### PR DESCRIPTION
**Summary**

This PR extends the types test that was initially added for #11960, with more tests and another case

**WARNING**: this PR is currently set to fail because of the new case, so i dont think it is good to merge it yet

---

Edit:
the first commit extends the initial test case to actually test what the reproduction repository of the mentioned issue had problematic
the second commit duplicates the test for `new` to also test `create` (which was not updated yet)