### PR TITLE
fix(aggregate): avoid adding extra `$match` stage if user manually set discriminator key to correct value in first pipeline stage

### DIFF
--- a/lib/helpers/aggregate/prepareDiscriminatorPipeline.js
+++ b/lib/helpers/aggregate/prepareDiscriminatorPipeline.js
@@ -12,7 +12,9 @@ module.exports = function prepareDiscriminatorPipeline(pipeline, schema, prefix)
     // If the first pipeline stage is a match and it doesn't specify a `__t`
     // key, add the discriminator key to it. This allows for potential
     // aggregation query optimizations not to be disturbed by this feature.
-    if (originalPipeline[0] != null && originalPipeline[0].$match && !originalPipeline[0].$match[filterKey]) {
+    if (originalPipeline[0] != null &&
+        originalPipeline[0].$match &&
+        (originalPipeline[0].$match[filterKey] === undefined || originalPipeline[0].$match[filterKey] === discriminatorValue)) {
       originalPipeline[0].$match[filterKey] = discriminatorValue;
       // `originalPipeline` is a ref, so there's no need for
       // aggregate._pipeline = originalPipeline

--- a/test/helpers/aggregate.test.js
+++ b/test/helpers/aggregate.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const prepareDiscriminatorPipeline = require('../../lib/helpers/aggregate/prepareDiscriminatorPipeline');
 const stringifyFunctionOperators = require('../../lib/helpers/aggregate/stringifyFunctionOperators');
 
 describe('stringifyFunctionOperators', function() {
@@ -61,5 +62,34 @@ describe('stringifyFunctionOperators', function() {
     stringifyFunctionOperators(pipeline);
 
     assert.equal(typeof pipeline[0].$addFields.newField.$function.body, 'string');
+  });
+});
+
+describe('prepareDiscriminatorPipeline', function() {
+  it('handles case where initial $match includes the discriminator key (gh-12478)', function() {
+    const pipeline = [
+      {
+        $match: {
+          partition: 'Child',
+          $text: {
+            $search: 'test'
+          }
+        }
+      }
+    ];
+    const fakeSchema = { discriminatorMapping: { isRoot: false, key: 'partition', value: 'Child' } };
+
+    prepareDiscriminatorPipeline(pipeline, fakeSchema);
+
+    assert.deepStrictEqual(pipeline, [
+      {
+        $match: {
+          partition: 'Child',
+          $text: {
+            $search: 'test'
+          }
+        }
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Fix #12478

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12478 points out that `prepareDiscriminatorPipeline()` unnecessarily adds a `$match` stage with the discriminator key if the user already explicitly set the correct discriminator key in the initial `$match`.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
