### PR TITLE
🚑️ hotfix: ObjectId infererence

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -429,7 +429,7 @@ export function autoTypedSchema() {
     mixed3: Schema.Types.Mixed,
     objectId1: Schema.Types.ObjectId,
     objectId2: 'ObjectId',
-    objectId3: 'ObjectID',
+    objectId3: 'objectId',
     customSchema: Int8,
     map1: { type: Map, of: String },
     map2: { type: Map, of: Number },

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -11,10 +11,11 @@ import {
   DateSchemaDefinition,
   ObtainDocumentType,
   DefaultTypeKey,
-  IfEquals,
-} from "mongoose";
+  ObjectIdSchemaDefinition,
+  IfEquals
+} from 'mongoose';
 
-declare module "mongoose" {
+declare module 'mongoose' {
   /**
    * @summary Obtains document schema type.
    * @description Obtains document schema type from document Definition OR returns enforced schema type if it's provided.
@@ -22,19 +23,11 @@ declare module "mongoose" {
    * @param {EnforcedDocType} EnforcedDocType A generic type enforced by user "provided before schema constructor".
    * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
    */
-  type ObtainDocumentType<
-    DocDefinition,
-    EnforcedDocType = any,
-    TypeKey extends TypeKeyBaseType = DefaultTypeKey
-  > = IsItRecordAndNotAny<EnforcedDocType> extends true
-    ? EnforcedDocType
-    : {
-        [K in keyof (RequiredPaths<DocDefinition, TypeKey> &
-          OptionalPaths<DocDefinition, TypeKey>)]: ObtainDocumentPathType<
-          DocDefinition[K],
-          TypeKey
-        >;
-      };
+   type ObtainDocumentType<DocDefinition, EnforcedDocType = any, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
+   IsItRecordAndNotAny<EnforcedDocType> extends true ? EnforcedDocType : {
+     [K in keyof (RequiredPaths<DocDefinition, TypeKey> &
+     OptionalPaths<DocDefinition, TypeKey>)]: ObtainDocumentPathType<DocDefinition[K], TypeKey>;
+   };
 
   /**
    * @summary Obtains document schema type from Schema instance.
@@ -45,35 +38,16 @@ declare module "mongoose" {
    * // result
    * type UserType = {userName?: string}
    */
-  type InferSchemaType<SchemaType> = ObtainSchemaGeneric<SchemaType, "DocType">;
+  type InferSchemaType<SchemaType> = ObtainSchemaGeneric<SchemaType, 'DocType'>;
 
   /**
    * @summary Obtains schema Generic type by using generic alias.
    * @param {TSchema} TSchema A generic of schema type instance.
    * @param {alias} alias Targeted generic alias.
    */
-  type ObtainSchemaGeneric<
-    TSchema,
-    alias extends
-      | "EnforcedDocType"
-      | "M"
-      | "TInstanceMethods"
-      | "TQueryHelpers"
-      | "TVirtuals"
-      | "TStaticMethods"
-      | "TPathTypeKey"
-      | "DocType"
-  > = TSchema extends Schema<
-    infer EnforcedDocType,
-    infer M,
-    infer TInstanceMethods,
-    infer TQueryHelpers,
-    infer TVirtuals,
-    infer TStaticMethods,
-    infer TPathTypeKey,
-    infer DocType
-  >
-    ? {
+  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TPathTypeKey' | 'DocType'> =
+    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TStaticMethods, infer TPathTypeKey, infer DocType>
+      ? {
         EnforcedDocType: EnforcedDocType;
         M: M;
         TInstanceMethods: TInstanceMethods;
@@ -83,7 +57,7 @@ declare module "mongoose" {
         TPathTypeKey: TPathTypeKey;
         DocType: DocType;
       }[alias]
-    : unknown;
+      : unknown;
 }
 
 /**
@@ -91,29 +65,25 @@ declare module "mongoose" {
  * @param {P} P Document path.
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  */
-type IsPathRequired<P, TypeKey extends TypeKeyBaseType> = P extends
-  | { required: true | [true, string | undefined] }
-  | ArrayConstructor
-  | any[]
-  ? true
-  : P extends Record<TypeKey, ArrayConstructor | any[]>
-  ? P extends { default: undefined }
-    ? false
-    : true
-  : P extends Record<TypeKey, any>
-  ? P extends { default: any }
-    ? IfEquals<P["default"], undefined, false, true>
-    : false
-  : false;
+type IsPathRequired<P, TypeKey extends TypeKeyBaseType> =
+  P extends { required: true | [true, string | undefined] } | ArrayConstructor | any[]
+    ? true
+    : P extends (Record<TypeKey, ArrayConstructor | any[]>)
+      ? P extends { default: undefined }
+        ? false
+        : true
+      : P extends (Record<TypeKey, any>)
+        ? P extends { default: any }
+          ? IfEquals<P['default'], undefined, false, true>
+          : false
+        : false;
 
 /**
  * @summary Path base type defined by using TypeKey
  * @description It helps to check if a path is defined by TypeKey OR not.
  * @param {TypeKey} TypeKey A literal string refers to path type property key.
  */
-type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = {
-  [k in TypeKey]: any;
-};
+type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in TypeKey]: any };
 
 /**
  * @summary A Utility to obtain schema's required path keys.
@@ -122,9 +92,7 @@ type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = {
  * @returns required paths keys of document definition.
  */
 type RequiredPathKeys<T, TypeKey extends TypeKeyBaseType> = {
-  [K in keyof T]: IsPathRequired<T[K], TypeKey> extends true
-    ? IfEquals<T[K], any, never, K>
-    : never;
+  [K in keyof T]: IsPathRequired<T[K], TypeKey> extends true ? IfEquals<T[K], any, never, K> : never;
 }[keyof T];
 
 /**
@@ -163,31 +131,19 @@ type OptionalPaths<T, TypeKey extends TypeKeyBaseType> = {
  * @param {PathValueType} PathValueType Document definition path type.
  * @param {TypeKey} TypeKey A generic refers to document definition.
  */
-type ObtainDocumentPathType<
-  PathValueType,
-  TypeKey extends TypeKeyBaseType
-> = PathValueType extends Schema<any>
+type ObtainDocumentPathType<PathValueType, TypeKey extends TypeKeyBaseType> = PathValueType extends Schema<any>
   ? InferSchemaType<PathValueType>
   : ResolvePathType<
-      PathValueType extends PathWithTypePropertyBaseType<TypeKey>
-        ? PathValueType[TypeKey]
-        : PathValueType,
-      PathValueType extends PathWithTypePropertyBaseType<TypeKey>
-        ? Omit<PathValueType, TypeKey>
-        : {},
-      TypeKey
-    >;
+  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
+  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {},
+  TypeKey
+  >;
 
 /**
  * @param {T} T A generic refers to string path enums.
  * @returns Path enum values type as literal strings or string.
  */
-type PathEnumOrString<T extends SchemaTypeOptions<string>["enum"]> =
-  T extends (infer E)[]
-    ? E
-    : T extends { values: any }
-    ? PathEnumOrString<T["values"]>
-    : string;
+type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (infer E)[] ? E : T extends { values: any } ? PathEnumOrString<T['values']> : string;
 
 /**
  * @summary Resolve path type by returning the corresponding type.
@@ -196,54 +152,21 @@ type PathEnumOrString<T extends SchemaTypeOptions<string>["enum"]> =
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  * @returns Number, "Number" or "number" will be resolved to number type.
  */
-type ResolvePathType<
-  PathValueType,
-  Options extends SchemaTypeOptions<PathValueType> = {},
-  TypeKey extends TypeKeyBaseType = DefaultTypeKey
-> = PathValueType extends Schema
-  ? InferSchemaType<PathValueType>
-  : PathValueType extends (infer Item)[]
-  ? IfEquals<
-      Item,
-      never,
-      any[],
-      Item extends Schema
-        ? Types.DocumentArray<ResolvePathType<Item>>
-        : ResolvePathType<Item>[]
-    >
-  : PathValueType extends StringSchemaDefinition
-  ? PathEnumOrString<Options["enum"]>
-  : PathValueType extends NumberSchemaDefinition
-  ? number
-  : PathValueType extends DateSchemaDefinition
-  ? Date
-  : PathValueType extends
-      | typeof Buffer
-      | "buffer"
-      | "Buffer"
-      | typeof Schema.Types.Buffer
-  ? Buffer
-  : PathValueType extends BooleanSchemaDefinition
-  ? boolean
-  : PathValueType extends "objectId" | "ObjectId" | typeof Schema.Types.ObjectId
-  ? Types.ObjectId
-  : PathValueType extends
-      | "decimal128"
-      | "Decimal128"
-      | typeof Schema.Types.Decimal128
-  ? Types.Decimal128
-  : PathValueType extends MapConstructor
-  ? Map<string, ResolvePathType<Options["of"]>>
-  : PathValueType extends ArrayConstructor
-  ? any[]
-  : PathValueType extends typeof Schema.Types.Mixed
-  ? any
-  : IfEquals<PathValueType, ObjectConstructor> extends true
-  ? any
-  : IfEquals<PathValueType, {}> extends true
-  ? any
-  : PathValueType extends typeof SchemaType
-  ? PathValueType["prototype"]
-  : PathValueType extends Record<string, any>
-  ? ObtainDocumentType<PathValueType, any, TypeKey>
-  : unknown;
+type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueType> = {}, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
+  PathValueType extends Schema ? InferSchemaType<PathValueType> :
+    PathValueType extends (infer Item)[] ? IfEquals<Item, never, any[], Item extends Schema ? Types.DocumentArray<ResolvePathType<Item>> : ResolvePathType<Item>[]> :
+      PathValueType extends StringSchemaDefinition ? PathEnumOrString<Options['enum']> :
+        PathValueType extends NumberSchemaDefinition ? number :
+          PathValueType extends DateSchemaDefinition ? Date :
+            PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
+              PathValueType extends BooleanSchemaDefinition ? boolean :
+                PathValueType extends ObjectIdSchemaDefinition ? Types.ObjectId :
+                  PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 ? Types.Decimal128 :
+                    PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
+                      PathValueType extends ArrayConstructor ? any[] :
+                        PathValueType extends typeof Schema.Types.Mixed ? any:
+                          IfEquals<PathValueType, ObjectConstructor> extends true ? any:
+                            IfEquals<PathValueType, {}> extends true ? any:
+                              PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+                                PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, TypeKey> :
+                                  unknown;

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -11,7 +11,6 @@ import {
   DateSchemaDefinition,
   ObtainDocumentType,
   DefaultTypeKey,
-  ObjectIdSchemaDefinition,
   IfEquals
 } from 'mongoose';
 
@@ -160,7 +159,7 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
           PathValueType extends DateSchemaDefinition ? Date :
             PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
               PathValueType extends BooleanSchemaDefinition ? boolean :
-                PathValueType extends ObjectIdSchemaDefinition ? Types.ObjectId :
+                PathValueType extends 'objectId' | 'ObjectId' | typeof Schema.Types.ObjectId ? Types.ObjectId :
                   PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 ? Types.Decimal128 :
                     PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
                       PathValueType extends ArrayConstructor ? any[] :

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -11,11 +11,10 @@ import {
   DateSchemaDefinition,
   ObtainDocumentType,
   DefaultTypeKey,
-  ObjectIdSchemaDefinition,
-  IfEquals
-} from 'mongoose';
+  IfEquals,
+} from "mongoose";
 
-declare module 'mongoose' {
+declare module "mongoose" {
   /**
    * @summary Obtains document schema type.
    * @description Obtains document schema type from document Definition OR returns enforced schema type if it's provided.
@@ -23,11 +22,19 @@ declare module 'mongoose' {
    * @param {EnforcedDocType} EnforcedDocType A generic type enforced by user "provided before schema constructor".
    * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
    */
-   type ObtainDocumentType<DocDefinition, EnforcedDocType = any, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
-   IsItRecordAndNotAny<EnforcedDocType> extends true ? EnforcedDocType : {
-     [K in keyof (RequiredPaths<DocDefinition, TypeKey> &
-     OptionalPaths<DocDefinition, TypeKey>)]: ObtainDocumentPathType<DocDefinition[K], TypeKey>;
-   };
+  type ObtainDocumentType<
+    DocDefinition,
+    EnforcedDocType = any,
+    TypeKey extends TypeKeyBaseType = DefaultTypeKey
+  > = IsItRecordAndNotAny<EnforcedDocType> extends true
+    ? EnforcedDocType
+    : {
+        [K in keyof (RequiredPaths<DocDefinition, TypeKey> &
+          OptionalPaths<DocDefinition, TypeKey>)]: ObtainDocumentPathType<
+          DocDefinition[K],
+          TypeKey
+        >;
+      };
 
   /**
    * @summary Obtains document schema type from Schema instance.
@@ -38,16 +45,35 @@ declare module 'mongoose' {
    * // result
    * type UserType = {userName?: string}
    */
-  type InferSchemaType<SchemaType> = ObtainSchemaGeneric<SchemaType, 'DocType'>;
+  type InferSchemaType<SchemaType> = ObtainSchemaGeneric<SchemaType, "DocType">;
 
   /**
    * @summary Obtains schema Generic type by using generic alias.
    * @param {TSchema} TSchema A generic of schema type instance.
    * @param {alias} alias Targeted generic alias.
    */
-  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TPathTypeKey' | 'DocType'> =
-    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TStaticMethods, infer TPathTypeKey, infer DocType>
-      ? {
+  type ObtainSchemaGeneric<
+    TSchema,
+    alias extends
+      | "EnforcedDocType"
+      | "M"
+      | "TInstanceMethods"
+      | "TQueryHelpers"
+      | "TVirtuals"
+      | "TStaticMethods"
+      | "TPathTypeKey"
+      | "DocType"
+  > = TSchema extends Schema<
+    infer EnforcedDocType,
+    infer M,
+    infer TInstanceMethods,
+    infer TQueryHelpers,
+    infer TVirtuals,
+    infer TStaticMethods,
+    infer TPathTypeKey,
+    infer DocType
+  >
+    ? {
         EnforcedDocType: EnforcedDocType;
         M: M;
         TInstanceMethods: TInstanceMethods;
@@ -57,7 +83,7 @@ declare module 'mongoose' {
         TPathTypeKey: TPathTypeKey;
         DocType: DocType;
       }[alias]
-      : unknown;
+    : unknown;
 }
 
 /**
@@ -65,25 +91,29 @@ declare module 'mongoose' {
  * @param {P} P Document path.
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  */
-type IsPathRequired<P, TypeKey extends TypeKeyBaseType> =
-  P extends { required: true | [true, string | undefined] } | ArrayConstructor | any[]
-    ? true
-    : P extends (Record<TypeKey, ArrayConstructor | any[]>)
-      ? P extends { default: undefined }
-        ? false
-        : true
-      : P extends (Record<TypeKey, any>)
-        ? P extends { default: any }
-          ? IfEquals<P['default'], undefined, false, true>
-          : false
-        : false;
+type IsPathRequired<P, TypeKey extends TypeKeyBaseType> = P extends
+  | { required: true | [true, string | undefined] }
+  | ArrayConstructor
+  | any[]
+  ? true
+  : P extends Record<TypeKey, ArrayConstructor | any[]>
+  ? P extends { default: undefined }
+    ? false
+    : true
+  : P extends Record<TypeKey, any>
+  ? P extends { default: any }
+    ? IfEquals<P["default"], undefined, false, true>
+    : false
+  : false;
 
 /**
  * @summary Path base type defined by using TypeKey
  * @description It helps to check if a path is defined by TypeKey OR not.
  * @param {TypeKey} TypeKey A literal string refers to path type property key.
  */
-type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in TypeKey]: any };
+type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = {
+  [k in TypeKey]: any;
+};
 
 /**
  * @summary A Utility to obtain schema's required path keys.
@@ -92,7 +122,9 @@ type PathWithTypePropertyBaseType<TypeKey extends TypeKeyBaseType> = { [k in Typ
  * @returns required paths keys of document definition.
  */
 type RequiredPathKeys<T, TypeKey extends TypeKeyBaseType> = {
-  [K in keyof T]: IsPathRequired<T[K], TypeKey> extends true ? IfEquals<T[K], any, never, K> : never;
+  [K in keyof T]: IsPathRequired<T[K], TypeKey> extends true
+    ? IfEquals<T[K], any, never, K>
+    : never;
 }[keyof T];
 
 /**
@@ -131,19 +163,31 @@ type OptionalPaths<T, TypeKey extends TypeKeyBaseType> = {
  * @param {PathValueType} PathValueType Document definition path type.
  * @param {TypeKey} TypeKey A generic refers to document definition.
  */
-type ObtainDocumentPathType<PathValueType, TypeKey extends TypeKeyBaseType> = PathValueType extends Schema<any>
+type ObtainDocumentPathType<
+  PathValueType,
+  TypeKey extends TypeKeyBaseType
+> = PathValueType extends Schema<any>
   ? InferSchemaType<PathValueType>
   : ResolvePathType<
-  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
-  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {},
-  TypeKey
-  >;
+      PathValueType extends PathWithTypePropertyBaseType<TypeKey>
+        ? PathValueType[TypeKey]
+        : PathValueType,
+      PathValueType extends PathWithTypePropertyBaseType<TypeKey>
+        ? Omit<PathValueType, TypeKey>
+        : {},
+      TypeKey
+    >;
 
 /**
  * @param {T} T A generic refers to string path enums.
  * @returns Path enum values type as literal strings or string.
  */
-type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (infer E)[] ? E : T extends { values: any } ? PathEnumOrString<T['values']> : string;
+type PathEnumOrString<T extends SchemaTypeOptions<string>["enum"]> =
+  T extends (infer E)[]
+    ? E
+    : T extends { values: any }
+    ? PathEnumOrString<T["values"]>
+    : string;
 
 /**
  * @summary Resolve path type by returning the corresponding type.
@@ -152,21 +196,54 @@ type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  * @returns Number, "Number" or "number" will be resolved to number type.
  */
-type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueType> = {}, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
-  PathValueType extends Schema ? InferSchemaType<PathValueType> :
-    PathValueType extends (infer Item)[] ? IfEquals<Item, never, any[], Item extends Schema ? Types.DocumentArray<ResolvePathType<Item>> : ResolvePathType<Item>[]> :
-      PathValueType extends StringSchemaDefinition ? PathEnumOrString<Options['enum']> :
-        PathValueType extends NumberSchemaDefinition ? number :
-          PathValueType extends DateSchemaDefinition ? Date :
-            PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
-              PathValueType extends BooleanSchemaDefinition ? boolean :
-                PathValueType extends ObjectIdSchemaDefinition ? Types.ObjectId :
-                  PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 ? Types.Decimal128 :
-                    PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
-                      PathValueType extends ArrayConstructor ? any[] :
-                        PathValueType extends typeof Schema.Types.Mixed ? any:
-                          IfEquals<PathValueType, ObjectConstructor> extends true ? any:
-                            IfEquals<PathValueType, {}> extends true ? any:
-                              PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
-                                PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, TypeKey> :
-                                  unknown;
+type ResolvePathType<
+  PathValueType,
+  Options extends SchemaTypeOptions<PathValueType> = {},
+  TypeKey extends TypeKeyBaseType = DefaultTypeKey
+> = PathValueType extends Schema
+  ? InferSchemaType<PathValueType>
+  : PathValueType extends (infer Item)[]
+  ? IfEquals<
+      Item,
+      never,
+      any[],
+      Item extends Schema
+        ? Types.DocumentArray<ResolvePathType<Item>>
+        : ResolvePathType<Item>[]
+    >
+  : PathValueType extends StringSchemaDefinition
+  ? PathEnumOrString<Options["enum"]>
+  : PathValueType extends NumberSchemaDefinition
+  ? number
+  : PathValueType extends DateSchemaDefinition
+  ? Date
+  : PathValueType extends
+      | typeof Buffer
+      | "buffer"
+      | "Buffer"
+      | typeof Schema.Types.Buffer
+  ? Buffer
+  : PathValueType extends BooleanSchemaDefinition
+  ? boolean
+  : PathValueType extends "objectId" | "ObjectId" | typeof Schema.Types.ObjectId
+  ? Types.ObjectId
+  : PathValueType extends
+      | "decimal128"
+      | "Decimal128"
+      | typeof Schema.Types.Decimal128
+  ? Types.Decimal128
+  : PathValueType extends MapConstructor
+  ? Map<string, ResolvePathType<Options["of"]>>
+  : PathValueType extends ArrayConstructor
+  ? any[]
+  : PathValueType extends typeof Schema.Types.Mixed
+  ? any
+  : IfEquals<PathValueType, ObjectConstructor> extends true
+  ? any
+  : IfEquals<PathValueType, {}> extends true
+  ? any
+  : PathValueType extends typeof SchemaType
+  ? PathValueType["prototype"]
+  : PathValueType extends Record<string, any>
+  ? ObtainDocumentType<PathValueType, any, TypeKey>
+  : unknown;


### PR DESCRIPTION
## Summary

> **Note**
> I initially spoke about this issue [here](https://github.com/mohammad0-0ahmad-forks/mongoose/commit/d092fdcf06cf3063e2d35530676c00f2af4edbfb#r79603415). I was trying to get @mohammad0-0ahmad's opinion on it.

A required `ObjectId` field in a schema caused the inferred type to be deeply checked for other schema properties.

## Examples

```ts
const MySchema = new Schema({ 
  class: { type: Schema.Types.ObjectId, required: true },
  dob: Date
});

type MySchemaType = InferSchemaType<typeof MySchema>;

// When hovered over in VS Code
// type MySchemaType = {
//   dob?: unknown;
//   class?: {
//       _id?: ... | undefined;
//       equals?: {} | undefined;
//       id?: {
//           [x: number]: unknown;
//           equals?: {} | undefined;
//           set?: {} | undefined;
//           toJSON?: {} | undefined;
//           [Symbol.iterator]?: {} | undefined;
//           ... 99 more ...;
//           some?: {} | undefined;
//       } | undefined;
//       ... 6 more ...;
//       toString: {};
//   } | undefined;
// }
```

It only affects schemas with at least one required `ObjectId` field. This means that a schema like ⬇️ works fine.
```ts
const MySchema = new Schema({
  class: Schema.Types.ObjectId,
  dob: Date
});

type MySchemaType = InferSchemaType<typeof MySchema>;

// When Hovered in VS Code
type MySchemaType = {
    dob?: Date | undefined;
    class?: Types.ObjectId | undefined;
}
```
