### PR TITLE
fix(types): add "estimatedDocumentCount" and "countDocuments" as possible hooks

### DIFF
--- a/test/types/middleware.test.ts
+++ b/test/types/middleware.test.ts
@@ -92,6 +92,24 @@ schema.pre<Model<ITest>>('insertMany', function(next, docs: Array<ITest>) {
   next();
 });
 
+schema.pre<Query<number, any>>('count', function(next) {});
+schema.post<Query<number, any>>('count', function(count, next) {
+  expectType<number>(count);
+  next();
+});
+
+schema.pre<Query<number, any>>('estimatedDocumentCount', function(next) {});
+schema.post<Query<number, any>>('estimatedDocumentCount', function(count, next) {
+  expectType<number>(count);
+  next();
+});
+
+schema.pre<Query<number, any>>('countDocuments', function(next) {});
+schema.post<Query<number, any>>('countDocuments', function(count, next) {
+  expectType<number>(count);
+  next();
+});
+
 schema.post<Query<ITest, ITest>>('findOneAndDelete', function(res, next) {
   expectType<ITest>(res);
   next();

--- a/types/middlewares.d.ts
+++ b/types/middlewares.d.ts
@@ -1,7 +1,7 @@
 declare module 'mongoose' {
 
   type MongooseDocumentMiddleware = 'validate' | 'save' | 'remove' | 'updateOne' | 'deleteOne' | 'init';
-  type MongooseQueryMiddleware = 'count' | 'deleteMany' | 'deleteOne' | 'distinct' | 'find' | 'findOne' | 'findOneAndDelete' | 'findOneAndRemove' | 'findOneAndReplace' | 'findOneAndUpdate' | 'remove' | 'replaceOne' | 'update' | 'updateOne' | 'updateMany';
+  type MongooseQueryMiddleware = 'count' | 'estimatedDocumentCount' | 'countDocuments' | 'deleteMany' | 'deleteOne' | 'distinct' | 'find' | 'findOne' | 'findOneAndDelete' | 'findOneAndRemove' | 'findOneAndReplace' | 'findOneAndUpdate' | 'remove' | 'replaceOne' | 'update' | 'updateOne' | 'updateMany';
 
   type MiddlewareOptions = { document?: boolean, query?: boolean };
   type SchemaPreOptions = MiddlewareOptions;


### PR DESCRIPTION
**Summary**

This PR adds `estimatedDocumentCount` and `countDocuments` as possible hooks in the types, plus tests

fixes #12516