### PR TITLE
chore(tidelift-alignment): run only in main repository, not in forks

### DIFF
--- a/.github/workflows/tidelift-alignment.yml
+++ b/.github/workflows/tidelift-alignment.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Run Tidelift to ensure approved open source packages are in use
     runs-on: ubuntu-latest
+    if: github.repository == 'Automattic/mongoose'
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2


### PR DESCRIPTION
**Summary**

This PR disabled the workflow `tidelift-alignment` on forks, because it would otherwise always run but error because of missing secrets.