### PR TITLE
fix(types): add "array of array key-value pairs" as a argument option for "query.sort()"

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2952,7 +2952,7 @@ Query.prototype.distinct = function(field, conditions, callback) {
  *     query.sort('field -test');
  *
  *     // also possible is to use a array with array key-value pairs
- *     query.sort([["field", "asc"]]);
+ *     query.sort([['field', 'asc']]);
  *
  * #### Note:
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -2951,11 +2951,14 @@ Query.prototype.distinct = function(field, conditions, callback) {
  *     // equivalent
  *     query.sort('field -test');
  *
+ *     // also possible is to use a array with array key-value pairs
+ *     query.sort([["field", "asc"]]);
+ *
  * #### Note:
  *
  * Cannot be used with `distinct()`
  *
- * @param {Object|String} arg
+ * @param {Object|String|Array.<Array<(string | number)>>} arg
  * @return {Query} this
  * @see cursor.sort https://docs.mongodb.org/manual/reference/method/cursor.sort/
  * @api public

--- a/lib/query.js
+++ b/lib/query.js
@@ -2958,7 +2958,7 @@ Query.prototype.distinct = function(field, conditions, callback) {
  *
  * Cannot be used with `distinct()`
  *
- * @param {Object|String|Array.<Array<(string | number)>>} arg
+ * @param {Object|String|Array<Array<(string | number)>>} arg
  * @return {Query} this
  * @see cursor.sort https://docs.mongodb.org/manual/reference/method/cursor.sort/
  * @api public

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -160,8 +160,13 @@ Test.find().sort({ name: -1 });
 Test.find().sort({ name: 'ascending' });
 Test.find().sort(undefined);
 Test.find().sort(null);
+Test.find().sort([['key', 'ascending']]);
+Test.find().sort([['key1', 'ascending'], ['key2', 'descending']]);
 expectError(Test.find().sort({ name: 2 }));
 expectError(Test.find().sort({ name: 'invalidSortOrder' }));
+expectError(Test.find().sort([['key', 'invalid']]));
+expectError(Test.find().sort([['key', false]]));
+expectError(Test.find().sort(['invalid']));
 
 // Super generic query
 function testGenericQuery(): void {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -601,7 +601,7 @@ declare module 'mongoose' {
     snapshot(val?: boolean): this;
 
     /** Sets the sort order. If an object is passed, values allowed are `asc`, `desc`, `ascending`, `descending`, `1`, and `-1`. */
-    sort(arg?: string | { [key: string]: SortOrder | { $meta: 'textScore' } } | undefined | null): this;
+    sort(arg?: string | { [key: string]: SortOrder | { $meta: 'textScore' } } | [string, SortOrder][] | undefined | null): this;
 
     /** Sets the tailable option (for use with capped collections). */
     tailable(bool?: boolean, opts?: {


### PR DESCRIPTION
**Summary**

This PR adds a type for the "array of array with key-value pairs" as a possible type
also adds some more documentation about this way to the jsdoc

fixes #12434
was broken by #11852