### PR TITLE
fix(types): add HydratedDocumentFromSchema to make it easier to pull inferred hydrated doc type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
       "rules": {
         "@typescript-eslint/triple-slash-reference": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-empty-function": "off",
         "spaced-comment": [
           "error",
           "always",

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -9,6 +9,7 @@ import {
   UpdateQuery,
   CallbackError,
   HydratedDocument,
+  HydratedDocumentFromSchema,
   LeanDocument,
   Query,
   UpdateWriteOpResult
@@ -493,4 +494,29 @@ async function gh12347() {
 
   const replaceOneResult = await User.replaceOne({}, {});
   expectType<UpdateWriteOpResult>(replaceOneResult);
+}
+
+async function gh12319() {
+  const projectSchema = new Schema(
+    {
+      name: {
+        type: String,
+        required: true
+      }
+    },
+    {
+      methods: {
+        async doSomething() {
+        }
+      }
+    }
+  );
+
+  const ProjectModel = model('Project', projectSchema);
+
+  type ProjectModelHydratedDoc = HydratedDocumentFromSchema<
+    typeof projectSchema
+  >;
+
+  expectType<ProjectModelHydratedDoc>(await ProjectModel.findOne().orFail());
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -118,6 +118,12 @@ declare module 'mongoose' {
 
   export type HydratedDocument<DocType, TMethodsAndOverrides = {}, TVirtuals = {}> = DocType extends Document ? Require_id<DocType> : (Document<unknown, any, DocType> & Require_id<DocType> & TVirtuals & TMethodsAndOverrides);
 
+  export type HydratedDocumentFromSchema<TSchema extends Schema> = HydratedDocument<
+  InferSchemaType<TSchema>,
+  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
+  ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>
+  >;
+
   export interface TagSet {
     [k: string]: string;
   }


### PR DESCRIPTION
Fix #12319

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12319 correctly pointed out that it is clunky to pull the hydrated document type from an inferred schema. This PR adds a helper `HydratedDocumentFromSchema` that helps make that cleaner.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
