### PR TITLE
[DOCS] Update remaining relative and static links, also add style guidelines for documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ If you'd like to preview your documentation changes, first commit your changes t
 
 Visit `http://localhost:8089` and you should see the docs with your local changes. Make sure you `npm run docs:clean` before committing, because automated generated files to `docs/*` should **not** be in PRs.
 
+#### Documentation Style Guidelines
+
+There are some guidelines to keep the style for the documentation consistent:
+
+- All links that refer to some other file in the mongoose documentation needs to be relative without a prefix unless required (use `guide.html` over `./guide.html` or `/docs/guide.html`)
+
 ### Plugins website
 
 The [plugins](http://plugins.mongoosejs.io/) site is also an [open source project](https://github.com/vkarpov15/mongooseplugins) that you can get involved with. Feel free to fork and improve it as well!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ If you have a question about Mongoose (not a bug report) please post it to eithe
 
 To contribute to the [API documentation](http://mongoosejs.com/docs/api.html) just make your changes to the inline documentation of the appropriate [source code](https://github.com/Automattic/mongoose/tree/master/lib) in the master branch and submit a [pull request](https://help.github.com/articles/using-pull-requests/). You might also use the github [Edit](https://github.com/blog/844-forking-with-the-edit-button) button.
 
-To contribute to the [guide](http://mongoosejs.com/docs/guide.html) or [quick start](http://mongoosejs.com/docs/index.html) docs, make your changes to the appropriate `.pug` files in the [docs](https://github.com/Automattic/mongoose/tree/master/docs) directory of the master branch and submit a pull request. Again, the [Edit](https://github.com/blog/844-forking-with-the-edit-button) button might work for you here.
+To contribute to the [guide](http://mongoosejs.com/docs/guide.html) or [quick start](http://mongoosejs.com/docs/index.html) docs, make your changes to the appropriate `.pug` / `.md` files in the [docs](https://github.com/Automattic/mongoose/tree/master/docs) directory of the master branch and submit a pull request. Again, the [Edit](https://github.com/blog/844-forking-with-the-edit-button) button might work for you here.
 
 If you'd like to preview your documentation changes, first commit your changes to your local master branch, then execute:
 
@@ -84,4 +84,3 @@ Thank you to all the people who have already contributed to mongoose!
 Thank you to all our backers! [[Become a backer](https://opencollective.com/mongoose#backer)]
 
 <a href="https://opencollective.com/mongoose#backers" target="_blank"><img src="https://opencollective.com/mongoose/backers.svg?width=890"></a>
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ If you have a question about Mongoose (not a bug report) please post it to eithe
 - Write typings-tests if you modify the typescript-typings. (tests are in the [test/types](https://github.com/Automattic/mongoose/tree/master/test/types) directory).
 
 ### Running the tests
+
 - Open a terminal and navigate to the root of the project
 - execute `npm install` to install the necessary dependencies
 - execute `npm run mongo` to start a MongoDB instance on port 27017. This step is optional, if you have already a database running on port 27017. To spin up a specific mongo version, you can do it by executing `npm run mongo -- {version}`. E.g. you want to spin up a mongo 4.2.2 server, you execute `npm run mongo -- 4.2.2`
@@ -69,21 +70,17 @@ There are some guidelines to keep the style for the documentation consistent:
 
 The [plugins](http://plugins.mongoosejs.io/) site is also an [open source project](https://github.com/vkarpov15/mongooseplugins) that you can get involved with. Feel free to fork and improve it as well!
 
-
 ## Financial contributions
 
 We also welcome financial contributions in full transparency on our [open collective](https://opencollective.com/mongoose).
 Anyone can file an expense. If the expense makes sense for the development of the community, it will be "merged" in the ledger of our open collective by the core contributors and the person who filed the expense will be reimbursed.
 
-
 ## Credits
-
 
 ### Contributors
 
 Thank you to all the people who have already contributed to mongoose!
 <a href="https://github.com/Automattic/mongoose/graphs/contributors"><img src="https://opencollective.com/mongoose/contributors.svg?width=890" /></a>
-
 
 ### Backers
 

--- a/docs/async-await.md
+++ b/docs/async-await.md
@@ -62,7 +62,7 @@ async function awaitUpdate() {
 }
 ```
 
-Note that the specific fulfillment values of different Mongoose methods vary, and may be affected by configuration. Please refer to the [API documentation](./api.html) for information about specific methods.
+Note that the specific fulfillment values of different Mongoose methods vary, and may be affected by configuration. Please refer to the [API documentation](api.html) for information about specific methods.
 
 ### Async Functions
 
@@ -108,7 +108,7 @@ Under the hood, [async/await is syntactic sugar](https://developer.mozilla.org/e
 Due to the surprisingly simple way promises are implemented in JavaScript, the keyword `await` will try to unwrap any object with a property whose key is the string ‘then’ and whose value is a function. 
 Such objects belong to a broader class of objects called [thenables](https://masteringjs.io/tutorials/fundamentals/thenable). 
 If the thenable being unwrapped is a genuine promise, e.g. an instance of the [Promise constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), we enjoy several guarantees about how the object’s ‘then’ function will behave. 
-However, Mongoose provides several static helper methods that return a different class of thenable object called a [Query](./queries.html)--and [Queries are not promises](./queries.html#queries-are-not-promises). 
+However, Mongoose provides several static helper methods that return a different class of thenable object called a [Query](queries.html)--and [Queries are not promises](queries.html#queries-are-not-promises). 
 Because Queries are also *thenables*, we can interact with a Query using async/await just as we would interact with a genuine promise, with one key difference: observing the fulfillment value of a genuine promise cannot under any circumstances change that value, but trying to re-observe the value of a Query may cause the Query to be re-executed.
 
 ```javascript
@@ -148,4 +148,4 @@ async function observeQuery() {
 
 You are most likely to accidentally re-execute queries in this way when mixing callbacks with async/await.
  This is never necessary and should be avoided.
- If you need a Query to return a fully-fledged promise instead of a thenable, you can use [Query#exec()](./api/query.html#query_Query-exec).
+ If you need a Query to return a fully-fledged promise instead of a thenable, you can use [Query#exec()](api/query.html#query_Query-exec).

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -60,7 +60,7 @@ setTimeout(function() {
 }, 60000);
 ```
 
-To disable buffering, turn off the [`bufferCommands` option on your schema](./guide.html#bufferCommands).
+To disable buffering, turn off the [`bufferCommands` option on your schema](guide.html#bufferCommands).
 If you have `bufferCommands` on and your connection is hanging, try turning
 `bufferCommands` off to see if you haven't opened a connection properly.
 You can also disable `bufferCommands` globally:
@@ -178,7 +178,7 @@ See [this page](http://mongodb.github.io/node-mongodb-native/3.1/reference/faq/)
 <h3 id="callback"><a href="#callback">Callback</a></h3>
 
 The `connect()` function also accepts a callback parameter and returns a
-[promise](./promises.html).
+[promise](promises.html).
 
 ```javascript
 mongoose.connect(uri, options, function(error) {
@@ -379,8 +379,8 @@ The `mongoose.createConnection()` function takes the same arguments as
 const conn = mongoose.createConnection('mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]', options);
 ```
 
-This [connection](./api.html#connection_Connection) object is then used to
-create and retrieve [models](./api.html#model_Model). Models are
+This [connection](api.html#connection_Connection) object is then used to
+create and retrieve [models](api.html#model_Model). Models are
 **always** scoped to a single connection.
 
 ```javascript

--- a/docs/documents.md
+++ b/docs/documents.md
@@ -1,8 +1,8 @@
 ## Documents
 
-Mongoose [documents](./api/document.html) represent a one-to-one mapping
+Mongoose [documents](api/document.html) represent a one-to-one mapping
 to documents as stored in MongoDB. Each document is an instance of its
-[Model](./models.html).
+[Model](models.html).
 
 <ul class="toc">
   <li><a href="#documents-vs-models">Documents vs Models</a></li>
@@ -134,7 +134,7 @@ await Person.updateOne({}, { age: 'bar' });
 await Person.updateOne({}, { age: -1 }, { runValidators: true });
 ```
 
-Read the [validation](./validation.html) guide for more details.
+Read the [validation](validation.html) guide for more details.
 
 <h2 id="overwriting"><a href="#overwriting">Overwriting</a></h2>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -119,7 +119,7 @@ console.log(new Model());
 
 **A**. This is a performance optimization. These empty objects are not saved
 to the database, nor are they in the result `toObject()`, nor do they show
-up in `JSON.stringify()` output unless you turn off the [`minimize` option](./guide.html#minimize).
+up in `JSON.stringify()` output unless you turn off the [`minimize` option](guide.html#minimize).
 
 The reason for this behavior is that Mongoose's change detection
 and getters/setters are based on [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
@@ -128,11 +128,11 @@ the overhead of running `Object.defineProperty()` every time a document is creat
 mongoose defines properties on the `Model` prototype when the model is compiled.
 Because mongoose needs to define getters and setters for `nested.prop`, `nested`
 must always be defined as an object on a mongoose document, even if `nested`
-is undefined on the underlying [POJO](./guide.html#minimize).
+is undefined on the underlying [POJO](guide.html#minimize).
 
 <hr id="arrow-functions" />
 
-<a class="anchor" href="#arrow-functions">**Q**</a>. I'm using an arrow function for a [virtual](./guide.html#virtuals), [middleware](./middleware.html), [getter](./api.html#schematype_SchemaType-get)/[setter](./api.html#schematype_SchemaType-set), or [method](./guide.html#methods) and the value of `this` is wrong.
+<a class="anchor" href="#arrow-functions">**Q**</a>. I'm using an arrow function for a [virtual](guide.html#virtuals), [middleware](middleware.html), [getter](api.html#schematype_SchemaType-get)/[setter](api.html#schematype_SchemaType-set), or [method](guide.html#methods) and the value of `this` is wrong.
 
 **A**. Arrow functions [handle the `this` keyword much differently than conventional functions](https://masteringjs.io/tutorials/fundamentals/arrow#why-not-arrow-functions).
 Mongoose getters/setters depend on `this` to give you access to the document that you're writing to, but this functionality does not work with arrow functions. Do **not** use arrow functions for mongoose getters/setters unless do not intend to access the document in the getter/setter.
@@ -225,7 +225,7 @@ new Schema({
 <a class="anchor" href="#model_functions_hanging">**Q**</a>. All function calls on my models hang, what am I doing wrong?
 
 **A**. By default, mongoose will buffer your function calls until it can
-connect to MongoDB. Read the [buffering section of the connection docs](./connections.html#buffering)
+connect to MongoDB. Read the [buffering section of the connection docs](connections.html#buffering)
 for more information.
 
 <hr id="enable_debugging" />
@@ -245,7 +245,7 @@ mongoose.set('debug', { color: false })
 mongoose.set('debug', { shell: true })
 ```
 
-For more debugging options (streams, callbacks), see the ['debug' option under `.set()`](./api.html#mongoose_Mongoose-set).
+For more debugging options (streams, callbacks), see the ['debug' option under `.set()`](api.html#mongoose_Mongoose-set).
 
 <hr id="callback_never_executes" />
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,6 +1,6 @@
 ## Schemas
 
-If you haven't yet done so, please take a minute to read the [quickstart](./index.html) to get an idea of how Mongoose works.
+If you haven't yet done so, please take a minute to read the [quickstart](index.html) to get an idea of how Mongoose works.
 If you are migrating from 5.x to 6.x please take a moment to read the [migration guide](migrating_to_6.html).
 
 <ul class="toc">
@@ -43,12 +43,12 @@ const blogSchema = new Schema({
 ```
 
 If you want to add additional keys later, use the
-[Schema#add](./api.html#schema_Schema-add) method.
+[Schema#add](api.html#schema_Schema-add) method.
 
 Each key in our code `blogSchema` defines a property in our documents which
-will be cast to its associated [SchemaType](./api.html#schematype_SchemaType).
+will be cast to its associated [SchemaType](api.html#schematype_SchemaType).
 For example, we've defined a property `title` which will be cast to the
-[String](./api.html#schema-string-js) SchemaType and property `date`
+[String](api.html#schema-string-js) SchemaType and property `date`
 which will be cast to a `Date` SchemaType.
 
 Notice above that if a property only requires a type, it can be specified using
@@ -63,34 +63,34 @@ In these cases, Mongoose only creates actual schema paths for leaves
 in the tree. (like `meta.votes` and `meta.favs` above),
 and the branches do not have actual paths.  A side-effect of this is that `meta`
 above cannot have its own validation.  If validation is needed up the tree, a path
-needs to be created up the tree - see the [Subdocuments](./subdocs.html) section
-for more information on how to do this.  Also read the [Mixed](./schematypes.html)
+needs to be created up the tree - see the [Subdocuments](subdocs.html) section
+for more information on how to do this.  Also read the [Mixed](schematypes.html)
 subsection of the SchemaTypes guide for some gotchas.
 
 The permitted SchemaTypes are:
 
-* [String](./schematypes.html#strings)
-* [Number](./schematypes.html#numbers)
-* [Date](./schematypes.html#dates)
-* [Buffer](./schematypes.html#buffers)
-* [Boolean](./schematypes.html#booleans)
-* [Mixed](./schematypes.html#mixed)
-* [ObjectId](./schematypes.html#objectids)
-* [Array](./schematypes.html#arrays)
-* [Decimal128](./api.html#mongoose_Mongoose-Decimal128)
-* [Map](./schematypes.html#maps)
+* [String](schematypes.html#strings)
+* [Number](schematypes.html#numbers)
+* [Date](schematypes.html#dates)
+* [Buffer](schematypes.html#buffers)
+* [Boolean](schematypes.html#booleans)
+* [Mixed](schematypes.html#mixed)
+* [ObjectId](schematypes.html#objectids)
+* [Array](schematypes.html#arrays)
+* [Decimal128](api.html#mongoose_Mongoose-Decimal128)
+* [Map](schematypes.html#maps)
 
-Read more about [SchemaTypes here](./schematypes.html).
+Read more about [SchemaTypes here](schematypes.html).
 
 Schemas not only define the structure of your document and casting of
 properties, they also define document [instance methods](#methods),
 [static Model methods](#statics), [compound indexes](#indexes),
-and document lifecycle hooks called [middleware](./middleware.html).
+and document lifecycle hooks called [middleware](middleware.html).
 
 <h3 id="models"><a href="#models">Creating a model</a></h3>
 
 To use our schema definition, we need to convert our `blogSchema` into a
-[Model](./models.html) we can work with.
+[Model](models.html) we can work with.
 To do so, we pass it into `mongoose.model(modelName, schema)`:
 
 ```javascript
@@ -137,8 +137,8 @@ await doc.save(); // works
 
 <h3 id="methods"><a href="#methods">Instance methods</a></h3>
 
-Instances of `Models` are [documents](./documents.html). Documents have
-many of their own [built-in instance methods](./api/document.html).
+Instances of `Models` are [documents](documents.html). Documents have
+many of their own [built-in instance methods](api/document.html).
 We may also define our own custom document instance methods.
 
 ```javascript
@@ -172,8 +172,8 @@ dog.findSimilarTypes((err, dogs) => {
 });
 ```
 
-* Overwriting a default mongoose document method may lead to unpredictable results. See [this](./api.html#schema_Schema-reserved) for more details.
-* The example above uses the `Schema.methods` object directly to save an instance method. You can also use the `Schema.method()` helper as described [here](./api.html#schema_Schema-method).
+* Overwriting a default mongoose document method may lead to unpredictable results. See [this](api.html#schema_Schema-reserved) for more details.
+* The example above uses the `Schema.methods` object directly to save an instance method. You can also use the `Schema.method()` helper as described [here](api.html#schema_Schema-method).
 * Do **not** declare methods using ES6 arrow functions (`=>`). Arrow functions [explicitly prevent binding `this`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_binding_of_this), so your method will **not** have access to the document and the above examples will not work.
 
 <h3 id="statics"><a href="#statics">Statics</a></h3>
@@ -217,7 +217,7 @@ Do **not** declare statics using ES6 arrow functions (`=>`). Arrow functions [ex
 
 You can also add query helper functions, which are like instance methods
 but for mongoose queries. Query helper methods let you extend mongoose's
-[chainable query builder API](./queries.html).
+[chainable query builder API](queries.html).
 
 ```javascript
 
@@ -252,7 +252,7 @@ Animal.findOne().byName('fido').exec((err, animal) => {
 <h3 id="indexes"><a href="#indexes">Indexes</a></h3>
 
 MongoDB supports [secondary indexes](http://docs.mongodb.org/manual/indexes/).
-With mongoose, we define these indexes within our `Schema` [at](./api.html#schematype_SchemaType-index) [the](./api.html#schematype_SchemaType-unique) [path](./api.html#schematype_SchemaType-sparse) [level](./api.html#schemadateoptions_SchemaDateOptions-expires) or the `schema` level.
+With mongoose, we define these indexes within our `Schema` [at](api.html#schematype_SchemaType-index) [the](api.html#schematype_SchemaType-unique) [path](api.html#schematype_SchemaType-sparse) [level](api.html#schemadateoptions_SchemaDateOptions-expires) or the `schema` level.
 Defining indexes at the schema level is necessary when creating
 [compound indexes](https://docs.mongodb.com/manual/core/index-compound/).
 
@@ -266,7 +266,7 @@ const animalSchema = new Schema({
 animalSchema.index({ name: 1, type: -1 }); // schema level
 ```
 
-See [SchemaType#index()](./api.html#schematype_SchemaType-index) for other index options.
+See [SchemaType#index()](api.html#schematype_SchemaType-index) for other index options.
 
 When your application starts up, Mongoose automatically calls [`createIndex`](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#db.collection.createIndex) for each defined index in your schema.
 Mongoose will call `createIndex` for each index sequentially, and emit an 'index' event on the model when all the `createIndex` calls succeeded or when there was an error.
@@ -300,11 +300,11 @@ Animal.on('index', error => {
 });
 ```
 
-See also the [Model#ensureIndexes](./api.html#model_Model-ensureIndexes) method.
+See also the [Model#ensureIndexes](api.html#model_Model-ensureIndexes) method.
 
 <h3 id="virtuals"><a href="#virtuals">Virtuals</a></h3>
 
-[Virtuals](./api.html#schema_Schema-virtual) are document properties that
+[Virtuals](api.html#schema_Schema-virtual) are document properties that
 you can get and set but that do not get persisted to MongoDB. The getters
 are useful for formatting or combining fields, while setters are useful for
 de-composing a single value into multiple values for storage.
@@ -337,7 +337,7 @@ But [concatenating](https://masteringjs.io/tutorials/fundamentals/string-concat)
 last name every time can get cumbersome.
 And what if you want to do some extra processing on the name, like
 [removing diacritics](https://www.npmjs.com/package/diacritics)? A
-[virtual property getter](./api.html#virtualtype_VirtualType-get) lets you
+[virtual property getter](api.html#virtualtype_VirtualType-get) lets you
 define a `fullName` property that won't get persisted to MongoDB.
 
 ```javascript
@@ -374,7 +374,7 @@ If you use `toJSON()` or `toObject()` mongoose will *not* include virtuals
 by default. This includes the output of calling [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 on a Mongoose document, because [`JSON.stringify()` calls `toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description).
 Pass `{ virtuals: true }` to either
-[`toObject()`](./api.html#document_Document-toObject) or [`toJSON()`](./api.html#document_Document-toJSON).
+[`toObject()`](api.html#document_Document-toObject) or [`toJSON()`](api.html#document_Document-toJSON).
 
 You can also add a custom setter to your virtual that will let you set both
 first name and last name via the `fullName` virtual.
@@ -599,7 +599,7 @@ new Schema({..}, { capped: { size: 1024, max: 1000, autoIndexId: true } });
 <h3 id="collection"><a href="#collection">option: collection</a></h3>
 
 Mongoose by default produces a collection name by passing the model name to
-the [utils.toCollectionName](./api.html#utils_exports-toCollectionName) method.
+the [utils.toCollectionName](api.html#utils_exports-toCollectionName) method.
 This method pluralizes the name. Set this option if you need a different name
 for your collection.
 
@@ -1180,7 +1180,7 @@ thing.save(); // version is not incremented
 <h3 id="timestamps"><a href="#timestamps">option: timestamps</a></h3>
 
 The `timestamps` option tells Mongoose to assign `createdAt` and `updatedAt` fields
-to your schema. The type assigned is [Date](./api.html#schema-date-js).
+to your schema. The type assigned is [Date](api.html#schema-date-js).
 
 By default, the names of the fields are `createdAt` and `updatedAt`. Customize
 the field names by setting `timestamps.createdAt` and `timestamps.updatedAt`.
@@ -1376,7 +1376,7 @@ console.log(schema.virtuals); // { myVirtual: VirtualType { ... } }
 
 <h3 id="plugins"><a href="#plugins">Pluggable</a></h3>
 
-Schemas are also [pluggable](./plugins.html) which allows us to package up reusable features into
+Schemas are also [pluggable](plugins.html) which allows us to package up reusable features into
 plugins that can be shared with the community or just between your projects.
 
 <h3 id="further-reading"><a href="#further-reading">Further Reading</a></h3>

--- a/docs/jest.md
+++ b/docs/jest.md
@@ -8,7 +8,7 @@ If you choose to delve into dangerous waters and test Mongoose apps with Jest, h
 
 <h2 id="recommended-testenvironment"><a href="#recommended-testenvironment">Recommended <code>testEnvironment</code></a></h2>
 
-If you are using Jest `<=26`, do **not** use Jest's default [`jsdom` test environment](https://jestjs.io/docs/en/configuration.html#testenvironment-string) when testing Mongoose apps, _unless_ you are explicitly testing an application that only uses [Mongoose's browser library](https://mongoosejs.com/docs/browser.html). In Jest `>=27`, ["node" is Jest's default `testEnvironment`](https://jestjs.io/ro/blog/2021/05/25/jest-27#flipping-defaults), so this is no longer an issue.
+If you are using Jest `<=26`, do **not** use Jest's default [`jsdom` test environment](https://jestjs.io/docs/en/configuration.html#testenvironment-string) when testing Mongoose apps, _unless_ you are explicitly testing an application that only uses [Mongoose's browser library](browser.html). In Jest `>=27`, ["node" is Jest's default `testEnvironment`](https://jestjs.io/ro/blog/2021/05/25/jest-27#flipping-defaults), so this is no longer an issue.
 
 The `jsdom` test environment attempts to create a browser-like test
 environment in Node.js, and it comes with numerous nasty surprises like a

--- a/docs/lodash.md
+++ b/docs/lodash.md
@@ -8,7 +8,7 @@ However, there are a few caveats that you should know about.
 ## `cloneDeep()`
 
 You should not use [Lodash's `cloneDeep()` function](https://lodash.com/docs/4.17.15#cloneDeep) on any Mongoose objects.
-This includes [connections](./connections.html), [model classes](./models.html), and [queries](./queries.html), but is _especially_ important for [documents](./documents.html).
+This includes [connections](connections.html), [model classes](models.html), and [queries](queries.html), but is _especially_ important for [documents](documents.html).
 For example, you may be tempted to do the following:
 
 ```javascript

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -2,7 +2,7 @@
 
 Middleware (also called pre and post *hooks*) are functions which are passed
 control during execution of asynchronous functions. Middleware is specified
-on the schema level and is useful for writing [plugins](./plugins.html).
+on the schema level and is useful for writing [plugins](plugins.html).
 
 <ul class="toc">
   <li><a href="#types-of-middleware">Types of Middleware</a></li>
@@ -39,42 +39,42 @@ Query middleware is supported for the following Query functions.
 Query middleware executes when you call `exec()` or `then()` on a Query object, or `await` on a Query object.
 In query middleware functions, `this` refers to the query.
 
-* [count](./api.html#query_Query-count)
-* [countDocuments](./api/query.html#query_Query-countDocuments)
-* [deleteMany](./api.html#query_Query-deleteMany)
-* [deleteOne](./api.html#query_Query-deleteOne)
-* [estimatedDocumentCount](./api/query.html#query_Query-estimatedDocumentCount)
-* [find](./api.html#query_Query-find)
-* [findOne](./api.html#query_Query-findOne)
-* [findOneAndDelete](./api.html#query_Query-findOneAndDelete)
-* [findOneAndRemove](./api.html#query_Query-findOneAndRemove)
-* [findOneAndReplace](./api/query.html#query_Query-findOneAndReplace)
-* [findOneAndUpdate](./api.html#query_Query-findOneAndUpdate)
-* [remove](./api.html#model_Model-remove)
-* [replaceOne](./api/query.html#query_Query-replaceOne)
-* [update](./api.html#query_Query-update)
-* [updateOne](./api.html#query_Query-updateOne)
-* [updateMany](./api.html#query_Query-updateMany)
+* [count](api.html#query_Query-count)
+* [countDocuments](api/query.html#query_Query-countDocuments)
+* [deleteMany](api.html#query_Query-deleteMany)
+* [deleteOne](api.html#query_Query-deleteOne)
+* [estimatedDocumentCount](api/query.html#query_Query-estimatedDocumentCount)
+* [find](api.html#query_Query-find)
+* [findOne](api.html#query_Query-findOne)
+* [findOneAndDelete](api.html#query_Query-findOneAndDelete)
+* [findOneAndRemove](api.html#query_Query-findOneAndRemove)
+* [findOneAndReplace](api/query.html#query_Query-findOneAndReplace)
+* [findOneAndUpdate](api.html#query_Query-findOneAndUpdate)
+* [remove](api.html#model_Model-remove)
+* [replaceOne](api/query.html#query_Query-replaceOne)
+* [update](api.html#query_Query-update)
+* [updateOne](api.html#query_Query-updateOne)
+* [updateMany](api.html#query_Query-updateMany)
 
 Aggregate middleware is for `MyModel.aggregate()`.
 Aggregate middleware executes when you call `exec()` on an aggregate object.
-In aggregate middleware, `this` refers to the [aggregation object](./api.html#model_Model-aggregate).
+In aggregate middleware, `this` refers to the [aggregation object](api.html#model_Model-aggregate).
 
-* [aggregate](./api.html#model_Model-aggregate)
+* [aggregate](api.html#model_Model-aggregate)
 
 Model middleware is supported for the following model functions.
 Don't confuse model middleware and document middleware: model middleware hooks into _static_ functions on a `Model` class, document middleware hooks into _methods_ on a `Model` class.
 In model middleware functions, `this` refers to the model.
 
-* [insertMany](./api.html#model_Model-insertMany)
+* [insertMany](api.html#model_Model-insertMany)
 
 All middleware types support pre and post hooks.
 How pre and post hooks work is described in more detail below.
 
 **Note:** If you specify `schema.pre('remove')`, Mongoose will register this
-middleware for [`doc.remove()`](./api.html#model_Model-remove) by default. If you
-want your middleware to run on [`Query.remove()`](./api.html#query_Query-remove)
-use [`schema.pre('remove', { query: true, document: false }, fn)`](./api.html#schema_Schema-pre).
+middleware for [`doc.remove()`](api.html#model_Model-remove) by default. If you
+want your middleware to run on [`Query.remove()`](api.html#query_Query-remove)
+use [`schema.pre('remove', { query: true, document: false }, fn)`](api.html#schema_Schema-pre).
 
 **Note:** Unlike `schema.pre('remove')`, Mongoose registers `updateOne` and
 `deleteOne` middleware on `Query#updateOne()` and `Query#deleteOne()` by default.
@@ -83,7 +83,7 @@ This means that both `doc.updateOne()` and `Model.updateOne()` trigger
 `updateOne` or `deleteOne` middleware as document middleware, use
 `schema.pre('updateOne', { document: true, query: false })`.
 
-**Note:** The [`create()`](./api.html#model_Model-create) function fires `save()` hooks.
+**Note:** The [`create()`](api.html#model_Model-create) function fires `save()` hooks.
 
 <h3 id="pre"><a href="#pre">Pre</a></h3>
 
@@ -492,7 +492,7 @@ pipeline from middleware.
 
 Certain Mongoose hooks are synchronous, which means they do **not** support
 functions that return promises or receive a `next()` callback. Currently,
-only `init` hooks are synchronous, because the [`init()` function](./api.html#document_Document-init)
+only `init` hooks are synchronous, because the [`init()` function](api.html#document_Document-init)
 is synchronous. Below is an example of using pre and post init hooks.
 
 ```javascript

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,8 +1,8 @@
 # Models
 
-[Models](./api.html#model-js) are fancy constructors compiled from
+[Models](api.html#model-js) are fancy constructors compiled from
 `Schema` definitions. An instance of a model is called a
-[document](./documents.html). Models are responsible for creating and
+[document](documents.html). Models are responsible for creating and
 reading documents from the underlying MongoDB database.
 
 * [Compiling your first model](#compiling)
@@ -34,7 +34,7 @@ before calling `.model()`!
 
 ## Constructing Documents
 
-An instance of a model is called a [document](./documents.html). Creating
+An instance of a model is called a [document](documents.html). Creating
 them and saving to the database is easy.
 
 ```javascript
@@ -76,13 +76,13 @@ const Tank = connection.model('Tank', yourSchema);
 
 ## Querying
 
-Finding documents is easy with Mongoose, which supports the [rich](http://www.mongodb.org/display/DOCS/Advanced+Queries) query syntax of MongoDB. Documents can be retrieved using a `model`'s [find](./api.html#model_Model-find), [findById](./api.html#model_Model-findById), [findOne](./api.html#model_Model-findOne), or [where](./api.html#model_Model-where) static methods.
+Finding documents is easy with Mongoose, which supports the [rich](http://www.mongodb.org/display/DOCS/Advanced+Queries) query syntax of MongoDB. Documents can be retrieved using a `model`'s [find](api.html#model_Model-find), [findById](api.html#model_Model-findById), [findOne](api.html#model_Model-findOne), or [where](api.html#model_Model-where) static methods.
 
 ```javascript
 Tank.find({ size: 'small' }).where('createdDate').gt(oneYearAgo).exec(callback);
 ```
 
-See the chapter on [queries](./queries.html) for more details on how to use the [Query](./api.html#query-js) api.
+See the chapter on [queries](queries.html) for more details on how to use the [Query](api.html#query-js) api.
 
 ## Deleting
 
@@ -100,7 +100,7 @@ Tank.deleteOne({ size: 'large' }, function (err) {
 
 Each `model` has its own `update` method for modifying documents in the
 database without returning them to your application. See the
-[API](./api.html#model_Model-updateOne) docs for more detail.
+[API](api.html#model_Model-updateOne) docs for more detail.
 
 ```javascript
 Tank.updateOne({ size: 'large' }, { name: 'T-90' }, function(err, res) {
@@ -110,7 +110,7 @@ Tank.updateOne({ size: 'large' }, { name: 'T-90' }, function(err, res) {
 ```
 
 _If you want to update a single document in the db and return it to your
-application, use [findOneAndUpdate](./api.html#model_Model-findOneAndUpdate)
+application, use [findOneAndUpdate](api.html#model_Model-findOneAndUpdate)
 instead._
 
 ## Change Streams
@@ -155,9 +155,9 @@ You can read more about [change streams in mongoose in this blog post](http://th
 
 ## Views
 
-[MongoDB Views](https://www.mongodb.com/docs/manual/core/views) are essentially read-only collections that contain data computed from other collections using [aggregations](./api/aggregate.html).
+[MongoDB Views](https://www.mongodb.com/docs/manual/core/views) are essentially read-only collections that contain data computed from other collections using [aggregations](api/aggregate.html).
 In Mongoose, you should define a separate Model for each of your Views.
-You can also create a View using [`createCollection()`](./api/model.html#model_Model-createCollection).
+You can also create a View using [`createCollection()`](api/model.html#model_Model-createCollection).
 
 The following example shows how you can create a new `RedactedUser` View on a `User` Model that hides potentially sensitive information, like name and email.
 
@@ -203,7 +203,7 @@ If you attempt to `save()` a document from a View, you will get an error from th
 
 ## Yet more
 
-The [API docs](./api.html#model_Model) cover many additional methods available like [count](./api.html#model_Model-count), [mapReduce](./api.html#model_Model-mapReduce), [aggregate](./api.html#model_Model-aggregate), and [more](./api.html#model_Model-findOneAndRemove).
+The [API docs](api.html#model_Model) cover many additional methods available like [count](api.html#model_Model-count), [mapReduce](api.html#model_Model-mapReduce), [aggregate](api.html#model_Model-aggregate), and [more](api.html#model_Model-findOneAndRemove).
 
 ## Next Up
 

--- a/docs/populate.md
+++ b/docs/populate.md
@@ -25,7 +25,7 @@ const Story = mongoose.model('Story', storySchema);
 const Person = mongoose.model('Person', personSchema);
 ```
 
-So far we've created two [Models](./models.html). Our `Person` model has
+So far we've created two [Models](models.html). Our `Person` model has
 its `stories` field set to an array of `ObjectId`s. The `ref` option is
 what tells Mongoose which model to use during population, in our case
 the `Story` model. All `_id`s we store here must be document `_id`s from
@@ -108,7 +108,7 @@ is replaced with the mongoose document returned from the database by
 performing a separate query before returning the results.
 
 Arrays of refs work the same way. Just call the
-[populate](./api.html#query_Query-populate) method on the query and an
+[populate](api.html#query_Query-populate) method on the query and an
 array of documents will be returned _in place_ of the original `_id`s.
 
 <h3 id="setting-populated-fields"><a href="#setting-populated-fields">Setting Populated Fields</a></h3>
@@ -187,7 +187,7 @@ story.authors; // `[]`
 
 What if we only want a few specific fields returned for the populated
 documents? This can be accomplished by passing the usual
-[field name syntax](./api.html#query_Query-select) as the second argument
+[field name syntax](api.html#query_Query-select) as the second argument
 to the populate method:
 
 ```javascript
@@ -372,10 +372,10 @@ Story.
 ```
 
 The documents returned from
-[query population](./api.html#query_Query-populate) become fully
+[query population](api.html#query_Query-populate) become fully
 functional, `remove`able, `save`able documents unless the
-[lean](./api.html#query_Query-lean) option is specified. Do not confuse
-them with [sub docs](./subdocs.html). Take caution when calling its
+[lean](api.html#query_Query-lean) option is specified. Do not confuse
+them with [sub docs](subdocs.html). Take caution when calling its
 remove method because you'll be removing it from the database, not just
 the array.
 
@@ -383,7 +383,7 @@ the array.
 
 If you have an existing mongoose document and want to populate some of its
 paths, you can use the
-[Document#populate()](./api.html#document_Document-populate) method.
+[Document#populate()](api.html#document_Document-populate) method.
 
 ```javascript
 const person = await Person.findOne({ name: 'Ian Fleming' });
@@ -408,8 +408,8 @@ person.populated('fans'); // Array of ObjectIds
 <h3 id="populate_multiple_documents"><a href="#populate_multiple_documents">Populating multiple existing documents</a></h3>
 
 If we have one or many mongoose documents or even plain objects
-(_like [mapReduce](./api.html#model_Model-mapReduce) output_), we may
-populate them using the [Model.populate()](./api.html#model_Model-populate)
+(_like [mapReduce](api.html#model_Model-mapReduce) output_), we may
+populate them using the [Model.populate()](api.html#model_Model-populate)
 method. This is what `Document#populate()`
 and `Query#populate()` use to populate documents.
 

--- a/docs/promises.md
+++ b/docs/promises.md
@@ -7,7 +7,7 @@ This means that you can do things like `MyModel.findOne({}).then()` and
 `await MyModel.findOne({}).exec()` if you're using
 [async/await](http://thecodebarbarian.com/80-20-guide-to-async-await-in-node.js.html).
  
-You can find the return type of specific operations [in the api docs](https://mongoosejs.com/docs/api.html)
+You can find the return type of specific operations [in the api docs](api.html)
 You can also read more about [promises in Mongoose](https://masteringjs.io/tutorials/mongoose/promise).
 
 ```javascript

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,6 +1,6 @@
 ## Queries
 
-Mongoose [models](./models.html) provide several static helper functions
+Mongoose [models](models.html) provide several static helper functions
 for [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete).
 Each of these functions returns a
 [mongoose `Query` object](api.html#Query).
@@ -55,7 +55,7 @@ Mongoose executed the query and passed the results to `callback`. All callbacks 
 `callback(error, result)`. If an error occurs executing the query, the `error` parameter will contain an error document, and `result`
 will be null. If the query is successful, the `error` parameter will be null, and the `result` will be populated with the results of the query.
 
-Anywhere a callback is passed to a query in Mongoose, the callback follows the pattern `callback(error, results)`. What `results` is depends on the operation: For `findOne()` it is a [potentially-null single document](./api.html#model_Model-findOne), `find()` a [list of documents](./api.html#model_Model-find), `count()` [the number of documents](./api.html#model_Model-count), `update()` the [number of documents affected](./api.html#model_Model-update), etc. The [API docs for Models](./api.html#model-js) provide more detail on what is passed to the callbacks.
+Anywhere a callback is passed to a query in Mongoose, the callback follows the pattern `callback(error, results)`. What `results` is depends on the operation: For `findOne()` it is a [potentially-null single document](api.html#model_Model-findOne), `find()` a [list of documents](api.html#model_Model-find), `count()` [the number of documents](api.html#model_Model-count), `update()` the [number of documents affected](api.html#model_Model-update), etc. The [API docs for Models](api.html#model-js) provide more detail on what is passed to the callbacks.
 
 Now let's look at what happens when no `callback` is passed:
 
@@ -75,7 +75,7 @@ query.exec(function (err, person) {
 });
 ```
 
-In the above code, the `query` variable is of type [Query](./api.html#query-js).
+In the above code, the `query` variable is of type [Query](api.html#query-js).
 A `Query` enables you to build up a query using chaining syntax, rather than specifying a JSON object.
 The below 2 examples are equivalent.
 
@@ -105,7 +105,7 @@ Person.
   exec(callback);
 ```
 
-A full list of [Query helper functions can be found in the API docs](./api.html#query-js).
+A full list of [Query helper functions can be found in the API docs](api.html#query-js).
 
 <h3 id="queries-are-not-promises">
   <a href="#queries-are-not-promises">
@@ -156,16 +156,16 @@ await BlogPost.updateOne({ title: 'Introduction to Promises' }, update, (err, re
 <h3 id="refs"><a href="#refs">References to other documents</a></h3>
 
 There are no joins in MongoDB but sometimes we still want references to
-documents in other collections. This is where [population](./populate.html)
+documents in other collections. This is where [population](populate.html)
 comes in. Read more about how to include documents from other collections in
-your query results [here](./api.html#query_Query-populate).
+your query results [here](api.html#query_Query-populate).
 
 <h3 id="streaming"><a href="#streaming">Streaming</a></h3>
 
 You can [stream](http://nodejs.org/api/stream.html) query results from
 MongoDB. You need to call the
-[Query#cursor()](./api.html#query_Query-cursor) function to return an instance of
-[QueryCursor](./api.html#query_Query-cursor).
+[Query#cursor()](api.html#query_Query-cursor) function to return an instance of
+[QueryCursor](api.html#query_Query-cursor).
 
 ```javascript
 const cursor = Person.find({ occupation: /host/ }).cursor();

--- a/docs/schematypes.md
+++ b/docs/schematypes.md
@@ -1,12 +1,12 @@
 <h2 id="schematypes"><a href="#schematypes">SchemaTypes</a></h2>
 
 SchemaTypes handle definition of path
-[defaults](./api.html#schematype_SchemaType-default),
-[validation](./api.html#schematype_SchemaType-validate),
+[defaults](api.html#schematype_SchemaType-default),
+[validation](api.html#schematype_SchemaType-validate),
 [getters](#getters),
-[setters](./api.html#schematype_SchemaType-set),
-[field selection defaults](./api.html#schematype_SchemaType-select) for
-[queries](./api.html#query-js),
+[setters](api.html#schematype_SchemaType-set),
+[field selection defaults](api.html#schematype_SchemaType-select) for
+[queries](api.html#query-js),
 and other general characteristics for Mongoose document properties.
 
 * [What is a SchemaType?](#what-is-a-schematype)
@@ -50,7 +50,7 @@ Check out [Mongoose's plugins search](http://plugins.mongoosejs.io) to find plug
 - [Mixed](#mixed)
 - [ObjectId](#objectids)
 - [Array](#arrays)
-- [Decimal128](./api.html#mongoose_Mongoose-Decimal128)
+- [Decimal128](api.html#mongoose_Mongoose-Decimal128)
 - [Map](#maps)
 - [Schema](#schemas)
 
@@ -201,13 +201,13 @@ types.
 
 <h5>All Schema Types</h5>
 
-* `required`: boolean or function, if true adds a [required validator](./validation.html#built-in-validators) for this property
+* `required`: boolean or function, if true adds a [required validator](validation.html#built-in-validators) for this property
 * `default`: Any or function, sets a default value for the path. If the value is a function, the return value of the function is used as the default.
 * `select`: boolean, specifies default [projections](https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results/) for queries
-* `validate`: function, adds a [validator function](./validation.html#built-in-validators) for this property
+* `validate`: function, adds a [validator function](validation.html#built-in-validators) for this property
 * `get`: function, defines a custom getter for this property using [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
 * `set`: function, defines a custom setter for this property using [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
-* `alias`: string, mongoose >= 4.10.0 only. Defines a [virtual](./guide.html#virtuals) with the given name that gets/sets this path.
+* `alias`: string, mongoose >= 4.10.0 only. Defines a [virtual](guide.html#virtuals) with the given name that gets/sets this path.
 * `immutable`: boolean, defines path as immutable. Mongoose prevents you from changing immutable paths unless the parent document has `isNew: true`.
 * `transform`: function, Mongoose calls this function when you call [`Document#toJSON()`](api/document.html#document_Document-toJSON) function, including when you [`JSON.stringify()`](https://thecodebarbarian.com/the-80-20-guide-to-json-stringify-in-javascript) a document.
 
@@ -257,23 +257,23 @@ const schema2 = new Schema({
 * `lowercase`: boolean, whether to always call `.toLowerCase()` on the value
 * `uppercase`: boolean, whether to always call `.toUpperCase()` on the value
 * `trim`: boolean, whether to always call [`.trim()`](https://masteringjs.io/tutorials/fundamentals/trim-string) on the value
-* `match`: RegExp, creates a [validator](./validation.html) that checks if the value matches the given regular expression
-* `enum`: Array, creates a [validator](./validation.html) that checks if the value is in the given array.
-* `minLength`: Number, creates a [validator](./validation.html) that checks if the value length is not less than the given number
-* `maxLength`: Number, creates a [validator](./validation.html) that checks if the value length is not greater than the given number
+* `match`: RegExp, creates a [validator](validation.html) that checks if the value matches the given regular expression
+* `enum`: Array, creates a [validator](validation.html) that checks if the value is in the given array.
+* `minLength`: Number, creates a [validator](validation.html) that checks if the value length is not less than the given number
+* `maxLength`: Number, creates a [validator](validation.html) that checks if the value length is not greater than the given number
 * `populate`: Object, sets default [populate options](populate.html#query-conditions)
 
 <h5 id="number-validators">Number</h5>
 
-* `min`: Number, creates a [validator](./validation.html) that checks if the value is greater than or equal to the given minimum.
-* `max`: Number, creates a [validator](./validation.html) that checks if the value is less than or equal to the given maximum.
-* `enum`: Array, creates a [validator](./validation.html) that checks if the value is strictly equal to one of the values in the given array.
+* `min`: Number, creates a [validator](validation.html) that checks if the value is greater than or equal to the given minimum.
+* `max`: Number, creates a [validator](validation.html) that checks if the value is less than or equal to the given maximum.
+* `enum`: Array, creates a [validator](validation.html) that checks if the value is strictly equal to one of the values in the given array.
 * `populate`: Object, sets default [populate options](populate.html#query-conditions)
 
 <h5>Date</h5>
 
-* `min`: Date, creates a [validator](./validation.html) that checks if the value is greater than or equal to the given minimum.
-* `max`: Date, creates a [validator](./validation.html) that checks if the value is less than or equal to the given maximum.
+* `min`: Date, creates a [validator](validation.html) that checks if the value is greater than or equal to the given minimum.
+* `max`: Date, creates a [validator](validation.html) that checks if the value is less than or equal to the given maximum.
 * `expires`: Number or String, creates a TTL index with the value expressed in seconds.
 
 <h5>ObjectId</h5>
@@ -388,7 +388,7 @@ like, but Mongoose loses the ability to auto detect and save those changes.
 To tell Mongoose that the value of a Mixed type has changed, you need to
 call `doc.markModified(path)`, passing the path to the Mixed type you just changed.
 
-To avoid these side-effects, a [Subdocument](./subdocs.html) path may be used
+To avoid these side-effects, a [Subdocument](subdocs.html) path may be used
 instead.
 
 ```javascript
@@ -460,8 +460,8 @@ console.log(new M({ b: 'nay' }).b); // false
 
 <h4 id="arrays">Arrays</h4>
 
-Mongoose supports arrays of [SchemaTypes](./api.html#schema_Schema-Types)
-and arrays of [subdocuments](./subdocs.html). Arrays of SchemaTypes are
+Mongoose supports arrays of [SchemaTypes](api.html#schema_Schema-Types)
+and arrays of [subdocuments](subdocs.html). Arrays of SchemaTypes are
 also called _primitive arrays_, and arrays of subdocuments are also called
 _document arrays_.
 
@@ -656,7 +656,7 @@ schema.path('arr.0.url').get(v => `${root}${v}`);
 
 <h3 id="schemas"><a href="#schemas">Schemas</a></h3>
 
-To declare a path as another [schema](./guide.html#definition),
+To declare a path as another [schema](guide.html#definition),
 set `type` to the sub-schema's instance.
 
 To set a default value based on the sub-schema's shape, simply set a default value,

--- a/docs/subdocs.md
+++ b/docs/subdocs.md
@@ -51,7 +51,7 @@ doc.child;
 ### What is a Subdocument?
 
 Subdocuments are similar to normal documents. Nested schemas can have
-[middleware](./middleware.html), [custom validation logic](./validation.html),
+[middleware](middleware.html), [custom validation logic](validation.html),
 virtuals, and any other feature top-level schemas can use. The major
 difference is that subdocuments are
 not saved individually, they are saved whenever their top-level parent
@@ -68,7 +68,7 @@ parent.children[0].name = 'Matthew';
 parent.save(callback);
 ```
 
-Subdocuments have `save` and `validate` [middleware](./middleware.html)
+Subdocuments have `save` and `validate` [middleware](middleware.html)
 just like top-level documents. Calling `save()` on the parent document triggers
 the `save()` middleware for all its subdocuments, and the same for `validate()`
 middleware.
@@ -223,7 +223,7 @@ doc.child; // { age: 0 }
 ### Finding a Subdocument
 
 Each subdocument has an `_id` by default. Mongoose document arrays have a
-special [id](./api.html#types_documentarray_MongooseDocumentArray-id) method
+special [id](api.html#types_documentarray_MongooseDocumentArray-id) method
 for searching a document array to find a document with a given `_id`.
 
 ```javascript
@@ -233,9 +233,9 @@ const doc = parent.children.id(_id);
 ### Adding Subdocs to Arrays
 
 MongooseArray methods such as
-[push](./api.html#mongoosearray_MongooseArray-push),
-[unshift](./api.html#mongoosearray_MongooseArray-unshift),
-[addToSet](./api.html#mongoosearray_MongooseArray-addToSet),
+[push](api.html#mongoosearray_MongooseArray-push),
+[unshift](api.html#mongoosearray_MongooseArray-unshift),
+[addToSet](api.html#mongoosearray_MongooseArray-addToSet),
 and others cast arguments to their proper types transparently:
 ```javascript
 const Parent = mongoose.model('Parent');
@@ -253,7 +253,7 @@ parent.save(function (err) {
 });
 ```
 
-You can also create a subdocument without adding it to an array by using the [`create()` method](./api/mongoosedocumentarray.html#mongoosedocumentarray_MongooseDocumentArray-create) of Document Arrays.
+You can also create a subdocument without adding it to an array by using the [`create()` method](api/mongoosedocumentarray.html#mongoosedocumentarray_MongooseDocumentArray-create) of Document Arrays.
 
 ```javascript
 const newdoc = parent.children.create({ name: 'Aaron' });
@@ -262,7 +262,7 @@ const newdoc = parent.children.create({ name: 'Aaron' });
 ### Removing Subdocs
 
 Each subdocument has its own
-[remove](./api.html#types_embedded_EmbeddedDocument-remove) method. For
+[remove](api.html#types_embedded_EmbeddedDocument-remove) method. For
 an array subdocument, this is equivalent to calling `.pull()` on the
 subdocument. For a single nested subdocument, `remove()` is equivalent
 to setting the subdocument to `null`.
@@ -337,4 +337,4 @@ const parentSchema = new Schema({
 ### Next Up
 
 Now that we've covered Subdocuments, let's take a look at
-[querying](./queries.html).
+[querying](queries.html).

--- a/docs/tutorials/custom-casting.md
+++ b/docs/tutorials/custom-casting.md
@@ -1,6 +1,6 @@
 # Custom Casting
 
-[Mongoose 5.4.0](https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md#540--2018-12-14) introduced [several ways to configure SchemaTypes globally](http://thecodebarbarian.com/whats-new-in-mongoose-54-global-schematype-configuration). One of these new features is the [`SchemaType.cast()` function](https://mongoosejs.com/docs/api.html#schematype_SchemaType-cast), which enables you to override Mongoose's built-in casting.
+[Mongoose 5.4.0](https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md#540--2018-12-14) introduced [several ways to configure SchemaTypes globally](http://thecodebarbarian.com/whats-new-in-mongoose-54-global-schematype-configuration). One of these new features is the [`SchemaType.cast()` function](../api.html#schematype_SchemaType-cast), which enables you to override Mongoose's built-in casting.
 
 For example, by default Mongoose will throw an error if you attempt to cast
 a string that contains a Japanese numeral to a number.

--- a/docs/tutorials/getters-setters.md
+++ b/docs/tutorials/getters-setters.md
@@ -26,7 +26,7 @@ app.get(function(req, res) {
 });
 ```
 
-To disable running getters when converting a document to JSON, set the [`toJSON.getters` option to `false` in your schema](https://mongoosejs.com/docs/guide.html#toJSON) as shown below.
+To disable running getters when converting a document to JSON, set the [`toJSON.getters` option to `false` in your schema](../guide.html#toJSON) as shown below.
 
 ```javascript
 const userSchema = new Schema({

--- a/docs/tutorials/query_casting.md
+++ b/docs/tutorials/query_casting.md
@@ -1,12 +1,12 @@
 # Query Casting
 
-The first parameter to [`Model.find()`](https://mongoosejs.com/docs/api.html#model_Model-find), [`Query#find()`](https://mongoosejs.com/docs/api.html#query_Query-find), [`Model.findOne()`](https://mongoosejs.com/docs/api.html#model_Model-findOne), etc. is called `filter`. In older content this parameter is sometimes called `query` or `conditions`. For example:
+The first parameter to [`Model.find()`](../api.html#model_Model-find), [`Query#find()`](../api.html#query_Query-find), [`Model.findOne()`](../api.html#model_Model-findOne), etc. is called `filter`. In older content this parameter is sometimes called `query` or `conditions`. For example:
 
 ```javascript
 [require:Cast Tutorial.*get and set]
 ```
 
-When you execute the query using [`Query#exec()`](https://mongoosejs.com/docs/api.html#query_Query-exec) or [`Query#then()`](https://mongoosejs.com/docs/api.html#query_Query-then), Mongoose _casts_ the filter to match your schema.
+When you execute the query using [`Query#exec()`](../api.html#query_Query-exec) or [`Query#then()`](../api.html#query_Query-then), Mongoose _casts_ the filter to match your schema.
 
 ```javascript
 [require:Cast Tutorial.*cast values]
@@ -27,7 +27,7 @@ By default, Mongoose does **not** cast filter properties that aren't in your sch
 [require:Cast Tutorial.*not in schema]
 ```
 
-You can configure this behavior using the [`strictQuery` option for schemas](https://mongoosejs.com/docs/guide.html#strictQuery). This option is analogous to the [`strict` option](https://mongoosejs.com/docs/guide.html#strict). Setting `strictQuery` to `true` removes non-schema properties from the filter:
+You can configure this behavior using the [`strictQuery` option for schemas](../guide.html#strictQuery). This option is analogous to the [`strict` option](../guide.html#strict). Setting `strictQuery` to `true` removes non-schema properties from the filter:
 
 ```javascript
 [require:Cast Tutorial.*strictQuery true]

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,13 +2,13 @@
 
 Before we get into the specifics of validation syntax, please keep the following rules in mind:
 
-- Validation is defined in the [SchemaType](./schematypes.html)
-- Validation is [middleware](./middleware.html). Mongoose registers validation as a `pre('save')` hook on every schema by default.
-- You can disable automatic validation before save by setting the [validateBeforeSave](./guide.html#validateBeforeSave) option
+- Validation is defined in the [SchemaType](schematypes.html)
+- Validation is [middleware](middleware.html). Mongoose registers validation as a `pre('save')` hook on every schema by default.
+- You can disable automatic validation before save by setting the [validateBeforeSave](guide.html#validateBeforeSave) option
 - You can manually run validation using `doc.validate(callback)` or `doc.validateSync()`
-- You can manually mark a field as invalid (causing validation to fail) by using [`doc.invalidate(...)`](./api.html#document_Document-invalidate)
-- Validators are not run on undefined values. The only exception is the [`required` validator](./api.html#schematype_SchemaType-required).
-- Validation is asynchronously recursive; when you call [Model#save](./api.html#model_Model-save), sub-document validation is executed as well. If an error occurs, your [Model#save](./api.html#model_Model-save) callback receives it
+- You can manually mark a field as invalid (causing validation to fail) by using [`doc.invalidate(...)`](api.html#document_Document-invalidate)
+- Validators are not run on undefined values. The only exception is the [`required` validator](api.html#schematype_SchemaType-required).
+- Validation is asynchronously recursive; when you call [Model#save](api.html#model_Model-save), sub-document validation is executed as well. If an error occurs, your [Model#save](api.html#model_Model-save) callback receives it
 - Validation is customizable
 
 ```javascript
@@ -33,9 +33,9 @@ Before we get into the specifics of validation syntax, please keep the following
 
 Mongoose has several built-in validators.
 
-- All [SchemaTypes](./schematypes.html) have the built-in [required](./api.html#schematype_SchemaType-required) validator. The required validator uses the [SchemaType's `checkRequired()` function](./api.html#schematype_SchemaType-checkRequired) to determine if the value satisfies the required validator.
-- [Numbers](./api.html#schema-number-js) have [`min` and `max`](./schematypes.html#number-validators) validators.
-- [Strings](./api.html#schema-string-js) have [`enum`, `match`, `minLength`, and `maxLength`](./schematypes.html#string-validators) validators.
+- All [SchemaTypes](schematypes.html) have the built-in [required](api.html#schematype_SchemaType-required) validator. The required validator uses the [SchemaType's `checkRequired()` function](api.html#schematype_SchemaType-checkRequired) to determine if the value satisfies the required validator.
+- [Numbers](api.html#schema-number-js) have [`min` and `max`](schematypes.html#number-validators) validators.
+- [Strings](api.html#schema-string-js) have [`enum`, `match`, `minLength`, and `maxLength`](schematypes.html#string-validators) validators.
 
 Each of the validator links above provide more information about how to enable them and customize their error messages.
 
@@ -75,7 +75,7 @@ to suit your needs.
 
 Custom validation is declared by passing a validation function.
 You can find detailed instructions on how to do this in the
-[`SchemaType#validate()` API docs](./api.html#schematype_SchemaType-validate).
+[`SchemaType#validate()` API docs](api.html#schematype_SchemaType-validate).
 
 ```javascript
 [require:Custom Validators]
@@ -96,7 +96,7 @@ the value `false`, Mongoose will consider that a validation error.
 
 Errors returned after failed validation contain an `errors` object
 whose values are `ValidatorError` objects. Each
-[ValidatorError](./api.html#error-validation-js) has `kind`, `path`,
+[ValidatorError](api.html#error-validation-js) has `kind`, `path`,
 `value`, and `message` properties.
 A ValidatorError also may have a `reason` property. If an error was
 thrown in the validator, this property will contain the error that was


### PR DESCRIPTION
**Summary**

This PR is a follow-up to #12623 and adds style-guidelines as said in #12645

All Changes:
- change remaining static links in the documentation to relative ones
- change all remaining not-required prefix links to no-prefix links (`./guide.html` -> `guide.html`)
- add a documentation style guidelines section to CONTRIBUTING
- change slightly outdated information in the CONTRIBUTING (about file extensions)
- consistenize spacing in CONTRIBUING

fixes #12645