### PR TITLE
fix(types): Update replaceWith pipeline stage

### DIFF
--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -213,7 +213,7 @@ declare module 'mongoose' {
 
     export interface ReplaceWith {
       /** [`$replaceWith` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/replaceWith/) */
-      $replaceWith: ObjectExpressionOperator | { [field: string]: Expression };
+      $replaceWith: ObjectExpressionOperator | { [field: string]: Expression } | `${string}`;
     }
 
     export interface Sample {

--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -213,7 +213,7 @@ declare module 'mongoose' {
 
     export interface ReplaceWith {
       /** [`$replaceWith` reference](https://docs.mongodb.com/manual/reference/operator/aggregation/replaceWith/) */
-      $replaceWith: ObjectExpressionOperator | { [field: string]: Expression } | `${string}`;
+      $replaceWith: ObjectExpressionOperator | { [field: string]: Expression } | `$${string}`;
     }
 
     export interface Sample {


### PR DESCRIPTION
See doc: https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/

![image](https://user-images.githubusercontent.com/342922/203358449-5d16ce4c-83eb-456b-92f4-644a88d702aa.png)

Not sure if `ObjectExpressionOperator` should be modified instead?