### PR TITLE
fix(query): handle deselecting _id when another field has schema-level `select: false`

### DIFF
--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -163,6 +163,9 @@ exports.applyPaths = function applyPaths(fields, schema) {
       if (!isDefiningProjection(field)) {
         continue;
       }
+      if (keys[keyIndex] === '_id') {
+        continue;
+      }
       exclude = !field;
       break;
     }

--- a/test/model.field.selection.test.js
+++ b/test/model.field.selection.test.js
@@ -475,7 +475,6 @@ describe('model field selection', function() {
     db.deleteModel(/BlogPost/);
     const BlogPost = db.model('BlogPost', BlogPostSchema);
 
-
     await BlogPost.create({
       author: 'me',
       settings: {
@@ -497,8 +496,6 @@ describe('model field selection', function() {
   });
 
   it('when `select: true` in schema, works with $elemMatch in projection', async function() {
-
-
     const productSchema = new Schema({
       attributes: {
         select: true,
@@ -524,11 +521,9 @@ describe('model field selection', function() {
   });
 
   it('selection specified in query overwrites option in schema', async function() {
-
     const productSchema = new Schema({ name: { type: String, select: false } });
 
     const Product = db.model('Product', productSchema);
-
 
     await Product.create({ name: 'Computer' });
 
@@ -538,7 +533,6 @@ describe('model field selection', function() {
   });
 
   it('selecting with `false` instead of `0` doesn\'t overwrite schema `select: false` (gh-8923)', async function() {
-
     const userSchema = new Schema({
       name: { type: String, select: false },
       age: { type: Number }
@@ -551,5 +545,22 @@ describe('model field selection', function() {
     const user = await User.findOne().select({ age: false });
 
     assert.ok(!user.name);
+  });
+
+  it('handles deselecting _id when other field has schema-level `select: false` (gh-12670)', async function() {
+    const schema = new mongoose.Schema({
+      field1: {
+        type: String,
+        select: false
+      },
+      field2: String
+    });
+    const User = db.model('User', schema);
+
+    await User.create({ field1: 'test1', field2: 'test2' });
+    const doc = await User.findOne().select('field2 -_id');
+    assert.ok(doc.field2);
+    assert.strictEqual(doc.field1, undefined);
+    assert.strictEqual(doc._id, undefined);
   });
 });


### PR DESCRIPTION
Fix #12670

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12670 is a fairly clear bug, thankfully with a quick fix.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
