### PR TITLE
Fix broken h4 markdown tags for example in documentation 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1223,7 +1223,7 @@ Mongoose.prototype._promiseOrCallback = function(callback, fn, ee) {
 /**
  * Use this function in `pre()` middleware to skip calling the wrapped function.
  *
- * ####Example:
+ * #### Example:
  *
  *     schema.pre('save', function() {
  *       // Will skip executing `save()`, but will execute post hooks as if
@@ -1241,7 +1241,7 @@ Mongoose.prototype.skipMiddlewareFunction = Kareem.skipWrappedFunction;
 /**
  * Use this function in `post()` middleware to replace the result
  *
- * ####Example:
+ * #### Example:
  *
  *     schema.post('find', function(res) {
  *       // Normally you have to modify `res` in place. But with

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -477,7 +477,7 @@ Schema.prototype.defaultOptions = function(options) {
  * Inherit a Schema by applying a discriminator on an existing Schema.
  *
  *
- * ####Example:
+ * #### Example:
  *
  *     const options = { discriminatorKey: 'kind' };
  *
@@ -648,7 +648,7 @@ Schema.prototype.add = function add(obj, prefix) {
  * removeIndex only removes indexes from your schema object. Does **not** affect the indexes
  * in MongoDB.
  *
- * ####Example:
+ * #### Example:
  *
  *     const ToySchema = new Schema({ name: String, color: String, price: Number });
  *
@@ -701,7 +701,7 @@ Schema.prototype.removeIndex = function removeIndex(index) {
  * clearIndexes only removes indexes from your schema object. Does **not** affect the indexes
  * in MongoDB.
  *
- * ####Example:
+ * #### Example:
  *
  *     const ToySchema = new Schema({ name: String, color: String, price: Number });
  *     ToySchema.index({ name: 1 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
For some of the methods which are mentioned below we didn't  give space between markdown tag as a result it's not being rendered properly in the documentation.

I've searched the entire codebase, it seems like we've issues in the following methods which are addressed in this PR.
- skipMiddlewareFunction
- overwriteMiddlewareResult
- discriminator
- removeIndex
- clearIndexes
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
For example, this is how the api for `skipMiddlewareFunction` is rendered right now

![CleanShot 2022-06-29 at 10 12 43@2x](https://user-images.githubusercontent.com/4201088/176353468-6bdd1a04-22c0-4a16-b81d-5575348c0416.png)

And after the fix, it'll be

![CleanShot 2022-06-29 at 10 11 10@2x](https://user-images.githubusercontent.com/4201088/176353488-5abb3991-92c2-409d-983c-892806d2cfd6.png)
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
