### PR TITLE
fix(cast): make schema-level strictQuery override schema-level strict for query filters

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -268,8 +268,11 @@ module.exports = function cast(schema, obj, options, context) {
           options.strictQuery :
           'strict' in options ?
             options.strict :
-            'strict' in schema._userProvidedOptions ? schema._userProvidedOptions.strict :
-              schema.options.strictQuery;
+            'strictQuery' in schema._userProvidedOptions ?
+              schema._userProvidedOptions.strictQuery :
+              'strict' in schema._userProvidedOptions ?
+                schema._userProvidedOptions.strict :
+                schema.options.strictQuery;
         if (options.upsert && strict) {
           if (strict === 'throw') {
             throw new StrictModeError(path);

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -264,15 +264,7 @@ module.exports = function cast(schema, obj, options, context) {
         }
 
         const strict = 'strict' in options ? options.strict : schema.options.strict;
-        const strictQuery = 'strictQuery' in options ?
-          options.strictQuery :
-          'strict' in options ?
-            options.strict :
-            'strictQuery' in schema._userProvidedOptions ?
-              schema._userProvidedOptions.strictQuery :
-              'strict' in schema._userProvidedOptions ?
-                schema._userProvidedOptions.strict :
-                schema.options.strictQuery;
+        const strictQuery = getStrictQuery(options, schema._userProvidedOptions, schema.options);
         if (options.upsert && strict) {
           if (strict === 'throw') {
             throw new StrictModeError(path);
@@ -380,4 +372,20 @@ function _cast(val, numbertype, context) {
       }
     }
   }
+}
+
+function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions) {
+  if ('strictQuery' in queryOptions) {
+    return queryOptions.strictQuery;
+  }
+  if ('strict' in queryOptions) {
+    return queryOptions.strict;
+  }
+  if ('strictQuery' in schemaUserProvidedOptions) {
+    return schemaUserProvidedOptions.strictQuery;
+  }
+  if ('strict' in schemaUserProvidedOptions) {
+    return schemaUserProvidedOptions.strict;
+  }
+  return schemaOptions.strictQuery;
 }

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -178,4 +178,19 @@ describe('cast: ', function() {
       roles: { $ne: 'super' }
     });
   });
+
+  it('uses schema-level strictQuery over schema-level strict (gh-12508)', function() {
+    const schema = new Schema({}, {
+      strict: 'throw',
+      strictQuery: false
+    });
+
+    const res = cast(schema, {
+      name: 'foo'
+    });
+
+    assert.deepEqual(res, {
+      name: 'foo'
+    });
+  });
 });


### PR DESCRIPTION
Fix #12508

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like schema-level `strict` overrides schema-level `strictQuery`, which is definitely not something we want given that we want to switch `strictQuery` back to `false` by default.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
