### PR TITLE
docs(models): fix non-matching closing tag

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -13,7 +13,7 @@ reading documents from the underlying MongoDB database.
 * [Change Streams](#change-streams)
 * [Views](#views)
 
-<h2 id="compiling"><a href="#compiling">Compiling your first model</a></h3>
+<h2 id="compiling"><a href="#compiling">Compiling your first model</a></h2>
 
 When you call `mongoose.model()` on a schema, Mongoose _compiles_ a model
 for you.


### PR DESCRIPTION
**Summary**

This fixes the closing tag missed in the suggestions at https://github.com/Automattic/mongoose/pull/12526#discussion_r988039671