### PR TITLE
fix(connection): re-run `Model.init()` if re-connecting after explicitly closing a connection

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -550,8 +550,8 @@ Connection.prototype.dropDatabase = _wrapConnHelper(function dropDatabase(cb) {
   // init-ed. It is sufficiently common to call `dropDatabase()` after
   // `mongoose.connect()` but before creating models that we want to
   // support this. See gh-6796
-  for (const name of Object.keys(this.models)) {
-    delete this.models[name].$init;
+  for (const model of Object.values(this.models)) {
+    delete model.$init;
   }
   this.db.dropDatabase(cb);
 });
@@ -838,6 +838,11 @@ Connection.prototype.openUri = function(uri, options, callback) {
     );
   }
 
+  for (const model of Object.values(this.models)) {
+    // Errors handled internally, so safe to ignore error
+    model.init(function $modelInitNoop() {});
+  }
+
   return this.$initialConnection;
 };
 
@@ -949,6 +954,13 @@ Connection.prototype.close = function(force, callback) {
     this.$wasForceClosed = !!force.force;
   } else {
     this.$wasForceClosed = !!force;
+  }
+
+  for (const model of Object.values(this.models)) {
+    // If manually disconnecting, make sure to clear each model's `$init`
+    // promise, so Mongoose knows to re-run `init()` in case the
+    // connection is re-opened. See gh-12047.
+    delete model.$init;
   }
 
   return promiseOrCallback(callback, cb => {
@@ -1442,6 +1454,11 @@ Connection.prototype.setClient = function setClient(client) {
 
   this._connectionString = client.s.url;
   _setClient(this, client, {}, client.s.options.dbName);
+
+  for (const model of Object.values(this.models)) {
+    // Errors handled internally, so safe to ignore error
+    model.init(function $modelInitNoop() {});
+  }
 
   return this;
 };


### PR DESCRIPTION
Fix #12047

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The [`Model.init()` function](https://mongoosejs.com/docs/api/model.html#model_Model-init) is responsible for:

1. Calling `createCollection()` to ensure the Model's underlying collection exists, unless `autoCreate = false`
2. Calling `createIndexes()` to ensure the indexes defined in the Model's schema exist, unless `autoIndex = false`

Mongoose calls `Model.init()` when you create a model using `mongoose.model()` or `Collection.prototype.model()`. The `createCollection()` and `createIndexes()` calls are queued up until Mongoose connects to MongoDB.

The issue is that, if you close a connection and then reconnect to a different database or cluster, Mongoose won't re-run `init()`. Because 1) Mongoose only runs `init()` when you call `model()`, and 2) Mongoose stores a `$init` property on a model that contains a promise wrapping the `init()` call [here](https://github.com/Automattic/mongoose/blob/422f9da02d2e8c0c227887265bce25cecaecf403/lib/model.js#L1315-L1327). If `$init` is set, then calling `init()` just returns `$init`. This is to avoid duplicate `init()` calls.

This fix deletes `$init` when the user calls `Connection.prototype.close()`, and ensures that Mongoose calls `init()` when the user opens a connection using `openUri()` or `setClient()`. So `close()` clears `$init` caches, and re-opening the connection means Mongoose re-runs `init()`.

Related issue: #11916

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

See tests