### PR TITLE
Touch-up JSDOC of some more files

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -73,7 +73,7 @@ mongoose.set('bufferCommands', false);
 Note that buffering is also responsible for waiting until Mongoose
 creates collections if you use the [`autoCreate` option](/docs/guide.html#autoCreate).
 If you disable buffering, you should also disable the `autoCreate`
-option and use [`createCollection()`](/docs/api/model.html#model_Model.createCollection)
+option and use [`createCollection()`](/docs/api/model.html#model_Model-createCollection)
 to create [capped collections](/docs/guide.html#capped) or
 [collections with collations](/docs/guide.html#collation).
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -28,7 +28,7 @@ deleteMany, or bulkWrite instead.
 ```
 
 To remove this deprecation warning, replace any usage of `remove()` with
-`deleteMany()`, _unless_ you specify the [`single` option to `remove()`](/docs/api.html#model_Model.remove). The `single`
+`deleteMany()`, _unless_ you specify the [`single` option to `remove()`](/docs/api.html#model_Model-remove). The `single`
 option limited `remove()` to deleting at most one document, so you should
 replace `remove(filter, { single: true })` with `deleteOne(filter)`.
 
@@ -46,9 +46,9 @@ MyModel.deleteOne({ answer: 42 });
 
 <h2 id="update"><a href="#update"><code>update()</code></a></h2>
 
-Like `remove()`, the [`update()` function](/docs/api.html#model_Model.update) is deprecated in favor
-of the more explicit [`updateOne()`](/docs/api.html#model_Model.updateOne), [`updateMany()`](/docs/api.html#model_Model.updateMany), and [`replaceOne()`](/docs/api.html#model_Model.replaceOne) functions. You should replace
-`update()` with `updateOne()`, unless you use the [`multi` or `overwrite` options](/docs/api.html#model_Model.update).
+Like `remove()`, the [`update()` function](/docs/api.html#model_Model-update) is deprecated in favor
+of the more explicit [`updateOne()`](/docs/api.html#model_Model-updateOne), [`updateMany()`](/docs/api.html#model_Model-updateMany), and [`replaceOne()`](/docs/api.html#model_Model-replaceOne) functions. You should replace
+`update()` with `updateOne()`, unless you use the [`multi` or `overwrite` options](/docs/api.html#model_Model-update).
 
 ```
 collection.update is deprecated. Use updateOne, updateMany, or bulkWrite

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -35,7 +35,7 @@ going through a model.
 
 <h2 id="retrieving"><a href="#retrieving">Retrieving</a></h2>
 
-When you load documents from MongoDB using model functions like [`findOne()`](api.html#model_Model.findOne),
+When you load documents from MongoDB using model functions like [`findOne()`](api.html#model_Model-findOne),
 you get a Mongoose document back.
 
 ```javascript
@@ -151,7 +151,7 @@ doc.overwrite({ name: 'Jean-Luc Picard' });
 await doc.save();
 ```
 
-The other way is to use [`Model.replaceOne()`](/docs/api/model.html#model_Model.replaceOne).
+The other way is to use [`Model.replaceOne()`](/docs/api/model.html#model_Model-replaceOne).
 
 ```javascript
 // Sets `name` and unsets all other properties

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -172,7 +172,7 @@ dog.findSimilarTypes((err, dogs) => {
 });
 ```
 
-* Overwriting a default mongoose document method may lead to unpredictable results. See [this](./api.html#schema_Schema.reserved) for more details.
+* Overwriting a default mongoose document method may lead to unpredictable results. See [this](./api.html#schema_Schema-reserved) for more details.
 * The example above uses the `Schema.methods` object directly to save an instance method. You can also use the `Schema.method()` helper as described [here](./api.html#schema_Schema-method).
 * Do **not** declare methods using ES6 arrow functions (`=>`). Arrow functions [explicitly prevent binding `this`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_binding_of_this), so your method will **not** have access to the document and the above examples will not work.
 
@@ -300,7 +300,7 @@ Animal.on('index', error => {
 });
 ```
 
-See also the [Model#ensureIndexes](./api.html#model_Model.ensureIndexes) method.
+See also the [Model#ensureIndexes](./api.html#model_Model-ensureIndexes) method.
 
 <h3 id="virtuals"><a href="#virtuals">Virtuals</a></h3>
 
@@ -468,9 +468,9 @@ Valid options:
 
 <h3 id="autoIndex"><a href="#autoIndex">option: autoIndex</a></h3>
 
-By default, Mongoose's [`init()` function](/docs/api.html#model_Model.init)
+By default, Mongoose's [`init()` function](/docs/api.html#model_Model-init)
 creates all the indexes defined in your model's schema by calling
-[`Model.createIndexes()`](/docs/api.html#model_Model.createIndexes)
+[`Model.createIndexes()`](/docs/api.html#model_Model-createIndexes)
 after you successfully connect to MongoDB. Creating indexes automatically is
 great for development and test environments. But index builds can also create
 significant load on your production database. If you want to manage indexes
@@ -561,7 +561,7 @@ new Schema({..}, { capped: { size: 1024, max: 1000, autoIndexId: true } });
 <h3 id="collection"><a href="#collection">option: collection</a></h3>
 
 Mongoose by default produces a collection name by passing the model name to
-the [utils.toCollectionName](./api.html#utils_exports.toCollectionName) method.
+the [utils.toCollectionName](./api.html#utils_exports-toCollectionName) method.
 This method pluralizes the name. Set this option if you need a different name
 for your collection.
 
@@ -613,7 +613,7 @@ console.log(p.id); // undefined
 
 Mongoose assigns each of your schemas an `_id` field by default if one
 is not passed into the [Schema](/docs/api.html#schema-js) constructor.
-The type assigned is an [ObjectId](/docs/api.html#schema_Schema.Types)
+The type assigned is an [ObjectId](/docs/api.html#schema_Schema-Types)
 to coincide with MongoDB's default behavior. If you don't want an `_id`
 added to your schema at all, you may disable it using this option.
 
@@ -1165,7 +1165,7 @@ await Thing.updateOne({}, { $set: { name: 'Test' } });
 await Thing.findOneAndUpdate({}, { $set: { name: 'Test2' } });
 
 // Mongoose also adds timestamps to bulkWrite() operations
-// See https://mongoosejs.com/docs/api.html#model_Model.bulkWrite
+// See https://mongoosejs.com/docs/api.html#model_Model-bulkWrite
 await Thing.bulkWrite([
   insertOne: {
     document: {

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -47,7 +47,7 @@ In query middleware functions, `this` refers to the query.
 * [findOneAndRemove](./api.html#query_Query-findOneAndRemove)
 * [findOneAndReplace](./api/query.html#query_Query-findOneAndReplace)
 * [findOneAndUpdate](./api.html#query_Query-findOneAndUpdate)
-* [remove](./api.html#model_Model.remove)
+* [remove](./api.html#model_Model-remove)
 * [replaceOne](./api/query.html#query_Query-replaceOne)
 * [update](./api.html#query_Query-update)
 * [updateOne](./api.html#query_Query-updateOne)
@@ -55,14 +55,14 @@ In query middleware functions, `this` refers to the query.
 
 Aggregate middleware is for `MyModel.aggregate()`. Aggregate middleware
 executes when you call `exec()` on an aggregate object.
-In aggregate middleware, `this` refers to the [aggregation object](./api.html#model_Model.aggregate).
+In aggregate middleware, `this` refers to the [aggregation object](./api.html#model_Model-aggregate).
 
-* [aggregate](./api.html#model_Model.aggregate)
+* [aggregate](./api.html#model_Model-aggregate)
 
 Model middleware is supported for the following model functions.
 In model middleware functions, `this` refers to the model.
 
-* [insertMany](./api.html#model_Model.insertMany)
+* [insertMany](./api.html#model_Model-insertMany)
 
 All middleware types support pre and post hooks.
 How pre and post hooks work is described in more detail below.
@@ -79,7 +79,7 @@ This means that both `doc.updateOne()` and `Model.updateOne()` trigger
 `updateOne` or `deleteOne` middleware as document middleware, use
 `schema.pre('updateOne', { document: true, query: false })`.
 
-**Note:** The [`create()`](./api.html#model_Model.create) function fires `save()` hooks.
+**Note:** The [`create()`](./api.html#model_Model-create) function fires `save()` hooks.
 
 <h3 id="pre"><a href="#pre">Pre</a></h3>
 
@@ -311,7 +311,7 @@ Model.remove();
 You can pass options to [`Schema.pre()`](/docs/api.html#schema_Schema-pre)
 and [`Schema.post()`](/docs/api.html#schema_Schema-post) to switch whether
 Mongoose calls your `remove()` hook for [`Document.remove()`](/docs/api.html#model_Model-remove)
-or [`Model.remove()`](/docs/api.html#model_Model.remove). Note here that you need to set both `document` and `query` properties in the passed object:
+or [`Model.remove()`](/docs/api.html#model_Model-remove). Note here that you need to set both `document` and `query` properties in the passed object:
 
 ```javascript
 // Only document middleware
@@ -462,7 +462,7 @@ function call will still error out.
 
 <h3 id="aggregate"><a href="#aggregate">Aggregation Hooks</a></h3>
 
-You can also define hooks for the [`Model.aggregate()` function](api.html#model_Model.aggregate).
+You can also define hooks for the [`Model.aggregate()` function](api.html#model_Model-aggregate).
 In aggregation middleware functions, `this` refers to the [Mongoose `Aggregate` object](api.html#Aggregate).
 For example, suppose you're implementing soft deletes on a `Customer` model
 by adding an `isDeleted` property. To make sure `aggregate()` calls only look

--- a/docs/migrating_to_5.md
+++ b/docs/migrating_to_5.md
@@ -465,7 +465,7 @@ In Mongoose 5.x, the above code will correctly overwrite `'baseball'` with `{ $n
 </a></h3>
 
 Mongoose 5.x uses version 3.x of the [MongoDB Node.js driver](http://npmjs.com/package/mongodb). MongoDB driver 3.x changed the format of
-the result of [`bulkWrite()` calls](/docs/api.html#model_Model.bulkWrite) so there is no longer a top-level `nInserted`, `nModified`, etc. property. The new result object structure is [described here](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~BulkWriteOpResult).
+the result of [`bulkWrite()` calls](/docs/api.html#model_Model-bulkWrite) so there is no longer a top-level `nInserted`, `nModified`, etc. property. The new result object structure is [described here](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~BulkWriteOpResult).
 
 ```javascript
 const Model = mongoose.model('Test', new Schema({ name: String }));

--- a/docs/models.md
+++ b/docs/models.md
@@ -75,7 +75,7 @@ const Tank = connection.model('Tank', yourSchema);
 
 ### Querying
 
-Finding documents is easy with Mongoose, which supports the [rich](http://www.mongodb.org/display/DOCS/Advanced+Queries) query syntax of MongoDB. Documents can be retrieved using a `model`'s [find](./api.html#model_Model.find), [findById](./api.html#model_Model.findById), [findOne](./api.html#model_Model.findOne), or [where](./api.html#model_Model.where) static methods.
+Finding documents is easy with Mongoose, which supports the [rich](http://www.mongodb.org/display/DOCS/Advanced+Queries) query syntax of MongoDB. Documents can be retrieved using a `model`'s [find](./api.html#model_Model-find), [findById](./api.html#model_Model-findById), [findOne](./api.html#model_Model-findOne), or [where](./api.html#model_Model-where) static methods.
 
 ```javascript
 Tank.find({ size: 'small' }).where('createdDate').gt(oneYearAgo).exec(callback);
@@ -99,7 +99,7 @@ Tank.deleteOne({ size: 'large' }, function (err) {
 
 Each `model` has its own `update` method for modifying documents in the
 database without returning them to your application. See the
-[API](./api.html#model_Model.updateOne) docs for more detail.
+[API](./api.html#model_Model-updateOne) docs for more detail.
 
 ```javascript
 Tank.updateOne({ size: 'large' }, { name: 'T-90' }, function(err, res) {
@@ -109,7 +109,7 @@ Tank.updateOne({ size: 'large' }, { name: 'T-90' }, function(err, res) {
 ```
 
 _If you want to update a single document in the db and return it to your
-application, use [findOneAndUpdate](./api.html#model_Model.findOneAndUpdate)
+application, use [findOneAndUpdate](./api.html#model_Model-findOneAndUpdate)
 instead._
 
 ### Change Streams
@@ -156,7 +156,7 @@ You can read more about [change streams in mongoose in this blog post](http://th
 
 ### Yet more
 
-The [API docs](./api.html#model_Model) cover many additional methods available like [count](./api.html#model_Model.count), [mapReduce](./api.html#model_Model.mapReduce), [aggregate](./api.html#model_Model.aggregate), and [more](./api.html#model_Model.findOneAndRemove).
+The [API docs](./api.html#model_Model) cover many additional methods available like [count](./api.html#model_Model-count), [mapReduce](./api.html#model_Model-mapReduce), [aggregate](./api.html#model_Model-aggregate), and [more](./api.html#model_Model-findOneAndRemove).
 
 ### Next Up
 

--- a/docs/populate.md
+++ b/docs/populate.md
@@ -407,8 +407,8 @@ person.populated('fans'); // Array of ObjectIds
 <h3 id="populate_multiple_documents"><a href="#populate_multiple_documents">Populating multiple existing documents</a></h3>
 
 If we have one or many mongoose documents or even plain objects
-(_like [mapReduce](./api.html#model_Model.mapReduce) output_), we may
-populate them using the [Model.populate()](./api.html#model_Model.populate)
+(_like [mapReduce](./api.html#model_Model-mapReduce) output_), we may
+populate them using the [Model.populate()](./api.html#model_Model-populate)
 method. This is what `Document#populate()`
 and `Query#populate()` use to populate documents.
 
@@ -475,7 +475,7 @@ This is known as a "cross-database populate," because it enables you to
 populate across MongoDB databases and even across MongoDB instances.
 
 If you don't have access to the model instance when defining your `eventSchema`,
-you can also pass [the model instance as an option to `populate()`](/docs/api/model.html#model_Model.populate).
+you can also pass [the model instance as an option to `populate()`](/docs/api/model.html#model_Model-populate).
 
 ```javascript
 const events = await Event.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -5,21 +5,21 @@ for [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_del
 Each of these functions returns a
 [mongoose `Query` object](http://mongoosejs.com/docs/api.html#Query).
 
-- [`Model.deleteMany()`](/docs/api.html#model_Model.deleteMany)
-- [`Model.deleteOne()`](/docs/api.html#model_Model.deleteOne)
-- [`Model.find()`](/docs/api.html#model_Model.find)
-- [`Model.findById()`](/docs/api.html#model_Model.findById)
-- [`Model.findByIdAndDelete()`](/docs/api.html#model_Model.findByIdAndDelete)
-- [`Model.findByIdAndRemove()`](/docs/api.html#model_Model.findByIdAndRemove)
-- [`Model.findByIdAndUpdate()`](/docs/api.html#model_Model.findByIdAndUpdate)
-- [`Model.findOne()`](/docs/api.html#model_Model.findOne)
-- [`Model.findOneAndDelete()`](/docs/api.html#model_Model.findOneAndDelete)
-- [`Model.findOneAndRemove()`](/docs/api.html#model_Model.findOneAndRemove)
-- [`Model.findOneAndReplace()`](/docs/api.html#model_Model.findOneAndReplace)
-- [`Model.findOneAndUpdate()`](/docs/api.html#model_Model.findOneAndUpdate)
-- [`Model.replaceOne()`](/docs/api.html#model_Model.replaceOne)
-- [`Model.updateMany()`](/docs/api.html#model_Model.updateMany)
-- [`Model.updateOne()`](/docs/api.html#model_Model.updateOne)
+- [`Model.deleteMany()`](/docs/api.html#model_Model-deleteMany)
+- [`Model.deleteOne()`](/docs/api.html#model_Model-deleteOne)
+- [`Model.find()`](/docs/api.html#model_Model-find)
+- [`Model.findById()`](/docs/api.html#model_Model-findById)
+- [`Model.findByIdAndDelete()`](/docs/api.html#model_Model-findByIdAndDelete)
+- [`Model.findByIdAndRemove()`](/docs/api.html#model_Model-findByIdAndRemove)
+- [`Model.findByIdAndUpdate()`](/docs/api.html#model_Model-findByIdAndUpdate)
+- [`Model.findOne()`](/docs/api.html#model_Model-findOne)
+- [`Model.findOneAndDelete()`](/docs/api.html#model_Model-findOneAndDelete)
+- [`Model.findOneAndRemove()`](/docs/api.html#model_Model-findOneAndRemove)
+- [`Model.findOneAndReplace()`](/docs/api.html#model_Model-findOneAndReplace)
+- [`Model.findOneAndUpdate()`](/docs/api.html#model_Model-findOneAndUpdate)
+- [`Model.replaceOne()`](/docs/api.html#model_Model-replaceOne)
+- [`Model.updateMany()`](/docs/api.html#model_Model-updateMany)
+- [`Model.updateOne()`](/docs/api.html#model_Model-updateOne)
 
 A mongoose query can be executed in one of two ways. First, if you
 pass in a `callback` function, Mongoose will execute the query asynchronously
@@ -55,7 +55,7 @@ Mongoose executed the query and passed the results to `callback`. All callbacks 
 `callback(error, result)`. If an error occurs executing the query, the `error` parameter will contain an error document, and `result`
 will be null. If the query is successful, the `error` parameter will be null, and the `result` will be populated with the results of the query.
 
-Anywhere a callback is passed to a query in Mongoose, the callback follows the pattern `callback(error, results)`. What `results` is depends on the operation: For `findOne()` it is a [potentially-null single document](./api.html#model_Model.findOne), `find()` a [list of documents](./api.html#model_Model.find), `count()` [the number of documents](./api.html#model_Model.count), `update()` the [number of documents affected](./api.html#model_Model.update), etc. The [API docs for Models](./api.html#model-js) provide more detail on what is passed to the callbacks.
+Anywhere a callback is passed to a query in Mongoose, the callback follows the pattern `callback(error, results)`. What `results` is depends on the operation: For `findOne()` it is a [potentially-null single document](./api.html#model_Model-findOne), `find()` a [list of documents](./api.html#model_Model-find), `count()` [the number of documents](./api.html#model_Model-count), `update()` the [number of documents affected](./api.html#model_Model-update), etc. The [API docs for Models](./api.html#model-js) provide more detail on what is passed to the callbacks.
 
 Now let's look at what happens when no `callback` is passed:
 
@@ -212,7 +212,7 @@ However, just because you can use `aggregate()` doesn't mean you should.
 In general, you should use queries where possible, and only use `aggregate()`
 when you absolutely need to.
 
-Unlike query results, Mongoose does **not** [`hydrate()`](/docs/api/model.html#model_Model.hydrate)
+Unlike query results, Mongoose does **not** [`hydrate()`](/docs/api/model.html#model_Model-hydrate)
 aggregation results. Aggregation results are always POJOs, not Mongoose
 documents.
 

--- a/docs/schematypes.md
+++ b/docs/schematypes.md
@@ -467,7 +467,7 @@ console.log(new M({ b: 'nay' }).b); // false
 
 <h4 id="arrays">Arrays</h4>
 
-Mongoose supports arrays of [SchemaTypes](./api.html#schema_Schema.Types)
+Mongoose supports arrays of [SchemaTypes](./api.html#schema_Schema-Types)
 and arrays of [subdocuments](./subdocs.html). Arrays of SchemaTypes are
 also called _primitive arrays_, and arrays of subdocuments are also called
 _document arrays_.

--- a/docs/tutorials/lean.md
+++ b/docs/tutorials/lean.md
@@ -1,7 +1,7 @@
 # Faster Mongoose Queries With Lean
 
 The [lean option](/docs/api.html#query_Query-lean) tells Mongoose to skip
-[hydrating](/docs/api.html#model_Model.hydrate) the result documents. This
+[hydrating](/docs/api.html#model_Model-hydrate) the result documents. This
 makes queries faster and less memory intensive, but the result documents are
 plain old JavaScript objects (POJOs), **not** [Mongoose documents](/docs/documents.html).
 In this tutorial, you'll learn more about the tradeoffs of using `lean()`.

--- a/docs/tutorials/query_casting.md
+++ b/docs/tutorials/query_casting.md
@@ -1,6 +1,6 @@
 # Query Casting
 
-The first parameter to [`Model.find()`](https://mongoosejs.com/docs/api.html#model_Model.find), [`Query#find()`](https://mongoosejs.com/docs/api.html#query_Query-find), [`Model.findOne()`](https://mongoosejs.com/docs/api.html#model_Model.findOne), etc. is called `filter`. In older content this parameter is sometimes called `query` or `conditions`. For example:
+The first parameter to [`Model.find()`](https://mongoosejs.com/docs/api.html#model_Model-find), [`Query#find()`](https://mongoosejs.com/docs/api.html#query_Query-find), [`Model.findOne()`](https://mongoosejs.com/docs/api.html#model_Model-findOne), etc. is called `filter`. In older content this parameter is sometimes called `query` or `conditions`. For example:
 
 ```javascript
 [require:Cast Tutorial.*get and set]

--- a/examples/mapreduce/mapreduce.js
+++ b/examples/mapreduce/mapreduce.js
@@ -86,7 +86,7 @@ mongoose.connect('mongodb://localhost/persons', function(err) {
     o.verbose = true; // default is false, provide stats on the job
     // o.out = {}; // objects to specify where output goes, by default is
     // returned, but can also be stored in a new collection
-    // see: http://mongoosejs.com/docs/api.html#model_Model.mapReduce
+    // see: http://mongoosejs.com/docs/api.html#model_Model-mapReduce
     Person.mapReduce(o, function(err, results, stats) {
       console.log('map reduce took %d ms', stats.processtime);
       console.log(results);

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -19,7 +19,7 @@ const validRedactStringValues = new Set(['$$DESCEND', '$$PRUNE', '$$KEEP']);
 
 /**
  * Aggregate constructor used for building aggregation pipelines. Do not
- * instantiate this class directly, use [Model.aggregate()](/docs/api.html#model_Model.aggregate) instead.
+ * instantiate this class directly, use [Model.aggregate()](/docs/api.html#model_Model-aggregate) instead.
  *
  * #### Example:
  *

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -38,11 +38,9 @@ const validRedactStringValues = new Set(['$$DESCEND', '$$PRUNE', '$$KEEP']);
  * - The documents returned are plain javascript objects, not mongoose documents (since any shape of document can be returned).
  * - Mongoose does **not** cast pipeline stages. The below will **not** work unless `_id` is a string in the database
  *
- * ```javascript
- *   new Aggregate([{ $match: { _id: '00000000000000000000000a' } }]);
- *   // Do this instead to cast to an ObjectId
- *   new Aggregate([{ $match: { _id: new mongoose.Types.ObjectId('00000000000000000000000a') } }]);
- * ```
+ *     new Aggregate([{ $match: { _id: '00000000000000000000000a' } }]);
+ *     // Do this instead to cast to an ObjectId
+ *     new Aggregate([{ $match: { _id: new mongoose.Types.ObjectId('00000000000000000000000a') } }]);
  *
  * @see MongoDB https://docs.mongodb.org/manual/applications/aggregation/
  * @see driver https://mongodb.github.com/node-mongodb-native/api-generated/collection.html#aggregate
@@ -72,8 +70,8 @@ function Aggregate(pipeline, model) {
  * - [`cursor`](./api.html#aggregate_Aggregate-cursor)
  * - [`explain`](./api.html#aggregate_Aggregate-explain)
  * - `fieldsAsRaw`
- * - hint
- * - let
+ * - `hint`
+ * - `let`
  * - `maxTimeMS`
  * - `raw`
  * - `readConcern`
@@ -92,6 +90,7 @@ Aggregate.prototype.options;
  * Get/set the model that this aggregation will execute on.
  *
  * #### Example:
+ *
  *     const aggregate = MyModel.aggregate([{ $match: { answer: 42 } }]);
  *     aggregate.model() === MyModel; // true
  *
@@ -99,7 +98,7 @@ Aggregate.prototype.options;
  *     aggregate.model(SomeOtherModel);
  *     aggregate.model() === SomeOtherModel; // true
  *
- * @param {Model} [model] set the model associated with this aggregate.
+ * @param {Model} [model] Set the model associated with this aggregate. If not provided, returns the already stored model.
  * @return {Model}
  * @api public
  */
@@ -135,7 +134,7 @@ Aggregate.prototype.model = function(model) {
  *     const pipeline = [{ $match: { daw: 'Logic Audio X' }} ];
  *     aggregate.append(pipeline);
  *
- * @param {Object} ops operator(s) to append
+ * @param {...Object|Object[]} ops operator(s) to append. Can either be a spread of objects or a single parameter of a object array.
  * @return {Aggregate}
  * @api public
  */
@@ -364,7 +363,7 @@ Aggregate.prototype.near = function(arg) {
  *     aggregate.unwind({ path: '$tags', preserveNullAndEmptyArrays: true });
  *
  * @see $unwind https://docs.mongodb.org/manual/reference/aggregation/unwind/
- * @param {String|Object} fields the field(s) to unwind, either as field names or as [objects with options](https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#document-operand-with-options). If passing a string, prefixing the field name with '$' is optional. If passing an object, `path` must start with '$'.
+ * @param {String|Object|String[]|Object[]} fields the field(s) to unwind, either as field names or as [objects with options](https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#document-operand-with-options). If passing a string, prefixing the field name with '$' is optional. If passing an object, `path` must start with '$'.
  * @return {Aggregate}
  * @api public
  */
@@ -495,6 +494,7 @@ Aggregate.prototype.lookup = function(options) {
  * Note that graphLookup can only consume at most 100MB of memory, and does not allow disk use even if `{ allowDiskUse: true }` is specified.
  *
  * #### Examples:
+ *
  *      // Suppose we have a collection of courses, where a document might look like `{ _id: 0, name: 'Calculus', prerequisite: 'Trigonometry'}` and `{ _id: 0, name: 'Trigonometry', prerequisite: 'Algebra' }`
  *      aggregate.graphLookup({ from: 'courses', startWith: '$prerequisite', connectFromField: 'prerequisite', connectToField: 'name', as: 'prerequisites', maxDepth: 3 }) // this will recursively search the 'courses' collection up to 3 prerequisites
  *
@@ -602,7 +602,8 @@ Aggregate.prototype.sort = function(arg) {
  *
  * @see $unionWith https://docs.mongodb.com/manual/reference/operator/aggregation/unionWith
  * @param {Object} options to $unionWith query as described in the above link
- * @return {Aggregate}* @api public
+ * @return {Aggregate}
+ * @api public
  */
 
 Aggregate.prototype.unionWith = function(options) {
@@ -617,8 +618,8 @@ Aggregate.prototype.unionWith = function(options) {
  *
  *     await Model.aggregate(pipeline).read('primaryPreferred');
  *
- * @param {String} pref one of the listed preference options or their aliases
- * @param {Array} [tags] optional tags for this query
+ * @param {String|ReadPreference} pref one of the listed preference options or their aliases
+ * @param {Array} [tags] optional tags for this query. DEPRECATED
  * @return {Aggregate} this
  * @api public
  * @see mongodb https://docs.mongodb.org/manual/applications/replication/#read-preference
@@ -703,9 +704,9 @@ Aggregate.prototype.redact = function(expression, thenExpr, elseExpr) {
  *
  *     Model.aggregate(..).explain(callback)
  *
- * @param {String} verbosity
- * @param {Function} callback
- * @return {Promise}
+ * @param {String} [verbosity]
+ * @param {Function} [callback] The callback function to call, if not specified, will return a Promise instead.
+ * @return {Promise} Returns a promise if no "callback" is given
  */
 
 Aggregate.prototype.explain = function(verbosity, callback) {
@@ -772,6 +773,7 @@ Aggregate.prototype.explain = function(verbosity, callback) {
  *     await Model.aggregate([{ $match: { foo: 'bar' } }]).allowDiskUse(true);
  *
  * @param {Boolean} value Should tell server it can use hard drive to store data during aggregation.
+ * @return {Aggregate} this
  * @see mongodb https://docs.mongodb.org/manual/reference/command/aggregate/
  */
 
@@ -788,6 +790,7 @@ Aggregate.prototype.allowDiskUse = function(value) {
  *     Model.aggregate(..).hint({ qty: 1, category: 1 }).exec(callback)
  *
  * @param {Object|String} value a hint object or the index name
+ * @return {Aggregate} this
  * @see mongodb https://docs.mongodb.org/manual/reference/command/aggregate/
  */
 
@@ -805,6 +808,7 @@ Aggregate.prototype.hint = function(value) {
  *     await Model.aggregate(..).session(session);
  *
  * @param {ClientSession} session
+ * @return {Aggregate} this
  * @see mongodb https://docs.mongodb.org/manual/reference/command/aggregate/
  */
 
@@ -826,10 +830,10 @@ Aggregate.prototype.session = function(session) {
  *     agg.options; // `{ allowDiskUse: true }`
  *
  * @param {Object} options keys to merge into current options
- * @param [options.maxTimeMS] number limits the time this aggregation will run, see [MongoDB docs on `maxTimeMS`](https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/)
- * @param [options.allowDiskUse] boolean if true, the MongoDB server will use the hard drive to store data during this aggregation
- * @param [options.collation] object see [`Aggregate.prototype.collation()`](./docs/api.html#aggregate_Aggregate-collation)
- * @param [options.session] ClientSession see [`Aggregate.prototype.session()`](./docs/api.html#aggregate_Aggregate-session)
+ * @param {Number} [options.maxTimeMS] number limits the time this aggregation will run, see [MongoDB docs on `maxTimeMS`](https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/)
+ * @param {Boolean} [options.allowDiskUse] boolean if true, the MongoDB server will use the hard drive to store data during this aggregation
+ * @param {Object} [options.collation] object see [`Aggregate.prototype.collation()`](./docs/api.html#aggregate_Aggregate-collation)
+ * @param {ClientSession} [options.session] ClientSession see [`Aggregate.prototype.session()`](./docs/api.html#aggregate_Aggregate-session)
  * @see mongodb https://docs.mongodb.org/manual/reference/command/aggregate/
  * @return {Aggregate} this
  * @api public
@@ -855,7 +859,7 @@ Aggregate.prototype.option = function(value) {
  *     });
  *
  * @param {Object} options
- * @param {Number} options.batchSize set the cursor batch size
+ * @param {Number} [options.batchSize] set the cursor batch size
  * @param {Boolean} [options.useMongooseAggCursor] use experimental mongoose-specific aggregation cursor (for `eachAsync()` and other query cursor semantics)
  * @return {AggregationCursor} cursor representing this aggregation
  * @api public
@@ -940,10 +944,9 @@ Aggregate.prototype.search = function(options) {
  *
  *     MyModel.aggregate().match({ test: 1 }).pipeline(); // [{ $match: { test: 1 } }]
  *
- * @return {Array}
+ * @return {Array} The current pipeline similar to the operation that will be executed
  * @api public
  */
-
 
 Aggregate.prototype.pipeline = function() {
   return this._pipeline;
@@ -957,12 +960,10 @@ Aggregate.prototype.pipeline = function() {
  *     aggregate.exec(callback);
  *
  *     // Because a promise is returned, the `callback` is optional.
- *     const promise = aggregate.exec();
- *     promise.then(..);
+ *     const result = await aggregate.exec();
  *
- * @see Promise #promise_Promise
  * @param {Function} [callback]
- * @return {Promise}
+ * @return {Promise} Returns a Promise if no "callback" is given.
  * @api public
  */
 
@@ -1018,13 +1019,13 @@ Aggregate.prototype.exec = function(callback) {
 };
 
 /**
- * Provides promise for aggregate.
+ * Provides a Promise-like `then` function, which will call `.exec` without a callback
+ * Compatible with `await`.
  *
  * #### Example:
  *
  *     Model.aggregate(..).then(successCallback, errorCallback);
  *
- * @see Promise #promise_Promise
  * @param {Function} [resolve] successCallback
  * @param {Function} [reject]  errorCallback
  * @return {Promise}
@@ -1037,6 +1038,7 @@ Aggregate.prototype.then = function(resolve, reject) {
  * Executes the query returning a `Promise` which will be
  * resolved with either the doc(s) or rejected with the error.
  * Like [`.then()`](#query_Query-then), but only takes a rejection handler.
+ * Compatible with `await`.
  *
  * @param {Function} [reject]
  * @return {Promise}

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -103,7 +103,7 @@ exports.VirtualType = require('./virtualtype');
  * _Alias of mongoose.Schema.Types for backwards compatibility._
  *
  * @property SchemaTypes
- * @see Schema.SchemaTypes #schema_Schema.Types
+ * @see Schema.SchemaTypes #schema_Schema-Types
  * @api public
  */
 

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -24,8 +24,8 @@ const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
  *
  * @param {Schema} schema
  * @param {Object} obj Object to cast
- * @param {Object} options the query options
- * @param {Query} context passed to setters
+ * @param {Object} [options] the query options
+ * @param {Query} [context] passed to setters
  * @api private
  */
 module.exports = function cast(schema, obj, options, context) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -15,7 +15,7 @@ const immediate = require('./helpers/immediate');
  *
  * @param {String} name name of the collection
  * @param {Connection} conn A MongooseConnection instance
- * @param {Object} opts optional collection options
+ * @param {Object} [opts] optional collection options
  * @api public
  */
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -393,7 +393,7 @@ Connection.prototype.config;
  * @param {string} collection The collection to create
  * @param {Object} [options] see [MongoDB driver docs](https://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#createCollection)
  * @param {Function} [callback]
- * @return {Promise}
+ * @return {Promise} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -521,7 +521,7 @@ Connection.prototype.transaction = function transaction(fn, options) {
  * @method dropCollection
  * @param {string} collection The collection to delete
  * @param {Function} [callback]
- * @return {Promise}
+ * @return {Promise} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -541,7 +541,7 @@ Connection.prototype.dropCollection = _wrapConnHelper(function dropCollection(co
  *
  * @method dropDatabase
  * @param {Function} [callback]
- * @return {Promise}
+ * @return {Promise} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -608,6 +608,8 @@ Connection.prototype._shouldBufferCommands = function _shouldBufferCommands() {
  *
  * @param {Error} err
  * @param {Function} callback optional
+ * @emits "error" Emits the `error` event with the given `err`, unless a callback is specified
+ * @returns {Promise|null} Returns a rejected Promise if no `callback` is given.
  * @api private
  */
 
@@ -668,7 +670,7 @@ Connection.prototype.onOpen = function() {
  * @param {Number} [options.family=0] Passed transparently to [Node.js' `dns.lookup()`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) function. May be either `0, `4`, or `6`. `4` means use IPv4 only, `6` means use IPv6 only, `0` means try both.
  * @param {Boolean} [options.autoCreate=false] Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection.
  * @param {Function} [callback]
- * @returns {Connection} this
+ * @returns {Promise<Connection>} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -913,6 +915,14 @@ function _setClient(conn, client, options, dbName) {
   }
 }
 
+/**
+ * Destory the connection (not just a alias of [`.close`](#connection_Connection-close))
+ *
+ * @param {Boolean} [force]
+ * @param {Function} [callback]
+ * @returns {Promise} Returns a Promise if no `callback` is given.
+ */
+
 Connection.prototype.destroy = function(force, callback) {
   if (typeof force === 'function') {
     callback = force;
@@ -935,7 +945,7 @@ Connection.prototype.destroy = function(force, callback) {
  *
  * @param {Boolean} [force] optional
  * @param {Function} [callback] optional
- * @return {Promise}
+ * @return {Promise} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -961,7 +971,8 @@ Connection.prototype.close = function(force, callback) {
  *
  * @param {Boolean} force
  * @param {Boolean} destroy
- * @param {Function} callback
+ * @param {Function} [callback]
+ * @returns {Connection} this
  * @api private
  */
 Connection.prototype._close = function(force, destroy, callback) {
@@ -1081,6 +1092,7 @@ Connection.prototype.collection = function(name, options) {
  * Equivalent to calling `.plugin(fn)` on each schema you create.
  *
  * #### Example:
+ *
  *     const db = mongoose.createConnection('mongodb://localhost:27017/mydb');
  *     db.plugin(() => console.log('Applied'));
  *     db.plugins.length; // 1
@@ -1330,6 +1342,7 @@ Connection.prototype.watch = function(pipeline, options) {
  * to connect.
  *
  * #### Example:
+ *
  *     const conn = await mongoose.createConnection('mongodb://localhost:27017/test').
  *       asPromise();
  *     conn.readyState; // 1, means Mongoose is connected
@@ -1345,7 +1358,7 @@ Connection.prototype.asPromise = function asPromise() {
 /**
  * Returns an array of model names created on this connection.
  * @api public
- * @return {Array}
+ * @return {String[]}
  */
 
 Connection.prototype.modelNames = function() {
@@ -1353,9 +1366,10 @@ Connection.prototype.modelNames = function() {
 };
 
 /**
- * @brief Returns if the connection requires authentication after it is opened. Generally if a
+ * Returns if the connection requires authentication after it is opened. Generally if a
  * username and password are both provided than authentication is needed, but in some cases a
  * password is not required.
+ *
  * @api private
  * @return {Boolean} true if the connection should be authenticated after it is opened, otherwise false.
  */
@@ -1365,8 +1379,9 @@ Connection.prototype.shouldAuthenticate = function() {
 };
 
 /**
- * @brief Returns a boolean value that specifies if the current authentication mechanism needs a
+ * Returns a boolean value that specifies if the current authentication mechanism needs a
  * password to authenticate according to the auth objects passed into the openUri methods.
+ *
  * @api private
  * @return {Boolean} true if the authentication mechanism specified in the options object requires
  *  a password, otherwise false.
@@ -1379,10 +1394,11 @@ Connection.prototype.authMechanismDoesNotRequirePassword = function() {
 };
 
 /**
- * @brief Returns a boolean value that specifies if the provided objects object provides enough
+ * Returns a boolean value that specifies if the provided objects object provides enough
  * data to authenticate with. Generally this is true if the username and password are both specified
  * but in some authentication methods, a password is not required for authentication so only a username
  * is required.
+ *
  * @param {Object} [options] the options object passed into the openUri methods.
  * @api private
  * @return {Boolean} true if the provided options object provides enough data to authenticate with,
@@ -1399,6 +1415,7 @@ Connection.prototype.optionsProvideAuthenticationData = function(options) {
  * that this connection uses to talk to MongoDB.
  *
  * #### Example:
+ *
  *     const conn = await mongoose.createConnection('mongodb://localhost:27017/test').
  *       asPromise();
  *
@@ -1418,6 +1435,7 @@ Connection.prototype.getClient = function getClient() {
  * reuse it.
  *
  * #### Example:
+ *
  *     const client = await mongodb.MongoClient.connect('mongodb://localhost:27017/test');
  *
  *     const conn = mongoose.createConnection().setClient(client);
@@ -1426,6 +1444,7 @@ Connection.prototype.getClient = function getClient() {
  *     conn.readyState; // 1, means 'CONNECTED'
  *
  * @api public
+ * @param {MongClient} client The Client to set to be used.
  * @return {Connection} this
  */
 
@@ -1447,12 +1466,11 @@ Connection.prototype.setClient = function setClient(client) {
 };
 
 /**
- *
  * Syncs all the indexes for the models registered with this connection.
  *
- * @param {Object} options
- * @param {Boolean} options.continueOnError `false` by default. If set to `true`, mongoose will not throw an error if one model syncing failed, and will return an object where the keys are the names of the models, and the values are the results/errors for each model.
- * @return {Promise} Returns a Promise, when the Promise resolves the value is a list of the dropped indexes.
+ * @param {Object} [options]
+ * @param {Boolean} [options.continueOnError] `false` by default. If set to `true`, mongoose will not throw an error if one model syncing failed, and will return an object where the keys are the names of the models, and the values are the results/errors for each model.
+ * @return {Promise<Object>} Returns a Promise, when the Promise resolves the value is a list of the dropped indexes.
  */
 Connection.prototype.syncIndexes = async function syncIndexes(options = {}) {
   const result = {};

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1120,7 +1120,7 @@ Connection.prototype.plugin = function(fn, opts) {
  *     const Ticket = db.model('Ticket', new Schema(..));
  *     const Venue = db.model('Venue');
  *
- * _When no `collection` argument is passed, Mongoose produces a collection name by passing the model `name` to the [utils.toCollectionName](#utils_exports.toCollectionName) method. This method pluralizes the name. If you don't like this behavior, either pass a collection name or set your schemas collection name option._
+ * _When no `collection` argument is passed, Mongoose produces a collection name by passing the model `name` to the [utils.toCollectionName](#utils_exports-toCollectionName) method. This method pluralizes the name. If you don't like this behavior, either pass a collection name or set your schemas collection name option._
  *
  * #### Example:
  *
@@ -1286,7 +1286,7 @@ Connection.prototype.deleteModel = function(name) {
 
 /**
  * Watches the entire underlying database for changes. Similar to
- * [`Model.watch()`](/docs/api/model.html#model_Model.watch).
+ * [`Model.watch()`](/docs/api/model.html#model_Model-watch).
  *
  * This function does **not** trigger any middleware. In particular, it
  * does **not** trigger aggregate middleware.

--- a/lib/document.js
+++ b/lib/document.js
@@ -193,6 +193,46 @@ function Document(obj, fields, skipId, options) {
   applyQueue(this);
 }
 
+/**
+ * Boolean flag specifying if the document is new. If you create a document
+ * using `new`, this document will be considered "new". `$isNew` is how
+ * Mongoose determines whether `save()` should use `insertOne()` to create
+ * a new document or `updateOne()` to update an existing document.
+ *
+ * #### Example:
+ *
+ *     const user = new User({ name: 'John Smith' });
+ *     user.$isNew; // true
+ *
+ *     await user.save(); // Sends an `insertOne` to MongoDB
+ *
+ * On the other hand, if you load an existing document from the database
+ * using `findOne()` or another [query operation](/docs/queries.html),
+ * `$isNew` will be false.
+ *
+ * #### Example:
+ *
+ *     const user = await User.findOne({ name: 'John Smith' });
+ *     user.$isNew; // false
+ *
+ * For subdocuments, `$isNew` is true if either the parent has `$isNew` set,
+ * or if you create a new subdocument.
+ *
+ * #### Example:
+ *
+ *     // Assume `Group` has a document array `users`
+ *     const group = await Group.findOne();
+ *     group.users[0].$isNew; // false
+ *
+ *     group.users.push({ name: 'John Smith' });
+ *     group.users[1].$isNew; // true
+ *
+ * @api public
+ * @property $isNew
+ * @memberOf Document
+ * @instance
+ */
+
 Object.defineProperty(Document.prototype, 'isNew', {
   get: function() {
     return this.$isNew;
@@ -202,6 +242,15 @@ Object.defineProperty(Document.prototype, 'isNew', {
   }
 });
 
+/**
+ * Hash containing current validation errors.
+ *
+ * @api public
+ * @property errors
+ * @memberOf Document
+ * @instance
+ */
+
 Object.defineProperty(Document.prototype, 'errors', {
   get: function() {
     return this.$errors;
@@ -210,6 +259,7 @@ Object.defineProperty(Document.prototype, 'errors', {
     this.$errors = value;
   }
 });
+
 /*!
  * Document exposes the NodeJS event emitter API, so you can use
  * `on`, `once`, etc.
@@ -298,52 +348,13 @@ Object.defineProperty(Document.prototype, '$locals', {
   }
 });
 
-
-/**
- * Boolean flag specifying if the document is new. If you create a document
- * using `new`, this document will be considered "new". `$isNew` is how
- * Mongoose determines whether `save()` should use `insertOne()` to create
- * a new document or `updateOne()` to update an existing document.
- *
- * #### Example:
- *     const user = new User({ name: 'John Smith' });
- *     user.$isNew; // true
- *
- *     await user.save(); // Sends an `insertOne` to MongoDB
- *
- * On the other hand, if you load an existing document from the database
- * using `findOne()` or another [query operation](/docs/queries.html),
- * `$isNew` will be false.
- *
- * #### Example:
- *     const user = await User.findOne({ name: 'John Smith' });
- *     user.$isNew; // false
- *
- * For subdocuments, `$isNew` is true if either the parent has `$isNew` set,
- * or if you create a new subdocument.
- *
- * #### Example:
- *     // Assume `Group` has a document array `users`
- *     const group = await Group.findOne();
- *     group.users[0].$isNew; // false
- *
- *     group.users.push({ name: 'John Smith' });
- *     group.users[1].$isNew; // true
- *
- * @api public
- * @property $isNew
- * @memberOf Document
- * @instance
- */
-
-Document.prototype.$isNew;
-
 /**
  * Legacy alias for `$isNew`.
  *
  * @api public
  * @property isNew
  * @memberOf Document
+ * @see $isNew #document_Document-$isNew
  * @instance
  */
 
@@ -399,17 +410,6 @@ Document.prototype.id;
  */
 
 Document.prototype.$errors;
-
-/**
- * Hash containing current validation errors.
- *
- * @api public
- * @property errors
- * @memberOf Document
- * @instance
- */
-
-Document.prototype.errors;
 
 /**
  * A string containing the current operation that Mongoose is executing
@@ -630,6 +630,8 @@ function $applyDefaultsToNested(val, path, doc) {
  * @param {Object} obj
  * @param {Object} [fields]
  * @param {Boolean} [skipId]
+ * @param {Boolean} [exclude]
+ * @param {Object} [hasIncludedChildren]
  * @api private
  * @method $__buildDoc
  * @memberOf Document
@@ -714,6 +716,8 @@ Document.prototype.toBSON = function() {
  * Note that `init` hooks are [synchronous](/docs/middleware.html#synchronous).
  *
  * @param {Object} doc document returned by mongo
+ * @param {Object} [opts]
+ * @param {Function} [fn]
  * @api public
  * @memberOf Document
  * @instance
@@ -734,9 +738,24 @@ Document.prototype.init = function(doc, opts, fn) {
   return this;
 };
 
+/**
+ * Alias for [`.init`](#document_Document-init)
+ *
+ * @api public
+ */
+
 Document.prototype.$init = function() {
   return this.constructor.prototype.init.apply(this, arguments);
 };
+
+/**
+ * Internal "init" function
+ *
+ * @param {Document} doc
+ * @param {Object} [opts]
+ * @returns {Document} this
+ * @api private
+ */
 
 Document.prototype.$__init = function(doc, opts) {
   this.$isNew = false;
@@ -871,17 +890,17 @@ function init(self, obj, doc, opts, prefix) {
  *
  * #### Example:
  *
- *     weirdCar.update({$inc: {wheels:1}}, { w: 1 }, callback);
+ *     weirdCar.update({ $inc: { wheels:1 } }, { w: 1 }, callback);
  *
  * #### Valid options:
  *
  *  - same as in [Model.update](#model_Model.update)
  *
  * @see Model.update #model_Model.update
- * @param {Object} doc
- * @param {Object} options
- * @param {Function} callback
- * @return {Query}
+ * @param {...Object} ops
+ * @param {Object} [options]
+ * @param {Function} [callback]
+ * @return {Query} this
  * @api public
  * @memberOf Document
  * @instance
@@ -918,7 +937,7 @@ Document.prototype.update = function update() {
  * @param {Object} [options.lean] if truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document. See [`Query.lean()`](/docs/api.html#query_Query-lean) and the [Mongoose lean tutorial](/docs/tutorials/lean.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
- * @param {Function} callback
+ * @param {Function} [callback]
  * @return {Query}
  * @api public
  * @memberOf Document
@@ -956,8 +975,8 @@ Document.prototype.updateOne = function updateOne(doc, options, callback) {
  *
  * @see Model.replaceOne #model_Model.replaceOne
  * @param {Object} doc
- * @param {Object} options
- * @param {Function} callback
+ * @param {Object} [options]
+ * @param {Function} [callback]
  * @return {Query}
  * @api public
  * @memberOf Document
@@ -1030,10 +1049,10 @@ Document.prototype.$session = function $session(session) {
  *
  * @param {Object} obj the object to overwrite this document with
  * @method overwrite
- * @name overwrite
  * @memberOf Document
  * @instance
  * @api public
+ * @return {Document} this
  */
 
 Document.prototype.overwrite = function overwrite(obj) {
@@ -1064,8 +1083,8 @@ Document.prototype.overwrite = function overwrite(obj) {
  * @param {Schema|String|Number|Buffer|*} [type] optionally specify a type for "on-the-fly" attributes
  * @param {Object} [options] optionally specify options that modify the behavior of the set
  * @param {Boolean} [options.merge=false] if true, setting a [nested path](/docs/subdocs.html#subdocuments-versus-nested-paths) will merge existing values rather than overwrite the whole object. So `doc.set('nested', { a: 1, b: 2 })` becomes `doc.set('nested.a', 1); doc.set('nested.b', 2);`
+ * @return {Document} this
  * @method $set
- * @name $set
  * @memberOf Document
  * @instance
  * @api public
@@ -1554,6 +1573,7 @@ function _isManuallyPopulatedArray(val, ref) {
 
 /**
  * Sets the value of a path, or many paths.
+ * Alias for [`.$set`](#document_Document-$set).
  *
  * #### Example:
  *
@@ -1581,6 +1601,7 @@ function _isManuallyPopulatedArray(val, ref) {
  * @param {Any} val the value to set
  * @param {Schema|String|Number|Buffer|*} [type] optionally specify a type for "on-the-fly" attributes
  * @param {Object} [options] optionally specify options that modify the behavior of the set
+ * @return {Document} this
  * @api public
  * @method set
  * @memberOf Document
@@ -1592,6 +1613,14 @@ Document.prototype.set = Document.prototype.$set;
 /**
  * Determine if we should mark this change as modified.
  *
+ * @param {never} pathToMark UNUSED
+ * @param {String|Symbol} path
+ * @param {Object} options
+ * @param {Any} constructing
+ * @param {never} parts UNUSED
+ * @param {Schema} schema
+ * @param {Any} val
+ * @param {Any} priorVal
  * @return {Boolean}
  * @api private
  * @method $__shouldModify
@@ -1652,6 +1681,14 @@ Document.prototype.$__shouldModify = function(pathToMark, path, options, constru
 /**
  * Handles the actual setting of the value and marking the path modified if appropriate.
  *
+ * @param {String} pathToMark
+ * @param {String|Symbol} path
+ * @param {Object} options
+ * @param {Any} constructing
+ * @param {Array} parts
+ * @param {Schema} schema
+ * @param {Any} val
+ * @param {Any} priorVal
  * @api private
  * @method $__set
  * @memberOf Document
@@ -1727,6 +1764,7 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
  * Gets a raw value from a path (no getters)
  *
  * @param {String} path
+ * @return {Any} Returns the value from the given `path`.
  * @api private
  */
 
@@ -1739,6 +1777,7 @@ Document.prototype.$__getValue = function(path) {
  *
  * @param {String} path
  * @param {Object} value
+ * @return {Document} this
  * @api private
  */
 
@@ -1763,6 +1802,7 @@ Document.prototype.$__setValue = function(path, val) {
  * @param {Object} [options]
  * @param {Boolean} [options.virtuals=false] Apply virtuals before getting this path
  * @param {Boolean} [options.getters=true] If false, skip applying getters and just get the raw value
+ * @return {Any}
  * @api public
  */
 
@@ -1831,10 +1871,12 @@ Document.prototype.get = function(path, type, options) {
 
 Document.prototype[getSymbol] = Document.prototype.get;
 Document.prototype.$get = Document.prototype.get;
+
 /**
  * Returns the schematype for the given `path`.
  *
  * @param {String} path
+ * @return {SchemaPath}
  * @api private
  * @method $__path
  * @memberOf Document
@@ -1924,6 +1966,7 @@ Document.prototype.$ignore = function(path) {
  * because a child of `a` was directly modified.
  *
  * #### Example:
+ *
  *     const schema = new Schema({ foo: String, nested: { bar: String } });
  *     const Model = mongoose.model('Test', schema);
  *     await Model.create({ foo: 'original', nested: { bar: 'original' } });
@@ -1933,7 +1976,7 @@ Document.prototype.$ignore = function(path) {
  *     doc.directModifiedPaths(); // ['nested.bar']
  *     doc.modifiedPaths(); // ['nested', 'nested.bar']
  *
- * @return {Array}
+ * @return {String[]}
  * @api public
  */
 
@@ -1947,6 +1990,7 @@ Document.prototype.directModifiedPaths = function() {
  * [minimize option](/docs/guide.html#minimize).
  *
  * #### Example:
+ *
  *     const schema = new Schema({ nested: { foo: String } });
  *     const Model = mongoose.model('Test', schema);
  *     const doc = new Model({});
@@ -1957,6 +2001,7 @@ Document.prototype.directModifiedPaths = function() {
  *     doc.$isEmpty('nested'); // false
  *     doc.nested.$isEmpty(); // false
  *
+ * @param {String} [path]
  * @memberOf Document
  * @instance
  * @api public
@@ -1989,6 +2034,10 @@ Document.prototype.$isEmpty = function(path) {
   return Object.keys(this.toObject(isEmptyOptions)).length === 0;
 };
 
+/*!
+ * ignore
+ */
+
 function _isEmpty(v) {
   if (v == null) {
     return true;
@@ -2009,7 +2058,7 @@ function _isEmpty(v) {
  *
  * @param {Object} [options]
  * @param {Boolean} [options.includeChildren=false] if true, returns children of modified paths as well. For example, if false, the list of modified paths for `doc.colors = { primary: 'blue' };` will **not** contain `colors.primary`. If true, `modifiedPaths()` will return an array that contains `colors.primary`.
- * @return {Array}
+ * @return {String[]}
  * @api public
  */
 
@@ -2118,6 +2167,14 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
   return this.$__.activePaths.some('modify');
 };
 
+/**
+ * Alias of [`.isModified`](#document_Document-isModified)
+ *
+ * @method $isModified
+ * @memberOf Document
+ * @api public
+ */
+
 Document.prototype.$isModified = Document.prototype.isModified;
 
 Document.prototype[documentIsModified] = Document.prototype.isModified;
@@ -2160,6 +2217,7 @@ Document.prototype.$isDefault = function(path) {
  * Getter/setter, determines whether the document was removed or not.
  *
  * #### Example:
+ *
  *     const product = await product.remove();
  *     product.$isDeleted(); // true
  *     product.remove(); // no-op, doesn't send anything to the db
@@ -2170,7 +2228,7 @@ Document.prototype.$isDefault = function(path) {
  *
  *
  * @param {Boolean} [val] optional, overrides whether mongoose thinks the doc is deleted
- * @return {Boolean} whether mongoose thinks this doc is deleted.
+ * @return {Boolean|Document} whether mongoose thinks this doc is deleted.
  * @method $isDeleted
  * @memberOf Document
  * @instance
@@ -2195,7 +2253,7 @@ Document.prototype.$isDeleted = function(val) {
  *     doc.isDirectModified('documents.0.title') // true
  *     doc.isDirectModified('documents') // false
  *
- * @param {String|String[]} path
+ * @param {String|String[]} [path]
  * @return {Boolean}
  * @api public
  */
@@ -2220,7 +2278,7 @@ Document.prototype.isDirectModified = function(path) {
 /**
  * Checks if `path` is in the `init` state, that is, it was set by `Document#init()` and not modified since.
  *
- * @param {String} path
+ * @param {String} [path]
  * @return {Boolean}
  * @api public
  */
@@ -2404,7 +2462,7 @@ Document.prototype.isDirectSelected = function isDirectSelected(path) {
  * @param {Boolean} [options.validateModifiedOnly=false] if `true` mongoose validates only modified paths.
  * @param {Array|string} [options.pathsToSkip] list of paths to skip. If set, Mongoose will validate every modified path that is not in this list.
  * @param {Function} [callback] optional callback called after validation completes, passing an error if one occurred
- * @return {Promise} Promise
+ * @return {Promise} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -2459,6 +2517,14 @@ Document.prototype.validate = function(pathsToValidate, options, callback) {
     });
   }, this.constructor.events);
 };
+
+/**
+ * Alias of [`.validate`](#document_Document-validate)
+ *
+ * @method $validate
+ * @memberOf Document
+ * @api public
+ */
 
 Document.prototype.$validate = Document.prototype.validate;
 
@@ -2854,6 +2920,7 @@ function _handlePathsToValidate(paths, pathsToValidate) {
 /*!
  * ignore
  */
+
 function _handlePathsToSkip(paths, pathsToSkip) {
   pathsToSkip = new Set(pathsToSkip);
   paths = paths.filter(p => !pathsToSkip.has(p));
@@ -2876,7 +2943,7 @@ function _handlePathsToSkip(paths, pathsToSkip) {
  *       // validation passed
  *     }
  *
- * @param {Array|string} pathsToValidate only validate the given paths
+ * @param {Array|string} [pathsToValidate] only validate the given paths
  * @param {Object} [options] options for validation
  * @param {Boolean} [options.validateModifiedOnly=false] If `true`, Mongoose will only validate modified paths, as opposed to modified paths and `required` paths.
  * @param {Array|string} [options.pathsToSkip] list of paths to skip. If set, Mongoose will validate every modified path that is not in this list.
@@ -2985,7 +3052,7 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
  * The `value` argument (if passed) will be available through the `ValidationError.value` property.
  *
  *     doc.invalidate('size', 'must be less than 20', 14);
-
+ *
  *     doc.validate(function (err) {
  *       console.log(err)
  *       // prints
@@ -3001,8 +3068,8 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
  *     })
  *
  * @param {String} path the field to invalidate. For array elements, use the `array.i.field` syntax, where `i` is the 0-based index in the array.
- * @param {String|Error} errorMsg the error which states the reason `path` was invalid
- * @param {Object|String|Number|any} value optional invalid value
+ * @param {String|Error} err the error which states the reason `path` was invalid
+ * @param {Object|String|Number|any} val optional invalid value
  * @param {String} [kind] optional `kind` property for the error
  * @return {ValidationError} the current ValidationError, with all currently invalidated paths
  * @api public
@@ -3138,7 +3205,7 @@ function _checkImmutableSubpaths(subdoc, schematype, priorVal) {
 /**
  * Checks if a path is invalid
  *
- * @param {String|String[]} path the field to check
+ * @param {String|String[]} [path] the field to check. If unset will always return "false"
  * @method $isValid
  * @memberOf Document
  * @instance
@@ -3167,7 +3234,7 @@ Document.prototype.$isValid = function(path) {
  * Resets the internal modified state of this document.
  *
  * @api private
- * @return {Document}
+ * @return {Document} this
  * @method $__reset
  * @memberOf Document
  * @instance
@@ -3279,6 +3346,7 @@ Document.prototype.$__undoReset = function $__undoReset() {
 /**
  * Returns this documents dirty paths / vals.
  *
+ * @return {Array}
  * @api private
  * @method $__dirty
  * @memberOf Document
@@ -3369,6 +3437,7 @@ Document.prototype.$__setSchema = function(schema) {
 /**
  * Get active path that were changed and are arrays
  *
+ * @return {Array}
  * @api private
  * @method $__getArrayPathsToValidate
  * @memberOf Document
@@ -3397,6 +3466,7 @@ Document.prototype.$__getArrayPathsToValidate = function() {
 /**
  * Get all subdocs (by bfs)
  *
+ * @return {Array}
  * @api public
  * @method $getAllSubdocs
  * @memberOf Document
@@ -3492,6 +3562,7 @@ Document.prototype.$__handleReject = function handleReject(err) {
 /**
  * Internal helper for toObject() and toJSON() that doesn't manipulate options
  *
+ * @return {Object}
  * @api private
  * @method $toObject
  * @memberOf Document
@@ -3638,18 +3709,6 @@ Document.prototype.$toObject = function(options, json) {
  *
  * Buffers are converted to instances of [mongodb.Binary](https://mongodb.github.com/node-mongodb-native/api-bson-generated/binary.html) for proper storage.
  *
- * #### Options:
- *
- * - `getters` apply all getters (path and virtual getters), defaults to false
- * - `aliases` apply all aliases if `virtuals=true`, defaults to true
- * - `virtuals` apply virtual getters (can override `getters` option), defaults to false
- * - `minimize` remove empty objects, defaults to true
- * - `transform` a transform function to apply to the resulting document before returning
- * - `depopulate` depopulate any populated paths, replacing them with their original refs, defaults to false
- * - `versionKey` whether to include the version key, defaults to true
- * - `flattenMaps` convert Maps to POJOs. Useful if you want to JSON.stringify() the result of toObject(), defaults to false
- * - `useProjection` set to `true` to omit fields that are excluded in this document's projection. Unless you specified a projection, this will omit any field that has `select: false` in the schema.
- *
  * #### Getters/Virtuals
  *
  * Example of only applying path getters
@@ -3774,7 +3833,7 @@ Document.prototype.$toObject = function(options, json) {
  * @param {Boolean} [options.versionKey=true] if false, exclude the version key (`__v` by default) from the output
  * @param {Boolean} [options.flattenMaps=false] if true, convert Maps to POJOs. Useful if you want to `JSON.stringify()` the result of `toObject()`.
  * @param {Boolean} [options.useProjection=false] - If true, omits fields that are excluded in this document's projection. Unless you specified a projection, this will omit any field that has `select: false` in the schema.
- * @return {Object} js object
+ * @return {Object} js object (not a POJO)
  * @see mongodb.Binary https://mongodb.github.com/node-mongodb-native/api-bson-generated/binary.html
  * @api public
  * @memberOf Document
@@ -4072,6 +4131,7 @@ Document.prototype.ownerDocument = function() {
  * If this document is a subdocument or populated document, returns the document's
  * parent. Returns the original document if there is no parent.
  *
+ * @return {Document}
  * @api public
  * @method parent
  * @memberOf Document
@@ -4086,9 +4146,10 @@ Document.prototype.parent = function() {
 };
 
 /**
- * Alias for `parent()`. If this document is a subdocument or populated
+ * Alias for [`parent()`](#document_Document-parent). If this document is a subdocument or populated
  * document, returns the document's parent. Returns `undefined` otherwise.
  *
+ * @return {Document}
  * @api public
  * @method $parent
  * @memberOf Document
@@ -4100,6 +4161,7 @@ Document.prototype.$parent = Document.prototype.parent;
 /**
  * Helper for console.log
  *
+ * @return {String}
  * @api public
  * @method inspect
  * @memberOf Document
@@ -4135,6 +4197,7 @@ if (inspect.custom) {
 /**
  * Helper for console.log
  *
+ * @return {String}
  * @api public
  * @method toString
  * @memberOf Document
@@ -4156,7 +4219,7 @@ Document.prototype.toString = function() {
  * document has an `_id`, in which case this function falls back to using
  * `deepEqual()`.
  *
- * @param {Document} doc a document to compare
+ * @param {Document} [doc] a document to compare. If falsy, will always return "false".
  * @return {Boolean}
  * @api public
  * @memberOf Document
@@ -4217,7 +4280,7 @@ Document.prototype.equals = function(doc) {
  * @see Model.populate #model_Model.populate
  * @memberOf Document
  * @instance
- * @return {Promise|null}
+ * @return {Promise|null} Returns a Promise if no `callback` is given.
  * @api public
  */
 
@@ -4274,7 +4337,7 @@ Document.prototype.populate = function populate() {
  * Gets all populated documents associated with this document.
  *
  * @api public
- * @return {Array<Document>} array of populated documents. Empty array if there are no populated documents associated with this document.
+ * @return {Document[]} array of populated documents. Empty array if there are no populated documents associated with this document.
  * @memberOf Document
  * @method $getPopulatedDocs
  * @instance
@@ -4310,6 +4373,8 @@ Document.prototype.$getPopulatedDocs = function $getPopulatedDocs() {
  * If the path was not populated, returns `undefined`.
  *
  * @param {String} path
+ * @param {Any} [val]
+ * @param {Object} [options]
  * @return {Array|ObjectId|Number|Buffer|String|undefined}
  * @memberOf Document
  * @instance
@@ -4357,6 +4422,14 @@ Document.prototype.populated = function(path, val, options) {
   return val;
 };
 
+/**
+ * Alias of [`.populated`](#document_Document-populated).
+ *
+ * @method $populated
+ * @memberOf Document
+ * @api public
+ */
+
 Document.prototype.$populated = Document.prototype.populated;
 
 /**
@@ -4370,7 +4443,7 @@ Document.prototype.$populated = Document.prototype.populated;
  *     doc.$assertPopulated('other path'); // throws an error
  *
  *
- * @param {String|String[]} path
+ * @param {String|String[]} paths
  * @return {Document} this
  * @memberOf Document
  * @method $assertPopulated
@@ -4404,7 +4477,7 @@ Document.prototype.$assertPopulated = function $assertPopulated(paths) {
  *
  * If the path was not provided, then all populated fields are returned to their unpopulated state.
  *
- * @param {String} path
+ * @param {String} [path] Specific Path to depopulate. If unset, will depopulate all paths on the Document.
  * @return {Document} this
  * @see Document.populate #document_Document-populate
  * @api public

--- a/lib/document.js
+++ b/lib/document.js
@@ -894,9 +894,9 @@ function init(self, obj, doc, opts, prefix) {
  *
  * #### Valid options:
  *
- *  - same as in [Model.update](#model_Model.update)
+ *  - same as in [Model.update](#model_Model-update)
  *
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @param {...Object} ops
  * @param {Object} [options]
  * @param {Function} [callback]
@@ -929,9 +929,9 @@ Document.prototype.update = function update() {
  *
  * #### Valid options:
  *
- *  - same as in [Model.updateOne](#model_Model.updateOne)
+ *  - same as in [Model.updateOne](#model_Model-updateOne)
  *
- * @see Model.updateOne #model_Model.updateOne
+ * @see Model.updateOne #model_Model-updateOne
  * @param {Object} doc
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Object} [options.lean] if truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document. See [`Query.lean()`](/docs/api.html#query_Query-lean) and the [Mongoose lean tutorial](/docs/tutorials/lean.html).
@@ -971,9 +971,9 @@ Document.prototype.updateOne = function updateOne(doc, options, callback) {
  *
  * #### Valid options:
  *
- *  - same as in [Model.replaceOne](https://mongoosejs.com/docs/api/model.html#model_Model.replaceOne)
+ *  - same as in [Model.replaceOne](https://mongoosejs.com/docs/api/model.html#model_Model-replaceOne)
  *
- * @see Model.replaceOne #model_Model.replaceOne
+ * @see Model.replaceOne #model_Model-replaceOne
  * @param {Object} doc
  * @param {Object} [options]
  * @param {Function} [callback]
@@ -4277,7 +4277,7 @@ Document.prototype.equals = function(doc) {
  * @param {Function} [callback] Callback
  * @see population ./populate.html
  * @see Query#select #query_Query-select
- * @see Model.populate #model_Model.populate
+ * @see Model.populate #model_Model-populate
  * @memberOf Document
  * @instance
  * @return {Promise|null} Returns a Promise if no `callback` is given.

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,7 +191,7 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
  * Currently supported options are:
  * - 'applyPluginsToChildSchemas': `true` by default. Set to false to skip applying global plugins to child schemas
  * - 'applyPluginsToDiscriminators': `false` by default. Set to true to apply global plugins to discriminator schemas. This typically isn't necessary because plugins are applied to the base schema and discriminators copy all middleware, methods, statics, and properties from the base schema.
- * - 'autoCreate': Set to `true` to make Mongoose call [`Model.createCollection()`](/docs/api/model.html#model_Model.createCollection) automatically when you create a model with `mongoose.model()` or `conn.model()`. This is useful for testing transactions, change streams, and other features that require the collection to exist.
+ * - 'autoCreate': Set to `true` to make Mongoose call [`Model.createCollection()`](/docs/api/model.html#model_Model-createCollection) automatically when you create a model with `mongoose.model()` or `conn.model()`. This is useful for testing transactions, change streams, and other features that require the collection to exist.
  * - 'autoIndex': `true` by default. Set to false to disable automatic index creation for all models associated with this Mongoose instance.
  * - 'debug': If `true`, prints the operations mongoose sends to MongoDB to the console. If a writable stream is passed, it will log to that stream, without colorization. If a callback function is passed, it will receive the collection name, the method name, then all arguments passed to the method. For example, if you wanted to replicate the default logging, you could output from the callback `Mongoose: ${collectionName}.${methodName}(${methodArgs.join(', ')})`.
  * - 'returnOriginal': If `false`, changes the default `returnOriginal` option to `findOneAndUpdate()`, `findByIdAndUpdate`, and `findOneAndReplace()` to false. This is equivalent to setting the `new` option to `true` for `findOneAndX()` calls by default. Read our [`findOneAndUpdate()` tutorial](/docs/tutorials/findoneandupdate.html) for more information.
@@ -861,7 +861,7 @@ Mongoose.prototype.SchemaType = SchemaType;
  * _Alias of mongoose.Schema.Types for backwards compatibility._
  *
  * @property SchemaTypes
- * @see Schema.SchemaTypes #schema_Schema.Types
+ * @see Schema.SchemaTypes #schema_Schema-Types
  * @api public
  */
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2302,7 +2302,7 @@ Model.estimatedDocumentCount = function estimatedDocumentCount(options, callback
  *     });
  *
  * If you want to count all documents in a large collection,
- * use the [`estimatedDocumentCount()` function](/docs/api.html#model_Model.estimatedDocumentCount)
+ * use the [`estimatedDocumentCount()` function](/docs/api.html#model_Model-estimatedDocumentCount)
  * instead. If you call `countDocuments({})`, MongoDB will always execute
  * a full collection scan and **not** use any indexes.
  *
@@ -2347,8 +2347,8 @@ Model.countDocuments = function countDocuments(conditions, options, callback) {
  * Counts number of documents that match `filter` in a database collection.
  *
  * This method is deprecated. If you want to count the number of documents in
- * a collection, e.g. `count({})`, use the [`estimatedDocumentCount()` function](/docs/api.html#model_Model.estimatedDocumentCount)
- * instead. Otherwise, use the [`countDocuments()`](/docs/api.html#model_Model.countDocuments) function instead.
+ * a collection, e.g. `count({})`, use the [`estimatedDocumentCount()` function](/docs/api.html#model_Model-estimatedDocumentCount)
+ * instead. Otherwise, use the [`countDocuments()`](/docs/api.html#model_Model-countDocuments) function instead.
  *
  * #### Example:
  *
@@ -2516,7 +2516,7 @@ Model.$where = function $where() {
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
- * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace(conditions, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
+ * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace(conditions, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model-findOneAndReplace).
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
@@ -2647,7 +2647,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
- * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace({ _id: id }, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model.findOneAndReplace).
+ * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `update`, Mongoose will wrap `update` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`. An alternative to this would be using [Model.findOneAndReplace({ _id: id }, update, options, callback)](https://mongoosejs.com/docs/api/model.html#model_Model-findOneAndReplace).
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
  * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
@@ -2657,7 +2657,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Function} [callback]
  * @return {Query}
- * @see Model.findOneAndUpdate #model_Model.findOneAndUpdate
+ * @see Model.findOneAndUpdate #model_Model-findOneAndUpdate
  * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
  * @api public
  */
@@ -2778,7 +2778,7 @@ Model.findOneAndDelete = function(conditions, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Function} [callback]
  * @return {Query}
- * @see Model.findOneAndRemove #model_Model.findOneAndRemove
+ * @see Model.findOneAndRemove #model_Model-findOneAndRemove
  * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
  */
 
@@ -2974,7 +2974,7 @@ Model.findOneAndRemove = function(conditions, options, callback) {
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Function} [callback]
  * @return {Query}
- * @see Model.findOneAndRemove #model_Model.findOneAndRemove
+ * @see Model.findOneAndRemove #model_Model-findOneAndRemove
  * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
  */
 
@@ -3054,7 +3054,7 @@ Model.create = function create(doc, options, callback) {
       // to use a spread to specify options, see gh-7535
       utils.warn('WARNING: to pass a `session` to `Model.create()` in ' +
         'Mongoose, you **must** pass an array as the first argument. See: ' +
-        'https://mongoosejs.com/docs/api.html#model_Model.create');
+        'https://mongoosejs.com/docs/api.html#model_Model-create');
     }
   }
 
@@ -3463,7 +3463,7 @@ function _setIsNew(doc, val) {
  *
  * This function does **not** trigger any middleware, neither `save()`, nor `update()`.
  * If you need to trigger
- * `save()` middleware for every document use [`create()`](https://mongoosejs.com/docs/api.html#model_Model.create) instead.
+ * `save()` middleware for every document use [`create()`](https://mongoosejs.com/docs/api.html#model_Model-create) instead.
  *
  * #### Example:
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -2133,7 +2133,7 @@ Query.prototype._unsetCastError = function _unsetCastError() {
  * Below are the current Mongoose-specific options.
  *
  * - `populate`: an array representing what paths will be populated. Should have one entry for each call to [`Query.prototype.populate()`](/docs/api.html#query_Query-populate)
- * - `lean`: if truthy, Mongoose will not [hydrate](/docs/api.html#model_Model.hydrate) any documents that are returned from this query. See [`Query.prototype.lean()`](/docs/api.html#query_Query-lean) for more information.
+ * - `lean`: if truthy, Mongoose will not [hydrate](/docs/api.html#model_Model-hydrate) any documents that are returned from this query. See [`Query.prototype.lean()`](/docs/api.html#query_Query-lean) for more information.
  * - `strict`: controls how Mongoose handles keys that aren't in the schema for updates. This option is `true` by default, which means Mongoose will silently strip any paths in the update that aren't in the schema. See the [`strict` mode docs](/docs/guide.html#strict) for more information.
  * - `strictQuery`: controls how Mongoose handles keys that aren't in the schema for the query `filter`. This option is `false` by default for backwards compatibility, which means Mongoose will allow `Model.find({ foo: 'bar' })` even if `foo` is not in the schema. See the [`strictQuery` docs](/docs/guide.html#strictQuery) for more information.
  * - `nearSphere`: use `$nearSphere` instead of `near()`. See the [`Query.prototype.nearSphere()` docs](/docs/api.html#query_Query-nearSphere)
@@ -4245,7 +4245,7 @@ Query.prototype.validate = function validate(castedDoc, options, isOverwriting, 
  * Internal thunk for .update()
  *
  * @param {Function} callback
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @api private
  */
 Query.prototype._execUpdate = wrapThunk(function(callback) {
@@ -4256,7 +4256,7 @@ Query.prototype._execUpdate = wrapThunk(function(callback) {
  * Internal thunk for .updateMany()
  *
  * @param {Function} callback
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @api private
  */
 Query.prototype._updateMany = wrapThunk(function(callback) {
@@ -4267,7 +4267,7 @@ Query.prototype._updateMany = wrapThunk(function(callback) {
  * Internal thunk for .updateOne()
  *
  * @param {Function} callback
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @api private
  */
 Query.prototype._updateOne = wrapThunk(function(callback) {
@@ -4278,7 +4278,7 @@ Query.prototype._updateOne = wrapThunk(function(callback) {
  * Internal thunk for .replaceOne()
  *
  * @param {Function} callback
- * @see Model.replaceOne #model_Model.replaceOne
+ * @see Model.replaceOne #model_Model-replaceOne
  * @api private
  */
 Query.prototype._replaceOne = wrapThunk(function(callback) {
@@ -4368,7 +4368,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
  * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
@@ -4432,7 +4432,7 @@ Query.prototype.update = function(conditions, doc, options, callback) {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
  * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
@@ -4497,7 +4497,7 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
  * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
@@ -4560,7 +4560,7 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
- * @see Model.update #model_Model.update
+ * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
  * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
@@ -5061,7 +5061,7 @@ function castQuery(query) {
  * @param {Object} [options.options=null] Additional options like `limit` and `lean`.
  * @see population ./populate.html
  * @see Query#select #query_Query-select
- * @see Model.populate #model_Model.populate
+ * @see Model.populate #model_Model-populate
  * @return {Query} this
  * @api public
  */

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -134,6 +134,7 @@ SchemaType.prototype.OptionsConstructor = SchemaTypeOptions;
  * The path to this SchemaType in a Schema.
  *
  * #### Example:
+ *
  *     const schema = new Schema({ name: String });
  *     schema.path('name').path; // 'name'
  *
@@ -148,6 +149,7 @@ SchemaType.prototype.path;
  * The validators that Mongoose should run to validate properties at this SchemaType's path.
  *
  * #### Example:
+ *
  *     const schema = new Schema({ name: { type: String, required: true } });
  *     schema.path('name').validators.length; // 1, the `required` validator
  *
@@ -162,6 +164,7 @@ SchemaType.prototype.validators;
  * True if this SchemaType has a required validator. False otherwise.
  *
  * #### Example:
+ *
  *     const schema = new Schema({ name: { type: String, required: true } });
  *     schema.path('name').isRequired; // true
  *
@@ -175,8 +178,11 @@ SchemaType.prototype.validators;
 
 SchemaType.prototype.validators;
 
-/*!
- * ignore
+/**
+ * Split the current dottet path into segments
+ *
+ * @return {String[]|undefined}
+ * @api private
  */
 
 SchemaType.prototype.splitPath = function() {
@@ -351,8 +357,8 @@ SchemaType.get = function(getter) {
  *     const m2 = new M;
  *     console.log(m2.mixed); // { added: 1 }
  *
- * @param {Function|any} val the default value
- * @return {defaultValue}
+ * @param {Function|any} val The default value to set
+ * @return {Any|undefined} Returns the set default value.
  * @api public
  */
 
@@ -414,7 +420,7 @@ SchemaType.prototype.index = function(options) {
  *
  * #### Example:
  *
- *     const s = new Schema({ name: { type: String, unique: true }});
+ *     const s = new Schema({ name: { type: String, unique: true } });
  *     s.path('name').index({ unique: true });
  *
  * _NOTE: violating the constraint returns an `E11000` error from MongoDB when saving, not a Mongoose validation error._
@@ -452,8 +458,9 @@ SchemaType.prototype.unique = function(bool) {
  *
  * ### Example:
  *
- *      const s = new Schema({name : {type: String, text : true })
- *      s.path('name').index({text : true});
+ *      const s = new Schema({ name : { type: String, text : true } })
+ *      s.path('name').index({ text : true });
+ *
  * @param {Boolean} bool
  * @return {SchemaType} this
  * @api public
@@ -606,19 +613,17 @@ SchemaType.prototype.transform = function(fn) {
  *
  * #### Example:
  *
- * ```javascript
- * function capitalize (val) {
- *   if (typeof val !== 'string') val = '';
- *   return val.charAt(0).toUpperCase() + val.substring(1);
- * }
+ *     function capitalize (val) {
+ *       if (typeof val !== 'string') val = '';
+ *       return val.charAt(0).toUpperCase() + val.substring(1);
+ *     }
  *
- * // defining within the schema
- * const s = new Schema({ name: { type: String, set: capitalize }});
+ *     // defining within the schema
+ *     const s = new Schema({ name: { type: String, set: capitalize }});
  *
- * // or with the SchemaType
- * const s = new Schema({ name: String })
- * s.path('name').set(capitalize);
- * ```
+ *     // or with the SchemaType
+ *     const s = new Schema({ name: String })
+ *     s.path('name').set(capitalize);
  *
  * Setters allow you to transform the data before it gets to the raw mongodb
  * document or query.
@@ -630,76 +635,68 @@ SchemaType.prototype.transform = function(fn) {
  *
  * You can set up email lower case normalization easily via a Mongoose setter.
  *
- * ```javascript
- * function toLower(v) {
- *   return v.toLowerCase();
- * }
+ *     function toLower(v) {
+ *       return v.toLowerCase();
+ *     }
  *
- * const UserSchema = new Schema({
- *   email: { type: String, set: toLower }
- * });
+ *     const UserSchema = new Schema({
+ *       email: { type: String, set: toLower }
+ *     });
  *
- * const User = db.model('User', UserSchema);
+ *     const User = db.model('User', UserSchema);
  *
- * const user = new User({email: 'AVENUE@Q.COM'});
- * console.log(user.email); // 'avenue@q.com'
+ *     const user = new User({email: 'AVENUE@Q.COM'});
+ *     console.log(user.email); // 'avenue@q.com'
  *
- * // or
- * const user = new User();
- * user.email = 'Avenue@Q.com';
- * console.log(user.email); // 'avenue@q.com'
- * User.updateOne({ _id: _id }, { $set: { email: 'AVENUE@Q.COM' } }); // update to 'avenue@q.com'
- * ```
+ *     // or
+ *     const user = new User();
+ *     user.email = 'Avenue@Q.com';
+ *     console.log(user.email); // 'avenue@q.com'
+ *     User.updateOne({ _id: _id }, { $set: { email: 'AVENUE@Q.COM' } }); // update to 'avenue@q.com'
  *
  * As you can see above, setters allow you to transform the data before it
  * stored in MongoDB, or before executing a query.
  *
  * _NOTE: we could have also just used the built-in `lowercase: true` SchemaType option instead of defining our own function._
  *
- * ```javascript
- * new Schema({ email: { type: String, lowercase: true }})
- * ```
+ *     new Schema({ email: { type: String, lowercase: true }})
  *
  * Setters are also passed a second argument, the schematype on which the setter was defined. This allows for tailored behavior based on options passed in the schema.
  *
- * ```javascript
- * function inspector (val, priorValue, schematype) {
- *   if (schematype.options.required) {
- *     return schematype.path + ' is required';
- *   } else {
- *     return val;
- *   }
- * }
+ *     function inspector (val, priorValue, schematype) {
+ *       if (schematype.options.required) {
+ *         return schematype.path + ' is required';
+ *       } else {
+ *         return val;
+ *       }
+ *     }
  *
- * const VirusSchema = new Schema({
- *   name: { type: String, required: true, set: inspector },
- *   taxonomy: { type: String, set: inspector }
- * })
+ *     const VirusSchema = new Schema({
+ *       name: { type: String, required: true, set: inspector },
+ *       taxonomy: { type: String, set: inspector }
+ *     })
  *
- * const Virus = db.model('Virus', VirusSchema);
- * const v = new Virus({ name: 'Parvoviridae', taxonomy: 'Parvovirinae' });
+ *     const Virus = db.model('Virus', VirusSchema);
+ *     const v = new Virus({ name: 'Parvoviridae', taxonomy: 'Parvovirinae' });
  *
- * console.log(v.name);     // name is required
- * console.log(v.taxonomy); // Parvovirinae
- * ```
+ *     console.log(v.name);     // name is required
+ *     console.log(v.taxonomy); // Parvovirinae
  *
  * You can also use setters to modify other properties on the document. If
  * you're setting a property `name` on a document, the setter will run with
  * `this` as the document. Be careful, in mongoose 5 setters will also run
  * when querying by `name` with `this` as the query.
  *
- * ```javascript
- * const nameSchema = new Schema({ name: String, keywords: [String] });
- * nameSchema.path('name').set(function(v) {
- *   // Need to check if `this` is a document, because in mongoose 5
- *   // setters will also run on queries, in which case `this` will be a
- *   // mongoose query object.
- *   if (this instanceof Document && v != null) {
- *     this.keywords = v.split(' ');
- *   }
- *   return v;
- * });
- * ```
+ *     const nameSchema = new Schema({ name: String, keywords: [String] });
+ *     nameSchema.path('name').set(function(v) {
+ *       // Need to check if `this` is a document, because in mongoose 5
+ *       // setters will also run on queries, in which case `this` will be a
+ *       // mongoose query object.
+ *       if (this instanceof Document && v != null) {
+ *         this.keywords = v.split(' ');
+ *       }
+ *       return v;
+ *     });
  *
  * @param {Function} fn
  * @return {SchemaType} this
@@ -1079,6 +1076,7 @@ SchemaType.prototype.required = function(required, message) {
  * looks at to determine the foreign collection it should query.
  *
  * #### Example:
+ *
  *     const userSchema = new Schema({ name: String });
  *     const User = mongoose.model('User', userSchema);
  *
@@ -1108,6 +1106,7 @@ SchemaType.prototype.ref = function(ref) {
  *
  * @param {Object} scope the scope which callback are executed
  * @param {Boolean} init
+ * @return {Any} The Stored default value.
  * @api private
  */
 
@@ -1175,6 +1174,7 @@ SchemaType.prototype._castNullish = function _castNullish(v) {
  * @param {Object} value
  * @param {Object} scope
  * @param {Boolean} init
+ * @return {Any}
  * @api private
  */
 
@@ -1195,6 +1195,7 @@ SchemaType.prototype.applySetters = function(value, scope, init, priorVal, optio
  *
  * @param {Object} value
  * @param {Object} scope
+ * @return {Any}
  * @api private
  */
 
@@ -1239,9 +1240,12 @@ SchemaType.prototype.select = function select(val) {
 /**
  * Performs a validation of `value` using the validators declared for this SchemaType.
  *
- * @param {any} value
+ * @param {Any} value
  * @param {Function} callback
  * @param {Object} scope
+ * @param {Object} [options]
+ * @param {String} [options.path]
+ * @return {Any} If no validators, returns the output from calling `fn`, otherwise no return
  * @api public
  */
 
@@ -1352,9 +1356,11 @@ function _validate(ok, validatorProperties) {
  *
  * This method ignores the asynchronous validators.
  *
- * @param {any} value
+ * @param {Any} value
  * @param {Object} scope
- * @return {MongooseError|undefined}
+ * @param {Object} [options]
+ * @param {Object} [options.path]
+ * @return {MongooseError|null}
  * @api private
  */
 
@@ -1595,7 +1601,8 @@ SchemaType.prototype.castForQueryWrapper = function(params) {
  * Cast the given value with the given optional query operator.
  *
  * @param {String} [$conditional] query operator, like `$eq` or `$in`
- * @param {any} val
+ * @param {Any} val
+ * @return {Any}
  * @api private
  */
 
@@ -1612,9 +1619,11 @@ SchemaType.prototype.castForQuery = function($conditional, val) {
   return this._castForQuery(val);
 };
 
-/*!
+/**
  * Internal switch for runSetters
  *
+ * @param {Any} val
+ * @return {Any}
  * @api private
  */
 
@@ -1623,6 +1632,7 @@ SchemaType.prototype._castForQuery = function(val) {
 };
 
 /**
+ * Set & Get the `checkRequired` function
  * Override the function the required validator uses to check whether a value
  * passes the `required` check. Override this on the individual SchemaType.
  *
@@ -1631,8 +1641,8 @@ SchemaType.prototype._castForQuery = function(val) {
  *     // Use this to allow empty strings to pass the `required` validator
  *     mongoose.Schema.Types.String.checkRequired(v => typeof v === 'string');
  *
- * @param {Function} fn
- * @return {Function}
+ * @param {Function} [fn] If set, will overwrite the current set function
+ * @return {Function} The input `fn` or the already set function
  * @static
  * @memberOf SchemaType
  * @function checkRequired
@@ -1650,7 +1660,8 @@ SchemaType.checkRequired = function(fn) {
 /**
  * Default check for if this path satisfies the `required` validator.
  *
- * @param {any} val
+ * @param {Any} val
+ * @return {Boolean} `true` when the value is not `null`, `false` otherwise
  * @api private
  */
 
@@ -1658,8 +1669,11 @@ SchemaType.prototype.checkRequired = function(val) {
   return val != null;
 };
 
-/*!
- * ignore
+/**
+ * Clone the current SchemaType
+ *
+ * @return {SchemaType} The cloned SchemaType instance
+ * @api private
  */
 
 SchemaType.prototype.clone = function() {

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -824,7 +824,7 @@ SchemaType.prototype.get = function(fn) {
  * From the examples above, you may have noticed that error messages support
  * basic templating. There are a few other template keywords besides `{PATH}`
  * and `{VALUE}` too. To find out more, details are available
- * [here](#error_messages_MongooseError.messages).
+ * [here](#error_messages_MongooseError-messages).
  *
  * If Mongoose's built-in error message templating isn't enough, Mongoose
  * supports setting the `message` property to a function.
@@ -993,9 +993,9 @@ SchemaType.prototype.validate = function(obj, message, type) {
  * @param {String} [message] optional custom error message
  * @return {SchemaType} this
  * @see Customized Error Messages #error_messages_MongooseError-messages
- * @see SchemaArray#checkRequired #schema_array_SchemaArray.checkRequired
+ * @see SchemaArray#checkRequired #schema_array_SchemaArray-checkRequired
  * @see SchemaBoolean#checkRequired #schema_boolean_SchemaBoolean-checkRequired
- * @see SchemaBuffer#checkRequired #schema_buffer_SchemaBuffer.schemaName
+ * @see SchemaBuffer#checkRequired #schema_buffer_SchemaBuffer-schemaName
  * @see SchemaNumber#checkRequired #schema_number_SchemaNumber-min
  * @see SchemaObjectId#checkRequired #schema_objectid_ObjectId-auto
  * @see SchemaString#checkRequired #schema_string_SchemaString-checkRequired

--- a/lib/virtualtype.js
+++ b/lib/virtualtype.js
@@ -13,18 +13,18 @@ const utils = require('./utils');
  *     fullname instanceof mongoose.VirtualType // true
  *
  * @param {Object} options
- * @param {string|function} [options.ref] if `ref` is not nullish, this becomes a [populated virtual](/docs/populate.html#populate-virtuals)
- * @param {string|function} [options.localField] the local field to populate on if this is a populated virtual.
- * @param {string|function} [options.foreignField] the foreign field to populate on if this is a populated virtual.
- * @param {boolean} [options.justOne=false] by default, a populated virtual is an array. If you set `justOne`, the populated virtual will be a single doc or `null`.
- * @param {boolean} [options.getters=false] if you set this to `true`, Mongoose will call any custom getters you defined on this virtual
- * @param {boolean} [options.count=false] if you set this to `true`, `populate()` will set this virtual to the number of populated documents, as opposed to the documents themselves, using [`Query#countDocuments()`](./api.html#query_Query-countDocuments)
+ * @param {String|Function} [options.ref] if `ref` is not nullish, this becomes a [populated virtual](/docs/populate.html#populate-virtuals)
+ * @param {String|Function} [options.localField] the local field to populate on if this is a populated virtual.
+ * @param {String|Function} [options.foreignField] the foreign field to populate on if this is a populated virtual.
+ * @param {Boolean} [options.justOne=false] by default, a populated virtual is an array. If you set `justOne`, the populated virtual will be a single doc or `null`.
+ * @param {Boolean} [options.getters=false] if you set this to `true`, Mongoose will call any custom getters you defined on this virtual
+ * @param {Boolean} [options.count=false] if you set this to `true`, `populate()` will set this virtual to the number of populated documents, as opposed to the documents themselves, using [`Query#countDocuments()`](./api.html#query_Query-countDocuments)
  * @param {Object|Function} [options.match=null] add an extra match condition to `populate()`
  * @param {Number} [options.limit=null] add a default `limit` to the `populate()` query
  * @param {Number} [options.skip=null] add a default `skip` to the `populate()` query
  * @param {Number} [options.perDocumentLimit=null] For legacy reasons, `limit` with `populate()` may give incorrect results because it only executes a single query for every document being populated. If you set `perDocumentLimit`, Mongoose will ensure correct `limit` per document by executing a separate query for each document to `populate()`. For example, `.find().populate({ path: 'test', perDocumentLimit: 2 })` will execute 2 additional queries if `.find()` returns 2 documents.
  * @param {Object} [options.options=null] Additional options like `limit` and `lean`.
- * @param {string} name
+ * @param {String} name
  * @api public
  */
 
@@ -36,10 +36,8 @@ function VirtualType(options, name) {
 }
 
 /**
- * If no getters/getters, add a default
+ * If no getters/setters, add a default
  *
- * @param {Function} fn
- * @return {VirtualType} this
  * @api private
  */
 
@@ -85,7 +83,7 @@ VirtualType.prototype.clone = function() {
  *       return this.name.first + ' ' + this.name.last;
  *     });
  *
- * @param {function} fn
+ * @param {Function} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -120,7 +118,7 @@ VirtualType.prototype.get = function(fn) {
  *     doc.name.first; // 'Jean-Luc'
  *     doc.name.last; // 'Picard'
  *
- * @param {function} fn
+ * @param {Function} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -135,7 +133,7 @@ VirtualType.prototype.set = function(fn) {
  *
  * @param {Object} value
  * @param {Document} doc The document this virtual is attached to
- * @return {any} the value after applying all getters
+ * @return {Any} the value after applying all getters
  * @api public
  */
 
@@ -158,7 +156,7 @@ VirtualType.prototype.applyGetters = function(value, doc) {
  *
  * @param {Object} value
  * @param {Document} doc
- * @return {any} the value after applying all setters
+ * @return {Any} the value after applying all setters
  * @api public
  */
 

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -229,7 +229,7 @@ declare module 'mongoose' {
     /** The username specified in the URI */
     readonly user: string;
 
-    /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model.watch). */
+    /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model-watch). */
     watch<ResultType extends mongodb.Document = any>(pipeline?: Array<any>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
   }
 


### PR DESCRIPTION
**Summary**

This PR does:
- touch-up some more file for JSDOC, for:
  - `lib/aggregate.js`
  - `lib/cast.js`
  - `lib/collection.js`
  - `lib/connection.js`
  - `lib/document.js`
- replace all old (broken) links `#\w+_\w+\.` to be `#\w+_\w+-` (from `#model_Model.find` to `#model_Model-find`)