### PR TITLE
Feature/enhance auto typed virtuals

### DIFF
--- a/test/types/virtuals.test.ts
+++ b/test/types/virtuals.test.ts
@@ -126,5 +126,10 @@ function autoTypedVirtuals() {
     }
   });
 
+  type TestDoc = InferSchemaType<typeof testSchema>;
+
+  const testDoc = { email: 'some email' } as TestDoc;
+  expectType<string>(testDoc.domain);
+
   expectType<FlatRecord<AutoTypedSchemaType & VirtualsType >>({} as InferredDocType);
 }

--- a/test/types/virtuals.test.ts
+++ b/test/types/virtuals.test.ts
@@ -89,7 +89,7 @@ function gh11543() {
 
 function autoTypedVirtuals() {
   type AutoTypedSchemaType = InferSchemaType<typeof testSchema>;
-  type VirtualsType = { domain: string };
+  type SchemaWithoutVirtual = Omit<AutoTypedSchemaType, 'domain'>;
   type InferredDocType = FlatRecord<AutoTypedSchemaType & ObtainSchemaGeneric<typeof testSchema, 'TVirtuals'>>;
 
   const testSchema = new Schema({
@@ -101,11 +101,11 @@ function autoTypedVirtuals() {
     virtuals: {
       domain: {
         get() {
-          expectType<Document<any, any, { email: string }> & AutoTypedSchemaType>(this);
+          expectType<Document<any, any, { email: string }>>(this);
           return this.email.slice(this.email.indexOf('@') + 1);
         },
         set() {
-          expectType<Document<any, any, AutoTypedSchemaType> & AutoTypedSchemaType>(this);
+          expectType<Document<any, any, SchemaWithoutVirtual>>(this);
         },
         options: {}
       }
@@ -131,5 +131,5 @@ function autoTypedVirtuals() {
   const testDoc = { email: 'some email' } as TestDoc;
   expectType<string>(testDoc.domain);
 
-  expectType<FlatRecord<AutoTypedSchemaType & VirtualsType >>({} as InferredDocType);
+  expectType<FlatRecord<AutoTypedSchemaType>>({} as InferredDocType);
 }

--- a/test/types/virtuals.test.ts
+++ b/test/types/virtuals.test.ts
@@ -118,5 +118,13 @@ function autoTypedVirtuals() {
   const doc = new TestModel();
   expectType<string>(doc.domain);
 
+  TestModel.findOne({}).then((doc) => {
+    if (doc) {
+      expectType<string>(doc.domain);
+      const json = doc.toJSON();
+      expectType<string>(json.domain);
+    }
+  });
+
   expectType<FlatRecord<AutoTypedSchemaType & VirtualsType >>({} as InferredDocType);
 }

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -38,7 +38,7 @@ declare module 'mongoose' {
    * // result
    * type UserType = {userName?: string}
    */
-  type InferSchemaType<TSchema> = IfAny<TSchema, any, ObtainSchemaGeneric<TSchema, 'DocType'>>;
+  type InferSchemaType<TSchema> = IfAny<TSchema, any, ObtainSchemaGeneric<TSchema, 'DocType'> & ObtainSchemaGeneric<TSchema, 'TVirtuals'>>;
 
   /**
    * @summary Obtains schema Generic type by using generic alias.

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -124,13 +124,13 @@ declare module 'mongoose' {
   interface RemoveOptions extends SessionOption, Omit<mongodb.DeleteOptions, 'session'> {}
 
   const Model: Model<any>;
-  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, TVirtuals = {}, TSchema = any> extends
+  interface Model<T, TQueryHelpers = {}, TMethodsAndOverrides = {}, EnforcedVirtuals = {}, TSchema = any,
+    TVirtuals extends IfEquals<EnforcedVirtuals, {}, ObtainSchemaGeneric<TSchema, 'TVirtuals'>, EnforcedVirtuals> = IfEquals<EnforcedVirtuals, {}, ObtainSchemaGeneric<TSchema, 'TVirtuals'>, EnforcedVirtuals>> extends
     NodeJS.EventEmitter,
     AcceptsDiscriminator,
     IndexManager,
     SessionStarter {
-    new <DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides,
-    IfEquals<TVirtuals, {}, ObtainSchemaGeneric<TSchema, 'TVirtuals'>, TVirtuals>> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
+    new <DocType = T>(doc?: DocType, fields?: any | null, options?: boolean | AnyObject): HydratedDocument<T, TMethodsAndOverrides, TVirtuals> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
     aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
     aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;


### PR DESCRIPTION
**Summary**

Further enhances existing virtual type inference originally from: https://github.com/Automattic/mongoose/pull/11908

Virtual properties are not available on model methods such as `findOne`, this PR adds that functionality across all model methods.

Also resolves: https://github.com/Automattic/mongoose/issues/12684