### PR TITLE
fix(setDefaultsOnInsert): avoid applying defaults on insert if nested property set

### DIFF
--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -105,6 +105,8 @@ function isModified(modified, path) {
   if (modified[path]) {
     return true;
   }
+
+  // Is any parent path of `path` modified?
   const sp = path.split('.');
   let cur = sp[0];
   for (let i = 1; i < sp.length; ++i) {
@@ -113,5 +115,13 @@ function isModified(modified, path) {
     }
     cur += '.' + sp[i];
   }
+
+  // Is any child of `path` modified?
+  for (const modifiedPath of Object.keys(modified)) {
+    if (modifiedPath.slice(0, path.length + 1) === path + '.') {
+      return true;
+    }
+  }
+
   return false;
 }

--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -117,9 +117,14 @@ function isModified(modified, path) {
   }
 
   // Is any child of `path` modified?
-  for (const modifiedPath of Object.keys(modified)) {
-    if (modifiedPath.slice(0, path.length + 1) === path + '.') {
-      return true;
+  const modifiedKeys = Object.keys(modified);
+  if (modifiedKeys.length) {
+    const parentPath = path + '.';
+
+    for (const modifiedPath of modifiedKeys) {
+      if (modifiedPath.slice(0, path.length + 1) === parentPath) {
+        return true;
+      }
     }
   }
 

--- a/test/helpers/setDefaultsOnInsert.test.js
+++ b/test/helpers/setDefaultsOnInsert.test.js
@@ -87,4 +87,25 @@ describe('setDefaultsOnInsert', function() {
 
     assert.equal(update.$setOnInsert['time.resolved'], 42);
   });
+
+  it('skips default if parent is $set (gh-12279)', function() {
+    const SubscriptionsConfigSchema = Schema({
+      hasPaidSubscription: { type: Boolean, required: true },
+      hasPastDueInvoice: { type: Boolean, required: true }
+    });
+
+    const CustomerSchema = Schema({
+      subscriptionsConfig: {
+        type: SubscriptionsConfigSchema,
+        required: true,
+        default: { hasPaidSubscription: false, hasPastDueInvoice: false }
+      }
+    });
+
+    const opts = {};
+    let update = { $set: { 'subscriptionsConfig.hasPaidSubscription': 100 } };
+    update = setDefaultsOnInsert({}, CustomerSchema, update, opts);
+
+    assert.ok(!update.$setOnInsert);
+  });
 });


### PR DESCRIPTION
Fix #12279

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12279 pointed out that we need to make sure we don't apply `setDefaultsOnInsert` on a subdoc path when a path nested underneath that subdoc path is `$set`. That makes the MongoDB server throw a `Updating the path 'subscriptionsConfig.hasPaidSubscription' would create a conflict at 'subscriptionsConfig'` error.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
