### PR TITLE
fix: isAtlas check not working properly

### DIFF
--- a/lib/helpers/topology/isAtlas.js
+++ b/lib/helpers/topology/isAtlas.js
@@ -2,25 +2,30 @@
 
 const getConstructorName = require('../getConstructorName');
 
+/**
+ * @typedef { import('mongodb').TopologyDescription } TopologyDescription
+ */
+
+/**
+ * Checks if topologyDescription contains servers connected to an atlas instance
+ *
+ * @param  {TopologyDescription} topologyDescription
+ * @returns {boolean}
+ */
 module.exports = function isAtlas(topologyDescription) {
   if (getConstructorName(topologyDescription) !== 'TopologyDescription') {
     return false;
   }
 
-  const hostnames = Array.from(topologyDescription.servers.keys());
-
-  if (hostnames.length === 0) {
+  if (topologyDescription.servers.size === 0) {
     return false;
   }
 
-  for (let i = 0, il = hostnames.length; i < il; ++i) {
-    const url = new URL(hostnames[i]);
-    if (
-      url.hostname.endsWith('.mongodb.net') === false ||
-      url.port !== '27017'
-    ) {
+  for (const server of topologyDescription.servers.values()) {
+    if (server.host.endsWith('.mongodb.net') === false || server.port !== 27017) {
       return false;
     }
   }
+
   return true;
 };


### PR DESCRIPTION
**Summary**

Use ServerDescription methods for getting server host and port instead of parsing hostname,
which did not work properly.


**Examples**

Closes #12063
