### PR TITLE
fix: Update ChangeStream hydration condition

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -54,7 +54,7 @@ class ChangeStream extends EventEmitter {
 
         ['close', 'change', 'end', 'error'].forEach(ev => {
           this.driverChangeStream.on(ev, data => {
-            if (data.fullDocument != null && this.options && this.options.hydrate) {
+            if (data != null && data.fullDocument != null && this.options && this.options.hydrate) {
               data.fullDocument = this.options.model.hydrate(data.fullDocument);
             }
             this.emit(ev, data);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
There is an issue when using a `ChangeStream` in a replica set, you'll get an `undefined` error when you try to call `mongoose.disconnect()`:

```js
await mongoose.connect(`mongodb://${host}:${port}/?replicaSet=${rset}`, {
  autoIndex: false,
});

const changeStream = mongoose.connection.watch(pipeline, {
  fullDocument: "updateLookup",
});
const stream = changeStream.on("change", (change) => {
  console.log(change);
});

await stream.close();
await mongoose.disconnect(); // `data.fullDocument` is undefined
```

The issue was introduced in one of the commits from versions 6.4.7 to 6.5.0, as stated in #12169. This PR fixes this by correctly addressing where the options are coming from.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

Here's the result for the current version:
![image](https://user-images.githubusercontent.com/50644753/182430815-6b302192-4746-4b98-b210-799139761869.png)

Here's the result for the fix:
![image](https://user-images.githubusercontent.com/50644753/182430576-f445fc0c-edfc-4e80-b9fc-06dff7d21ba8.png)

Closes #12169 