### PR TITLE
fix(types): allow using an object to configure timestamps

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -106,7 +106,7 @@ declare module 'mongoose' {
     checkKeys?: boolean;
     j?: boolean;
     safe?: boolean | WriteConcern;
-    timestamps?: boolean;
+    timestamps?: boolean | QueryTimestampsConfig;
     validateBeforeSave?: boolean;
     validateModifiedOnly?: boolean;
     w?: number | string;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -90,6 +90,11 @@ declare module 'mongoose' {
     [key: string]: any;
   };
 
+  interface QueryTimestampsConfig {
+    createdAt?: boolean;
+    updatedAt?: boolean;
+  }
+
   interface QueryOptions<DocType = unknown> extends
     PopulateOption,
     SessionOption {
@@ -157,7 +162,7 @@ declare module 'mongoose' {
      * skip timestamps for this update. Note that this allows you to overwrite
      * timestamps. Does nothing if schema-level timestamps are not set.
      */
-    timestamps?: boolean;
+    timestamps?: boolean | QueryTimestampsConfig;
     upsert?: boolean;
     writeConcern?: mongodb.WriteConcern;
 


### PR DESCRIPTION
**Summary**

This is a documented feature. Users should be able to configure
createdAt and updatedAt separately when making a query from TypeScript.

**Examples**

Allow code like this to compile:

```typescript
const result = await Token.findOneAndUpdate(
  { uid },
  { $set: { field: value }, $setOnInsert: { createdAt: new Date('2022-01-01T00:00:00.000Z') } },
  { session, upsert: true, new: true, timestamps: { createdAt: false, updatedAt: true } },
).exec();
```
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
