### PR TITLE
fix(ChangeStream): try to fix "cannot read property fullDocument of undefined"

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -54,7 +54,7 @@ class ChangeStream extends EventEmitter {
 
         ['close', 'change', 'end', 'error'].forEach(ev => {
           this.driverChangeStream.on(ev, data => {
-            if (data.fullDocument != null && this.options && this.options.hydrate) {
+            if (data != null && data.fullDocument != null && this.options && this.options.hydrate) {
               data.fullDocument = this.options.model.hydrate(data.fullDocument);
             }
             this.emit(ev, data);


### PR DESCRIPTION
**Summary**

This PR tries to fix the errors `Uncaught TypeError: Cannot read properties of undefined (reading 'fullDocument')` that were often thrown in ReplicaSet tests, see [This Run](https://github.com/Automattic/mongoose/runs/7662155766?check_suite_focus=true) as a example.

PS: i dont know if this fully fixes it, but it should at least help