### PR TITLE
docs(api_split.pug): add "code" to parameter name

### DIFF
--- a/docs/api_split.pug
+++ b/docs/api_split.pug
@@ -57,11 +57,11 @@ block content
             - if (param.nested)
               ul(style="margin-top: 0.5em")
                 li
-                  | #{param.name}
+                  | <code>#{param.name}</code>
                   | <span class="method-type">&laquo;#{param.types}&raquo;</span> !{param.description}
             - else
               li.param
-                | #{param.name}
+                | <code>#{param.name}</code>
                 | <span class="method-type">&laquo;#{param.types}&raquo;</span> !{param.description}
       if prop.return != null
         h5 Returns:


### PR DESCRIPTION
**Summary**

This changes Documentation Parameter names from "someOption" to `someOption`, which in my opinion is better to read

before:
![before img](https://user-images.githubusercontent.com/10911626/180603175-2806af15-816a-4e98-8faa-839b77ecfabf.png)

after:
![after img](https://user-images.githubusercontent.com/10911626/180603176-78eb4d3f-1ec9-4c76-ab35-3a885dcc1116.png)


<details>
<summary>before/after with darkreader</summary>
before:

![before img](https://user-images.githubusercontent.com/10911626/180603127-3a09cf45-8134-4772-a64e-096aadbd2691.png)

after:
![after img](https://user-images.githubusercontent.com/10911626/180603129-44550085-e8b2-47e9-a3d7-47f5396ca91e.png)

</details>