### PR TITLE
fix(document): correct context for default functions in subdocuments with init

### DIFF
--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -170,7 +170,7 @@ SubdocumentPath.prototype.cast = function(val, doc, init, priorVal, options) {
   }, null);
   options = Object.assign({}, options, { priorDoc: priorVal });
   if (init) {
-    subdoc = new Constructor(void 0, selected, doc);
+    subdoc = new Constructor(void 0, selected, doc, false, { defaults: false });
     subdoc.$init(val);
   } else {
     if (Object.keys(val).length === 0) {

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -9,6 +9,7 @@ const EventEmitter = require('events').EventEmitter;
 const ObjectExpectedError = require('../error/objectExpected');
 const SchemaSubdocumentOptions = require('../options/SchemaSubdocumentOptions');
 const SchemaType = require('../schematype');
+const applyDefaults = require('../helpers/document/applyDefaults');
 const $exists = require('./operators/exists');
 const castToNumber = require('./operators/helpers').castToNumber;
 const discriminator = require('../helpers/model/discriminator');
@@ -172,6 +173,7 @@ SubdocumentPath.prototype.cast = function(val, doc, init, priorVal, options) {
   if (init) {
     subdoc = new Constructor(void 0, selected, doc, false, { defaults: false });
     subdoc.$init(val);
+    applyDefaults(subdoc, selected);
   } else {
     if (Object.keys(val).length === 0) {
       return new Constructor({}, selected, doc, undefined, options);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11833,6 +11833,28 @@ describe('document', function() {
 
     assert.ok(doc.nestedPath1.mapOfSchema);
   });
+
+  it('correct context for default functions in subdocuments with init (gh-12328)', async function() {
+    const subSchema = new mongoose.Schema({
+      propertyA: { type: String },
+      propertyB: { type: String, default: function() {
+        return this.propertyA;
+      } }
+    });
+
+    const testSchema = new mongoose.Schema(
+      {
+        name: String,
+        sub: { type: subSchema, default: () => ({}) }
+      }
+    );
+
+    const Test = db.model('Test', testSchema);
+
+    await Test.collection.insertOne({ name: 'test', sub: { propertyA: 'foo' } });
+    const doc = await Test.findOne({ name: 'test' });
+    assert.strictEqual(doc.sub.propertyB, 'foo');
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11835,11 +11835,17 @@ describe('document', function() {
   });
 
   it('correct context for default functions in subdocuments with init (gh-12328)', async function() {
+    let called = 0;
+
     const subSchema = new mongoose.Schema({
       propertyA: { type: String },
-      propertyB: { type: String, default: function() {
-        return this.propertyA;
-      } }
+      propertyB: {
+        type: String,
+        default: function() {
+          ++called;
+          return this.propertyA;
+        }
+      }
     });
 
     const testSchema = new mongoose.Schema(
@@ -11852,8 +11858,11 @@ describe('document', function() {
     const Test = db.model('Test', testSchema);
 
     await Test.collection.insertOne({ name: 'test', sub: { propertyA: 'foo' } });
+    assert.strictEqual(called, 0);
+
     const doc = await Test.findOne({ name: 'test' });
     assert.strictEqual(doc.sub.propertyB, 'foo');
+    assert.strictEqual(called, 1);
   });
 });
 


### PR DESCRIPTION
Fix #12328

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12328 pointed out that, when initializing a subdocument, we call default functions _before_ applying the initial property values. This is problematic for default functions.

Looks like easy fix: just skip applying defaults when creating the empty object, and let `init()` apply defaults.

Still one failing test case though that I need to fix, thought I had fixed it but guess not.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
