### PR TITLE
Use setPrototypeOf() instead of __proto__ to allow running on Deno

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -81,7 +81,7 @@ function Connection(base) {
  * Inherit from EventEmitter
  */
 
-Connection.prototype.__proto__ = EventEmitter.prototype;
+Object.setPrototypeOf(Connection.prototype, EventEmitter.prototype);
 
 /**
  * Connection ready state

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -34,7 +34,7 @@ function NativeCollection(name, conn, options) {
  * Inherit from abstract Collection.
  */
 
-NativeCollection.prototype.__proto__ = MongooseCollection.prototype;
+Object.setPrototypeOf(NativeCollection.prototype, MongooseCollection.prototype);
 
 /**
  * Called when the connection opens.

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -32,7 +32,7 @@ NativeConnection.STATES = STATES;
  * Inherits from Connection.
  */
 
-NativeConnection.prototype.__proto__ = MongooseConnection.prototype;
+Object.setPrototypeOf(NativeConnection.prototype, MongooseConnection.prototype);
 
 /**
  * Switches to a different database using the same connection pool.

--- a/lib/model.js
+++ b/lib/model.js
@@ -126,7 +126,7 @@ function Model(doc, fields, skipId) {
  * top level (non-sub) documents.
  */
 
-Model.prototype.__proto__ = Document.prototype;
+Object.setPrototypeOf(Model.prototype, Document.prototype);
 Model.prototype.$isMongooseModelPrototype = true;
 
 /**
@@ -1218,7 +1218,7 @@ Model.discriminator = function(name, schema, options) {
   model = this.db.model(model || name, schema, this.$__collection.name);
   this.discriminators[name] = model;
   const d = this.discriminators[name];
-  d.prototype.__proto__ = this.prototype;
+  Object.setPrototypeOf(d.prototype, this.prototype);
   Object.defineProperty(d, 'baseModelName', {
     value: this.modelName,
     configurable: true,
@@ -4944,8 +4944,8 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   model.modelName = name;
 
   if (!(model.prototype instanceof Model)) {
-    model.__proto__ = Model;
-    model.prototype.__proto__ = Model.prototype;
+    Object.setPrototypeOf(model, Model);
+    Object.setPrototypeOf(model.prototype, Model.prototype);
   }
   model.model = function model(name) {
     return this.db.model(name);
@@ -5037,8 +5037,8 @@ Model.__subclass = function subclass(conn, schema, collection) {
     _this.call(this, doc, fields, skipId);
   };
 
-  Model.__proto__ = _this;
-  Model.prototype.__proto__ = _this.prototype;
+  Object.setPrototypeOf(Model, _this);
+  Object.setPrototypeOf(Model.prototype, _this.prototype);
   Model.db = conn;
   Model.prototype.db = conn;
   Model.prototype[modelDbSymbol] = conn;

--- a/test/document.isselected.test.js
+++ b/test/document.isselected.test.js
@@ -27,7 +27,7 @@ function TestDocument() {
  * Inherits from Document.
  */
 
-TestDocument.prototype.__proto__ = Document.prototype;
+Object.setPrototypeOf(TestDocument.prototype, Document.prototype);
 
 for (const i in EventEmitter.prototype) {
   TestDocument[i] = EventEmitter.prototype[i];

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -30,7 +30,7 @@ function TestDocument() {
  * Inherits from Document.
  */
 
-TestDocument.prototype.__proto__ = Document.prototype;
+Object.setPrototypeOf(TestDocument.prototype, Document.prototype);
 
 /**
  * Set a dummy schema to simulate compilation.

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -38,7 +38,7 @@ function TestDocument() {
  * Inherits from Document.
  */
 
-TestDocument.prototype.__proto__ = Document.prototype;
+Object.setPrototypeOf(TestDocument.prototype, Document.prototype);
 
 for (const i in EventEmitter.prototype) {
   TestDocument[i] = EventEmitter.prototype[i];

--- a/test/document.unit.test.js
+++ b/test/document.unit.test.js
@@ -22,7 +22,7 @@ describe('sharding', function() {
       this.$__schema = mockSchema;
       this.$__ = {};
     };
-    Stub.prototype.__proto__ = mongoose.Document.prototype;
+    Object.setPrototypeOf(Stub.prototype, mongoose.Document.prototype);
     const d = new Stub();
     const currentTime = new Date();
     d._doc = { date: currentTime };

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -96,8 +96,6 @@ describe('model', function() {
       const employee = new Employee();
       assert.ok(employee instanceof Person);
       assert.ok(employee instanceof Employee);
-      assert.strictEqual(employee.__proto__.constructor, Employee);
-      assert.strictEqual(employee.__proto__.__proto__.constructor, Person);
     });
 
     it('can define static and instance methods', function() {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -33,7 +33,7 @@ function TestDocument() {
  * Inherits from Document.
  */
 
-TestDocument.prototype.__proto__ = Document.prototype;
+Object.setPrototypeOf(TestDocument.prototype, Document.prototype);
 
 /**
  * Test.

--- a/test/types.document.test.js
+++ b/test/types.document.test.js
@@ -33,7 +33,7 @@ describe('types.document', function() {
       mongoose.Document.call(this, {});
     }
     Dummy = _Dummy;
-    Dummy.prototype.__proto__ = mongoose.Document.prototype;
+    Object.setPrototypeOf(Dummy.prototype, mongoose.Document.prototype);
     Dummy.prototype.$__setSchema(new Schema());
 
     function _Subdocument() {
@@ -43,7 +43,7 @@ describe('types.document', function() {
     }
     Subdocument = _Subdocument;
 
-    Subdocument.prototype.__proto__ = ArraySubdocument.prototype;
+    Object.setPrototypeOf(Subdocument.prototype, ArraySubdocument.prototype);
 
     for (const i in EventEmitter.prototype) {
       Subdocument[i] = EventEmitter.prototype[i];

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -29,7 +29,7 @@ function TestDoc(schema) {
    * Inherits from ArraySubdocument.
    */
 
-  Subdocument.prototype.__proto__ = ArraySubdocument.prototype;
+  Object.setPrototypeOf(Subdocument.prototype, ArraySubdocument.prototype);
 
   /**
    * Set schema.


### PR DESCRIPTION
Re: #9056

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

With this change and `--unstable`, I've been able to successfully execute crud operations on Deno v1.24.3.

```javascript
import { createRequire } from "https://deno.land/std/node/module.ts";

const require = createRequire(import.meta.url);

const mongoose = require('mongoose');

console.log(mongoose.version);

run().catch(err => {
  console.error(err);
  process.exit(-1);
});

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test');

  const Test = mongoose.model('Test', mongoose.Schema({ name: String }));
  await Test.deleteMany({});
  await Test.create({ name: 'foo' });

  console.log(await Test.findOne());
  await mongoose.disconnect();
}
```

```
$ deno run --allow-read --allow-env --allow-net --unstable ./test.js 
6.5.2
model {
  "$__": InternalCache {
    activePaths: StateMachine { paths: { _id: "init", name: "init", __v: "init" }, states: { init: [Object] } },
    skipId: true
  },
  "$isNew": false,
  _doc: {
    _id: ObjectId {
      [Symbol(id)]: Buffer(12) [
         99,   3, 232, 161, 119,
         74, 216, 211,  11,  47,
        135,  14
      ]
    },
    name: "foo",
    __v: 0
  }
}
$ 
```

The `console.log()` output isn't great, looks like Deno doesn't support Node's `inspect()` output. But that's fixable. Turns out the big issue was that Deno doesn't support `__proto__`: https://github.com/denoland/deno/issues/4324.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
