### PR TITLE
fix(types): apply changes from #11563 to "connection.model"

### DIFF
--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -1,6 +1,7 @@
-import { createConnection, Schema, Collection, Connection, ConnectionSyncIndexesResult, Model } from 'mongoose';
+import { createConnection, Schema, Collection, Connection, ConnectionSyncIndexesResult, Model, connection } from 'mongoose';
 import * as mongodb from 'mongodb';
-import { expectError, expectType } from 'tsd';
+import { expectAssignable, expectError, expectType } from 'tsd';
+import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
 
 expectType<Connection>(createConnection());
 expectType<Connection>(createConnection('mongodb://localhost:27017/test'));
@@ -9,7 +10,7 @@ expectType<void>(createConnection('mongodb://localhost:27017/test', { appName: '
 
 const conn = createConnection();
 
-expectType<Model<{ name: string }, any, any, any>>(conn.model('Test', new Schema<{ name: string }>({ name: { type: String } })));
+expectAssignable<Model<{ name: string }, any, any, any>>(conn.model('Test', new Schema<{ name: string }>({ name: { type: String } })));
 expectType<Model<{ name: string }>>(conn.model<{ name: string }>('Test', new Schema({ name: { type: String } })));
 
 expectType<Promise<Connection>>(conn.openUri('mongodb://localhost:27017/test'));
@@ -112,3 +113,32 @@ expectType<Connection>(conn.useDb('test'));
 expectType<Connection>(conn.useDb('test', {}));
 expectType<Connection>(conn.useDb('test', { noListener: true }));
 expectType<Connection>(conn.useDb('test', { useCache: true }));
+
+export function autoTypedModelConnection() {
+  const AutoTypedSchema = autoTypedSchema();
+  const AutoTypedModel = connection.model('AutoTypeModelConnection', AutoTypedSchema);
+
+  (async() => {
+  // Model-functions-test
+  // Create should works with arbitrary objects.
+    const randomObject = await AutoTypedModel.create({ unExistKey: 'unExistKey', description: 'st' });
+    expectType<AutoTypedSchemaType['schema']['userName']>(randomObject.userName);
+
+    const testDoc1 = await AutoTypedModel.create({ userName: 'M0_0a' });
+    expectType<AutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
+    expectType<AutoTypedSchemaType['schema']['description']>(testDoc1.description);
+
+    const testDoc2 = await AutoTypedModel.insertMany([{ userName: 'M0_0a' }]);
+    expectType<AutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
+    expectType<AutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
+
+    const testDoc3 = await AutoTypedModel.findOne({ userName: 'M0_0a' });
+    expectType<AutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
+    expectType<AutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
+
+    // Model-statics-functions-test
+    expectType<ReturnType<AutoTypedSchemaType['statics']['staticFn']>>(AutoTypedModel.staticFn());
+
+  })();
+  return AutoTypedModel;
+}

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -1,6 +1,7 @@
 import { Schema, model, Model, Document, Types } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { autoTypedModel } from './models.test';
+import { autoTypedModelConnection } from './connection.test';
 import { AutoTypedSchemaType } from './schema.test';
 
 const Drink = model('Drink', new Schema({
@@ -187,6 +188,19 @@ async function gh11598() {
 
 function autoTypedDocument() {
   const AutoTypedModel = autoTypedModel();
+  const AutoTypeModelInstance = new AutoTypedModel({ unExistProperty: 1, description: 2 });
+
+  expectType<AutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);
+  expectType<AutoTypedSchemaType['schema']['favoritDrink']>(AutoTypeModelInstance.favoritDrink);
+  expectType<AutoTypedSchemaType['schema']['favoritColorMode']>(AutoTypeModelInstance.favoritColorMode);
+
+  // Document-Methods-tests
+  expectType<ReturnType<AutoTypedSchemaType['methods']['instanceFn']>>(new AutoTypedModel().instanceFn());
+
+}
+
+function autoTypedDocumentConnection() {
+  const AutoTypedModel = autoTypedModelConnection();
   const AutoTypeModelInstance = new AutoTypedModel({ unExistProperty: 1, description: 2 });
 
   expectType<AutoTypedSchemaType['schema']['userName']>(AutoTypeModelInstance.userName);

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -142,6 +142,12 @@ declare module 'mongoose' {
     readonly models: Readonly<{ [index: string]: Model<any> }>;
 
     /** Defines or retrieves a model. */
+    model<TSchema extends Schema = any>(
+      name: string,
+      schema?: TSchema,
+      collection?: string,
+      options?: CompileModelOptions
+    ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
     model<T, U, TQueryHelpers = {}>(
       name: string,
       schema?: Schema<T, any, any, TQueryHelpers, any, any>,


### PR DESCRIPTION
**Summary**

This PR apply the changes from #11563 to `connection.model`

fixes #12129

PS: for now i have just let the old `connection.model` types stay there as fallbacks, i dont know if they can be removed without breaking something