### PR TITLE
Reduce CI time by directly collecting coverage from requested config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             mongodb-os: ubuntu1804
           - os: ubuntu-20.04
             mongodb-os: ubuntu2004
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
             mongodb: 5.0.2
             node: 16
             coverage: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,35 +107,6 @@ jobs:
       - name: Test
         run: npm run test-rs
 
-  # coverage:
-  #   needs:
-  #     - test-replica-sets
-  #   runs-on: ubuntu-20.04
-  #   name: Coverage
-  #   steps:
-  #     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-  #     - name: Setup node
-  #       uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3.4.1
-  #       with:
-  #         node-version: 16
-  #     - run: npm install
-  #     - name: Setup
-  #       run: |
-  #         wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
-  #         tar xf mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
-  #         mkdir -p ./data/db/27017 ./data/db/27000
-  #         printf "\n--timeout 8000" >> ./test/mocha.opts
-  #         ./mongodb-linux-x86_64-ubuntu2004-5.0.2/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
-  #         sleep 2
-  #         mongod --version
-  #         echo `pwd`/mongodb-linux-x86_64-ubuntu2004-5.0.2/bin >> $GITHUB_PATH
-  #     - name: test with coverage
-  #       run: npm run test-coverage
-  #     - name: Archive code coverage results
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: coverage
-  #         path: coverage
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,18 @@ jobs:
           sleep 2
           mongod --version
           echo `pwd`/mongodb-linux-x86_64-${{ matrix.mongodb-os }}-${{ matrix.mongodb }}/bin >> $GITHUB_PATH
-      - run: npm test
+      - name: NPM Test without Coverage
+        run: npm test
+        if: matrix.node != 16
+      - name: NPM Test with Coverage
+        run: npm test-coverage
+        if: matrix.node == 16
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        if: matrix.node == 16
+        with:
+          name: coverage
+          path: coverage
 
   test-replica-sets:
     needs:
@@ -92,35 +103,35 @@ jobs:
       - name: Test
         run: npm run test-rs
 
-  coverage:
-    needs:
-      - test-replica-sets
-    runs-on: ubuntu-20.04
-    name: Coverage
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-      - name: Setup node
-        uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3.4.1
-        with:
-          node-version: 16
-      - run: npm install
-      - name: Setup
-        run: |
-          wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
-          tar xf mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
-          mkdir -p ./data/db/27017 ./data/db/27000
-          printf "\n--timeout 8000" >> ./test/mocha.opts
-          ./mongodb-linux-x86_64-ubuntu2004-5.0.2/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
-          sleep 2
-          mongod --version
-          echo `pwd`/mongodb-linux-x86_64-ubuntu2004-5.0.2/bin >> $GITHUB_PATH
-      - name: test with coverage
-        run: npm run test-coverage
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage
+  # coverage:
+  #   needs:
+  #     - test-replica-sets
+  #   runs-on: ubuntu-20.04
+  #   name: Coverage
+  #   steps:
+  #     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+  #     - name: Setup node
+  #       uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3.4.1
+  #       with:
+  #         node-version: 16
+  #     - run: npm install
+  #     - name: Setup
+  #       run: |
+  #         wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
+  #         tar xf mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz
+  #         mkdir -p ./data/db/27017 ./data/db/27000
+  #         printf "\n--timeout 8000" >> ./test/mocha.opts
+  #         ./mongodb-linux-x86_64-ubuntu2004-5.0.2/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
+  #         sleep 2
+  #         mongod --version
+  #         echo `pwd`/mongodb-linux-x86_64-ubuntu2004-5.0.2/bin >> $GITHUB_PATH
+  #     - name: test with coverage
+  #       run: npm run test-coverage
+  #     - name: Archive code coverage results
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: coverage
+  #         path: coverage
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,10 @@ jobs:
             mongodb-os: ubuntu1804
           - os: ubuntu-20.04
             mongodb-os: ubuntu2004
+          - os: ubuntu-20.04
+            mongodb: 5.0.2
+            node: 16
+            coverage: true
         exclude:
           - os: ubuntu-18.04 # exclude because nodejs 18 requires higher GLIBC
             node: 18
@@ -77,13 +81,13 @@ jobs:
           echo `pwd`/mongodb-linux-x86_64-${{ matrix.mongodb-os }}-${{ matrix.mongodb }}/bin >> $GITHUB_PATH
       - name: NPM Test without Coverage
         run: npm test
-        if: matrix.node != 16
+        if: matrix.coverage != true
       - name: NPM Test with Coverage
-        run: npm test-coverage
-        if: matrix.node == 16
+        run: npm run test-coverage
+        if: matrix.coverage == true
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
-        if: matrix.node == 16
+        if: matrix.coverage == true
         with:
           name: coverage
           path: coverage


### PR DESCRIPTION
**Summary**

This PR removes the "coverage" step and directly collects coverage from the requested configuration

the configuration where it will be collected from can be configured in the matrix `include` with the `coverage: true` property
current configuration to collect coverage (like in the removed `coverage` job) is:
- os: ubuntu-20.04
- mongodb: 5.0.2
- node: 16

This reduces test time (and also likelihood of the tests failing) by one mocha test run - also less duplicated script