### PR TITLE
fix(document): allow creating document with document array and top-level key named `schema`

### DIFF
--- a/lib/types/DocumentArray/index.js
+++ b/lib/types/DocumentArray/index.js
@@ -57,7 +57,7 @@ function MongooseDocumentArray(values, path, doc) {
   // to make more proof against unusual node environments
   if (doc && doc instanceof Document) {
     internals[arrayParentSymbol] = doc;
-    internals[arraySchemaSymbol] = doc.schema.path(path);
+    internals[arraySchemaSymbol] = doc.$__schema.path(path);
 
     // `schema.path()` doesn't drill into nested arrays properly yet, see
     // gh-6398, gh-6602. This is a workaround because nested arrays are

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11928,6 +11928,26 @@ describe('document', function() {
     assert.ok(rawDoc);
     assert.deepStrictEqual(rawDoc.tags, ['mongodb']);
   });
+
+  it('can create document with document array and top-level key named `schema` (gh-12480)', async function() {
+    const AuthorSchema = new Schema({
+      fullName: { type: 'String', required: true }
+    });
+
+    const BookSchema = new Schema({
+      schema: { type: 'String', required: true },
+      title: { type: 'String', required: true },
+      authors: [AuthorSchema]
+    }, { supressReservedKeysWarning: true });
+
+    const Book = db.model('Book', BookSchema);
+
+    await Book.create({
+      schema: 'design',
+      authors: [{ fullName: 'Sourabh Bagrecha' }],
+      title: 'The power of JavaScript'
+    });
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #12480

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like we missed a spot when we allowed using `schema` as a top-level key: `DocumentArray/index.js` still uses `doc.schema` rather than `doc.$__schema`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
