### PR TITLE
fix(model+query): handle populate with lean transform that deletes `_id`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4599,6 +4599,17 @@ function populate(model, docs, options, callback) {
       mod.options.options.sort || void 0;
     assignmentOpts.excludeId = excludeIdReg.test(select) || (select && select._id === 0);
 
+    // Lean transform may delete `_id`, which would cause assignment
+    // to fail. So delay running lean transform until _after_
+    // `_assign()`
+    if (mod.options &&
+        mod.options.options &&
+        mod.options.options.lean &&
+        mod.options.options.lean.transform) {
+      mod.options.options._leanTransform = mod.options.options.lean.transform;
+      mod.options.options.lean = true;
+    }
+
     if (ids.length === 0 || ids.every(utils.isNullOrUndefined)) {
       // Ensure that we set to 0 or empty array even
       // if we don't actually execute a query to make sure there's a value
@@ -4672,6 +4683,14 @@ function populate(model, docs, options, callback) {
 
     for (const arr of params) {
       removeDeselectedForeignField(arr[0].foreignField, arr[0].options, vals);
+    }
+    for (const arr of params) {
+      const mod = arr[0];
+      if (mod.options && mod.options.options && mod.options.options._leanTransform) {
+        for (const doc of vals) {
+          mod.options.options._leanTransform(doc);
+        }
+      }
     }
     callback();
   }


### PR DESCRIPTION
Fix #12143

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Right now populate doesn't work if you use `lean: { transform: function myTransform(doc) { ... } }` and `myTransform` deletes `_id`. That's because the lean transform runs before populate's `_assign()` step, and `_assign()` needs `_id` (or whatever the foreign field for populate is) to figure out where to put the populated documents.

This is similar to #9175, where we had to also remove the foreign field from the projection, and just delete the projected-out field in memory after `_assign()`.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
