### PR TITLE
fix(types): make schema.plugin() more flexible for schemas that don't define any generics

### DIFF
--- a/test/types/plugin.test.ts
+++ b/test/types/plugin.test.ts
@@ -59,10 +59,17 @@ const testSchema = new Schema<Test, TestModel, TestInstanceMethods, TestQueryHel
   lastName: { type: String, required: true }
 });
 
+function pluginGeneric(schema: Schema): void {
+  schema.static('test', function() {
+    return 0;
+  });
+}
+
 testSchema.plugin(pluginVirtuals);
 testSchema.plugin(pluginQueryHelpers);
 testSchema.plugin(pluginMethods);
 testSchema.plugin(pluginStatics);
+testSchema.plugin(pluginGeneric);
 
 const Foo = connection.model<Test, TestModel, TestQueryHelpers>('Test', testSchema);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -264,7 +264,7 @@ declare module 'mongoose' {
     pathType(path: string): string;
 
     /** Registers a plugin for this schema. */
-    plugin<PFunc extends PluginFunction<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods>, POptions extends Parameters<PFunc>[1] = Parameters<PFunc>[1]>(fn: PFunc, opts?: POptions): this;
+    plugin<PFunc extends PluginFunction<any, any, any, any, any, any>, POptions extends Parameters<PFunc>[1] = Parameters<PFunc>[1]>(fn: PFunc, opts?: POptions): this;
 
     /** Defines a post hook for the model. */
     post<T = HydratedDocument<DocType, TInstanceMethods>>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, fn: PostMiddlewareFunction<T, T>): this;


### PR DESCRIPTION
Fix #12454
Re: #12139

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I think just switching to `any` should be enough to fix #12454, it doesn't break any of the tests from #12139. Any thoughts @emiljanitzek ?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
