### PR TITLE
style(model): update for-index loop to a for-of loop

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3120,10 +3120,9 @@ Model.create = function create(doc, options, callback) {
     }
     const _done = (error, res) => {
       const savedDocs = [];
-      const len = res.length;
-      for (let i = 0; i < len; ++i) {
-        if (res[i].doc) {
-          savedDocs.push(res[i].doc);
+      for (const val of res) {
+        if (val.doc) {
+          savedDocs.push(val.doc);
         }
       }
 


### PR DESCRIPTION
**Summary**

This PR changes a `for(-index)` to a `for-of`, which removes the need for 2 variables and should make use of the [iterable-symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#iterating_over_other_iterable_objects) (this `for-of` is supported since nodejs 0.12.0 according to MDN)

i dont quite know the impact on performance, because there was no existing benchmark, and i believe the change would not be noticeable when having a active mongodb connection (and i dont know enough about mongoose to everything required)