### PR TITLE
Update JSDOC `...` (spread) definition

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -229,7 +229,7 @@ SchemaArray.prototype.checkRequired = function checkRequired(value, doc) {
  * Adds an enum validator if this is an array of strings or numbers. Equivalent to
  * `SchemaString.prototype.enum()` or `SchemaNumber.prototype.enum()`
  *
- * @param {String|Object} [args...] enumeration values
+ * @param {...String|Object} [args] enumeration values
  * @return {SchemaArray} this
  */
 

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -199,7 +199,7 @@ SchemaString.checkRequired = SchemaType.checkRequired;
  *       m.save(callback) // success
  *     })
  *
- * @param {String|Object} [args...] enumeration values
+ * @param {...String|Object} [args] enumeration values
  * @return {SchemaType} this
  * @see Customized Error Messages #error_messages_MongooseError-messages
  * @api public

--- a/lib/types/DocumentArray/methods/index.js
+++ b/lib/types/DocumentArray/methods/index.js
@@ -181,7 +181,7 @@ const methods = {
   /**
    * Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking.
    *
-   * @param {Object} [args...]
+   * @param {...Object} [args]
    * @api public
    * @method push
    * @memberOf MongooseDocumentArray
@@ -198,7 +198,7 @@ const methods = {
   /**
    * Pulls items from the array atomically.
    *
-   * @param {Object} [args...]
+   * @param {...Object} [args]
    * @api public
    * @method pull
    * @memberOf MongooseDocumentArray

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -372,7 +372,7 @@ const methods = {
    *     console.log(doc.array) // [2,3,4,5]
    *     console.log(added)     // [5]
    *
-   * @param {any} [args...]
+   * @param {...any} [args]
    * @return {Array} the values that were added
    * @memberOf MongooseArray
    * @api public
@@ -502,7 +502,7 @@ const methods = {
    *
    * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
    *
-   * @param {any} [args...]
+   * @param {...any} [args]
    * @api public
    * @method nonAtomicPush
    * @memberOf MongooseArray
@@ -560,7 +560,7 @@ const methods = {
    *
    * The first pull call will result in a atomic operation on the database, if pull is called repeatedly without saving the document, a $set operation is used on the complete array instead, overwriting possible changes that happened on the database in the meantime.
    *
-   * @param {any} [args...]
+   * @param {...any} [args]
    * @see mongodb https://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
    * @api public
    * @method pull
@@ -628,7 +628,7 @@ const methods = {
    *     });
    *     doc.nums; // [1, 2, 3, 4, 5]
    *
-   * @param {Object} [args...]
+   * @param {...Object} [args]
    * @api public
    * @method push
    * @memberOf MongooseArray


### PR DESCRIPTION
**Summary**

This PR updates all invalid spread JSDOC syntaxes and updated the documentation code to properly handle the spread.

also includes some updates to the documentation script types.

Note: `{String} ...arg` is invalid, the proper definition is `{...String} arg`, and because this is not directly included from dox in the `name` property, it is "moneky"-patched in