### PR TITLE
Add `String[]` as type in jsdoc for `Schema.prototype.pre/post`

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1577,7 +1577,7 @@ Schema.prototype.queue = function(name, args) {
  *       // Runs when you call `doc.deleteOne()`
  *     });
  *
- * @param {String|RegExp|String[]} name The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} methodName The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware. For example, set `options.document` to `true` to apply this hook to `Document#deleteOne()` rather than `Query#deleteOne()`.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
@@ -1633,7 +1633,7 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fires after the post find hook');
  *     });
  *
- * @param {String|RegExp|String[]} name The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} methodName The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1577,7 +1577,7 @@ Schema.prototype.queue = function(name, args) {
  *       // Runs when you call `doc.deleteOne()`
  *     });
  *
- * @param {String|RegExp|String[]} The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} name The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware. For example, set `options.document` to `true` to apply this hook to `Document#deleteOne()` rather than `Query#deleteOne()`.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
@@ -1633,7 +1633,7 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fires after the post find hook');
  *     });
  *
- * @param {String|RegExp|String[]} The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} name The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1577,7 +1577,7 @@ Schema.prototype.queue = function(name, args) {
  *       // Runs when you call `doc.deleteOne()`
  *     });
  *
- * @param {String|RegExp} The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware. For example, set `options.document` to `true` to apply this hook to `Document#deleteOne()` rather than `Query#deleteOne()`.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
@@ -1633,7 +1633,7 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fires after the post find hook');
  *     });
  *
- * @param {String|RegExp} The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.


### PR DESCRIPTION
**Summary**

Add `String[]` as a available type for `Schema.prototype.pre` and `Schema.prototype.post`.
Also fixes those parameter to not have a parameter name.

fixes #11989 