### PR TITLE
ts-benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-name: Benchmark
+name: TypeScript Benchmark
 on:
   pull_request:
     paths:
@@ -23,7 +23,8 @@ jobs:
     name: Benchmark TypeScript Types
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-
+        with:
+          fetch-depth: 0
       - name: Setup node
         uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3.4.1
         with:
@@ -31,6 +32,6 @@ jobs:
 
       - run: npm install
 
-      - run: npx ts-benchmark -p ./benchmarks/typescript/simple -f 17/100000 18 29 32 -b master -g --colors
+      - run: npx ts-benchmark -p ./benchmarks/typescript/simple -f 17/100000 18 29 32 -b master -g -t --colors
         env:
           DB_URL: ${{ secrets.DB_URL }}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve-handler": "6.1.3",
     "sinon": "14.0.0",
     "stream-browserify": "3.0.0",
-    "ts-benchmark": "^1.1.5",
+    "ts-benchmark": "^1.1.10",
     "tsd": "0.20.0",
     "typescript": "4.7.4",
     "uuid": "8.3.2",


### PR DESCRIPTION
Use the latest release of ts-benchmark.
Reasons:
- Fix some issues related to GitHub integration.
- Add ability to benchmark the target branch of the pull request. "Helpful if target branch is not the master branch is our case."

Screenshots:
This show how the result will be look like when creating a PR against 6.5 branch for instance instead of master.

![Capture](https://user-images.githubusercontent.com/50488054/180632799-49a2a646-b661-4883-b16e-617127e5ed41.PNG)

