### PR TITLE
fix(model): allow defining discriminator virtuals and methods using schema options

### DIFF
--- a/lib/helpers/model/discriminator.js
+++ b/lib/helpers/model/discriminator.js
@@ -9,7 +9,9 @@ const CUSTOMIZABLE_DISCRIMINATOR_OPTIONS = {
   toJSON: true,
   toObject: true,
   _id: true,
-  id: true
+  id: true,
+  virtuals: true,
+  methods: true
 };
 
 /*!

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -130,6 +130,34 @@ describe('model', function() {
       assert.equal(Boss.notStaticMethod, undefined);
     });
 
+    it('can define virtuals and methods using schema options (gh-12246)', function() {
+      const baseSchema = new mongoose.Schema({
+        name: String
+      }, {
+        virtuals: {
+          virtualA: {
+            get: () => 'virtualA'
+          }
+        }
+      });
+
+      const discriminatorSchema = new mongoose.Schema({
+        prop: String
+      }, {
+        virtuals: {
+          virtualB: {
+            get: () => 'virtualB'
+          }
+        }
+      });
+      const BaseModel = db.model('Test', baseSchema);
+      const DiscriminatorModel = BaseModel.discriminator('Test1', discriminatorSchema);
+
+      const doc = new DiscriminatorModel();
+      assert.equal(doc.virtualA, 'virtualA');
+      assert.equal(doc.virtualB, 'virtualB');
+    });
+
     it('sets schema root discriminator mapping', function(done) {
       assert.deepEqual(Person.schema.discriminatorMapping, { key: '__t', value: null, isRoot: true });
       done();


### PR DESCRIPTION
Fix #12246

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

We now support defining virtuals and methods using schema options, but that doesn't work well with discriminators unless the discriminator schema has the exact same virtuals and methods as the base schema.

With this PR, you can define additional virtuals on a discriminator schema using `new Schema(definition, { virtuals: { myVirtual: () => 42 } })`

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
