### PR TITLE
Better support for populating maps of arrays of refs

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -52,6 +52,11 @@ module.exports = function assignVals(o) {
 
     const _allIds = o.allIds[i];
 
+    if (o.path.endsWith('.$*')) {
+      // Skip maps re: gh-12494
+      return valueFilter(val, options, populateOptions, _allIds);
+    }
+
     if (o.justOne === true && Array.isArray(val)) {
       // Might be an embedded discriminator (re: gh-9244) with multiple models, so make sure to pick the right
       // model before assigning.

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -207,6 +207,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     let isRefPath = false;
     let justOne = null;
 
+    const originalSchema = schema;
     if (schema && schema.instance === 'Array') {
       schema = schema.caster;
     }
@@ -277,7 +278,9 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
         schemaForCurrentDoc = schema;
       }
 
-      if (schemaForCurrentDoc != null) {
+      if (originalSchema && originalSchema.path.endsWith('.$*')) {
+        justOne = !originalSchema.$isMongooseArray && !originalSchema._arrayPath;
+      } else if (schemaForCurrentDoc != null) {
         justOne = !schemaForCurrentDoc.$isMongooseArray && !schemaForCurrentDoc._arrayPath;
       }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -4784,7 +4784,11 @@ function populate(model, docs, options, callback) {
       for (const val of vals) {
         mod.options._childDocs.push(val);
       }
-      _assign(model, vals, mod, assignmentOpts);
+      try {
+        _assign(model, vals, mod, assignmentOpts);
+      } catch (err) {
+        return callback(err);
+      }
     }
 
     for (const arr of params) {

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -97,15 +97,27 @@ class MongooseMap extends Map {
 
     const fullPath = this.$__path + '.' + key;
     const populated = this.$__parent != null && this.$__parent.$__ ?
-      this.$__parent.$populated(fullPath) || this.$__parent.$populated(this.$__path) :
+      this.$__parent.$populated(fullPath, true) || this.$__parent.$populated(this.$__path, true) :
       null;
     const priorVal = this.get(key);
 
     if (populated != null) {
-      if (value.$__ == null) {
-        value = new populated.options[populateModelSymbol](value);
+      if (Array.isArray(value) && this.$__schemaType.$isMongooseArray) {
+        value = value.map(v => {
+          if (v.$__ == null) {
+            v = new populated.options[populateModelSymbol](v);
+          }
+          // Doesn't support single nested "in-place" populate
+          v.$__.wasPopulated = { value: v._id };
+          return v;
+        });
+      } else {
+        if (value.$__ == null) {
+          value = new populated.options[populateModelSymbol](value);
+        }
+        // Doesn't support single nested "in-place" populate
+        value.$__.wasPopulated = { value: value._id };
       }
-      value.$__.wasPopulated = { value: populated.value };
     } else {
       try {
         value = this.$__schemaType.

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Mixed = require('../schema/mixed');
+const MongooseError = require('../error/mongooseError');
 const clone = require('../helpers/clone');
 const deepEqual = require('../utils').deepEqual;
 const getConstructorName = require('../helpers/getConstructorName');
@@ -102,6 +103,12 @@ class MongooseMap extends Map {
     const priorVal = this.get(key);
 
     if (populated != null) {
+      if (this.$__schemaType.$isSingleNested) {
+        throw new MongooseError(
+          'Cannot manually populate single nested subdoc underneath Map ' +
+          `at path "${this.$__path}". Try using an array instead of a Map.`
+        );
+      }
       if (Array.isArray(value) && this.$__schemaType.$isMongooseArray) {
         value = value.map(v => {
           if (v.$__ == null) {

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1071,7 +1071,7 @@ describe('Map', function() {
     const UserModel = db.model('User', User);
     const AddressModel = db.model('Address', Address);
 
-    const address = await new AddressModel({ city: 'London' }).save();
+    const address = await AddressModel.create({ city: 'London' });
 
     const { _id } = await new UserModel({
       name: 'Name',

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1073,12 +1073,12 @@ describe('Map', function() {
 
     const address = await AddressModel.create({ city: 'London' });
 
-    const { _id } = await new UserModel({
+    const { _id } = await UserModel.create({
       name: 'Name',
       addresses: {
         home: [address._id]
       }
-    }).save();
+    });
 
     // Using `.$*`
     let query = UserModel.findById(_id);

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1080,13 +1080,24 @@ describe('Map', function() {
       }
     }).save();
 
-    const query = UserModel.findById(_id);
-
+    // Using `.$*`
+    let query = UserModel.findById(_id);
     query.populate({
       path: 'addresses.$*'
     });
 
-    const doc = await query.exec();
+    let doc = await query.exec();
+    assert.ok(Array.isArray(doc.addresses.get('home')));
+    assert.equal(doc.addresses.get('home').length, 1);
+    assert.equal(doc.addresses.get('home')[0].city, 'London');
+
+    // Populating just one path in the map
+    query = UserModel.findById(_id);
+    query.populate({
+      path: 'addresses.home'
+    });
+
+    doc = await query.exec();
     assert.ok(Array.isArray(doc.addresses.get('home')));
     assert.equal(doc.addresses.get('home').length, 1);
     assert.equal(doc.addresses.get('home')[0].city, 'London');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

#12494 shows that, in 5.x, you could use maps of arrays of refs. We don't currently have any test coverage for that case, so in 5.x it worked more by accident than by design. In 6.x we unexpectedly broke that. This PR gives us better support for populating maps of arrays of refs, including populating just one entry in the map.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
