### PR TITLE
chore(mocha-fixtures): fix spelling and remove "example" comments

### DIFF
--- a/test/mocha-fixtures.js
+++ b/test/mocha-fixtures.js
@@ -12,7 +12,7 @@ let mongoinstance;
 // a replset-instance for running repl-set tests
 let mongorreplset;
 
-// decide wheter to start a instance or not
+// decide whether to start an instance or not
 const startMemoryInstance = !process.env.MONGOOSE_TEST_URI;
 const startMemoryReplset = !process.env.MONGOOSE_REPLSET_URI;
 

--- a/test/mocha-fixtures.js
+++ b/test/mocha-fixtures.js
@@ -12,7 +12,7 @@ let mongoinstance;
 // a replset-instance for running repl-set tests
 let mongorreplset;
 
-// decide whether to start an instance or not
+// decide whether to start MMS instances or use the existing URI's
 const startMemoryInstance = !process.env.MONGOOSE_TEST_URI;
 const startMemoryReplset = !process.env.MONGOOSE_REPLSET_URI;
 


### PR DESCRIPTION
**Summary**

This PR is a small follow-up of #12262, where i noticed some spelling mistakes and example comments left-overs, also using `MONGOOSE_REPLSET_URI` in the false case of `startMemoryReplset`