### PR TITLE
Improve handling of defaults when using `pull()`

### DIFF
--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -603,7 +603,11 @@ const methods = {
 
     if (values[0] instanceof ArraySubdocument) {
       this._registerAtomic('$pullDocs', values.map(function(v) {
-        return v.$__getValue('_id') || v;
+        const _id = v.$__getValue('_id');
+        if (_id === undefined || v.$isDefault('_id')) {
+          return v;
+        }
+        return _id;
       }));
     } else {
       this._registerAtomic('$pullAll', values);

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -5,6 +5,7 @@ const ArraySubdocument = require('../../ArraySubdocument');
 const MongooseError = require('../../../error/mongooseError');
 const cleanModifiedSubpaths = require('../../../helpers/document/cleanModifiedSubpaths');
 const internalToObjectOptions = require('../../../options').internalToObjectOptions;
+const mpath = require('mpath');
 const utils = require('../../../utils');
 const isBsonType = require('../../../helpers/isBsonType');
 
@@ -349,7 +350,9 @@ const methods = {
               }
 
               Object.keys(v.$__.activePaths.getStatePaths('default')).forEach(path => {
-                delete ret[path];
+                mpath.unset(path, ret);
+
+                _minimizePath(ret, path);
               });
 
               return ret;
@@ -935,6 +938,40 @@ function _isAllSubdocs(docs, ref) {
   }
 
   return true;
+}
+
+/*!
+ * Minimize _just_ empty objects along the path chain specified
+ * by `parts`, ignoring all other paths. Useful in cases where
+ * you want to minimize after unsetting a path.
+ *
+ * #### Example:
+ *
+ *     const obj = { foo: { bar: { baz: {} } }, a: {} };
+ *     _minimizePath(obj, 'foo.bar.baz');
+ *     obj; // { a: {} }
+ */
+
+function _minimizePath(obj, parts, i) {
+  if (typeof parts === 'string') {
+    if (parts.indexOf('.') === -1) {
+      return;
+    }
+
+    parts = mpath.stringToParts(parts);
+  }
+  i = i || 0;
+  if (i >= parts.length) {
+    return;
+  }
+  if (obj == null || typeof obj !== 'object') {
+    return;
+  }
+
+  _minimizePath(obj[parts[0]], parts, i + 1);
+  if (obj[parts[0]] != null && typeof obj[parts[0]] === 'object' && Object.keys(obj[parts[0]]).length === 0) {
+    delete obj[parts[0]];
+  }
 }
 
 /*!

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -341,8 +341,21 @@ const methods = {
       const pullOp = atomics['$pull'] || (atomics['$pull'] = {});
       if (val[0] instanceof ArraySubdocument) {
         selector = pullOp['$or'] || (pullOp['$or'] = []);
-        Array.prototype.push.apply(selector, val.map(function(v) {
-          return v.toObject({ transform: false, virtuals: false });
+        Array.prototype.push.apply(selector, val.map(v => {
+          return v.toObject({
+            transform: (doc, ret) => {
+              if (v == null || v.$__ == null) {
+                return ret;
+              }
+
+              Object.keys(v.$__.activePaths.getStatePaths('default')).forEach(path => {
+                delete ret[path];
+              });
+
+              return ret;
+            },
+            virtuals: false
+          });
         }));
       } else {
         selector = pullOp['_id'] || (pullOp['_id'] = { $in: [] });

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -846,6 +846,29 @@ describe('types array', function() {
         { $or: [{ name: 'Orange' }] }
       ]]);
     });
+
+    it('avoids adding default paths to query filter with _id (gh-12294)', async function() {
+      const catschema = new Schema({
+        name: String,
+        colors: [{
+          hex: { type: String, default: '#ffffff' },
+          name: String
+        }]
+      });
+      const Cat = db.model('Test', catschema);
+
+      const cat = new Cat({});
+      cat.init({
+        name: 'Garfield',
+        colors: [{ name: 'Orange' }]
+      });
+
+      cat.colors.pull({ name: 'Orange' });
+      assert.deepStrictEqual(cat.colors.$__getAtomics(), [[
+        '$pull',
+        { $or: [{ name: 'Orange' }] }
+      ]]);
+    });
   });
 
   describe('$pop()', function() {

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -829,6 +829,9 @@ describe('types array', function() {
         colors: [{
           _id: false,
           hex: { type: String, default: '#ffffff' },
+          properties: {
+            hue: { type: Number, default: 0 }
+          },
           name: String
         }]
       });

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -822,6 +822,30 @@ describe('types array', function() {
         });
       });
     });
+
+    it('avoids adding default paths to query filter (gh-12294)', async function() {
+      const catschema = new Schema({
+        name: String,
+        colors: [{
+          _id: false,
+          hex: { type: String, default: '#ffffff' },
+          name: String
+        }]
+      });
+      const Cat = db.model('Test', catschema);
+
+      const cat = new Cat({});
+      cat.init({
+        name: 'Garfield',
+        colors: [{ name: 'Orange' }]
+      });
+
+      cat.colors.pull({ name: 'Orange' });
+      assert.deepStrictEqual(cat.colors.$__getAtomics(), [[
+        '$pull',
+        { $or: [{ name: 'Orange' }] }
+      ]]);
+    });
   });
 
   describe('$pop()', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The problem here is that `pull()` adds defaults to the query filter that is sent to MongoDB on `save()`, so it won't match documents that don't have the default set. This behavior is problematic because this may cause `save()` to start not pulling documents if the user adds a new property with a default to the schema.

We fix this by explicitly removing any fields that are set to `default` in the document.

```javascript
const catschema = new Schema({
  name: String,
  colors: [{
    _id: false,
    hex: { type: String, default: '#ffffff' },
    name: String
  }]
});
const Cat = db.model('Test', catschema);

const cat = new Cat({});
cat.init({
  name: 'Garfield',
  colors: [{ name: 'Orange' }]
});

cat.colors.pull({ name: 'Orange' });
// Sends `{ $pull: { colors: { $or: [{ name: 'Orange', hex: '#ffffff' }] } } }
await cat.save();
```

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
