### PR TITLE
style(buffer): change ".split" to "utils.each" for defining methods

### DIFF
--- a/lib/types/buffer.js
+++ b/lib/types/buffer.js
@@ -142,25 +142,26 @@ MongooseBuffer.mixin = {
  * Compile other Buffer methods marking this buffer as modified.
  */
 
-(
-// node < 0.5
-  ('writeUInt8 writeUInt16 writeUInt32 writeInt8 writeInt16 writeInt32 ' +
-    'writeFloat writeDouble fill ' +
-    'utf8Write binaryWrite asciiWrite set ' +
+utils.each(
+  [
+    // node < 0.5
+    'writeUInt8', 'writeUInt16', 'writeUInt32', 'writeInt8', 'writeInt16', 'writeInt32',
+    'writeFloat', 'writeDouble', 'fill',
+    'utf8Write', 'binaryWrite', 'asciiWrite', 'set',
 
-  // node >= 0.5
-    'writeUInt16LE writeUInt16BE writeUInt32LE writeUInt32BE ' +
-    'writeInt16LE writeInt16BE writeInt32LE writeInt32BE ' + 'writeFloatLE writeFloatBE writeDoubleLE writeDoubleBE')
-).split(' ').forEach(function(method) {
-  if (!Buffer.prototype[method]) {
-    return;
-  }
-  MongooseBuffer.mixin[method] = function() {
-    const ret = Buffer.prototype[method].apply(this, arguments);
-    this._markModified();
-    return ret;
-  };
-});
+    // node >= 0.5
+    'writeUInt16LE', 'writeUInt16BE', 'writeUInt32LE', 'writeUInt32BE',
+    'writeInt16LE', 'writeInt16BE', 'writeInt32LE', 'writeInt32BE', 'writeFloatLE', 'writeFloatBE', 'writeDoubleLE', 'writeDoubleBE']
+  , function(method) {
+    if (!Buffer.prototype[method]) {
+      return;
+    }
+    MongooseBuffer.mixin[method] = function() {
+      const ret = Buffer.prototype[method].apply(this, arguments);
+      this._markModified();
+      return ret;
+    };
+  });
 
 /**
  * Converts this buffer to its Binary type representation.


### PR DESCRIPTION
**Summary**

This PR changes in `buffer.js` a `.split` call into a `utils.each` call for defining functions, to be consistent