### PR TITLE
add `rewind` function to `QueryCursor`

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -195,6 +195,21 @@ QueryCursor.prototype.close = function(callback) {
 };
 
 /**
+ * Rewind this cursor to its uninitialized state. Any options that are present on the cursor will
+ * remain in effect. Iterating this cursor will cause new queries to be sent to the server, even
+ * if the resultant data has already been retrieved by this cursor.
+ *
+ * @return {AggregationCursor} this
+ * @api public
+ * @method rewind
+ */
+
+ QueryCursor.prototype.rewind = function() {
+  this.cursor.rewind();
+  return this;
+};  
+
+/**
  * Get the next document from this cursor. Will return `null` when there are
  * no documents left.
  *

--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -204,8 +204,11 @@ QueryCursor.prototype.close = function(callback) {
  * @method rewind
  */
 
- QueryCursor.prototype.rewind = function() {
-  this.cursor.rewind();
+QueryCursor.prototype.rewind = function() {
+  const _this = this;
+  _waitForCursor(this, function() {
+    _this.cursor.rewind();
+  });
   return this;
 };  
 

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -27,6 +27,13 @@ declare module 'mongoose' {
     close(): Promise<void>;
 
     /**
+     * Rewind this cursor to its uninitialized state. Any options that are present on the cursor will
+     * remain in effect. Iterating this cursor will cause new queries to be sent to the server, even
+     * if the resultant data has already been retrieved by this cursor.
+     */
+    rewind(): this;
+
+    /**
      * Execute `fn` for every document(s) in the cursor. If batchSize is provided
      * `fn` will be executed for each batch of documents. If `fn` returns a promise,
      * will wait for the promise to resolve before iterating on to the next one.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Wraps the `mongodb.FindCursor.rewind` function to reset the cursor to its uninitialized state, effectively resetting the cursor to the beginning.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```ts
const options = {}
ModelClass.find(options) 
// - instance1
// - instance2
// - instance3

// ================================================

const cursor = ModelClass.findOne(options).cursor()
await cursor.next() // instance1
await cursor.next() // instance2

cursor.rewind()
await cursor.next() // instance1
```