### PR TITLE
feat(index): add ability to set multiple options at once in ".set"

### DIFF
--- a/lib/error/setOptionError.js
+++ b/lib/error/setOptionError.js
@@ -5,8 +5,8 @@
 'use strict';
 
 const MongooseError = require('./mongooseError');
-// const getConstructorName = require('../helpers/getConstructorName');
 const util = require('util');
+const combinePathErrors = require('../helpers/error/combinePathErrors');
 
 class SetOptionError extends MongooseError {
   /**
@@ -25,7 +25,7 @@ class SetOptionError extends MongooseError {
    * Console.log helper
    */
   toString() {
-    return _generateMessage(this);
+    return combinePathErrors(this);
   }
 
   /**
@@ -53,7 +53,7 @@ class SetOptionError extends MongooseError {
     }
 
     this.errors[key] = error;
-    this.message = _generateMessage(this);
+    this.message = combinePathErrors(this);
   }
 }
 
@@ -81,27 +81,6 @@ Object.defineProperty(SetOptionError.prototype, 'toJSON', {
 Object.defineProperty(SetOptionError.prototype, 'name', {
   value: 'SetOptionError'
 });
-
-/*!
- * ignore
- */
-
-function _generateMessage(err) {
-  const keys = Object.keys(err.errors || {});
-  const len = keys.length;
-  const msgs = [];
-  let key;
-
-  for (let i = 0; i < len; ++i) {
-    key = keys[i];
-    if (err === err.errors[key]) {
-      continue;
-    }
-    msgs.push(key + ': ' + err.errors[key].message);
-  }
-
-  return msgs.join(', ');
-}
 
 class SetOptionInnerError extends MongooseError {
   /**

--- a/lib/error/setOptionError.js
+++ b/lib/error/setOptionError.js
@@ -1,0 +1,122 @@
+/*!
+ * Module requirements
+ */
+
+'use strict';
+
+const MongooseError = require('./mongooseError');
+// const getConstructorName = require('../helpers/getConstructorName');
+const util = require('util');
+
+class SetOptionError extends MongooseError {
+  /**
+   * Mongoose.set Error
+   *
+   * @api private
+   * @inherits MongooseError
+   */
+  constructor() {
+    super('');
+
+    this.errors = {};
+  }
+
+  /**
+   * Console.log helper
+   */
+  toString() {
+    return _generateMessage(this);
+  }
+
+  /**
+   * inspect helper
+   * @api private
+   */
+  inspect() {
+    return Object.assign(new Error(this.message), this);
+  }
+
+  /**
+  * add message
+  * @param {String} key
+  * @param {String|Error} error
+  * @api private
+  */
+  addError(key, error) {
+    if (error instanceof SetOptionError) {
+      const { errors } = error;
+      for (const optionKey of Object.keys(errors)) {
+        this.addError(optionKey, errors[optionKey]);
+      }
+
+      return;
+    }
+
+    this.errors[key] = error;
+    this.message = _generateMessage(this);
+  }
+}
+
+
+if (util.inspect.custom) {
+  // Avoid Node deprecation warning DEP0079
+  SetOptionError.prototype[util.inspect.custom] = SetOptionError.prototype.inspect;
+}
+
+/**
+ * Helper for JSON.stringify
+ * Ensure `name` and `message` show up in toJSON output re: gh-9847
+ * @api private
+ */
+Object.defineProperty(SetOptionError.prototype, 'toJSON', {
+  enumerable: false,
+  writable: false,
+  configurable: true,
+  value: function() {
+    return Object.assign({}, this, { name: this.name, message: this.message });
+  }
+});
+
+
+Object.defineProperty(SetOptionError.prototype, 'name', {
+  value: 'SetOptionError'
+});
+
+/*!
+ * ignore
+ */
+
+function _generateMessage(err) {
+  const keys = Object.keys(err.errors || {});
+  const len = keys.length;
+  const msgs = [];
+  let key;
+
+  for (let i = 0; i < len; ++i) {
+    key = keys[i];
+    if (err === err.errors[key]) {
+      continue;
+    }
+    msgs.push(key + ': ' + err.errors[key].message);
+  }
+
+  return msgs.join(', ');
+}
+
+class SetOptionInnerError extends MongooseError {
+  /**
+   * Error for the "errors" array in "SetOptionError" with consistent message
+   * @param {String} key
+   */
+  constructor(key) {
+    super(`"${key}" is not a valid option to set`);
+  }
+}
+
+SetOptionError.SetOptionInnerError = SetOptionInnerError;
+
+/*!
+ * Module exports
+ */
+
+module.exports = SetOptionError;

--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -7,6 +7,7 @@
 const MongooseError = require('./mongooseError');
 const getConstructorName = require('../helpers/getConstructorName');
 const util = require('util');
+const combinePathErrors = require('../helpers/error/combinePathErrors');
 
 class ValidationError extends MongooseError {
   /**
@@ -38,7 +39,7 @@ class ValidationError extends MongooseError {
    * Console.log helper
    */
   toString() {
-    return this.name + ': ' + _generateMessage(this);
+    return this.name + ': ' + combinePathErrors(this);
   }
 
   /**
@@ -66,7 +67,7 @@ class ValidationError extends MongooseError {
     }
 
     this.errors[path] = error;
-    this.message = this._message + ': ' + _generateMessage(this);
+    this.message = this._message + ': ' + combinePathErrors(this);
   }
 }
 
@@ -94,27 +95,6 @@ Object.defineProperty(ValidationError.prototype, 'toJSON', {
 Object.defineProperty(ValidationError.prototype, 'name', {
   value: 'ValidationError'
 });
-
-/*!
- * ignore
- */
-
-function _generateMessage(err) {
-  const keys = Object.keys(err.errors || {});
-  const len = keys.length;
-  const msgs = [];
-  let key;
-
-  for (let i = 0; i < len; ++i) {
-    key = keys[i];
-    if (err === err.errors[key]) {
-      continue;
-    }
-    msgs.push(key + ': ' + err.errors[key].message);
-  }
-
-  return msgs.join(', ');
-}
 
 /*!
  * Module exports

--- a/lib/helpers/error/combinePathErrors.js
+++ b/lib/helpers/error/combinePathErrors.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/*!
+ * ignore
+ */
+
+module.exports = function combinePathErrors(err) {
+  const keys = Object.keys(err.errors || {});
+  const len = keys.length;
+  const msgs = [];
+  let key;
+
+  for (let i = 0; i < len; ++i) {
+    key = keys[i];
+    if (err === err.errors[key]) {
+      continue;
+    }
+    msgs.push(key + ': ' + err.errors[key].message);
+  }
+
+  return msgs.join(', ');
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,6 +228,10 @@ Mongoose.prototype.set = function(key, value) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
   if (arguments.length === 1 && typeof key !== 'object') {
+    if (VALID_OPTIONS.indexOf(key) === -1) {
+      throw new Error(`\`${key}\` is an invalid option.`);
+    }
+
     return _mongoose.options[key];
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ const trusted = require('./helpers/query/trusted').trusted;
 const sanitizeFilter = require('./helpers/query/sanitizeFilter');
 const isBsonType = require('./helpers/isBsonType');
 const MongooseError = require('./error/mongooseError');
+const SetOptionError = require('./error/setOptionError');
 
 const defaultMongooseSymbol = Symbol.for('mongoose:default');
 
@@ -229,7 +230,9 @@ Mongoose.prototype.set = function(key, value) {
 
   if (arguments.length === 1 && typeof key !== 'object') {
     if (VALID_OPTIONS.indexOf(key) === -1) {
-      throw new Error(`\`${key}\` is an invalid option.`);
+      const error = new SetOptionError();
+      error.addError(key, new SetOptionError.SetOptionInnerError(key));
+      throw error;
     }
 
     return _mongoose.options[key];
@@ -246,11 +249,14 @@ Mongoose.prototype.set = function(key, value) {
   }
 
   // array for errors to collect all errors for all key-value pairs, like ".validate"
-  const errors = [];
+  let error = undefined;
 
   for (const [optionKey, optionValue] of Object.entries(options)) {
     if (VALID_OPTIONS.indexOf(optionKey) === -1) {
-      errors.push(new Error(`\`${optionKey}\` is an invalid option.`));
+      if (!error) {
+        error = new SetOptionError();
+      }
+      error.addError(optionKey, new SetOptionError.SetOptionInnerError(optionKey));
       continue;
     }
 
@@ -271,12 +277,8 @@ Mongoose.prototype.set = function(key, value) {
     }
   }
 
-  if (errors.length) {
-    // this is to keep backwards-compat
-    if (errors.length === 1) {
-      throw errors[0];
-    }
-    throw errors;
+  if (error) {
+    throw error;
   }
 
   return _mongoose;

--- a/lib/index.js
+++ b/lib/index.js
@@ -182,6 +182,9 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
 /**
  * Sets mongoose options
  *
+ * `key` can be used a object to set multiple options at once.
+ * If a error gets thrown for one option, other options will still be evaluated.
+ *
  * #### Example:
  *
  *     mongoose.set('test', value) // sets the 'test' option to `value`
@@ -189,6 +192,8 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
  *     mongoose.set('debug', true) // enable logging collection methods + arguments to the console/file
  *
  *     mongoose.set('debug', function(collectionName, methodName, ...methodArgs) {}); // use custom function to log collection methods + arguments
+ *
+ *     mongoose.set({ debug: true, autoIndex: false }); // set multiple options at once
  *
  * Currently supported options are:
  * - 'applyPluginsToChildSchemas': `true` by default. Set to false to skip applying global plugins to child schemas
@@ -213,36 +218,61 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
  * - 'toJSON': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toJSON()`](/docs/api.html#document_Document-toJSON), for determining how Mongoose documents get serialized by `JSON.stringify()`
  * - 'toObject': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toObject()`](/docs/api.html#document_Document-toObject)
  *
- * @param {String} key
- * @param {String|Function|Boolean} value
+ * @param {String|Object} key The name of the option or a object of multiple key-value pairs
+ * @param {String|Function|Boolean} value The value of the option, unused if "key" is a object
+ * @returns {Mongoose} The used Mongoose instnace
  * @api public
  */
 
 Mongoose.prototype.set = function(key, value) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
-  if (VALID_OPTIONS.indexOf(key) === -1) {
-    throw new Error(`\`${key}\` is an invalid option.`);
-  }
-
-  if (arguments.length === 1) {
+  if (arguments.length === 1 && typeof key !== 'object') {
     return _mongoose.options[key];
   }
 
-  _mongoose.options[key] = value;
+  let options = {};
 
-  if (key === 'objectIdGetter') {
-    if (value) {
-      Object.defineProperty(mongoose.Types.ObjectId.prototype, '_id', {
-        enumerable: false,
-        configurable: true,
-        get: function() {
-          return this;
-        }
-      });
-    } else {
-      delete mongoose.Types.ObjectId.prototype._id;
+  if (arguments.length === 2) {
+    options = { [key]: value };
+  }
+
+  if (arguments.length === 1 && typeof key === 'object') {
+    options = key;
+  }
+
+  // array for errors to collect all errors for all key-value pairs, like ".validate"
+  const errors = [];
+
+  for (const [k, v] of Object.entries(options)) {
+    if (VALID_OPTIONS.indexOf(k) === -1) {
+      errors.push(new Error(`\`${k}\` is an invalid option.`));
+      continue;
     }
+
+    _mongoose.options[k] = v;
+
+    if (k === 'objectIdGetter') {
+      if (v) {
+        Object.defineProperty(mongoose.Types.ObjectId.prototype, '_id', {
+          enumerable: false,
+          configurable: true,
+          get: function() {
+            return this;
+          }
+        });
+      } else {
+        delete mongoose.Types.ObjectId.prototype._id;
+      }
+    }
+  }
+
+  if (errors.length) {
+    // this is to keep backwards-compat
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    throw errors;
   }
 
   return _mongoose;

--- a/lib/index.js
+++ b/lib/index.js
@@ -248,16 +248,16 @@ Mongoose.prototype.set = function(key, value) {
   // array for errors to collect all errors for all key-value pairs, like ".validate"
   const errors = [];
 
-  for (const [k, v] of Object.entries(options)) {
-    if (VALID_OPTIONS.indexOf(k) === -1) {
-      errors.push(new Error(`\`${k}\` is an invalid option.`));
+  for (const [optionKey, optionValue] of Object.entries(options)) {
+    if (VALID_OPTIONS.indexOf(optionKey) === -1) {
+      errors.push(new Error(`\`${optionKey}\` is an invalid option.`));
       continue;
     }
 
-    _mongoose.options[k] = v;
+    _mongoose.options[optionKey] = optionValue;
 
-    if (k === 'objectIdGetter') {
-      if (v) {
+    if (optionKey === 'objectIdGetter') {
+      if (optionValue) {
         Object.defineProperty(mongoose.Types.ObjectId.prototype, '_id', {
           enumerable: false,
           configurable: true,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1168,5 +1168,15 @@ describe('mongoose module:', function() {
         assert.strictEqual(m.options['debug'], true);
       }
     });
+
+    it('should throw a single error when using a invalid key when getting', function() {
+      try {
+        m.set('invalid');
+        assert.fail('Expected .set to throw');
+      } catch (err) {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, '`invalid` is an invalid option.');
+      }
+    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1102,4 +1102,71 @@ describe('mongoose module:', function() {
       assert.equal(entry.id, undefined);
     });
   });
+
+  describe('set()', function() {
+    let m;
+
+    beforeEach(() => {
+      m = new mongoose.Mongoose();
+    });
+
+    it('should be able to set a option through set with (key, value)', function() {
+      // also test the getter behavior of the function
+      assert.strictEqual(m.options['debug'], undefined);
+      assert.strictEqual(m.set('debug'), undefined);
+      m.set('debug', true);
+
+      assert.strictEqual(m.options['debug'], true);
+      assert.strictEqual(m.set('debug'), true);
+    });
+
+    it('should be able to set a option through a object with {key: value}', function() {
+      assert.strictEqual(m.options['debug'], undefined);
+      m.set({ debug: true });
+
+      assert.strictEqual(m.options['debug'], true);
+    });
+
+    it('should throw a single error when using a invalid key', function() {
+      try {
+        m.set('invalid', true);
+        assert.fail('Expected .set to throw');
+      } catch (err) {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, '`invalid` is an invalid option.');
+      }
+    });
+
+    it('should throw a a array of errors when using multiple invalid keys', function() {
+      try {
+        m.set({
+          invalid1: true,
+          invalid2: true
+        });
+        assert.fail('Expected .set to throw');
+      } catch (err) {
+        assert.ok(err instanceof Array);
+        assert.strictEqual(err.length, 2);
+        assert.ok(err[0] instanceof Error);
+        assert.strictEqual(err[0].message, '`invalid1` is an invalid option.');
+        assert.ok(err[1] instanceof Error);
+        assert.strictEqual(err[1].message, '`invalid2` is an invalid option.');
+      }
+    });
+
+    it('should apply all values, even if there are errors', function() {
+      assert.strictEqual(m.options['debug'], undefined);
+      try {
+        m.set({
+          invalid: true,
+          debug: true
+        });
+        assert.fail('Expected .set to throw');
+      } catch (err) {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, '`invalid` is an invalid option.');
+        assert.strictEqual(m.options['debug'], true);
+      }
+    });
+  });
 });

--- a/test/types/base.test.ts
+++ b/test/types/base.test.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import { expectType } from 'tsd';
+import { expectError, expectType } from 'tsd';
 
 Object.values(mongoose.models).forEach(model => {
   model.modelName;
@@ -50,4 +50,13 @@ function gh10139() {
 function gh12100() {
   mongoose.syncIndexes({ continueOnError: true, noResponse: true });
   mongoose.syncIndexes({ continueOnError: false, noResponse: true });
+}
+
+function setAsObject() {
+  mongoose.set({
+    debug: true,
+    autoIndex: false
+  });
+
+  expectError(mongoose.set({ invalid: true }));
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,6 +103,7 @@ declare module 'mongoose' {
 
   /** Sets mongoose options */
   export function set<K extends keyof MongooseOptions>(key: K, value: MongooseOptions[K]): Mongoose;
+  export function set(options: { [K in keyof MongooseOptions]: MongooseOptions[K] }): Mongoose;
 
   /** The Mongoose version */
   export const version: string;


### PR DESCRIPTION
**Summary**

This PR adds the ability to set multiple options at once for `mongoose.set`

behavior is:
- if `key` is not a `object` and no `value` is given, return the option (like before)
- if `key` is not a `object` and `value` is given, convert them to a `{ key: value }` object
- if `key` is a `object`, ignore `value` and use that object
- if there is a error for a specific option, collect the error and evaluate all other options
- if there is only `1` error, throw that error (to keep backwards compat)
- if there are multiple errors, throw the whole array of errors

fixes #10438