### PR TITLE
feat(array): add property option "castNonArrays"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,6 @@ jobs:
         run: npm run lint-js
 
   test:
-    needs:
-      - lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ docs/tutorials/*.html
 docs/typescript/*.html
 docs/api/*.html
 index.html
+examples/ecommerce-netlify-functions/.netlify/state.json

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,8 @@ docs/tutorials/*.html
 docs/typescript/*.html
 docs/api/*.html
 index.html
+
+# yarn package-lock
+yarn.lock
+
 examples/ecommerce-netlify-functions/.netlify/state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+6.4.4 / 2022-07-08
+==================
+ * fix(types): allow using an object to configure timestamps #12061 [lantw44](https://github.com/lantw44)
+ * fix(types): support findOneAndReplace with rawResult #12062 [lantw44](https://github.com/lantw44)
+ * docs: upgrade API documentation parser #12078 #12072 #12071 #12024 [hasezoey](https://github.com/hasezoey)
+ * docs(document): add more info on $isNew #11990
+ * docs: add SchemaType doValidate() to docs #12068
+
 6.4.3 / 2022-07-05
 ==================
  * fix(document): handle validating deeply nested subdocuments underneath nested paths with required: false #12021

--- a/benchmarks/typescript.js
+++ b/benchmarks/typescript.js
@@ -21,6 +21,8 @@ async function run() {
 
   const tsProjectsDirectories = await fs.readdir('benchmarks/typescript');
 
+  let failed = [];
+
   for (const tsProjectDirectory of tsProjectsDirectories) {
     let instantiations = 0;
     let memoryUsed = 0;
@@ -62,11 +64,19 @@ async function run() {
       totalTime,
       testName: tsProjectDirectory
     });
+
+    if (instantiations >= 100000) {
+      failed.push(tsProjectDirectory);
+    }
   }
 
   await persist({ results });
 
   await mongoose.disconnect();
+
+  if (failed.length > 0) {
+    throw new Error(`Benchmarks ${failed.join(', ')} had over 100k instantiations`);
+  }
 }
 
 async function persist({ results }) {

--- a/docs/search.js
+++ b/docs/search.js
@@ -40,6 +40,7 @@ for (const filename of files) {
         });
         const err = content.validateSync();
         if (err != null) {
+          console.log(content);
           throw err;
         }
         contents.push(content);

--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -234,11 +234,6 @@ function parse() {
         ctx.string = ctx.string + "()";
       }
 
-      // fixing up "something.prototypemissingdot" to "something.prototype.missingdot"
-      if (/\.prototype[^.]/.test(ctx.string)) {
-        ctx.string = `${ctx.constructor}.prototype.${ctx.name}`;
-      }
-
       // Backwards compat anchors
       if (typeof ctx.constructor === 'string') {
         ctx.anchorId = `${ctx.constructor.toLowerCase()}_${ctx.constructor}-${ctx.name}`;

--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -50,12 +50,34 @@ const out = module.exports.docs;
 
 const combinedFiles = [];
 for (const file of files) {
-  const comments = dox.parseComments(fs.readFileSync(`./${file}`, 'utf8'), { raw: true });
-  comments.file = file;
-  combinedFiles.push(comments);
+  try {
+    const comments = dox.parseComments(fs.readFileSync(`./${file}`, 'utf8'), { raw: true });
+    comments.file = file;
+    combinedFiles.push(comments);
+  } catch (err) {
+    // show log of which file has thrown a error for easier debugging
+    console.error("Error while trying to parseComments for ", file);
+    throw err;
+  }
 }
 
 parse();
+
+/**
+ * @typedef {Object} PropContext
+ * @property {boolean} [isStatic] Defines wheter the current property is a static property (not mutually exlusive with "isInstance")
+ * @property {boolean} [isInstance] Defines wheter the current property is a instance property (not mutually exlusive with "isStatic")
+ * @property {boolean} [isFunction] Defines wheter the current property is meant to be a function
+ * @property {string} [constructor] Defines the Constructor (or rather path) the current property is on
+ * @property {boolean} [constructorWasUndefined] Defined wheter the "constructor" property was defined by "dox", but was set to "undefined"
+ * @property {string} [type] Defines the type the property is meant to be
+ * @property {string} [name] Defines the current Properties name
+ * @property {Object} [return] The full object for a "@return" jsdoc tag
+ * @property {string} [string] Defines the full string the property will be listed as
+ * @property {string} [anchorId] Defines the Anchor ID to be used for linking
+ * @property {string} [description] Defines the Description the property will be listed with
+ * @property {string} [deprecated] Defines wheter the current Property is signaled as deprecated
+ */
 
 function parse() {
   for (const props of combinedFiles) {
@@ -88,8 +110,22 @@ function parse() {
       if (prop.ignore || prop.isPrivate) {
         continue;
       }
-
+     
+      /** @type {PropContext} */
       const ctx = prop.ctx || {};
+
+      // somehow in "dox", it is named "receiver" sometimes, not "constructor"
+      // this is used as a fall-back if the handling below does not overwrite it
+      if ("receiver" in ctx) {
+        ctx.constructor = ctx.receiver;
+        delete ctx.receiver;
+      }
+
+      // in some cases "dox" has "ctx.constructor" defined but set to "undefined", which will later be used for setting "ctx.string"
+      if ("constructor" in ctx && ctx.constructor === undefined) {
+        ctx.constructorWasUndefined = true;
+      }
+
       for (const tag of prop.tags) {
         switch (tag.type) {
           case 'receiver':
@@ -97,34 +133,44 @@ function parse() {
             break;
           case 'property':
             ctx.type = 'property';
+
+            // somewhere since 6.0 the "string" property came back, which was gone with 4.5
             let str = tag.string;
+            
             const match = str.match(/^{\w+}/);
             if (match != null) {
               ctx.type = match[0].substring(1, match[0].length - 1);
               str = str.replace(/^{\w+}\s*/, '');
             }
             ctx.name = str;
-            ctx.string = `${ctx.constructor}.prototype.${ctx.name}`;
             break;
           case 'type':
             ctx.type = Array.isArray(tag.types) ? tag.types.join('|') : tag.types;
             break;
           case 'static':
             ctx.type = 'property';
-            ctx.static = true;
-            ctx.name = tag.string;
-            ctx.string = `${data.name}.${ctx.name}`;
+            ctx.isStatic = true;
+            // dont take "string" as "name" from here, because jsdoc definitions of "static" do not have parameters, also its defined elsewhere anyway
+            // ctx.name = tag.string;
             break;
           case 'function':
             ctx.type = 'function';
-            ctx.static = true;
+            ctx.isStatic = true;
             ctx.name = tag.string;
-            ctx.string = `${data.name}.${ctx.name}()`;
+            // extra parameter to make function definitions independant of where "@function" is defined
+            // like "@static" could have overwritten "ctx.string" again if defined after "@function"
+            ctx.isFunction = true;
             break;
           case 'return':
-            tag.return = tag.description ?
-              md.parse(tag.description).replace(/^<p>/, '').replace(/<\/p>$/, '') :
+            tag.description = tag.description ?
+              md.parse(tag.description).replace(/^<p>/, '').replace(/<\/p>\n?$/, '') :
               '';
+
+            // dox does not add "void" / "undefined" to types, so in the documentation it would result in a empty "«»"
+            if (tag.string.includes('void') || tag.string.includes('undefined')) {
+              tag.types.push("void");
+            }
+
             ctx.return = tag;
             break;
           case 'inherits':
@@ -133,6 +179,10 @@ function parse() {
           case 'event':
           case 'param':
             ctx[tag.type] = (ctx[tag.type] || []);
+            // the following is required, because in newer "dox" version "null" is not included in "types" anymore, but a seperate property
+            if (tag.nullable) {
+              tag.types.push('null');
+            }
             if (tag.types) {
               tag.types = tag.types.join('|');
             }
@@ -147,26 +197,49 @@ function parse() {
           case 'method':
             ctx.type = 'method';
             ctx.name = tag.string;
-            ctx.string = `${ctx.constructor}.prototype.${ctx.name}()`;
+            ctx.isFunction = true;
             break;
           case 'memberOf':
             ctx.constructor = tag.parent;
-            ctx.string = `${ctx.constructor}.prototype.${ctx.name}`;
-            if (ctx.type === 'method') {
-              ctx.string += '()';
-            }
             break;
           case 'constructor':
-            ctx.string = tag.string + '()';
+            ctx.string = tag.string;
             ctx.name = tag.string;
+            ctx.isFunction = true;
+            break;
+          case 'instance':
+            ctx.isInstance = true;
+            break;
+          case 'deprecated':
+            ctx.deprecated = true;
+            break;
         }
       }
 
+      if (ctx.isInstance && ctx.isStatic) {
+        console.warn(`Property "${ctx.name}" in "${ctx.constructor}" has both instance and static JSDOC markings (most likely both @instance and @static)! (File: "${props.file}")`);
+      }
+
+      // the following if-else-if statement is in this order, because there are more "instance" methods thans static
+      // the following condition will be true if "isInstance = true" or if "isInstance = false && isStatic = false" AND "ctx.string" are empty or not defined
+      // if "isStatic" and "isInstance" are falsy and "ctx.string" is not falsy, then rely on the "ctx.string" set by "dox"
+      if (ctx.isInstance || (!ctx.isStatic && !ctx.isInstance && (!ctx.string || ctx.constructorWasUndefined))) {
+        ctx.string = `${ctx.constructor}.prototype.${ctx.name}`;
+      } else if (ctx.isStatic) {
+        ctx.string = `${ctx.constructor}.${ctx.name}`;
+      }
+
+      // add "()" to the end of the string if function
+      if ((ctx.isFunction || ctx.type === "method") && !ctx.string.endsWith("()")) {
+        ctx.string = ctx.string + "()";
+      }
+
+      // fixing up "something.prototypemissingdot" to "something.prototype.missingdot"
       if (/\.prototype[^.]/.test(ctx.string)) {
         ctx.string = `${ctx.constructor}.prototype.${ctx.name}`;
       }
 
-      // Backwards compat
+      // Backwards compat anchors
       if (typeof ctx.constructor === 'string') {
         ctx.anchorId = `${ctx.constructor.toLowerCase()}_${ctx.constructor}-${ctx.name}`;
       } else if (typeof ctx.receiver === 'string') {
@@ -178,9 +251,6 @@ function parse() {
       ctx.description = prop.description.full.
         replace(/<br \/>/ig, ' ').
         replace(/&gt;/ig, '>');
-      if (ctx.description.includes('function capitalize')) {
-        console.log('\n\n-------\n\n', ctx);
-      }
       ctx.description = md.parse(ctx.description);
 
       data.props.push(ctx);

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -481,7 +481,8 @@ Aggregate.prototype.sortByCount = function(arg) {
  *
  * @see $lookup https://docs.mongodb.org/manual/reference/operator/aggregation/lookup/#pipe._S_lookup
  * @param {Object} options to $lookup as described in the above link
- * @return {Aggregate}* @api public
+ * @return {Aggregate}
+ * @api public
  */
 
 Aggregate.prototype.lookup = function(options) {
@@ -1051,7 +1052,7 @@ Aggregate.prototype.catch = function(reject) {
  * You do not need to call this function explicitly, the JavaScript runtime
  * will call it for you.
  *
- * #### Example
+ * #### Example:
  *
  *     const agg = Model.aggregate([{ $match: { age: { $gte: 25 } } }]);
  *     for await (const doc of agg) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -93,7 +93,7 @@ Connection.prototype.__proto__ = EventEmitter.prototype;
  *
  * Each state change emits its associated event name.
  *
- * #### Example
+ * #### Example:
  *
  *     conn.on('connected', callback);
  *     conn.on('disconnected', callback);
@@ -193,7 +193,7 @@ Connection.prototype.collections;
 /**
  * The name of the database this connection points to.
  *
- * #### Example
+ * #### Example:
  *
  *     mongoose.createConnection('mongodb://localhost:27017/mydb').name; // "mydb"
  *
@@ -210,7 +210,7 @@ Connection.prototype.name;
  * a map from model names to models. Contains all models that have been
  * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).
  *
- * #### Example
+ * #### Example:
  *
  *     const conn = mongoose.createConnection();
  *     const Test = conn.model('Test', mongoose.Schema({ name: String }));
@@ -230,7 +230,7 @@ Connection.prototype.models;
  * A number identifier for this connection. Used for debugging when
  * you have [multiple connections](/docs/connections.html#multiple_connections).
  *
- * #### Example
+ * #### Example:
  *
  *     // The default connection has `id = 0`
  *     mongoose.connection.id; // 0
@@ -274,7 +274,7 @@ Object.defineProperty(Connection.prototype, 'plugins', {
  * The host name portion of the URI. If multiple hosts, such as a replica set,
  * this will contain the first host name in the URI
  *
- * #### Example
+ * #### Example:
  *
  *     mongoose.createConnection('mongodb://localhost:27017/mydb').host; // "localhost"
  *
@@ -294,7 +294,7 @@ Object.defineProperty(Connection.prototype, 'host', {
  * The port portion of the URI. If multiple hosts, such as a replica set,
  * this will contain the port from the first host name in the URI.
  *
- * #### Example
+ * #### Example:
  *
  *     mongoose.createConnection('mongodb://localhost:27017/mydb').port; // 27017
  *
@@ -313,7 +313,7 @@ Object.defineProperty(Connection.prototype, 'port', {
 /**
  * The username specified in the URI
  *
- * #### Example
+ * #### Example:
  *
  *     mongoose.createConnection('mongodb://val:psw@localhost:27017/mydb').user; // "val"
  *
@@ -332,7 +332,7 @@ Object.defineProperty(Connection.prototype, 'user', {
 /**
  * The password specified in the URI
  *
- * #### Example
+ * #### Example:
  *
  *     mongoose.createConnection('mongodb://val:psw@localhost:27017/mydb').pass; // "psw"
  *
@@ -1452,7 +1452,7 @@ Connection.prototype.setClient = function setClient(client) {
  *
  * @param {Object} options
  * @param {Boolean} options.continueOnError `false` by default. If set to `true`, mongoose will not throw an error if one model syncing failed, and will return an object where the keys are the names of the models, and the values are the results/errors for each model.
- * @returns
+ * @return {Promise} Returns a Promise, when the Promise resolves the value is a list of the dropped indexes.
  */
 Connection.prototype.syncIndexes = async function syncIndexes(options = {}) {
   const result = {};

--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -107,7 +107,7 @@ if (Symbol.asyncIterator != null) {
  * Registers a transform function which subsequently maps documents retrieved
  * via the streams interface or `.next()`
  *
- * #### Example
+ * #### Example:
  *
  *     // Map documents returned by `data` events
  *     Thing.
@@ -132,6 +132,7 @@ if (Symbol.asyncIterator != null) {
  *
  * @param {Function} fn
  * @return {AggregationCursor}
+ * @memberOf AggregationCursor
  * @api public
  * @method map
  */
@@ -226,7 +227,7 @@ AggregationCursor.prototype.eachAsync = function(fn, opts, callback) {
  * You do not need to call this function explicitly, the JavaScript runtime
  * will call it for you.
  *
- * #### Example
+ * #### Example:
  *
  *     // Async iterator without explicitly calling `cursor()`. Mongoose still
  *     // creates an AggregationCursor instance internally.

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -112,7 +112,7 @@ QueryCursor.prototype._read = function() {
  * Registers a transform function which subsequently maps documents retrieved
  * via the streams interface or `.next()`
  *
- * #### Example
+ * #### Example:
  *
  *     // Map documents returned by `data` events
  *     Thing.
@@ -137,6 +137,7 @@ QueryCursor.prototype._read = function() {
  *
  * @param {Function} fn
  * @return {QueryCursor}
+ * @memberOf QueryCursor
  * @api public
  * @method map
  */
@@ -211,7 +212,7 @@ QueryCursor.prototype.next = function(callback) {
  * will wait for the promise to resolve before iterating on to the next one.
  * Returns a promise that resolves when done.
  *
- * #### Example
+ * #### Example:
  *
  *     // Iterate over documents asynchronously
  *     Thing.
@@ -300,7 +301,7 @@ QueryCursor.prototype._transformForAsyncIterator = function() {
  * You do not need to call this function explicitly, the JavaScript runtime
  * will call it for you.
  *
- * #### Example
+ * #### Example:
  *
  *     // Works without using `cursor()`
  *     for await (const doc of Model.find([{ $sort: { name: 1 } }])) {
@@ -320,7 +321,7 @@ QueryCursor.prototype._transformForAsyncIterator = function() {
  * support async iterators.
  *
  * @method Symbol.asyncIterator
- * @memberOf Query
+ * @memberOf QueryCursor
  * @instance
  * @api public
  */

--- a/lib/document.js
+++ b/lib/document.js
@@ -300,7 +300,35 @@ Object.defineProperty(Document.prototype, '$locals', {
 
 
 /**
- * Boolean flag specifying if the document is new.
+ * Boolean flag specifying if the document is new. If you create a document
+ * using `new`, this document will be considered "new". `$isNew` is how
+ * Mongoose determines whether `save()` should use `insertOne()` to create
+ * a new document or `updateOne()` to update an existing document.
+ *
+ * #### Example:
+ *     const user = new User({ name: 'John Smith' });
+ *     user.$isNew; // true
+ * 
+ *     await user.save(); // Sends an `insertOne` to MongoDB
+ *
+ * On the other hand, if you load an existing document from the database
+ * using `findOne()` or another [query operation](/docs/queries.html),
+ * `$isNew` will be false.
+ *
+ * #### Example:
+ *     const user = await User.findOne({ name: 'John Smith' });
+ *     user.$isNew; // false
+ *
+ * For subdocuments, `$isNew` is true if either the parent has `$isNew` set,
+ * or if you create a new subdocument.
+ *
+ * #### Example:
+ *     // Assume `Group` has a document array `users`
+ *     const group = await Group.findOne();
+ *     group.users[0].$isNew; // false
+ *
+ *     group.users.push({ name: 'John Smith' });
+ *     group.users[1].$isNew; // true
  *
  * @api public
  * @property $isNew
@@ -311,7 +339,7 @@ Object.defineProperty(Document.prototype, '$locals', {
 Document.prototype.$isNew;
 
 /**
- * Boolean flag specifying if the document is new.
+ * Legacy alias for `$isNew`.
  *
  * @api public
  * @property isNew

--- a/lib/document.js
+++ b/lib/document.js
@@ -308,7 +308,7 @@ Object.defineProperty(Document.prototype, '$locals', {
  * #### Example:
  *     const user = new User({ name: 'John Smith' });
  *     user.$isNew; // true
- * 
+ *
  *     await user.save(); // Sends an `insertOne` to MongoDB
  *
  * On the other hand, if you load an existing document from the database

--- a/lib/document.js
+++ b/lib/document.js
@@ -2167,7 +2167,7 @@ Document.prototype.$isDeleted = function(val) {
  *     doc.isDirectModified('documents.0.title') // true
  *     doc.isDirectModified('documents') // false
  *
- * @param {String|Array<String>} path
+ * @param {String|String[]} path
  * @return {Boolean}
  * @api public
  */
@@ -2223,7 +2223,7 @@ Document.prototype.isInit = function(path) {
  *     doc.isSelected('name') // true
  *     doc.isSelected('age')  // false
  *
- * @param {String|Array<String>} path
+ * @param {String|String[]} path
  * @return {Boolean}
  * @api public
  */
@@ -3110,7 +3110,7 @@ function _checkImmutableSubpaths(subdoc, schematype, priorVal) {
 /**
  * Checks if a path is invalid
  *
- * @param {String|Array<String>} path the field to check
+ * @param {String|String[]} path the field to check
  * @method $isValid
  * @memberOf Document
  * @instance
@@ -4342,7 +4342,7 @@ Document.prototype.$populated = Document.prototype.populated;
  *     doc.$assertPopulated('other path'); // throws an error
  *
  *
- * @param {String|Array<String>} path
+ * @param {String|String[]} path
  * @return {Document} this
  * @memberOf Document
  * @method $assertPopulated

--- a/lib/document.js
+++ b/lib/document.js
@@ -1722,7 +1722,7 @@ Document.prototype.$__setValue = function(path, val) {
 /**
  * Returns the value of a path.
  *
- * #### Example
+ * #### Example:
  *
  *     // path
  *     doc.get('age') // 47
@@ -1895,7 +1895,7 @@ Document.prototype.$ignore = function(path) {
  * A path `a` may be in `modifiedPaths()` but not in `directModifiedPaths()`
  * because a child of `a` was directly modified.
  *
- * #### Example
+ * #### Example:
  *     const schema = new Schema({ foo: String, nested: { bar: String } });
  *     const Model = mongoose.model('Test', schema);
  *     await Model.create({ foo: 'original', nested: { bar: 'original' } });
@@ -2051,7 +2051,7 @@ Document.prototype[documentModifiedPaths] = Document.prototype.modifiedPaths;
  *
  * If `path` is given, checks if a path or any full path containing `path` as part of its path chain has been modified.
  *
- * #### Example
+ * #### Example:
  *
  *     doc.set('documents.0.title', 'changed');
  *     doc.isModified()                      // true
@@ -2097,7 +2097,7 @@ Document.prototype[documentIsModified] = Document.prototype.isModified;
 /**
  * Checks if a path is set to its default.
  *
- * #### Example
+ * #### Example:
  *
  *     MyModel = mongoose.model('test', { name: { type: String, default: 'Val '} });
  *     const m = new MyModel();
@@ -2161,7 +2161,7 @@ Document.prototype.$isDeleted = function(val) {
 /**
  * Returns true if `path` was directly set and modified, else false.
  *
- * #### Example
+ * #### Example:
  *
  *     doc.set('documents.0.title', 'changed');
  *     doc.isDirectModified('documents.0.title') // true
@@ -2217,7 +2217,7 @@ Document.prototype.isInit = function(path) {
 /**
  * Checks if `path` was selected in the source query which initialized this document.
  *
- * #### Example
+ * #### Example:
  *
  *     const doc = await Thing.findOne().select('name');
  *     doc.isSelected('name') // true
@@ -2298,7 +2298,7 @@ Document.prototype.$__isSelected = Document.prototype.isSelected;
  * Checks if `path` was explicitly selected. If no projection, always returns
  * true.
  *
- * #### Example
+ * #### Example:
  *
  *     Thing.findOne().select('nested.name').exec(function (err, doc) {
  *        doc.isDirectSelected('nested.name') // true
@@ -3640,7 +3640,7 @@ Document.prototype.$toObject = function(options, json) {
  *
  *     schema.set('toObject', { virtuals: true })
  *
- * #### Transform
+ * #### Transform:
  *
  * We may need to perform a transformation of the resulting object based on some criteria, say to remove some sensitive information or return a custom object. In this case we set the optional `transform` function.
  *
@@ -3652,7 +3652,7 @@ Document.prototype.$toObject = function(options, json) {
  * - `ret` The plain object representation which has been converted
  * - `options` The options in use (either schema options or the options passed inline)
  *
- * #### Example
+ * #### Example:
  *
  *     // specify the transform schema option
  *     if (!schema.options.toObject) schema.options.toObject = {};

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -56,7 +56,7 @@ module.exports = exports = MongooseError;
  * @see Error.messages #error_messages_MongooseError-messages
  * @api public
  * @memberOf Error
- * @static messages
+ * @static
  */
 
 MongooseError.messages = require('./messages');
@@ -73,7 +73,7 @@ MongooseError.Messages = MongooseError.messages;
  *
  * @api public
  * @memberOf Error
- * @static DocumentNotFoundError
+ * @static
  */
 
 MongooseError.DocumentNotFoundError = require('./notFound');
@@ -84,7 +84,7 @@ MongooseError.DocumentNotFoundError = require('./notFound');
  *
  * @api public
  * @memberOf Error
- * @static CastError
+ * @static
  */
 
 MongooseError.CastError = require('./cast');
@@ -96,7 +96,7 @@ MongooseError.CastError = require('./cast');
  *
  * @api public
  * @memberOf Error
- * @static ValidationError
+ * @static
  */
 
 MongooseError.ValidationError = require('./validation');
@@ -131,7 +131,7 @@ MongooseError.ValidationError = require('./validation');
  *
  * @api public
  * @memberOf Error
- * @static ValidatorError
+ * @static
  */
 
 MongooseError.ValidatorError = require('./validator');
@@ -143,7 +143,7 @@ MongooseError.ValidatorError = require('./validator');
  *
  * @api public
  * @memberOf Error
- * @static VersionError
+ * @static
  */
 
 MongooseError.VersionError = require('./version');
@@ -155,7 +155,7 @@ MongooseError.VersionError = require('./version');
  *
  * @api public
  * @memberOf Error
- * @static ParallelSaveError
+ * @static
  */
 
 MongooseError.ParallelSaveError = require('./parallelSave');
@@ -166,7 +166,7 @@ MongooseError.ParallelSaveError = require('./parallelSave');
  *
  * @api public
  * @memberOf Error
- * @static OverwriteModelError
+ * @static
  */
 
 MongooseError.OverwriteModelError = require('./overwriteModel');
@@ -176,7 +176,7 @@ MongooseError.OverwriteModelError = require('./overwriteModel');
  *
  * @api public
  * @memberOf Error
- * @static MissingSchemaError
+ * @static
  */
 
 MongooseError.MissingSchemaError = require('./missingSchema');
@@ -187,7 +187,7 @@ MongooseError.MissingSchemaError = require('./missingSchema');
  *
  * @api public
  * @memberOf Error
- * @static MongooseServerSelectionError
+ * @static
  */
 
 MongooseError.MongooseServerSelectionError = require('./serverSelection');
@@ -198,7 +198,7 @@ MongooseError.MongooseServerSelectionError = require('./serverSelection');
  *
  * @api public
  * @memberOf Error
- * @static DivergentArrayError
+ * @static
  */
 
 MongooseError.DivergentArrayError = require('./divergentArray');
@@ -210,7 +210,7 @@ MongooseError.DivergentArrayError = require('./divergentArray');
  *
  * @api public
  * @memberOf Error
- * @static StrictModeError
+ * @static
  */
 
 MongooseError.StrictModeError = require('./strict');

--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -16,7 +16,7 @@
  *
  * Click the "show code" link below to see all defaults.
  *
- * @static messages
+ * @static
  * @receiver MongooseError
  * @api public
  */

--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -17,7 +17,7 @@
  * Click the "show code" link below to see all defaults.
  *
  * @static
- * @receiver MongooseError
+ * @memberOf MongooseError
  * @api public
  */
 

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -155,12 +155,12 @@ function castPipelineOperator(op, val) {
  * according to its schema.
  *
  * @param {Schema} schema
- * @param {Object} obj - part of a query
- * @param {String} op - the atomic operator ($pull, $set, etc)
+ * @param {Object} obj part of a query
+ * @param {String} op the atomic operator ($pull, $set, etc)
  * @param {Object} options
  * @param {Boolean|String} [options.strict]
  * @param {Query} context
- * @param {String} pref - path prefix (internal only)
+ * @param {String} pref path prefix (internal only)
  * @return {Bool} true if this path has keys to update
  * @api private
  */
@@ -451,7 +451,7 @@ const overwriteOps = {
  *
  * @param {SchemaType} schema
  * @param {Object} val
- * @param {String} op - the atomic operator ($pull, $set, etc)
+ * @param {String} op the atomic operator ($pull, $set, etc)
  * @param {String} $conditional
  * @param {Query} context
  * @api private

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,6 +172,7 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
 
   const Connection = driver.getConnection();
   _mongoose.connections = [new Connection(_mongoose)];
+  _mongoose.connections[0].models = _mongoose.models;
 
   return _mongoose;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -762,6 +762,8 @@ Mongoose.prototype.Aggregate = Aggregate;
 /**
  * The Mongoose Collection constructor
  *
+ * @memberOf Mongoose
+ * @instance
  * @method Collection
  * @api public
  */
@@ -800,7 +802,7 @@ Object.defineProperty(Mongoose.prototype, 'Connection', {
 /**
  * The Mongoose version
  *
- * #### Example
+ * #### Example:
  *
  *     console.log(mongoose.version); // '5.x.x'
  *
@@ -1045,7 +1047,7 @@ Mongoose.prototype.isObjectIdOrHexString = function(v) {
  *
  * @param {Object} options
  * @param {Boolean} options.continueOnError `false` by default. If set to `true`, mongoose will not throw an error if one model syncing failed, and will return an object where the keys are the names of the models, and the values are the results/errors for each model.
- * @returns
+ * @return {Promise} Returns a Promise, when the Promise resolves the value is a list of the dropped indexes.
  */
 Mongoose.prototype.syncIndexes = function(options) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1822,7 +1822,7 @@ function _ensureIndexes(model, options, callback) {
  * Schema the model uses.
  *
  * @property schema
- * @receiver Model
+ * @static
  * @api public
  * @memberOf Model
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -3687,11 +3687,13 @@ function handleSuccessfulWrite(document, resolve, reject) {
 }
 
 /**
- *
+ * Build bulk write operations for `bulkSave()`.
+ * 
  * @param {Array<Document>} documents The array of documents to build write operations of
  * @param {Object} options
  * @param {Boolean} options.skipValidation defaults to `false`, when set to true, building the write operations will bypass validating the documents.
  * @return {Array<Promise>} Returns a array of all Promises the function executes to be awaited.
+ * @api private
  */
 Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
   if (!Array.isArray(documents)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -2129,7 +2129,7 @@ Model.deleteMany = function deleteMany(conditions, options, callback) {
  *     await MyModel.find({ name: /john/i }, null, { skip: 10 }).exec();
  *
  * @param {Object|ObjectId} filter
- * @param {Object|String|Array<String>} [projection] optional fields to return, see [`Query.prototype.select()`](https://mongoosejs.com/docs/api.html#query_Query-select)
+ * @param {Object|String|String[]} [projection] optional fields to return, see [`Query.prototype.select()`](https://mongoosejs.com/docs/api.html#query_Query-select)
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback]
  * @return {Query}
@@ -2192,7 +2192,7 @@ Model.find = function find(conditions, projection, options, callback) {
  *     await Adventure.findById(id, 'name length').exec();
  *
  * @param {Any} id value of `_id` to query by
- * @param {Object|String|Array<String>} [projection] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [projection] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback]
  * @return {Query}
@@ -2235,7 +2235,7 @@ Model.findById = function findById(id, projection, options, callback) {
  *     await Adventure.findOne({ country: 'Croatia' }, 'name length').exec();
  *
  * @param {Object} [conditions]
- * @param {Object|String|Array<String>} [projection] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [projection] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback]
  * @return {Query}
@@ -2533,7 +2533,7 @@ Model.$where = function $where() {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace(conditions, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
- * @param {Object|String|Array<String>} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Function} [callback]
  * @return {Query}
  * @see Tutorial /docs/tutorials/findoneandupdate.html
@@ -2749,7 +2749,7 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
- * @param {Object|String|Array<String>} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Function} [callback]
  * @return {Query}
@@ -2855,7 +2855,7 @@ Model.findByIdAndDelete = function(id, options, callback) {
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
- * @param {Object|String|Array<String>} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Function} [callback]
  * @return {Query}
  * @api public
@@ -2942,7 +2942,7 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
- * @param {Object|String|Array<String>} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Function} [callback]
  * @return {Query}
  * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
@@ -3008,7 +3008,7 @@ Model.findOneAndRemove = function(conditions, options, callback) {
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
- * @param {Object|String|Array<String>} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
+ * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Function} [callback]
  * @return {Query}
  * @see Model.findOneAndRemove #model_Model.findOneAndRemove
@@ -3288,11 +3288,11 @@ Model.startSession = function() {
  *
  * @param {Array|Object|*} doc(s)
  * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#insertMany)
- * @param {Boolean} [options.ordered = true] if true, will fail fast on the first error encountered. If false, will insert all the documents it can and report errors later. An `insertMany()` with `ordered = false` is called an "unordered" `insertMany()`.
- * @param {Boolean} [options.rawResult = false] if false, the returned promise resolves to the documents that passed mongoose document validation. If `true`, will return the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~insertWriteOpCallback) with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
- * @param {Boolean} [options.lean = false] if `true`, skips hydrating and validating the documents. This option is useful if you need the extra performance, but Mongoose won't validate the documents before inserting.
- * @param {Number} [options.limit = null] this limits the number of documents being processed (validation/casting) by mongoose in parallel, this does **NOT** send the documents in batches to MongoDB. Use this option if you're processing a large number of documents and your app is running out of memory.
- * @param {String|Object|Array} [options.populate = null] populates the result documents. This option is a no-op if `rawResult` is set.
+ * @param {Boolean} [options.ordered=true] if true, will fail fast on the first error encountered. If false, will insert all the documents it can and report errors later. An `insertMany()` with `ordered = false` is called an "unordered" `insertMany()`.
+ * @param {Boolean} [options.rawResult=false] if false, the returned promise resolves to the documents that passed mongoose document validation. If `true`, will return the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~insertWriteOpCallback) with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
+ * @param {Boolean} [options.lean=false] if `true`, skips hydrating and validating the documents. This option is useful if you need the extra performance, but Mongoose won't validate the documents before inserting.
+ * @param {Number} [options.limit=null] this limits the number of documents being processed (validation/casting) by mongoose in parallel, this does **NOT** send the documents in batches to MongoDB. Use this option if you're processing a large number of documents and your app is running out of memory.
+ * @param {String|Object|Array} [options.populate=null] populates the result documents. This option is a no-op if `rawResult` is set.
  * @param {Function} [callback] callback
  * @return {Promise} resolving to the raw result from the MongoDB driver if `options.rawResult` was `true`, or the documents that passed validation, otherwise
  * @api public
@@ -3765,7 +3765,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
  *     const mongooseCandy = Candy.hydrate({ _id: '54108337212ffb6d459f854c', type: 'jelly bean' });
  *
  * @param {Object} obj
- * @param {Object|String|Array<String>} [projection] optional projection containing which fields should be selected for this document
+ * @param {Object|String|String[]} [projection] optional projection containing which fields should be selected for this document
  * @return {Document} document instance
  * @api public
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -212,7 +212,7 @@ Model.prototype.baseModelName;
  * @api public
  * @fires error whenever any query or model function errors
  * @memberOf Model
- * @static events
+ * @static
  */
 
 Model.events;
@@ -899,6 +899,7 @@ Model.prototype.$__version = function(where, delta) {
  *     })
  *
  * @see versionKeys https://mongoosejs.com/docs/guide.html#versionKey
+ * @memberOf Model
  * @api public
  */
 
@@ -1453,7 +1454,7 @@ Model.createCollection = function createCollection(options, callback) {
  * @param {Object} [options] options to pass to `ensureIndexes()`
  * @param {Boolean} [options.background=null] if specified, overrides each index's `background` property
  * @param {Function} [callback] optional callback
- * @return {Promise|undefined} Returns `undefined` if callback is specified, returns a promise if no callback.
+ * @return {Promise|undefined} Returns `undefined` if callback is specified, returns a promise if no callback, when the Promise resolves the value is a list of the dropped indexes.
  * @api public
  */
 
@@ -2383,7 +2384,7 @@ Model.count = function count(conditions, callback) {
  *
  * Passing a `callback` executes the query.
  *
- * #### Example
+ * #### Example:
  *
  *     Link.distinct('url', { clicks: {$gt: 100}}, function (err, result) {
  *       if (err) return handleError(err);
@@ -3613,7 +3614,7 @@ Model.bulkWrite = function(ops, options, callback) {
  *
  * `bulkSave` uses `bulkWrite` under the hood, so it's mostly useful when dealing with many documents (10K+)
  *
- * @param {[Document]} documents
+ * @param {Array<Document>} documents
  * @param {Object} [options] options passed to the underlying `bulkWrite()`
  * @param {ClientSession} [options.session=null] The session associated with this bulk write. See [transactions docs](/docs/transactions.html).
  * @param {String|number} [options.w=1] The [write concern](https://docs.mongodb.com/manual/reference/write-concern/). See [`Query#w()`](/docs/api.html#query_Query-w) for more information.
@@ -3687,10 +3688,10 @@ function handleSuccessfulWrite(document, resolve, reject) {
 
 /**
  *
- * @param {[Document]} documents The array of documents to build write operations of
+ * @param {Array<Document>} documents The array of documents to build write operations of
  * @param {Object} options
  * @param {Boolean} options.skipValidation defaults to `false`, when set to true, building the write operations will bypass validating the documents.
- * @returns
+ * @return {Array<Promise>} Returns a array of all Promises the function executes to be awaited.
  */
 Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
   if (!Array.isArray(documents)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3688,7 +3688,7 @@ function handleSuccessfulWrite(document, resolve, reject) {
 
 /**
  * Build bulk write operations for `bulkSave()`.
- * 
+ *
  * @param {Array<Document>} documents The array of documents to build write operations of
  * @param {Object} options
  * @param {Boolean} options.skipValidation defaults to `false`, when set to true, building the write operations will bypass validating the documents.

--- a/lib/options/SchemaArrayOptions.js
+++ b/lib/options/SchemaArrayOptions.js
@@ -26,7 +26,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property enum
  * @memberOf SchemaArrayOptions
- * @type Array
+ * @type {Array}
  * @instance
  */
 
@@ -46,7 +46,7 @@ Object.defineProperty(SchemaArrayOptions.prototype, 'enum', opts);
  * @api public
  * @property of
  * @memberOf SchemaArrayOptions
- * @type Function|String
+ * @type {Function|String}
  * @instance
  */
 

--- a/lib/options/SchemaArrayOptions.js
+++ b/lib/options/SchemaArrayOptions.js
@@ -52,6 +52,25 @@ Object.defineProperty(SchemaArrayOptions.prototype, 'enum', opts);
 
 Object.defineProperty(SchemaArrayOptions.prototype, 'of', opts);
 
+/**
+ * If set to `false`, will always deactivate casting non-array values to arrays.
+ * If set to `true`, will cast non-array values to arrays if `init` and `SchemaArray.options.castNonArrays` are also `true`
+ *
+ * #### Example:
+ *
+ *     const Model = db.model('Test', new Schema({ x1: { castNonArrays: false, type: [String] } }));
+ *     const doc = new Model({ x1: "some non-array value" });
+ *     await doc.validate(); // Errors with "CastError"
+ *
+ * @api public
+ * @property castNonArrays
+ * @memberOf SchemaArrayOptions
+ * @type {Boolean}
+ * @instance
+ */
+
+Object.defineProperty(SchemaArrayOptions.prototype, 'castNonArrays', opts);
+
 /*!
  * ignore
  */

--- a/lib/options/SchemaBufferOptions.js
+++ b/lib/options/SchemaBufferOptions.js
@@ -25,7 +25,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property subtype
  * @memberOf SchemaBufferOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 

--- a/lib/options/SchemaDateOptions.js
+++ b/lib/options/SchemaDateOptions.js
@@ -26,7 +26,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property min
  * @memberOf SchemaDateOptions
- * @type Date
+ * @type {Date}
  * @instance
  */
 
@@ -39,7 +39,7 @@ Object.defineProperty(SchemaDateOptions.prototype, 'min', opts);
  * @api public
  * @property max
  * @memberOf SchemaDateOptions
- * @type Date
+ * @type {Date}
  * @instance
  */
 
@@ -58,7 +58,7 @@ Object.defineProperty(SchemaDateOptions.prototype, 'max', opts);
  * @api public
  * @property expires
  * @memberOf SchemaDateOptions
- * @type Date
+ * @type {Date}
  * @instance
  */
 

--- a/lib/options/SchemaDocumentArrayOptions.js
+++ b/lib/options/SchemaDocumentArrayOptions.js
@@ -35,7 +35,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property excludeIndexes
  * @memberOf SchemaDocumentArrayOptions
- * @type Array
+ * @type {Array}
  * @instance
  */
 
@@ -55,7 +55,7 @@ Object.defineProperty(SchemaDocumentArrayOptions.prototype, 'excludeIndexes', op
  * @api public
  * @property _id
  * @memberOf SchemaDocumentArrayOptions
- * @type Array
+ * @type {Array}
  * @instance
  */
 

--- a/lib/options/SchemaMapOptions.js
+++ b/lib/options/SchemaMapOptions.js
@@ -34,7 +34,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property of
  * @memberOf SchemaMapOptions
- * @type Function|string
+ * @type {Function|string}
  * @instance
  */
 

--- a/lib/options/SchemaNumberOptions.js
+++ b/lib/options/SchemaNumberOptions.js
@@ -26,7 +26,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property min
  * @memberOf SchemaNumberOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 
@@ -39,7 +39,7 @@ Object.defineProperty(SchemaNumberOptions.prototype, 'min', opts);
  * @api public
  * @property max
  * @memberOf SchemaNumberOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 
@@ -61,7 +61,7 @@ Object.defineProperty(SchemaNumberOptions.prototype, 'max', opts);
  * @api public
  * @property enum
  * @memberOf SchemaNumberOptions
- * @type Array
+ * @type {Array}
  * @instance
  */
 
@@ -86,7 +86,7 @@ Object.defineProperty(SchemaNumberOptions.prototype, 'enum', opts);
  * @api public
  * @property populate
  * @memberOf SchemaNumberOptions
- * @type Object
+ * @type {Object}
  * @instance
  */
 

--- a/lib/options/SchemaObjectIdOptions.js
+++ b/lib/options/SchemaObjectIdOptions.js
@@ -25,7 +25,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property auto
  * @memberOf SchemaObjectIdOptions
- * @type Boolean
+ * @type {Boolean}
  * @instance
  */
 
@@ -50,7 +50,7 @@ Object.defineProperty(SchemaObjectIdOptions.prototype, 'auto', opts);
  * @api public
  * @property populate
  * @memberOf SchemaObjectIdOptions
- * @type Object
+ * @type {Object}
  * @instance
  */
 

--- a/lib/options/SchemaStringOptions.js
+++ b/lib/options/SchemaStringOptions.js
@@ -25,7 +25,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property enum
  * @memberOf SchemaStringOptions
- * @type Array
+ * @type {Array}
  * @instance
  */
 
@@ -38,7 +38,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'enum', opts);
  * @api public
  * @property match
  * @memberOf SchemaStringOptions
- * @type RegExp
+ * @type {RegExp}
  * @instance
  */
 
@@ -51,7 +51,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'match', opts);
  * @api public
  * @property lowercase
  * @memberOf SchemaStringOptions
- * @type Boolean
+ * @type {Boolean}
  * @instance
  */
 
@@ -64,7 +64,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'lowercase', opts);
  * @api public
  * @property trim
  * @memberOf SchemaStringOptions
- * @type Boolean
+ * @type {Boolean}
  * @instance
  */
 
@@ -77,7 +77,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'trim', opts);
  * @api public
  * @property uppercase
  * @memberOf SchemaStringOptions
- * @type Boolean
+ * @type {Boolean}
  * @instance
  */
 
@@ -94,7 +94,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'uppercase', opts);
  * @api public
  * @property minLength
  * @memberOf SchemaStringOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 
@@ -112,7 +112,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'minlength', opts);
  * @api public
  * @property maxLength
  * @memberOf SchemaStringOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 
@@ -125,7 +125,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'maxlength', opts);
  * @api public
  * @property populate
  * @memberOf SchemaStringOptions
- * @type Object
+ * @type {Object}
  * @instance
  */
 

--- a/lib/options/SchemaSubdocumentOptions.js
+++ b/lib/options/SchemaSubdocumentOptions.js
@@ -33,7 +33,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property of
  * @memberOf SchemaSubdocumentOptions
- * @type Function|string
+ * @type {Function|string}
  * @instance
  */
 

--- a/lib/options/SchemaTypeOptions.js
+++ b/lib/options/SchemaTypeOptions.js
@@ -31,7 +31,7 @@ const opts = require('./propertyOptions');
  * @api public
  * @property type
  * @memberOf SchemaTypeOptions
- * @type Function|String|Object
+ * @type {Function|String|Object}
  * @instance
  */
 
@@ -43,7 +43,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'type', opts);
  * @api public
  * @property validate
  * @memberOf SchemaTypeOptions
- * @type Function|Object
+ * @type {Function|Object}
  * @instance
  */
 
@@ -74,7 +74,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'validate', opts);
  * @api public
  * @property cast
  * @memberOf SchemaTypeOptions
- * @type String
+ * @type {String}
  * @instance
  */
 
@@ -88,7 +88,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'cast', opts);
  * @api public
  * @property required
  * @memberOf SchemaTypeOptions
- * @type Function|Boolean
+ * @type {Function|Boolean}
  * @instance
  */
 
@@ -101,7 +101,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'required', opts);
  * @api public
  * @property default
  * @memberOf SchemaTypeOptions
- * @type Function|Any
+ * @type {Function|Any}
  * @instance
  */
 
@@ -113,7 +113,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'default', opts);
  * @api public
  * @property ref
  * @memberOf SchemaTypeOptions
- * @type Function|String
+ * @type {Function|String}
  * @instance
  */
 
@@ -126,7 +126,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'ref', opts);
  * @api public
  * @property ref
  * @memberOf SchemaTypeOptions
- * @type Function|String
+ * @type {Function|String}
  * @instance
  */
 
@@ -139,7 +139,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'refPath', opts);
  * @api public
  * @property select
  * @memberOf SchemaTypeOptions
- * @type Boolean|Number
+ * @type {Boolean|Number}
  * @instance
  */
 
@@ -152,7 +152,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'select', opts);
  * @api public
  * @property index
  * @memberOf SchemaTypeOptions
- * @type Boolean|Number|Object
+ * @type {Boolean|Number|Object}
  * @instance
  */
 
@@ -166,7 +166,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'index', opts);
  * @api public
  * @property unique
  * @memberOf SchemaTypeOptions
- * @type Boolean|Number
+ * @type {Boolean|Number}
  * @instance
  */
 
@@ -180,7 +180,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'unique', opts);
  * @api public
  * @property immutable
  * @memberOf SchemaTypeOptions
- * @type Function|Boolean
+ * @type {Function|Boolean}
  * @instance
  */
 
@@ -193,7 +193,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'immutable', opts);
  * @api public
  * @property sparse
  * @memberOf SchemaTypeOptions
- * @type Boolean|Number
+ * @type {Boolean|Number}
  * @instance
  */
 
@@ -206,7 +206,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'sparse', opts);
  * @api public
  * @property text
  * @memberOf SchemaTypeOptions
- * @type Boolean|Number|Object
+ * @type {Boolean|Number|Object}
  * @instance
  */
 
@@ -235,7 +235,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'text', opts);
  * @api public
  * @property transform
  * @memberOf SchemaTypeOptions
- * @type Function
+ * @type {Function}
  * @instance
  */
 

--- a/lib/options/VirtualOptions.js
+++ b/lib/options/VirtualOptions.js
@@ -19,7 +19,7 @@ class VirtualOptions {
  * @api public
  * @property ref
  * @memberOf VirtualOptions
- * @type String|Model|Function
+ * @type {String|Model|Function}
  * @instance
  */
 
@@ -32,7 +32,7 @@ Object.defineProperty(VirtualOptions.prototype, 'ref', opts);
  * @api public
  * @property refPath
  * @memberOf VirtualOptions
- * @type String|Function
+ * @type {String|Function}
  * @instance
  */
 
@@ -45,7 +45,7 @@ Object.defineProperty(VirtualOptions.prototype, 'refPath', opts);
  * @api public
  * @property localField
  * @memberOf VirtualOptions
- * @type String|Function
+ * @type {String|Function}
  * @instance
  */
 
@@ -58,7 +58,7 @@ Object.defineProperty(VirtualOptions.prototype, 'localField', opts);
  * @api public
  * @property foreignField
  * @memberOf VirtualOptions
- * @type String|Function
+ * @type {String|Function}
  * @instance
  */
 
@@ -71,7 +71,7 @@ Object.defineProperty(VirtualOptions.prototype, 'foreignField', opts);
  * @api public
  * @property justOne
  * @memberOf VirtualOptions
- * @type Boolean
+ * @type {Boolean}
  * @instance
  */
 
@@ -86,7 +86,7 @@ Object.defineProperty(VirtualOptions.prototype, 'justOne', opts);
  * @api public
  * @property count
  * @memberOf VirtualOptions
- * @type Boolean
+ * @type {Boolean}
  * @instance
  */
 
@@ -99,7 +99,7 @@ Object.defineProperty(VirtualOptions.prototype, 'count', opts);
  * @api public
  * @property match
  * @memberOf VirtualOptions
- * @type Object|Function
+ * @type {Object|Function}
  * @instance
  */
 
@@ -115,7 +115,7 @@ Object.defineProperty(VirtualOptions.prototype, 'match', opts);
  * @api public
  * @property options
  * @memberOf VirtualOptions
- * @type Object
+ * @type {Object}
  * @instance
  */
 
@@ -127,7 +127,7 @@ Object.defineProperty(VirtualOptions.prototype, 'options', opts);
  * @api public
  * @property skip
  * @memberOf VirtualOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 
@@ -139,7 +139,7 @@ Object.defineProperty(VirtualOptions.prototype, 'skip', opts);
  * @api public
  * @property limit
  * @memberOf VirtualOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 
@@ -155,7 +155,7 @@ Object.defineProperty(VirtualOptions.prototype, 'limit', opts);
  * @api public
  * @property perDocumentLimit
  * @memberOf VirtualOptions
- * @type Number
+ * @type {Number}
  * @instance
  */
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -170,7 +170,7 @@ Query.base = mquery.prototype;
  * @default true
  * @property use$geoWithin
  * @memberOf Query
- * @receiver Query
+ * @static
  * @api public
  */
 
@@ -1847,7 +1847,7 @@ Query.prototype.setUpdate = function(val) {
  * @method _fieldsForExec
  * @return {Object}
  * @api private
- * @receiver Query
+ * @memberOf Query
  */
 
 Query.prototype._fieldsForExec = function() {
@@ -1859,8 +1859,9 @@ Query.prototype._fieldsForExec = function() {
  * Return an update document with corrected `$set` operations.
  *
  * @method _updateForExec
+ * @return {Object}
  * @api private
- * @receiver Query
+ * @memberOf Query
  */
 
 Query.prototype._updateForExec = function() {
@@ -1907,10 +1908,12 @@ Query.prototype._updateForExec = function() {
 /**
  * Makes sure _path is set.
  *
+ * This method is inherited by `mquery`
+ *
  * @method _ensurePath
  * @param {String} method
  * @api private
- * @receiver Query
+ * @memberOf Query
  */
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -179,7 +179,7 @@ Query.use$geoWithin = mquery.use$geoWithin;
 /**
  * Converts this query to a customized, reusable query constructor with all arguments and options retained.
  *
- * #### Example
+ * #### Example:
  *
  *     // Create a query for adventure movies and read from the primary
  *     // node in the replica-set unless it is down, in which case we'll
@@ -309,7 +309,7 @@ Query.prototype.clone = function clone() {
 /**
  * Specifies a javascript function or expression to pass to MongoDBs query system.
  *
- * #### Example
+ * #### Example:
  *
  *     query.$where('this.comments.length === 10 || this.name.length === 5')
  *
@@ -337,7 +337,7 @@ Query.prototype.clone = function clone() {
 /**
  * Specifies a `path` for use with chaining.
  *
- * #### Example
+ * #### Example:
  *
  *     // instead of writing:
  *     User.find({age: {$gte: 21, $lte: 65}}, callback);
@@ -367,7 +367,7 @@ Query.prototype.clone = function clone() {
 /**
  * Specifies a `$slice` projection for an array.
  *
- * #### Example
+ * #### Example:
  *
  *     query.slice('comments', 5);
  *     query.slice('comments', -5);
@@ -445,7 +445,7 @@ Query.prototype._validateOp = function() {
 /**
  * Specifies the complementary comparison value for paths specified with `where()`
  *
- * #### Example
+ * #### Example:
  *
  *     User.where('age').equals(49);
  *
@@ -464,7 +464,7 @@ Query.prototype._validateOp = function() {
 /**
  * Specifies arguments for an `$or` condition.
  *
- * #### Example
+ * #### Example:
  *
  *     query.or([{ color: 'red' }, { status: 'emergency' }]);
  *
@@ -480,7 +480,7 @@ Query.prototype._validateOp = function() {
 /**
  * Specifies arguments for a `$nor` condition.
  *
- * #### Example
+ * #### Example:
  *
  *     query.nor([{ color: 'green' }, { status: 'ok' }]);
  *
@@ -496,7 +496,7 @@ Query.prototype._validateOp = function() {
 /**
  * Specifies arguments for a `$and` condition.
  *
- * #### Example
+ * #### Example:
  *
  *     query.and([{ color: 'green' }, { status: 'ok' }])
  *
@@ -514,7 +514,7 @@ Query.prototype._validateOp = function() {
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
- * #### Example
+ * #### Example:
  *
  *     Thing.find().where('age').gt(21);
  *
@@ -639,7 +639,7 @@ Query.prototype._validateOp = function() {
  *
  * When called with one argument, the most recent path passed to `where()` is used.
  *
- * #### Example
+ * #### Example:
  *
  *     const docs = await MyModel.where('tags').size(0).exec();
  *     assert(Array.isArray(docs));
@@ -686,7 +686,7 @@ Query.prototype._validateOp = function() {
  * Specifies a `$mod` condition, filters documents for documents whose
  * `path` property is a number that is equal to `remainder` modulo `divisor`.
  *
- * #### Example
+ * #### Example:
  *
  *     // All find products whose inventory is odd
  *     Product.find().mod('inventory', [2, 1]);
@@ -732,7 +732,7 @@ Query.prototype.mod = function() {
 /**
  * Specifies an `$exists` condition
  *
- * #### Example
+ * #### Example:
  *
  *     // { name: { $exists: true }}
  *     Thing.where('name').exists()
@@ -756,7 +756,7 @@ Query.prototype.mod = function() {
 /**
  * Specifies an `$elemMatch` condition
  *
- * #### Example
+ * #### Example:
  *
  *     query.elemMatch('comment', { author: 'autobot', votes: {$gte: 5}})
  *
@@ -785,7 +785,7 @@ Query.prototype.mod = function() {
 /**
  * Defines a `$within` or `$geoWithin` argument for geo-spatial queries.
  *
- * #### Example
+ * #### Example:
  *
  *     query.where(path).within().box()
  *     query.where(path).within().circle()
@@ -824,11 +824,11 @@ Query.prototype.mod = function() {
 /**
  * Specifies the maximum number of documents the query will return.
  *
- * #### Example
+ * #### Example:
  *
  *     query.limit(20);
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -857,11 +857,11 @@ Query.prototype.limit = function limit(v) {
 /**
  * Specifies the number of documents to skip.
  *
- * #### Example
+ * #### Example:
  *
  *     query.skip(100).limit(20);
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -891,11 +891,11 @@ Query.prototype.skip = function skip(v) {
 /**
  * Specifies the maxScan option.
  *
- * #### Example
+ * #### Example:
  *
  *     query.maxScan(100);
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -910,11 +910,11 @@ Query.prototype.skip = function skip(v) {
 /**
  * Specifies the batchSize option.
  *
- * #### Example
+ * #### Example:
  *
  *     query.batchSize(100)
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -929,11 +929,11 @@ Query.prototype.skip = function skip(v) {
 /**
  * Specifies the `comment` option.
  *
- * #### Example
+ * #### Example:
  *
  *     query.comment('login query')
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -948,13 +948,13 @@ Query.prototype.skip = function skip(v) {
 /**
  * Specifies this query as a `snapshot` query.
  *
- * #### Example
+ * #### Example:
  *
  *     query.snapshot(); // true
  *     query.snapshot(true);
  *     query.snapshot(false);
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -969,11 +969,11 @@ Query.prototype.skip = function skip(v) {
 /**
  * Sets query hints.
  *
- * #### Example
+ * #### Example:
  *
  *     query.hint({ indexA: 1, indexB: -1 });
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -1036,7 +1036,7 @@ Query.prototype.projection = function(arg) {
  * either list the fields to include (which excludes all others), or list the fields
  * to exclude (which implies all other fields are included). The [`_id` field is the only exception because MongoDB includes it by default](https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results/#suppress-id-field).
  *
- * #### Example
+ * #### Example:
  *
  *     // include a and b, exclude other fields
  *     query.select('a b');
@@ -2291,7 +2291,7 @@ Query.prototype._find = wrapThunk(function(callback) {
  * If there are too many documents in the result to fit in memory, use
  * [`Query.prototype.cursor()`](api.html#query_Query-cursor)
  *
- * #### Example
+ * #### Example:
  *
  *     // Using async/await
  *     const arr = await Movie.find({ year: { $gte: 1980, $lte: 1989 } });
@@ -2506,7 +2506,7 @@ Query.prototype._findOne = wrapThunk(function(callback) {
  *
  * - `findOne()`
  *
- * #### Example
+ * #### Example:
  *
  *     const query  = Kitten.where({ color: 'white' });
  *     query.findOne(function (err, kitten) {
@@ -2857,7 +2857,7 @@ Query.prototype.__distinct = wrapThunk(function __distinct(callback) {
  *
  * This function does not trigger any middleware.
  *
- * #### Example
+ * #### Example:
  *
  *     distinct(field, conditions, callback)
  *     distinct(field, conditions)
@@ -2918,7 +2918,7 @@ Query.prototype.distinct = function(field, conditions, callback) {
  * sort order of each path is ascending unless the path name is prefixed with `-`
  * which will be treated as descending.
  *
- * #### Example
+ * #### Example:
  *
  *     // sort by "field" ascending and "test" descending
  *     query.sort({ field: 'asc', test: -1 });
@@ -2926,7 +2926,7 @@ Query.prototype.distinct = function(field, conditions, callback) {
  *     // equivalent
  *     query.sort('field -test');
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -2951,7 +2951,7 @@ Query.prototype.sort = function(arg) {
  *
  * This function does not trigger any middleware
  *
- * #### Example
+ * #### Example:
  *
  *     Character.remove({ name: /Stark/ }, callback);
  *
@@ -2963,13 +2963,13 @@ Query.prototype.sort = function(arg) {
  * - `deletedCount`: the number of documents deleted
  * - `n`: the number of documents deleted. Equal to `deletedCount`.
  *
- * #### Example
+ * #### Example:
  *
  *     const res = await Character.remove({ name: /Stark/ });
  *     // Number of docs deleted
  *     res.deletedCount;
  *
- * #### Note
+ * #### Note:
  *
  * Calling `remove()` creates a [Mongoose query](./queries.html), and a query
  * does not execute until you either pass a callback, call [`Query#then()`](#query_Query-then),
@@ -3043,7 +3043,7 @@ Query.prototype._remove = wrapThunk(function(callback) {
  *
  * This function triggers `deleteOne` middleware.
  *
- * #### Example
+ * #### Example:
  *
  *     await Character.deleteOne({ name: 'Eddard Stark' });
  *
@@ -3058,7 +3058,7 @@ Query.prototype._remove = wrapThunk(function(callback) {
  * - `deletedCount`: the number of documents deleted
  * - `n`: the number of documents deleted. Equal to `deletedCount`.
  *
- * #### Example
+ * #### Example:
  *
  *     const res = await Character.deleteOne({ name: 'Eddard Stark' });
  *     // `1` if MongoDB deleted a doc, `0` if no docs matched the filter `{ name: ... }`
@@ -3129,7 +3129,7 @@ Query.prototype._deleteOne = wrapThunk(function(callback) {
  *
  * This function triggers `deleteMany` middleware.
  *
- * #### Example
+ * #### Example:
  *
  *     await Character.deleteMany({ name: /Stark/, age: { $gte: 18 } });
  *
@@ -3144,7 +3144,7 @@ Query.prototype._deleteOne = wrapThunk(function(callback) {
  * - `deletedCount`: the number of documents deleted
  * - `n`: the number of documents deleted. Equal to `deletedCount`.
  *
- * #### Example
+ * #### Example:
  *
  *     const res = await Character.deleteMany({ name: /Stark/, age: { $gte: 18 } });
  *     // `0` if no docs matched the filter, number of docs deleted otherwise
@@ -3296,7 +3296,7 @@ function prepareDiscriminatorCriteria(query) {
  *       // doc: the document before updates are applied if `new: false`, or after updates if `new = true`
  *     }
  *
- * #### Examples
+ * #### Examples:
  *
  *     query.findOneAndUpdate(conditions, update, options, callback) // executes
  *     query.findOneAndUpdate(conditions, update, options)  // returns Query
@@ -3438,7 +3438,7 @@ Query.prototype._findOneAndUpdate = wrapThunk(function(callback) {
  *       // doc: the document before updates are applied if `new: false`, or after updates if `new = true`
  *     }
  *
- * #### Examples
+ * #### Examples:
  *
  *     A.where().findOneAndRemove(conditions, options, callback) // executes
  *     A.where().findOneAndRemove(conditions, options)  // return Query
@@ -3525,7 +3525,7 @@ Query.prototype.findOneAndRemove = function(conditions, options, callback) {
  *       // doc: the document before updates are applied if `new: false`, or after updates if `new = true`
  *     }
  *
- * #### Examples
+ * #### Examples:
  *
  *     A.where().findOneAndDelete(conditions, options, callback) // executes
  *     A.where().findOneAndDelete(conditions, options)  // return Query
@@ -3644,7 +3644,7 @@ Query.prototype._findOneAndDelete = wrapThunk(function(callback) {
  *       // doc: the document before updates are applied if `new: false`, or after updates if `new = true`
  *     }
  *
- * #### Examples
+ * #### Examples:
  *
  *     A.where().findOneAndReplace(filter, replacement, options, callback); // executes
  *     A.where().findOneAndReplace(filter, replacement, options); // return Query
@@ -3865,7 +3865,7 @@ function _getOption(query, option, def) {
 /*!
  * Override mquery.prototype._findAndModify to provide casting etc.
  *
- * @param {String} type - either "remove" or "update"
+ * @param {String} type either "remove" or "update"
  * @param {Function} callback
  * @api private
  */
@@ -4285,7 +4285,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  *
  * - `update()`
  *
- * #### Example
+ * #### Example:
  *
  *     Model.where({ _id: id }).update({ title: 'words' });
  *
@@ -4303,11 +4303,11 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  *  - `read`
  *  - `writeConcern`
  *
- * #### Note
+ * #### Note:
  *
  * Passing an empty object `{}` as the doc will result in a no-op. The update operation will be ignored and the callback executed without sending the command to MongoDB.
  *
- * #### Note
+ * #### Note:
  *
  * The operation is only executed when a callback is passed. To force execution without a callback, we must first call update() and then execute it by using the `exec()` method.
  *
@@ -5164,7 +5164,7 @@ function _getPopulatedPaths(list, arr, prefix) {
 /**
  * Casts this query to the schema of `model`
  *
- * #### Note
+ * #### Note:
  *
  * If `obj` is present, it is cast instead of this query.
  *
@@ -5289,7 +5289,7 @@ Query.prototype._applyPaths = function applyPaths() {
  *
  * The `.cursor()` function triggers pre find hooks, but **not** post find hooks.
  *
- * #### Example
+ * #### Example:
  *
  *     // There are 2 ways to use a cursor. First, as a stream:
  *     Thing.
@@ -5360,7 +5360,7 @@ Query.prototype.maxscan = Query.base.maxScan;
 /**
  * Sets the tailable option (for use with capped collections).
  *
- * #### Example
+ * #### Example:
  *
  *     query.tailable(); // true
  *     query.tailable(true);
@@ -5369,7 +5369,7 @@ Query.prototype.maxscan = Query.base.maxScan;
  *     // Set both `tailable` and `awaitData` options
  *     query.tailable({ awaitData: true });
  *
- * #### Note
+ * #### Note:
  *
  * Cannot be used with `distinct()`
  *
@@ -5410,7 +5410,7 @@ Query.prototype.tailable = function(val, opts) {
 /**
  * Declares an intersects query for `geometry()`.
  *
- * #### Example
+ * #### Example:
  *
  *     query.where('path').intersects().geometry({
  *       type: 'LineString',
@@ -5443,7 +5443,7 @@ Query.prototype.tailable = function(val, opts) {
 /**
  * Specifies a `$geometry` condition
  *
- * #### Example
+ * #### Example:
  *
  *     const polyA = [[[ 10, 20 ], [ 10, 40 ], [ 30, 40 ], [ 30, 20 ]]]
  *     query.where('loc').within().geometry({ type: 'Polygon', coordinates: polyA })
@@ -5485,7 +5485,7 @@ Query.prototype.tailable = function(val, opts) {
  *
  * These operators return documents sorted by distance.
  *
- * #### Example
+ * #### Example:
  *
  *     query.where('loc').near({ center: [10, 10] });
  *     query.where('loc').near({ center: [10, 10], maxDistance: 5 });
@@ -5568,13 +5568,13 @@ Query.prototype.near = function() {
 /**
  * _DEPRECATED_ Specifies a `$nearSphere` condition
  *
- * #### Example
+ * #### Example:
  *
  *     query.where('loc').nearSphere({ center: [10, 10], maxDistance: 5 });
  *
  * **Deprecated.** Use `query.near()` instead with the `spherical` option set to `true`.
  *
- * #### Example
+ * #### Example:
  *
  *     query.where('loc').near({ center: [10, 10], spherical: true });
  *
@@ -5597,7 +5597,7 @@ Query.prototype.nearSphere = function() {
  * You do not need to call this function explicitly, the JavaScript runtime
  * will call it for you.
  *
- * #### Example
+ * #### Example:
  *
  *     for await (const doc of Model.aggregate([{ $sort: { name: 1 } }])) {
  *       console.log(doc.name);
@@ -5625,7 +5625,7 @@ if (Symbol.asyncIterator != null) {
 /**
  * Specifies a `$polygon` condition
  *
- * #### Example
+ * #### Example:
  *
  *     query.where('loc').within().polygon([10, 20], [13, 25], [7, 15]);
  *     query.polygon('loc', [10, 20], [13, 25], [7, 15]);
@@ -5644,7 +5644,7 @@ if (Symbol.asyncIterator != null) {
 /**
  * Specifies a `$box` condition
  *
- * #### Example
+ * #### Example:
  *
  *     const lowerLeft = [40.73083, -73.99756]
  *     const upperRight= [40.741404,  -73.988135]
@@ -5658,8 +5658,8 @@ if (Symbol.asyncIterator != null) {
  * @see $box https://docs.mongodb.org/manual/reference/operator/box/
  * @see within() Query#within #query_Query-within
  * @see https://www.mongodb.org/display/DOCS/Geospatial+Indexing
- * @param {Object} val
- * @param [Array] Upper Right Coords
+ * @param {Object|Array<Number>} val1 Lower Left Coordinates OR a object of lower-left(ll) and upper-right(ur) Coordinates
+ * @param {Array<Number>} [val2] Upper Right Coordinates
  * @return {Query} this
  * @api public
  */
@@ -5681,7 +5681,7 @@ Query.prototype.box = function(ll, ur) {
 /**
  * Specifies a `$center` or `$centerSphere` condition.
  *
- * #### Example
+ * #### Example:
  *
  *     const area = { center: [50, 50], radius: 10, unique: true }
  *     query.where('loc').within().circle(area)
@@ -5726,7 +5726,7 @@ Query.prototype.center = Query.base.circle;
  *
  * **Deprecated.** Use [circle](#query_Query-circle) instead.
  *
- * #### Example
+ * #### Example:
  *
  *     const area = { center: [50, 50], radius: 10 };
  *     query.where('loc').within().centerSphere(area);

--- a/lib/query.js
+++ b/lib/query.js
@@ -1069,7 +1069,7 @@ Query.prototype.projection = function(arg) {
  * @method select
  * @memberOf Query
  * @instance
- * @param {Object|String|Array<String>} arg
+ * @param {Object|String|String[]} arg
  * @return {Query} this
  * @see SchemaType
  * @api public
@@ -5038,7 +5038,7 @@ function castQuery(query) {
  * a response for each query has also been returned, the results are passed to
  * the callback.
  *
- * @param {Object|String|Array<String>} path either the path(s) to populate or an object specifying all parameters
+ * @param {Object|String|String[]} path either the path(s) to populate or an object specifying all parameters
  * @param {Object|String} [select] Field selection for the population query
  * @param {Model} [model] The model you wish to use for population. If not specified, populate will look up the model by the name in the Schema's `ref` field.
  * @param {Object} [match] Conditions for the population query

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -788,7 +788,7 @@ reserved.collection = 1;
  * Sets a path (if arity 2)
  * Gets a path (if arity 1)
  *
- * #### Example
+ * #### Example:
  *
  *     schema.path('name') // returns a SchemaType
  *     schema.path('name', Number) // changes the schemaType of `name` to Number
@@ -1545,7 +1545,7 @@ Schema.prototype.queue = function(name, args) {
 /**
  * Defines a pre hook for the model.
  *
- * #### Example
+ * #### Example:
  *
  *     const toySchema = new Schema({ name: String, created: Date });
  *
@@ -1701,7 +1701,7 @@ Schema.prototype.plugin = function(fn, opts) {
 /**
  * Adds an instance method to documents constructed from Models compiled from this schema.
  *
- * #### Example
+ * #### Example:
  *
  *     const schema = kittySchema = new Schema(..);
  *
@@ -1748,7 +1748,7 @@ Schema.prototype.method = function(name, fn, options) {
 /**
  * Adds static "class" methods to Models compiled from this schema.
  *
- * #### Example
+ * #### Example:
  *
  *     const schema = new Schema(..);
  *     // Equivalent to `schema.statics.findByName = function(name) {}`;
@@ -1781,7 +1781,7 @@ Schema.prototype.static = function(name, fn) {
 /**
  * Defines an index (most likely compound) for this schema.
  *
- * #### Example
+ * #### Example:
  *
  *     schema.index({ first: 1, last: -1 })
  *
@@ -1806,7 +1806,7 @@ Schema.prototype.index = function(fields, options) {
 /**
  * Sets a schema option.
  *
- * #### Example
+ * #### Example:
  *
  *     schema.set('strict'); // 'true' by default
  *     schema.set('strict', false); // Sets 'strict' to false
@@ -1874,7 +1874,7 @@ Schema.prototype.get = function(key) {
  * The allowed index types
  *
  * @receiver Schema
- * @static indexTypes
+ * @static
  * @api public
  */
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1577,7 +1577,7 @@ Schema.prototype.queue = function(name, args) {
  *       // Runs when you call `doc.deleteOne()`
  *     });
  *
- * @param {String|RegExp} The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} methodName The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware. For example, set `options.document` to `true` to apply this hook to `Document#deleteOne()` rather than `Query#deleteOne()`.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
@@ -1633,7 +1633,7 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fires after the post find hook');
  *     });
  *
- * @param {String|RegExp} The method name or regular expression to match method name
+ * @param {String|RegExp|String[]} methodName The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -79,6 +79,7 @@ let id = 0;
  * - [pluginTags](/docs/guide.html#pluginTags): array of strings - defaults to `undefined`. If set and plugin called with `tags` option, will only apply that plugin to schemas with a matching tag.
  *
  * #### Options for Nested Schemas:
+ *
  * - `excludeIndexes`: bool - defaults to `false`. If `true`, skip building indexes on this schema's paths.
  *
  * #### Note:
@@ -233,6 +234,7 @@ Object.defineProperty(Schema.prototype, 'childSchemas', {
  * You do not need to interact with this property at all to use mongoose.
  *
  * #### Example:
+ *
  *     const schema = new Schema({});
  *     schema.virtual('answer').get(() => 42);
  *
@@ -272,6 +274,7 @@ Schema.prototype.obj;
  * in this schema, and the values are instances of the SchemaType class.
  *
  * #### Example:
+ *
  *     const schema = new Schema({ name: String }, { _id: false });
  *     schema.paths; // { name: SchemaString { ... } }
  *
@@ -290,6 +293,7 @@ Schema.prototype.paths;
  * Schema as a tree
  *
  * #### Example:
+ *
  *     {
  *         '_id'     : ObjectId
  *       , 'nested'  : {
@@ -395,8 +399,8 @@ Schema.prototype._clone = function _clone(Constructor) {
  *     newSchema.path('name'); // SchemaString { ... }
  *     newSchema.path('age'); // undefined
  *
- * @param {Array} paths list of paths to pick
- * @param {Object} [options] options to pass to the schema constructor. Defaults to `this.options` if not set.
+ * @param {String[]} paths List of Paths to pick for the new Schema
+ * @param {Object} [options] Options to pass to the new Schema Constructor (same as `new Schema(.., Options)`). Defaults to `this.options` if not set.
  * @return {Schema}
  * @api public
  */
@@ -426,8 +430,8 @@ Schema.prototype.pick = function(paths, options) {
 /**
  * Returns default options for this schema, merged with `options`.
  *
- * @param {Object} options
- * @return {Object}
+ * @param {Object} [options] Options to overwrite the default options
+ * @return {Object} The merged options of `options` and the default options
  * @api private
  */
 
@@ -755,6 +759,10 @@ Schema.prototype.clearIndexes = function clearIndexes() {
  *
  *      const schema = new Schema(..);
  *      schema.methods.init = function () {} // potentially breaking
+ *
+ * @property reserved
+ * @memberOf Schema
+ * @static
  */
 
 Schema.reserved = Object.create(null);
@@ -793,8 +801,8 @@ reserved.collection = 1;
  *     schema.path('name') // returns a SchemaType
  *     schema.path('name', Number) // changes the schemaType of `name` to Number
  *
- * @param {String} path
- * @param {Object} constructor
+ * @param {String} path The name of the Path to get / set
+ * @param {Object} [obj] The Type to set the path to, if provided the path will be SET, otherwise the path will be GET
  * @api public
  */
 
@@ -1059,6 +1067,7 @@ Object.defineProperty(Schema.prototype, 'base', {
  *
  * @param {String} path
  * @param {Object} obj constructor
+ * @param {Object} options
  * @api private
  */
 
@@ -1316,6 +1325,7 @@ Schema.prototype.eachPath = function(fn) {
  * Returns an Array of path strings that are required by this schema.
  *
  * #### Example:
+ *
  *     const s = new Schema({
  *       name: { type: String, required: true },
  *       age: { type: String, required: true },
@@ -1324,7 +1334,7 @@ Schema.prototype.eachPath = function(fn) {
  *     s.requiredPaths(); // [ 'age', 'name' ]
  *
  * @api public
- * @param {Boolean} invalidate refresh the cache
+ * @param {Boolean} invalidate Refresh the cache
  * @return {Array}
  */
 
@@ -1673,8 +1683,14 @@ Schema.prototype.post = function(name) {
  *     s.plugin(schema => console.log(schema.path('name').path));
  *     mongoose.model('Test', s); // Prints 'name'
  *
- * @param {Function} plugin callback
- * @param {Object} [opts]
+ * Or with Options:
+ *
+ *     const s = new Schema({ name: String });
+ *     s.plugin((schema, opts) => console.log(opts.text, schema.path('name').path), { text: "Schema Path Name:" });
+ *     mongoose.model('Test', s); // Prints 'Schema Path Name: name'
+ *
+ * @param {Function} plugin The Plugin's callback
+ * @param {Object} [opts] Options to pass to the plugin
  * @see plugins
  * @api public
  */
@@ -1722,13 +1738,14 @@ Schema.prototype.plugin = function(fn, opts) {
  *     });
  *
  *     // later
+ *     const fizz = new Kitty;
  *     fizz.purr();
  *     fizz.scratch();
  *
  * NOTE: `Schema.method()` adds instance methods to the `Schema.methods` object. You can also add instance methods directly to the `Schema.methods` object as seen in the [guide](/docs/guide.html#methods)
  *
- * @param {String|Object} method name
- * @param {Function} [fn]
+ * @param {String|Object} name The Method Name for a single function, or a Object of "string-function" pairs.
+ * @param {Function} [fn] The Function in a single-function definition.
  * @api public
  */
 
@@ -1759,10 +1776,21 @@ Schema.prototype.method = function(name, fn, options) {
  *     const Drink = mongoose.model('Drink', schema);
  *     await Drink.findByName('LaCroix');
  *
+ * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
+ *
+ *     schema.static({
+ *         findByName: function () {..}
+ *       , findByCost: function () {..}
+ *     });
+ *
+ *     const Drink = mongoose.model('Drink', schema);
+ *     await Drink.findByName('LaCroix');
+ *     await Drink.findByCost(3);
+ *
  * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as statics.
  *
- * @param {String|Object} name
- * @param {Function} [fn]
+ * @param {String|Object} name The Method Name for a single function, or a Object of "string-function" pairs.
+ * @param {Function} [fn] The Function in a single-function definition.
  * @api public
  * @see Statics /docs/guide.html#statics
  */
@@ -1785,7 +1813,7 @@ Schema.prototype.static = function(name, fn) {
  *
  *     schema.index({ first: 1, last: -1 })
  *
- * @param {Object} fields
+ * @param {Object} fields The Fields to index, with the order, available values: `1 | -1 | '2d' | '2dsphere' | 'geoHaystack' | 'hashed' | 'text'`
  * @param {Object} [options] Options to pass to [MongoDB driver's `createIndex()` function](https://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#createIndex)
  * @param {String | number} [options.expires=null] Mongoose-specific syntactic sugar, uses [ms](https://www.npmjs.com/package/ms) to convert `expires` option into seconds for the `expireAfterSeconds` in the above link.
  * @api public
@@ -1812,8 +1840,8 @@ Schema.prototype.index = function(fields, options) {
  *     schema.set('strict', false); // Sets 'strict' to false
  *     schema.set('strict'); // 'false'
  *
- * @param {String} key option name
- * @param {Object} [value] if not passed, the current option value is returned
+ * @param {String} key The name of the option to set the value to
+ * @param {Object} [value] The value to set the option to, if not passed, the option will be reset to default
  * @see Schema ./
  * @api public
  */
@@ -1861,7 +1889,7 @@ Schema.prototype.set = function(key, value, _tags) {
  *     schema.set('strict', false);
  *     schema.get('strict'); // false
  *
- * @param {String} key option name
+ * @param {String} key The name of the Option to get the current value for
  * @api public
  * @return {Any} the option's value
  */
@@ -1927,7 +1955,7 @@ Schema.prototype.indexes = function() {
 /**
  * Creates a virtual type with the given name.
  *
- * @param {String} name
+ * @param {String} name The name of the Virtual
  * @param {Object} [options]
  * @param {String|Model} [options.ref] model name or model instance. Marks this as a [populate virtual](/docs/populate.html#populate-virtuals).
  * @param {String|Function} [options.localField] Required for populate virtuals. See [populate virtual docs](/docs/populate.html#populate-virtuals) for more information.
@@ -2045,8 +2073,8 @@ Schema.prototype.virtual = function(name, options) {
 /**
  * Returns the virtual type with the given `name`.
  *
- * @param {String} name
- * @return {VirtualType}
+ * @param {String} name The name of the Virtual to get
+ * @return {VirtualType|null}
  */
 
 Schema.prototype.virtualpath = function(name) {
@@ -2063,7 +2091,13 @@ Schema.prototype.virtualpath = function(name) {
  *     schema.path('name'); // Undefined
  *     schema.path('age'); // SchemaNumber { ... }
  *
- * @param {String|Array} path
+ * Or as a Array:
+ *
+ *     schema.remove(['name', 'age']);
+ *     schema.path('name'); // Undefined
+ *     schema.path('age'); // Undefined
+ *
+ * @param {String|Array} path The Path(s) to remove
  * @return {Schema} the Schema instance
  * @api public
  */
@@ -2151,7 +2185,7 @@ function _deletePath(schema, name) {
  * userSchema.loadClass(UserClass);
  * ```
  *
- * @param {Function} model
+ * @param {Function} model The Class to load
  * @param {Boolean} [virtualsOnly] if truthy, only pulls virtuals from the class, not methods or statics
  */
 Schema.prototype.loadClass = function(model, virtualsOnly) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1870,15 +1870,16 @@ Schema.prototype.get = function(key) {
   return this.options[key];
 };
 
+const indexTypes = '2d 2dsphere hashed text'.split(' ');
+
 /**
  * The allowed index types
  *
- * @receiver Schema
+ * @property {String[]} indexTypes
+ * @memberOf Schema
  * @static
  * @api public
  */
-
-const indexTypes = '2d 2dsphere hashed text'.split(' ');
 
 Object.defineProperty(Schema, 'indexTypes', {
   get: function() {

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -314,23 +314,27 @@ SubdocumentPath.prototype.discriminator = function(name, schema, options) {
   return this.caster.discriminators[name];
 };
 
+/*!
+ * ignore
+ */
+
+SubdocumentPath.defaultOptions = {};
+
 /**
  * Sets a default option for all SubdocumentPath instances.
  *
  * #### Example:
  *
  *     // Make all numbers have option `min` equal to 0.
- *     mongoose.Schema.Embedded.set('required', true);
+ *     mongoose.Schema.SubdocumentPath.set('required', true);
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
- * @return {undefined}
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
+ * @return {void}
  * @function set
  * @static
  * @api public
  */
-
-SubdocumentPath.defaultOptions = {};
 
 SubdocumentPath.set = SchemaType.set;
 

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -138,7 +138,7 @@ SchemaArray.schemaName = 'Array';
  *
  * - `castNonArrays`: `true` by default. If `false`, Mongoose will throw a CastError when a value isn't an array. If `true`, Mongoose will wrap the provided value in an array before casting.
  *
- * @static options
+ * @static
  * @api public
  */
 
@@ -161,8 +161,8 @@ SchemaArray.defaultOptions = {};
  *     const User = mongoose.model('User', new Schema({ test: Array }));
  *     new User({ }).validateSync().errors.test.message; // Path `test` is required.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @api public

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -393,7 +393,7 @@ SchemaArray.prototype.cast = function(value, doc, init, prev, options) {
     return value;
   }
 
-  if (init || SchemaArray.options.castNonArrays) {
+  if ((init || SchemaArray.options.castNonArrays) && (typeof this.options.castNonArrays === 'boolean' ? this.options.castNonArrays : true)) {
     // gh-2442: if we're loading this from the db and its not an array, mark
     // the whole array as modified.
     if (!!doc && !!init) {

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -393,7 +393,8 @@ SchemaArray.prototype.cast = function(value, doc, init, prev, options) {
     return value;
   }
 
-  if ((init || SchemaArray.options.castNonArrays) && (typeof this.options.castNonArrays === 'boolean' ? this.options.castNonArrays : true)) {
+  const castNonArraysOption = this.options.castNonArrays != null ? this.options.castNonArrays : SchemaArray.options.castNonArrays;
+  if (init || castNonArraysOption) {
     // gh-2442: if we're loading this from the db and its not an array, mark
     // the whole array as modified.
     if (!!doc && !!init) {

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -55,8 +55,8 @@ SchemaBoolean._cast = castBoolean;
  *     const Order = mongoose.model('Order', new Schema({ isPaid: Boolean }));
  *     new Order({ }).isPaid; // false
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static
@@ -156,7 +156,7 @@ SchemaBoolean.prototype.checkRequired = function(value) {
  *     new M({ b: 'affirmative' }).b; // true
  *
  * @property convertToTrue
- * @type Set
+ * @type {Set}
  * @api public
  */
 
@@ -176,7 +176,7 @@ Object.defineProperty(SchemaBoolean, 'convertToTrue', {
  *     new M({ b: 'nay' }).b; // false
  *
  * @property convertToFalse
- * @type Set
+ * @type {Set}
  * @api public
  */
 
@@ -189,7 +189,7 @@ Object.defineProperty(SchemaBoolean, 'convertToFalse', {
  * Casts to boolean
  *
  * @param {Object} value
- * @param {Object} model - this value is optional
+ * @param {Object} model this value is optional
  * @api private
  */
 

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -60,8 +60,8 @@ SchemaBuffer._checkRequired = v => !!(v && v.length);
  *     const User = mongoose.model('User', new Schema({ test: Buffer }));
  *     new User({ }).validateSync().errors.test.message; // Path `test` is required.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -60,8 +60,8 @@ SchemaDate._cast = castDate;
  *     const User = mongoose.model('User', new Schema({ test: Date }));
  *     new User({ }).validateSync().errors.test.message; // Path `test` is required.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -56,8 +56,8 @@ Decimal128._cast = castDecimal128;
  *     const User = mongoose.model('User', new Schema({ test: mongoose.Decimal128 }));
  *     new User({ }).validateSync().errors.test.message; // Path `test` is required.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -536,9 +536,9 @@ DocumentArrayPath.prototype.applyGetters = function(value, scope) {
  * Scopes paths selected in a query to this array.
  * Necessary for proper default application of subdocument values.
  *
- * @param {DocumentArrayPath} array - the array to scope `fields` paths
- * @param {Object|undefined} fields - the root fields selected in the query
- * @param {Boolean|undefined} init - if we are being created part of a query result
+ * @param {DocumentArrayPath} array the array to scope `fields` paths
+ * @param {Object|undefined} fields the root fields selected in the query
+ * @param {Boolean|undefined} init if we are being created part of a query result
  */
 
 function scopePaths(array, fields, init) {
@@ -572,6 +572,12 @@ function scopePaths(array, fields, init) {
   return hasKeys && selected || undefined;
 }
 
+/*!
+ * ignore
+ */
+
+DocumentArrayPath.defaultOptions = {};
+
 /**
  * Sets a default option for all DocumentArray instances.
  *
@@ -580,15 +586,13 @@ function scopePaths(array, fields, init) {
  *     // Make all numbers have option `min` equal to 0.
  *     mongoose.Schema.DocumentArray.set('_id', false);
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
- * @return {undefined}
+ * @param {String} option The name of the option you'd like to set (e.g. trim, lowercase, etc...)
+ * @param {Any} value The value of the option you'd like to set.
+ * @return {void}
  * @function set
  * @static
  * @api public
  */
-
-DocumentArrayPath.defaultOptions = {};
 
 DocumentArrayPath.set = SchemaType.set;
 

--- a/lib/schema/mixed.js
+++ b/lib/schema/mixed.js
@@ -84,8 +84,8 @@ Mixed.get = SchemaType.get;
  *     const User = mongoose.model('User', new Schema({ test: mongoose.Mixed }));
  *     new User({ }).validateSync().errors.test.message; // Path `test` is required.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -57,8 +57,8 @@ SchemaNumber.get = SchemaType.get;
  *     const Order = mongoose.model('Order', new Schema({ amount: Number }));
  *     new Order({ amount: -10 }).validateSync().errors.amount.message; // Path `amount` must be larger than 0.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -84,8 +84,8 @@ ObjectId.get = SchemaType.get;
  *     const Order = mongoose.model('Order', new Schema({ userId: ObjectId }));
  *     new Order({ }).validateSync().errors.userId.message; // Path `userId` is required.
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -133,8 +133,8 @@ SchemaString.get = SchemaType.get;
  *     const User = mongoose.model('User', new Schema({ name: String }));
  *     new User({ name: '   John Doe   ' }).name; // 'John Doe'
  *
- * @param {String} option - The option you'd like to set the value for
- * @param {*} value - value for option
+ * @param {String} option The option you'd like to set the value for
+ * @param {Any} value value for option
  * @return {undefined}
  * @function set
  * @static

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1242,7 +1242,7 @@ SchemaType.prototype.select = function select(val) {
  * @param {any} value
  * @param {Function} callback
  * @param {Object} scope
- * @api private
+ * @api public
  */
 
 SchemaType.prototype.doValidate = function(value, fn, scope, options) {

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -206,7 +206,7 @@ SchemaType.prototype.splitPath = function() {
  * @param {Function|false} caster Function that casts arbitrary values to this type, or throws an error if casting failed
  * @return {Function}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function cast
  * @api public
  */
@@ -280,7 +280,7 @@ SchemaType.prototype.cast = function cast() {
  * @param {Any} value The value of the option you'd like to set.
  * @return {void}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function set
  * @api public
  */
@@ -303,7 +303,7 @@ SchemaType.set = function set(option, value) {
  * @param {Function} getter
  * @return {this}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function get
  * @api public
  */
@@ -1634,7 +1634,7 @@ SchemaType.prototype._castForQuery = function(val) {
  * @param {Function} fn
  * @return {Function}
  * @static
- * @receiver SchemaType
+ * @memberOf SchemaType
  * @function checkRequired
  * @api public
  */

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -239,9 +239,7 @@ SchemaType.cast = function cast(caster) {
  *
  * @param {Function|false} caster Function that casts arbitrary values to this type, or throws an error if casting failed
  * @return {Function}
- * @static
- * @receiver SchemaType
- * @function cast
+ * @memberOf SchemaType
  * @api public
  */
 
@@ -279,7 +277,7 @@ SchemaType.prototype.cast = function cast() {
  *     mongoose.SchemaTypes.String.set('trim', true);
  *
  * @param {String} option The name of the option you'd like to set (e.g. trim, lowercase, etc...)
- * @param {*} value The value of the option you'd like to set.
+ * @param {Any} value The value of the option you'd like to set.
  * @return {void}
  * @static
  * @receiver SchemaType

--- a/lib/types/DocumentArray/methods/index.js
+++ b/lib/types/DocumentArray/methods/index.js
@@ -35,7 +35,7 @@ const methods = {
    *
    * @method _cast
    * @api private
-   * @receiver MongooseDocumentArray
+   * @memberOf MongooseDocumentArray
    */
 
   _cast(value, index) {

--- a/lib/types/buffer.js
+++ b/lib/types/buffer.js
@@ -70,7 +70,8 @@ MongooseBuffer.mixin = {
    *
    * @api private
    * @property _subtype
-   * @memberOf MongooseBuffer
+   * @memberOf MongooseBuffer.mixin
+   * @static
    */
 
   _subtype: undefined,
@@ -80,7 +81,8 @@ MongooseBuffer.mixin = {
    *
    * @api private
    * @method _markModified
-   * @memberOf MongooseBuffer
+   * @memberOf MongooseBuffer.mixin
+   * @static
    */
 
   _markModified: function() {
@@ -97,7 +99,8 @@ MongooseBuffer.mixin = {
    *
    * @api public
    * @method write
-   * @memberOf MongooseBuffer
+   * @memberOf MongooseBuffer.mixin
+   * @static
    */
 
   write: function() {
@@ -120,7 +123,8 @@ MongooseBuffer.mixin = {
    * @return {Number} The number of bytes copied.
    * @param {Buffer} target
    * @method copy
-   * @memberOf MongooseBuffer
+   * @memberOf MongooseBuffer.mixin
+   * @static
    */
 
   copy: function(target) {

--- a/lib/types/decimal128.js
+++ b/lib/types/decimal128.js
@@ -1,7 +1,7 @@
 /**
  * Decimal128 type constructor
  *
- * #### Example
+ * #### Example:
  *
  *     const id = new mongoose.Types.Decimal128('3.1415');
  *

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -275,7 +275,7 @@ Object.defineProperty(MongooseMap.prototype, '$__schemaType', {
  *
  * @api public
  * @property $isMongooseMap
- * @memberOf Map
+ * @memberOf MongooseMap
  * @instance
  */
 

--- a/lib/types/objectid.js
+++ b/lib/types/objectid.js
@@ -1,7 +1,7 @@
 /**
  * ObjectId type constructor
  *
- * #### Example
+ * #### Example:
  *
  *     const id = new mongoose.Types.ObjectId;
  *

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -188,7 +188,7 @@ Subdocument.prototype.isModified = function(paths, modifiedPaths) {
  * @param {String} path the field to mark as valid
  * @api private
  * @method $markValid
- * @receiver Subdocument
+ * @memberOf Subdocument
  */
 
 Subdocument.prototype.$markValid = function(path) {

--- a/lib/virtualtype.js
+++ b/lib/virtualtype.js
@@ -75,7 +75,7 @@ VirtualType.prototype.clone = function() {
  * Mongoose calls the getter function with the below 3 parameters.
  *
  * - `value`: the value returned by the previous getter. If there is only one getter, `value` will be `undefined`.
- * - `virtual`: the virtual object you called `.get()` on
+ * - `virtual`: the virtual object you called `.get()` on.
  * - `doc`: the document this virtual is attached to. Equivalent to `this`.
  *
  * #### Example:
@@ -85,7 +85,7 @@ VirtualType.prototype.clone = function() {
  *       return this.name.first + ' ' + this.name.last;
  *     });
  *
- * @param {Function(Any, VirtualType, Document)} fn
+ * @param {function} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -100,8 +100,8 @@ VirtualType.prototype.get = function(fn) {
  *
  * Mongoose calls the setter function with the below 3 parameters.
  *
- * - `value`: the value being set
- * - `virtual`: the virtual object you're calling `.set()` on
+ * - `value`: the value being set.
+ * - `virtual`: the virtual object you're calling `.set()` on.
  * - `doc`: the document this virtual is attached to. Equivalent to `this`.
  *
  * #### Example:
@@ -120,7 +120,7 @@ VirtualType.prototype.get = function(fn) {
  *     doc.name.first; // 'Jean-Luc'
  *     doc.name.last; // 'Picard'
  *
- * @param {Function(Any, VirtualType, Document)} fn
+ * @param {function} fn
  * @return {VirtualType} this
  * @api public
  */

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "stream-browserify": "3.0.0",
     "ts-benchmark": "^1.0.2",
-    "tsd": "0.22.0",
+    "tsd": "0.20.0",
     "typescript": "4.7.4",
     "uuid": "8.3.2",
     "webpack": "5.73.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "buffer": "^5.6.0",
     "cheerio": "1.0.0-rc.12",
     "crypto-browserify": "3.12.0",
-    "dox": "0.3.1",
+    "dox": "0.9.1",
     "eslint": "8.19.0",
     "eslint-plugin-mocha-no-only": "1.1.1",
     "highlight.js": "11.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose",
   "description": "Mongoose MongoDB ODM",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",
   "keywords": [
     "mongodb",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test-tsd": "node ./test/types/check-types-filename && tsd",
     "tdd": "mocha ./test/*.test.js --inspect --watch --recursive --watch-files ./**/*.{js,ts}",
     "test-coverage": "nyc --reporter=html --reporter=text npm test",
-    "ts-benchmark": "ts-benchmark -p ./benchmarks/typescript/simple -f 17 18 29 32",
+    "ts-benchmark": "node ./benchmarks/typescript.js",
     "ts-benchmark-watch": "ts-benchmark -p ./benchmarks/typescript/simple -w ./types -i -s -f 17 18 29 32 -b master"
   },
   "main": "./index.js",

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -1194,12 +1194,11 @@ describe('types array', function() {
 
       // test also having the property option set
 
+      // the following should work because "castNonArrays" (property option) overwrites global
       const bothSchema = new Schema({ arr: { castNonArrays: true, type: [String] }, docArr: { castNonArrays: true, type: [{ name: String }] } });
       const bothModel = db.model('Test2', bothSchema);
       let bothdoc = new bothModel({ arr: 'fail', docArr: { name: 'fail' } });
-      assert.ok(bothdoc.validateSync().errors);
-      assert.equal(bothdoc.validateSync().errors['arr'].name, 'CastError');
-      assert.equal(bothdoc.validateSync().errors['docArr'].name, 'CastError');
+      assert.ifError(doc.validateSync());
 
       bothdoc = new bothModel({ arr: ['good'] });
       assert.ifError(bothdoc.validateSync());
@@ -2191,5 +2190,20 @@ describe('types array', function() {
     doc.x3.push('foo');
     assert.ifError(doc.validateSync());
     assert.deepEqual(doc.x3.toObject(), ['hello', 'foo']);
+  });
+
+  it('`castNonArrays` on specific paths takes precedence over global option', function() {
+    // Arrange
+    const m = new mongoose.Mongoose();
+    m.Schema.Types.Array.options.castNonArrays = false;
+
+    const userSchema = new Schema({ friendsNames: { type: [String], castNonArrays: true } });
+    const User = m.model('User', userSchema);
+
+    // Act
+    const user = new User({ friendsNames: 'Sam' });
+
+    // Assert
+    assert.ifError(user.validateSync());
   });
 });

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -1192,7 +1192,7 @@ describe('types array', function() {
       assert.ifError(doc.validateSync());
       assert.deepEqual(doc.arr.toObject(), ['good', 'foo']);
 
-      // test also having the property option set to false
+      // test also having the property option set
 
       const bothSchema = new Schema({ arr: { castNonArrays: true, type: [String] }, docArr: { castNonArrays: true, type: [{ name: String }] } });
       const bothModel = db.model('Test2', bothSchema);

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -1192,6 +1192,21 @@ describe('types array', function() {
       assert.ifError(doc.validateSync());
       assert.deepEqual(doc.arr.toObject(), ['good', 'foo']);
 
+      // test also having the property option set to false
+
+      const bothSchema = new Schema({ arr: { castNonArrays: true, type: [String] }, docArr: { castNonArrays: true, type: [{ name: String }] } });
+      const bothModel = db.model('Test2', bothSchema);
+      let bothdoc = new bothModel({ arr: 'fail', docArr: { name: 'fail' } });
+      assert.ok(bothdoc.validateSync().errors);
+      assert.equal(bothdoc.validateSync().errors['arr'].name, 'CastError');
+      assert.equal(bothdoc.validateSync().errors['docArr'].name, 'CastError');
+
+      bothdoc = new bothModel({ arr: ['good'] });
+      assert.ifError(bothdoc.validateSync());
+      bothdoc.arr.push('foo');
+      assert.ifError(bothdoc.validateSync());
+      assert.deepEqual(bothdoc.arr.toObject(), ['good', 'foo']);
+
       return Promise.resolve();
     });
 

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -2151,4 +2151,30 @@ describe('types array', function() {
     assert.strictEqual(doc.arr[0], '42');
     assert.strictEqual(arr[0], 42);
   });
+
+  it('test "castNonArrays" property option', function() {
+    const Model = db.model('Test', new Schema({ x1: { castNonArrays: false, type: [String] }, x2: { castNonArrays: true, type: [String] }, x3: { type: [String] } }));
+
+    const string = 'hello';
+
+    // error testing
+    let doc = new Model({ x1: string });
+    const validateErrors = doc.validateSync().errors;
+    assert.ok(validateErrors);
+    assert.equal(validateErrors['x1'].name, 'CastError');
+
+    // good testing
+    doc = new Model({ x2: string });
+    assert.ifError(doc.validateSync());
+    doc.x2.push('foo');
+    assert.ifError(doc.validateSync());
+    assert.deepEqual(doc.x2.toObject(), ['hello', 'foo']);
+
+    // without option (default)
+    doc = new Model({ x3: string });
+    assert.ifError(doc.validateSync());
+    doc.x3.push('foo');
+    assert.ifError(doc.validateSync());
+    assert.deepEqual(doc.x3.toObject(), ['hello', 'foo']);
+  });
 });

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -106,7 +106,7 @@ declare module 'mongoose' {
     checkKeys?: boolean;
     j?: boolean;
     safe?: boolean | WriteConcern;
-    timestamps?: boolean;
+    timestamps?: boolean | QueryTimestampsConfig;
     validateBeforeSave?: boolean;
     validateModifiedOnly?: boolean;
     w?: number | string;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -351,6 +351,7 @@ declare module 'mongoose' {
     findOneAndRemove<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 
     /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
+    findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { rawResult: true }, callback?: (err: CallbackError, doc: any, res: any) => void): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, T>;
     findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter: FilterQuery<T>, replacement: T | AnyObject, options: QueryOptions<T> & { upsert: true } & ReturnsNewDoc, callback?: (err: CallbackError, doc: ResultDoc, res: any) => void): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, T>;
     findOneAndReplace<ResultDoc = HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>(filter?: FilterQuery<T>, replacement?: T | AnyObject, options?: QueryOptions<T> | null, callback?: (err: CallbackError, doc: ResultDoc | null, res: any) => void): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, T>;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -90,6 +90,11 @@ declare module 'mongoose' {
     [key: string]: any;
   };
 
+  interface QueryTimestampsConfig {
+    createdAt?: boolean;
+    updatedAt?: boolean;
+  }
+
   interface QueryOptions<DocType = unknown> extends
     PopulateOption,
     SessionOption {
@@ -157,7 +162,7 @@ declare module 'mongoose' {
      * skip timestamps for this update. Note that this allows you to overwrite
      * timestamps. Does nothing if schema-level timestamps are not set.
      */
-    timestamps?: boolean;
+    timestamps?: boolean | QueryTimestampsConfig;
     upsert?: boolean;
     writeConcern?: mongodb.WriteConcern;
 

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -204,7 +204,7 @@ declare module 'mongoose' {
     query?: Record<any, <T extends QueryWithHelpers<unknown, DocType>>(this: T, ...args: any) => T> | QueryHelpers,
 
     /**
-     * Set wheter to cast non-array values to arrays
+     * Set whether to cast non-array values to arrays.
      * @default true
      */
     castNonArrays?: boolean;

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -202,5 +202,11 @@ declare module 'mongoose' {
      * Query helper functions
      */
     query?: Record<any, <T extends QueryWithHelpers<unknown, DocType>>(this: T, ...args: any) => T> | QueryHelpers,
+
+    /**
+     * Set wheter to cast non-array values to arrays
+     * @default true
+     */
+    castNonArrays?: boolean;
   }
 }


### PR DESCRIPTION
fixes #10398

**Summary**

Adds Property option `castNonArrays` to disable casting non-array values per-property instead of globally

**Examples**

```js
const Model = db.model('Test', new Schema({ x1: { castNonArrays: false, type: [String] } }));
const doc = new Model({ x1: "some non-array value" });
await doc.validate(); // Errors with "CastError"
```

PS: this is my first actual code contribution, please check if i changes everything necessary

Note on performance:
This may affect performance by doing additional checks, but it should not be too much
