### PR TITLE
Fix dynamic virtual populate on sub-documents

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -355,114 +355,118 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
   const virtual = _virtualRes.virtual;
 
   for (const doc of docs) {
-    let modelNames = null;
-    const data = {};
+    // Use the correct target doc/sub-doc for dynamic ref on nested schema. See gh-12363
+    let subDocs = _virtualRes.nestedSchemaPath ?
+      utils.getValue(_virtualRes.nestedSchemaPath, doc) : doc;
+    subDocs = Array.isArray(subDocs) ? subDocs : subDocs ? [subDocs] : [];
+    for (const subDoc of subDocs) {
+      let modelNames = null;
+      const data = {};
 
-    // localField and foreignField
-    let localField;
-    const virtualPrefix = _virtualRes.nestedSchemaPath ?
-      _virtualRes.nestedSchemaPath + '.' : '';
-    if (typeof virtual.options.localField === 'function') {
-      localField = virtualPrefix + virtual.options.localField.call(doc, doc);
-    } else if (Array.isArray(virtual.options.localField)) {
-      localField = virtual.options.localField.map(field => virtualPrefix + field);
-    } else {
-      localField = virtualPrefix + virtual.options.localField;
-    }
-    data.count = virtual.options.count;
-
-    if (virtual.options.skip != null && !options.hasOwnProperty('skip')) {
-      options.skip = virtual.options.skip;
-    }
-    if (virtual.options.limit != null && !options.hasOwnProperty('limit')) {
-      options.limit = virtual.options.limit;
-    }
-    if (virtual.options.perDocumentLimit != null && !options.hasOwnProperty('perDocumentLimit')) {
-      options.perDocumentLimit = virtual.options.perDocumentLimit;
-    }
-    let foreignField = virtual.options.foreignField;
-
-    if (!localField || !foreignField) {
-      return new MongooseError('If you are populating a virtual, you must set the ' +
-        'localField and foreignField options');
-    }
-
-    if (typeof localField === 'function') {
-      localField = localField.call(doc, doc);
-    }
-    if (typeof foreignField === 'function') {
-      foreignField = foreignField.call(doc, doc);
-    }
-
-    data.isRefPath = false;
-
-    // `justOne = null` means we don't know from the schema whether the end
-    // result should be an array or a single doc. This can result from
-    // populating a POJO using `Model.populate()`
-    let justOne = null;
-    if ('justOne' in options && options.justOne !== void 0) {
-      justOne = options.justOne;
-    }
-
-    if (virtual.options.refPath) {
-      modelNames =
-        modelNamesFromRefPath(virtual.options.refPath, doc, options.path);
-      justOne = !!virtual.options.justOne;
-      data.isRefPath = true;
-    } else if (virtual.options.ref) {
-      let normalizedRef;
-      if (typeof virtual.options.ref === 'function' && !virtual.options.ref[modelSymbol]) {
-        normalizedRef = virtual.options.ref.call(doc, doc);
+      // localField and foreignField
+      let localField = virtual.options.localField;
+      const virtualPrefix = _virtualRes.nestedSchemaPath ?
+        _virtualRes.nestedSchemaPath + '.' : '';
+      if (typeof localField === 'function') {
+        localField = localField.call(subDoc, subDoc);
+      }
+      if (Array.isArray(localField)) {
+        localField = localField.map(field => virtualPrefix + field);
       } else {
-        normalizedRef = virtual.options.ref;
+        localField = virtualPrefix + localField;
       }
-      justOne = !!virtual.options.justOne;
-      // When referencing nested arrays, the ref should be an Array
-      // of modelNames.
-      if (Array.isArray(normalizedRef)) {
-        modelNames = normalizedRef;
-      } else {
-        modelNames = [normalizedRef];
+      data.count = virtual.options.count;
+
+      if (virtual.options.skip != null && !options.hasOwnProperty('skip')) {
+        options.skip = virtual.options.skip;
       }
-    }
+      if (virtual.options.limit != null && !options.hasOwnProperty('limit')) {
+        options.limit = virtual.options.limit;
+      }
+      if (virtual.options.perDocumentLimit != null && !options.hasOwnProperty('perDocumentLimit')) {
+        options.perDocumentLimit = virtual.options.perDocumentLimit;
+      }
+      let foreignField = virtual.options.foreignField;
 
-    data.isVirtual = true;
-    data.virtual = virtual;
-    data.justOne = justOne;
-
-    // `match`
-    let match = get(options, 'match', null) ||
-      get(data, 'virtual.options.match', null) ||
-      get(data, 'virtual.options.options.match', null);
-
-    let hasMatchFunction = typeof match === 'function';
-    if (hasMatchFunction) {
-      match = match.call(doc, doc);
-    }
-
-    if (Array.isArray(localField) && Array.isArray(foreignField) && localField.length === foreignField.length) {
-      match = Object.assign({}, match);
-      for (let i = 1; i < localField.length; ++i) {
-        match[foreignField[i]] = convertTo_id(mpath.get(localField[i], doc, lookupLocalFields), model.schema);
-        hasMatchFunction = true;
+      if (!localField || !foreignField) {
+        return new MongooseError('If you are populating a virtual, you must set the ' +
+          'localField and foreignField options');
       }
 
-      localField = localField[0];
-      foreignField = foreignField[0];
-    }
+      if (typeof foreignField === 'function') {
+        foreignField = foreignField.call(subDoc, subDoc);
+      }
 
-    data.localField = localField;
-    data.foreignField = foreignField;
-    data.match = match;
-    data.hasMatchFunction = hasMatchFunction;
+      data.isRefPath = false;
 
-    // Get local fields
-    const ret = _getLocalFieldValues(doc, localField, model, options, virtual);
+      // `justOne = null` means we don't know from the schema whether the end
+      // result should be an array or a single doc. This can result from
+      // populating a POJO using `Model.populate()`
+      let justOne = null;
+      if ('justOne' in options && options.justOne !== void 0) {
+        justOne = options.justOne;
+      }
 
-    try {
-      addModelNamesToMap(model, map, available, modelNames, options, data, ret, doc);
-    } catch (err) {
-      return err;
+      if (virtual.options.refPath) {
+        modelNames =
+          modelNamesFromRefPath(virtualPrefix + virtual.options.refPath, doc, options.path);
+        justOne = !!virtual.options.justOne;
+        data.isRefPath = true;
+      } else if (virtual.options.ref) {
+        let normalizedRef;
+        if (typeof virtual.options.ref === 'function' && !virtual.options.ref[modelSymbol]) {
+          normalizedRef = virtual.options.ref.call(subDoc, subDoc);
+        } else {
+          normalizedRef = virtual.options.ref;
+        }
+        justOne = !!virtual.options.justOne;
+        // When referencing nested arrays, the ref should be an Array
+        // of modelNames.
+        if (Array.isArray(normalizedRef)) {
+          modelNames = normalizedRef;
+        } else {
+          modelNames = [normalizedRef];
+        }
+      }
+
+      data.isVirtual = true;
+      data.virtual = virtual;
+      data.justOne = justOne;
+
+      // `match`
+      let match = get(options, 'match', null) ||
+        get(data, 'virtual.options.match', null) ||
+        get(data, 'virtual.options.options.match', null);
+
+      let hasMatchFunction = typeof match === 'function';
+      if (hasMatchFunction) {
+        match = match.call(subDoc, subDoc);
+      }
+
+      if (Array.isArray(localField) && Array.isArray(foreignField) && localField.length === foreignField.length) {
+        match = Object.assign({}, match);
+        for (let i = 1; i < localField.length; ++i) {
+          match[foreignField[i]] = convertTo_id(mpath.get(localField[i], doc, lookupLocalFields), model.schema);
+          hasMatchFunction = true;
+        }
+
+        localField = localField[0];
+        foreignField = foreignField[0];
+      }
+
+      data.localField = localField;
+      data.foreignField = foreignField;
+      data.match = match;
+      data.hasMatchFunction = hasMatchFunction;
+
+      // Get local fields
+      const ret = _getLocalFieldValues(doc, localField, model, options, virtual);
+
+      try {
+        addModelNamesToMap(model, map, available, modelNames, options, data, ret, doc);
+      } catch (err) {
+        return err;
+      }
     }
   }
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -10843,18 +10843,18 @@ describe('model: populate:', function() {
 
   describe('dynamic virtual populate on nested schema (gh-12363)', function() {
     const referredSchemaA = new Schema({
-      name: String,
+      name: String
     });
 
     const referredSchemaB = new Schema({
-      name: String,
+      name: String
     });
 
     const nestedSchema = new Schema({
       name: String,
       refType: String,
       refId: Schema.Types.ObjectId,
-      refName: String,
+      refName: String
     }, {
       virtuals: {
         dynRef: {
@@ -10862,7 +10862,7 @@ describe('model: populate:', function() {
             ref: doc => doc.refType,
             localField: 'refId',
             foreignField: '_id',
-            justOne: true,
+            justOne: true
           }
         },
         refPath: {
@@ -10870,7 +10870,7 @@ describe('model: populate:', function() {
             refPath: 'refType',
             localField: 'refId',
             foreignField: '_id',
-            justOne: true,
+            justOne: true
           }
         },
         dynRefFields: {
@@ -10878,7 +10878,7 @@ describe('model: populate:', function() {
             refPath: 'refType',
             localField: doc => doc.refName ? 'refName' : 'refId',
             foreignField: doc => doc.refName ? 'name' : '_id',
-            justOne: true,
+            justOne: true
           }
         },
         dynMatch: {
@@ -10887,15 +10887,15 @@ describe('model: populate:', function() {
             localField: 'refId',
             foreignField: '_id',
             match: doc => ({ name: doc.refName }),
-            justOne: true,
+            justOne: true
           }
         },
         dynRefMultiLocalField: {
           options: {
             ref: doc => doc.refType,
-            localField: doc => ['refName', 'refId'],
+            localField: () => ['refName', 'refId'],
             foreignField: ['name', '_id'],
-            justOne: true,
+            justOne: true
           }
         }
       }
@@ -10908,12 +10908,12 @@ describe('model: populate:', function() {
       const referredB1 = await ReferredB.create({ name: 'referredB1' });
 
       const NestedTest = db.model('NestedTest', new Schema({
-        nested: nestedSchema,
+        nested: nestedSchema
       }));
       const nestedTest1 = new NestedTest({
         nested: {
           refType: 'ReferredA',
-          refId: referredA1._id,
+          refId: referredA1._id
         }
       });
       await nestedTest1.populate('nested.dynRef');
@@ -10927,7 +10927,7 @@ describe('model: populate:', function() {
         nested: {
           refType: 'ReferredB',
           refId: referredB1._id,
-          refName: referredB1.name,
+          refName: referredB1.name
         }
       });
       await nestedTest2.populate(['nested.dynRef', 'nested.refPath', 'nested.dynMatch', 'nested.dynRefMultiLocalField']);
@@ -10938,7 +10938,7 @@ describe('model: populate:', function() {
 
       const nestedTest3 = new NestedTest({});
       await nestedTest3.populate('nested.dynRef');
-      assert.equal(nestedTest3.nested?.dynRef, undefined);
+      assert.equal(nestedTest3.nested, undefined);
     });
 
     it('populate virtual on sub-document array', async function() {
@@ -10948,25 +10948,25 @@ describe('model: populate:', function() {
       const referredB1 = await ReferredB.create({ name: 'referredB1' });
 
       const NestedTest = db.model('NestedTest', new Schema({
-        nested: [nestedSchema],
+        nested: [nestedSchema]
       }));
       const nestedTest1 = new NestedTest({
         nested: [{
           refType: 'ReferredA',
-          refId: referredA1._id,
+          refId: referredA1._id
         }, {
           refType: 'ReferredA',
           refId: referredA1._id,
-          refName: referredA1.name,
+          refName: referredA1.name
         }, {
           refType: 'ReferredB',
           refId: referredB1._id,
-          refName: referredB1.name,
+          refName: referredB1.name
         }]
       });
       await nestedTest1.populate([
         'nested.dynRef',
-        'nested.refPath',
+        'nested.refPath'
       ]);
       assert.equal(nestedTest1.nested[0].dynRef.name, referredA1.name);
       assert.equal(nestedTest1.nested[0].refPath.name, referredA1.name);
@@ -10985,32 +10985,32 @@ describe('model: populate:', function() {
 
       const NestedTest = db.model('NestedTest', new Schema({
         nested1: [new Schema({
-          nested2: nestedSchema,
-        })],
+          nested2: nestedSchema
+        })]
       }));
       const nestedTest1 = new NestedTest({
         nested1: [{
           nested2: {
             refType: 'ReferredA',
-            refId: referredA1._id,
+            refId: referredA1._id
           }
         }, {
           nested2: {
             refType: 'ReferredA',
             refId: referredA2._id,
-            refName: referredA2.name,
+            refName: referredA2.name
           }
         }, {
           nested2: {
             refType: 'ReferredB',
             refId: referredB1._id,
-            refName: referredB1.name,
+            refName: referredB1.name
           }
         }]
       });
       await nestedTest1.populate([
         'nested1.nested2.dynRef',
-        'nested1.nested2.refPath',
+        'nested1.nested2.refPath'
       ]);
       assert.equal(nestedTest1.nested1[0].nested2.dynRef.name, referredA1.name);
       assert.equal(nestedTest1.nested1[0].nested2.refPath.name, referredA1.name);


### PR DESCRIPTION
Fix #12363

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
Apply dynamic ref getter of virtual population on sub-documents instead of the parent document.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Mongoose supports dynamic virtual populate via `ref` and `refPath` options. However, the `ref` function is called on the parent document, and `refPath` is relative to the parent document. It does not make much sense for dynamic virtual populates defined on nested schemas, because the child schema has no knowledge of the parent schema.

After this patch, `ref` is called on sub-document, and `refPath` is relative to sub-document instead of the parent document.