### PR TITLE
Update Node.js EventEmitter url

### DIFF
--- a/lib/browserDocument.js
+++ b/lib/browserDocument.js
@@ -20,7 +20,7 @@ const isObject = require('./helpers/isObject');
  * @param {Object} schema
  * @param {Object} [fields] optional object containing the fields which were selected in the query returning this document and any populated paths data
  * @param {Boolean} [skipId] bool, should we auto create an ObjectId _id
- * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#events_class_events_eventemitter
+ * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#class-eventemitter
  * @event `init`: Emitted on a document after it has was retrieved from the db and fully hydrated by Mongoose.
  * @event `save`: Emitted when the document is successfully saved
  * @api private

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -42,7 +42,7 @@ const noPasswordAuthMechanisms = [
  * For practical reasons, a Connection equals a Db.
  *
  * @param {Mongoose} base a mongoose instance
- * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#events_class_events_eventemitter
+ * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#class-eventemitter
  * @event `connecting`: Emitted when `connection.openUri()` is executed on this connection.
  * @event `connected`: Emitted when this connection successfully connects to the db. May be emitted _multiple_ times in `reconnected` scenarios.
  * @event `open`: Emitted after we `connected` and `onOpen` is executed on all of this connection's models.

--- a/lib/document.js
+++ b/lib/document.js
@@ -70,7 +70,7 @@ const specialProperties = utils.specialProperties;
  * @param {Object} [fields] optional object containing the fields which were selected in the query returning this document and any populated paths data
  * @param {Object} [options] various configuration options for the document
  * @param {Boolean} [options.defaults=true] if `false`, skip applying default values to this document.
- * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#events_class_events_eventemitter
+ * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#class-eventemitter
  * @event `init`: Emitted on a document after it has been retrieved from the db and fully hydrated by Mongoose.
  * @event `save`: Emitted when the document is successfully saved
  * @api private

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -88,7 +88,7 @@ let id = 0;
  *
  * @param {Object|Schema|Array} [definition] Can be one of: object describing schema paths, or schema to copy, or array of objects and schemas
  * @param {Object} [options]
- * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#events_class_events_eventemitter
+ * @inherits NodeJS EventEmitter https://nodejs.org/api/events.html#class-eventemitter
  * @event `init`: Emitted after the schema is compiled into a `Model`.
  * @api public
  */


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
This pull request updates the Node.js EventEmitter url 
From https://nodejs.org/api/events.html#events_class_events_eventemitter 
to https://nodejs.org/api/events.html#class-eventemitter