### PR TITLE
Docs: add "code" to Headers (and index list)

### DIFF
--- a/docs/api_split.pug
+++ b/docs/api_split.pug
@@ -49,7 +49,7 @@ block content
       hr.separate-api-elements
       h3(id=prop.anchorId)
         a(href='#' + prop.anchorId)
-          | #{prop.string}
+          | <code>#{prop.string}</code>
       if prop.deprecated 
         <span class="deprecated">~DEPRECATED~</span>
       if prop.param != null

--- a/docs/api_split.pug
+++ b/docs/api_split.pug
@@ -44,7 +44,7 @@ block content
       each prop in props
         li
           a(href='#' + prop.anchorId)
-            | #{prop.string}
+            | <code>#{prop.string}</code>
     each prop in props
       hr.separate-api-elements
       h3(id=prop.anchorId)


### PR DESCRIPTION
**Summary**

(continuation of https://github.com/Automattic/mongoose/pull/12145#issuecomment-1194372064)

This PR adds code blocks to the headers and the index list:

<details>
<summary>Headers</summary>

before:
![headers before](https://user-images.githubusercontent.com/10911626/180986966-b8b8044c-c7c2-4ac4-a8a4-8c947fa21345.png)

after:
![headers after](https://user-images.githubusercontent.com/10911626/180987020-46ad22c2-7760-476f-b2c9-5eb87a91a20f.png)

</details>


<details>
<summary>Index List</summary>

before:
![index list before](https://user-images.githubusercontent.com/10911626/180987080-c0e6e4ce-7e0e-4a7e-888b-ca69c6774fca.png)

after:
![index list after](https://user-images.githubusercontent.com/10911626/180987083-faa828a2-d92e-47d2-9e11-58acbd6645ad.png)

</details>

PS: yes this change does not screw up any anchor ids or click-ablility