### PR TITLE
Update document.js

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -993,6 +993,12 @@ Document.prototype.overwrite = function overwrite(obj) {
  */
 
 Document.prototype.$set = function $set(path, val, type, options) {
+  if(utils.isPOJO(path) {
+     options = type;
+     type = val;
+     val = undefined;
+   }
+  
   if (utils.isPOJO(type)) {
     options = type;
     type = undefined;

--- a/lib/document.js
+++ b/lib/document.js
@@ -993,7 +993,7 @@ Document.prototype.overwrite = function overwrite(obj) {
  */
 
 Document.prototype.$set = function $set(path, val, type, options) {
-  if(utils.isPOJO(path) {
+  if (utils.isPOJO(path) {
      options = type;
      type = val;
      val = undefined;

--- a/lib/document.js
+++ b/lib/document.js
@@ -993,7 +993,7 @@ Document.prototype.overwrite = function overwrite(obj) {
  */
 
 Document.prototype.$set = function $set(path, val, type, options) {
-  if (utils.isPOJO(path) {
+  if (utils.isPOJO(path)) {
      options = type;
      type = val;
      val = undefined;

--- a/lib/document.js
+++ b/lib/document.js
@@ -994,11 +994,11 @@ Document.prototype.overwrite = function overwrite(obj) {
 
 Document.prototype.$set = function $set(path, val, type, options) {
   if (utils.isPOJO(path)) {
-     options = type;
-     type = val;
-     val = undefined;
-   }
-  
+    options = type;
+    type = val;
+    val = undefined;
+  }
+
   if (utils.isPOJO(type)) {
     options = type;
     type = undefined;


### PR DESCRIPTION
Fix for Issue #12157

**Summary**
Allow document.set to take an object of key/value pairs for path value, per the documentation.

**Examples**

Please see issue #12157 for example code.
