### PR TITLE
fix: allow null values inside $expr objects

### DIFF
--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -77,8 +77,8 @@ module.exports = function cast$expr(val, schema, strictQuery) {
 };
 
 function _castExpression(val, schema, strictQuery) {
-  if (isPath(val)) {
-    // Assume path
+  // Preserve the value if it represents a path or if it's null
+  if (isPath(val) || val === null) {
     return val;
   }
 


### PR DESCRIPTION
**Summary**

Version [6.2.0](https://github.com/Automattic/mongoose/releases/tag/6.2.0) introduced a feature which casts literals inside `$expr` queries to their respective types based on the models schema. This pull request fixes an issue with this feature where JS would throw a null-reference error when using `null` as a value inside `$ifNull` arrays in the expression. 

The implemented fix is non-intrusive an solely checks if the value which is to be cast is `null` and preserves the value if it is.

**Examples**

A common scenario is reproducing an `$exists` operator in an `$expr` using `$ifNull`. Let's say we want to fetch all books which don't have an `authorId` or where the `authorId` is `null`.
```.js
await bookModel.find({ $expr: { $eq: [ { $ifNull: [ "$authorId", null ] }, null ] } })
```
Executing this code will output the following error
```
TypeError: Cannot read properties of null (reading '$cond')
    at _castExpression (E:\project\node_modules\mongoose\lib\helpers\query\cast$expr.js:85:11)
    at E:\project\node_modules\mongoose\lib\helpers\query\cast$expr.js:94:26
    at Array.map (<anonymous>)
    at _castExpression (E:\project\node_modules\mongoose\lib\helpers\query\cast$expr.js:94:17)
    at castComparison (E:\project\node_modules\mongoose\lib\helpers\query\cast$expr.js:206:12)
    at _castExpression (E:\project\node_modules\mongoose\lib\helpers\query\cast$expr.js:105:18)
    at cast$expr (E:\project\node_modules\mongoose\lib\helpers\query\cast$expr.js:76:10)
    at cast (E:\project\node_modules\mongoose\lib\cast.js:87:13)
    at model.Query.Query.cast (E:\project\node_modules\mongoose\lib\query.js:5312:12)
    at model.Query.Query._castConditions (E:\project\node_modules\mongoose\lib\query.js:2198:10)
```