### PR TITLE
fix(types): make array paths optional in inferred type of array default returns undefined

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -412,6 +412,7 @@ export function autoTypedSchema() {
     array5: any[];
     array6: string[];
     array7?: string[];
+    array8?: string[];
     decimal1?: Types.Decimal128;
     decimal2?: Types.Decimal128;
     decimal3?: Types.Decimal128;
@@ -458,6 +459,7 @@ export function autoTypedSchema() {
     array5: [],
     array6: { type: [String] },
     array7: { type: [String], default: undefined },
+    array8: { type: [String], default: () => undefined },
     decimal1: Schema.Types.Decimal128,
     decimal2: 'Decimal128',
     decimal3: 'decimal128'
@@ -869,16 +871,4 @@ function gh12431() {
 
   type Example = InferSchemaType<typeof testSchema>;
   expectType<{ testDate?: Date, testDecimal?: Types.Decimal128 }>({} as Example);
-}
-
-function gh12420() {
-  const TestSchema = new Schema(
-    {
-      comments: { type: [String], default: () => undefined }
-    }
-  );
-
-  expectType<{
-    comments?: string[]
-  }>({} as InferSchemaType<typeof TestSchema>);
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -870,3 +870,15 @@ function gh12431() {
   type Example = InferSchemaType<typeof testSchema>;
   expectType<{ testDate?: Date, testDecimal?: Types.Decimal128 }>({} as Example);
 }
+
+function gh12420() {
+  const TestSchema = new Schema(
+    {
+      comments: { type: [String], default: () => undefined }
+    }
+  );
+
+  expectType<{
+    comments?: string[]
+  }>({} as InferSchemaType<typeof TestSchema>);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -60,6 +60,12 @@ declare module 'mongoose' {
       : unknown;
 }
 
+type IsPathDefaultUndefined<PathType> = PathType extends { default: undefined } ?
+  true :
+  PathType extends { default: (...args: any[]) => undefined } ?
+    true :
+    false;
+
 /**
  * @summary Checks if a document path is required or optional.
  * @param {P} P Document path.
@@ -69,7 +75,7 @@ type IsPathRequired<P, TypeKey extends TypeKeyBaseType = DefaultTypeKey> =
   P extends { required: true | [true, string | undefined] } | ArrayConstructor | any[]
     ? true
     : P extends (Record<TypeKey, ArrayConstructor | any[]>)
-      ? P extends { default: undefined }
+      ? IsPathDefaultUndefined<P> extends true
         ? false
         : true
       : P extends (Record<TypeKey, any>)


### PR DESCRIPTION
Fix #12420

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Our types should treat setting `default` to a function that always returns `undefined` in the same way we treat setting `default: undefined`.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
