### PR TITLE
fix: correct browser build and improve isAsyncFunction check for browser

### DIFF
--- a/lib/helpers/isAsyncFunction.js
+++ b/lib/helpers/isAsyncFunction.js
@@ -1,22 +1,9 @@
 'use strict';
 
-let asyncFunctionPrototype = null;
-// try/catch for Babel compatibility, because Babel preset-env requires
-// regenerator-runtime for async/await and we don't want to include that
-// for a simple check.
-try {
-  asyncFunctionPrototype = Object.getPrototypeOf(async function() {});
-} catch (err) {}
-
-if (asyncFunctionPrototype == null) {
-  module.exports = function isAsyncFunction() {
-    return false;
-  };
-} else {
-  module.exports = function isAsyncFunction(v) {
-    return (
-      typeof v === 'function' &&
-      Object.getPrototypeOf(v) === asyncFunctionPrototype
-    );
-  };
-}
+module.exports = function isAsyncFunction(v) {
+  return (
+    typeof v === 'function' &&
+    v.constructor &&
+    v.constructor.name === 'AsyncFunction'
+  );
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.19.3",
+    "@babel/preset-env": "7.19.3",
     "@typescript-eslint/eslint-plugin": "5.38.1",
     "@typescript-eslint/parser": "5.38.1",
     "acquit": "1.2.1",
@@ -88,7 +89,7 @@
     "lint": "eslint .",
     "lint-js": "eslint . --ext .js",
     "lint-ts": "eslint . --ext .ts",
-    "build-browser": "node ./scripts/build-browser.js",
+    "build-browser": "(rm ./dist/* || true) && node ./scripts/build-browser.js",
     "prepublishOnly": "npm run build-browser",
     "release": "git pull && git push origin master --tags && npm publish",
     "release-legacy": "git pull origin 5.x && git push origin 5.x --tags && npm publish --tag legacy",


### PR DESCRIPTION
Re: #12576

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A couple of related fixes:

1. Fix the issue that was causing browser build to fail
2. Remove `dist` to prevent accidentally publishing out-of-date browser build if `build-browser` fails
3. Use a different approach for `isAsyncFunction()` based on [this SO thread](https://stackoverflow.com/questions/38508420/how-to-know-if-a-function-is-async), because our current approach doesn't seem to work very well when compiled through Babel. I suspect the issue is that Babel converts `Object.getPrototypeOf(async function() {});` to `Object.getPrototypeOf(function() {});` under the hood.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
