### PR TITLE
fix(cursor): make `eachAsync()` avoid modifying batch when mixing `parallel` and `batchSize`

### DIFF
--- a/lib/helpers/cursor/eachAsync.js
+++ b/lib/helpers/cursor/eachAsync.js
@@ -33,7 +33,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
   const aggregatedErrors = [];
   const enqueue = asyncQueue();
 
-  let drained = false;
+  let aborted = false;
 
   return promiseOrCallback(callback, cb => {
     if (signal != null) {
@@ -42,7 +42,7 @@ module.exports = function eachAsync(next, fn, options, callback) {
       }
 
       signal.addEventListener('abort', () => {
-        drained = true;
+        aborted = true;
         return cb(null);
       }, { once: true });
     }
@@ -63,90 +63,104 @@ module.exports = function eachAsync(next, fn, options, callback) {
   function iterate(finalCallback) {
     let handleResultsInProgress = 0;
     let currentDocumentIndex = 0;
-    let documentsBatch = [];
 
     let error = null;
     for (let i = 0; i < parallel; ++i) {
-      enqueue(fetch);
+      enqueue(createFetch());
     }
 
-    function fetch(done) {
-      if (drained || error) {
-        return done();
-      }
+    function createFetch() {
+      let documentsBatch = [];
+      let drained = false;
 
-      next(function(err, doc) {
-        if (drained || error != null) {
+      return fetch;
+
+      function fetch(done) {
+        if (drained || aborted) {
+          return done();
+        } else if (error) {
           return done();
         }
-        if (err != null) {
-          if (continueOnError) {
-            aggregatedErrors.push(err);
-          } else {
-            error = err;
-            finalCallback(err);
+
+        next(function(err, doc) {
+          if (error != null) {
             return done();
           }
-        }
-        if (doc == null) {
-          drained = true;
-          if (handleResultsInProgress <= 0) {
-            const finalErr = continueOnError ?
-              createEachAsyncMultiError(aggregatedErrors) :
-              error;
-
-            finalCallback(finalErr);
-          } else if (batchSize && documentsBatch.length) {
-            handleNextResult(documentsBatch, currentDocumentIndex++, handleNextResultCallBack);
-          }
-          return done();
-        }
-
-        ++handleResultsInProgress;
-
-        // Kick off the subsequent `next()` before handling the result, but
-        // make sure we know that we still have a result to handle re: #8422
-        immediate(() => done());
-
-        if (batchSize) {
-          documentsBatch.push(doc);
-        }
-
-        // If the current documents size is less than the provided patch size don't process the documents yet
-        if (batchSize && documentsBatch.length !== batchSize) {
-          immediate(() => enqueue(fetch));
-          return;
-        }
-
-        const docsToProcess = batchSize ? documentsBatch : doc;
-
-        function handleNextResultCallBack(err) {
-          if (batchSize) {
-            handleResultsInProgress -= documentsBatch.length;
-            documentsBatch = [];
-          } else {
-            --handleResultsInProgress;
-          }
           if (err != null) {
-            if (continueOnError) {
+            if (err.name === 'MongoCursorExhaustedError') {
+              // We may end up calling `next()` multiple times on an exhausted
+              // cursor, which leads to an error. In case cursor is exhausted,
+              // just treat it as if the cursor returned no document, which is
+              // how a cursor indicates it is exhausted.
+              doc = null;
+            } else if (continueOnError) {
               aggregatedErrors.push(err);
             } else {
               error = err;
-              return finalCallback(err);
+              finalCallback(err);
+              return done();
             }
           }
-          if (drained && handleResultsInProgress <= 0) {
-            const finalErr = continueOnError ?
-              createEachAsyncMultiError(aggregatedErrors) :
-              error;
-            return finalCallback(finalErr);
+          if (doc == null) {
+            drained = true;
+            if (handleResultsInProgress <= 0) {
+              const finalErr = continueOnError ?
+                createEachAsyncMultiError(aggregatedErrors) :
+                error;
+
+              finalCallback(finalErr);
+            } else if (batchSize && documentsBatch.length) {
+              handleNextResult(documentsBatch, currentDocumentIndex++, handleNextResultCallBack);
+            }
+            return done();
           }
 
-          immediate(() => enqueue(fetch));
-        }
+          ++handleResultsInProgress;
 
-        handleNextResult(docsToProcess, currentDocumentIndex++, handleNextResultCallBack);
-      });
+          // Kick off the subsequent `next()` before handling the result, but
+          // make sure we know that we still have a result to handle re: #8422
+          immediate(() => done());
+
+          if (batchSize) {
+            documentsBatch.push(doc);
+          }
+
+          // If the current documents size is less than the provided batch size don't process the documents yet
+          if (batchSize && documentsBatch.length !== batchSize) {
+            immediate(() => enqueue(fetch));
+            return;
+          }
+
+          const docsToProcess = batchSize ? documentsBatch : doc;
+
+          function handleNextResultCallBack(err) {
+            if (batchSize) {
+              handleResultsInProgress -= documentsBatch.length;
+              documentsBatch = [];
+            } else {
+              --handleResultsInProgress;
+            }
+            if (err != null) {
+              if (continueOnError) {
+                aggregatedErrors.push(err);
+              } else {
+                error = err;
+                return finalCallback(err);
+              }
+            }
+            if ((drained || aborted) && handleResultsInProgress <= 0) {
+              const finalErr = continueOnError ?
+                createEachAsyncMultiError(aggregatedErrors) :
+                error;
+              return finalCallback(finalErr);
+            }
+
+            immediate(() => enqueue(fetch));
+          }
+
+          handleNextResult(docsToProcess, currentDocumentIndex++, handleNextResultCallBack);
+        });
+      }
     }
   }
 

--- a/test/helpers/cursor.eachAsync.test.js
+++ b/test/helpers/cursor.eachAsync.test.js
@@ -189,6 +189,30 @@ describe('eachAsync()', function() {
     assert.equal(numCalled, 1);
   });
 
+  it('avoids mutating document batch with parallel (gh-12652)', async() => {
+    const max = 100;
+    let numCalled = 0;
+    function next(cb) {
+      setImmediate(() => {
+        if (++numCalled > max) {
+          return cb(null, null);
+        }
+        cb(null, { num: numCalled });
+      });
+    }
+
+    let numDocsProcessed = 0;
+    async function fn(batch) {
+      numDocsProcessed += batch.length;
+      const length = batch.length;
+      await new Promise(resolve => setTimeout(resolve, 50));
+      assert.equal(batch.length, length);
+    }
+
+    await eachAsync(next, fn, { parallel: 7, batchSize: 10 });
+    assert.equal(numDocsProcessed, max);
+  });
+
   it('using AbortSignal (gh-12173)', async function() {
     if (typeof AbortController === 'undefined') {
       return this.skip();


### PR DESCRIPTION
Fix #12652

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12652 points out that there is a race condition in `eachAsync()` when `parallel > 1` and `batchSize` is set. Given that we run a bunch of parallel queues, `documentsBatch` can change while the `eachAsync` callback is running.

This fixes part of the issue: makes it so that at least every document gets processed, and each `eachAsync()` callback gets a consistent batch of documents that doesn't change.

However, there is still the potential issue that the individual documents in the batch can be in any order when `parallel > 1`. Because we run `next()` in parallel, you can end up with surprising behavior like document 9613 in the same batch as documents 9900-9999. Or an `eachAsync()` callback running with a batch of size 67 followed by a batch of 33 even though you have `batchSize = 100` and there's 10000 documents in the result set.

We should consider running `next()` in a queue, getting documents in order and building up the batch, and then building the next batch while `eachAsync()` runs. Rather than running the whole "build up a batch and then call the `eachAsync()` callback" process in parallel. What do you think @hasezoey ?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
