### PR TITLE
Removed outdated example from `createConnection` method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -322,10 +322,6 @@ Mongoose.prototype.get = Mongoose.prototype.set;
  *     const opts = { replset: { strategy: 'ping', rs_name: 'testSet' }}
  *     db = mongoose.createConnection('mongodb://user:pass@localhost:port,anotherhost:port,yetanother:port/database', opts);
  *
- *     // and options
- *     const opts = { server: { auto_reconnect: false }, user: 'username', pass: 'mypassword' }
- *     db = mongoose.createConnection('localhost', 'database', port, opts)
- *
  *     // initialize now, connect later
  *     db = mongoose.createConnection();
  *     db.openUri('localhost', 'database', port, [opts]);


### PR DESCRIPTION
fix #12618

**Summary**
Canceled an example that was related to the old `createConnection` syntax and wasn't removed in #6766