### PR TITLE
fix(types): infer virtuals in query results

### DIFF
--- a/test/types/virtuals.test.ts
+++ b/test/types/virtuals.test.ts
@@ -87,7 +87,7 @@ function gh11543() {
   expectType<PetVirtuals>(personSchema.virtuals);
 }
 
-function autoTypedVirtuals() {
+async function autoTypedVirtuals() {
   type AutoTypedSchemaType = InferSchemaType<typeof testSchema>;
   type VirtualsType = { domain: string };
   type InferredDocType = FlatRecord<AutoTypedSchemaType & ObtainSchemaGeneric<typeof testSchema, 'TVirtuals'>>;
@@ -119,4 +119,7 @@ function autoTypedVirtuals() {
   expectType<string>(doc.domain);
 
   expectType<FlatRecord<AutoTypedSchemaType & VirtualsType >>({} as InferredDocType);
+
+  const doc2 = await TestModel.findOne().orFail();
+  expectType<string>(doc2.domain);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,7 +78,13 @@ declare module 'mongoose' {
     schema?: TSchema,
     collection?: string,
     options?: CompileModelOptions
-  ): Model<InferSchemaType<TSchema>, ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>, ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>, {}, TSchema> & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
+  ): Model<
+  InferSchemaType<TSchema>,
+  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
+  ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
+  ObtainSchemaGeneric<TSchema, 'TVirtuals'>,
+  TSchema
+  > & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
   export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
 


### PR DESCRIPTION
Fix #12702
Re: #11908

@carlosingles can you also please take a look?

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like `model()` isn't pulling TVirtuals correctly, which is leading to virtuals not showing up in query results if you're using inferred schemas.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
