### PR TITLE
Refactor all `@receiver` tags to proper jsdoc tags

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -134,7 +134,7 @@ function parse() {
       for (const tag of prop.tags) {
         switch (tag.type) {
           case 'receiver':
-            ctx.constructor = tag.string;
+            console.warn(`Found "@receiver" tag in ${ctx.constructor} ${ctx.name}`);
             break;
           case 'property':
             ctx.type = 'property';

--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -126,6 +126,11 @@ function parse() {
         ctx.constructorWasUndefined = true;
       }
 
+      // helper function to keep translating array types to string consistent
+      function convertTypesToString(types) {
+        return Array.isArray(types) ? types.join('|') : types
+      }
+
       for (const tag of prop.tags) {
         switch (tag.type) {
           case 'receiver':
@@ -134,18 +139,16 @@ function parse() {
           case 'property':
             ctx.type = 'property';
 
-            // somewhere since 6.0 the "string" property came back, which was gone with 4.5
-            let str = tag.string;
-            
-            const match = str.match(/^{\w+}/);
-            if (match != null) {
-              ctx.type = match[0].substring(1, match[0].length - 1);
-              str = str.replace(/^{\w+}\s*/, '');
+            // using "name" over "string" because "string" also contains the type and maybe other stuff
+            ctx.name = tag.name;
+            // only assign "type" if there are types
+            if (tag.types.length > 0) {
+              ctx.type = convertTypesToString(tag.types);
             }
-            ctx.name = str;
+
             break;
           case 'type':
-            ctx.type = Array.isArray(tag.types) ? tag.types.join('|') : tag.types;
+            ctx.type = convertTypesToString(tag.types);
             break;
           case 'static':
             ctx.type = 'property';
@@ -184,7 +187,7 @@ function parse() {
               tag.types.push('null');
             }
             if (tag.types) {
-              tag.types = tag.types.join('|');
+              tag.types = convertTypesToString(tag.types);
             }
             ctx[tag.type].push(tag);
             if (tag.name != null && tag.name.startsWith('[') && tag.name.endsWith(']') && tag.name.includes('.')) {

--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -17,7 +17,7 @@
  * Click the "show code" link below to see all defaults.
  *
  * @static
- * @receiver MongooseError
+ * @memberOf MongooseError
  * @api public
  */
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1822,7 +1822,7 @@ function _ensureIndexes(model, options, callback) {
  * Schema the model uses.
  *
  * @property schema
- * @receiver Model
+ * @static
  * @api public
  * @memberOf Model
  */

--- a/lib/query.js
+++ b/lib/query.js
@@ -170,7 +170,7 @@ Query.base = mquery.prototype;
  * @default true
  * @property use$geoWithin
  * @memberOf Query
- * @receiver Query
+ * @static
  * @api public
  */
 
@@ -1847,7 +1847,7 @@ Query.prototype.setUpdate = function(val) {
  * @method _fieldsForExec
  * @return {Object}
  * @api private
- * @receiver Query
+ * @memberOf Query
  */
 
 Query.prototype._fieldsForExec = function() {
@@ -1859,8 +1859,9 @@ Query.prototype._fieldsForExec = function() {
  * Return an update document with corrected `$set` operations.
  *
  * @method _updateForExec
+ * @return {Object}
  * @api private
- * @receiver Query
+ * @memberOf Query
  */
 
 Query.prototype._updateForExec = function() {
@@ -1907,10 +1908,12 @@ Query.prototype._updateForExec = function() {
 /**
  * Makes sure _path is set.
  *
+ * This method is inherited by `mquery`
+ *
  * @method _ensurePath
  * @param {String} method
  * @api private
- * @receiver Query
+ * @memberOf Query
  */
 
 /**

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1875,7 +1875,8 @@ const indexTypes = '2d 2dsphere hashed text'.split(' ');
 /**
  * The allowed index types
  *
- * @receiver Schema
+ * @property {String[]} indexTypes
+ * @memberOf Schema
  * @static
  * @api public
  */

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1870,6 +1870,8 @@ Schema.prototype.get = function(key) {
   return this.options[key];
 };
 
+const indexTypes = '2d 2dsphere hashed text'.split(' ');
+
 /**
  * The allowed index types
  *
@@ -1877,8 +1879,6 @@ Schema.prototype.get = function(key) {
  * @static
  * @api public
  */
-
-const indexTypes = '2d 2dsphere hashed text'.split(' ');
 
 Object.defineProperty(Schema, 'indexTypes', {
   get: function() {

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -206,7 +206,7 @@ SchemaType.prototype.splitPath = function() {
  * @param {Function|false} caster Function that casts arbitrary values to this type, or throws an error if casting failed
  * @return {Function}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function cast
  * @api public
  */
@@ -280,7 +280,7 @@ SchemaType.prototype.cast = function cast() {
  * @param {Any} value The value of the option you'd like to set.
  * @return {void}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function set
  * @api public
  */
@@ -303,7 +303,7 @@ SchemaType.set = function set(option, value) {
  * @param {Function} getter
  * @return {this}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function get
  * @api public
  */
@@ -1634,7 +1634,7 @@ SchemaType.prototype._castForQuery = function(val) {
  * @param {Function} fn
  * @return {Function}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function checkRequired
  * @api public
  */

--- a/lib/types/DocumentArray/methods/index.js
+++ b/lib/types/DocumentArray/methods/index.js
@@ -35,7 +35,7 @@ const methods = {
    *
    * @method _cast
    * @api private
-   * @receiver MongooseDocumentArray
+   * @memberOf MongooseDocumentArray
    */
 
   _cast(value, index) {

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -188,7 +188,7 @@ Subdocument.prototype.isModified = function(paths, modifiedPaths) {
  * @param {String} path the field to mark as valid
  * @api private
  * @method $markValid
- * @receiver Subdocument
+ * @memberOf Subdocument
  */
 
 Subdocument.prototype.$markValid = function(path) {


### PR DESCRIPTION
**Summary**

- refactor all `@receiver` tags into proper jsdoc tags where needed
- changes case `receiver` in `docs/source/api` to be a warning and no-op
- also change handling of case `property` to properly use types instead of trying to parse them from the string (now properly uses arrays and other symbols)

re https://github.com/Automattic/mongoose/pull/12024#pullrequestreview-1026843166
