### PR TITLE
docs(api_split): add basic DEPRECATED output

### DIFF
--- a/docs/api_split.pug
+++ b/docs/api_split.pug
@@ -50,6 +50,8 @@ block content
       h3(id=prop.anchorId)
         a(href='#' + prop.anchorId)
           | #{prop.string}
+      if prop.deprecated 
+        <span class="deprecated">~DEPRECATED~</span>
       if prop.param != null
         h5 Parameters
         ul.params

--- a/docs/css/api.css
+++ b/docs/css/api.css
@@ -155,3 +155,7 @@ hr.separate-api {
   text-transform: uppercase;
   letter-spacing: .2px;
 }
+
+.deprecated {
+  color: #ff0000;
+}


### PR DESCRIPTION
**Summary**

This PR adds basic Output of `@deprecated` as a follow-up to #12024 which added `@deprecated` handling

Currently looks like this (directly after the header):
![deprecated](https://user-images.githubusercontent.com/10911626/180603676-f7f9ee71-61a6-4f0e-9a6f-e742154376ab.png)

fixes #12080

PS: i am not great at styles, so this is just basic, but it is there at least