### PR TITLE
Add path level descending index example in docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -260,11 +260,13 @@ Defining indexes at the schema level is necessary when creating
 const animalSchema = new Schema({
   name: String,
   type: String,
-  tags: { type: [String], index: true } // field level
+  tags: { type: [String], index: true } // path level
 });
 
 animalSchema.index({ name: 1, type: -1 }); // schema level
 ```
+
+See [SchemaType#index()](./api.html#schematype_SchemaType-index) for other index options.
 
 When your application starts up, Mongoose automatically calls [`createIndex`](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#db.collection.createIndex) for each defined index in your schema.
 Mongoose will call `createIndex` for each index sequentially, and emit an 'index' event on the model when all the `createIndex` calls succeeded or when there was an error.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -252,7 +252,7 @@ Animal.findOne().byName('fido').exec((err, animal) => {
 <h3 id="indexes"><a href="#indexes">Indexes</a></h3>
 
 MongoDB supports [secondary indexes](http://docs.mongodb.org/manual/indexes/).
-With mongoose, we define these indexes within our `Schema` [at](./api.html#schematype_SchemaType-index) [the](./api.html#schematype_SchemaType-unique) [path](./api.html#schematype_SchemaType-sparse) [level](./api.html#schema_date_SchemaDate-expires) or the `schema` level.
+With mongoose, we define these indexes within our `Schema` [at](./api.html#schematype_SchemaType-index) [the](./api.html#schematype_SchemaType-unique) [path](./api.html#schematype_SchemaType-sparse) [level](./api.html#schemadateoptions_SchemaDateOptions-expires) or the `schema` level.
 Defining indexes at the schema level is necessary when creating
 [compound indexes](https://docs.mongodb.com/manual/core/index-compound/).
 

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -384,6 +384,7 @@ SchemaType.prototype.default = function(val) {
  * #### Example:
  *
  *     const s = new Schema({ name: { type: String, index: true })
+ *     const s = new Schema({ name: { type: String, index: -1 })
  *     const s = new Schema({ loc: { type: [Number], index: 'hashed' })
  *     const s = new Schema({ loc: { type: [Number], index: '2d', sparse: true })
  *     const s = new Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }})
@@ -399,7 +400,7 @@ SchemaType.prototype.default = function(val) {
  * read/write operations you send until the index build.
  * Specify `background: false` to override Mongoose's default._
  *
- * @param {Object|Boolean|String} options
+ * @param {Object|Boolean|String|Number} options
  * @return {SchemaType} this
  * @api public
  */


### PR DESCRIPTION
**Summary**

As per https://github.com/Automattic/mongoose/issues/8895 and https://github.com/Automattic/mongoose/pull/8896 it seems index options such as `-1` are available at the path level. Updating the documentation accordingly.

**Examples**

N/A
