### PR TITLE
Fix regression for `overwriteModels` flag

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1230,7 +1230,9 @@ Connection.prototype.model = function(name, schema, collection, options) {
     return sub;
   }
   
-  model = this.models[name];
+  if (arguments.length === 1) {
+    return this.models[name];
+  }
 
   if (!model) {
     throw new MongooseError.MissingSchemaError(name);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1231,7 +1231,11 @@ Connection.prototype.model = function(name, schema, collection, options) {
   }
   
   if (arguments.length === 1) {
-    return this.models[name];
+    model = this.models[name];
+    if (!model) {
+      throw new MongooseError.MissingSchemaError(name);
+    }
+    return model;
   }
 
   if (!model) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1229,6 +1229,8 @@ Connection.prototype.model = function(name, schema, collection, options) {
     // do not cache the sub model
     return sub;
   }
+  
+  model = this.models[name];
 
   if (!model) {
     throw new MongooseError.MissingSchemaError(name);


### PR DESCRIPTION
Below code throws `MissingSchemaError` in the `populate` statement:
```js
const mongoose = require("mongoose");

const { Schema } = mongoose;

async function run() {
  try {
    await mongoose.connect(process.env.MONGODB_URI);

    mongoose.set("overwriteModels", true);

    const personSchema = Schema({
      name: String,
    });

    const storySchema = Schema({
      author: { type: Schema.Types.ObjectId, ref: "Person" },
      title: String,
    });

    const Story = mongoose.model("Story", storySchema);
    const Person = mongoose.model("Person", personSchema);

    const person = await Person.create({ name: "David" });
    await Story.create({
      title: "My Story",
      author: person._id,
    });

    await Story.findOne({ title: "My Story" })
      .populate("author")
      .exec();
  } catch (error) {
    console.error(error);
  }
}

run();
```
It will works if I do not set `overwriteModels` as `true`.

I find that it is caused by 6865fea216220a88d2e7128d3a8eb8228f29155e. Looks like that commit prevents mixing models registered in non-default connection and global mongoose instance. 

How about adding back the line for model lookup but lookup from the connection itself (lookup from `this.models` instead of `this.base.models`)?

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
