### PR TITLE
fix(types): sync single-generic-no-constraint "model" between "index.d.ts" and "connection.d.ts"

### DIFF
--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -154,7 +154,7 @@ declare module 'mongoose' {
       collection?: string,
       options?: CompileModelOptions
     ): U;
-    model<T>(name: string, schema?: Schema<T>, collection?: string, options?: CompileModelOptions): Model<T>;
+    model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
 
     /** Returns an array of model names created on this connection. */
     modelNames(): Array<string>;


### PR DESCRIPTION
**Summary**

This PR syncs the types for `.model` for `index.d.ts` and `connection.d.ts` for the single-no-constraint-generic overload