### PR TITLE
test(types): add types-test for find & findOne with ObjectId argument

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -520,3 +520,10 @@ async function gh12319() {
 
   expectType<ProjectModelHydratedDoc>(await ProjectModel.findOne().orFail());
 }
+
+function findWithId() {
+  const id = new Types.ObjectId();
+  const TestModel = model('test', new Schema({}));
+  TestModel.find(id);
+  TestModel.findOne(id);
+}


### PR DESCRIPTION
**Summary**

This PR adds types-tests for `find` and `findOne` with a direct `ObjectId` argument, because it was missing in the original PR

re #12485