### PR TITLE
fix(populate): handle specifying recursive populate as a string with discriminators

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4704,7 +4704,7 @@ function populate(model, docs, options, callback) {
  */
 
 function _execPopulateQuery(mod, match, select, assignmentOpts, callback) {
-  const subPopulate = utils.clone(mod.options.populate);
+  let subPopulate = utils.clone(mod.options.populate);
   const queryOptions = Object.assign({
     skip: mod.options.skip,
     limit: mod.options.limit,
@@ -4749,6 +4749,8 @@ function _execPopulateQuery(mod, match, select, assignmentOpts, callback) {
     if (mod.model.baseModelName != null) {
       if (Array.isArray(subPopulate)) {
         subPopulate.forEach(pop => { pop.strictPopulate = false; });
+      } else if (typeof subPopulate === 'string') {
+        subPopulate = { path: subPopulate, strictPopulate: false };
       } else {
         subPopulate.strictPopulate = false;
       }

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -6467,7 +6467,7 @@ describe('model: populate:', function() {
             return Log.find({}).
               populate({
                 path: 'activity',
-                populate: { path: 'postedBy' }
+                populate: 'postedBy'
               }).
               sort({ seq: -1 });
           }).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

A bug that I ran into earlier today. If you `populate()` on a discriminator model and set the `populate` option to a string as follows:

```javascript
return Log.find({}).
              populate({
                path: 'activity',
                populate: 'postedBy'
              }).
              sort({ seq: -1 });
```

You'll get the following error:

```
TypeError: Cannot create property 'strictPopulate' on string 'postedBy'
```

This fixes that case

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
