### PR TITLE
CVE-2022-2564 vulnerability for version 5.x

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -478,6 +478,10 @@ Schema.prototype.add = function add(obj, prefix) {
   const keys = Object.keys(obj);
 
   for (const key of keys) {
+    if (utils.specialProperties.has(key)) {
+      continue;
+    }
+
     const fullPath = prefix + key;
 
     if (obj[key] == null) {
@@ -663,6 +667,9 @@ Schema.prototype.path = function(path, obj) {
   let fullPath = '';
 
   for (const sub of subpaths) {
+    if (utils.specialProperties.has(sub)) {
+      throw new Error('Cannot set special property `' + sub + '` on a schema');
+    }
     fullPath = fullPath += (fullPath.length > 0 ? '.' : '') + sub;
     if (!branch[sub]) {
       this.nested[fullPath] = true;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2682,8 +2682,8 @@ describe('schema', function() {
     assert.equal(TestSchema.path('testprop.$*').instance, 'Number');
     assert.equal(TestSchema.path('testprop.$*').options.ref, 'OtherModel');
   });
-  
-  it('disallows setting special properties with `add()` or constructor (gh-12085)', async function() {
+
+  it('disallows setting special properties with `add()` or constructor (gh-12085)', function() {
     const maliciousPayload = '{"__proto__.toString": "Number"}';
 
     assert.throws(() => {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2682,4 +2682,14 @@ describe('schema', function() {
     assert.equal(TestSchema.path('testprop.$*').instance, 'Number');
     assert.equal(TestSchema.path('testprop.$*').options.ref, 'OtherModel');
   });
+  
+  it('disallows setting special properties with `add()` or constructor (gh-12085)', async function() {
+    const maliciousPayload = '{"__proto__.toString": "Number"}';
+
+    assert.throws(() => {
+      mongoose.Schema(JSON.parse(maliciousPayload));
+    }, /__proto__/);
+
+    assert.ok({}.toString());
+  });
 });


### PR DESCRIPTION
Fix #12281 
patch for prototype pollution vulnerability CVE-2022-2564 The CVS score is 7.0.
This patch is [already available](https://github.com/Automattic/mongoose/commit/a45cfb6b0ce0067ae9794cfa80f7917e1fb3c6f8) in version 6.4.6 , downporting it for 5.x 