### PR TITLE
fix(query): treat `findOne(_id)` as equivalent to `findOne({ _id })`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2403,6 +2403,10 @@ Query.prototype.merge = function(source) {
     utils.merge(this._mongooseOptions, source._mongooseOptions);
 
     return this;
+  } else if (this.model != null && source instanceof this.model.base.Types.ObjectId) {
+    utils.merge(this._conditions, { _id: source }, opts);
+
+    return this;
   }
 
   // plain object

--- a/test/helpers/update.castArrayFilters.test.js
+++ b/test/helpers/update.castArrayFilters.test.js
@@ -2,6 +2,7 @@
 
 const Query = require('../../lib/query');
 const Schema = require('../../lib/schema');
+const Types = require('../../lib/types');
 const assert = require('assert');
 const castArrayFilters = require('../../lib/helpers/update/castArrayFilters');
 
@@ -231,7 +232,7 @@ describe('castArrayFilters', function() {
     });
     let q = new Query();
     q.schema = schema;
-    q.model = { base: { options: { strictQuery: false } } };
+    q.model = { base: { Types, options: { strictQuery: false } } };
 
     let p = { 'arr.$[arr].id': 42 };
     let opts = {
@@ -247,7 +248,7 @@ describe('castArrayFilters', function() {
 
     q = new Query();
     q.schema = schema;
-    q.model = { base: { options: { strictQuery: true } } };
+    q.model = { base: { Types, options: { strictQuery: true } } };
 
     p = { 'arr.$[arr].id': 42 };
     opts = {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4132,4 +4132,15 @@ describe('Query', function() {
     assert.equal(item.get('select.key.some'), 'value');
     assert.equal(item.doNotSelect, undefined);
   });
+
+  it('treats ObjectId as object with `_id` for `merge()` (gh-12325)', async function() {
+    const testSchema = new mongoose.Schema({ name: String });
+    const Test = db.model('Test', testSchema);
+    const _id = new mongoose.Types.ObjectId();
+
+    const q = Test.find(_id);
+
+    assert.ok(q.getFilter()._id instanceof mongoose.Types.ObjectId);
+    assert.equal(q.getFilter()._id.toHexString(), _id.toHexString());
+  });
 });

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4138,7 +4138,12 @@ describe('Query', function() {
     const Test = db.model('Test', testSchema);
     const _id = new mongoose.Types.ObjectId();
 
-    const q = Test.find(_id);
+    let q = Test.find(_id);
+
+    assert.ok(q.getFilter()._id instanceof mongoose.Types.ObjectId);
+    assert.equal(q.getFilter()._id.toHexString(), _id.toHexString());
+
+    q = Test.findOne(_id);
 
     assert.ok(q.getFilter()._id instanceof mongoose.Types.ObjectId);
     assert.equal(q.getFilter()._id.toHexString(), _id.toHexString());


### PR DESCRIPTION
Fix #12325

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12325 pointed out that, in Mongoose 5, `findOne(ObjectId)` worked the same as `findById(ObjectId)`. I don't see any reason why we shouldn't continue to support this behavior.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
