### PR TITLE
docs: fix inverted explanation of `justOne` option for populate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4556,7 +4556,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
  * - match: optional query conditions to match
  * - model: optional name of the model to use for population
  * - options: optional query options like sort, limit, etc
- * - justOne: optional boolean, if true Mongoose will always set `path` to an array. Inferred from schema by default.
+ * - justOne: optional boolean, if true Mongoose will always set `path` to a document or `null`. If false, Mongoose will always set `path` to a potentially empty array. Inferred from schema by default.
  * - strictPopulate: optional boolean, set to `false` to allow populating paths that aren't in the schema.
  *
  * #### Example:

--- a/lib/model.js
+++ b/lib/model.js
@@ -4556,7 +4556,7 @@ Model.validate = function validate(obj, pathsToValidate, context, callback) {
  * - match: optional query conditions to match
  * - model: optional name of the model to use for population
  * - options: optional query options like sort, limit, etc
- * - justOne: optional boolean, if true Mongoose will always set `path` to a document or `null`. If false, Mongoose will always set `path` to a potentially empty array. Inferred from schema by default.
+ * - justOne: optional boolean, if true Mongoose will always set `path` to a document, or `null` if no document was found. If false, Mongoose will always set `path` to an array, which will be empty if no documents are found. Inferred from schema by default.
  * - strictPopulate: optional boolean, set to `false` to allow populating paths that aren't in the schema.
  *
  * #### Example:

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -26,8 +26,9 @@ declare module 'mongoose' {
      /** deep populate */
      populate?: string | PopulateOptions | (string | PopulateOptions)[];
      /**
-     * If true Mongoose will always set `path` to an array, if false Mongoose will
-     * always set `path` to a document. Inferred from schema by default.
+     * If true Mongoose will always set `path` to a document or `null`.
+     * If false Mongoose will always set `path` to a potentially empty array.
+     * Inferred from schema by default.
      */
      justOne?: boolean;
      /** transform function to call on every populated doc */

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -26,8 +26,8 @@ declare module 'mongoose' {
      /** deep populate */
      populate?: string | PopulateOptions | (string | PopulateOptions)[];
      /**
-     * If true Mongoose will always set `path` to a document or `null`.
-     * If false Mongoose will always set `path` to a potentially empty array.
+     * If true Mongoose will always set `path` to a document, or `null` if no document was found.
+     * If false Mongoose will always set `path` to an array, which will be empty if no documents are found.
      * Inferred from schema by default.
      */
      justOne?: boolean;


### PR DESCRIPTION
Fix #12599

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In a couple of places our description of the `justOne` flag is flipped. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
