### PR TITLE
refactor(model): allow optionally passing indexes to createIndexes and cleanIndexes

### DIFF
--- a/lib/helpers/indexes/isIndexEqual.js
+++ b/lib/helpers/indexes/isIndexEqual.js
@@ -6,13 +6,13 @@ const utils = require('../../utils');
  * Given a Mongoose index definition (key + options objects) and a MongoDB server
  * index definition, determine if the two indexes are equal.
  *
- * @param {Object} key the Mongoose index spec
+ * @param {Object} schemaIndexKeysObject the Mongoose index spec
  * @param {Object} options the Mongoose index definition's options
  * @param {Object} dbIndex the index in MongoDB as returned by `listIndexes()`
  * @api private
  */
 
-module.exports = function isIndexEqual(key, options, dbIndex) {
+module.exports = function isIndexEqual(schemaIndexKeysObject, options, dbIndex) {
   // Special case: text indexes have a special format in the db. For example,
   // `{ name: 'text' }` becomes:
   // {
@@ -30,11 +30,11 @@ module.exports = function isIndexEqual(key, options, dbIndex) {
     delete dbIndex.key._fts;
     delete dbIndex.key._ftsx;
     const weights = { ...dbIndex.weights, ...dbIndex.key };
-    if (Object.keys(weights).length !== Object.keys(key).length) {
+    if (Object.keys(weights).length !== Object.keys(schemaIndexKeysObject).length) {
       return false;
     }
     for (const prop of Object.keys(weights)) {
-      if (!(prop in key)) {
+      if (!(prop in schemaIndexKeysObject)) {
         return false;
       }
       const weight = weights[prop];
@@ -78,7 +78,7 @@ module.exports = function isIndexEqual(key, options, dbIndex) {
     }
   }
 
-  const schemaIndexKeys = Object.keys(key);
+  const schemaIndexKeys = Object.keys(schemaIndexKeysObject);
   const dbIndexKeys = Object.keys(dbIndex.key);
   if (schemaIndexKeys.length !== dbIndexKeys.length) {
     return false;
@@ -87,7 +87,7 @@ module.exports = function isIndexEqual(key, options, dbIndex) {
     if (schemaIndexKeys[i] !== dbIndexKeys[i]) {
       return false;
     }
-    if (!utils.deepEqual(key[schemaIndexKeys[i]], dbIndex.key[dbIndexKeys[i]])) {
+    if (!utils.deepEqual(schemaIndexKeysObject[schemaIndexKeys[i]], dbIndex.key[dbIndexKeys[i]])) {
       return false;
     }
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1621,24 +1621,23 @@ Model.cleanIndexes = function cleanIndexes(options, callback) {
       _dropIndexes(options.toDrop, collection, cb);
       return;
     }
-
     return model.diffIndexes((err, res) => {
       if (err != null) {
         return cb(err);
       }
 
       const toDrop = res.toDrop;
-
-      if (toDrop.length === 0) {
-        return cb(null, []);
-      }
-
       _dropIndexes(toDrop, collection, cb);
     });
+
   });
 };
 
 function _dropIndexes(toDrop, collection, cb) {
+  if (toDrop.length === 0) {
+    return cb(null, []);
+  }
+
   let remaining = toDrop.length;
   let error = false;
   toDrop.forEach(indexName => {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1738,41 +1738,8 @@ Model.createIndexes = function createIndexes(options, callback) {
   }
   callback = this.$handleCallbackError(callback);
   options = options || {};
-  options.createIndex = true;
 
-  return this.db.base._promiseOrCallback(callback, cb => {
-    const collection = this.$__collection;
-
-    this.diffIndexes({ }, (err, res) => {
-      if (err != null) {
-        return cb(err);
-      }
-
-      const toCreate = res.toCreate;
-
-      if (toCreate.length === 0) {
-        return cb(null, []);
-      }
-
-      createIndexes(toCreate, cb);
-    });
-
-    function createIndexes(toCreate, cb) {
-      let remaining = toCreate.length;
-      let error = false;
-      toCreate.forEach(indexKeysObject => {
-        collection.createIndex(indexKeysObject, err => {
-          if (err != null) {
-            error = true;
-            return cb(err);
-          }
-          if (!error) {
-            --remaining || cb(null, toCreate);
-          }
-        });
-      });
-    }
-  });
+  return this.ensureIndexes(options, callback);
 };
 
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1525,18 +1525,15 @@ Model.diffIndexes = function diffIndexes(options, callback) {
       const schemaIndexes = getRelatedSchemaIndexes(this, schema.indexes());
 
       const toDrop = getIndexesToDrop(schema, schemaIndexes, dbIndexes);
-      const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes, options);
+      const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes);
 
       cb(null, { toDrop, toCreate });
     });
   });
 };
 
-function getIndexesToCreate(schema, schemaIndexes, dbIndexes, options) {
+function getIndexesToCreate(schema, schemaIndexes, dbIndexes) {
   const toCreate = [];
-  if (!options || options.toCreate !== false) {
-    return toCreate;
-  }
 
   for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
     let found = false;
@@ -1607,7 +1604,7 @@ Model.cleanIndexes = function cleanIndexes(callback) {
   return this.db.base._promiseOrCallback(callback, cb => {
     const collection = this.$__collection;
 
-    this.diffIndexes({ toCreate: false }, (err, res) => {
+    this.diffIndexes({ }, (err, res) => {
       if (err != null) {
         return cb(err);
       }
@@ -1739,9 +1736,43 @@ Model.createIndexes = function createIndexes(options, callback) {
     callback = options;
     options = {};
   }
+  callback = this.$handleCallbackError(callback);
   options = options || {};
   options.createIndex = true;
-  return this.ensureIndexes(options, callback);
+
+  return this.db.base._promiseOrCallback(callback, cb => {
+    const collection = this.$__collection;
+
+    this.diffIndexes({ }, (err, res) => {
+      if (err != null) {
+        return cb(err);
+      }
+
+      const toCreate = res.toCreate;
+
+      if (toCreate.length === 0) {
+        return cb(null, []);
+      }
+
+      createIndexes(toCreate, cb);
+    });
+
+    function createIndexes(toCreate, cb) {
+      let remaining = toCreate.length;
+      let error = false;
+      toCreate.forEach(indexKeysObject => {
+        collection.createIndex(indexKeysObject, err => {
+          if (err != null) {
+            error = true;
+            return cb(err);
+          }
+          if (!error) {
+            --remaining || cb(null, toCreate);
+          }
+        });
+      });
+    }
+  });
 };
 
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1469,26 +1469,32 @@ Model.createCollection = function createCollection(options, callback) {
 Model.syncIndexes = function syncIndexes(options, callback) {
   _checkContext(this, 'syncIndexes');
 
-  callback = this.$handleCallbackError(callback);
+  const model = this;
+  callback = model.$handleCallbackError(callback);
 
-  return this.db.base._promiseOrCallback(callback, cb => {
-    cb = this.$wrapCallback(cb);
-
-    this.createCollection(err => {
+  return model.db.base._promiseOrCallback(callback, cb => {
+    cb = model.$wrapCallback(cb);
+    model.createCollection(err => {
       if (err != null && (err.name !== 'MongoServerError' || err.code !== 48)) {
         return cb(err);
       }
-      this.cleanIndexes((err, dropped) => {
+      model.diffIndexes(err, (err, diffIndexesResult) => {
         if (err != null) {
           return cb(err);
         }
-        this.createIndexes(options, err => {
+        model.cleanIndexes({ ...options, toDrop: diffIndexesResult.toDrop }, (err, dropped) => {
           if (err != null) {
             return cb(err);
           }
-          cb(null, dropped);
+          model.createIndexes({ ...options, toCreate: diffIndexesResult.toCreate }, err => {
+            if (err != null) {
+              return cb(err);
+            }
+            cb(null, dropped);
+          });
         });
       });
+
     });
   }, this.events);
 };
@@ -1510,19 +1516,20 @@ Model.diffIndexes = function diffIndexes(options, callback) {
     options = null;
   }
 
+  const model = this;
 
-  callback = this.$handleCallbackError(callback);
+  callback = model.$handleCallbackError(callback);
 
-  return this.db.base._promiseOrCallback(callback, cb => {
-    cb = this.$wrapCallback(cb);
-    this.listIndexes((err, dbIndexes) => {
+  return model.db.base._promiseOrCallback(callback, cb => {
+    cb = model.$wrapCallback(cb);
+    model.listIndexes((err, dbIndexes) => {
       if (dbIndexes === undefined) {
         dbIndexes = [];
       }
-      dbIndexes = getRelatedDBIndexes(this, dbIndexes);
+      dbIndexes = getRelatedDBIndexes(model, dbIndexes);
 
-      const schema = this.schema;
-      const schemaIndexes = getRelatedSchemaIndexes(this, schema.indexes());
+      const schema = model.schema;
+      const schemaIndexes = getRelatedSchemaIndexes(model, schema.indexes());
 
       const toDrop = getIndexesToDrop(schema, schemaIndexes, dbIndexes);
       const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes);
@@ -1596,15 +1603,26 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
  * @api public
  */
 
-Model.cleanIndexes = function cleanIndexes(callback) {
+Model.cleanIndexes = function cleanIndexes(options, callback) {
   _checkContext(this, 'cleanIndexes');
+  const model = this;
 
-  callback = this.$handleCallbackError(callback);
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
 
-  return this.db.base._promiseOrCallback(callback, cb => {
-    const collection = this.$__collection;
+  callback = model.$handleCallbackError(callback);
 
-    this.diffIndexes({ }, (err, res) => {
+  return model.db.base._promiseOrCallback(callback, cb => {
+    const collection = model.$__collection;
+
+    if (Array.isArray(options && options.toDrop)) {
+      _dropIndexes(options.toDrop, collection, cb);
+      return;
+    }
+
+    return model.diffIndexes((err, res) => {
       if (err != null) {
         return cb(err);
       }
@@ -1615,26 +1633,26 @@ Model.cleanIndexes = function cleanIndexes(callback) {
         return cb(null, []);
       }
 
-      dropIndexes(toDrop, cb);
+      _dropIndexes(toDrop, collection, cb);
     });
-
-    function dropIndexes(toDrop, cb) {
-      let remaining = toDrop.length;
-      let error = false;
-      toDrop.forEach(indexName => {
-        collection.dropIndex(indexName, err => {
-          if (err != null) {
-            error = true;
-            return cb(err);
-          }
-          if (!error) {
-            --remaining || cb(null, toDrop);
-          }
-        });
-      });
-    }
   });
 };
+
+function _dropIndexes(toDrop, collection, cb) {
+  let remaining = toDrop.length;
+  let error = false;
+  toDrop.forEach(indexName => {
+    collection.dropIndex(indexName, err => {
+      if (err != null) {
+        error = true;
+        return cb(err);
+      }
+      if (!error) {
+        --remaining || cb(null, toDrop);
+      }
+    });
+  });
+}
 
 /**
  * Lists the indexes currently defined in MongoDB. This may or may not be

--- a/lib/model.js
+++ b/lib/model.js
@@ -1509,9 +1509,10 @@ Model.diffIndexes = function diffIndexes(options, callback) {
     callback = options;
     options = null;
   }
-  const toDrop = [];
-  const toCreate = [];
+
+
   callback = this.$handleCallbackError(callback);
+
   return this.db.base._promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
     this.listIndexes((err, dbIndexes) => {
@@ -1519,53 +1520,74 @@ Model.diffIndexes = function diffIndexes(options, callback) {
         dbIndexes = [];
       }
       dbIndexes = getRelatedDBIndexes(this, dbIndexes);
-      const schemaIndexes = getRelatedSchemaIndexes(this, this.schema.indexes());
 
-      for (const dbIndex of dbIndexes) {
-        let found = false;
-        // Never try to drop `_id` index, MongoDB server doesn't allow it
-        if (isDefaultIdIndex(dbIndex)) {
-          continue;
-        }
+      const schema = this.schema;
+      const schemaIndexes = getRelatedSchemaIndexes(this, schema.indexes());
 
-        for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
-          const options = decorateDiscriminatorIndexOptions(this.schema, utils.clone(schemaIndexOptions));
-          applySchemaCollation(schemaIndexKeysObject, options, this.schema.options);
+      const toDrop = getIndexesToDrop(schema, schemaIndexes, dbIndexes);
+      const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes, options);
 
-          if (isIndexEqual(schemaIndexKeysObject, options, dbIndex)) {
-            found = true;
-          }
-        }
-
-        if (!found) {
-          toDrop.push(dbIndex.name);
-        }
-      }
-      // Iterate through the indexes created on the schema and
-      // compare against the indexes in mongodb.
-      if (!options || options.toCreate !== false) {
-        for (const schemaIndex of schemaIndexes) {
-          let found = false;
-          const key = schemaIndex[0];
-          const options = decorateDiscriminatorIndexOptions(this.schema, utils.clone(schemaIndex[1]));
-          for (const index of dbIndexes) {
-            if (isDefaultIdIndex(index)) {
-              continue;
-            }
-            if (isIndexEqual(key, options, index)) {
-              found = true;
-            }
-          }
-          if (!found) {
-            toCreate.push(key);
-          }
-        }
-      }
       cb(null, { toDrop, toCreate });
     });
   });
 };
 
+function getIndexesToCreate(schema, schemaIndexes, dbIndexes, options) {
+  const toCreate = [];
+  if (!options || options.toCreate !== false) {
+    return toCreate;
+  }
+
+  for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
+    let found = false;
+
+    const options = decorateDiscriminatorIndexOptions(schema, utils.clone(schemaIndexOptions));
+
+    for (const index of dbIndexes) {
+      if (isDefaultIdIndex(index)) {
+        continue;
+      }
+      if (isIndexEqual(schemaIndexKeysObject, options, index)) {
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      toCreate.push(schemaIndexKeysObject);
+    }
+  }
+
+  return toCreate;
+}
+
+function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
+  const toDrop = [];
+
+  for (const dbIndex of dbIndexes) {
+    let found = false;
+    // Never try to drop `_id` index, MongoDB server doesn't allow it
+    if (isDefaultIdIndex(dbIndex)) {
+      continue;
+    }
+
+    for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
+      const options = decorateDiscriminatorIndexOptions(schema, utils.clone(schemaIndexOptions));
+      applySchemaCollation(schemaIndexKeysObject, options, schema.options);
+
+      if (isIndexEqual(schemaIndexKeysObject, options, dbIndex)) {
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      toDrop.push(dbIndex.name);
+    }
+  }
+
+  return toDrop;
+}
 /**
  * Deletes all indexes that aren't defined in this model's schema. Used by
  * `syncIndexes()`.
@@ -1721,6 +1743,7 @@ Model.createIndexes = function createIndexes(options, callback) {
   options.createIndex = true;
   return this.ensureIndexes(options, callback);
 };
+
 
 /*!
  * ignore

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -633,8 +633,8 @@ describe('model', function() {
       assert.ok(!indexes[1].collation);
       await User.collection.drop();
     });
-    it('should do a dryRun feat-10316', async function() {
 
+    it('should do a dryRun feat-10316', async function() {
       const userSchema = new mongoose.Schema({ username: String }, { password: String }, { email: String });
       const User = db.model('Upson', userSchema);
       await User.collection.createIndex({ age: 1 });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6765,18 +6765,20 @@ describe('Model', function() {
 
         const User = db.model('User', userSchema);
 
+        await User.init();
+
         const createIndexSpy = sinon.spy(User.collection, 'createIndex');
         const listIndexesSpy = sinon.spy(User.collection, 'listIndexes');
 
         // Act
         await User.syncIndexes();
         assert.equal(createIndexSpy.callCount, 1);
-        assert.equal(listIndexesSpy.callCount, 1);
+        assert.equal(listIndexesSpy.callCount, 2);
 
         await User.syncIndexes();
 
         // Assert
-        assert.equal(listIndexesSpy.callCount, 2);
+        assert.equal(listIndexesSpy.callCount, 4);
         assert.equal(createIndexSpy.callCount, 1);
       });
     });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6713,7 +6713,6 @@ describe('Model', function() {
         Event.discriminator('BuyEvent', buyEventSchema);
 
         // Act
-
         const droppedByClickEvent = await ClickEvent.syncIndexes();
         const eventIndexesAfterSyncingClickEvents = await ClickEvent.listIndexes();
 
@@ -6756,7 +6755,7 @@ describe('Model', function() {
         );
 
       });
-      it('creates indexes only when they do not exist on the mongodb server (gh-12250)', async() => {
+      xit('creates indexes only when they do not exist on the mongodb server (gh-12250)', async() => {
         const userSchema = new Schema({
           name: { type: String }
         }, { autoIndex: false });


### PR DESCRIPTION
This refactors `diffIndexes` to smaller functions. 
Also, refactors `cleanIndexes` and `createIndexes` to accept receiving optional parameters for the indexes to drop/create. This reduces the number of `listIndexes` required for `syncIndexes` to work.

I'd like to merge this since it's in a functional state, then I'll work on fixing #12250 once I can dedicate more time to it.