### PR TITLE
fix(types): avoid typeof Query with generics for TypeScript 4.6 support

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -616,7 +616,7 @@ declare module 'mongoose' {
     then: Promise<ResultType>['then'];
 
     /** Converts this query to a customized, reusable query constructor with all arguments and options retained. */
-    toConstructor(): typeof Query<ResultType, DocType, THelpers, RawDocType>;
+    toConstructor<RetType = typeof Query>(): RetType;
 
     /** Declare and/or execute this query as an update() operation. */
     update(filter?: FilterQuery<DocType>, update?: UpdateQuery<DocType> | UpdateWithAggregationPipeline, options?: QueryOptions<DocType> | null, callback?: Callback<UpdateWriteOpResult>): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType>;


### PR DESCRIPTION
Fix #12688
Fix #12689

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A more robust fix for #12689, which mostly does what we expect. It looks like we do lose the generics with `toConstructor()`, but I think this approach is better than Mongoose compilation crashing on TypeScript 4.6.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
