### PR TITLE
fix(cast): Update cast to allow correctly querying for nested discriminators

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -260,6 +260,11 @@ module.exports = function cast(schema, obj, options, context) {
           continue;
         }
 
+        // allows finding nested discriminators (gh-12318)
+        if (schema.discriminators && Object.keys(schema.discriminators).length > 0) {
+          continue;
+        }
+
         const strict = 'strict' in options ? options.strict : schema.options.strict;
         const strictQuery = 'strictQuery' in options ?
           options.strictQuery :
@@ -273,7 +278,9 @@ module.exports = function cast(schema, obj, options, context) {
           }
           throw new StrictModeError(path, 'Path "' + path + '" is not in ' +
             'schema, strict mode is `true`, and upsert is `true`.');
-        } if (strictQuery === 'throw') {
+        }
+
+        if (strictQuery === 'throw') {
           throw new StrictModeError(path, 'Path "' + path + '" is not in ' +
             'schema and strictQuery is \'throw\'.');
         } else if (strictQuery) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This PR is an attempt to fix #12318. Due to the `strictQuery` changes from version 5 to 6 from Mongoose, `Model.find` doesn't work how it used to.

I tracked this issue down to `lib/cast.js`. It was apparently introduced in https://github.com/Automattic/mongoose/commit/d1d8492fe2ecb120a39af1a8ab0a2624b0bdb834.

Just some observations, I also tried using `schema.options.discriminatorType`, but it didn't work.
Instead I opted by checking the amount of discriminators in the schema.
