### PR TITLE
fix(types): support using `UpdateQuery` in `bulkWrite()`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -496,7 +496,12 @@ declare module 'mongoose' {
     $pullAll?: AnyKeys<TSchema> & AnyObject;
 
     /** @see https://docs.mongodb.com/manual/reference/operator/update-bitwise/ */
-    $bit?: Record<string, mongodb.NumericType>;
+    // Needs to be `AnyKeys` for now, because anything stricter makes us incompatible
+    // with the MongoDB Node driver's `UpdateFilter` interface (see gh-12595, gh-11911)
+    // and using the Node driver's `$bit` definition breaks because their `OnlyFieldsOfType`
+    // interface breaks on Mongoose Document class due to circular references.
+    // Re-evaluate this when we drop `extends Document` support in document interfaces.
+    $bit?: AnyKeys<TSchema>;
   };
 
   export type UpdateWithAggregationPipeline = UpdateAggregationStage[];


### PR DESCRIPTION
Fix #12595
Re: #11911

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Not my favorite change, but unfortunately necessary if we want to support #12595 with `extends Document`. Once we drop support for `extends Document`, we can revisit this issue. See comments about why this change is necessary.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

```ts
import mongoose, { UpdateQuery } from 'mongoose';
const { Schema, model } = mongoose;

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test');

  interface IAnimal {
    name?: string;
  }

  const animalSchema = new Schema<IAnimal>({
    name: { type: String }
  });

  const Animal = model<IAnimal>('Animal', animalSchema);

  const writeOperations = ['foo', 'bar', 'baz'].map(name => {
    const changes: UpdateQuery<IAnimal> = { }

    if (name === 'foo') {
      changes.name = name.repeat(2);
    } else {
      changes.name = name.repeat(4);
    }

    return {
      updateOne: {
        filter: { name },
        update: changes
      }
    }
  })

  await Animal.bulkWrite(writeOperations);
}
run();
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
