### PR TITLE
TypeScript query helpers quick fix and docs improvements

### DIFF
--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -201,7 +201,7 @@ declare module 'mongoose' {
     /**
      * Query helper functions.
      */
-    query?: Record<any, <T extends QueryWithHelpers<unknown, DocType>>(this: T, ...args: any) => T> | QueryHelpers,
+    query?: Record<any, <T extends QueryWithHelpers<unknown, HydratedDocument<DocType>>>(this: T, ...args: any) => T> | QueryHelpers,
 
     /**
      * Set whether to cast non-array values to arrays.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I cleaned up the TS query helper docs based on feedback from #12342, and also found an issue with auto typed query helpers. Looks like they defaulted to using raw DocType rather than a `HydratedDocument`, which meant TS thought that every query helper returned a lean result.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
