### PR TITLE
fix(query): use correct Query constructor when cloning query

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -5069,8 +5069,9 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   model.Query = function() {
     Query.apply(this, arguments);
   };
-  model.Query.prototype = Object.create(Query.prototype);
+  Object.setPrototypeOf(model.Query.prototype, Query.prototype);
   model.Query.base = Query.base;
+  model.Query.prototype.constructor = Query;
   applyQueryMiddleware(model.Query, model);
   applyQueryMethods(model, schema.query);
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -280,7 +280,7 @@ Query.prototype.clone = function clone() {
   const model = this.model;
   const collection = this.mongooseCollection;
 
-  const q = new this.constructor({}, {}, model, collection);
+  const q = new this.model.Query({}, {}, model, collection);
 
   // Need to handle `sort()` separately because entries-style `sort()` syntax
   // `sort([['prop1', 1]])` confuses mquery into losing the outer nested array.

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3562,7 +3562,8 @@ describe('Query', function() {
     let Model;
 
     beforeEach(function() {
-      Model = db.model('Test', Schema({ name: String, age: Number }));
+      const schema = new Schema({ name: String, age: Number });
+      Model = db.model('Test', schema);
 
       return Model.create([
         { name: 'Jean-Luc Picard', age: 59 },
@@ -3571,7 +3572,6 @@ describe('Query', function() {
     });
 
     it('with findOne', async function() {
-
       const q = Model.findOne({ age: 29 });
       const q2 = q.clone();
 
@@ -3589,7 +3589,6 @@ describe('Query', function() {
     });
 
     it('with deleteOne', async function() {
-
       const q = Model.deleteOne({ age: 29 });
 
       await q;
@@ -3603,7 +3602,6 @@ describe('Query', function() {
     });
 
     it('with updateOne', async function() {
-
       const q = Model.updateOne({ name: 'Will Riker' }, { name: 'Thomas Riker' });
 
       await q;
@@ -3627,6 +3625,22 @@ describe('Query', function() {
       assert.deepEqual(q2._distinct, 'name');
       await q2;
       assert.deepEqual(res.sort(), ['Jean-Luc Picard', 'Will Riker']);
+    });
+
+    it('with hooks (gh-12365)', async function() {
+      db.deleteModel('Test');
+
+      const schema = new Schema({ name: String, age: Number });
+      let called = 0;
+      schema.pre('find', () => ++called);
+      Model = db.model('Test', schema);
+
+      assert.strictEqual(called, 0);
+
+      const res = await Model.find().clone();
+      assert.strictEqual(called, 1);
+      assert.equal(res.length, 2);
+      assert.deepEqual(res.map(doc => doc.name).sort(), ['Jean-Luc Picard', 'Will Riker']);
     });
   });
 


### PR DESCRIPTION
Fix #12365

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12365 pointed out that we're not cloning hooks correctly. That's because `this.constructor` doesn't seem to pick up the correct Query class - it picks up the default `Query`, not the model-specific `Query`.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
