### PR TITLE
docs: make `Document.prototype.$clone()` public

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4655,7 +4655,7 @@ Document.prototype.getChanges = function() {
  * Returns a copy of this document with a deep clone of `_doc` and `$__`.
  *
  * @return {Document} a copy of this document
- * @api private
+ * @api public
  * @method $clone
  * @memberOf Document
  * @instance

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -28,6 +28,9 @@ declare module 'mongoose' {
     /** Assert that a given path or paths is populated. Throws an error if not populated. */
     $assertPopulated<Paths = {}>(path: string | string[], values?: Partial<Paths>): Omit<this, keyof Paths> & Paths;
 
+    /** Returns a deep clone of this document */
+    $clone(): this;
+
     /* Get all subdocs (by bfs) */
     $getAllSubdocs(): Document[];
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

For @lpizzinidev . We intended to make `$clone()` public for 6.8 in #12549, but looks like we didn't add it to TypeScript or the docs :cry: 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
