### PR TITLE
fix(schema): fix setupTimestamps for browser.umd

### DIFF
--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -28,7 +28,7 @@ module.exports = function setupTimestamps(schema, timestamps) {
   schema.$timestamps = { createdAt: createdAt, updatedAt: updatedAt };
 
   if (createdAt && !schema.paths[createdAt]) {
-    const baseImmutableCreatedAt = schema.base.get('timestamps.createdAt.immutable');
+    const baseImmutableCreatedAt = schema.base != null ? schema.base.get('timestamps.createdAt.immutable') : null;
     const immutable = baseImmutableCreatedAt != null ? baseImmutableCreatedAt : true;
     schemaAdditions[createdAt] = { [schema.options.typeKey || 'type']: Date, immutable };
   }


### PR DESCRIPTION
With the current browser.umd it‘s no longer possible to create schemas in the browser with `timestamps: true`. The following error is thrown: `Cannot read properties of null (reading 'get')`

Example to reproduce:
```
import mongoose from "mongoose";

const TestSchema = new mongoose.Schema(
  { a: String },
  { timestamps: true }
);
```