### PR TITLE
fix(schematype): actually always return "this" where specified

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -462,7 +462,7 @@ SchemaType.prototype.unique = function(bool) {
 SchemaType.prototype.text = function(bool) {
   if (this._index === false) {
     if (!bool) {
-      return;
+      return this;
     }
     throw new Error('Path "' + this.path + '" may not have `index` set to ' +
       'false and `text` set to true');
@@ -499,7 +499,7 @@ SchemaType.prototype.text = function(bool) {
 SchemaType.prototype.sparse = function(bool) {
   if (this._index === false) {
     if (!bool) {
-      return;
+      return this;
     }
     throw new Error('Path "' + this.path + '" may not have `index` set to ' +
       'false and `sparse` set to true');


### PR DESCRIPTION
**Summary**

while going through the code for #12140, i noticed that 2 functions were saying they always return `this`, which was not actually true for 1 case (in each function), this PR fixes that
