### PR TITLE
feat(model): add `castObject()` function that casts a POJO to the model's schema

### DIFF
--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -52,6 +52,15 @@ class ValidationError extends MongooseError {
   * add message
   */
   addError(path, error) {
+    if (error instanceof ValidationError) {
+      const { errors } = error;
+      for (const errorPath of Object.keys(errors)) {
+        this.addError(`${path}.${errorPath}`, errors[errorPath]);
+      }
+
+      return;
+    }
+
     this.errors[path] = error;
     this.message = this._message + ': ' + _generateMessage(this);
   }

--- a/lib/helpers/model/pushNestedArrayPaths.js
+++ b/lib/helpers/model/pushNestedArrayPaths.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function pushNestedArrayPaths(paths, nestedArray, path) {
+  if (nestedArray == null) {
+    return;
+  }
+
+  for (let i = 0; i < nestedArray.length; ++i) {
+    if (Array.isArray(nestedArray[i])) {
+      pushNestedArrayPaths(paths, nestedArray[i], path + '.' + i);
+    } else {
+      paths.push(path + '.' + i);
+    }
+  }
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -56,6 +56,7 @@ const leanPopulateMap = require('./helpers/populate/leanPopulateMap');
 const modifiedPaths = require('./helpers/update/modifiedPaths');
 const parallelLimit = require('./helpers/parallelLimit');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
+const pushNestedArrayPaths = require('./helpers/model/pushNestedArrayPaths');
 const removeDeselectedForeignField = require('./helpers/populate/removeDeselectedForeignField');
 const setDottedPath = require('./helpers/path/setDottedPath');
 const util = require('util');
@@ -3682,6 +3683,96 @@ Model.applyDefaults = function applyDefaults(doc) {
 };
 
 /**
+ * Cast the given POJO to the model's schema
+ *
+ * #### Example:
+ *     const Test = mongoose.model('Test', Schema({ num: Number }));
+ *
+ *     const obj = Test.castObject({ num: '42' });
+ *     obj.num; // 42 as a number
+ *
+ *     Test.castObject({ num: 'not a number' }); // Throws a ValidationError
+ *
+ * @param {Object} obj object or document to cast
+ * @returns {Object} POJO casted to the model's schema
+ * @throws {ValidationError} if casting failed for at least one path
+ * @api public
+ */
+
+Model.castObject = function castObject(obj) {
+  const ret = {};
+
+  const schema = this.schema;
+  const paths = Object.keys(schema.paths);
+
+  for (const path of paths) {
+    const schemaType = schema.path(path);
+    if (!schemaType || !schemaType.$isMongooseArray) {
+      continue;
+    }
+
+    const val = get(obj, path);
+    pushNestedArrayPaths(paths, val, path);
+  }
+
+  let error = null;
+
+  for (const path of paths) {
+    const schemaType = schema.path(path);
+    if (schemaType == null) {
+      continue;
+    }
+
+    let val = get(obj, path, void 0);
+
+    if (val == null) {
+      continue;
+    }
+
+    const pieces = path.indexOf('.') === -1 ? [path] : path.split('.');
+    let cur = ret;
+    for (let i = 0; i < pieces.length - 1; ++i) {
+      if (cur[pieces[i]] == null) {
+        cur[pieces[i]] = isNaN(pieces[i + 1]) ? {} : [];
+      }
+      cur = cur[pieces[i]];
+    }
+
+    if (schemaType.$isMongooseDocumentArray) {
+      continue;
+    }
+    if (schemaType.$isSingleNested || schemaType.$isMongooseDocumentArrayElement) {
+      try {
+        val = Model.castObject.call(schemaType.caster, val);
+      } catch (err) {
+        error = error || new ValidationError();
+        error.addError(path, err);
+        continue;
+      }
+
+      cur[pieces[pieces.length - 1]] = val;
+      continue;
+    }
+
+    try {
+      val = schemaType.cast(val);
+      cur[pieces[pieces.length - 1]] = val;
+    } catch (err) {
+      error = error || new ValidationError();
+      error.addError(path, err);
+
+      continue;
+    }
+  }
+
+  if (error != null) {
+    throw error;
+  }
+
+  return ret;
+};
+
+/**
  * Build bulk write operations for `bulkSave()`.
  *
  * @param {Array<Document>} documents The array of documents to build write operations of
@@ -4278,7 +4369,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
       }
 
       const val = get(obj, path);
-      pushNestedArrayPaths(val, path);
+      pushNestedArrayPaths(paths, val, path);
     }
 
     let remaining = paths.length;
@@ -4291,7 +4382,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
         continue;
       }
 
-      const pieces = path.split('.');
+      const pieces = path.indexOf('.') === -1 ? [path] : path.split('.');
       let cur = obj;
       for (let i = 0; i < pieces.length - 1; ++i) {
         cur = cur[pieces[i]];
@@ -4315,30 +4406,10 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
       schemaType.doValidate(val, err => {
         if (err) {
           error = error || new ValidationError();
-          if (err instanceof ValidationError) {
-            for (const _err of Object.keys(err.errors)) {
-              error.addError(`${path}.${err.errors[_err].path}`, _err);
-            }
-          } else {
-            error.addError(err.path, err);
-          }
+          error.addError(path, err);
         }
         _checkDone();
       }, context, { path: path });
-    }
-
-    function pushNestedArrayPaths(nestedArray, path) {
-      if (nestedArray == null) {
-        return;
-      }
-
-      for (let i = 0; i < nestedArray.length; ++i) {
-        if (Array.isArray(nestedArray[i])) {
-          pushNestedArrayPaths(nestedArray[i], path + '.' + i);
-        } else {
-          paths.push(path + '.' + i);
-        }
-      }
     }
 
     function _checkDone() {

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -1917,7 +1917,7 @@ describe('model: update:', function() {
       const opts = { new: true, runValidators: true };
       Model.findOneAndUpdate({}, update, opts, function(error) {
         assert.ok(error);
-        assert.ok(error.errors['children']);
+        assert.ok(error.errors['children.lastName']);
         done();
       });
     });
@@ -2383,9 +2383,9 @@ describe('model: update:', function() {
 
       Parent.update({}, { d: { d2: 'test' } }, { runValidators: true }, function(error) {
         assert.ok(error);
-        assert.ok(error.errors['d']);
-        assert.ok(error.errors['d'].message.indexOf('Path `d1` is required') !== -1,
-          error.errors['d'].message);
+        assert.ok(error.errors['d.d1']);
+        assert.ok(error.errors['d.d1'].message.indexOf('Path `d1` is required') !== -1,
+          error.errors['d.d1'].message);
         done();
       });
     });

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -133,6 +133,9 @@ declare module 'mongoose' {
      */
     baseModelName: string | undefined;
 
+    /* Cast the given POJO to the model's schema */
+    castObject(obj: AnyObject): T;
+
     /**
      * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,
      * `deleteOne`, and/or `deleteMany` operations to the MongoDB server in one


### PR DESCRIPTION
Fix #11945

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We're adding a couple of model helpers that make it easier to access various Mongoose features without creating a full document. We already have `Model.validate()` and `Model.applyDefaults()`. `Model.validate()` does some casting, but doesn't return a casted object. This `Model.castObject()` function takes in a POJO, and casts it to the given schema, _except_ for creating Mongoose-specific data structures like document arrays and subdocuments. `castObject()` should return a POJO.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```javascript
const Test = db.model('Test', mongoose.Schema({
  _id: false,
  num: Number,
  nested: {
    num: Number
  },
  subdoc: {
    type: mongoose.Schema({
      _id: false,
      num: Number
    }),
    default: () => ({})
  },
  docArr: [{
    _id: false,
    num: Number
  }]
}));

const obj = {
  num: '1',
  nested: { num: '2' },
  subdoc: { num: '3' },
  docArr: [{ num: '4' }]
};
const ret = Test.castObject(obj);

ret.num; // 1 as a number
ret.nested; // POJO
ret.nested.num; // 2 as a number
ret.subdoc; // POJO
ret.subdoc.num; // 3 as a number
ret.docArr; // Vanilla JS array
ret.docArr[0].num; // 4 as a number
```
