### PR TITLE
make `modifiedPaths` safer.

### DIFF
--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -7,6 +7,8 @@
 const Binary = require('../driver').get().Binary;
 const isBsonType = require('./isBsonType');
 const isMongooseObject = require('./isMongooseObject');
+const MongooseError = require('../error');
+const util = require('util');
 
 exports.flatten = flatten;
 exports.modifiedPaths = modifiedPaths;
@@ -67,18 +69,21 @@ function flatten(update, path, options, schema) {
  * ignore
  */
 
-function modifiedPaths(update, path, result, recursion=null) {
-  if(recursion == null){
+function modifiedPaths(update, path, result, recursion = null) {
+  if (recursion == null) {
     recursion = {
-      count: 0,
-      raw: {update, path}
+      raw: { update, path },
+      trace: new WeakSet()
     };
   }
 
-  recursion.count++;
-  if(recursion.count >= 1024){
-    throw new Error(`Mongoose: bad update value, ${recursion.raw.update}, ${recursion.raw.path}`);
+  if (recursion.trace.has(update)) {
+    throw new MongooseError(`a circular reference in the update value, updateValue:
+${util.inspect(recursion.raw.update, { showHidden: false, depth: 1 })}
+updatePath: ${recursion.raw.path}
+-------`);
   }
+  recursion.trace.add(update);
 
   const keys = Object.keys(update || {});
   const numKeys = keys.length;
@@ -108,11 +113,11 @@ function modifiedPaths(update, path, result, recursion=null) {
 
 function shouldFlatten(val) {
   return val &&
-    typeof val === 'object' &&
-    !(val instanceof Date) &&
-    !isBsonType(val, 'ObjectID') &&
-    (!Array.isArray(val) || val.length !== 0) &&
-    !(val instanceof Buffer) &&
-    !isBsonType(val, 'Decimal128') &&
-    !(val instanceof Binary);
+      typeof val === 'object' &&
+      !(val instanceof Date) &&
+      !isBsonType(val, 'ObjectID') &&
+      (!Array.isArray(val) || val.length !== 0) &&
+      !(val instanceof Buffer) &&
+      !isBsonType(val, 'Decimal128') &&
+      !(val instanceof Binary);
 }

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -70,7 +70,9 @@ function flatten(update, path, options, schema) {
  */
 
 function modifiedPaths(update, path, result, recursion = null) {
-  if (update == null) return result || {};
+  if (update == null || typeof update !== 'object') {
+    return;
+  }
 
   if (recursion == null) {
     recursion = {

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -67,7 +67,19 @@ function flatten(update, path, options, schema) {
  * ignore
  */
 
-function modifiedPaths(update, path, result) {
+function modifiedPaths(update, path, result, recursion=null) {
+  if(recursion == null){
+    recursion = {
+      count: 0,
+      raw: {update, path}
+    };
+  }
+
+  recursion.count++;
+  if(recursion.count >= 1024){
+    throw new Error(`Mongoose: bad update value, ${recursion.raw.update}, ${recursion.raw.path}`);
+  }
+
   const keys = Object.keys(update || {});
   const numKeys = keys.length;
   result = result || {};
@@ -83,7 +95,7 @@ function modifiedPaths(update, path, result) {
       val = val.toObject({ transform: false, virtuals: false });
     }
     if (shouldFlatten(val)) {
-      modifiedPaths(val, path + key, result);
+      modifiedPaths(val, path + key, result, recursion);
     }
   }
 

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -70,6 +70,8 @@ function flatten(update, path, options, schema) {
  */
 
 function modifiedPaths(update, path, result, recursion = null) {
+  if (update == null) return result;
+
   if (recursion == null) {
     recursion = {
       raw: { update, path },
@@ -80,8 +82,7 @@ function modifiedPaths(update, path, result, recursion = null) {
   if (recursion.trace.has(update)) {
     throw new MongooseError(`a circular reference in the update value, updateValue:
 ${util.inspect(recursion.raw.update, { showHidden: false, depth: 1 })}
-updatePath: ${recursion.raw.path}
--------`);
+updatePath: '${recursion.raw.path}'`);
   }
   recursion.trace.add(update);
 

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -70,7 +70,7 @@ function flatten(update, path, options, schema) {
  */
 
 function modifiedPaths(update, path, result, recursion = null) {
-  if (update == null) return result;
+  if (update == null) return result || {};
 
   if (recursion == null) {
     recursion = {

--- a/test/helpers/common.test.js
+++ b/test/helpers/common.test.js
@@ -9,39 +9,14 @@ const { Schema } = mongoose;
 
 
 describe('modifiedPaths, bad update value which has circular reference field', () => {
-
   it('update value can be null', function() {
     modifiedPaths(null, 'path', null);
   });
 
-  it('values with obvious error', function() {
+  it('values with obvious error on circular reference', function() {
     const objA = {};
     objA.a = objA;
 
     assert.throws(() => modifiedPaths(objA, 'path', null), /circular reference/);
-  });
-
-  it('original error i made', async function() {
-    await mongoose.connect(start.uri);
-
-    const test1Schema = new Schema({
-      v: Number,
-      n: String
-    });
-
-    const Test1Model = mongoose.model('Test1', test1Schema);
-
-    const test2Schema = new Schema({
-      v: Number
-    });
-
-    const Test2Model = mongoose.model('Test2', test2Schema);
-
-    for (let i = 0; i < 5; i++) {
-      const doc = new Test2Model({ v: i });
-      await doc.save();
-    }
-    
-    assert.rejects(() => Test1Model.updateOne({ n: 'x' }, { v: Test2Model.countDocuments() }, { upsert: true }), /circular reference/);
   });
 });

--- a/test/helpers/common.test.js
+++ b/test/helpers/common.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const start = require('../common');
+
+const modifiedPaths = require('../../lib/helpers/common').modifiedPaths;
+const mongoose = start.mongoose;
+const { Schema } = mongoose;
+
+
+describe('modifiedPaths, bad update value which has circular reference field', () => {
+
+  it('values with obvious error', function() {
+    const objA = {};
+    objA.a = objA;
+
+    try {
+      modifiedPaths(objA, 'path', null);
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
+  it('original error i made', async function() {
+    await mongoose.connect(start.uri);
+
+    const test1Schema = new Schema({
+      v: Number,
+      n: String
+    });
+
+    const Test1Model = mongoose.model('Test1', test1Schema);
+
+    const test2Schema = new Schema({
+      v: Number
+    });
+
+    const Test2Model = mongoose.model('Test2', test2Schema);
+
+    for (let i = 0; i < 5; i++) {
+      const doc = new Test2Model({ v: i });
+      await doc.save();
+    }
+
+    try {
+      // miss an `await` before `Test2Model.countDocuments()`
+      await Test1Model.updateOne({ n: 'x' }, { v: Test2Model.countDocuments() }, { upsert: true });
+    } catch (e) {
+      console.log(e);
+    }
+  });
+});

--- a/test/helpers/common.test.js
+++ b/test/helpers/common.test.js
@@ -9,6 +9,10 @@ const { Schema } = mongoose;
 
 describe('modifiedPaths, bad update value which has circular reference field', () => {
 
+  it('update value can be null', function() {
+    modifiedPaths(null, 'path', null);
+  });
+
   it('values with obvious error', function() {
     const objA = {};
     objA.a = objA;

--- a/test/helpers/common.test.js
+++ b/test/helpers/common.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const start = require('../common');
 
 const modifiedPaths = require('../../lib/helpers/common').modifiedPaths;

--- a/test/helpers/common.test.js
+++ b/test/helpers/common.test.js
@@ -17,11 +17,7 @@ describe('modifiedPaths, bad update value which has circular reference field', (
     const objA = {};
     objA.a = objA;
 
-    try {
-      modifiedPaths(objA, 'path', null);
-    } catch (e) {
-      console.log(e);
-    }
+    assert.throws(() => modifiedPaths(objA, 'path', null), /circular reference/);
   });
 
   it('original error i made', async function() {
@@ -44,12 +40,7 @@ describe('modifiedPaths, bad update value which has circular reference field', (
       const doc = new Test2Model({ v: i });
       await doc.save();
     }
-
-    try {
-      // miss an `await` before `Test2Model.countDocuments()`
-      await Test1Model.updateOne({ n: 'x' }, { v: Test2Model.countDocuments() }, { upsert: true });
-    } catch (e) {
-      console.log(e);
-    }
+    
+    assert.rejects(() => Test1Model.updateOne({ n: 'x' }, { v: Test2Model.countDocuments() }, { upsert: true }), /circular reference/);
   });
 });


### PR DESCRIPTION
**Summary**

`helpers.common.modifiedPaths` is a recursion function.

when user call `db.updateOne({key: badValue})`, the `badValue` will cause a endless recursion call. but it is impossible to check user's input. so I think we can check the recursion level , it will be helpful for debugging.

**Examples**

```javascript

async function updateDoc(){
    const count = collectionA.countDocuments({}); // miss an `await`, will cause a endless recursion call.
    await collectionB.updateOne({key: count}, {upsert: true});
}

```
