### PR TITLE
docs(compatibility): change to use a table

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,20 +1,33 @@
 # MongoDB Server Version Compatibility
 
-Mongoose relies on the [MongoDB Node.js Driver](http://mongodb.github.io/node-mongodb-native/) to talk to MongoDB. 
+<style>
+    tr > td, tr > th {
+        border: 1px solid;
+        padding: 8px;
+    }
+
+    table tr:nth-child(2n) {
+        background: rgba(0,0,0,.03);
+    }
+</style>
+
+Mongoose relies on the [MongoDB Node.js Driver](http://mongodb.github.io/node-mongodb-native/) to talk to MongoDB.  
 You can refer to [this table](https://docs.mongodb.com/drivers/node/current/compatibility/) for up-to-date information as to which version of the MongoDB driver supports which version of MongoDB.
 
 Below are the [semver](http://semver.org/) ranges representing which versions of mongoose are compatible with the listed versions of MongoDB server.
 
-* MongoDB Server 2.4.x: mongoose `^3.8` or `4.x`
-* MongoDB Server 2.6.x: mongoose `^3.8.8` or `4.x`
-* MongoDB Server 3.0.x: mongoose `^3.8.22`, `4.x`, or `5.x`
-* MongoDB Server 3.2.x: mongoose `^4.3.0` or `5.x`
-* MongoDB Server 3.4.x: mongoose `^4.7.3` or `5.x`
-* MongoDB Server 3.6.x: mongoose `5.x`
-* MongoDB Server 4.0.x: mongoose `^5.2.0` or `6.x`
-* MongoDB Server 4.2.x: mongoose `^5.7.0` or `6.x`
-* MongoDB Server 4.4.x: mongoose `^5.10.0` or `6.x`
-* MongoDB Server 5.x: mongoose `^6.0.0`
-* MongoDB Server 6.x: mongoose `^6.5.0`
+| MongoDB Sever |            Mongoose            |
+| :-----------: | :----------------------------: |
+|     `6.x`     |            `^6.5.0`            |
+|     `5.x`     |            `^6.0.0`            |
+|    `4.4.x`    |      `^5.10.0 \| ^6.0.0`       |
+|    `4.2.x`    |      `^5.7.0  \| ^6.0.0`       |
+|    `4.0.x`    |      `^5.2.0  \| ^6.0.0`       |
+|    `3.6.x`    |            `^5.0.0`            |
+|    `3.4.x`    |      `^4.7.3  \| ^5.0.0`       |
+|    `3.2.x`    |       `^4.3.0  \| 5.0.0`       |
+|    `3.0.x`    | `^3.8.22 \| ^4.0.0  \| ^5.0.0` |
+|    `2.6.x`    |      `^3.8.8  \| ^4.0.0`       |
+|    `2.4.x`    |      `^3.8.0  \| ^4.0.0`       |
 
-Note that Mongoose 5.x dropped support for all versions of MongoDB before 3.0.0. If you need to use MongoDB 2.6 or older, use Mongoose 4.x.
+Note that Mongoose `5.x` dropped support for all versions of MongoDB before `3.0.0`. If you need to use MongoDB `2.6` or older, use Mongoose `4.x`.


### PR DESCRIPTION
**Summary**

This PR changes `compatibility.md` to use a table instead of a list, which is sorted from newest to oldest

<details>
<summary>Before / After Screenshots</summary>

Before (master):
![before](https://user-images.githubusercontent.com/10911626/182391430-ce330af8-99e8-429b-b86b-10aa016e58db.png)

After (this pr):
![after](https://user-images.githubusercontent.com/10911626/182391435-6d0db79b-a5c9-48da-90f5-ea52a8b79b8a.png)

</details>