### PR TITLE
fix(types): add $let as a possible expression to $addFields

### DIFF
--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -392,3 +392,26 @@ const stages3: PipelineStage[] = [
     }
   }
 ];
+
+const stages4: PipelineStage[] = [
+  {
+    $addFields: {
+      usersCount: {
+        $let: {
+          vars: {
+            users: { $push: '$user' }
+          },
+          in: {
+            $reduce: {
+              input: '$users',
+              initialValue: 0,
+              in: {
+                $cond: { if: { $isArray: '$$this' }, then: { $size: '$$this' }, else: '$$this' }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+];

--- a/types/expressions.d.ts
+++ b/types/expressions.d.ts
@@ -2448,7 +2448,8 @@ declare module 'mongoose' {
     BinaryExpression |
     FunctionExpression |
     ObjectIdExpression |
-    ConditionalExpressionOperator;
+    ConditionalExpressionOperator |
+    Expression.Let;
 
   export type ObjectIdExpression =
     TypeExpressionOperatorReturningObjectId;


### PR DESCRIPTION
Aggregation pipeline types currently don't accept the valid 
`$addFields: { myFieldName: { $let: { /* $let expression goes here */ } } }`

This PR fixes that, although I'm not sure if adding `Expression.Let` follows the desired structure for types.