### PR TITLE
fix(update): handle runValidators when using `$set` on a doc array in discriminator schema

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -130,12 +130,12 @@ function _createConstructor(schema, options, baseClass) {
   Subdocument || (Subdocument = require('../types/ArraySubdocument'));
 
   // compile an embedded document for this schema
-  function EmbeddedDocument(_value, parentArray) {
+  function EmbeddedDocument() {
     Subdocument.apply(this, arguments);
-    if (parentArray == null || parentArray.getArrayParent() == null) {
+    if (this.__parentArray == null || this.__parentArray.getArrayParent() == null) {
       return;
     }
-    this.$session(parentArray.getArrayParent().$session());
+    this.$session(this.__parentArray.getArrayParent().$session());
   }
 
   schema._preCompile();

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -2023,6 +2023,37 @@ describe('model: update:', function() {
         catch(done);
     });
 
+    it('handles $set on document array in discriminator with runValidators (gh-12518)', async function() {
+      const options = { discriminatorKey: 'kind', runValidators: true };
+
+      const countrySchema = new mongoose.Schema({ title: String }, options);
+      const areasSubSchema = new mongoose.Schema({ country: [countrySchema] }, options);
+      const WorldSchema = new mongoose.Schema({ areas: areasSubSchema }, options);
+
+      const World = db.model(
+        'World',
+        new mongoose.Schema({ title: String }, options)
+      );
+      const Earth = World.discriminator('Earth', WorldSchema);
+
+      const data = {
+        areas: {
+          country: [
+            {
+              title: 'titlec'
+            }
+          ]
+        }
+      };
+      await Earth.updateOne(
+        { _id: mongoose.Types.ObjectId() },
+        data,
+        {
+          runValidators: true
+        }
+      );
+    });
+
     it('single nested schema with geo (gh-4465)', function(done) {
       const addressSchema = new Schema({
         geo: { type: [Number], index: '2dsphere' }


### PR DESCRIPTION
Fix #12518

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`ArraySubdocument` gracefully handles the case when `parentArray` is a `Query`, but looks like the schematype-specific subclass `EmbeddedDocument` does not. This PR makes it so that `EmbeddedDocument` relies on the `__parentArray` property that `ArraySubdocument` sets.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
