### PR TITLE
fix(types): support findOneAndReplace with rawResult

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -351,6 +351,7 @@ declare module 'mongoose' {
     findOneAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
     /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
+    findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { rawResult: true }, callback?: (err: CallbackError, doc: any, res: any) => void): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
     findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
     findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, replacement?: T | AnyObject, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 


### PR DESCRIPTION
**Summary**

Both findOneAndReplace and findOneAndUpdate support the rawResult
option, which changes the return type to include more information from
the MongoDB driver. Add an overload for findOneAndReplace to support
rawResult in a way similar to findOneAndUpdate.

**Examples**

Allow code like this to compile:
```typescript
const result = await models.OCPISession.findOneAndReplace(
  { uid },
  { uid, field: value },
  { session, rawResult: true, upsert: true, new: true },
).exec();
console.log(result.lastErrorObject?.upserted);
```