### PR TITLE
Improve tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -203,17 +203,6 @@ before(dropDBs);
 
 after(dropDBs);
 
-beforeEach(function() {
-  if (this.currentTest) {
-    global.CURRENT_TEST = this.currentTest.title;
-    if (this.currentTest.parent.title) {
-      global.CURRENT_TEST = this.currentTest.parent.title + global.CURRENT_TEST;
-    }
-  } else {
-    global.CURRENT_TEST = 'N/A';
-  }
-});
-
 process.on('unhandledRejection', function(error, promise) {
   if (error.$expected) {
     return;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1476,7 +1476,7 @@ describe('document', function() {
     });
 
     it('validator should run only once per sub-doc gh-1743', async function() {
-      this.timeout(process.env.TRAVIS ? 8000 : 4500);
+      this.timeout(4500);
 
       let count = 0;
       const db = start();

--- a/test/gh-1408.test.js
+++ b/test/gh-1408.test.js
@@ -14,7 +14,7 @@ const Schema = mongoose.Schema;
 
 describe('documents should not be converted to _id (gh-1408)', function() {
   it('if an embedded doc', async function() {
-    this.timeout(process.env.TRAVIS ? 8000 : 4500);
+    this.timeout(4500);
 
     const db = start();
 

--- a/test/model.aggregate.test.js
+++ b/test/model.aggregate.test.js
@@ -24,7 +24,7 @@ const userSchema = new Schema({
 });
 
 describe('model aggregate', function() {
-  this.timeout(process.env.TRAVIS ? 8000 : 4500);
+  this.timeout(4500);
 
   const group = { $group: { _id: null, maxAge: { $max: '$age' } } };
   const project = { $project: { maxAge: 1, _id: 0 } };

--- a/test/model.populate.setting.test.js
+++ b/test/model.populate.setting.test.js
@@ -20,7 +20,7 @@ const DocObjectId = mongoose.Types.ObjectId;
  */
 
 describe('model: populate:', function() {
-  this.timeout(process.env.TRAVIS ? 8000 : 4500);
+  this.timeout(4500);
 
   describe('setting populated paths (gh-570)', function() {
     const types = {

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1651,7 +1651,7 @@ describe('model: querying:', function() {
     });
 
     it('with Dates', function(done) {
-      this.timeout(process.env.TRAVIS ? 8000 : 4500);
+      this.timeout(4500);
       const SSchema = new Schema({ d: Date });
       const PSchema = new Schema({ sub: [SSchema] });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5995,7 +5995,7 @@ describe('Model', function() {
 
     it.skip('save() with wtimeout defined in schema (gh-6862)', function(done) {
       // If you want to test this, setup replica set with 1 primary up and 1 secondary down
-      this.timeout(process.env.TRAVIS ? 9000 : 5500);
+      this.timeout(5500);
       const schema = new Schema({
         name: String
       }, {
@@ -6022,7 +6022,7 @@ describe('Model', function() {
 
     it.skip('save with wtimeout in options (gh_6862)', function(done) {
       // If you want to test this, setup replica set with 1 primary up and 1 secondary down
-      this.timeout(process.env.TRAVIS ? 9000 : 5500);
+      this.timeout(5500);
       const schema = new Schema({
         name: String
       });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -87,7 +87,7 @@ describe('Model', function() {
   afterEach(() => util.clearTestData(db));
   afterEach(() => require('./util').stopRemainingOps(db));
 
-  it('can be created using _id as embedded document', function(done) {
+  it('can be created using _id as embedded document', async function() {
     const Test = db.model('Test', Schema({
       _id: { first_name: String, age: Number },
       last_name: String,
@@ -106,24 +106,20 @@ describe('Model', function() {
       }
     });
 
-    t.save(function(err) {
-      assert.ifError(err);
-      Test.findOne({}, function(err, doc) {
-        assert.ifError(err);
+    await t.save();
 
-        assert.ok('last_name' in doc);
-        assert.ok('_id' in doc);
-        assert.ok('first_name' in doc._id);
-        assert.equal(doc._id.first_name, 'Daniel');
-        assert.ok('age' in doc._id);
-        assert.equal(doc._id.age, 21);
+    const doc = await Test.findOne();
 
-        assert.ok('doc_embed' in doc);
-        assert.ok('some' in doc.doc_embed);
-        assert.equal(doc.doc_embed.some, 'a');
-        done();
-      });
-    });
+    assert.ok('last_name' in doc);
+    assert.ok('_id' in doc);
+    assert.ok('first_name' in doc._id);
+    assert.equal(doc._id.first_name, 'Daniel');
+    assert.ok('age' in doc._id);
+    assert.equal(doc._id.age, 21);
+
+    assert.ok('doc_embed' in doc);
+    assert.ok('some' in doc.doc_embed);
+    assert.equal(doc.doc_embed.some, 'a');
   });
 
   describe('constructor', function() {


### PR DESCRIPTION
**Summary**

This PR updates some tests:
- removes usage of `process.env.TRAVIS`
- removes setting `global.CURRENT_TEST`
- converts a test to be async/await instead of callback-style in hopes that it fails less (see node results at https://github.com/Automattic/mongoose/pull/12397#issuecomment-1237912666)