### PR TITLE
Check if nextTick is set to fakeTimer function #12514

### DIFF
--- a/lib/helpers/printJestWarning.js
+++ b/lib/helpers/printJestWarning.js
@@ -9,7 +9,10 @@ if (typeof jest !== 'undefined' && typeof window !== 'undefined') {
     'https://mongoosejs.com/docs/jest.html');
 }
 
-if (typeof jest !== 'undefined' && process.nextTick.toString().indexOf('nextTick') === -1) {
+if (typeof jest !== 'undefined' && process.nextTick.toString() ===
+  'function () {\n' +
+  '                return clock[method].apply(clock, arguments);\n' +
+  '            }') {
   utils.warn('Mongoose: looks like you\'re trying to test a Mongoose app ' +
     'with Jest\'s mock timers enabled. Please make sure you read ' +
     'Mongoose\'s docs on configuring Jest to test Node.js apps: ' +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Jest mock timer warning is printed when `fakeTimers` are not enabled.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
As per this comment https://github.com/Automattic/mongoose/issues/12514#issuecomment-1267965749, `newrelicWinstonFormatter` will no longer cause the Jest fake timer warning to print.
