### PR TITLE
chore(template::bug): add field for typescript version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -40,7 +40,7 @@ body:
   - type: input
     id: typescript-version
     attributes:
-      label: Typescript version
+      label: Typescript version (if applicable)
       placeholder: 4.8.x
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,6 +37,14 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: typescript-version
+    attributes:
+      label: Typescript version
+      placeholder: 4.8.x
+    validations:
+      required: false
+
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
**Summary**

This PR adds a optional field to the `bug` github issue template for the Typescript version

re https://github.com/Automattic/mongoose/issues/12512#issuecomment-1268898713