### PR TITLE
chore(workflow): make tests run even if lint fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,6 @@ jobs:
         run: npm run lint-js
 
   test:
-    needs:
-      - lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/lib/model.js
+++ b/lib/model.js
@@ -3688,7 +3688,7 @@ function handleSuccessfulWrite(document, resolve, reject) {
 
 /**
  * Build bulk write operations for `bulkSave()`.
- * 
+ *
  * @param {Array<Document>} documents The array of documents to build write operations of
  * @param {Object} options
  * @param {Boolean} options.skipValidation defaults to `false`, when set to true, building the write operations will bypass validating the documents.


### PR DESCRIPTION
This is both faster and gives better visibility on PRs, I want to see whether the PR is good or not, but right now if there is an extra space I have to wait for the person who submitted the PR to fix it before I can see if it introduces breaking changes.