### PR TITLE
fix(model): make `applyHooks()` and `applyMethods()` handle case where custom method is set to Mongoose implementation

### DIFF
--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -22,6 +22,12 @@ applyHooks.middlewareFunctions = [
   'init'
 ];
 
+/*!
+ * ignore
+ */
+
+const alreadyHookedFunctions = new Set(applyHooks.middlewareFunctions.flatMap(fn => ([fn, `$__${fn}`])));
+
 /**
  * Register hooks for this model
  *
@@ -117,6 +123,9 @@ function applyHooks(model, schema, options) {
     checkForPromise: true
   });
   for (const method of customMethods) {
+    if (alreadyHookedFunctions.has(method)) {
+      continue;
+    }
     if (!middleware.hasHooks(method)) {
       // Don't wrap if there are no hooks for the custom method to avoid
       // surprises. Also, `createWrapper()` enforces consistent async,

--- a/lib/helpers/model/applyMethods.js
+++ b/lib/helpers/model/applyMethods.js
@@ -30,6 +30,15 @@ module.exports = function applyMethods(model, schema) {
       throw new Error('You have a method and a property in your schema both ' +
         'named "' + method + '"');
     }
+
+    // Avoid making custom methods if user sets a method to itself, e.g.
+    // `schema.method(save, Document.prototype.save)`. Can happen when
+    // calling `loadClass()` with a class that `extends Document`. See gh-12254
+    if (typeof fn === 'function' && model.prototype[method] === fn) {
+      delete schema.methods[method];
+      continue;
+    }
+
     if (schema.reserved[method] &&
         !get(schema, `methodOptions.${method}.suppressWarning`, false)) {
       utils.warn(`mongoose: the method name "${method}" is used by mongoose ` +

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11833,6 +11833,23 @@ describe('document', function() {
 
     assert.ok(doc.nestedPath1.mapOfSchema);
   });
+
+  it('works if passing class that extends Document to `loadClass()` (gh-12254)', async function() {
+    const DownloadJobSchema = new mongoose.Schema({ test: String });
+
+    class B extends mongoose.Document {}
+
+    B.prototype.foo = 'bar';
+
+    DownloadJobSchema.loadClass(B);
+
+    const Test = db.model('Test', DownloadJobSchema);
+
+    const { _id } = await Test.create({ test: 'value' });
+    const doc = await Test.findById(_id);
+    assert.ok(doc);
+    assert.equal(doc.test, 'value');
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11833,23 +11833,6 @@ describe('document', function() {
 
     assert.ok(doc.nestedPath1.mapOfSchema);
   });
-
-  it('works if passing class that extends Document to `loadClass()` (gh-12254)', async function() {
-    const DownloadJobSchema = new mongoose.Schema({ test: String });
-
-    class B extends mongoose.Document {}
-
-    B.prototype.foo = 'bar';
-
-    DownloadJobSchema.loadClass(B);
-
-    const Test = db.model('Test', DownloadJobSchema);
-
-    const { _id } = await Test.create({ test: 'value' });
-    const doc = await Test.findById(_id);
-    assert.ok(doc);
-    assert.equal(doc.test, 'value');
-  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8864,9 +8864,9 @@ describe('Model', function() {
   it('works if passing class that extends Document to `loadClass()` (gh-12254)', async function() {
     const DownloadJobSchema = new mongoose.Schema({ test: String });
 
-    class B extends mongoose.Document {}
-
-    B.prototype.foo = 'bar';
+    class B extends mongoose.Document {
+      get foo() { return 'bar'; }
+    }
 
     DownloadJobSchema.loadClass(B);
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8875,6 +8875,7 @@ describe('Model', function() {
     const { _id } = await Test.create({ test: 'value' });
     const doc = await Test.findById(_id);
     assert.ok(doc);
+    assert.equal(doc.foo, 'bar');
     assert.equal(doc.test, 'value');
   });
 });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8860,6 +8860,23 @@ describe('Model', function() {
       assert.equal(error.errors['docArr.0.num'].name, 'CastError');
     });
   });
+
+  it('works if passing class that extends Document to `loadClass()` (gh-12254)', async function() {
+    const DownloadJobSchema = new mongoose.Schema({ test: String });
+
+    class B extends mongoose.Document {}
+
+    B.prototype.foo = 'bar';
+
+    DownloadJobSchema.loadClass(B);
+
+    const Test = db.model('Test', DownloadJobSchema);
+
+    const { _id } = await Test.create({ test: 'value' });
+    const doc = await Test.findById(_id);
+    assert.ok(doc);
+    assert.equal(doc.test, 'value');
+  });
 });
 
 describe('Check if static function that is supplied in schema option is available', function() {


### PR DESCRIPTION
Fix #12254

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12254 was a tricky issue, but comes down to the fact that `applyHooks()` will apply hooks twice if you have a custom method named `init`, which leads to infinite recursion. I added a workaround in `applyHooks()`.

I also made `applyMethods()` ignore methods that are strictly equal to the Mongoose implementation. That is, calling `schema.method('save', Model.prototype.save)` will be a no-op now. Which is better behavior IMO, that better supports the case of calling `loadClass()` with a class that extends Document, since in that case you don't want `save()` to be a custom method anyway.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
