### PR TITLE
Add support for AbortSignal on eachAsync()

### DIFF
--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -16,6 +16,9 @@ const promiseOrCallback = require('../promiseOrCallback');
  * @param {Function} next the thunk to call to get the next document
  * @param {Function} fn
  * @param {Object} options
+ * @param {Number} [options.batchSize=null] if set, Mongoose will call `fn` with an array of at most `batchSize` documents, instead of a single document
+ * @param {Number} [options.parallel=1] maximum number of `fn` calls that Mongoose will run in parallel
+ * @param {AbortSignal} [options.signal] allow cancelling this eachAsync(). Once the abort signal is fired, `eachAsync()` will immediately fulfill the returned promise (or call the callback) and not fetch any more documents.
  * @param {Function} [callback] executed when all docs have been processed
  * @return {Promise}
  * @api public
@@ -25,11 +28,25 @@ const promiseOrCallback = require('../promiseOrCallback');
 module.exports = function eachAsync(next, fn, options, callback) {
   const parallel = options.parallel || 1;
   const batchSize = options.batchSize;
+  const signal = options.signal;
   const continueOnError = options.continueOnError;
   const aggregatedErrors = [];
   const enqueue = asyncQueue();
 
+  let drained = false;
+
   return promiseOrCallback(callback, cb => {
+    if (signal != null) {
+      if (signal.aborted) {
+        return cb(null);
+      }
+
+      signal.addEventListener('abort', () => {
+        drained = true;
+        return cb(null);
+      }, { once: true });
+    }
+
     if (batchSize != null) {
       if (typeof batchSize !== 'number') {
         throw new TypeError('batchSize must be a number');
@@ -44,7 +61,6 @@ module.exports = function eachAsync(next, fn, options, callback) {
   });
 
   function iterate(finalCallback) {
-    let drained = false;
     let handleResultsInProgress = 0;
     let currentDocumentIndex = 0;
     let documentsBatch = [];

--- a/test/helpers/cursor.eachAsync.test.js
+++ b/test/helpers/cursor.eachAsync.test.js
@@ -188,4 +188,38 @@ describe('eachAsync()', function() {
     assert.equal(err.errors[0].message, 'Fetching doc 1');
     assert.equal(numCalled, 1);
   });
+
+  it('using AbortSignal (gh-12173)', async function() {
+    if (typeof AbortController === 'undefined') {
+      return this.skip();
+    }
+
+    const ac = new AbortController();
+    const signal = ac.signal;
+
+    let numCalled = 0;
+    const abortAfter = 2;
+    let numNextCalls = 0;
+    let numFnCalls = 0;
+    function next(cb) {
+      ++numNextCalls;
+      setImmediate(() => {
+        if (numCalled++ === abortAfter) {
+          ac.abort();
+
+          return setImmediate(() => {
+            cb(null, { num: numCalled });
+          });
+        }
+
+        cb(null, { num: numCalled });
+      });
+    }
+
+    await eachAsync(next, () => ++numFnCalls, { signal });
+
+    assert.equal(numNextCalls, 3);
+    assert.equal(numCalled, 3);
+    assert.equal(numFnCalls, 2);
+  });
 });


### PR DESCRIPTION
Fix #12173

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Node has support for AbortController and AbortSignal now: https://www.nearform.com/blog/using-abortsignal-in-node-js/ . So we can reasonably easily add support for AbortSignal in a few places, like `eachAsync()`.

The only potential problem with this implementation is that it doesn't actually kill the underlying MongoDB cursor (see https://www.mongodb.com/docs/manual/reference/command/killCursors/ ). However, MongoDB does recommend not killing cursors directly from applications, so this omission is justifiable.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
