### PR TITLE
Speed up TypeScript perf

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -452,10 +452,6 @@ declare module 'mongoose' {
 
   export type SortOrder = -1 | 1 | 'asc' | 'ascending' | 'desc' | 'descending';
 
-  type Mutable<T> = {
-    -readonly [K in keyof T]: T[K];
-  };
-
   type _UpdateQuery<TSchema> = {
     /** @see https://docs.mongodb.com/manual/reference/operator/update-field/ */
     $currentDate?: AnyKeys<TSchema> & AnyObject;
@@ -469,7 +465,7 @@ declare module 'mongoose' {
     $unset?: AnyKeys<TSchema> & AnyObject;
 
     /** @see https://docs.mongodb.com/manual/reference/operator/update-array/ */
-    $addToSet?: Mutable<mongodb.SetFields<TSchema>>;
+    $addToSet?: AnyKeys<TSchema> & AnyObject;
     $pop?: AnyKeys<TSchema> & AnyObject;
     $pull?: AnyKeys<TSchema> & AnyObject;
     $push?: AnyKeys<TSchema> & AnyObject;
@@ -487,13 +483,6 @@ declare module 'mongoose' {
   { $replaceRoot: any } |
   { $replaceWith: any };
 
-  export type __UpdateDefProperty<T> =
-    [Extract<T, mongodb.ObjectId>] extends [never] ? T :
-      T | string;
-  export type _UpdateQueryDef<T> = {
-    [K in keyof T]?: __UpdateDefProperty<T[K]>;
-  };
-
   /**
    * Update query command to perform on the document
    * @example
@@ -501,7 +490,7 @@ declare module 'mongoose' {
    * { age: 30 }
    * ```
    */
-  export type UpdateQuery<T> = _UpdateQuery<_UpdateQueryDef<T>> & AnyObject;
+  export type UpdateQuery<T> = _UpdateQuery<T> & AnyObject;
 
   export type DocumentDefinition<T> = {
     [K in keyof Omit<T, Exclude<keyof Document, '_id' | 'id' | '__v'>>]:

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -195,7 +195,7 @@ declare module 'mongoose' {
     /** Returns a copy of this schema */
     clone<T = this>(): T;
 
-    discriminator<T extends Schema = Schema>(name: string, schema: T): DiscriminatorSchema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, T>;
+    discriminator<T = Schema>(name: string, schema: T): DiscriminatorSchema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, T>;
 
     /** Returns a new schema that has the picked `paths` from this schema. */
     pick<T = this>(paths: string[], options?: SchemaOptions): T;
@@ -256,8 +256,8 @@ declare module 'mongoose' {
     /** Defines a post hook for the model. */
     post<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, fn: PostMiddlewareFunction<T, T>): this;
     post<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, T>): this;
-    post<T extends Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, fn: PostMiddlewareFunction<T, QueryResultType<T>>): this;
-    post<T extends Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, QueryResultType<T>>): this;
+    post<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, fn: PostMiddlewareFunction<T, QueryResultType<T>>): this;
+    post<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, QueryResultType<T>>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: PostMiddlewareFunction<T, Array<AggregateExtract<T>>>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, Array<AggregateExtract<T>>>): this;
     post<T = M>(method: 'insertMany' | RegExp, fn: PostMiddlewareFunction<T, T>): this;
@@ -265,8 +265,8 @@ declare module 'mongoose' {
 
     post<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, fn: ErrorHandlingMiddlewareFunction<T>): this;
     post<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T>): this;
-    post<T extends Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, fn: ErrorHandlingMiddlewareFunction<T>): this;
-    post<T extends Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T>): this;
+    post<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, fn: ErrorHandlingMiddlewareFunction<T>): this;
+    post<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: ErrorHandlingMiddlewareFunction<T, Array<any>>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T, Array<any>>): this;
     post<T = M>(method: 'insertMany' | RegExp, fn: ErrorHandlingMiddlewareFunction<T>): this;
@@ -277,9 +277,8 @@ declare module 'mongoose' {
     pre<T = HydratedDocument<DocType, TInstanceMethods>>(method: 'save', options: SchemaPreOptions, fn: PreSaveMiddlewareFunction<T>): this;
     pre<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, fn: PreMiddlewareFunction<T>): this;
     pre<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
-    pre<T extends Query<any, any>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
-    pre<T extends Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, fn: PreMiddlewareFunction<T>): this;
-    pre<T extends Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | string | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
+    pre<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, fn: PreMiddlewareFunction<T>): this;
+    pre<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
     pre<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: PreMiddlewareFunction<T>): this;
     pre<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
     pre<T = M>(method: 'insertMany' | RegExp, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,7 +62,10 @@ declare module 'mongoose' {
   export function get<K extends keyof MongooseOptions>(key: K): MongooseOptions[K];
 
   /* ! ignore */
-  export type CompileModelOptions = { overwriteModels?: boolean, connection?: Connection };
+  export type CompileModelOptions = {
+    overwriteModels?: boolean,
+    connection?: Connection
+  };
 
   export function model<TSchema extends Schema = any>(
     name: string,
@@ -112,10 +115,6 @@ declare module 'mongoose' {
   export type Require_id<T> = T extends { _id?: infer U }
     ? IfAny<U, T & { _id: Types.ObjectId }, T & Required<{ _id: U }>>
     : T & { _id: Types.ObjectId };
-
-  export type RequireOnlyTypedId<T> = T extends { _id?: infer U; }
-    ? Required<{ _id: U }>
-    : { _id: Types.ObjectId };
 
   export type HydratedDocument<DocType, TMethodsAndOverrides = {}, TVirtuals = {}> = DocType extends Document ? Require_id<DocType> : (Document<unknown, any, DocType> & Require_id<DocType> & TVirtuals & TMethodsAndOverrides);
 
@@ -515,7 +514,6 @@ declare module 'mongoose' {
       T extends TreatAsPrimitives ? T : // primitives
         T extends Types.Subdocument ? Omit<LeanDocument<T>, '$isSingleNested' | 'ownerDocument' | 'parent'> :
           LeanDocument<T>; // Documents and everything else
-
 
   export type LeanArray<T extends unknown[]> = T extends unknown[][] ? LeanArray<T[number]>[] : LeanType<T[number]>[];
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -260,21 +260,21 @@ declare module 'mongoose' {
     init(callback?: CallbackWithoutResult): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
 
     /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
-    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }, callback: Callback<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>): void;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }, callback: Callback<Array<MergeType<MergeType<T, DocContents>, Require_id<T>>>>): void;
     insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true; }, callback: Callback<mongodb.InsertManyResult<T>>): void;
-    insertMany<DocContents = T>(docs: Array<DocContents | T>, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
-    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }, callback: Callback<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>): void;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }, callback: Callback<Array<MergeType<MergeType<T, DocContents>, Require_id<T>>>>): void;
     insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true; }, callback: Callback<mongodb.InsertManyResult<T>>): void;
-    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean?: false | undefined }, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
-    insertMany<DocContents = T>(doc: DocContents, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean?: false | undefined }, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
+    insertMany<DocContents = T>(doc: DocContents, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
 
-    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, Require_id<T>>>>;
     insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true; }): Promise<mongodb.InsertManyResult<T>>;
-    insertMany<DocContents = T>(docs: Array<DocContents | T>): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>;
-    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>>>;
+    insertMany<DocContents = T>(docs: Array<DocContents | T>): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, Require_id<T>>>>;
     insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { rawResult: true; }): Promise<mongodb.InsertManyResult<T>>;
-    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>;
-    insertMany<DocContents = T>(doc: DocContents): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, RequireOnlyTypedId<T>>, TMethodsAndOverrides, TVirtuals>>>;
+    insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>;
+    insertMany<DocContents = T>(doc: DocContents): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>;
 
     /** The name of the model */
     modelName: string;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -271,7 +271,7 @@ declare module 'mongoose' {
     distinct<ReturnType = any>(field: string, filter?: FilterQuery<DocType>, callback?: Callback<number>): QueryWithHelpers<Array<ReturnType>, DocType, THelpers, RawDocType>;
 
     /** Specifies a `$elemMatch` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    elemMatch<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$elemMatch']): this;
+    elemMatch<K = string>(path: K, val: any): this;
     elemMatch(val: Function | any): this;
 
     /**
@@ -288,7 +288,7 @@ declare module 'mongoose' {
     estimatedDocumentCount(options?: QueryOptions<DocType>, callback?: Callback<number>): QueryWithHelpers<number, DocType, THelpers, RawDocType>;
 
     /** Specifies a `$exists` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    exists<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$exists']): this;
+    exists<K = string>(path: K, val: boolean): this;
     exists(val: boolean): this;
 
     /**
@@ -403,18 +403,18 @@ declare module 'mongoose' {
     getUpdate(): UpdateQuery<DocType> | UpdateWithAggregationPipeline | null;
 
     /** Specifies a `$gt` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    gt<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$gt']): this;
+    gt<K = string>(path: K, val: any): this;
     gt(val: number): this;
 
     /** Specifies a `$gte` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    gte<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$gte']): this;
+    gte<K = string>(path: K, val: any): this;
     gte(val: number): this;
 
     /** Sets query hints. */
     hint(val: any): this;
 
     /** Specifies an `$in` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    in<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$in']): this;
+    in<K = string>(path: K, val: any[]): this;
     in(val: Array<any>): this;
 
     /** Declares an intersects query for `geometry()`. */
@@ -430,11 +430,11 @@ declare module 'mongoose' {
     limit(val: number): this;
 
     /** Specifies a `$lt` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    lt<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$lt']): this;
+    lt<K = string>(path: K, val: any): this;
     lt(val: number): this;
 
     /** Specifies a `$lte` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    lte<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$lte']): this;
+    lte<K = string>(path: K, val: any): this;
     lte(val: number): this;
 
     /**
@@ -461,7 +461,7 @@ declare module 'mongoose' {
     merge(source: Query<any, any> | FilterQuery<DocType>): this;
 
     /** Specifies a `$mod` condition, filters documents for documents whose `path` property is a number that is equal to `remainder` modulo `divisor`. */
-    mod<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$mod']): this;
+    mod<K = string>(path: K, val: number): this;
     mod(val: Array<number>): this;
 
     /** The model this query was created from */
@@ -474,15 +474,15 @@ declare module 'mongoose' {
     mongooseOptions(val?: MongooseQueryOptions): MongooseQueryOptions;
 
     /** Specifies a `$ne` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    ne<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$ne']): this;
+    ne<K = string>(path: K, val: any): this;
     ne(val: any): this;
 
     /** Specifies a `$near` or `$nearSphere` condition */
-    near<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$near']): this;
+    near<K = string>(path: K, val: any): this;
     near(val: any): this;
 
     /** Specifies an `$nin` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    nin<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$nin']): this;
+    nin<K = string>(path: K, val: any[]): this;
     nin(val: Array<any>): this;
 
     /** Specifies arguments for an `$nor` condition. */
@@ -518,7 +518,7 @@ declare module 'mongoose' {
     readConcern(level: string): this;
 
     /** Specifies a `$regex` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    regex<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$regex']): this;
+    regex<K = string>(path: K, val: RegExp): this;
     regex(val: string | RegExp): this;
 
     /**
@@ -570,7 +570,7 @@ declare module 'mongoose' {
     setUpdate(update: UpdateQuery<DocType> | UpdateWithAggregationPipeline): void;
 
     /** Specifies an `$size` query condition. When called with one argument, the most recent path passed to `where()` is used. */
-    size<K extends keyof FilterQuery<DocType>>(path: K, val: FilterQuery<DocType>[K]['$size']): this;
+    size<K = string>(path: K, val: number): this;
     size(val: number): this;
 
     /** Specifies the number of documents to skip. */
@@ -599,7 +599,7 @@ declare module 'mongoose' {
     then: Promise<ResultType>['then'];
 
     /** Converts this query to a customized, reusable query constructor with all arguments and options retained. */
-    toConstructor(): new (...args: any[]) => QueryWithHelpers<ResultType, DocType, THelpers, RawDocType>;
+    toConstructor(): typeof this;
 
     /** Declare and/or execute this query as an update() operation. */
     update(filter?: FilterQuery<DocType>, update?: UpdateQuery<DocType> | UpdateWithAggregationPipeline, options?: QueryOptions<DocType> | null, callback?: Callback<UpdateWriteOpResult>): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fixes up #10349. Before this PR:

```
$ ./node_modules/.bin/tsc --extendedDiagnostics gh-10349.ts 
Files:                         126
Lines of Library:            27583
Lines of Definitions:        53181
Lines of TypeScript:            20
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Nodes of Library:           118533
Nodes of Definitions:       142841
Nodes of TypeScript:            89
Nodes of JavaScript:             0
Nodes of JSON:                   0
Nodes of Other:                  0
Identifiers:                 92346
Symbols:                    177166
Types:                       76289
Instantiations:             334872
Memory used:               204744K
Assignability cache size:    26192
Identity cache size:           175
Subtype cache size:              2
Strict subtype cache size:       4
I/O Read time:               0.01s
Parse time:                  0.55s
ResolveModule time:          0.03s
ResolveTypeReference time:   0.00s
Program time:                0.62s
Bind time:                   0.24s
Check time:                  2.62s
transformTime time:          0.01s
commentTime time:            0.00s
I/O Write time:              0.00s
printTime time:              0.01s
Emit time:                   0.01s
Total time:                  3.50s
```

After this PR:

```
$ ./node_modules/.bin/tsc --extendedDiagnostics gh-10349.ts 
Files:                         126
Lines of Library:            27583
Lines of Definitions:        53167
Lines of TypeScript:            20
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Nodes of Library:           118533
Nodes of Definitions:       142530
Nodes of TypeScript:            89
Nodes of JavaScript:             0
Nodes of JSON:                   0
Nodes of Other:                  0
Identifiers:                 92229
Symbols:                    101736
Types:                       47377
Instantiations:              75893
Memory used:               166417K
Assignability cache size:    17401
Identity cache size:           171
Subtype cache size:              2
Strict subtype cache size:       4
I/O Read time:               0.05s
Parse time:                  0.53s
ResolveModule time:          0.03s
ResolveTypeReference time:   0.02s
Program time:                0.66s
Bind time:                   0.23s
Check time:                  1.80s
transformTime time:          0.01s
commentTime time:            0.00s
I/O Write time:              0.00s
printTime time:              0.01s
Emit time:                   0.01s
Total time:                  2.70s
```

We're mostly undoing some more changes from #11650: typing `exists<>`, etc. based on schema is pretty slow. But most of the performance impact, oddly enough, came from adding `extends Query` in `Schema.pre()` and `Schema.post()`. Removing that has brought us back to the perf we had back in 6.3.0 :+1:

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
