### PR TITLE
fix(document): handle setting array to itself after saving and pushing a new value

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1468,13 +1468,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
       const doc = this.$isSubdocument ? this.ownerDocument() : this;
       savedState = doc.$__.savedState;
       savedStatePath = this.$isSubdocument ? this.$__.fullPath + '.' + path : path;
-      if (savedState != null) {
-        const firstDot = savedStatePath.indexOf('.');
-        const topLevelPath = firstDot === -1 ? savedStatePath : savedStatePath.slice(0, firstDot);
-        if (!savedState.hasOwnProperty(topLevelPath)) {
-          savedState[topLevelPath] = utils.clone(doc.$__getValue(topLevelPath));
-        }
-      }
+      doc.$__saveInitialState(savedStatePath);
     }
 
     this.$__set(pathToMark, path, options, constructing, parts, schema, val, priorVal);
@@ -1581,6 +1575,10 @@ Document.prototype.$__shouldModify = function(pathToMark, path, options, constru
     return false;
   }
   if (this.$isNew) {
+    return true;
+  }
+  // Is path already modified? If so, always modify. We may unmark modified later.
+  if (path in this.$__.activePaths.getStatePaths('modify')) {
     return true;
   }
 
@@ -1780,11 +1778,10 @@ Document.prototype.$inc = function $inc(path, val) {
 
   const currentValue = this.$__getValue(path) || 0;
 
-  this.$__setValue(path, currentValue + val);
-
   this.$__.primitiveAtomics = this.$__.primitiveAtomics || {};
   this.$__.primitiveAtomics[path] = { $inc: val };
   this.markModified(path);
+  this.$__setValue(path, currentValue + val);
 
   return this;
 };
@@ -1927,10 +1924,28 @@ Document.prototype.$__path = function(path) {
  */
 
 Document.prototype.markModified = function(path, scope) {
+  this.$__saveInitialState(path);
+
   this.$__.activePaths.modify(path);
   if (scope != null && !this.$isSubdocument) {
     this.$__.pathsToScopes = this.$__pathsToScopes || {};
     this.$__.pathsToScopes[path] = scope;
+  }
+};
+
+/*!
+ * ignore
+ */
+
+Document.prototype.$__saveInitialState = function $__saveInitialState(path) {
+  const savedState = this.$__.savedState;
+  const savedStatePath = path;
+  if (savedState != null) {
+    const firstDot = savedStatePath.indexOf('.');
+    const topLevelPath = firstDot === -1 ? savedStatePath : savedStatePath.slice(0, firstDot);
+    if (!savedState.hasOwnProperty(topLevelPath)) {
+      savedState[topLevelPath] = utils.clone(this.$__getValue(topLevelPath));
+    }
   }
 };
 
@@ -3379,6 +3394,7 @@ Document.prototype.$__dirty = function() {
       schema: _this.$__path(path)
     };
   });
+
   // gh-2558: if we had to set a default and the value is not undefined,
   // we have to save as well
   all = all.concat(this.$__.activePaths.map('default', function(path) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -9191,7 +9191,6 @@ describe('document', function() {
 
     const Test = db.model('Test', schema);
 
-
     const foo = new Test({ bar: 'bar' });
     await foo.save();
     assert.ok(!foo.isModified('bar'));
@@ -11995,6 +11994,28 @@ describe('document', function() {
       authors: [{ fullName: 'Sourabh Bagrecha' }],
       title: 'The power of JavaScript'
     });
+  });
+
+  it('handles setting array to itself after saving and pushing a new value (gh-12656)', async function() {
+    const Test = db.model('Test', new Schema({
+      list: [{
+        a: Number
+      }]
+    }));
+    await Test.create({ list: [{ a: 1, b: 11 }] });
+
+    let doc = await Test.findOne();
+    doc.list.push({ a: 2 });
+    doc.list = [...doc.list];
+    await doc.save();
+
+    doc.list.push({ a: 3 });
+    doc.list = [...doc.list];
+    await doc.save();
+
+    doc = await Test.findOne();
+    assert.equal(doc.list.length, 3);
+    assert.deepStrictEqual(doc.list.map(el => el.a), [1, 2, 3]);
   });
 });
 


### PR DESCRIPTION
Fix #12656

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We added some tracking of what the "saved state" of a document is in #9396 and #10773, but #12656 pointed out that we're not actually storing this saved state correctly when the first operation is a `push()`. Thankfully, #11644 makes this a bit easier: we can copy the state in `markModified()`.

Hopefully this is all we need, but we may want to consider tracking `savedState` by just cloning the document when the document is saved or loaded. That is easier from an implementation perspective, but bad from a performance perspective. I would prefer to not have to do that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
