### PR TITLE
fix(model): avoid deleting shared schema methods in fix for #12254

### DIFF
--- a/lib/helpers/model/applyMethods.js
+++ b/lib/helpers/model/applyMethods.js
@@ -12,6 +12,8 @@ const utils = require('../../utils');
  */
 
 module.exports = function applyMethods(model, schema) {
+  const Model = require('../../model');
+
   function apply(method, schema) {
     Object.defineProperty(model.prototype, method, {
       get: function() {
@@ -34,7 +36,8 @@ module.exports = function applyMethods(model, schema) {
     // Avoid making custom methods if user sets a method to itself, e.g.
     // `schema.method(save, Document.prototype.save)`. Can happen when
     // calling `loadClass()` with a class that `extends Document`. See gh-12254
-    if (typeof fn === 'function' && model.prototype[method] === fn) {
+    if (typeof fn === 'function' &&
+        Model.prototype[method] === fn) {
       delete schema.methods[method];
       continue;
     }


### PR DESCRIPTION
Fix #12423

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In #12423 it looks like we now delete shared schema methods, which is definitely unintentional. We should only delete schema methods that exactly match methods on the Mongoose `Model` class prototype.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
