### PR TITLE
Fixing diffIndexes to cleanly return error instead of resulting in ty…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1427,6 +1427,14 @@ Model.diffIndexes = function diffIndexes(options, callback) {
   return this.db.base._promiseOrCallback(callback, cb => {
     cb = this.$wrapCallback(cb);
     this.listIndexes((err, indexes) => {
+      if (err) {
+        // If the collection does not exist, it does not have indexes; safely proceed
+        if (err.codeName === 'NamespaceNotFound') {
+          indexes = [];
+        } else {
+          return cb(err, { toDrop, toCreate });
+        }
+      }
       const schemaIndexes = this.schema.indexes();
       // Iterate through the indexes created in mongodb and
       // compare against the indexes in the schema.

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -70,6 +70,15 @@ describe('model', function() {
       });
     });
 
+    it('should have schema-defined indexes in toCreate when calling diffIndexes on model with no documents (gh-12676)', () => {
+      const MySchema = new Schema({
+        name: { type: String, index: true }
+      });
+
+      const MyModel = db.model('my-model', MySchema); // This collection should not exist in DB; no documents
+      return MyModel.diffIndexes().then((res) => assert.deepEqual(res.toCreate[0], { name: 1 }));
+    });
+
     it('of embedded documents', function(done) {
       const BlogPosts = new Schema({
         _id: { type: ObjectId, index: true },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Current behavior: Calling `diffIndexes()` on model whose collection doesn't exist results in a TypeError. See https://github.com/Automattic/mongoose/issues/12676#issue-1444579141

Use Case:
Dry runs of creating indexes. Occasionally calls from a newly introduced model whose collection doesn't yet exist because no documents haven been inserted. We need to return an error, if it exists, to the callback so invokers are able to gracefully handle the error.
**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
