### PR TITLE
test(model.test): move test inside suite

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8843,13 +8843,13 @@ describe('Model', function() {
     assert.equal(doc.foo, 'bar');
     assert.equal(doc.test, 'value');
   });
-});
 
-describe('Check if static function that is supplied in schema option is available', function() {
-  it('should give a static function back rather than undefined', function ModelJS() {
-    const testSchema = new mongoose.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
-    const TestModel = mongoose.model('TestModel', testSchema);
-    assert.equal(TestModel.staticFn(), 'Returned from staticFn');
+  describe('Check if static function that is supplied in schema option is available', function() {
+    it('should give a static function back rather than undefined', function() {
+      const testSchema = new db.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
+      const TestModel = db.model('TestModel', testSchema);
+      assert.equal(TestModel.staticFn(), 'Returned from staticFn');
+    });
   });
 });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8846,7 +8846,7 @@ describe('Model', function() {
 
   describe('Check if static function that is supplied in schema option is available', function() {
     it('should give a static function back rather than undefined', function() {
-      const testSchema = new db.Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
+      const testSchema = new Schema({}, { statics: { staticFn() { return 'Returned from staticFn'; } } });
       const TestModel = db.model('TestModel', testSchema);
       assert.equal(TestModel.staticFn(), 'Returned from staticFn');
     });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6213,7 +6213,6 @@ describe('Model', function() {
       });
     });
     describe('Model.syncIndexes()', () => {
-      afterEach(() => db.dropDatabase());
       it('adds indexes to the collection', async() => {
         // Arrange
         const collectionName = generateRandomCollectionName();


### PR DESCRIPTION
**Summary**

This PR moves a test inside the suite of the file and changes where the model gets registered in

this resolves the following error
```txt
  1) Check if static function that is supplied in schema option is available
       should give a static function back rather than undefined:
     OverwriteModelError: Cannot overwrite `TestModel` model once compiled.
      at Mongoose.model (file:///mnt/projects/nodejs/mongoose/lib/index.js:554:13)
      at Context.ModelJS (file:///mnt/projects/nodejs/mongoose/test/model.test.js:8851:32)
      at https://deno.land/std@0.154.0/node/timers.ts:21:21
      at Object.action (deno:ext/web/02_timers.js:148:13)
      at handleTimerMacrotask (deno:ext/web/02_timers.js:65:12)
```

encountered in https://github.com/Automattic/mongoose/pull/12397#issuecomment-1243519912

Edit:
this PR also includes a removal of a duplicate `afterEach -> drop database` hook (in mocha a `afterEach` hook runs after each `it`, even if it is nested - unlike jest IIRC)