### PR TITLE
fix(query): select Map field with `select: false` when explicitly requested

### DIFF
--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -232,7 +232,9 @@ exports.applyPaths = function applyPaths(fields, schema) {
     schema.eachPath(function(path, type) {
       if (prefix) path = prefix + '.' + path;
       if (type.$isSchemaMap || path.endsWith('.$*')) {
-        if (type.options && type.options.select === false) {
+        const plusPath = '+' + path;
+        const hasPlusPath = fields && plusPath in fields;
+        if (type.options && type.options.select === false && !hasPlusPath) {
           excluded.push(path);
         }
         return;

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4133,6 +4133,34 @@ describe('Query', function() {
     assert.equal(item.doNotSelect, undefined);
   });
 
+  it('Map field with select: false is selected when explicitly requested (gh-12603)', async function() {
+    const testSchema = new mongoose.Schema({
+      title: String,
+      body: {
+        type: Map,
+        of: { en: String, pt: String },
+        select: false
+      }
+    });
+
+    const Test = db.model('Test', testSchema);
+    await Test.create({
+      title: 'test',
+      body: {
+        A: { en: 'en test A value', pt: 'pt test A value' },
+        B: { en: 'en test B value', pt: 'pt test B value' }
+      }
+    });
+
+    const item = await Test.findOne({}).select('+body');
+    assert.equal(item.title, 'test');
+    assert.equal(item.get('body.A.en'), 'en test A value');
+
+    const item2 = await Test.findOne({}).select('body');
+    assert.equal(item2.title, undefined);
+    assert.equal(item2.get('body.A.en'), 'en test A value');
+  });
+
   it('treats ObjectId as object with `_id` for `merge()` (gh-12325)', async function() {
     const testSchema = new mongoose.Schema({ name: String });
     const Test = db.model('Test', testSchema);


### PR DESCRIPTION
fix #12603

**Summary**
Selecting a Map field with the flag `select` to `false` in the schema declaration using the `.select('+field')` syntax now correctly returns the field.