### PR TITLE
fix(types): fix $switch expression type

### DIFF
--- a/test/types/expressions.test.ts
+++ b/test/types/expressions.test.ts
@@ -193,3 +193,13 @@ const nullExpr: Expression = {
 const nullNETupleExpr: Expression = {
   $ne: ['$name', null]
 };
+
+const switchExpr: Expression.Switch = {
+  $switch: {
+    branches: [
+      { case: { $eq: ['$name', 'Detlef'] }, then: 'Detlef' },
+      { case: { $eq: ['$name', 'John'] }, then: 'John' }
+    ],
+    default: 'Hello'
+  }
+};

--- a/types/expressions.d.ts
+++ b/types/expressions.d.ts
@@ -1067,13 +1067,13 @@ declare module 'mongoose' {
          * - $case
          * - $then
          */
-        $branches: { $case: Expression, then: Expression }[];
+        branches: { case: Expression, then: Expression }[];
         /**
          * The path to take if no branch case expression evaluates to true.
          *
          * Although optional, if default is unspecified and no branch case evaluates to true, $switch returns an error.
          */
-        $default: Expression;
+        default: Expression;
       };
     }
 


### PR DESCRIPTION
[$switch](https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/#mongodb-expression-exp.-switch) statements accept `branches` instead of the current `$branches`, `case` instead of `$case`, and `default` instead of `$default`.