### PR TITLE
Make bulkWrite's type parameter conditional

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -144,9 +144,9 @@ declare module 'mongoose' {
      * if you use `create()`) because with `bulkWrite()` there is only one network
      * round trip to the MongoDB server.
      */
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T>>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T>>, callback: Callback<mongodb.BulkWriteResult>): void;
-    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T>>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T extends {} ? T : any>>, options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions, callback: Callback<mongodb.BulkWriteResult>): void;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T extends {} ? T : any>>, callback: Callback<mongodb.BulkWriteResult>): void;
+    bulkWrite(writes: Array<mongodb.AnyBulkWriteOperation<T extends {} ? T : any>>, options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions): Promise<mongodb.BulkWriteResult>;
 
     /**
      * Sends multiple `save()` calls in a single `bulkWrite()`. This is faster than


### PR DESCRIPTION
Smaller alternative fix to #12212.
Also fixes #12213, but unsafely when the model's type parameter allows null or undefined.
