### PR TITLE
fix(document): set defaults on subdocuments underneath init-ed single nested subdocument

### DIFF
--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -174,6 +174,7 @@ SubdocumentPath.prototype.cast = function(val, doc, init, priorVal, options) {
     subdoc = new Constructor(void 0, selected, doc, false, { defaults: false });
     subdoc.$init(val);
     applyDefaults(subdoc, selected);
+    delete subdoc.$__.defaults;
   } else {
     if (Object.keys(val).length === 0) {
       return new Constructor({}, selected, doc, undefined, options);


### PR DESCRIPTION
Fix #12515

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

There was a bug with our fix for #12328 (https://github.com/Automattic/mongoose/commit/47ce1254abb6c88264af8e7b93f22b0dddd57b58): we were really trying to just skip applying defaults on the initial construction of the document. But we ended up skipping applying defaults for the rest of the subdocument's lifecycle, which introduces the bug pointed out in #12515. With this fix, we're only skipping applying defaults on the initial subdocument creation, as intended.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
