### PR TITLE
test(types-plugin): reproduce #12454

### DIFF
--- a/test/types/plugin.test.ts
+++ b/test/types/plugin.test.ts
@@ -38,6 +38,12 @@ function pluginStatics(schema: Schema<Test, TestModel, any, TestQueryHelpers, an
   });
 }
 
+function pluginGeneric(schema: Schema): void {
+  schema.static('test', function() {
+    return 0;
+  });
+}
+
 type Test = { firstName: string; lastName: string };
 type TestVirtuals = {
   fullName: string;
@@ -63,6 +69,7 @@ testSchema.plugin(pluginVirtuals);
 testSchema.plugin(pluginQueryHelpers);
 testSchema.plugin(pluginMethods);
 testSchema.plugin(pluginStatics);
+testSchema.plugin(pluginGeneric);
 
 const Foo = connection.model<Test, TestModel, TestQueryHelpers>('Test', testSchema);
 


### PR DESCRIPTION
**Summary**

Add a types test case for #12454

Error:
```txt
  test/types/plugin.test.ts:72:18
  ✖  72:18  Argument of type (schema: Schema<any, Model<any, any, any, any, any>, {}, {}, {}, {}, "type", { [x: string]: any; }>) => void is not assignable to parameter of type PluginFunction<Test, TestModel, TestInstanceMethods, TestQueryHelpers, TestVirtuals, TestStaticMethods>.
  Types of parameters schema and schema are incompatible.
    Type Schema<Test, TestModel, TestInstanceMethods, TestQueryHelpers, TestVirtuals, TestStaticMethods, "type", Test> is not assignable to type Schema<any, Model<any, any, any, any, any>, {}, {}, {}, {}, "type", { [x: string]: any; }>.
      The types returned by discriminator(...) are incompatible between these types.
        Type Schema<Omit<Test, never>, unknown, unknown, unknown, unknown, {}, "type", Omit<Test, never>> | Schema<Test, TestModel, TestInstanceMethods, ... 4 more ..., Test> is not assignable to type Schema<{ [x: string]: any; }, Model<any, any, any, any, any>, {}, {}, {}, {}, "type", { [x: string]: any; }> | Schema<Omit<{ [x: string]: any; }, never>, unknown, unknown, unknown, unknown, {}, "type", Omit<...>>.
          Type Schema<Test, TestModel, TestInstanceMethods, TestQueryHelpers, TestVirtuals, {}, "type", Test> is not assignable to type Schema<{ [x: string]: any; }, Model<any, any, any, any, any>, {}, {}, {}, {}, "type", { [x: string]: any; }> | Schema<Omit<{ [x: string]: any; }, never>, unknown, unknown, unknown, unknown, {}, "type", Omit<...>>.
            Type Schema<Test, TestModel, TestInstanceMethods, TestQueryHelpers, TestVirtuals, {}, "type", Test> is not assignable to type Schema<{ [x: string]: any; }, Model<any, any, any, any, any>, {}, {}, {}, {}, "type", { [x: string]: any; }>.
              Types of property statics are incompatible.
                Type {} & { [name: string]: (this: TestModel, ...args: any[]) => any; } is not assignable to type {} & { [name: string]: (this: Model<any, any, any, any, any>, ...args: any[]) => any; }.
                  Type {} & { [name: string]: (this: TestModel, ...args: any[]) => any; } is not assignable to type { [name: string]: (this: Model<any, any, any, any, any>, ...args: any[]) => any; }.
                    string index signatures are incompatible.
                      Type (this: TestModel, ...args: any[]) => any is not assignable to type (this: Model<any, any, any, any, any>, ...args: any[]) => any.
                        The this types of each signature are incompatible.
                          Type Model<any, any, any, any, any> is not assignable to type TestModel.  

  1 error
```

Currently a DRAFT, because the types error and i cannot get it fixed (see #12457 and #12455)