### PR TITLE
Documentation-Generation remove `.prototype.` fix-up code

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -234,11 +234,6 @@ function parse() {
         ctx.string = ctx.string + "()";
       }
 
-      // fixing up "something.prototypemissingdot" to "something.prototype.missingdot"
-      if (/\.prototype[^.]/.test(ctx.string)) {
-        ctx.string = `${ctx.constructor}.prototype.${ctx.name}`;
-      }
-
       // Backwards compat anchors
       if (typeof ctx.constructor === 'string') {
         ctx.anchorId = `${ctx.constructor.toLowerCase()}_${ctx.constructor}-${ctx.name}`;


### PR DESCRIPTION
**Summary**

This should no longer be required, because ".prototype." is now set in one place only so if a error occurs, it should be easy to find and fix

re https://github.com/Automattic/mongoose/pull/12024#discussion_r912474117
