### PR TITLE
Model JSDOC Touch-Up

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2637,7 +2637,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  *
  *     const doc = await Model.findById(id)
  *     doc.name = 'jason bourne';
- *     await doc.save(callback);
+ *     await doc.save();
  *
  * @param {Object|Number|String} id value of `_id` to query by
  * @param {Object} [update]
@@ -2728,7 +2728,7 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  *
  *     const doc = await Model.findById(id)
  *     doc.name = 'jason bourne';
- *     await doc.save(callback);
+ *     await doc.save();
  *
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
@@ -2904,7 +2904,7 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  *
  *     const doc = await Model.findById(id);
  *     doc.name = 'jason bourne';
- *     await doc.save(callback);
+ *     await doc.save();
  *
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)

--- a/lib/model.js
+++ b/lib/model.js
@@ -2660,11 +2660,9 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * If you need full-fledged validation, use the traditional approach of first
  * retrieving the document.
  *
- *     Model.findById(id, function (err, doc) {
- *       if (err) ..
- *       doc.name = 'jason bourne';
- *       doc.save(callback);
- *     });
+ *     const doc = await Model.findById(id)
+ *     doc.name = 'jason bourne';
+ *     await doc.save(callback);
  *
  * @param {Object|Number|String} id value of `_id` to query by
  * @param {Object} [update]

--- a/lib/model.js
+++ b/lib/model.js
@@ -2969,13 +2969,6 @@ Model.findOneAndRemove = function(conditions, options, callback) {
  *
  * - `findOneAndRemove()`
  *
- * #### Options:
- *
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- * - `select`: sets the document fields to return
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * - `strict`: overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict) for this update
- *
  * #### Examples:
  *
  *     A.findByIdAndRemove(id, options, callback) // executes
@@ -2989,6 +2982,9 @@ Model.findOneAndRemove = function(conditions, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
  * @param {Function} [callback]
  * @return {Query}
  * @see Model.findOneAndRemove #model_Model.findOneAndRemove

--- a/lib/model.js
+++ b/lib/model.js
@@ -3864,7 +3864,6 @@ Model.hydrate = function(obj, projection) {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `doc`, Mongoose will wrap `doc` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`.
  * @param {Function} [callback] params are (error, [updateWriteOpResult](https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#~updateWriteOpResult))
- * @param {Function} [callback]
  * @return {Query}
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
  * @see writeOpResult https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#~updateWriteOpResult

--- a/lib/model.js
+++ b/lib/model.js
@@ -2614,17 +2614,6 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  *
  * - `findOneAndUpdate()`
  *
- * #### Options:
- *
- * - `new`: bool - true to return the modified document rather than the original. defaults to false
- * - `upsert`: bool - creates the object if it doesn't exist. defaults to false.
- * - `runValidators`: if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema.
- * - `setDefaultsOnInsert`: `true` by default. If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created.
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- * - `select`: sets the document fields to return
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * - `strict`: overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict) for this update
- *
  * #### Examples:
  *
  *     A.findByIdAndUpdate(id, update, options, callback) // executes
@@ -2667,6 +2656,13 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace({ _id: id }, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
+ * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
+ * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
+ * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
+ * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
  * @param {Function} [callback]
  * @return {Query}
  * @see Model.findOneAndUpdate #model_Model.findOneAndUpdate

--- a/lib/model.js
+++ b/lib/model.js
@@ -2703,15 +2703,6 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  * this distinction is purely pedantic. You should use `findOneAndDelete()`
  * unless you have a good reason not to.
  *
- * #### Options:
- *
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `select`: sets the document fields to return, ex. `{ projection: { _id: 0 } }`
- * - `projection`: equivalent to `select`
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * - `strict`: overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict) for this update
- *
  * #### Examples:
  *
  *     A.findOneAndDelete(conditions, options, callback) // executes
@@ -2735,6 +2726,10 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
+ * @param {Object|String} [options.select] sets the document fields to return.
+ * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
  * @return {Query}
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -2746,11 +2746,9 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  * If you need full-fledged validation, use the traditional approach of first
  * retrieving the document.
  *
- *     Model.findById(id, function (err, doc) {
- *       if (err) ..
- *       doc.name = 'jason bourne';
- *       doc.save(callback);
- *     });
+ *     const doc = await Model.findById(id)
+ *     doc.name = 'jason bourne';
+ *     await doc.save(callback);
  *
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)

--- a/lib/model.js
+++ b/lib/model.js
@@ -96,7 +96,7 @@ const saveToObjectOptions = Object.assign({}, internalToObjectOptions, {
  *     const userFromDb = await UserModel.findOne({ name: 'Foo' });
  *
  * @param {Object} doc values for initial set
- * @param [fields] optional object containing the fields that were selected in the query which returned this document. You do **not** need to set this parameter to ensure Mongoose handles your [query projection](./api.html#query_Query-select).
+ * @param {Object} [fields] optional object containing the fields that were selected in the query which returned this document. You do **not** need to set this parameter to ensure Mongoose handles your [query projection](./api.html#query_Query-select).
  * @param {Boolean} [skipId=false] optional boolean. If true, mongoose doesn't add an `_id` field to the document.
  * @inherits Document https://mongoosejs.com/docs/api/document.html
  * @event `error`: If listening to this event, 'error' is emitted when a document was saved without passing a callback and an `error` occurred. If not listening, the event bubbles to the connection used to create this Model.

--- a/lib/model.js
+++ b/lib/model.js
@@ -4030,54 +4030,34 @@ function _update(model, op, conditions, doc, options, callback) {
 /**
  * Executes a mapReduce command.
  *
- * `o` is an object specifying all mapReduce options as well as the map and reduce functions. All options are delegated to the driver implementation. See [node-mongodb-native mapReduce() documentation](https://mongodb.github.io/node-mongodb-native/api-generated/collection.html#mapreduce) for more detail about options.
+ * `opts` is an object specifying all mapReduce options as well as the map and reduce functions. All options are delegated to the driver implementation. See [node-mongodb-native mapReduce() documentation](https://mongodb.github.io/node-mongodb-native/api-generated/collection.html#mapreduce) for more detail about options.
  *
  * This function does not trigger any middleware.
  *
  * #### Example:
  *
- *     const o = {};
+ *     const opts = {};
  *     // `map()` and `reduce()` are run on the MongoDB server, not Node.js,
  *     // these functions are converted to strings
- *     o.map = function () { emit(this.name, 1) };
- *     o.reduce = function (k, vals) { return vals.length };
- *     User.mapReduce(o, function (err, results) {
+ *     opts.map = function () { emit(this.name, 1) };
+ *     opts.reduce = function (k, vals) { return vals.length };
+ *     User.mapReduce(opts, function (err, results) {
  *       console.log(results)
  *     })
  *
- * #### Other options:
- *
- * - `query` {Object} query filter object.
- * - `sort` {Object} sort input objects using this key
- * - `limit` {Number} max number of documents
- * - `keeptemp` {Boolean, default:false} keep temporary data
- * - `finalize` {Function} finalize function
- * - `scope` {Object} scope variables exposed to map/reduce/finalize during execution
- * - `jsMode` {Boolean, default:false} it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X
- * - `verbose` {Boolean, default:false} provide statistics on job execution time.
- * - `readPreference` {String}
- * - `out*` {Object, default: {inline:1}} sets the output target for the map reduce job.
- *
- * #### * out options:
- *
- * - `{inline:1}` the results are returned in an array
- * - `{replace: 'collectionName'}` add the results to collectionName: the results replace the collection
- * - `{reduce: 'collectionName'}` add the results to collectionName: if dups are detected, uses the reducer / finalize functions
- * - `{merge: 'collectionName'}` add the results to collectionName: if dups exist the new docs overwrite the old
- *
- * If `options.out` is set to `replace`, `merge`, or `reduce`, a Model instance is returned that can be used for further querying. Queries run against this model are all executed with the [`lean` option](/docs/tutorials/lean.html); meaning only the js object is returned and no Mongoose magic is applied (getters, setters, etc).
+ * If `opts.out` is set to `replace`, `merge`, or `reduce`, a Model instance is returned that can be used for further querying. Queries run against this model are all executed with the [`lean` option](/docs/tutorials/lean.html); meaning only the js object is returned and no Mongoose magic is applied (getters, setters, etc).
  *
  * #### Example:
  *
- *     const o = {};
+ *     const opts = {};
  *     // You can also define `map()` and `reduce()` as strings if your
  *     // linter complains about `emit()` not being defined
- *     o.map = 'function () { emit(this.name, 1) }';
- *     o.reduce = 'function (k, vals) { return vals.length }';
- *     o.out = { replace: 'createdCollectionNameForResults' }
- *     o.verbose = true;
+ *     opts.map = 'function () { emit(this.name, 1) }';
+ *     opts.reduce = 'function (k, vals) { return vals.length }';
+ *     opts.out = { replace: 'createdCollectionNameForResults' }
+ *     opts.verbose = true;
  *
- *     User.mapReduce(o, function (err, model, stats) {
+ *     User.mapReduce(opts, function (err, model, stats) {
  *       console.log('map reduce took %d ms', stats.processtime)
  *       model.find().where('value').gt(10).exec(function (err, docs) {
  *         console.log(docs);
@@ -4086,8 +4066,8 @@ function _update(model, op, conditions, doc, options, callback) {
  *
  *     // `mapReduce()` returns a promise. However, ES6 promises can only
  *     // resolve to exactly one value,
- *     o.resolveToObject = true;
- *     const promise = User.mapReduce(o);
+ *     opts.resolveToObject = true;
+ *     const promise = User.mapReduce(opts);
  *     promise.then(function (res) {
  *       const model = res.model;
  *       const stats = res.stats;
@@ -4098,6 +4078,20 @@ function _update(model, op, conditions, doc, options, callback) {
  *     }).then(null, handleError).end()
  *
  * @param {Object} opts an object specifying map-reduce options
+ * @param {Boolean} [opts.verbose=false] provide statistics on job execution time
+ * @param {String} [opts.readPreference]
+ * @param {Boolean} [opts.jsMode=false] it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X
+ * @param {Object} [opts.scope] scope variables exposed to map/reduce/finalize during execution
+ * @param {Function} [opts.finalize] finalize function
+ * @param {Boolean} [opts.keeptemp=false] keep temporary data
+ * @param {Number} [opts.limit] max number of documents
+ * @param {Object} [opts.sort] sort input objects using this key
+ * @param {Object} [opts.query] query filter object
+ * @param {Object} [opts.out] sets the output target for the map reduce job
+ * @param {Number} [opts.out.inline=1] the results are returned in an array
+ * @param {String} [opts.out.replace] add the results to collectionName: the results replace the collection
+ * @param {String} [opts.out.reduce] add the results to collectionName: if dups are detected, uses the reducer / finalize functions
+ * @param {String} [opts.out.merge] add the results to collectionName: if dups exist the new docs overwrite the old
  * @param {Function} [callback] optional callback
  * @see https://www.mongodb.org/display/DOCS/MapReduce
  * @return {Promise}

--- a/lib/model.js
+++ b/lib/model.js
@@ -943,6 +943,7 @@ Model.prototype.$__where = function _where(where) {
  * Removes this document from the db.
  *
  * #### Example:
+ *
  *     product.remove(function (err, product) {
  *       if (err) return handleError(err);
  *       Product.findById(product._id, function (err, product) {
@@ -954,6 +955,7 @@ Model.prototype.$__where = function _where(where) {
  * As an extra measure of flow control, remove will return a Promise (bound to `fn` if passed) so it could be chained, or hooked to receive errors
  *
  * #### Example:
+ *
  *     product.remove().then(function (product) {
  *        ...
  *     }).catch(function (err) {
@@ -1001,6 +1003,7 @@ Model.prototype.delete = Model.prototype.remove;
  * Removes this document from the db. Equivalent to `.remove()`.
  *
  * #### Example:
+ *
  *     product = await product.deleteOne();
  *     await Product.findById(product._id); // null
  *
@@ -1110,6 +1113,7 @@ Model.prototype.$model = function $model(name) {
  * `MyModel.findOne({ answer: 42 }).select({ _id: 1 }).lean()`
  *
  * #### Example:
+ *
  *     await Character.deleteMany({});
  *     await Character.create({ name: 'Jean-Luc Picard' });
  *
@@ -1279,7 +1283,7 @@ for (const i in EventEmitter.prototype) {
  *
  * #### Example:
  *
- *     const eventSchema = new Schema({ thing: { type: 'string', unique: true }})
+ *     const eventSchema = new Schema({ thing: { type: 'string', unique: true } })
  *     // This calls `Event.init()` implicitly, so you don't need to call
  *     // `Event.init()` on your own.
  *     const Event = mongoose.model('Event', eventSchema);
@@ -1497,7 +1501,7 @@ Model.syncIndexes = function syncIndexes(options, callback) {
  * Model.syncIndexes().
  *
  * @param {Object} [options]
- * @param {Function} callback optional callback
+ * @param {Function} [callback] optional callback
  * @returns {Promise} which contains an object, {toDrop, toCreate}, which
  * are indexes that would be dropped in MongoDB and indexes that would be created in MongoDB.
  */
@@ -1661,7 +1665,7 @@ Model.listIndexes = function init(callback) {
  *
  * #### Example:
  *
- *     const eventSchema = new Schema({ thing: { type: 'string', unique: true }})
+ *     const eventSchema = new Schema({ thing: { type: 'string', unique: true } })
  *     const Event = mongoose.model('Event', eventSchema);
  *
  *     Event.on('index', function (err) {
@@ -1896,6 +1900,7 @@ Model.discriminators;
  *       .exec(function(err, characters) {})
  *
  * #### Note:
+ *
  * Only translate arguments of object type anything else is returned raw
  *
  * @param {Object} fields fields/conditions that may contain aliased keys
@@ -2392,7 +2397,7 @@ Model.count = function count(conditions, callback) {
  *
  * #### Example:
  *
- *     Link.distinct('url', { clicks: {$gt: 100}}, function (err, result) {
+ *     Link.distinct('url', { clicks: { $gt: 100 } }, function (err, result) {
  *       if (err) return handleError(err);
  *
  *       assert(Array.isArray(result));
@@ -2428,7 +2433,7 @@ Model.distinct = function distinct(field, conditions, callback) {
  *
  * For example, instead of writing:
  *
- *     User.find({age: {$gte: 21, $lte: 65}}, callback);
+ *     User.find({ age: { $gte: 21, $lte: 65 } }, callback);
  *
  * we can instead write:
  *

--- a/lib/model.js
+++ b/lib/model.js
@@ -2522,7 +2522,7 @@ Model.$where = function $where() {
  * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
  * @param {Object|String} [options.fields] Field selection. Equivalent to `.select(fields).findOneAndUpdate()`
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
- * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
  * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
@@ -2648,13 +2648,13 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace({ _id: id }, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
- * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
  * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
- * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
+ * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Function} [callback]
  * @return {Query}
  * @see Model.findOneAndUpdate #model_Model.findOneAndUpdate
@@ -2831,9 +2831,9 @@ Model.findByIdAndDelete = function(id, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
- * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
+ * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
  * @return {Query}
@@ -2911,9 +2911,9 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
- * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
+ * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
  * @return {Query}
@@ -2974,9 +2974,9 @@ Model.findOneAndRemove = function(conditions, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
- * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
+ * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Function} [callback]
  * @return {Query}
  * @see Model.findOneAndRemove #model_Model.findOneAndRemove

--- a/lib/model.js
+++ b/lib/model.js
@@ -2938,11 +2938,9 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  * If you need full-fledged validation, use the traditional approach of first
  * retrieving the document.
  *
- *     Model.findById(id, function (err, doc) {
- *       if (err) ..
- *       doc.name = 'jason bourne';
- *       doc.save(callback);
- *     });
+ *     const doc = await Model.findById(id);
+ *     doc.name = 'jason bourne';
+ *     await doc.save(callback);
  *
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)

--- a/lib/model.js
+++ b/lib/model.js
@@ -903,10 +903,9 @@ function increment() {
  *
  * #### Example:
  *
- *     Model.findById(id, function (err, doc) {
- *       doc.increment();
- *       doc.save(function (err) { .. })
- *     })
+ *     const doc = await Model.findById(id);
+ *     doc.increment();
+ *     await doc.save();
  *
  * @see versionKeys https://mongoosejs.com/docs/guide.html#versionKey
  * @memberOf Model

--- a/lib/model.js
+++ b/lib/model.js
@@ -2896,15 +2896,6 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  *
  * - `findOneAndRemove()`
  *
- * #### Options:
- *
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `select`: sets the document fields to return
- * - `projection`: like select, it determines which fields to return, ex. `{ projection: { _id: 0 } }`
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * - `strict`: overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict) for this update
- *
  * #### Examples:
  *
  *     A.findOneAndRemove(conditions, options, callback) // executes
@@ -2928,6 +2919,10 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
+ * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
  * @return {Query}
  * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command

--- a/lib/model.js
+++ b/lib/model.js
@@ -943,23 +943,11 @@ Model.prototype.$__where = function _where(where) {
  *
  * #### Example:
  *
- *     product.remove(function (err, product) {
- *       if (err) return handleError(err);
- *       Product.findById(product._id, function (err, product) {
- *         console.log(product) // null
- *       })
- *     })
- *
- *
- * As an extra measure of flow control, remove will return a Promise (bound to `fn` if passed) so it could be chained, or hooked to receive errors
- *
- * #### Example:
- *
- *     product.remove().then(function (product) {
- *        ...
- *     }).catch(function (err) {
- *        assert.ok(err)
- *     })
+ *     const product = await product.remove().catch(function (err) {
+ *        assert.ok(err);
+ *     });
+ *     const foundProduct = await Product.findById(product._id);
+ *     console.log(foundProduct) // null
  *
  * @param {Object} [options]
  * @param {Session} [options.session=null] the [session](https://docs.mongodb.com/manual/reference/server-sessions/) associated with this operation. If not specified, defaults to the [document's associated session](api.html#document_Document-$session).

--- a/lib/model.js
+++ b/lib/model.js
@@ -2482,19 +2482,6 @@ Model.$where = function $where() {
  *
  * Finds a matching document, updates it according to the `update` arg, passing any `options`, and returns the found document (if any) to the callback. The query executes if `callback` is passed else a Query object is returned.
  *
- * #### Options:
- *
- * - `new`: bool - if true, return the modified document rather than the original. defaults to false (changed in 4.0)
- * - `upsert`: bool - creates the object if it doesn't exist. defaults to false.
- * - `overwrite`: bool - if true, replace the entire document.
- * - `fields`: {Object|String} - Field selection. Equivalent to `.select(fields).findOneAndUpdate()`
- * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- * - `runValidators`: if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema.
- * - `setDefaultsOnInsert`: `true` by default. If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created.
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * - `strict`: overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict) for this update
- *
  * #### Examples:
  *
  *     A.findOneAndUpdate(conditions, update, options, callback) // executes
@@ -2540,6 +2527,13 @@ Model.$where = function $where() {
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace(conditions, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
+ * @param {Object|String} [options.fields] Field selection. Equivalent to `.select(fields).findOneAndUpdate()`
+ * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
+ * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
+ * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
  * @param {Function} [callback]
  * @return {Query}
  * @see Tutorial /docs/tutorials/findoneandupdate.html

--- a/lib/model.js
+++ b/lib/model.js
@@ -4035,7 +4035,7 @@ function _update(model, op, conditions, doc, options, callback) {
  *
  * @param {Object} opts an object specifying map-reduce options
  * @param {Boolean} [opts.verbose=false] provide statistics on job execution time
- * @param {String} [opts.readPreference]
+ * @param {ReadPreference|String} [opts.readPreference] a read-preference string or a read-preference instance
  * @param {Boolean} [opts.jsMode=false] it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X
  * @param {Object} [opts.scope] scope variables exposed to map/reduce/finalize during execution
  * @param {Function} [opts.finalize] finalize function

--- a/lib/model.js
+++ b/lib/model.js
@@ -2822,15 +2822,6 @@ Model.findByIdAndDelete = function(id, options, callback) {
  *
  * - `findOneAndReplace()`
  *
- * #### Options:
- *
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
- * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `select`: sets the document fields to return
- * - `projection`: like select, it determines which fields to return, ex. `{ projection: { _id: 0 } }`
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
- * - `strict`: overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict) for this update
- *
  * #### Examples:
  *
  *     A.findOneAndReplace(filter, replacement, options, callback) // executes
@@ -2848,6 +2839,10 @@ Model.findByIdAndDelete = function(id, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Any} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update. TODO: Update type to proper type
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Any} [options.select] sets the document fields to return. TODO: Update type to proper type
+ * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
  * @return {Query}
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -889,6 +889,15 @@ Model.prototype.$__version = function(where, delta) {
   }
 };
 
+/*!
+ * ignore
+ */
+
+function increment() {
+  this.$__.version = VERSION_ALL;
+  return this;
+}
+
 /**
  * Signal that we desire an increment of this documents version.
  *
@@ -901,13 +910,9 @@ Model.prototype.$__version = function(where, delta) {
  *
  * @see versionKeys https://mongoosejs.com/docs/guide.html#versionKey
  * @memberOf Model
+ * @method increment
  * @api public
  */
-
-function increment() {
-  this.$__.version = VERSION_ALL;
-  return this;
-}
 
 Model.prototype.increment = increment;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -4097,14 +4097,14 @@ function _update(model, op, conditions, doc, options, callback) {
  *        console.log(docs);
  *     }).then(null, handleError).end()
  *
- * @param {Object} o an object specifying map-reduce options
+ * @param {Object} opts an object specifying map-reduce options
  * @param {Function} [callback] optional callback
  * @see https://www.mongodb.org/display/DOCS/MapReduce
  * @return {Promise}
  * @api public
  */
 
-Model.mapReduce = function mapReduce(o, callback) {
+Model.mapReduce = function mapReduce(opts, callback) {
   _checkContext(this, 'mapReduce');
 
   callback = this.$handleCallbackError(callback);
@@ -4117,20 +4117,20 @@ Model.mapReduce = function mapReduce(o, callback) {
       Model.mapReduce.schema = new Schema({}, opts);
     }
 
-    if (!o.out) o.out = { inline: 1 };
-    if (o.verbose !== false) o.verbose = true;
+    if (!opts.out) opts.out = { inline: 1 };
+    if (opts.verbose !== false) opts.verbose = true;
 
-    o.map = String(o.map);
-    o.reduce = String(o.reduce);
+    opts.map = String(opts.map);
+    opts.reduce = String(opts.reduce);
 
-    if (o.query) {
-      let q = new this.Query(o.query);
+    if (opts.query) {
+      let q = new this.Query(opts.query);
       q.cast(this);
-      o.query = q._conditions;
+      opts.query = q._conditions;
       q = undefined;
     }
 
-    this.$__collection.mapReduce(null, null, o, (err, res) => {
+    this.$__collection.mapReduce(null, null, opts, (err, res) => {
       if (err) {
         return cb(err);
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -210,6 +210,7 @@ Model.prototype.baseModelName;
  *     await MyModel.findOne({ _id: 'Not a valid ObjectId' }).catch(noop);
  *
  * @api public
+ * @property events
  * @fires error whenever any query or model function errors
  * @memberOf Model
  * @static


### PR DESCRIPTION
**Summary**

This PR Improves the JSDOC of `lib/model.js`.

Changes include:
- fix missing types from `@param` tags
- changes some examples from callback-style to await-style
- moves options to `@param` tags
- change some things to make the style consistent
- renames parameter `o` to `opts` for `mapReduce` to be more clear what that parameter does

There are some added TODO's, because i was not sure what type they were