### PR TITLE
Extend JSDOC Return type for `Aggregate.prototype.exec`

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -963,7 +963,7 @@ Aggregate.prototype.pipeline = function() {
  *     const result = await aggregate.exec();
  *
  * @param {Function} [callback]
- * @return {Promise} Returns a Promise if no "callback" is given.
+ * @return {Promise<Document[]>} Returns a Promise if no "callback" is given.
  * @api public
  */
 

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -677,6 +677,7 @@ describe('aggregate: ', function() {
         sort('sal').
         exec(function(err, docs) {
           assert.ifError(err);
+          assert.ok(docs && docs.length > 0);
           assert.equal(docs[0].sal, 14000);
         });
     });


### PR DESCRIPTION
**Summary**

This PR does:
- extend JSDOC Return type for `Aggregate.prototype.exec`
- add a extra check in a aggregate test for sanity ([see this run](https://github.com/Automattic/mongoose/runs/7729209058))