### PR TITLE
test(common): change mongoose require to be explicit "index" file

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const mongoose = require('../');
+const mongoose = require('../index');
 const Collection = mongoose.Collection;
 const assert = require('assert');
 


### PR DESCRIPTION
**Summary**

This PR changes the `test/common.js` import for `mongoose` to be a explicit file.

Before typescript's language server could not infer the types for mongoose, but now it has actual proper types, which should make writing (and following) tests easier by having intellisense / auto-completion available.

<details>
<summary>Screenshot showcasing problem</summary>

Before change:
![before](https://user-images.githubusercontent.com/10911626/187070813-cdf5b64f-4988-4afc-a4cd-d71b8cf76aea.png)

After Change:
![after](https://user-images.githubusercontent.com/10911626/187070811-9103b473-39ad-4598-9947-1454c0546af2.png)

</details>

PS: weirdly this "typescript cannot infer the index file" only happens when trying to import the root `index.js`, from `index.js` itself importing `lib/` actually has proper intellisense