### PR TITLE
Update dox

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
   open-pull-requests-limit: 100
   target-branch: master
   ignore:
-    - dependency-name: "dox"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/docs/api_split.pug
+++ b/docs/api_split.pug
@@ -68,7 +68,7 @@ block content
       if prop.inherits != null
         h5 Inherits:
         ul
-          li <span class="method-type">&laquo;#{prop.inherits}&raquo;</span>
+          li <span class="method-type"><a href="#{prop.inherits.url}">&laquo;#{prop.inherits.text}&raquo;</a></span>
       if prop.see != null && prop.see.length > 0
         h5 See:
         ul

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "buffer": "^5.6.0",
     "cheerio": "1.0.0-rc.12",
     "crypto-browserify": "3.12.0",
-    "dox": "0.9.1",
+    "dox": "1.0.0",
     "eslint": "8.23.0",
     "eslint-plugin-mocha-no-only": "1.1.1",
     "express": "^4.18.1",


### PR DESCRIPTION
**Summary**

This PR updates `dox` to `1.0.0` which (finally) includes a update of `jsdoctypeparser` and so fixes some of the audit problems

also includes a update so that `@inherits` having a URL is handled like a `@see`

Note: this change does not include a change to `api.pug`, because that file does not include the `Inherits` section and is probably gone soon anyway