### PR TITLE
fix(types): set `this` to doc type in `SchemaType.prototype.validate()`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -907,7 +907,7 @@ function gh12590() {
 
   expectType<SchemaType<User>>(UserSchema.path('hashed_password'));
 
-  UserSchema.path('hashed_password').validate(function(v: any) {
+  UserSchema.path('hashed_password').validate(function(v) {
     expectType<HydratedDocument<User>>(this);
     if (this._password && this._password.length < 8) {
       this.invalidate('password', 'Password must be at least 8 characters.');

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -897,3 +897,21 @@ function gh12562() {
     }
   );
 }
+
+function gh12590() {
+  const UserSchema = new Schema({
+    _password: String
+  });
+
+  type User = InferSchemaType<typeof UserSchema>;
+
+  expectType<SchemaType<User>>(UserSchema.path('hashed_password'));
+
+  UserSchema.path('hashed_password').validate(function(v: any) {
+    expectType<HydratedDocument<User>>(this);
+    if (this._password && this._password.length < 8) {
+      this.invalidate('password', 'Password must be at least 8 characters.');
+    }
+  });
+
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -258,8 +258,8 @@ declare module 'mongoose' {
     obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>>;
 
     /** Gets/sets schema paths. */
+    path<ResultType extends SchemaType = SchemaType<any, HydratedDocument<DocType, TInstanceMethods>>>(path: string): ResultType;
     path<pathGeneric extends keyof EnforcedDocType>(path: pathGeneric): SchemaType<EnforcedDocType[pathGeneric]>;
-    path<ResultType extends SchemaType = SchemaType>(path: string): ResultType;
     path(path: string, constructor: any): this;
 
     /** Lists all paths and their type in the schema. */

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -188,7 +188,11 @@ declare module 'mongoose' {
     [other: string]: any;
   }
 
-  class SchemaType<T = any> {
+  interface Validator {
+    message?: string; type?: string; validator?: Function
+  }
+
+  class SchemaType<T = any, DocType = any> {
     /** SchemaType constructor */
     constructor(path: string, options?: AnyObject, instance?: string);
 
@@ -270,10 +274,10 @@ declare module 'mongoose' {
     unique(bool: boolean): this;
 
     /** The validators that Mongoose should run to validate properties at this SchemaType's path. */
-    validators: { message?: string; type?: string; validator?: Function }[];
+    validators: Validator[];
 
     /** Adds validator(s) for this document path. */
-    validate(obj: RegExp | Function | any, errorMsg?: string, type?: string): this;
+    validate(obj: RegExp | ((this: DocType, value: any, validatorProperties?: Validator) => any), errorMsg?: string, type?: string): this;
   }
 
   namespace Schema {


### PR DESCRIPTION
Fix #12590

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

`SchemaType` should have a reference to the `DocType` so it knows that type to set `this` to in when the user does `schema.path('mypath').validate(function(v) { ... })`. With this PR, the following script compiles fine

```ts
import { Schema, SchemaType, InferSchemaType } from 'mongoose';
  
const UserSchema = new Schema({
  _password: String
});

type User = InferSchemaType<typeof UserSchema>;

UserSchema.path('hashed_password').validate(function (v) {
  if (this._password && this._password.length < 8) {
    this.invalidate('password', 'Password must be at least 8 characters.');
  }
});

```

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
