### PR TITLE
Fix search url

### DIFF
--- a/docs/js/navbar-search.js
+++ b/docs/js/navbar-search.js
@@ -1,6 +1,6 @@
 document.getElementById('search-button-nav').onclick = function() {
   var q = document.getElementById('search-input-nav').value;
-  window.location.href = 'search.html?q=' + encodeURIComponent(q);
+  window.location.href = '/docs/search.html?q=' + encodeURIComponent(q);
 };
 
 var q = document.getElementById('search-input-nav').onkeyup = function(ev) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

## Bug description
Clicking the search button to search anything under the API section that contains the URL like **mongoosejs.com/docs/api/<name.html>** will redirect to the 404 page not found.
![mongoose_1](https://user-images.githubusercontent.com/63643748/184482289-46a6d2e9-b379-4d4b-aa09-16fa86472e9b.png)
![mongoose_2](https://user-images.githubusercontent.com/63643748/184482599-b5f243af-2708-4850-bcde-e72e233c8629.png)

## Solution for the bug
In the [navbar js code](https://github.com/Automattic/mongoose/blob/master/docs/js/navbar-search.js) that has onClick function which redirects to **'search.html?q=' + encodeURIComponent(q); -> https://mongoosejs.com/docs/api/search.html?q=find** but it should redirect to **https://mongoosejs.com/docs/search.html?q=find**
![mongoose_3](https://user-images.githubusercontent.com/63643748/184485339-7ba99157-8066-4a89-8d47-7c4d41a0e269.png)
Changing ```location.href = 'search.html?q=' + encodeURIComponent(q);``` **to** ```location.href = '/docs/search.html?q=' + encodeURIComponent(q);``` will resolve the issue.


<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
