### PR TITLE
return value from super.delete()

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -180,7 +180,7 @@ class MongooseMap extends Map {
     }
 
     this.set(key, undefined);
-    super.delete(key);
+    return super.delete(key);
   }
 
   /**


### PR DESCRIPTION
**Summary**

Currently, the Mongoose Map type doesn't abide by the native JS map API. The map's `delete` method should return `true` if the item was deleted and `false` if not as described [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete).

In order to abide by the native API and be more predictable to use I have simply returned the value that is returned by the `super.delete` method

**Examples**

```
const accountSchema = new mongoose.Schema({
  id: Number,
  shops: { type: Map, of: String }
})

const Account = mongoose.model('Account', accountSchema);

const newAccount = new Account({ id: 1, shops: { one: '111', two: '222' } });
await newAccount.save();

const wasDeletedWhenKeyExists = mapInstance.delete('one');
// Before change: wasDeletedWhenKeyExists == undefined
// After change: wasDeletedWhenKeyExists == true

const wasDeletedWhenKeyNotExists = mapInstance.delete('one');
// Before change: wasDeletedWhenKeyNotExists == undefined
// After change: wasDeletedWhenKeyNotExists == false
```
