### PR TITLE
docs(query): updated examples for `updateOne` and `replaceOne`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4574,8 +4574,11 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * #### Example:
  *
  *     const res = await Person.updateOne({ name: 'Jean-Luc Picard' }, { ship: 'USS Enterprise' });
- *     res.n; // Number of documents matched
- *     res.nModified; // Number of documents modified
+ *     res.acknowledged; // Indicates if this write result was acknowledged. If not, then all other members of this result will be undefined.
+ *     res.matchedCount; // Number of documents that matched the filter
+ *     res.modifiedCount; // Number of documents that were modified
+ *     res.upsertedCount; // Number of documents that were upserted
+ *     res.upsertedId; // Identifier of the inserted document (if an upsert took place)
  *
  * This function triggers the following middleware.
  *
@@ -4638,8 +4641,11 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * #### Example:
  *
  *     const res = await Person.replaceOne({ _id: 24601 }, { name: 'Jean Valjean' });
- *     res.n; // Number of documents matched
- *     res.nModified; // Number of documents modified
+ *     res.acknowledged; // Indicates if this write result was acknowledged. If not, then all other members of this result will be undefined.
+ *     res.matchedCount; // Number of documents that matched the filter
+ *     res.modifiedCount; // Number of documents that were modified
+ *     res.upsertedCount; // Number of documents that were upserted
+ *     res.upsertedId; // Identifier of the inserted document (if an upsert took place)
  *
  * This function triggers the following middleware.
  *


### PR DESCRIPTION
fix #12706

**Summary**
Updated documentation for the `updateOne` and `replaceOne` queries to match MongoDB Node driver v4.x return values