### PR TITLE
fix(timestamps): set timestamps on child schema when child schema has timestamps: true but parent schema does not

### DIFF
--- a/lib/helpers/update/applyTimestampsToChildren.js
+++ b/lib/helpers/update/applyTimestampsToChildren.js
@@ -82,11 +82,14 @@ function applyTimestampsToChildren(now, update, schema) {
 function applyTimestampsToDocumentArray(arr, schematype, now) {
   const timestamps = schematype.schema.options.timestamps;
 
+  const len = arr.length;
+
   if (!timestamps) {
+    for (let i = 0; i < len; ++i) {
+      applyTimestampsToChildren(now, arr[i], schematype.schema);
+    }
     return;
   }
-
-  const len = arr.length;
 
   const createdAt = handleTimestampOption(timestamps, 'createdAt');
   const updatedAt = handleTimestampOption(timestamps, 'updatedAt');
@@ -105,6 +108,7 @@ function applyTimestampsToDocumentArray(arr, schematype, now) {
 function applyTimestampsToSingleNested(subdoc, schematype, now) {
   const timestamps = schematype.schema.options.timestamps;
   if (!timestamps) {
+    applyTimestampsToChildren(now, subdoc, schematype.schema);
     return;
   }
 


### PR DESCRIPTION
Fix #12119

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12119 is due to the fact that `applyTimestampsToChildren()` stops when it finds a schema that doesn't have `timestamps: true`. With this PR, `applyTimestampsToChildren()` will keep going to find any child schemas that have `timestamps: true`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
