### PR TITLE
fix(types): indicate that Schema.prototype.discriminator() returns `this`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -570,9 +570,7 @@ export type AutoTypedSchemaType = {
 // discriminator
 const eventSchema = new Schema<{ message: string }>({ message: String }, { discriminatorKey: 'kind' });
 const batchSchema = new Schema<{ name: string }>({ name: String }, { discriminatorKey: 'kind' });
-const discriminatedSchema = batchSchema.discriminator('event', eventSchema);
-
-expectType<Schema<Omit<{ name: string }, 'message'> & { message: string }>>(discriminatedSchema);
+batchSchema.discriminator('event', eventSchema);
 
 // discriminator statics
 const eventSchema2 = new Schema({ message: String }, { discriminatorKey: 'kind', statics: { static1: function() {
@@ -581,9 +579,7 @@ const eventSchema2 = new Schema({ message: String }, { discriminatorKey: 'kind',
 const batchSchema2 = new Schema({ name: String }, { discriminatorKey: 'kind', statics: { static2: function() {
   return 1;
 } } });
-const discriminatedSchema2 = batchSchema2.discriminator('event', eventSchema2);
-
-expectAssignable<Schema<Omit<{ name: string }, 'message'> & { message: string }, Model<any>, {}, {}, {}, { static1(): number; static2(): number; }>>(discriminatedSchema2);
+batchSchema2.discriminator('event', eventSchema2);
 
 function gh11828() {
   interface IUser {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -208,7 +208,7 @@ declare module 'mongoose' {
     /** Returns a copy of this schema */
     clone<T = this>(): T;
 
-    discriminator<DisSchema = Schema>(name: string, schema: DisSchema): DiscriminatorSchema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods, DisSchema>;
+    discriminator<DisSchema = Schema>(name: string, schema: DisSchema): this;
 
     /** Returns a new schema that has the picked `paths` from this schema. */
     pick<T = this>(paths: string[], options?: SchemaOptions): T;


### PR DESCRIPTION
Fix #12457

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12457 pointed out that our types are slightly incorrect: `Schema.prototype.discriminator()` returns `this`, not the discriminated schema. Needed to change some tests which relied on the incorrect behavior. In cases like this where the TS types and runtime behavior disagree, we should assume the runtime behavior is more correct and fix the types, including any incorrect typing tests.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
