### PR TITLE
docs(scripts/website): remove setting "latest38x" which is not used anywhere

### DIFF
--- a/scripts/website.js
+++ b/scripts/website.js
@@ -100,7 +100,6 @@ function getLatestLegacyVersion(startsWith) {
 pkg.version = getVersion();
 pkg.latest5x = getLatestLegacyVersion('5.');
 pkg.latest4x = getLatestLegacyVersion('4.');
-pkg.latest38x = getLatestLegacyVersion('3.8');
 
 // Create api dir if it doesn't already exist
 try {


### PR DESCRIPTION
**Summary**

This PR removes setting `pkg.latest38x` which is not used anywhere anymore

re #11725