### PR TITLE
Improve ValidateOpts type

### DIFF
--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -12,7 +12,7 @@ declare module 'mongoose' {
   }
 
   interface ValidateFn<T> {
-    (value: T): boolean;
+    (value: T, props?: ValidatorProps & Record<string, any>): boolean;
   }
 
   interface LegacyAsyncValidateFn<T> {
@@ -20,7 +20,7 @@ declare module 'mongoose' {
   }
 
   interface AsyncValidateFn<T> {
-    (value: any): Promise<boolean>;
+    (value: T, props?: ValidatorProps & Record<string, any>): Promise<boolean>;
   }
 
   interface ValidateOpts<T> {

--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -28,5 +28,6 @@ declare module 'mongoose' {
     message?: string | ValidatorMessageFn;
     type?: string;
     validator: ValidateFn<T> | LegacyAsyncValidateFn<T> | AsyncValidateFn<T>;
+    propsParameter?: boolean;
   }
 }


### PR DESCRIPTION
**Summary**

As the documention mentions [it](https://mongoosejs.com/docs/api.html#schematype_SchemaType-validate), the `propsParameter` property does not exists on the `ValidateOpts<T>` type and cause TypeScript to generate an error.

**Examples**

I have created a validator to check if the ObjectId references existing mongoDB collection document.

```ts
export const refExists: ValidateOpts<string> = {
  async validator(_id, props): Promise<boolean> {
    const self = this.constructor as Model<any>;
    const {ref} = self.schema.paths[props.path].options;
    const model = models[ref];
    
    return await model.exists({_id}).exec() !== null;
  },
  propsParameter: true,
};
```

This snippet generate two TypeScript errors:

> error TS2322: Type '{ validator(_id: string, props: (result: boolean) => void): Promise<boolean>; propsParameter: boolean; }' is not assignable to type 'ValidateOpts<string>'.
      Object literal may only specify known properties, and 'propsParameter' does not exist in type 'ValidateOpts<string>'.

Here, the compiler is thinking we are using `LegacyAsyncValidateFn<T>` because it's the only one validator to have two parameters.

and
 
> error TS2322: Type '{ validator(_id: any, opts: any): Promise<boolean>; propsParameter: boolean; }' is not assignable to type 'ValidateOpts<string>'.
      Object literal may only specify known properties, and 'propsParameter' does not exist in type 'ValidateOpts<string>'.

Here, the compiler is saying that `propsParameter` is not a valid property on that type.