### PR TITLE
chore(devDeps): upgrade "mongodb-memory-server" to 8.9.3 to fix some CI errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mkdirp": "^1.0.4",
     "mocha": "10.0.0",
     "moment": "2.x",
-    "mongodb-memory-server": "8.9.1",
+    "mongodb-memory-server": "8.9.3",
     "ncp": "^2.0.0",
     "nyc": "15.1.0",
     "pug": "3.0.2",


### PR DESCRIPTION
**Summary**

This PR updates `mongodb-memory-server` to the latest patch version, because this fixes some CI errors that may occur for replsets

this change is also included in #12262, but i thought that this change should maybe land earlier