### PR TITLE
fix: update links on api docs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -367,7 +367,7 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
  * @param {Number} [options.family=0] Passed transparently to [Node.js' `dns.lookup()`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) function. May be either `0`, `4`, or `6`. `4` means use IPv4 only, `6` means use IPv6 only, `0` means try both.
  * @param {Boolean} [options.autoCreate=false] Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection.
  * @param {Function} [callback]
- * @see Mongoose#createConnection #index_Mongoose-createConnection
+ * @see Mongoose#createConnection /docs/api.html#mongoose_Mongoose-createConnection
  * @api public
  * @return {Promise} resolves to `this` if connection succeeded
  */
@@ -862,7 +862,7 @@ Mongoose.prototype.SchemaType = SchemaType;
  * _Alias of mongoose.Schema.Types for backwards compatibility._
  *
  * @property SchemaTypes
- * @see Schema.SchemaTypes #schema_Schema-Types
+ * @see Schema.SchemaTypes /docs/schematypes
  * @api public
  */
 


### PR DESCRIPTION
On the [API Mongoose page](https://mongoosejs.com/docs/api/mongoose.html) `Mongoose#createConnection` and `Schema.SchemaTypes` links are outdated. The sections no longer exist on the same page but are elsewhere. Update with the correct links which are now:
https://mongoosejs.com/docs/schematypes
https://mongoosejs.com/docs/api.html#mongoose_Mongoose-createConnection
