### PR TITLE
Chore: Add test for auto typed approach.

### DIFF
--- a/.github/workflows/benchmark-auto-typed.yml
+++ b/.github/workflows/benchmark-auto-typed.yml
@@ -1,0 +1,37 @@
+name: TypeScript Benchmark "auto-typed-mongoose"
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/benchmark.yml"
+      - "package.json"
+      - "types/**"
+      - "benchmarks/typescript/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/benchmark.yml"
+      - "package.json"
+      - "types/**"
+      - "benchmarks/typescript/**"
+permissions:
+  contents: read
+
+jobs:
+  typescript:
+    runs-on: ubuntu-20.04
+    name: Benchmark TypeScript Types
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        with:
+          fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3.4.1
+        with:
+          node-version: 16
+
+      - run: npm install
+
+      - run: npx ts-benchmark -p ./benchmarks/typescript/auto-typed -f 17/100000 18 29 32 -b master -g -t --colors
+        env:
+          DB_URL: ${{ secrets.DB_URL }}

--- a/benchmarks/typescript/auto-typed/index.ts
+++ b/benchmarks/typescript/auto-typed/index.ts
@@ -1,0 +1,9 @@
+import { Schema, Model, model } from 'mongoose';
+
+const schema = new Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true },
+  avatar: String
+});
+
+const UserModel = model('User', schema);

--- a/benchmarks/typescript/auto-typed/tsconfig.json
+++ b/benchmarks/typescript/auto-typed/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "mongoose": ["../../../"]
+    }
+  },
+  "esModuleInterop": true,
+  "outDir": "typescript",
+  "strictNullChecks": true,
+  "include": [
+    "./*.ts",
+    "../../../index.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "tdd": "mocha ./test/*.test.js --inspect --watch --recursive --watch-files ./**/*.{js,ts}",
     "test-coverage": "nyc --reporter=html --reporter=text npm test",
     "ts-benchmark": "ts-benchmark -p ./benchmarks/typescript/simple -f 17/100000 18 29 32",
-    "ts-benchmark-watch": "ts-benchmark -p ./benchmarks/typescript/simple -w ./types -i -s -f 17/100000 18 29 32 -b master"
+    "ts-benchmark-watch": "ts-benchmark -p ./benchmarks/typescript/simple -w ./types -i -s -f 17/100000 18 29 32 -b master",
+    "ts-benchmark-auto": "ts-benchmark -p ./benchmarks/typescript/auto-typed -f 17/100000 18 29 32"
   },
   "main": "./index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
Related to https://github.com/Automattic/mongoose/issues/10349#issuecomment-1201805483
Note: the new added test fails because the test folder "benchmarks\typescript\auto-typed" doesn't exist in master branch yet.
It should work as it should when target master and targeted branch does have the mentioned test folder.