### PR TITLE
fix(types): infer number enum types from schema if using `enum: [0, 1] as const`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -741,3 +741,14 @@ function pluginOptions() {
   schema.plugin<any, SomePluginOptions>(pluginFunction2, { option2: 0 });
   expectError(schema.plugin<any, SomePluginOptions>(pluginFunction2, {})); // should error because "option2" is not optional
 }
+
+function gh12242() {
+  const dbExample = new Schema(
+    {
+      active: { type: Number, enum: [0, 1] as const, required: true }
+    }
+  );
+
+  type Example = InferSchemaType<typeof dbExample>;
+  expectType<0 | 1>({} as Example['active']);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -156,7 +156,7 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
   PathValueType extends Schema ? InferSchemaType<PathValueType> :
     PathValueType extends (infer Item)[] ? IfEquals<Item, never, any[], Item extends Schema ? Types.DocumentArray<ResolvePathType<Item>> : ResolvePathType<Item>[]> :
       PathValueType extends StringSchemaDefinition ? PathEnumOrString<Options['enum']> :
-        PathValueType extends NumberSchemaDefinition ? number :
+        PathValueType extends NumberSchemaDefinition ? Options['enum'] extends ReadonlyArray<any> ? Options['enum'][number] : number :
           PathValueType extends DateSchemaDefinition ? Date :
             PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
               PathValueType extends BooleanSchemaDefinition ? boolean :


### PR DESCRIPTION
Fix #12242

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12242 shows that we can do a better job of inferring enum types for numbers, like how we infer enums from strings. You do need to use `as const` as @hasezoey pointed out, but otherwise this approach seems to work.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
