### PR TITLE
fix(types): allow $search in $lookup pipeline stages for MongoDB v6.x support

### DIFF
--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -423,3 +423,21 @@ const stages4: PipelineStage[] = [
     }
   };
 })();
+
+
+function gh12269() {
+  const lookup: PipelineStage.Lookup = {
+    $lookup: {
+      as: 'user',
+      from: 'users',
+      pipeline: [{
+        $search: {
+          index: 'users',
+          highlight: {
+            path: 'user.highlighted'
+          }
+        }
+      }]
+    }
+  };
+}

--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -141,7 +141,7 @@ declare module 'mongoose' {
         localField?: string
         foreignField?: string
         let?: Record<string, any>
-        pipeline?: Exclude<PipelineStage, PipelineStage.Merge | PipelineStage.Out | PipelineStage.Search>[]
+        pipeline?: Exclude<PipelineStage, PipelineStage.Merge | PipelineStage.Out>[]
       }
     }
 


### PR DESCRIPTION
fixes #12269