### PR TITLE
fix: setting global `strictQuery` after Schema creation wasn't working

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -264,7 +264,7 @@ module.exports = function cast(schema, obj, options, context) {
         }
 
         const strict = 'strict' in options ? options.strict : schema.options.strict;
-        const strictQuery = getStrictQuery(options, schema._userProvidedOptions, schema.options);
+        const strictQuery = getStrictQuery(options, schema._userProvidedOptions, schema.options, context);
         if (options.upsert && strict) {
           if (strict === 'throw') {
             throw new StrictModeError(path);
@@ -374,7 +374,7 @@ function _cast(val, numbertype, context) {
   }
 }
 
-function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions) {
+function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions, context) {
   if ('strictQuery' in queryOptions) {
     return queryOptions.strictQuery;
   }
@@ -386,6 +386,18 @@ function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions) 
   }
   if ('strict' in schemaUserProvidedOptions) {
     return schemaUserProvidedOptions.strict;
+  }
+  if (
+    context.mongooseCollection &&
+    context.mongooseCollection.conn &&
+    context.mongooseCollection.conn.base) {
+    const mongooseOptions = context.mongooseCollection.conn.base.options;
+    if ('strictQuery' in mongooseOptions) {
+      return mongooseOptions.strictQuery;
+    }
+    if ('strict' in mongooseOptions) {
+      return mongooseOptions.strict;
+    }
   }
   return schemaOptions.strictQuery;
 }

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -390,7 +390,7 @@ function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions, 
   if (
     context.mongooseCollection &&
     context.mongooseCollection.conn &&
-    context.mongooseCollection.conn.base && 
+    context.mongooseCollection.conn.base &&
     context.mongooseCollection.conn.base.options) {
     const mongooseOptions = context.mongooseCollection.conn.base.options;
     if ('strictQuery' in mongooseOptions) {

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -390,7 +390,8 @@ function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions, 
   if (
     context.mongooseCollection &&
     context.mongooseCollection.conn &&
-    context.mongooseCollection.conn.base) {
+    context.mongooseCollection.conn.base && 
+    context.mongooseCollection.conn.base.options) {
     const mongooseOptions = context.mongooseCollection.conn.base.options;
     if ('strictQuery' in mongooseOptions) {
       return mongooseOptions.strictQuery;


### PR DESCRIPTION
fix #12703