### PR TITLE
fix(types): update SchemaTypeOptions.index to use "IndexDirection"

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -89,6 +89,16 @@ movieSchema.index({ tile: 'ascending' });
 movieSchema.index({ tile: 'asc' });
 movieSchema.index({ tile: 'descending' });
 movieSchema.index({ tile: 'desc' });
+movieSchema.index({ tile: 'hashed' });
+movieSchema.index({ tile: 'geoHaystack' });
+
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: 2 }); // test invalid number
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: -2 }); // test invalid number
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: '' }); // test empty string
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: 'invalid' }); // test invalid string
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: new Date() }); // test invalid type
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: true }); // test that booleans are not allowed
+expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: false }); // test that booleans are not allowed
 
 // Using `SchemaDefinition`
 interface IProfile {

--- a/test/types/schemaTypeOptions.test.ts
+++ b/test/types/schemaTypeOptions.test.ts
@@ -14,7 +14,7 @@ import {
   ObjectIdSchemaDefinition,
   StringSchemaDefinition
 } from 'mongoose';
-import { expectType } from 'tsd';
+import { expectError, expectType } from 'tsd';
 
 (new SchemaTypeOptions<boolean>()) instanceof SchemaTypeOptions;
 
@@ -31,3 +31,25 @@ expectType<AnyArray<StringSchemaDefinition> | AnyArray<SchemaTypeOptions<string>
 expectType<AnyArray<NumberSchemaDefinition> | AnyArray<SchemaTypeOptions<number>> | undefined>(new SchemaTypeOptions<number[]>().type);
 expectType<AnyArray<BooleanSchemaDefinition> | AnyArray<SchemaTypeOptions<boolean>> | undefined>(new SchemaTypeOptions<boolean[]>().type);
 expectType<(Function | typeof SchemaType | Schema<any, any, any> | SchemaDefinition<Function> | Function | AnyArray<Function>) | undefined>(new SchemaTypeOptions<Function>().type);
+
+function index() {
+  new SchemaTypeOptions<string>().index = true;
+  new SchemaTypeOptions<string>().index = false;
+  new SchemaTypeOptions<string>().index = 1;
+  new SchemaTypeOptions<string>().index = -1;
+  new SchemaTypeOptions<string>().index = 'text';
+  new SchemaTypeOptions<string>().index = '2d';
+  new SchemaTypeOptions<string>().index = 'geoHaystack';
+  new SchemaTypeOptions<string>().index = 'hashed';
+  new SchemaTypeOptions<string>().index = 'ascending';
+  new SchemaTypeOptions<string>().index = 'asc';
+  new SchemaTypeOptions<string>().index = 'descending';
+  new SchemaTypeOptions<string>().index = 'desc';
+
+  expectError<SchemaTypeOptions<string>['index']>(''); // test empty string value
+  expectError<SchemaTypeOptions<string>['index']>('invalid'); // test invalid string value
+  expectError<SchemaTypeOptions<string>['index']>(0); // test invalid number
+  expectError<SchemaTypeOptions<string>['index']>(2); // test invalid number
+  expectError<SchemaTypeOptions<string>['index']>(-2); // test invalid number
+  expectError<SchemaTypeOptions<string>['index']>(new Date()); // test invalid type
+}

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -100,7 +100,7 @@ declare module 'mongoose' {
      * If [truthy](https://masteringjs.io/tutorials/fundamentals/truthy), Mongoose will
      * build an index on this path when the model is compiled.
      */
-    index?: boolean | number | IndexOptions | '2d' | '2dsphere' | 'hashed' | 'text';
+    index?: boolean | IndexDirection;
 
     /**
      * If [truthy](https://masteringjs.io/tutorials/fundamentals/truthy), Mongoose


### PR DESCRIPTION
**Summary**

This PR changes `SchemaTypeOption.index` to use the same definition as the `schema.index` function
also adds some tests for that field

fixes #12395

Edit:
also added some more tests for the `schema.index` function