### PR TITLE
Add missing densify type pipeline type

### DIFF
--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -8,6 +8,7 @@ declare module 'mongoose' {
     | PipelineStage.BucketAuto
     | PipelineStage.CollStats
     | PipelineStage.Count
+    | PipelineStage.Densify
     | PipelineStage.Facet
     | PipelineStage.GeoNear
     | PipelineStage.GraphLookup


### PR DESCRIPTION
densify pipeline stage was not in the union type
for PipelineStage, this was causing ts error when
users were trying to call the aggregate method with
densify stage

**Summary**

After declaring a model and using its `.aggregation` method with a `$densify` stage, I received an error related to the fact that there was no method overload matching a pipeline with `$densify` as a stage.
Looking at the `PipelineStage` type, I saw that `PipelineStage.Densify` was missing in the union type.
So I just added it.

**Examples**
The following was causing an error, now it's allowed.
```typescript
MyModel.aggregate([
  {
    $densify: ...
  }
])
```
