### PR TITLE
style: add names to previously anonymous plugin functions

### DIFF
--- a/lib/plugins/removeSubdocs.js
+++ b/lib/plugins/removeSubdocs.js
@@ -6,7 +6,7 @@ const each = require('../helpers/each');
  * ignore
  */
 
-module.exports = function(schema) {
+module.exports = function removeSubdocs(schema) {
   const unshift = true;
   schema.s.hooks.pre('remove', false, function(next) {
     if (this.$isSubdocument) {

--- a/lib/plugins/saveSubdocs.js
+++ b/lib/plugins/saveSubdocs.js
@@ -6,7 +6,7 @@ const each = require('../helpers/each');
  * ignore
  */
 
-module.exports = function(schema) {
+module.exports = function saveSubdocs(schema) {
   const unshift = true;
   schema.s.hooks.pre('save', false, function(next) {
     if (this.$isSubdocument) {

--- a/lib/plugins/validateBeforeSave.js
+++ b/lib/plugins/validateBeforeSave.js
@@ -4,7 +4,7 @@
  * ignore
  */
 
-module.exports = function(schema) {
+module.exports = function validateBeforeSave(schema) {
   const unshift = true;
   schema.pre('save', false, function validateBeforeSave(next, options) {
     const _this = this;


### PR DESCRIPTION
**Summary**

This PR adds names to previously `anonymous` plugin functions, which could be logged with `schema.plugins`, this should make it easier to debug if there should ever be the need (and for users to actually see what it is doing instead of a unhelpful `anonymous`)