### PR TITLE
Update some tests and config to be more maintainable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-${{ matrix.mongodb-os }}-${{ matrix.mongodb }}.tgz
           tar xf mongodb-linux-x86_64-${{ matrix.mongodb-os }}-${{ matrix.mongodb }}.tgz
           mkdir -p ./data/db/27017 ./data/db/27000
-          printf "\n--timeout 8000" >> ./test/mocha.opts
+          printf "\ntimeout: 8000" >> ./.mocharc.yml
           ./mongodb-linux-x86_64-${{ matrix.mongodb-os }}-${{ matrix.mongodb }}/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
           sleep 2
           mongod --version
@@ -109,7 +109,7 @@ jobs:
           wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
           tar xf mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
           mkdir -p ./data/db/27017 ./data/db/27000
-          printf "\n--timeout 8000" >> ./test/mocha.opts
+          printf "\ntimeout: 8000" >> ./.mocharc.yml
           ./mongodb-linux-x86_64-ubuntu2004-5.0.2/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
           sleep 2
           mongod --version

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,2 @@
+reporter: spec # better to identify failing / slow tests than "dot"
+ui: bdd # explicitly setting, even though it is mocha default

--- a/test/common.js
+++ b/test/common.js
@@ -188,7 +188,7 @@ before(async function() {
     const uri = await startReplicaSet();
 
     module.exports.uri = uri;
-    module.exports.uri2 = uri.replace('mongoose_test', 'mongoose_test2');
+    module.exports.uri2 = uri.replace(databases[0], databases[1]);
 
     process.env.REPLICA_SET = 'rs0';
 
@@ -239,7 +239,7 @@ async function startReplicaSet() {
         args: ['--setParameter', 'ttlMonitorSleepSecs=1']
       }
     ],
-    dbName: 'mongoose_test',
+    dbName: databases[0],
     replSet: {
       name: 'rs0',
       count: 2,
@@ -252,5 +252,5 @@ async function startReplicaSet() {
 
   await new Promise(resolve => setTimeout(resolve, 10000));
 
-  return replSet.getUri('mongoose_test');
+  return replSet.getUri(databases[0]);
 }

--- a/test/common.js
+++ b/test/common.js
@@ -121,17 +121,26 @@ function getUri(env, default_uri, db) {
   return use.slice(0, lastIndex <= 9 ? use.length : lastIndex) + `/${db}`;
 }
 
+/**
+ * Testing Databases, used for consistency
+ */
+
+const databases = module.exports.databases = [
+  'mongoose_test',
+  'mongoose_test_2'
+];
+
 /*!
  * testing uri
  */
 
-module.exports.uri = getUri(process.env.MONGOOSE_TEST_URI, 'mongodb://127.0.0.1:27017/', 'mongoose_test');
+module.exports.uri = getUri(process.env.MONGOOSE_TEST_URI, 'mongodb://127.0.0.1:27017/', databases[0]);
 
 /*!
  * testing uri for 2nd db
  */
 
-module.exports.uri2 = getUri(process.env.MONGOOSE_TEST_URI, 'mongodb://127.0.0.1:27017/', 'mongoose_test_2');
+module.exports.uri2 = getUri(process.env.MONGOOSE_TEST_URI, 'mongodb://127.0.0.1:27017/', databases[1]);
 
 /**
  * expose mongoose

--- a/test/common.js
+++ b/test/common.js
@@ -114,17 +114,24 @@ module.exports = function(options) {
   return conn;
 };
 
+function getUri(env, default_uri, db) {
+  const use = env ? env : default_uri;
+  const lastIndex = use.lastIndexOf('/');
+  // use length if lastIndex is 9 or lower, because that would mean it found the last character of "mongodb://"
+  return use.slice(0, lastIndex <= 9 ? use.length : lastIndex) + `/${db}`;
+}
+
 /*!
  * testing uri
  */
 
-module.exports.uri = process.env.MONGOOSE_TEST_URI || 'mongodb://127.0.0.1:27017/mongoose_test';
+module.exports.uri = getUri(process.env.MONGOOSE_TEST_URI, 'mongodb://127.0.0.1:27017/', 'mongoose_test');
 
 /*!
  * testing uri for 2nd db
  */
 
-module.exports.uri2 = 'mongodb://127.0.0.1:27017/mongoose_test_2';
+module.exports.uri2 = getUri(process.env.MONGOOSE_TEST_URI, 'mongodb://127.0.0.1:27017/', 'mongoose_test_2');
 
 /**
  * expose mongoose

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -36,7 +36,8 @@ describe('connections:', function() {
       return conn.asPromise().
         then(function(conn) {
           assert.equal(conn.constructor.name, 'NativeConnection');
-          const match = /mongodb:\/\/([\d.]+)(?::(\d+))?\/(\w+)/i.exec(start.uri);
+          // the regex below extract the first ip & port, because the created connection's properties only have the first anyway as "host" and "port"
+          const match = /mongodb:\/\/([\d.]+)(?::(\d+))?(?:,[\d.]+(?::\d+)?)*\/(\w+)/i.exec(start.uri);
           assert.ok(match);
           assert.equal(conn.host, match[1]);
           assert.equal(conn.port, parseInt(match[2]));

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -25,7 +25,7 @@ describe('connections:', function() {
 
   describe('openUri (gh-5304)', function() {
     it('with mongoose.createConnection()', function() {
-      const conn = mongoose.createConnection(start.uri.slice(0, start.uri.lastIndexOf('/')) + '/mongoosetest');
+      const conn = mongoose.createConnection(start.uri.slice(0, start.uri.lastIndexOf('/')) + '/' + start.databases[0]);
       assert.equal(conn.constructor.name, 'NativeConnection');
 
       const Test = conn.model('Test', new Schema({ name: String }));
@@ -40,7 +40,7 @@ describe('connections:', function() {
           assert.ok(match);
           assert.equal(conn.host, match[1]);
           assert.equal(conn.port, parseInt(match[2]));
-          assert.equal(conn.name, 'mongoosetest');
+          assert.equal(conn.name, start.databases[0]);
 
           return findPromise;
         }).

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -561,7 +561,7 @@ describe('connections:', function() {
 
     it('saves correctly', async function() {
       const db = start();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
 
       const schema = new Schema({
         body: String,
@@ -596,7 +596,7 @@ describe('connections:', function() {
 
     it('emits connecting events on both', async function() {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
 
       db2.on('connecting', async function() {
@@ -618,7 +618,7 @@ describe('connections:', function() {
 
     it('emits connected events on both', function() {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
 
       db2.on('connected', function() {
@@ -639,7 +639,7 @@ describe('connections:', function() {
 
     it('emits open events on both', function() {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
       db2.on('open', function() {
         hit && close();
@@ -659,7 +659,7 @@ describe('connections:', function() {
 
     it('emits disconnecting events on both, closing initial db', function(done) {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
       db2.on('disconnecting', function() {
         hit && done();
@@ -677,7 +677,7 @@ describe('connections:', function() {
 
     it('emits disconnecting events on both, closing secondary db', function(done) {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
       db2.on('disconnecting', function() {
         hit && done();
@@ -695,7 +695,7 @@ describe('connections:', function() {
 
     it('emits disconnected events on both, closing initial db', function(done) {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
       db2.on('disconnected', function() {
         hit && done();
@@ -713,7 +713,7 @@ describe('connections:', function() {
 
     it('emits disconnected events on both, closing secondary db', function(done) {
       const db = mongoose.createConnection();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
       let hit = false;
       db2.on('disconnected', function() {
         hit && done();
@@ -731,7 +731,7 @@ describe('connections:', function() {
 
     it('closes correctly for all dbs, closing initial db', async function() {
       const db = await start({ noErrorListener: true }).asPromise();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
 
       const p = new Promise(resolve => {
         db2.on('close', function() {
@@ -744,7 +744,7 @@ describe('connections:', function() {
 
     it('handles re-opening base connection (gh-11240)', async function() {
       const db = await start().asPromise();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
 
       await db.close();
 
@@ -754,7 +754,7 @@ describe('connections:', function() {
 
     it('closes correctly for all dbs, closing secondary db', function(done) {
       const db = start();
-      const db2 = db.useDb('mongoose-test-2');
+      const db2 = db.useDb(start.databases[1]);
 
       db.on('disconnected', function() {
         done();
@@ -764,8 +764,8 @@ describe('connections:', function() {
 
     it('cache connections to the same db', function() {
       const db = start();
-      const db2 = db.useDb('mongoose-test-2', { useCache: true });
-      const db3 = db.useDb('mongoose-test-2', { useCache: true });
+      const db2 = db.useDb(start.databases[1], { useCache: true });
+      const db3 = db.useDb(start.databases[1], { useCache: true });
 
       assert.strictEqual(db2, db3);
       db.close();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,8 +15,6 @@ const mongoose = start.mongoose;
 const Mongoose = mongoose.Mongoose;
 const Schema = mongoose.Schema;
 
-const uri = start.uri;
-
 const options = {};
 
 describe('mongoose module:', function() {
@@ -25,7 +23,7 @@ describe('mongoose module:', function() {
       const goose = new Mongoose();
       const db = goose.connection;
 
-      await goose.connect(process.env.MONGOOSE_TEST_URI || uri, options);
+      await goose.connect(start.uri, options);
       await db.close();
     });
 
@@ -33,7 +31,7 @@ describe('mongoose module:', function() {
       const goose = new Mongoose();
       const db = goose.connection;
 
-      await goose.connect(process.env.MONGOOSE_TEST_URI || uri, options);
+      await goose.connect(start.uri, options);
 
       await db.close();
     });
@@ -85,7 +83,7 @@ describe('mongoose module:', function() {
     const User = mongoose.model('User', new Schema({ name: String }));
 
 
-    await mongoose.connect(uri);
+    await mongoose.connect(start.uri);
     await User.findOne();
     assert.equal(written.length, 1);
     assert.ok(written[0].startsWith('users.findOne('));
@@ -190,7 +188,7 @@ describe('mongoose module:', function() {
       name: { type: String, required: true }
     }));
 
-    await mongoose.connect(uri, options);
+    await mongoose.connect(start.uri, options);
 
     const err = await M.updateOne({}, { name: null }).then(() => null, err => err);
     assert.ok(err.errors['name']);
@@ -472,7 +470,7 @@ describe('mongoose module:', function() {
     const M = mongoose.model('gh6728', schema);
 
 
-    await mongoose.connect(uri);
+    await mongoose.connect(start.uri);
 
     const doc = new M({ name: 'foo' });
 
@@ -525,7 +523,7 @@ describe('mongoose module:', function() {
         let disconnections = 0;
         let pending = 4;
 
-        mong.connect(process.env.MONGOOSE_TEST_URI || uri, options);
+        mong.connect(start.uri, options);
         const db = mong.connection;
 
         function cb() {
@@ -548,7 +546,7 @@ describe('mongoose module:', function() {
         const events = [];
         mong.events.on('createConnection', conn => events.push(conn));
 
-        const db2 = mong.createConnection(process.env.MONGOOSE_TEST_URI || uri, options);
+        const db2 = mong.createConnection(start.uri, options);
 
         assert.equal(events.length, 1);
         assert.equal(events[0], db2);
@@ -570,7 +568,7 @@ describe('mongoose module:', function() {
     it('with callback', function(done) {
       const mong = new Mongoose();
 
-      mong.connect(process.env.MONGOOSE_TEST_URI || uri, options);
+      mong.connect(start.uri, options);
 
       mong.connection.on('open', function() {
         mong.disconnect(function() {
@@ -582,7 +580,7 @@ describe('mongoose module:', function() {
     it('with promise (gh-3790)', function(done) {
       const _mongoose = new Mongoose();
 
-      _mongoose.connect(process.env.MONGOOSE_TEST_URI || uri, options);
+      _mongoose.connect(start.uri, options);
 
       _mongoose.connection.on('open', function() {
         _mongoose.disconnect().then(function() { done(); });
@@ -712,7 +710,7 @@ describe('mongoose module:', function() {
     it('with single mongod', async function() {
       const mong = new Mongoose();
 
-      await mong.connect(uri, options);
+      await mong.connect(start.uri, options);
 
       await mong.connection.close();
     });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---reporter dot
---ui bdd

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -349,11 +349,9 @@ describe('model: populate:', function() {
           .findById(post._id)
           .populate({ path: '_creator', select: 'name', model: User })
           .exec(function(err, post) {
-            db2.db.dropDatabase(function() {
-              assert.ifError(err);
-              assert.ok(post._creator.name === 'Guillermo');
-              done();
-            });
+            assert.ifError(err);
+            assert.ok(post._creator.name === 'Guillermo');
+            done();
           });
       });
     });

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -10724,7 +10724,7 @@ describe('model: populate:', function() {
 
     const User = db.model('User', UserSchema);
 
-    const conn2 = db.useDb('mongoose-test2');
+    const conn2 = db.useDb(start.databases[1]);
     const Test = conn2.model('Test', TestSchema);
 
     await Test.deleteMany({});

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -317,7 +317,6 @@ describe('model: populate:', function() {
   });
 
   it('across DBs', function(done) {
-    const db = start();
     const db2 = db.useDb('mongoose_test2');
     const BlogPost = db.model('BlogPost', blogPostSchema);
     const User = db2.model('User', userSchema);
@@ -338,8 +337,6 @@ describe('model: populate:', function() {
           .populate({ path: '_creator', select: 'name', model: User })
           .exec(function(err, post) {
             db2.db.dropDatabase(function() {
-              db.close();
-              db2.close();
               assert.ifError(err);
               assert.ok(post._creator.name === 'Guillermo');
               done();
@@ -6661,7 +6658,6 @@ describe('model: populate:', function() {
 
     describe('populates an array of objects', function() {
       it('subpopulates array w/ space separated path (gh-6284)', async function() {
-        const db = start();
         const houseSchema = new Schema({ location: String });
         const citySchema = new Schema({ name: String });
         const districtSchema = new Schema({ name: String });

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -317,7 +317,7 @@ describe('model: populate:', function() {
   });
 
   it('across DBs', function(done) {
-    const db2 = db.useDb('mongoose_test2');
+    const db2 = db.useDb(start.databases[1]);
     const BlogPost = db.model('BlogPost', blogPostSchema);
     const User = db2.model('User', userSchema);
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6985,7 +6985,7 @@ describe('Model', function() {
       assert.ok(beforeExpirationCount === 12);
       await new Promise(resolve => setTimeout(resolve, 6000));
       const afterExpirationCount = await Test.count({});
-      assert.ok(afterExpirationCount === 0);
+      assert.equal(afterExpirationCount, 0);
       await Test.collection.drop().catch(() => {});
     });
 
@@ -7107,7 +7107,7 @@ describe('Model', function() {
       assert.ok(beforeExpirationCount === 12);
       await new Promise(resolve => setTimeout(resolve, 6000));
       const afterExpirationCount = await Test.count({});
-      assert.ok(afterExpirationCount === 0);
+      assert.equal(afterExpirationCount, 0);
       await Test.collection.drop().catch(() => {});
     });
 
@@ -7200,7 +7200,7 @@ describe('Model', function() {
       assert.ok(beforeExpirationCount === 12);
       await new Promise(resolve => setTimeout(resolve, 6000));
       const afterExpirationCount = await Test.count({});
-      assert.ok(afterExpirationCount === 0);
+      assert.equal(afterExpirationCount, 0);
       await Test.collection.drop().catch(() => {});
     });
 

--- a/test/shard.test.js
+++ b/test/shard.test.js
@@ -10,6 +10,7 @@ const Schema = mongoose.Schema;
 
 const uri = process.env.MONGOOSE_SHARD_TEST_URI;
 const redColorEscapeCharacter = '\x1b[31m';
+const colorResetEscapeCharacter = '\u001b[39m';
 
 if (!uri) {
   console.log([
@@ -17,7 +18,8 @@ if (!uri) {
     'You\'re not testing shards!',
     'Please set the MONGOOSE_SHARD_TEST_URI env variable.',
     'e.g: `mongodb://localhost:27017/database',
-    'Sharding must already be enabled on your database'
+    'Sharding must already be enabled on your database',
+    colorResetEscapeCharacter
   ].join('\n'));
 
   return;


### PR DESCRIPTION
**Summary**

This PR does:
- change from `mocha.opts` to `mocha.yml` because mocha stopped supporting the `.opts` format
- re-set the ANSI color for the SHARD warning (otherwise the next console log's / debug logs would also be in that color)
- change `common.js`'s uris to be consistent across both `uri` and `uri2` (before only `uri` would have the env applied)
- change `common.js` to have a extra value `databases` so that the databases for `uri` and `uri2` can also be used for things like `useDb` instead of just the full uri's
- change many tests from static uri's to use `common.js`'s `uri` and `uri2`
- change many tests from static database names to use `common.js`'s `databases` array
- change many tests to unify database naming to what is available in `common.js`'s `databases` array
- change `model.populate.test.js` to not create connections in the tests themself when not required (and use global instead)
- change `model.populate.test.js` to handle cleaning `db2` outside of the tests themself

Note: some changes have been cherry-picked from #12262 to have them already applied (because i dont know how long that PR will be open for) and those changes were unrelated to the point of the mentioned PR

Note for the mocha opts change: i have not re-set the `reporter` to be `dot` but instead `spec` because this is way more readable (both in CI and locally)