### PR TITLE
fix(model): prevent index creation on syncIndexes if not necessary

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1570,14 +1570,14 @@ Model.diffIndexes = function diffIndexes(options, callback) {
       const schemaIndexes = getRelatedSchemaIndexes(model, schema.indexes());
 
       const toDrop = getIndexesToDrop(schema, schemaIndexes, dbIndexes);
-      const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes);
+      const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop);
 
       cb(null, { toDrop, toCreate });
     });
   });
 };
 
-function getIndexesToCreate(schema, schemaIndexes, dbIndexes) {
+function getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop) {
   const toCreate = [];
 
   for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
@@ -1589,7 +1589,10 @@ function getIndexesToCreate(schema, schemaIndexes, dbIndexes) {
       if (isDefaultIdIndex(index)) {
         continue;
       }
-      if (isIndexEqual(schemaIndexKeysObject, options, index)) {
+      if (
+        isIndexEqual(schemaIndexKeysObject, options, index) &&
+        !toDrop.includes(index.name)
+      ) {
         found = true;
         break;
       }
@@ -1885,6 +1888,12 @@ function _ensureIndexes(model, options, callback) {
 
     if ('background' in options) {
       indexOptions.background = options.background;
+    }
+
+    if ('toCreate' in options) {
+      if (options.toCreate.length === 0) {
+        return done();
+      }
     }
 
     model.collection.createIndex(indexFields, indexOptions, utils.tick(function(err, name) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6767,7 +6767,8 @@ describe('Model', function() {
         );
 
       });
-      xit('creates indexes only when they do not exist on the mongodb server (gh-12250)', async() => {
+
+      it('creates indexes only when they do not exist on the mongodb server (gh-12250)', async() => {
         const userSchema = new Schema({
           name: { type: String }
         }, { autoIndex: false });
@@ -6784,12 +6785,12 @@ describe('Model', function() {
         // Act
         await User.syncIndexes();
         assert.equal(createIndexSpy.callCount, 1);
-        assert.equal(listIndexesSpy.callCount, 2);
+        assert.equal(listIndexesSpy.callCount, 1);
 
         await User.syncIndexes();
 
         // Assert
-        assert.equal(listIndexesSpy.callCount, 4);
+        assert.equal(listIndexesSpy.callCount, 2);
         assert.equal(createIndexSpy.callCount, 1);
       });
     });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6782,14 +6782,13 @@ describe('Model', function() {
         const createIndexSpy = sinon.spy(User.collection, 'createIndex');
         const listIndexesSpy = sinon.spy(User.collection, 'listIndexes');
 
-        // Act
         await User.syncIndexes();
+
         assert.equal(createIndexSpy.callCount, 1);
         assert.equal(listIndexesSpy.callCount, 1);
 
         await User.syncIndexes();
 
-        // Assert
         assert.equal(listIndexesSpy.callCount, 2);
         assert.equal(createIndexSpy.callCount, 1);
       });


### PR DESCRIPTION
fix #12250

**Summary**
The `model.collection.createIndex` is now executed only if there are indexes in the `toCreate` array.
`getIndexesToCreate` now includes a check to evaluate if the index was dropped. In that case, it will proceed to recreate it.