### PR TITLE
fix(schema): copy indexes when calling `add()` with schema instance

### DIFF
--- a/lib/helpers/schema/merge.js
+++ b/lib/helpers/schema/merge.js
@@ -23,5 +23,6 @@ module.exports = function merge(s1, s2, skipConflictingPaths) {
     s1.virtuals[virtual] = s2.virtuals[virtual].clone();
   }
 
+  s1._indexes = s1._indexes.concat(s2._indexes || []);
   s1.s.hooks.merge(s2.s.hooks, false);
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2406,6 +2406,16 @@ describe('schema', function() {
     assert.equal(TurboManSchema.path('year').instance, 'Number');
   });
 
+  it('copies indexes when calling add() with schema instance (gh-12654)', function() {
+    const ToySchema = Schema({ name: String });
+    ToySchema.index({ name: 1 });
+
+    const TurboManSchema = Schema();
+    TurboManSchema.add(ToySchema);
+
+    assert.deepStrictEqual(TurboManSchema.indexes(), [[{ name: 1 }, { background: true }]]);
+  });
+
   describe('gh-8849', function() {
     it('treats `select: undefined` as not specifying `select` option', async function() {
       const userSchema = new Schema({ name: { type: String, select: undefined } });


### PR DESCRIPTION
Fix #12654

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Docs say that `Schema.prototype.add()` copies indexes if you call `add()` with a schema instance, but looks like that doesn't actually happen. I can see the case for putting this change in a minor release, but I think patch is fine since the docs indicate that this is the correct behavior.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
