### PR TITLE
Replace used before defined User with this.

### DIFF
--- a/docs/typescript/statics-and-methods.md
+++ b/docs/typescript/statics-and-methods.md
@@ -112,7 +112,7 @@ const schema = new Schema<IUser, UserModel, IUserMethods>({
 });
 schema.static('createWithFullName', function createWithFullName(name: string) {
   const [firstName, lastName] = name.split(' ');
-  return User.create({ firstName, lastName });
+  return this.create({ firstName, lastName });
 });
 schema.method('fullName', function fullName(): string {
   return this.firstName + ' ' + this.lastName;


### PR DESCRIPTION
Changed line gave "'User' was used before it was defined" linting error. Will compile if you ignore the lint error but I think it's more informative to show that `this` can be used - as it is an instance of `UserModel` here.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->