### PR TITLE
fix(types): remove unused defaults in "PluginFunction"

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -158,11 +158,11 @@ declare module 'mongoose' {
 
   type PluginFunction<
     DocType,
-    M = Model<DocType, any, any, any>,
-    TInstanceMethods = {},
-    TQueryHelpers = {},
-    TVirtuals = {},
-    TStaticMethods = {}> = (schema: Schema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods>, opts?: any) => void;
+    M,
+    TInstanceMethods,
+    TQueryHelpers,
+    TVirtuals,
+    TStaticMethods> = (schema: Schema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods>, opts?: any) => void;
 
   export class Schema<
     EnforcedDocType = any,


### PR DESCRIPTION
**Summary**

Remove default from helper type `PluginFunction`, these default are unnecessary because all values are passed-through from where the helper type is used and so they go always unused

i already did a ts-benchmark, but nothing changed (`Instantiations` are the same as master and this branch, and time is within margin of error)