### PR TITLE
fix(document): allow calling `$assertPopulated()` with values to better support manual population

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4418,7 +4418,7 @@ Document.prototype.$populated = Document.prototype.populated;
  *     doc.$assertPopulated('other path'); // throws an error
  *
  *
- * @param {String|String[]} paths
+ * @param {String|String[]} path
  * @return {Document} this
  * @memberOf Document
  * @method $assertPopulated
@@ -4426,14 +4426,18 @@ Document.prototype.$populated = Document.prototype.populated;
  * @api public
  */
 
-Document.prototype.$assertPopulated = function $assertPopulated(paths) {
-  if (Array.isArray(paths)) {
-    paths.forEach(path => this.$assertPopulated(path));
+Document.prototype.$assertPopulated = function $assertPopulated(path, values) {
+  if (Array.isArray(path)) {
+    path.forEach(p => this.$assertPopulated(p, values));
     return this;
   }
 
-  if (!this.$populated(paths)) {
-    throw new MongooseError(`Expected path "${paths}" to be populated`);
+  if (arguments.length > 1) {
+    this.$set(values);
+  }
+
+  if (!this.$populated(path)) {
+    throw new MongooseError(`Expected path "${path}" to be populated`);
   }
 
   return this;

--- a/lib/document.js
+++ b/lib/document.js
@@ -4417,8 +4417,13 @@ Document.prototype.$populated = Document.prototype.populated;
  *     doc.$assertPopulated('author'); // does not throw
  *     doc.$assertPopulated('other path'); // throws an error
  *
+ *     // Manually populate and assert in one call. The following does
+ *     // `doc.$set({ likes })` before asserting.
+ *     doc.$assertPopulated('likes', { likes });
  *
- * @param {String|String[]} path
+ *
+ * @param {String|String[]} path path or array of paths to check. `$assertPopulated` throws if any of the given paths is not populated.
+ * @param {Object} [values] optional values to `$set()`. Convenient if you want to manually populate a path and assert that the path was populated in 1 call.
  * @return {Document} this
  * @memberOf Document
  * @method $assertPopulated

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -26,7 +26,7 @@ declare module 'mongoose' {
     __v?: any;
 
     /** Assert that a given path or paths is populated. Throws an error if not populated. */
-    $assertPopulated<Paths = {}>(paths: string | string[]): Omit<this, keyof Paths> & Paths;
+    $assertPopulated<Paths = {}>(path: string | string[], values?: Partial<Paths>): Omit<this, keyof Paths> & Paths;
 
     /* Get all subdocs (by bfs) */
     $getAllSubdocs(): Document[];


### PR DESCRIPTION
Fix #12233

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12233 highlighted a gap in `$assertPopulated()`: there's no way to manually populate using `=`.

```ts
// TypeScript complains about incorrect type
newParent.nestedChild = new NestedChildModel({ name: 'NestedChild' })

newParent.$assertPopulated<{ nestedChild: NestedChildModel }>('nestedChild')
```

```ts
// Throws at runtime because `nestedChild` isn't populated yet
newParent.$assertPopulated<{ nestedChild: NestedChildModel }>('nestedChild')

newParent.nestedChild = new NestedChildModel({ name: 'NestedChild' })
```

This PR combines the two steps into 1 for TypeScript's benefit:

```ts
// Does `$assertPopulated()` and `$set()` in one operation
const doc = newParent.$assertPopulated<{nestedChild: NestedChild}>('nestedChild', {
  nestedChild: new NestedChildModel({ name: 'NestedChild' })
})
```

What do you think of this @ajwootto ?

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
