### PR TITLE
feat(document): add `$timestamps()` method to set timestamps for `save()`, `bulkSave()`, and `insertMany()`

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -963,7 +963,7 @@ Document.prototype.$session = function $session(session) {
  *     await doc.save(); // Does **not** apply timestamps
  *
  * @param {Boolean} [value] overwrite the current session
- * @return {Document} this
+ * @return {Document|boolean|undefined} When used as a getter (no argument), a boolean will be returned indicating the timestamps option state or if unset "undefined" will be used, otherwise will return "this"
  * @method $timestamps
  * @api public
  * @memberOf Document

--- a/lib/document.js
+++ b/lib/document.js
@@ -949,6 +949,48 @@ Document.prototype.$session = function $session(session) {
 };
 
 /**
+ * Getter/setter around whether this document will apply timestamps by
+ * default when using `save()` and `bulkSave()`.
+ *
+ * #### Example:
+ *
+ *     const TestModel = mongoose.model('Test', new Schema({ name: String }, { timestamps: true }));
+ *     const doc = new TestModel({ name: 'John Smith' });
+ *
+ *     doc.$timestamps(); // true
+ *
+ *     doc.$timestamps(false);
+ *     await doc.save(); // Does **not** apply timestamps
+ *
+ * @param {Boolean} [value] overwrite the current session
+ * @return {Document} this
+ * @method $timestamps
+ * @api public
+ * @memberOf Document
+ */
+
+Document.prototype.$timestamps = function $timestamps(value) {
+  if (arguments.length === 0) {
+    if (this.$__.timestamps != null) {
+      return this.$__.timestamps;
+    }
+
+    if (this.$__schema) {
+      return this.$__schema.options.timestamps;
+    }
+
+    return undefined;
+  }
+
+  const currentValue = this.$timestamps();
+  if (value !== currentValue) {
+    this.$__.timestamps = value;
+  }
+
+  return this;
+};
+
+/**
  * Overwrite all values in this document with the values of `obj`, except
  * for immutable properties. Behaves similarly to `set()`, except for it
  * unsets all properties that aren't in `obj`.

--- a/lib/model.js
+++ b/lib/model.js
@@ -511,6 +511,9 @@ Model.prototype.save = function(options, fn) {
   if (options.hasOwnProperty('session')) {
     this.$session(options.session);
   }
+  if (this.$__.timestamps != null) {
+    options.timestamps = this.$__.timestamps;
+  }
   this.$__.$versionError = generateVersionError(this, this.modifiedPaths());
 
   fn = this.constructor.$handleCallbackError(fn);
@@ -3455,7 +3458,8 @@ Model.$__insertMany = function(arr, options, callback) {
       if (doc.$__schema.options.versionKey) {
         doc[doc.$__schema.options.versionKey] = 0;
       }
-      if ((!options || options.timestamps !== false) && doc.initializeTimestamps) {
+      const shouldSetTimestamps = (!options || options.timestamps !== false) && doc.initializeTimestamps && (!doc.$__ || doc.$__.timestamps !== false);
+      if (shouldSetTimestamps) {
         return doc.initializeTimestamps().toObject(internalToObjectOptions);
       }
       return doc.toObject(internalToObjectOptions);
@@ -3695,6 +3699,13 @@ Model.bulkSave = async function(documents, options) {
     for (const document of documents) {
       document.$__.saveOptions = document.$__.saveOptions || {};
       document.$__.saveOptions.timestamps = options.timestamps;
+    }
+  } else {
+    for (const document of documents) {
+      if (document.$__.timestamps != null) {
+        document.$__.saveOptions = document.$__.saveOptions || {};
+        document.$__.saveOptions.timestamps = document.$__.timestamps;
+      }
     }
   }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1789,6 +1789,7 @@ Schema.prototype.post = function(name) {
  *
  * @param {Function} plugin The Plugin's callback
  * @param {Object} [opts] Options to pass to the plugin
+ * @param {Boolean} [opts.deduplicate=false] If true, ignore duplicate plugins (same `fn` argument using `===`)
  * @see plugins /docs/plugins.html
  * @api public
  */

--- a/test/timestamps.test.js
+++ b/test/timestamps.test.js
@@ -626,6 +626,20 @@ describe('timestamps', function() {
       assert.strictEqual(cat.updatedAt, old);
     });
 
+    it('can skip with `$timestamps(false)` (gh-12117)', async function() {
+      const cat = await Cat.findOne();
+      const old = cat.updatedAt;
+
+      await delay(10);
+
+      cat.hobby = 'fishing';
+
+      cat.$timestamps(false);
+      await cat.save();
+
+      assert.strictEqual(cat.updatedAt, old);
+    });
+
     it('should change updatedAt when findOneAndUpdate', function(done) {
       Cat.create({ name: 'test123' }, function(err) {
         assert.ifError(err);


### PR DESCRIPTION
Fix #12117

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick feature for 6.7 to make working with timestamps and `bulkSave()` + `insertMany()` easier. Right now, there's no way to configure timestamps for individual documents when using `bulkSave()` and `insertMany()`. This PR adds a `$timestamps()` method that sets the timestamps option for all future `save()`, `bulkSave()`, and `insertMany()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
