### PR TITLE
Make ArraySubdocuments apply `_id` defaults on init

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -392,7 +392,7 @@ DocumentArrayPath.prototype.getDefault = function(scope, init, options) {
 };
 
 const _toObjectOptions = Object.freeze({ transform: false, virtuals: false });
-const initDocumentOptions = Object.freeze({ skipId: true, willInit: true });
+const initDocumentOptions = Object.freeze({ skipId: false, willInit: true });
 
 /**
  * Casts contents

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -748,4 +748,18 @@ describe('types.documentarray', function() {
     doc.arr.push(subdoc);
     await doc.validate();
   });
+
+  it('applies _id default (gh-12264)', function() {
+    mongoose.deleteModel(/Test/);
+    const nestedArraySchema = Schema({
+      subDocArray: [{ name: String }]
+    });
+
+    const Model = db.model('Test', nestedArraySchema);
+    const doc = new Model().init({
+      subDocArray: [{ name: 'foo' }]
+    });
+
+    assert.ok(doc.subDocArray[0]._id instanceof mongoose.Types.ObjectId);
+  });
 });


### PR DESCRIPTION
Fix #12264

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

@AbdelrahmanHafez you're right that https://github.com/Automattic/mongoose/commit/4c85c7008677db89ee9eb142785a09076a548a14 is the root cause of #12264. I think the `skipId` change is a bug, because that change makes it so that init-ing an array subdocument skips the `_id` default, but not any other defaults.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
