### PR TITLE
feat(model): allow passing `timestamps` option to `Model.bulkSave(...)`

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -20,7 +20,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
       const model = decideModelByObject(originalModel, op['insertOne']['document']);
 
       const doc = new model(op['insertOne']['document']);
-      if (model.schema.options.timestamps) {
+      if (model.schema.options.timestamps && options.timestamps !== false) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3623,35 +3623,33 @@ Model.bulkWrite = function(ops, options, callback) {
  * @param {Boolean} [options.j=true] If false, disable [journal acknowledgement](https://docs.mongodb.com/manual/reference/write-concern/#j-option)
  *
  */
-Model.bulkSave = function(documents, options) {
-  const preSavePromises = documents.map(buildPreSavePromise);
+Model.bulkSave = async function(documents, options) {
+  await Promise.all(documents.map(buildPreSavePromise));
 
   const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options && options.timestamps });
+  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, options).then(
+    (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
+    (err) => ({ bulkWriteResult: null, bulkWriteError: err })
+  );
 
-  let bulkWriteResultPromise;
-  return Promise.all(preSavePromises)
-    .then(() => bulkWriteResultPromise = this.bulkWrite(writeOperations, options))
-    .then(() => documents.map(buildSuccessfulWriteHandlerPromise))
-    .then(() => bulkWriteResultPromise)
-    .catch((err) => {
-      if (!(err && err.writeErrors && err.writeErrors.length)) {
-        throw err;
-      }
-      return Promise.all(
-        documents.map((document) => {
-          const documentError = err.writeErrors.find(writeError => {
-            const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
-            return writeErrorDocumentId.toString() === document._id.toString();
-          });
-
-          if (documentError == null) {
-            return buildSuccessfulWriteHandlerPromise(document);
-          }
-        })
-      ).then(() => {
-        throw err;
+  await Promise.all(
+    documents.map(async(document) => {
+      const documentError = bulkWriteError && bulkWriteError.writeErrors.find(writeError => {
+        const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
+        return writeErrorDocumentId.toString() === document._id.toString();
       });
-    });
+
+      if (documentError == null) {
+        await handleSuccessfulWrite(document);
+      }
+    })
+  );
+
+  if (bulkWriteError && bulkWriteError.writeErrors && bulkWriteError.writeErrors.length) {
+    throw bulkWriteError;
+  }
+
+  return bulkWriteResult;
 };
 
 function buildPreSavePromise(document) {
@@ -3666,24 +3664,21 @@ function buildPreSavePromise(document) {
   });
 }
 
-function buildSuccessfulWriteHandlerPromise(document) {
+function handleSuccessfulWrite(document) {
   return new Promise((resolve, reject) => {
-    handleSuccessfulWrite(document, resolve, reject);
-  });
-}
-
-function handleSuccessfulWrite(document, resolve, reject) {
-  if (document.$isNew) {
-    _setIsNew(document, false);
-  }
-
-  document.$__reset();
-  document.schema.s.hooks.execPost('save', document, {}, (err) => {
-    if (err) {
-      reject(err);
-      return;
+    if (document.$isNew) {
+      _setIsNew(document, false);
     }
-    resolve();
+
+    document.$__reset();
+    document.schema.s.hooks.execPost('save', document, {}, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+
   });
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3625,9 +3625,18 @@ Model.bulkWrite = function(ops, options, callback) {
  */
 Model.bulkSave = async function(documents, options) {
   options = options || {};
-  await Promise.all(documents.map(buildPreSavePromise));
 
   const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options.timestamps });
+
+  if (options.timestamps != null) {
+    for (const document of documents) {
+      document.$__.saveOptions = document.$__.saveOptions || {};
+      document.$__.saveOptions.timestamps = options.timestamps;
+    }
+  }
+
+  await Promise.all(documents.map(buildPreSavePromise));
+
   const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, options).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })

--- a/lib/model.js
+++ b/lib/model.js
@@ -3624,9 +3624,10 @@ Model.bulkWrite = function(ops, options, callback) {
  *
  */
 Model.bulkSave = async function(documents, options) {
+  options = options || {};
   await Promise.all(documents.map(buildPreSavePromise));
 
-  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options && options.timestamps });
+  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options.timestamps });
   const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, options).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })

--- a/lib/model.js
+++ b/lib/model.js
@@ -3616,6 +3616,7 @@ Model.bulkWrite = function(ops, options, callback) {
  *
  * @param {Array<Document>} documents
  * @param {Object} [options] options passed to the underlying `bulkWrite()`
+ * @param {Boolean} [options.timestamps] defaults to `null`, when set to false, mongoose will not add/update timestamps to the documents.
  * @param {ClientSession} [options.session=null] The session associated with this bulk write. See [transactions docs](/docs/transactions.html).
  * @param {String|number} [options.w=1] The [write concern](https://docs.mongodb.com/manual/reference/write-concern/). See [`Query#w()`](/docs/api.html#query_Query-w) for more information.
  * @param {number} [options.wtimeout=null] The [write concern timeout](https://docs.mongodb.com/manual/reference/write-concern/#wtimeout).
@@ -3625,7 +3626,7 @@ Model.bulkWrite = function(ops, options, callback) {
 Model.bulkSave = function(documents, options) {
   const preSavePromises = documents.map(buildPreSavePromise);
 
-  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true });
+  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options && options.timestamps });
 
   let bulkWriteResultPromise;
   return Promise.all(preSavePromises)
@@ -3691,6 +3692,7 @@ function handleSuccessfulWrite(document, resolve, reject) {
  * @param {Array<Document>} documents The array of documents to build write operations of
  * @param {Object} options
  * @param {Boolean} options.skipValidation defaults to `false`, when set to true, building the write operations will bypass validating the documents.
+ * @param {Boolean} options.timestamps defaults to `null`, when set to false, mongoose will not add/update timestamps to the documents.
  * @return {Array<Promise>} Returns a array of all Promises the function executes to be awaited.
  */
 Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
@@ -3713,9 +3715,9 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
 
     const isANewDocument = document.isNew;
     if (isANewDocument) {
-      accumulator.push({
-        insertOne: { document }
-      });
+      const writeOperation = { insertOne: { document } };
+      utils.injectTimestampsOption(writeOperation.insertOne, options.timestamps);
+      accumulator.push(writeOperation);
 
       return accumulator;
     }
@@ -3730,13 +3732,9 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
       _applyCustomWhere(document, where);
 
       document.$__version(where, delta);
-
-      accumulator.push({
-        updateOne: {
-          filter: where,
-          update: changes
-        }
-      });
+      const writeOperation = { updateOne: { filter: where, update: changes } };
+      utils.injectTimestampsOption(writeOperation.updateOne, options.timestamps);
+      accumulator.push(writeOperation);
 
       return accumulator;
     }
@@ -3754,6 +3752,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
     }
   }
 };
+
 
 /**
  * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -972,3 +972,11 @@ exports.errorToPOJO = function errorToPOJO(error) {
 exports.warn = function warn(message) {
   return process.emitWarning(message, { code: 'MONGOOSE' });
 };
+
+
+exports.injectTimestampsOption = function injectTimestampsOption(writeOperation, timestampsOption) {
+  if (timestampsOption == null) {
+    return;
+  }
+  writeOperation.timestamps = timestampsOption;
+};

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8117,9 +8117,65 @@ describe('Model', function() {
 
       assert.equal(writeOperations.length, 3);
     });
-  });
 
-  describe('bulkSave() (gh-9673)', function() {
+    it('accepts `timestamps: false` (gh-12059)', async() => {
+      // Arrange
+      const userSchema = new Schema({
+        name: { type: String, minLength: 5 }
+      });
+
+      const User = db.model('User', userSchema);
+
+      const newUser = new User({ name: 'Hafez' });
+      const userToUpdate = await User.create({ name: 'Hafez' });
+      userToUpdate.name = 'John Doe';
+
+      // Act
+      const writeOperations = User.buildBulkWriteOperations([newUser, userToUpdate], { timestamps: false, skipValidation: true });
+
+      // Assert
+      const timestampsOptions = writeOperations.map(writeOperation => writeOperation.timestamps);
+      assert.deepEqual(timestampsOptions, [false, false]);
+    });
+    it('accepts `timestamps: true` (gh-12059)', async() => {
+      // Arrange
+      const userSchema = new Schema({
+        name: { type: String, minLength: 5 }
+      });
+
+      const User = db.model('User', userSchema);
+
+      const newUser = new User({ name: 'Hafez' });
+      const userToUpdate = await User.create({ name: 'Hafez' });
+      userToUpdate.name = 'John Doe';
+
+      // Act
+      const writeOperations = User.buildBulkWriteOperations([newUser, userToUpdate], { timestamps: true, skipValidation: true });
+
+      // Assert
+      const timestampsOptions = writeOperations.map(writeOperation => writeOperation.timestamps);
+      assert.deepEqual(timestampsOptions, [true, true]);
+    });
+    it('`timestamps` has `undefined` as default value (gh-12059)', async() => {
+      // Arrange
+      const userSchema = new Schema({
+        name: { type: String, minLength: 5 }
+      });
+
+      const User = db.model('User', userSchema);
+
+      const newUser = new User({ name: 'Hafez' });
+      const userToUpdate = await User.create({ name: 'Hafez' });
+      userToUpdate.name = 'John Doe';
+
+      // Act
+      const writeOperations = User.buildBulkWriteOperations([newUser, userToUpdate], { skipValidation: true });
+
+      // Assert
+      const timestampsOptions = writeOperations.map(writeOperation => writeOperation.timestamps);
+      assert.deepEqual(timestampsOptions, [undefined, undefined]);
+    });
+  });
     it('saves new documents', async function() {
 
       const userSchema = new Schema({

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8449,7 +8449,7 @@ describe('Model', function() {
       assert.ok(res);
     });
 
-    xit('accepts `timestamps: false` (gh-12059)', async() => {
+    it('accepts `timestamps: false` (gh-12059)', async() => {
       // Arrange
       const userSchema = new Schema({
         name: { type: String, minLength: 5 }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8456,13 +8456,11 @@ describe('Model', function() {
       }, { timestamps: true });
 
       const User = db.model('User', userSchema);
-      mongoose.set('debug', true);
       const userToUpdate = await User.create({ name: 'Hafez', createdAt: new Date('1994-12-04'), updatedAt: new Date('1994-12-04') });
       userToUpdate.name = 'John Doe';
 
       // Act
       await User.bulkSave([userToUpdate], { timestamps: false });
-      mongoose.set('debug', false);
 
       // Assert
       assert.deepStrictEqual(userToUpdate.createdAt, new Date('1994-12-04'));

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8272,7 +8272,6 @@ describe('Model', function() {
 
     });
     it('throws an error on failure', async() => {
-
       const userSchema = new Schema({
         name: { type: String, unique: true }
       });
@@ -8292,8 +8291,8 @@ describe('Model', function() {
 
       const err = await User.bulkSave(users).then(() => null, err => err);
       assert.ok(err);
-
     });
+
     it('changes document state from `isNew` `false` to `true`', async() => {
 
       const userSchema = new Schema({

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8451,17 +8451,26 @@ describe('Model', function() {
     it('accepts `timestamps: false` (gh-12059)', async() => {
       // Arrange
       const userSchema = new Schema({
-        name: { type: String, minLength: 5 }
+        name: { type: String }
       }, { timestamps: true });
 
       const User = db.model('User', userSchema);
+      const newUser = new User({ name: 'Sam' });
+
       const userToUpdate = await User.create({ name: 'Hafez', createdAt: new Date('1994-12-04'), updatedAt: new Date('1994-12-04') });
       userToUpdate.name = 'John Doe';
 
       // Act
-      await User.bulkSave([userToUpdate], { timestamps: false });
+      await User.bulkSave([newUser, userToUpdate], { timestamps: false });
+
 
       // Assert
+      const createdUserPersistedInDB = await User.findOne({ _id: newUser._id });
+      assert.deepStrictEqual(newUser.createdAt, undefined);
+      assert.deepStrictEqual(newUser.updatedAt, undefined);
+
+      assert.deepStrictEqual(createdUserPersistedInDB.createdAt, undefined);
+      assert.deepStrictEqual(createdUserPersistedInDB.updatedAt, undefined);
       assert.deepStrictEqual(userToUpdate.createdAt, new Date('1994-12-04'));
       assert.deepStrictEqual(userToUpdate.updatedAt, new Date('1994-12-04'));
     });

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -319,3 +319,22 @@ function gh11911() {
     update: changes
   });
 }
+
+
+function gh12059() {
+
+  interface IAnimal {
+    name?: string;
+  }
+
+  const animalSchema = new Schema<IAnimal>({
+    name: { type: String }
+  });
+
+  const Animal = model<IAnimal>('Animal', animalSchema);
+  const animal = new Animal();
+
+  Animal.bulkSave([animal], { timestamps: false });
+  Animal.bulkSave([animal], { timestamps: true });
+  Animal.bulkSave([animal], {});
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -149,7 +149,7 @@ declare module 'mongoose' {
    * sending multiple `save()` calls because with `bulkSave()` there is only one
    * network round trip to the MongoDB server.
    */
-    bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+    bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions & { timestamps?: boolean }): Promise<mongodb.BulkWriteResult>;
 
     /** Collection the model uses. */
     collection: Collection;


### PR DESCRIPTION
fixes #12059
I also refactored `bulkSave` to use async/await instead of the ugly promise chain, even though I wrote it, I find it difficult to read.
This comes with the downside of shorter stack traces, hopefully, this is not an issue.

@vkarpov15 
There is a test failing, `bulkSave` calls `bulkWrite` with `timestamps` false, so mongoose sends the writeOperations to MongoDB without `updatedAt` or `createdAt`, but the documents in memory still have `updatedAt` and `createdAt` that is inconsistent with the database.

This happens when we `document.schema.s.hooks.execPre('save',...)`. Do you know if there is a way to make pre-save hook not update timestamps? or pass an option to it? pre-post hooks seem like a blackbox to me and for years I couldn't figure out how they work.