### PR TITLE
Add clarification about overwrite flag in model.js

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2558,7 +2558,7 @@ Model.$where = function $where() {
  *     Model.findOneAndUpdate(query, { $set: { name: 'jason bourne' }}, options, callback)
  *
  * This helps prevent accidentally overwriting your document with `{ name: 'jason bourne' }`.
- * To prevent this behaviour, see the `overwrite` flag
+ * To prevent this behaviour, see the `overwrite` option
  *
  * #### Note:
  *

--- a/lib/model.js
+++ b/lib/model.js
@@ -2691,7 +2691,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  *     Model.findByIdAndUpdate(id, { $set: { name: 'jason bourne' }}, options, callback)
  *
  * This helps prevent accidentally overwriting your document with `{ name: 'jason bourne' }`.
- * To prevent this behaviour, see the `overwrite` flag
+ * To prevent this behaviour, see the `overwrite` option
  *
  * #### Note:
  *

--- a/lib/model.js
+++ b/lib/model.js
@@ -2558,6 +2558,7 @@ Model.$where = function $where() {
  *     Model.findOneAndUpdate(query, { $set: { name: 'jason bourne' }}, options, callback)
  *
  * This helps prevent accidentally overwriting your document with `{ name: 'jason bourne' }`.
+ * To prevent this behaviour, see the `overwrite` flag
  *
  * #### Note:
  *
@@ -2690,6 +2691,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  *     Model.findByIdAndUpdate(id, { $set: { name: 'jason bourne' }}, options, callback)
  *
  * This helps prevent accidentally overwriting your document with `{ name: 'jason bourne' }`.
+ * To prevent this behaviour, see the `overwrite` flag
  *
  * #### Note:
  *


### PR DESCRIPTION
Add calrification for using the `overwrite` flag in model.findByIdAndUpdate and model.findOneAndUpdate

**Summary**

The way mongoose changes the update behaviour (adds `$set` to the update command) and how to prevent it is not intirely clear.
I believe this note could help save some time and effort for future users.
