### PR TITLE
fix(types): pass type to mongodb bulk write operation

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -282,6 +282,33 @@ function bulkWrite() {
   M.bulkWrite(ops);
 }
 
+function bulkWriteAddToSet() {
+  const schema = new Schema({
+    arr: [String]
+  });
+
+  const M = model('Test', schema);
+
+  const ops = [
+    {
+      updateOne: {
+        filter: {
+          arr: {
+            $nin: ['abc']
+          }
+        },
+        update: {
+          $addToSet: {
+            arr: 'abc'
+          }
+        }
+      }
+    }
+  ];
+
+  return M.bulkWrite(ops);
+}
+
 export function autoTypedModel() {
   const AutoTypedSchema = autoTypedSchema();
   const AutoTypedModel = model('AutoTypeModel', AutoTypedSchema);

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -144,9 +144,9 @@ declare module 'mongoose' {
      * if you use `create()`) because with `bulkWrite()` there is only one network
      * round trip to the MongoDB server.
      */
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, callback: Callback<mongodb.BulkWriteResult>): void;
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T>>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T>>, callback: Callback<mongodb.BulkWriteResult>): void;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T>>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
 
     /**
      * Sends multiple `save()` calls in a single `bulkWrite()`. This is faster than


### PR DESCRIPTION
**Summary**

Found issue when trying to perform a `bulkWrite` using `$addToSet`. The mongodb definition of `AnyBulkWriteOperation`requires the type to be passed to accept any input to $addToSet

**Examples**

See test
