### PR TITLE
style: update old mongodb nodejs driver documentation urls

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -43,7 +43,7 @@ const validRedactStringValues = new Set(['$$DESCEND', '$$PRUNE', '$$KEEP']);
  *     new Aggregate([{ $match: { _id: new mongoose.Types.ObjectId('00000000000000000000000a') } }]);
  *
  * @see MongoDB https://docs.mongodb.org/manual/applications/aggregation/
- * @see driver https://mongodb.github.com/node-mongodb-native/api-generated/collection.html#aggregate
+ * @see driver https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#aggregate
  * @param {Array} [pipeline] aggregation pipeline as an array of objects
  * @param {Model} [model] the model to use with this aggregate.
  * @api public
@@ -623,7 +623,6 @@ Aggregate.prototype.unionWith = function(options) {
  * @return {Aggregate} this
  * @api public
  * @see mongodb https://docs.mongodb.org/manual/applications/replication/#read-preference
- * @see driver https://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences
  */
 
 Aggregate.prototype.read = function(pref, tags) {
@@ -863,7 +862,7 @@ Aggregate.prototype.option = function(value) {
  * @param {Boolean} [options.useMongooseAggCursor] use experimental mongoose-specific aggregation cursor (for `eachAsync()` and other query cursor semantics)
  * @return {AggregationCursor} cursor representing this aggregation
  * @api public
- * @see mongodb https://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html
+ * @see mongodb https://mongodb.github.io/node-mongodb-native/4.9/classes/AggregationCursor.html
  */
 
 Aggregate.prototype.cursor = function(options) {
@@ -881,7 +880,7 @@ Aggregate.prototype.cursor = function(options) {
  * @param {Object} collation options
  * @return {Aggregate} this
  * @api public
- * @see mongodb https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate
+ * @see mongodb https://mongodb.github.io/node-mongodb-native/4.9/interfaces/CollationOptions.html
  */
 
 Aggregate.prototype.collation = function(collation) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -387,11 +387,11 @@ Connection.prototype.config;
  * with specified options. Used to create [capped collections](https://docs.mongodb.com/manual/core/capped-collections/)
  * and [views](https://docs.mongodb.com/manual/core/views/) from mongoose.
  *
- * Options are passed down without modification to the [MongoDB driver's `createCollection()` function](https://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#createCollection)
+ * Options are passed down without modification to the [MongoDB driver's `createCollection()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Db.html#createCollection)
  *
  * @method createCollection
  * @param {string} collection The collection to create
- * @param {Object} [options] see [MongoDB driver docs](https://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#createCollection)
+ * @param {Object} [options] see [MongoDB driver docs](https://mongodb.github.io/node-mongodb-native/4.9/classes/Db.html#createCollection)
  * @param {Function} [callback]
  * @return {Promise} Returns a Promise if no `callback` is given.
  * @api public
@@ -423,7 +423,7 @@ Connection.prototype.createCollection = _wrapConnHelper(function createCollectio
  *
  *
  * @method startSession
- * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#startSession)
+ * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html#startSession)
  * @param {Boolean} [options.causalConsistency=true] set to false to disable causal consistency
  * @param {Function} [callback]
  * @return {Promise<ClientSession>} promise that resolves to a MongoDB driver `ClientSession`
@@ -445,7 +445,7 @@ Connection.prototype.startSession = _wrapConnHelper(function startSession(option
  * async function executes successfully and attempt to retry if
  * there was a retriable error.
  *
- * Calls the MongoDB driver's [`session.withTransaction()`](https://mongodb.github.io/node-mongodb-native/3.5/api/ClientSession.html#withTransaction),
+ * Calls the MongoDB driver's [`session.withTransaction()`](https://mongodb.github.io/node-mongodb-native/4.9/classes/ClientSession.html#withTransaction),
  * but also handles resetting Mongoose document state as shown below.
  *
  * #### Example:
@@ -656,7 +656,7 @@ Connection.prototype.onOpen = function() {
  * Opens the connection with a URI using `MongoClient.connect()`.
  *
  * @param {String} uri The URI to connect with.
- * @param {Object} [options] Passed on to https://mongodb.github.io/node-mongodb-native/2.2/api/MongoClient.html#connect
+ * @param {Object} [options] Passed on to [`MongoClient.connect`](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html#connect-1)
  * @param {Boolean} [options.bufferCommands=true] Mongoose specific option. Set to false to [disable buffering](https://mongoosejs.com/docs/faq.html#callback_never_executes) on all models associated with this connection.
  * @param {Number} [options.bufferTimeoutMS=10000] Mongoose specific option. If `bufferCommands` is true, Mongoose will throw an error after `bufferTimeoutMS` if the operation is still buffered.
  * @param {String} [options.dbName] The name of the database we want to use. If not provided, use database name from connection string.
@@ -667,7 +667,7 @@ Connection.prototype.onOpen = function() {
  * @param {Number} [options.serverSelectionTimeoutMS] If `useUnifiedTopology = true`, the MongoDB driver will try to find a server to send any given operation to, and keep retrying for `serverSelectionTimeoutMS` milliseconds before erroring out. If not set, the MongoDB driver defaults to using `30000` (30 seconds).
  * @param {Number} [options.heartbeatFrequencyMS] If `useUnifiedTopology = true`, the MongoDB driver sends a heartbeat every `heartbeatFrequencyMS` to check on the status of the connection. A heartbeat is subject to `serverSelectionTimeoutMS`, so the MongoDB driver will retry failed heartbeats for up to 30 seconds by default. Mongoose only emits a `'disconnected'` event after a heartbeat has failed, so you may want to decrease this setting to reduce the time between when your server goes down and when Mongoose emits `'disconnected'`. We recommend you do **not** set this setting below 1000, too many heartbeats can lead to performance degradation.
  * @param {Boolean} [options.autoIndex=true] Mongoose-specific option. Set to false to disable automatic index creation for all models associated with this connection.
- * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html).
+ * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html#promiseLibrary).
  * @param {Number} [options.connectTimeoutMS=30000] How long the MongoDB driver will wait before killing a socket due to inactivity _during initial connection_. Defaults to 30000. This option is passed transparently to [Node.js' `socket#setTimeout()` function](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback).
  * @param {Number} [options.socketTimeoutMS=30000] How long the MongoDB driver will wait before killing a socket due to inactivity _after initial connection_. A socket may be inactive because of either no activity or a long-running operation. This is set to `30000` by default, you should set this to 2-3x your longest running operation if you expect some of your database operations to run longer than 20 seconds. This option is passed to [Node.js `socket#setTimeout()` function](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback) after the MongoDB driver successfully completes.
  * @param {Number} [options.family=0] Passed transparently to [Node.js' `dns.lookup()`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) function. May be either `0, `4`, or `6`. `4` means use IPv4 only, `6` means use IPv6 only, `0` means try both.
@@ -1332,7 +1332,7 @@ Connection.prototype.deleteModel = function(name) {
  *
  * @api public
  * @param {Array} [pipeline]
- * @param {Object} [options] passed without changes to [the MongoDB driver's `Db#watch()` function](https://mongodb.github.io/node-mongodb-native/3.4/api/Db.html#watch)
+ * @param {Object} [options] passed without changes to [the MongoDB driver's `Db#watch()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Db.html#watch)
  * @return {ChangeStream} mongoose-specific change stream wrapper, inherits from EventEmitter
  */
 
@@ -1434,7 +1434,7 @@ Connection.prototype.optionsProvideAuthenticationData = function(options) {
 };
 
 /**
- * Returns the [MongoDB driver `MongoClient`](https://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+ * Returns the [MongoDB driver `MongoClient`](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html) instance
  * that this connection uses to talk to MongoDB.
  *
  * #### Example:
@@ -1453,7 +1453,7 @@ Connection.prototype.getClient = function getClient() {
 };
 
 /**
- * Set the [MongoDB driver `MongoClient`](https://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+ * Set the [MongoDB driver `MongoClient`](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html) instance
  * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
  * reuse it.
  *

--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -173,7 +173,7 @@ AggregationCursor.prototype._markError = function(error) {
  * @api public
  * @method close
  * @emits close
- * @see MongoDB driver cursor#close https://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
+ * @see AggregationCursor.close https://mongodb.github.io/node-mongodb-native/4.9/classes/AggregationCursor.html#close
  */
 
 AggregationCursor.prototype.close = function(callback) {
@@ -301,7 +301,7 @@ function _transformForAsyncIterator(doc) {
 }
 
 /**
- * Adds a [cursor flag](https://mongodb.github.io/node-mongodb-native/2.2/api/Cursor.html#addCursorFlag).
+ * Adds a [cursor flag](https://mongodb.github.io/node-mongodb-native/4.9/classes/AggregationCursor.html#addCursorFlag).
  * Useful for setting the `noCursorTimeout` and `tailable` flags.
  *
  * @param {String} flag

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -178,7 +178,7 @@ QueryCursor.prototype._markError = function(error) {
  * @api public
  * @method close
  * @emits close
- * @see MongoDB driver cursor#close https://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
+ * @see AggregationCursor.close https://mongodb.github.io/node-mongodb-native/4.9/classes/AggregationCursor.html#close
  */
 
 QueryCursor.prototype.close = function(callback) {
@@ -263,7 +263,7 @@ QueryCursor.prototype.eachAsync = function(fn, opts, callback) {
 QueryCursor.prototype.options;
 
 /**
- * Adds a [cursor flag](https://mongodb.github.io/node-mongodb-native/2.2/api/Cursor.html#addCursorFlag).
+ * Adds a [cursor flag](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html#addCursorFlag).
  * Useful for setting the `noCursorTimeout` and `tailable` flags.
  *
  * @param {String} flag

--- a/lib/document.js
+++ b/lib/document.js
@@ -3681,7 +3681,7 @@ Document.prototype.$toObject = function(options, json) {
 /**
  * Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)).
  *
- * Buffers are converted to instances of [mongodb.Binary](https://mongodb.github.com/node-mongodb-native/api-bson-generated/binary.html) for proper storage.
+ * Buffers are converted to instances of [mongodb.Binary](https://mongodb.github.io/node-mongodb-native/4.9/classes/Binary.html) for proper storage.
  *
  * #### Getters/Virtuals
  *
@@ -3808,7 +3808,7 @@ Document.prototype.$toObject = function(options, json) {
  * @param {Boolean} [options.flattenMaps=false] if true, convert Maps to POJOs. Useful if you want to `JSON.stringify()` the result of `toObject()`.
  * @param {Boolean} [options.useProjection=false] - If true, omits fields that are excluded in this document's projection. Unless you specified a projection, this will omit any field that has `select: false` in the schema.
  * @return {Object} js object (not a POJO)
- * @see mongodb.Binary https://mongodb.github.com/node-mongodb-native/api-bson-generated/binary.html
+ * @see mongodb.Binary https://mongodb.github.io/node-mongodb-native/4.9/classes/Binary.html
  * @api public
  * @memberOf Document
  * @instance

--- a/lib/index.js
+++ b/lib/index.js
@@ -293,14 +293,14 @@ Mongoose.prototype.get = Mongoose.prototype.set;
  *     db = mongoose.createConnection();
  *     db.openUri('localhost', 'database', port, [opts]);
  *
- * @param {String} [uri] a mongodb:// URI
- * @param {Object} [options] passed down to the [MongoDB driver's `connect()` function](https://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html), except for 4 mongoose-specific options explained below.
+ * @param {String} uri mongodb URI to connect to
+ * @param {Object} [options] passed down to the [MongoDB driver's `connect()` function](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html), except for 4 mongoose-specific options explained below.
  * @param {Boolean} [options.bufferCommands=true] Mongoose specific option. Set to false to [disable buffering](https://mongoosejs.com/docs/faq.html#callback_never_executes) on all models associated with this connection.
  * @param {String} [options.dbName] The name of the database you want to use. If not provided, Mongoose uses the database name from connection string.
  * @param {String} [options.user] username for authentication, equivalent to `options.auth.user`. Maintained for backwards compatibility.
  * @param {String} [options.pass] password for authentication, equivalent to `options.auth.password`. Maintained for backwards compatibility.
  * @param {Boolean} [options.autoIndex=true] Mongoose-specific option. Set to false to disable automatic index creation for all models associated with this connection.
- * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html).
+ * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html#promiseLibrary).
  * @param {Number} [options.maxPoolSize=5] The maximum number of sockets the MongoDB driver will keep open for this connection. Keep in mind that MongoDB only allows one operation per socket at a time, so you may want to increase this if you find you have a few slow queries that are blocking faster queries from proceeding. See [Slow Trains in MongoDB and Node.js](https://thecodebarbarian.com/slow-trains-in-mongodb-and-nodejs).
  * @param {Number} [options.minPoolSize=1] The minimum number of sockets the MongoDB driver will keep open for this connection. Keep in mind that MongoDB only allows one operation per socket at a time, so you may want to increase this if you find you have a few slow queries that are blocking faster queries from proceeding. See [Slow Trains in MongoDB and Node.js](https://thecodebarbarian.com/slow-trains-in-mongodb-and-nodejs).
  * @param {Number} [options.connectTimeoutMS=30000] How long the MongoDB driver will wait before killing a socket due to inactivity _during initial connection_. Defaults to 30000. This option is passed transparently to [Node.js' `socket#setTimeout()` function](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback).
@@ -349,8 +349,8 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
  *       // if error is truthy, the initial connection failed.
  *     })
  *
- * @param {String} uri(s)
- * @param {Object} [options] passed down to the [MongoDB driver's `connect()` function](https://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html), except for 4 mongoose-specific options explained below.
+ * @param {String} uri mongodb URI to connect to
+ * @param {Object} [options] passed down to the [MongoDB driver's `connect()` function](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html), except for 4 mongoose-specific options explained below.
  * @param {Boolean} [options.bufferCommands=true] Mongoose specific option. Set to false to [disable buffering](https://mongoosejs.com/docs/faq.html#callback_never_executes) on all models associated with this connection.
  * @param {Number} [options.bufferTimeoutMS=10000] Mongoose specific option. If `bufferCommands` is true, Mongoose will throw an error after `bufferTimeoutMS` if the operation is still buffered.
  * @param {String} [options.dbName] The name of the database we want to use. If not provided, use database name from connection string.
@@ -361,7 +361,7 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
  * @param {Number} [options.serverSelectionTimeoutMS] If `useUnifiedTopology = true`, the MongoDB driver will try to find a server to send any given operation to, and keep retrying for `serverSelectionTimeoutMS` milliseconds before erroring out. If not set, the MongoDB driver defaults to using `30000` (30 seconds).
  * @param {Number} [options.heartbeatFrequencyMS] If `useUnifiedTopology = true`, the MongoDB driver sends a heartbeat every `heartbeatFrequencyMS` to check on the status of the connection. A heartbeat is subject to `serverSelectionTimeoutMS`, so the MongoDB driver will retry failed heartbeats for up to 30 seconds by default. Mongoose only emits a `'disconnected'` event after a heartbeat has failed, so you may want to decrease this setting to reduce the time between when your server goes down and when Mongoose emits `'disconnected'`. We recommend you do **not** set this setting below 1000, too many heartbeats can lead to performance degradation.
  * @param {Boolean} [options.autoIndex=true] Mongoose-specific option. Set to false to disable automatic index creation for all models associated with this connection.
- * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html).
+ * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html#promiseLibrary).
  * @param {Number} [options.connectTimeoutMS=30000] How long the MongoDB driver will wait before killing a socket due to inactivity _during initial connection_. Defaults to 30000. This option is passed transparently to [Node.js' `socket#setTimeout()` function](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback).
  * @param {Number} [options.socketTimeoutMS=30000] How long the MongoDB driver will wait before killing a socket due to inactivity _after initial connection_. A socket may be inactive because of either no activity or a long-running operation. This is set to `30000` by default, you should set this to 2-3x your longest running operation if you expect some of your database operations to run longer than 20 seconds. This option is passed to [Node.js `socket#setTimeout()` function](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback) after the MongoDB driver successfully completes.
  * @param {Number} [options.family=0] Passed transparently to [Node.js' `dns.lookup()`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) function. May be either `0`, `4`, or `6`. `4` means use IPv4 only, `6` means use IPv6 only, `0` means try both.
@@ -424,7 +424,7 @@ Mongoose.prototype.disconnect = function(callback) {
  * Sessions are scoped to a connection, so calling `mongoose.startSession()`
  * starts a session on the [default mongoose connection](/docs/api.html#mongoose_Mongoose-connection).
  *
- * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#startSession)
+ * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html#startSession)
  * @param {Boolean} [options.causalConsistency=true] set to false to disable causal consistency
  * @param {Function} [callback]
  * @return {Promise<ClientSession>} promise that resolves to a MongoDB driver `ClientSession`

--- a/lib/model.js
+++ b/lib/model.js
@@ -1388,7 +1388,7 @@ Model.init = function init(callback) {
  *     });
  *
  * @api public
- * @param {Object} [options] see [MongoDB driver docs](https://mongodb.github.io/node-mongodb-native/3.1/api/Db.html#createCollection)
+ * @param {Object} [options] see [MongoDB driver docs](https://mongodb.github.io/node-mongodb-native/4.9/classes/Db.html#createCollection)
  * @param {Function} [callback]
  * @returns {Promise}
  */
@@ -1714,7 +1714,7 @@ Model.ensureIndexes = function ensureIndexes(options, callback) {
 };
 
 /**
- * Similar to `ensureIndexes()`, except for it uses the [`createIndex`](https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#createIndex)
+ * Similar to `ensureIndexes()`, except for it uses the [`createIndex`](https://mongodb.github.io/node-mongodb-native/4.9/classes/Db.html#createIndex)
  * function.
  *
  * @param {Object} [options] internal options
@@ -2332,7 +2332,7 @@ Model.estimatedDocumentCount = function estimatedDocumentCount(options, callback
  * a full collection scan and **not** use any indexes.
  *
  * The `countDocuments()` function is similar to `count()`, but there are a
- * [few operators that `countDocuments()` does not support](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
+ * [few operators that `countDocuments()` does not support](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#countDocuments).
  * Below are the operators that `count()` supports but `countDocuments()` does not,
  * and the suggested replacement:
  *
@@ -2550,7 +2550,7 @@ Model.$where = function $where() {
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
  * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Function} [callback]
  * @return {Query}
  * @see Tutorial /docs/tutorials/findoneandupdate.html
@@ -2677,7 +2677,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.runValidators] if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
  * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
  * @param {Object|String} [options.select] sets the document fields to return.
@@ -2752,7 +2752,7 @@ Model.findByIdAndUpdate = function(id, update, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
@@ -2853,7 +2853,7 @@ Model.findByIdAndDelete = function(id, options, callback) {
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
@@ -2933,7 +2933,7 @@ Model.findOneAndReplace = function(filter, replacement, options, callback) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
  * @param {Function} [callback]
@@ -2996,7 +2996,7 @@ Model.findOneAndRemove = function(conditions, options, callback) {
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Object|String|String[]} [options.projection=null] optional fields to return, see [`Query.prototype.select()`](#query_Query-select)
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Function} [callback]
  * @return {Query}
@@ -3191,7 +3191,7 @@ Model.create = function create(doc, options, callback) {
  *     await doc.remove();
  *
  * @param {Array} [pipeline]
- * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#watch)
+ * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#watch)
  * @param {Boolean} [options.hydrate=false] if true and `fullDocument: 'updateLookup'` is set, Mongoose will automatically hydrate `fullDocument` into a fully fledged Mongoose document
  * @return {ChangeStream} mongoose-specific change stream wrapper, inherits from EventEmitter
  * @api public
@@ -3243,7 +3243,7 @@ Model.watch = function(pipeline, options) {
  *     // secondary that is experiencing replication lag.
  *     doc = await Person.findOne({ name: 'Ned Stark' }, null, { session, readPreference: 'secondary' });
  *
- * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#startSession)
+ * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html#startSession)
  * @param {Boolean} [options.causalConsistency=true] set to false to disable causal consistency
  * @param {Function} [callback]
  * @return {Promise<ClientSession>} promise that resolves to a MongoDB driver `ClientSession`
@@ -3279,9 +3279,9 @@ Model.startSession = function() {
  *     Movies.insertMany(arr, function(error, docs) {});
  *
  * @param {Array|Object|*} doc(s)
- * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#insertMany)
+ * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#insertMany)
  * @param {Boolean} [options.ordered=true] if true, will fail fast on the first error encountered. If false, will insert all the documents it can and report errors later. An `insertMany()` with `ordered = false` is called an "unordered" `insertMany()`.
- * @param {Boolean} [options.rawResult=false] if false, the returned promise resolves to the documents that passed mongoose document validation. If `true`, will return the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~insertWriteOpCallback) with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
+ * @param {Boolean} [options.rawResult=false] if false, the returned promise resolves to the documents that passed mongoose document validation. If `true`, will return the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/InsertManyResult.html) with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
  * @param {Boolean} [options.lean=false] if `true`, skips hydrating and validating the documents. This option is useful if you need the extra performance, but Mongoose won't validate the documents before inserting.
  * @param {Number} [options.limit=null] this limits the number of documents being processed (validation/casting) by mongoose in parallel, this does **NOT** send the documents in batches to MongoDB. Use this option if you're processing a large number of documents and your app is running out of memory.
  * @param {String|Object|Array} [options.populate=null] populates the result documents. This option is a no-op if `rawResult` is set.
@@ -3570,7 +3570,7 @@ function _setIsNew(doc, val) {
  * @param {Boolean} [options.bypassDocumentValidation=false] If true, disable [MongoDB server-side schema validation](https://docs.mongodb.com/manual/core/schema-validation/) for all writes in this bulk.
  * @param {Boolean} [options.strict=null] Overwrites the [`strict` option](/docs/guide.html#strict) on schema. If false, allows filtering and writing fields not defined in the schema for all writes in this bulk.
  * @param {Function} [callback] callback `function(error, bulkWriteOpResult) {}`
- * @return {Promise} resolves to a [`BulkWriteOpResult`](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~BulkWriteOpResult) if the operation succeeds
+ * @return {Promise} resolves to a [`BulkWriteOpResult`](https://mongodb.github.io/node-mongodb-native/4.9/classes/BulkWriteResult.html) if the operation succeeds
  * @api public
  */
 
@@ -3983,10 +3983,10 @@ Model.hydrate = function(obj, projection, options) {
  * @param {Boolean} [options.setDefaultsOnInsert=false] `true` by default. If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created.
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.overwrite=false] By default, if you don't include any [update operators](https://docs.mongodb.com/manual/reference/operator/update/) in `doc`, Mongoose will wrap `doc` in `$set` for you. This prevents you from accidentally overwriting the document. This option tells Mongoose to skip adding `$set`.
- * @param {Function} [callback] params are (error, [updateWriteOpResult](https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#~updateWriteOpResult))
+ * @param {Function} [callback] params are (error, [updateWriteOpResult](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html))
  * @return {Query}
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#~updateWriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @api public
  */
@@ -4029,7 +4029,7 @@ Model.update = function update(conditions, doc, options, callback) {
  * @return {Query}
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @api public
  */
 
@@ -4070,7 +4070,7 @@ Model.updateMany = function updateMany(conditions, doc, options, callback) {
  * @return {Query}
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @api public
  */
 
@@ -4107,7 +4107,7 @@ Model.updateOne = function updateOne(conditions, doc, options, callback) {
  * @param {Function} [callback] `function(error, res) {}` where `res` has 3 properties: `n`, `nModified`, `ok`.
  * @return {Query}
  * @see Query docs https://mongoosejs.com/docs/queries.html
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @return {Query}
  * @api public
  */
@@ -4153,7 +4153,7 @@ function _update(model, op, conditions, doc, options, callback) {
 /**
  * Executes a mapReduce command.
  *
- * `opts` is an object specifying all mapReduce options as well as the map and reduce functions. All options are delegated to the driver implementation. See [node-mongodb-native mapReduce() documentation](https://mongodb.github.io/node-mongodb-native/api-generated/collection.html#mapreduce) for more detail about options.
+ * `opts` is an object specifying all mapReduce options as well as the map and reduce functions. All options are delegated to the driver implementation. See [node-mongodb-native mapReduce() documentation](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#mapReduce) for more detail about options.
  *
  * This function does not trigger any middleware.
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -1191,7 +1191,7 @@ Query.prototype.select = function select() {
  *     // read from secondaries with matching tags
  *     new Query().read('s', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }])
  *
- * Read more about how to use read preferences [here](https://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](https://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
+ * Read more about how to use read preferences [here](https://docs.mongodb.org/manual/applications/replication/#read-preference).
  *
  * @method read
  * @memberOf Query
@@ -1199,7 +1199,6 @@ Query.prototype.select = function select() {
  * @param {String} pref one of the listed preference options or aliases
  * @param {Array} [tags] optional tags for this query
  * @see mongodb https://docs.mongodb.org/manual/applications/replication/#read-preference
- * @see driver https://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences
  * @return {Query} this
  * @api public
  */
@@ -1311,7 +1310,7 @@ Query.prototype.session = function session(v) {
  * @memberOf Query
  * @instance
  * @param {Object} writeConcern the write concern value to set
- * @see mongodb https://mongodb.github.io/node-mongodb-native/3.1/api/global.html#WriteConcern
+ * @see WriteConcernSettings https://mongodb.github.io/node-mongodb-native/4.9/interfaces/WriteConcernSettings.html
  * @return {Query} this
  * @api public
  */
@@ -2630,7 +2629,7 @@ Query.prototype._count = wrapThunk(function(callback) {
  * Thunk around countDocuments()
  *
  * @param {Function} [callback]
- * @see countDocuments https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments
+ * @see countDocuments https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#countDocuments
  * @api private
  */
 
@@ -2658,7 +2657,7 @@ Query.prototype._countDocuments = wrapThunk(function(callback) {
  * Thunk around estimatedDocumentCount()
  *
  * @param {Function} [callback]
- * @see estimatedDocumentCount https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount
+ * @see estimatedDocumentCount https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#estimatedDocumentCount
  * @api private
  */
 
@@ -2746,10 +2745,10 @@ Query.prototype.count = function(filter, callback) {
  *
  *     await Model.find().estimatedDocumentCount();
  *
- * @param {Object} [options] passed transparently to the [MongoDB driver](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount)
+ * @param {Object} [options] passed transparently to the [MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/EstimatedDocumentCountOptions.html)
  * @param {Function} [callback] optional params are (error, count)
  * @return {Query} this
- * @see estimatedDocumentCount https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount
+ * @see estimatedDocumentCount https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#estimatedDocumentCount
  * @api public
  */
 
@@ -2779,7 +2778,7 @@ Query.prototype.estimatedDocumentCount = function(options, callback) {
  * except it always does a full collection scan when passed an empty filter `{}`.
  *
  * There are also minor differences in how `countDocuments()` handles
- * [`$where` and a couple geospatial operators](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
+ * [`$where` and a couple geospatial operators](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#countDocuments).
  * versus `count()`.
  *
  * Passing a `callback` executes the query.
@@ -2802,7 +2801,7 @@ Query.prototype.estimatedDocumentCount = function(options, callback) {
  *     });
  *
  * The `countDocuments()` function is similar to `count()`, but there are a
- * [few operators that `countDocuments()` does not support](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
+ * [few operators that `countDocuments()` does not support](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#countDocuments).
  * Below are the operators that `count()` supports but `countDocuments()` does not,
  * and the suggested replacement:
  *
@@ -2814,7 +2813,7 @@ Query.prototype.estimatedDocumentCount = function(options, callback) {
  * @param {Object} [options]
  * @param {Function} [callback] optional params are (error, count)
  * @return {Query} this
- * @see countDocuments https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments
+ * @see countDocuments https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#countDocuments
  * @api public
  */
 
@@ -2981,7 +2980,7 @@ Query.prototype.sort = function(arg) {
  *
  *     Character.remove({ name: /Stark/ }, callback);
  *
- * This function calls the MongoDB driver's [`Collection#remove()` function](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#remove).
+ * This function calls the MongoDB driver's [`Collection#remove()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#remove).
  * The returned [promise](https://mongoosejs.com/docs/queries.html) resolves to an
  * object that contains 3 properties:
  *
@@ -3015,8 +3014,8 @@ Query.prototype.sort = function(arg) {
  * @param {Function} [callback] optional params are (error, mongooseDeleteResult)
  * @return {Query} this
  * @deprecated
- * @see deleteWriteOpResult https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~deleteWriteOpResult
- * @see MongoDB driver remove https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#remove
+ * @see DeleteResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/DeleteResult.html
+ * @see remove https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#remove
  * @api public
  */
 
@@ -3081,7 +3080,7 @@ Query.prototype._remove = wrapThunk(function(callback) {
  *     // Using callbacks:
  *     Character.deleteOne({ name: 'Eddard Stark' }, callback);
  *
- * This function calls the MongoDB driver's [`Collection#deleteOne()` function](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteOne).
+ * This function calls the MongoDB driver's [`Collection#deleteOne()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteOne).
  * The returned [promise](https://mongoosejs.com/docs/queries.html) resolves to an
  * object that contains 3 properties:
  *
@@ -3099,8 +3098,8 @@ Query.prototype._remove = wrapThunk(function(callback) {
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback] optional params are (error, mongooseDeleteResult)
  * @return {Query} this
- * @see deleteWriteOpResult https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~deleteWriteOpResult
- * @see MongoDB Driver deleteOne https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteOne
+ * @see DeleteResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/DeleteResult.html
+ * @see deleteOne https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteOne
  * @api public
  */
 
@@ -3172,7 +3171,7 @@ Query.prototype._deleteOne = wrapThunk(function(callback) {
  *     // Using callbacks:
  *     Character.deleteMany({ name: /Stark/, age: { $gte: 18 } }, callback);
  *
- * This function calls the MongoDB driver's [`Collection#deleteMany()` function](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteMany).
+ * This function calls the MongoDB driver's [`Collection#deleteMany()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteMany).
  * The returned [promise](https://mongoosejs.com/docs/queries.html) resolves to an
  * object that contains 3 properties:
  *
@@ -3190,8 +3189,8 @@ Query.prototype._deleteOne = wrapThunk(function(callback) {
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
  * @param {Function} [callback] optional params are (error, mongooseDeleteResult)
  * @return {Query} this
- * @see deleteWriteOpResult https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~deleteWriteOpResult
- * @see MongoDB Driver deleteMany https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteMany
+ * @see DeleteResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/DeleteResult.html
+ * @see deleteMany https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteMany
  * @api public
  */
 
@@ -3332,7 +3331,7 @@ function prepareDiscriminatorCriteria(query) {
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
  * - `runValidators`: if true, runs [update validators](/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema.
  * - `setDefaultsOnInsert`: `true` by default. If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created.
- * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * - `rawResult`: if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  *
  * #### Callback Signature
  *
@@ -3358,7 +3357,7 @@ function prepareDiscriminatorCriteria(query) {
  * @param {Object|Query} [filter]
  * @param {Object} [doc]
  * @param {Object} [options]
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
@@ -3370,8 +3369,9 @@ function prepareDiscriminatorCriteria(query) {
  * @param {Boolean} [options.returnOriginal=null] An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
  * @param {Function} [callback] optional params are (error, doc), _unless_ `rawResult` is used, in which case params are (error, writeOpResult)
  * @see Tutorial /docs/tutorials/findoneandupdate.html
- * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see findAndModify command https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+ * @see ModifyResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html
+ * @see findOneAndUpdate https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#findOneAndUpdate
  * @return {Query} this
  * @api public
  */
@@ -3477,7 +3477,7 @@ Query.prototype._findOneAndUpdate = wrapThunk(function(callback) {
  *
  * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `rawResult`: if true, resolves to the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * - `rawResult`: if true, resolves to the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  *
  * #### Callback Signature
  *
@@ -3500,12 +3500,12 @@ Query.prototype._findOneAndUpdate = wrapThunk(function(callback) {
  * @instance
  * @param {Object} [conditions]
  * @param {Object} [options]
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Function} [callback] optional params are (error, document)
  * @return {Query} this
- * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
+ * @see findAndModify command https://www.mongodb.com/docs/manual/reference/command/findAndModify/
  * @api public
  */
 
@@ -3565,7 +3565,7 @@ Query.prototype.findOneAndRemove = function(conditions, options, callback) {
  *
  * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `rawResult`: if true, resolves to the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * - `rawResult`: if true, resolves to the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  *
  * #### Callback Signature
  *
@@ -3587,12 +3587,12 @@ Query.prototype.findOneAndRemove = function(conditions, options, callback) {
  * @memberOf Query
  * @param {Object} [conditions]
  * @param {Object} [options]
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Function} [callback] optional params are (error, document)
  * @return {Query} this
- * @see mongodb https://www.mongodb.org/display/DOCS/findAndModify+Command
+ * @see findAndModify command https://www.mongodb.com/docs/manual/reference/command/findAndModify/
  * @api public
  */
 
@@ -3687,7 +3687,7 @@ Query.prototype._findOneAndDelete = wrapThunk(function(callback) {
  *
  * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
- * - `rawResult`: if true, resolves to the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * - `rawResult`: if true, resolves to the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  *
  * #### Callback Signature
  *
@@ -3710,7 +3710,7 @@ Query.prototype._findOneAndDelete = wrapThunk(function(callback) {
  * @param {Object} [filter]
  * @param {Object} [replacement]
  * @param {Object} [options]
- * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.3/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](/docs/transactions.html).
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.new=false] By default, `findOneAndUpdate()` returns the document as it was **before** `update` was applied. If you set `new: true`, `findOneAndUpdate()` will instead give you the object after `update` was applied.
@@ -4456,7 +4456,7 @@ Query.prototype._replaceOne = wrapThunk(function(callback) {
  * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
  * @api public
  */
@@ -4521,7 +4521,7 @@ Query.prototype.update = function(conditions, doc, options, callback) {
  * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
  * @api public
  */
@@ -4587,7 +4587,7 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
  * @api public
  */
@@ -4651,7 +4651,7 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * @see Model.update #model_Model-update
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see update https://docs.mongodb.org/manual/reference/method/db.collection.update/
- * @see writeOpResult https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#~WriteOpResult
+ * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/command/update/#update-command-output
  * @api public
  */
@@ -5397,7 +5397,7 @@ Query.prototype._applyPaths = function applyPaths() {
 };
 
 /**
- * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html).
+ * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html).
  * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
  *
  * The `.cursor()` function triggers pre find hooks, but **not** post find hooks.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1844,7 +1844,7 @@ Schema.prototype.static = function(name, fn) {
  *     schema.index({ first: 1, last: -1 })
  *
  * @param {Object} fields The Fields to index, with the order, available values: `1 | -1 | '2d' | '2dsphere' | 'geoHaystack' | 'hashed' | 'text'`
- * @param {Object} [options] Options to pass to [MongoDB driver's `createIndex()` function](https://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#createIndex)
+ * @param {Object} [options] Options to pass to [MongoDB driver's `createIndex()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#createIndex)
  * @param {String | number} [options.expires=null] Mongoose-specific syntactic sugar, uses [ms](https://www.npmjs.com/package/ms) to convert `expires` option into seconds for the `expireAfterSeconds` in the above link.
  * @param {String} [options.language_override=null] Tells mongodb to use the specified field instead of `language` for parsing text indexes.
  * @api public

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -117,7 +117,7 @@ declare module 'mongoose' {
     get(key: string): any;
 
     /**
-     * Returns the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+     * Returns the [MongoDB driver `MongoClient`](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html) instance
      * that this connection uses to talk to MongoDB.
      */
     getClient(): mongodb.MongoClient;
@@ -197,7 +197,7 @@ declare module 'mongoose' {
     set(key: string, value: any): any;
 
     /**
-     * Set the [MongoDB driver `MongoClient`](http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html) instance
+     * Set the [MongoDB driver `MongoClient`](https://mongodb.github.io/node-mongodb-native/4.9/classes/MongoClient.html) instance
      * that this connection uses to talk to MongoDB. This is useful if you already have a MongoClient instance, and want to
      * reuse it.
      */

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -14,7 +14,7 @@ declare module 'mongoose' {
     [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
 
     /**
-     * Adds a [cursor flag](http://mongodb.github.io/node-mongodb-native/2.2/api/Cursor.html#addCursorFlag).
+     * Adds a [cursor flag](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html#addCursorFlag).
      * Useful for setting the `noCursorTimeout` and `tailable` flags.
      */
     addCursorFlag(flag: CursorFlag, value: boolean): this;

--- a/types/indexes.d.ts
+++ b/types/indexes.d.ts
@@ -12,7 +12,7 @@ declare module 'mongoose' {
 
   interface IndexManager {
     /**
-     * Similar to `ensureIndexes()`, except for it uses the [`createIndex`](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#createIndex)
+     * Similar to `ensureIndexes()`, except for it uses the [`createIndex`](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#createIndex)
      * function.
      */
     createIndexes(options: mongodb.CreateIndexesOptions, callback: CallbackWithoutResult): void;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -173,7 +173,7 @@ declare module 'mongoose' {
     _mongooseOptions: MongooseQueryOptions<DocType>;
 
     /**
-     * Returns a wrapper around a [mongodb driver cursor](http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html).
+     * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html).
      * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
      * This is equivalent to calling `.cursor()` with no arguments.
      */
@@ -244,7 +244,7 @@ declare module 'mongoose' {
     countDocuments(callback?: Callback<number>): QueryWithHelpers<number, DocType, THelpers, RawDocType>;
 
     /**
-     * Returns a wrapper around a [mongodb driver cursor](http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html).
+     * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html).
      * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
      */
     cursor(options?: QueryOptions<DocType>): Cursor<DocType, QueryOptions<DocType>>;


### PR DESCRIPTION
**Summary**

This PR updates old mongodb driver urls to be consistently referring to the `4.9` documentation at https://mongodb.github.io/node-mongodb-native/4.9/modules.html

also updated some (now redirecting) `https://www.mongodb.org/display/DOCS` to the pages they redirect to

One thing i was not sure on is where `http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html` lead to, for now i have replace it to `https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html`  and for `https://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html` to `https://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html`