### PR TITLE
[types] Apply #12125 to Connection

### DIFF
--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -150,7 +150,7 @@ declare module 'mongoose' {
     ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
     model<T, U, TQueryHelpers = {}>(
       name: string,
-      schema?: Schema<T, U, any, TQueryHelpers, any, any>,
+      schema?: Schema<T, any, any, TQueryHelpers, any, any>,
       collection?: string,
       options?: CompileModelOptions
     ): U;


### PR DESCRIPTION
**Summary**

This PR applies the changes from #12125 (and also adapts the tests for `connection.model`)