### PR TITLE
docs(subdocs): clarify that populated docs are not subdocs

### DIFF
--- a/docs/subdocs.md
+++ b/docs/subdocs.md
@@ -11,15 +11,31 @@ const childSchema = new Schema({ name: 'string' });
 const parentSchema = new Schema({
   // Array of subdocuments
   children: [childSchema],
-  // Single nested subdocuments. Caveat: single nested subdocs only work
-  // in mongoose >= 4.2.0
+  // Single nested subdocuments
   child: childSchema
 });
 ```
 
-Aside from code reuse, one important reason to use subdocuments is to create
-a path where there would otherwise not be one to allow for validation over
-a group of fields (e.g. dateRange.fromDate <= dateRange.toDate).
+Note that populated documents are **not** subdocuments in Mongoose.
+Subdocument data is embedded in the top-level document.
+Referenced documents are separate top-level documents.
+
+```javascript
+const childSchema = new Schema({ name: 'string' });
+const Child = mongoose.model('Child', childSchema);
+
+const parentSchema = new Schema({
+  child: {
+    type: mongoose.ObjectId,
+    ref: 'Child'
+  }
+});
+const Parent = mongoose.model('Parent', parentSchema);
+
+const doc = await Parent.findOne().populate('child');
+// NOT a subdocument. `doc.child` is a separate top-level document.
+doc.child;
+```
 
 <ul class="toc">
   <li><a href="#what-is-a-subdocument-">What is a Subdocument?</a></li>


### PR DESCRIPTION
Fix #12398

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We don't mention anywhere in the subdocuments docs that populated documents are _not_ subdocuments. Should clarify that so people know exactly what is a subdocument and what isn't a subdocument, before clarifying what subdocuments do.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
