### PR TITLE
Handle maps when applying defaults to nested paths

### DIFF
--- a/lib/helpers/path/flattenObjectWithDottedPaths.js
+++ b/lib/helpers/path/flattenObjectWithDottedPaths.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MongooseError = require('../../error/mongooseError');
+const isMongooseObject = require('../isMongooseObject');
 const setDottedPath = require('../path/setDottedPath');
 const util = require('util');
 
@@ -13,8 +14,8 @@ module.exports = function flattenObjectWithDottedPaths(obj) {
   if (obj == null || typeof obj !== 'object' || Array.isArray(obj)) {
     return;
   }
-  // Avoid Mongoose docs
-  if (obj.$__) {
+  // Avoid Mongoose docs, like docs and maps, because these may cause infinite recursion
+  if (isMongooseObject(obj)) {
     return;
   }
   const keys = Object.keys(obj);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11820,9 +11820,7 @@ describe('document', function() {
 
     const data = {
       nestedPath1: {
-        mapOfSchema: {
-          // 2022: { 1: 0 }, // this data does not affect the error
-        }
+        mapOfSchema: {}
       }
     };
     const doc = await Test.create(data);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11771,7 +11771,7 @@ describe('document', function() {
     });
   });
 
-  it('supports virtuals named isValid (gh-12124) (gh-6262)', async function() {
+  it('supports virtuals named `isValid` (gh-12124) (gh-6262)', async function() {
     const Schema = new mongoose.Schema({
       test: String,
       data: { sub: String }
@@ -11797,6 +11797,37 @@ describe('document', function() {
     doc.set({ data: { sub: 'sub' } });
     await doc.save();
     assert.equal(doc.data.sub, 'sub');
+  });
+
+  it('handles maps when applying defaults to nested paths (gh-12220)', async function() {
+    const nestedSchema = new mongoose.Schema({
+      1: {
+        type: Number,
+        default: 0
+      }
+    });
+
+    const topSchema = new mongoose.Schema({
+      nestedPath1: {
+        mapOfSchema: {
+          type: Map,
+          of: nestedSchema
+        }
+      }
+    });
+
+    const Test = db.model('Test', topSchema);
+
+    const data = {
+      nestedPath1: {
+        mapOfSchema: {
+          // 2022: { 1: 0 }, // this data does not affect the error
+        }
+      }
+    };
+    const doc = await Test.create(data);
+
+    assert.ok(doc.nestedPath1.mapOfSchema);
   });
 });
 


### PR DESCRIPTION
Fix #12220

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The issue is that `flattenObjectWithDottedPaths()` drills down into Mongoose maps, which leads to infinite recursion because, among other things, maps have an instance of `Schema`, and `Schema` -> `Mongoose` -> `Model` -> `Schema`

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
