### PR TITLE
Adjust replaceWith type pipeline stage

### DIFF
--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -202,7 +202,7 @@ declare module 'mongoose' {
 
     export interface ReplaceWith {
       /** [`$replaceWith` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/replaceWith/) */
-      $replaceWith: ObjectExpressionOperator;
+      $replaceWith: ObjectExpressionOperator | { [field: string]: Expression };
     }
 
     export interface Sample {


### PR DESCRIPTION
**Summary**

For how the `$replaceWith` pipeline stage type was written, it wasn't possible to replace the document by using expressions.

**Examples**

Things like the following were not possible, now they're.

```js
db.sales.insertMany([
  { "_id" : 1, "item" : "butter", "price" : 10, "quantity": 2, date: ISODate("2019-03-01T08:00:00Z"), status: "C" },
  { "_id" : 2, "item" : "cream", "price" : 20, "quantity": 1, date: ISODate("2019-03-01T09:00:00Z"), status: "A" },
  { "_id" : 3, "item" : "jam", "price" : 5, "quantity": 10, date: ISODate("2019-03-15T09:00:00Z"), status: "C" },
  { "_id" : 4, "item" : "muffins", "price" : 5, "quantity": 10, date: ISODate("2019-03-15T09:00:00Z"), status: "C" }
])
```
```js
SalesModel.aggregate([
    { $match: { status: "C" } },
    { 
        $replaceWith: {
            _id: "$_id",
            item: "$item",
            amount: {
                $multiply: [ "$price", "$quantity"]
            },
            status: "Complete", asofDate: "$NOW" 
        }
    }
])
```