### PR TITLE
fix(types): map correct generics from model to schema

### DIFF
--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -144,7 +144,7 @@ declare module 'mongoose' {
     /** Defines or retrieves a model. */
     model<T, U, TQueryHelpers = {}>(
       name: string,
-      schema?: Schema<T, U, TQueryHelpers>,
+      schema?: Schema<T, U, any, TQueryHelpers, any, any>,
       collection?: string,
       options?: CompileModelOptions
     ): U;

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -144,7 +144,7 @@ declare module 'mongoose' {
     /** Defines or retrieves a model. */
     model<T, U, TQueryHelpers = {}>(
       name: string,
-      schema?: Schema<T, U, any, TQueryHelpers, any, any>,
+      schema?: Schema<T, any, any, TQueryHelpers, any, any>,
       collection?: string,
       options?: CompileModelOptions
     ): U;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ declare module 'mongoose' {
 
   export function model<T, U, TQueryHelpers = {}>(
     name: string,
-    schema?: Schema<T, any, TQueryHelpers>,
+    schema?: Schema<T, U, any, TQueryHelpers, any, any>,
     collection?: string,
     options?: CompileModelOptions
   ): U;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ declare module 'mongoose' {
 
   export function model<T, U, TQueryHelpers = {}>(
     name: string,
-    schema?: Schema<T, U, any, TQueryHelpers, any, any>,
+    schema?: Schema<T, any, any, TQueryHelpers, any, any>,
     collection?: string,
     options?: CompileModelOptions
   ): U;


### PR DESCRIPTION
**Summary**

It is not possible to define a model with both generic `TInstanceMethods` and `TQueryHelpers`. There is a mismatch between generics for the `model` and the the `Schema`.

**Examples**

See type test for example