### PR TITLE
Model's type parameter must be defined

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -176,7 +176,7 @@ function gh11435() {
   const ItemSchema = new Schema<Item>({ name: String });
 
   ItemSchema.pre('validate', function preValidate() {
-    expectType<Model<unknown>>(this.$model('Item1'));
+    expectType<Model<{}>>(this.$model('Item1'));
   });
 }
 

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -142,13 +142,13 @@ declare module 'mongoose' {
     readonly models: Readonly<{ [index: string]: Model<any> }>;
 
     /** Defines or retrieves a model. */
-    model<T, U, TQueryHelpers = {}>(
+    model<T extends {}, U, TQueryHelpers = {}>(
       name: string,
       schema?: Schema<T, any, any, TQueryHelpers, any, any>,
       collection?: string,
       options?: CompileModelOptions
     ): U;
-    model<T>(name: string, schema?: Schema<T>, collection?: string, options?: CompileModelOptions): Model<T>;
+    model<T extends {}>(name: string, schema?: Schema<T>, collection?: string, options?: CompileModelOptions): Model<T>;
 
     /** Returns an array of model names created on this connection. */
     modelNames(): Array<string>;

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -71,7 +71,7 @@ declare module 'mongoose' {
     $markValid(path: string): void;
 
     /** Returns the model with the given name on this document's associated connection. */
-    $model<ModelType = Model<unknown>>(name: string): ModelType;
+    $model<ModelType = Model<{}>>(name: string): ModelType;
 
     /**
      * A string containing the current operation that Mongoose is executing

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,9 +71,9 @@ declare module 'mongoose' {
     options?: CompileModelOptions
   ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
-  export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
+  export function model<T extends {}>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
 
-  export function model<T, U, TQueryHelpers = {}>(
+  export function model<T extends {}, U, TQueryHelpers = {}>(
     name: string,
     schema?: Schema<T, any, any, TQueryHelpers, any, any>,
     collection?: string,
@@ -151,15 +151,15 @@ declare module 'mongoose' {
       : M
     : M;
 
-  export type DiscriminatorSchema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, T> = T extends Schema<infer T1, infer T2, infer T3, infer T4, infer T5>
+  export type DiscriminatorSchema<DocType extends {}, M, TInstanceMethods, TQueryHelpers, TVirtuals, T> = T extends Schema<infer T1, infer T2, infer T3, infer T4, infer T5>
     ? Schema<Omit<DocType, keyof T1> & T1, DiscriminatorModel<T2, M>, T3 | TInstanceMethods, T4 | TQueryHelpers, T5 | TVirtuals>
     : Schema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals>;
 
   type QueryResultType<T> = T extends Query<infer ResultType, any> ? ResultType : never;
 
-  type PluginFunction<DocType> = (schema: Schema<DocType>, opts?: any) => void;
+  type PluginFunction<DocType extends {}> = (schema: Schema<DocType>, opts?: any) => void;
 
-  export class Schema<EnforcedDocType = any, M = Model<EnforcedDocType, any, any, any>, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = {},
+  export class Schema<EnforcedDocType extends {} = any, M = Model<EnforcedDocType, any, any, any>, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = {},
     TStaticMethods = {},
     TPathTypeKey extends TypeKeyBaseType = DefaultTypeKey,
     DocType extends ObtainDocumentType<DocType, EnforcedDocType, TPathTypeKey> = ObtainDocumentType<any, EnforcedDocType, TPathTypeKey>>

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -3,8 +3,8 @@ declare module 'mongoose' {
 
   export interface AcceptsDiscriminator {
     /** Adds a discriminator type. */
-    discriminator<D>(name: string | number, schema: Schema, value?: string | number | ObjectId): Model<D>;
-    discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
+    discriminator<D extends {}>(name: string | number, schema: Schema, value?: string | number | ObjectId): Model<D>;
+    discriminator<T extends {}, U>(name: string | number, schema: Schema<T, U>, value?: string | number | ObjectId): U;
   }
 
   interface MongooseBulkWriteOptions {
@@ -114,7 +114,7 @@ declare module 'mongoose' {
   }
 
   const Model: Model<any>;
-  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> extends
+  interface Model<T extends {}, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> extends
     NodeJS.EventEmitter,
     AcceptsDiscriminator,
     IndexManager,

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -10,7 +10,7 @@ declare module 'mongoose' {
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
-  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, DocType = unknown, TInstanceMethods = {}, QueryHelpers = {}, TStaticMethods = {}, TVirtuals = {}> {
+  interface SchemaOptions<PathTypeKey extends TypeKeyBaseType = DefaultTypeKey, DocType extends {} = {}, TInstanceMethods = {}, QueryHelpers = {}, TStaticMethods = {}, TVirtuals = {}> {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
      * calling Model.createIndexes() after you successfully connect to MongoDB. If you want to disable

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -284,8 +284,8 @@ declare module 'mongoose' {
 
         static options: { castNonArrays: boolean; };
 
-        discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
-        discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
+        discriminator<T extends {}, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
+        discriminator<D extends {}>(name: string | number, schema: Schema, value?: string): Model<D>;
 
         /** The schematype embedded in this array */
         caster?: SchemaType;
@@ -344,8 +344,8 @@ declare module 'mongoose' {
 
         static options: { castNonArrays: boolean; };
 
-        discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
-        discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
+        discriminator<D extends {}>(name: string | number, schema: Schema, value?: string): Model<D>;
+        discriminator<T extends {}, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
 
         /** The schema used for documents in this array */
         schema: Schema;
@@ -393,8 +393,8 @@ declare module 'mongoose' {
         /** The document's schema */
         schema: Schema;
 
-        discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
-        discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
+        discriminator<T extends {}, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
+        discriminator<D extends {}>(name: string | number, schema: Schema, value?: string): Model<D>;
       }
 
       class String extends SchemaType {


### PR DESCRIPTION
In Typescript 4.8 and mongodb [since at least 4.8.1](https://github.com/Automattic/mongoose/commit/547e5fc92051ca602c7c7d16b2518a5745711711), `mongodb.AnyBulkWriteOperation` requires its type argument to be defined. It forbids `null` and `undefined`. Previous versions of Typescript didn't check this properly for unconstrained type parameters (lone type parameters like `T`). Typescript 4.8, which is in beta and will release in a week or two, does.

This PR adds a constraint to Model that requires its type parameter to be defined. It can no longer include `null` or `undefined`. In particular, that means `Model<unknown>` is no longer allowed; you have to write `Model<{}>` instead, which is the same type excluding `null` and `undefined` [1]. You can see this change in test/types/document.test.ts:179:

```ts
    expectType<Model<unknown>>(this.$model('Item1'));
// becomes
    expectType<Model<{}>>(this.$model('Item1'));
```

This change ripples out to other types as well, most notably the type parameter for `Schema`, which now also disallows `null` and `undefined`.

#### Alternative Fix

This is a pretty comprehensive PR. It should be possible to isolate the change to `Model.bulkWrite` by adding a conditional type:

```ts
mongodb.AnyBulkWriteOperation<T>
// would become
mongodb.AnyBulkWriteOperation<T extends {} ? T : any>
```

But this is unsafe since you can pass in writes that don't match Model's `T`, and because presumably AnyBulkWriteOperation really doesn't expect `null` or `undefined` and might crash at runtime.

I wouldn't recommend this smaller alternative except temporarily.

[1] `unknown` means "any value in Javascript". `{}` means "any value except null or undefined". `object` means "any non-primitive" (and does *not* allow null)

#### Recommendation

I'd recommend testing with typescript@beta during the Typescript beta period or, even better, typescript@next.

Fixes #12213