### PR TITLE
Call _markModified in splice array method

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,18 +16,18 @@ You can refer to [this table](https://docs.mongodb.com/drivers/node/current/comp
 
 Below are the [semver](http://semver.org/) ranges representing which versions of mongoose are compatible with the listed versions of MongoDB server.
 
-| MongoDB Sever |            Mongoose            |
-| :-----------: | :----------------------------: |
-|     `6.x`     |            `^6.5.0`            |
-|     `5.x`     |            `^6.0.0`            |
-|    `4.4.x`    |      `^5.10.0 \| ^6.0.0`       |
-|    `4.2.x`    |      `^5.7.0  \| ^6.0.0`       |
-|    `4.0.x`    |      `^5.2.0  \| ^6.0.0`       |
-|    `3.6.x`    |            `^5.0.0`            |
-|    `3.4.x`    |      `^4.7.3  \| ^5.0.0`       |
-|    `3.2.x`    |       `^4.3.0  \| 5.0.0`       |
-|    `3.0.x`    | `^3.8.22 \| ^4.0.0  \| ^5.0.0` |
-|    `2.6.x`    |      `^3.8.8  \| ^4.0.0`       |
-|    `2.4.x`    |      `^3.8.0  \| ^4.0.0`       |
+| MongoDB Server |           Mongoose            |
+| :------------: | :---------------------------: |
+|     `6.x`      |           `^6.5.0`            |
+|     `5.x`      |           `^6.0.0`            |
+|    `4.4.x`     |      `^5.10.0 \| ^6.0.0`      |
+|    `4.2.x`     |      `^5.7.0 \| ^6.0.0`       |
+|    `4.0.x`     |      `^5.2.0 \| ^6.0.0`       |
+|    `3.6.x`     |           `^5.0.0`            |
+|    `3.4.x`     |      `^4.7.3 \| ^5.0.0`       |
+|    `3.2.x`     |       `^4.3.0 \| 5.0.0`       |
+|    `3.0.x`     | `^3.8.22 \| ^4.0.0 \| ^5.0.0` |
+|    `2.6.x`     |      `^3.8.8 \| ^4.0.0`       |
+|    `2.4.x`     |      `^3.8.0 \| ^4.0.0`       |
 
 Note that Mongoose `5.x` dropped support for all versions of MongoDB before `3.0.0`. If you need to use MongoDB `2.6` or older, use Mongoose `4.x`.

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -25,6 +25,9 @@ const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
  * @param {Schema} schema
  * @param {Object} obj Object to cast
  * @param {Object} [options] the query options
+ * @param {Boolean|"throw"} [options.strict] Wheter to enable all strict options
+ * @param {Boolean|"throw"} [options.strictQuery] Enable strict Queries
+ * @param {Boolean} [options.upsert]
  * @param {Query} [context] passed to setters
  * @api private
  */

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -805,6 +805,7 @@ const methods = {
     let ret;
     const arr = utils.isMongooseArray(this) ? this.__array : this;
 
+    this._markModified();
     _checkManualPopulation(this, Array.prototype.slice.call(arguments, 2));
 
     if (arguments.length) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11753,6 +11753,12 @@ describe('document', function() {
         const res = await Test.findById(doc);
         assert.equal(res.docArr[0].counter, 1);
       });
+      it('Splice call registers path modification', async function() {
+        await Test.create({ docArr: [{ counter: 0 }, { counter: 2 }, { counter: 3 }, { counter: 4}] });
+        const doc = await Test.findOne();
+        doc.docArr.splice(1, 0, { counter: 1 });
+        assert.equal(doc.isModified('docArr'), true);
+      });
     });
 
     it('stores CastError if trying to $inc a non-numeric path', async function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11754,7 +11754,7 @@ describe('document', function() {
         assert.equal(res.docArr[0].counter, 1);
       });
       it('Splice call registers path modification', async function() {
-        await Test.create({ docArr: [{ counter: 0 }, { counter: 2 }, { counter: 3 }, { counter: 4}] });
+        await Test.create({ docArr: [{ counter: 0 }, { counter: 2 }, { counter: 3 }, { counter: 4 }] });
         const doc = await Test.findOne();
         doc.docArr.splice(1, 0, { counter: 1 });
         assert.equal(doc.isModified('docArr'), true);


### PR DESCRIPTION
In the implementation of the other array methods that mutate the array,
the _markModified function is called, but in the splice method it
wasn't.

This leads to do not detect changes that happen in arrays when the splice method is used.
