### PR TITLE
added deprecation warning for default `strictQuery`

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -898,6 +898,7 @@ You can prepare for the change by specifying:
 ```javascript
 // Set `strictQuery` to `false` to prepare for the change
 mongoose.set('strictQuery', false);
+
 // Set `strictQuery` to `true` to suppress the warning message
 mongoose.set('strictQuery', true);
 ```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -896,8 +896,11 @@ In Mongoose 7, `strictQuery` default value will be switched back to `false`.
 You can prepare for the change by specifying:
 
 ```javascript
-// Set `strictQuery` to `false`
+// Set `strictQuery` to `false` to prepare for the change
 mongoose.set('strictQuery', false);
+
+// Set `strictQuery` to `true` to suppress the warning message
+mongoose.set('strictQuery', true);
 ```
 
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -898,7 +898,6 @@ You can prepare for the change by specifying:
 ```javascript
 // Set `strictQuery` to `false` to prepare for the change
 mongoose.set('strictQuery', false);
-
 // Set `strictQuery` to `true` to suppress the warning message
 mongoose.set('strictQuery', true);
 ```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -892,6 +892,15 @@ However, you can override this behavior globally:
 mongoose.set('strictQuery', false);
 ```
 
+In Mongoose 7, `strictQuery` default value will be switched back to `false`.
+You can prepare for the change by specifying:
+
+```javascript
+// Set `strictQuery` to `false`
+mongoose.set('strictQuery', false);
+```
+
+
 <h3 id="toJSON"><a href="#toJSON">option: toJSON</a></h3>
 
 Exactly the same as the [toObject](#toObject) option but only applies when

--- a/lib/helpers/printStrictQueryWarning.js
+++ b/lib/helpers/printStrictQueryWarning.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const util = require('node:util');
+const util = require('util');
 
 module.exports = util.deprecate(
   function() { },

--- a/lib/helpers/printStrictQueryWarning.js
+++ b/lib/helpers/printStrictQueryWarning.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const util = require('node:util');
+
+module.exports = util.deprecate(
+  function() { },
+  'Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
+    'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
+    'for this change. Or use `mongoose.set(\'strictQuery\', true);` to suppress this warning.',
+  'MONGOOSE'
+);

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ const validateBeforeSave = require('./plugins/validateBeforeSave');
 
 const Aggregate = require('./aggregate');
 const PromiseProvider = require('./promise_provider');
+const printStrictQueryWarning = require('./helpers/printStrictQueryWarning');
 const shardingPlugin = require('./plugins/sharding');
 const trusted = require('./helpers/query/trusted').trusted;
 const sanitizeFilter = require('./helpers/query/sanitizeFilter');
@@ -409,9 +410,7 @@ Mongoose.prototype.connect = function(uri, options, callback) {
   const conn = _mongoose.connection;
 
   if (_mongoose.options.strictQuery === undefined) {
-    utils.warn('Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
-              'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
-              'for this change. Or use `mongoose.set(\'strictQuery\', true);` to suppress this warning.');
+    printStrictQueryWarning();
   }
 
   return _mongoose._promiseOrCallback(callback, cb => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -214,7 +214,7 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
  * - 'sanitizeFilter': `false` by default. Set to true to enable the [sanitization of the query filters](/docs/api.html#mongoose_Mongoose-sanitizeFilter) against query selector injection attacks by wrapping any nested objects that have a property whose name starts with `$` in a `$eq`.
  * - 'selectPopulatedPaths': `true` by default. Set to false to opt out of Mongoose adding all fields that you `populate()` to your `select()`. The schema-level option `selectPopulatedPaths` overwrites this one.
  * - 'strict': `true` by default, may be `false`, `true`, or `'throw'`. Sets the default strict mode for schemas.
- * - 'strictQuery': same value as 'strict' by default (`true`), may be `false`, `true`, or `'throw'`. Sets the default [strictQuery](/docs/guide.html#strictQuery) mode for schemas.
+ * - 'strictQuery': same value as 'strict' by default (`true`), may be `false`, `true`, or `'throw'`. Sets the default [strictQuery](/docs/guide.html#strictQuery) mode for schemas. The default value will be switched back to `false` in Mongoose 7, use `mongoose.set('strictQuery', false);` if you want to prepare for the change.
  * - 'toJSON': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toJSON()`](/docs/api.html#document_Document-toJSON), for determining how Mongoose documents get serialized by `JSON.stringify()`
  * - 'toObject': `{ transform: true, flattenDecimals: true }` by default. Overwrites default objects to [`toObject()`](/docs/api.html#document_Document-toObject)
  *
@@ -407,6 +407,12 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
 Mongoose.prototype.connect = function(uri, options, callback) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
   const conn = _mongoose.connection;
+
+  if (_mongoose.options.strictQuery === undefined) {
+    utils.warn('Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
+              'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
+              'for this change.');
+  }
 
   return _mongoose._promiseOrCallback(callback, cb => {
     conn.openUri(uri, options, err => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -411,7 +411,7 @@ Mongoose.prototype.connect = function(uri, options, callback) {
   if (_mongoose.options.strictQuery === undefined) {
     utils.warn('Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
               'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
-              'for this change.');
+              'for this change. Or use `mongoose.set(\'strictQuery\', true);` to suppress this warning.');
   }
 
   return _mongoose._promiseOrCallback(callback, cb => {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4904,7 +4904,7 @@ Query.prototype.exec = function exec(op, callback) {
   ) {
     utils.warn('Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
               'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
-              'for this change.');
+              'for this change. Or use `mongoose.set(\'strictQuery\', true);` to suppress this warning.');
   }
 
   if (typeof op === 'function') {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4898,6 +4898,7 @@ Query.prototype.exec = function exec(op, callback) {
   const collection = this.mongooseCollection;
 
   if (
+    collection.conn &&
     collection.conn.base.options.strictQuery === undefined &&
     _this.options.strictQuery === true
   ) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4895,6 +4895,16 @@ Query.prototype.exec = function exec(op, callback) {
   // Ensure that `exec()` is the first thing that shows up in
   // the stack when cast errors happen.
   const castError = new CastError();
+  const collection = this.mongooseCollection;
+
+  if (
+    collection.conn.base.options.strictQuery === undefined &&
+    _this.options.strictQuery === true
+  ) {
+    utils.warn('Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
+              'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
+              'for this change.');
+  }
 
   if (typeof op === 'function') {
     callback = op;

--- a/lib/query.js
+++ b/lib/query.js
@@ -30,6 +30,7 @@ const isSubpath = require('./helpers/projection/isSubpath');
 const mpath = require('mpath');
 const mquery = require('mquery');
 const parseProjection = require('./helpers/projection/parseProjection');
+const printStrictQueryWarning = require('./helpers/printStrictQueryWarning');
 const removeUnusedArrayFilters = require('./helpers/update/removeUnusedArrayFilters');
 const sanitizeFilter = require('./helpers/query/sanitizeFilter');
 const sanitizeProjection = require('./helpers/query/sanitizeProjection');
@@ -4902,9 +4903,7 @@ Query.prototype.exec = function exec(op, callback) {
     collection.conn.base.options.strictQuery === undefined &&
     _this.options.strictQuery === true
   ) {
-    utils.warn('Mongoose: the `strictQuery` option will be switched back to `false` by default ' +
-              'in Mongoose 7. Use `mongoose.set(\'strictQuery\', false);` if you want to prepare ' +
-              'for this change. Or use `mongoose.set(\'strictQuery\', true);` to suppress this warning.');
+    printStrictQueryWarning();
   }
 
   if (typeof op === 'function') {

--- a/lib/query.js
+++ b/lib/query.js
@@ -30,7 +30,6 @@ const isSubpath = require('./helpers/projection/isSubpath');
 const mpath = require('mpath');
 const mquery = require('mquery');
 const parseProjection = require('./helpers/projection/parseProjection');
-const printStrictQueryWarning = require('./helpers/printStrictQueryWarning');
 const removeUnusedArrayFilters = require('./helpers/update/removeUnusedArrayFilters');
 const sanitizeFilter = require('./helpers/query/sanitizeFilter');
 const sanitizeProjection = require('./helpers/query/sanitizeProjection');
@@ -4896,15 +4895,6 @@ Query.prototype.exec = function exec(op, callback) {
   // Ensure that `exec()` is the first thing that shows up in
   // the stack when cast errors happen.
   const castError = new CastError();
-  const collection = this.mongooseCollection;
-
-  if (
-    collection.conn &&
-    collection.conn.base.options.strictQuery === undefined &&
-    _this.options.strictQuery === true
-  ) {
-    printStrictQueryWarning();
-  }
 
   if (typeof op === 'function') {
     callback = op;


### PR DESCRIPTION
fix #12666

**Summary**
`strictQuery` will be switched back to `false` by default in Mongoose 7 so a warning message is shown on the database connection and on query execution if the `strictQuery` option is undefined and forced to true by the user.

Let me know if I understood the suggested logic correctly for the query warning message.