### PR TITLE
Correctly find paths underneath single nested document with an array of mixed

### DIFF
--- a/lib/helpers/populate/getSchemaTypes.js
+++ b/lib/helpers/populate/getSchemaTypes.js
@@ -173,6 +173,8 @@ module.exports = function getSchemaTypes(model, schema, doc, path) {
             }
           }
         }
+      } else if (foundschema.$isSchemaMap && foundschema.$__schemaType instanceof Mixed) {
+        return foundschema.$__schemaType;
       }
 
       const fullPath = nestedPath.concat([trypath]).join('.');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2409,8 +2409,15 @@ Schema.prototype._getSchema = function(path) {
           if (p + 1 >= parts.length) {
             return foundschema.$__schemaType;
           }
-          const ret = search(parts.slice(p + 1), foundschema.$__schemaType.schema);
-          return ret;
+
+          if (foundschema.$__schemaType instanceof MongooseTypes.Mixed) {
+            return foundschema.$__schemaType;
+          }
+          if (foundschema.$__schemaType.schema != null) {
+            // Map of docs
+            const ret = search(parts.slice(p + 1), foundschema.$__schemaType.schema);
+            return ret;
+          }
         }
 
         foundschema.$fullPath = resultPath.join('.');

--- a/test/helpers/populate.getSchemaTypes.test.js
+++ b/test/helpers/populate.getSchemaTypes.test.js
@@ -178,4 +178,18 @@ describe('getSchemaTypes', function() {
     assert.equal(schemaTypes.length, 1);
     assert.equal(schemaTypes[0].options.ref, 'Enemy');
   });
+
+  it('finds path underneath nested subdocument with map of mixed (gh-12530)', function() {
+    const schema = new Schema({
+      child: new Schema({
+        testMap: {
+          type: Map,
+          of: 'Mixed'
+        }
+      })
+    });
+
+    const schemaTypes = getSchemaTypes(null, schema, null, 'child.testMap.foo.bar');
+    assert.equal(schemaTypes.instance, 'Mixed');
+  });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2885,4 +2885,17 @@ describe('schema', function() {
     assert.equal(schema.path('num').instance, 'Decimal128');
     assert.equal(schema.path('num2').instance, 'Decimal128');
   });
+
+  it('_getSchema finds path underneath nested subdocument with map of mixed (gh-12530)', function() {
+    const schema = new Schema({
+      child: new Schema({
+        testMap: {
+          type: Map,
+          of: 'Mixed'
+        }
+      })
+    });
+
+    assert.equal(schema._getSchema('child.testMap.foo.bar').instance, 'Mixed');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #12530 

Current handling for getting schema types underneath maps of mixed from #9298 and https://github.com/Automattic/mongoose/commit/63a34bec66f263c96a72d0ffb2f28a6c563a2a12 doesn't do a good job of handling `Mixed`. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
