### PR TITLE
Update schematypes.md

### DIFF
--- a/docs/schematypes.md
+++ b/docs/schematypes.md
@@ -279,8 +279,9 @@ const schema2 = new Schema({
 
 <h5>Date</h5>
 
-* `min`: Date
-* `max`: Date
+* `min`: Date, creates a [validator](./validation.html) that checks if the value is greater than or equal to the given minimum.
+* `max`: Date, creates a [validator](./validation.html) that checks if the value is less than or equal to the given maximum.
+* `expires`: Number or String, creates a TTL index with the value expressed in seconds.
 
 <h5>ObjectId</h5>
 


### PR DESCRIPTION
Expand description of `min` and `max` and include `expires` option for Date schema type.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The documentation for [SchemaType Options](https://mongoosejs.com/docs/schematypes.html#schematype-options) does not include the `expires` option for the `Date` type. It _can_ be found [here](https://mongoosejs.com/docs/api.html#schemadateoptions_SchemaDateOptions-expires) but it can be difficult to find.

