### PR TITLE
fix: (5.x) make access to `process.versions` lazy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
           ln -s `pwd` ./test/typescript/node_modules/mongoose
           echo `pwd`/mongodb-linux-x86_64-ubuntu1804-4.0.2/bin >> $GITHUB_PATH
 
+      - run: npm run build-browser
+
       - run: npm test
 
   lint:

--- a/lib/cursor/AggregationCursor.js
+++ b/lib/cursor/AggregationCursor.js
@@ -39,7 +39,7 @@ const utils = require('../../lib/utils');
 function AggregationCursor(agg) {
   const streamOpts = { objectMode: true };
   // for node < 12 we will emit 'close' event after 'end'
-  if (utils.nodeMajorVersion >= 12) {
+  if (utils.nodeMajorVersion() >= 12) {
     // set autoDestroy=true because on node 12 it's by default false
     // gh-10902 need autoDestroy to destroy correctly and emit 'close' event for node >= 12
     streamOpts.autoDestroy = true;
@@ -95,7 +95,7 @@ AggregationCursor.prototype._read = function() {
           return _this.emit('error', error);
         }
         // for node >= 12 the autoDestroy will emit the 'close' event
-        if (utils.nodeMajorVersion < 12) {
+        if (utils.nodeMajorVersion() < 12) {
           _this.on('end', () => _this.emit('close'));
         }
       });

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -37,7 +37,7 @@ const utils = require('../../lib/utils');
 function QueryCursor(query, options) {
   const streamOpts = { objectMode: true };
   // for node < 12 we will emit 'close' event after 'end'
-  if (utils.nodeMajorVersion >= 12) {
+  if (utils.nodeMajorVersion() >= 12) {
     // set autoDestroy=true because on node 12 it's by default false
     // gh-10902 need autoDestroy to destroy correctly and emit 'close' event for node >= 12
     streamOpts.autoDestroy = true;
@@ -104,7 +104,7 @@ QueryCursor.prototype._read = function() {
           return _this.emit('error', error);
         }
         // for node >= 12 the autoDestroy will emit the 'close' event
-        if (utils.nodeMajorVersion < 12) {
+        if (utils.nodeMajorVersion() < 12) {
           _this.on('end', () => _this.emit('close'));
         }
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -936,4 +936,6 @@ exports.errorToPOJO = function errorToPOJO(error) {
   return ret;
 };
 
-exports.nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
+exports.nodeMajorVersion = function nodeMajorVersion() {
+  return parseInt(process.versions.node.split('.')[0], 10);
+};

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -20,6 +20,10 @@ describe('browser', function() {
     exec('node --eval "require(\'./lib/browser\')"', done);
   });
 
+  it('require() works in an environment where process.versions is an empty object (gh-5842)', function(done) {
+    exec('node --eval "Object.defineProperty(process, \'versions\', { value: {} }); require(\'./dist/browser.umd\')"', done);
+  });
+
   it('using schema (gh-7170)', function(done) {
     exec('node --eval "const mongoose = require(\'./lib/browser\'); new mongoose.Schema();"', done);
   });

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -4,6 +4,8 @@
  * Module dependencies.
  */
 
+require('../lib/browser');
+
 const Document = require('../lib/browserDocument');
 const Schema = require('../lib/schema');
 const assert = require('assert');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This PR (commit: 9396dbbd5962532eeebc7aa18840f1f4a5af66bf) fixes gh-11943 in 5.x branch. It makes access to `process.versions` lazy (in a function, not at module level) and thus does not crash mongoose loaded in a browser.

This PR (commit: f9146a304339283bbb45aca63ad82baf1ad5c5f5) also contains an *attempt* to implement a test for this issue. Unfortunately it does not achieve the main goal. I haven't been able to mock/replace value of `process.versions` to mimic what is available in the browser. Whatever is written to it (or its properties) is lost and the original values are always returned.
I am open for any suggestion on how to achieve that and can work on the PR until it is good enough. I have checked that the main change fixes the issue in our project.

Also it includes a fix (commit: c290eea2d6dc1e9ad5e7ae1b04fde926065e6d9d) to enable running `browser.test.js` in isolation (`npx mocha --exit ./test/browser.test.js`). Without the change the driver is not set before being accessed.
It doesn't fail when running all tests in batch, so it raises a question if driver objects set by tests do not interfere with results of other tests.



**Examples**

No examples needed. For the failure, just load the original `dist/browser.umd.js` into a browser.
