### PR TITLE
docs(document): explain that `$isNew` is `false` in post('save') hooks

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -219,13 +219,13 @@ function Document(obj, fields, skipId, options) {
  *
  *     const user = await User.findOne({ name: 'John Smith' });
  *     user.$isNew; // false
- * 
+ *
  * Mongoose sets `$isNew` to `false` immediately after `save()` succeeds.
  * That means Mongoose sets `$isNew` to false **before** `post('save')` hooks run.
  * In `post('save')` hooks, `$isNew` will be `false` if `save()` succeeded.
- * 
+ *
  * #### Example:
- * 
+ *
  *     userSchema.post('save', function() {
  *       this.$isNew; // false
  *     });

--- a/lib/document.js
+++ b/lib/document.js
@@ -219,6 +219,17 @@ function Document(obj, fields, skipId, options) {
  *
  *     const user = await User.findOne({ name: 'John Smith' });
  *     user.$isNew; // false
+ * 
+ * Mongoose sets `$isNew` to `false` immediately after `save()` succeeds.
+ * That means Mongoose sets `$isNew` to false **before** `post('save')` hooks run.
+ * In `post('save')` hooks, `$isNew` will be `false` if `save()` succeeded.
+ * 
+ * #### Example:
+ * 
+ *     userSchema.post('save', function() {
+ *       this.$isNew; // false
+ *     });
+ *     await User.create({ name: 'John Smith' });
  *
  * For subdocuments, `$isNew` is true if either the parent has `$isNew` set,
  * or if you create a new subdocument.


### PR DESCRIPTION
Fix #11990

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Docs need to explain that `$isNew` is false in post('save') hooks, this question has come up a few times.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
