### PR TITLE
feat(model): add `hydrate` option to `Model.watch()` to automatically hydrate `fullDocument`

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -20,6 +20,13 @@ class ChangeStream extends EventEmitter {
     this.pipeline = pipeline;
     this.options = options;
 
+    if (options && options.hydrate && !options.model) {
+      throw new Error(
+        'Cannot create change stream with `hydrate: true` ' +
+        'unless calling `Model.watch()`'
+      );
+    }
+
     // This wrapper is necessary because of buffering.
     changeStreamThunk((err, driverChangeStream) => {
       if (err != null) {
@@ -46,7 +53,12 @@ class ChangeStream extends EventEmitter {
         });
 
         ['close', 'change', 'end', 'error'].forEach(ev => {
-          this.driverChangeStream.on(ev, data => this.emit(ev, data));
+          this.driverChangeStream.on(ev, data => {
+            if (data.fullDocument != null && this.options && this.options.hydrate) {
+              data.fullDocument = this.options.model.hydrate(data.fullDocument);
+            }
+            this.emit(ev, data);
+          });
         });
       });
 
@@ -69,6 +81,32 @@ class ChangeStream extends EventEmitter {
   }
 
   next(cb) {
+    if (this.options && this.options.hydrate) {
+      if (cb != null) {
+        const originalCb = cb;
+        cb = (err, data) => {
+          if (err != null) {
+            return originalCb(err);
+          }
+          if (data.fullDocument != null) {
+            data.fullDocument = this.options.model.hydrate(data.fullDocument);
+          }
+          return originalCb(null, data);
+        };
+      }
+
+      let maybePromise = this.driverChangeStream.next(cb);
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise = maybePromise.then(data => {
+          if (data.fullDocument != null) {
+            data.fullDocument = this.options.model.hydrate(data.fullDocument);
+          }
+          return data;
+        });
+      }
+      return maybePromise;
+    }
+
     return this.driverChangeStream.next(cb);
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3177,6 +3177,7 @@ Model.create = function create(doc, options, callback) {
  *
  * @param {Array} [pipeline]
  * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#watch)
+ * @param {Boolean} [options.hydrate=false] if true and `fullDocument: 'updateLookup'` is set, Mongoose will automatically hydrate `fullDocument` into a fully fledged Mongoose document
  * @return {ChangeStream} mongoose-specific change stream wrapper, inherits from EventEmitter
  * @api public
  */
@@ -3200,6 +3201,9 @@ Model.watch = function(pipeline, options) {
       cb(null, driverChangeStream);
     }
   };
+
+  options = options || {};
+  options.model = this;
 
   return new ChangeStream(changeStreamThunk, pipeline, options);
 };

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -288,7 +288,7 @@ declare module 'mongoose' {
     validate(optional: any, pathsToValidate: PathsToValidate, callback?: CallbackWithoutResult): Promise<void>;
 
     /** Watches the underlying collection for changes using [MongoDB change streams](https://docs.mongodb.com/manual/changeStreams/). */
-    watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
+    watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions & { hydrate?: boolean }): mongodb.ChangeStream<ResultType>;
 
     /** Adds a `$where` clause to this query */
     $where(argument: string | Function): QueryWithHelpers<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;


### PR DESCRIPTION
Fix #11936

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Automatically hydrate `fullDocument` if `hydrate: true` is set, but only if you call `Model.watch()`. `Connection.prototype.watch()` doesn't support `hydrate: true`.

Helpful because 1) it might be hard to figure out what function you need to call to init a Mongoose document without setting anything modified or firing setters, 2) this makes it easier for us to add a global `hydrateFullDocument` option so we can do this on all `Model.watch()` calls by default.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
