### PR TITLE
fix(model): avoid saving applied defaults if path is deselected

### DIFF
--- a/lib/helpers/projection/isPathExcluded.js
+++ b/lib/helpers/projection/isPathExcluded.js
@@ -12,6 +12,10 @@ const isDefiningProjection = require('./isDefiningProjection');
  */
 
 module.exports = function isPathExcluded(projection, path) {
+  if (projection == null) {
+    return false;
+  }
+
   if (path === '_id') {
     return projection._id === 0;
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -51,11 +51,13 @@ const {
   getRelatedDBIndexes,
   getRelatedSchemaIndexes
 } = require('./helpers/indexes/getRelatedIndexes');
+const isPathExcluded = require('./helpers/projection/isPathExcluded');
 const decorateDiscriminatorIndexOptions = require('./helpers/indexes/decorateDiscriminatorIndexOptions');
 const isPathSelectedInclusive = require('./helpers/projection/isPathSelectedInclusive');
 const leanPopulateMap = require('./helpers/populate/leanPopulateMap');
 const modifiedPaths = require('./helpers/update/modifiedPaths');
 const parallelLimit = require('./helpers/parallelLimit');
+const parentPaths = require('./helpers/path/parentPaths');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
 const pushNestedArrayPaths = require('./helpers/model/pushNestedArrayPaths');
 const removeDeselectedForeignField = require('./helpers/populate/removeDeselectedForeignField');
@@ -760,6 +762,19 @@ Model.prototype.$__delta = function() {
       }
     }
 
+    // If this path is set to default, and either this path or one of
+    // its parents is excluded, don't treat this path as dirty.
+    if (this.$isDefault(data.path) && this.$__.selected) {
+      if (data.path.indexOf('.') === -1 && isPathExcluded(this.$__.selected, data.path)) {
+        continue;
+      }
+
+      const pathsToCheck = parentPaths(data.path);
+      if (pathsToCheck.find(path => isPathExcluded(this.$__.isSelected, path))) {
+        continue;
+      }
+    }
+
     if (divergent.length) continue;
     if (value === undefined) {
       operand(this, where, delta, data, 1, '$unset');
@@ -798,6 +813,11 @@ Model.prototype.$__delta = function() {
   if (this.$__.version) {
     this.$__version(where, delta);
   }
+
+  if (Object.keys(delta).length === 0) {
+    return [where, null];
+  }
+
   return [where, delta];
 };
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11881,6 +11881,24 @@ describe('document', function() {
     const addedDoc = await Model.findOne({ name: 'Test' });
     assert.strictEqual(addedDoc.count, 1);
   });
+
+  it('avoids overwriting array if saving with no changes with array deselected (gh-12414)', async function() {
+    const schema = new mongoose.Schema({
+      name: String,
+      tags: [String]
+    });
+    const Test = db.model('Test', schema);
+
+    const { _id } = await Test.create({ name: 'Mongoose', tags: ['mongodb'] });
+
+    const doc = await Test.findById(_id).select('name');
+    assert.deepStrictEqual(doc.getChanges(), {});
+    await doc.save();
+
+    const rawDoc = await Test.collection.findOne({ _id });
+    assert.ok(rawDoc);
+    assert.deepStrictEqual(rawDoc.tags, ['mongodb']);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #12414

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If you load a document with an array deselected `const doc = await Model.findOne().select({ arr: 0 })` and then save with no changes, Mongoose will save an empty array. This looks like it applies to all deselected defaults.

This PR makes it so that Mongoose skips deselected defaults when calculating what changed in the document.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
