### PR TITLE
Add ESLint rule `no-multiple-empty-lines` and apply it

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -187,6 +187,7 @@
       "error"
     ],
     "no-empty": "off",
-    "eol-last": "warn"
+    "eol-last": "warn",
+    "no-multiple-empty-lines": ["warn", { "max": 2 }]
   }
 }

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1838,7 +1838,6 @@ describe('model: querying:', function() {
     const [a, b, c, d] = await Test.create([docA, docB, docC, docD]);
 
 
-
     assert.equal(a.block.toString('utf8'), 'über');
     assert.equal(b.block.toString('utf8'), 'buffer shtuffs are neat');
     assert.equal(c.block.toString('utf8'), 'hello world');

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8514,7 +8514,6 @@ describe('Check if static function that is supplied in schema option is availabl
 });
 
 
-
 async function delay(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
**Summary**

This change is to make coding style more consistent by only allowing up to `2` empty lines after each other
