### PR TITLE
Fix wrong circular dependency detection

### DIFF
--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -106,6 +106,7 @@ updatePath: '${recursion.raw.path}'`);
       modifiedPaths(val, path + key, result, recursion);
     }
   }
+  recursion.trace.delete(update);
 
   return result;
 }

--- a/test/helpers/common.test.js
+++ b/test/helpers/common.test.js
@@ -14,4 +14,11 @@ describe('modifiedPaths, bad update value which has circular reference field', (
 
     assert.throws(() => modifiedPaths(objA, 'path', null), /circular reference/);
   });
+
+  it('values with multiple references which are not circular should succeed', function() {
+    const objA = {};
+    const objB = { a: objA, b: objA };
+
+    modifiedPaths(objB, 'path', null);
+  });
 });


### PR DESCRIPTION
**Summary**

If the same object is referenced in multiple places, it was wrongfully detected as circular, even when it wasn't.

Amends commit 7974f004fae549ac11bbc247ac371fe6be4aa137.

Fixes #12775.

**Examples**

Demonstrated by the added test.