### PR TITLE
fix(update): handle embedded discriminators when casting array filters

### DIFF
--- a/lib/helpers/update/castArrayFilters.js
+++ b/lib/helpers/update/castArrayFilters.js
@@ -37,14 +37,36 @@ function _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilt
     if (filter == null) {
       throw new Error(`Got null array filter in ${arrayFilters}`);
     }
-    for (const key of Object.keys(filter)) {
-      if (key === '$and' || key === '$or') {
+    const keys = Object.keys(filter).filter(key => filter[key] != null);
+    if (keys.length === 0) {
+      continue;
+    }
+
+    const firstKey = keys[0];
+    if (firstKey === '$and' || firstKey === '$or') {
+      for (const key of keys) {
         _castArrayFilters(filter[key], schema, strictQuery, updatedPathsByFilter, query);
-        continue;
       }
-      if (filter[key] == null) {
-        continue;
-      }
+      continue;
+    }
+    const dot = firstKey.indexOf('.');
+    const filterWildcardPath = dot === -1 ? firstKey : firstKey.substring(0, dot);
+    if (updatedPathsByFilter[filterWildcardPath] == null) {
+      continue;
+    }
+    const baseFilterPath = cleanPositionalOperators(
+      updatedPathsByFilter[filterWildcardPath]
+    );
+
+    const baseSchematype = getPath(schema, baseFilterPath);
+    let filterBaseSchema = baseSchematype != null ? baseSchematype.schema : null;
+    if (filterBaseSchema != null &&
+        filterBaseSchema.discriminators != null &&
+        filter[filterWildcardPath + '.' + filterBaseSchema.options.discriminatorKey]) {
+      filterBaseSchema = filterBaseSchema.discriminators[filter[filterWildcardPath + '.' + filterBaseSchema.options.discriminatorKey]] || filterBaseSchema;
+    }
+
+    for (const key of keys) {
       if (updatedPathsByFilter[key] === null) {
         continue;
       }
@@ -52,21 +74,25 @@ function _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilt
         continue;
       }
       const dot = key.indexOf('.');
-      let filterPath = dot === -1 ?
-        updatedPathsByFilter[key] + '.0' :
-        updatedPathsByFilter[key.substring(0, dot)] + '.0' + key.substring(dot);
-      if (filterPath == null) {
-        throw new Error(`Filter path not found for ${key}`);
+
+      let filterPathRelativeToBase = dot === -1 ? null : key.substring(dot);
+      let schematype;
+      if (filterPathRelativeToBase == null || filterBaseSchema == null) {
+        schematype = baseSchematype;
+      } else {
+        // If there are multiple array filters in the path being updated, make sure
+        // to replace them so we can get the schema path.
+        filterPathRelativeToBase = cleanPositionalOperators(filterPathRelativeToBase);
+        schematype = getPath(filterBaseSchema, filterPathRelativeToBase);
       }
 
-      // If there are multiple array filters in the path being updated, make sure
-      // to replace them so we can get the schema path.
-      filterPath = cleanPositionalOperators(filterPath);
-      const schematype = getPath(schema, filterPath);
       if (schematype == null) {
         if (!strictQuery) {
           return;
         }
+        const filterPath = filterPathRelativeToBase == null ?
+          baseFilterPath + '.0' :
+          baseFilterPath + '.0' + filterPathRelativeToBase;
         // For now, treat `strictQuery = true` and `strictQuery = 'throw'` as
         // equivalent for casting array filters. `strictQuery = true` doesn't
         // quite work in this context because we never want to silently strip out


### PR DESCRIPTION
Fix #12565

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`castArrayFilters()` doesn't handle embedded discriminators. With this PR, you should be able to use embedded discriminators, as long as you explicitly specify the embedded discriminator key in the array filter.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
