### PR TITLE
docs(api_split.pug): add "code" to sidebar entries

### DIFF
--- a/docs/api_split.pug
+++ b/docs/api_split.pug
@@ -33,7 +33,7 @@ block content
                 each prop in item.props
                   li
                     a(href='#' + prop.anchorId)
-                      | #{prop.string}
+                      | <code>#{prop.string}</code>
             - else
               div.nav-item-title
                 a(href=item.name.toLowerCase() + '.html')

--- a/docs/css/api.css
+++ b/docs/css/api.css
@@ -32,6 +32,10 @@
   font-size: 0.66em;
 }
 
+.nav-item-sub > li {
+  padding: 2px 0px;
+}
+
 .api-nav ul {
   margin-top: 0.25em;
   padding-left: 1em;


### PR DESCRIPTION
**Summary**

This PR adds "code" blocks to the API sidebar entries (and increases padding)

<details>
<summary>Screenshots</summary>

before:
![before](https://user-images.githubusercontent.com/10911626/180988386-8563f258-6008-4c45-a796-62ccce1d7357.png)

without extra padding:
![without padding](https://user-images.githubusercontent.com/10911626/180988388-a12ae444-2f81-48c0-8f54-8374fb249373.png)

final with 2px extra padding (top-bottom):
![with padding](https://user-images.githubusercontent.com/10911626/180988392-91c1e4dd-4b7c-49fe-ad3e-fbf951805b79.png)

</details>

PS: i am not sure on the spacing, please review if the spacing is OK or needs to be changed