### PR TITLE
fix(populate): avoid calling `transform` if there's no populate results and using lean

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -253,6 +253,8 @@ function valueFilter(val, assignmentOpts, populateOptions, allIds) {
       const _allIds = Array.isArray(allIds) ? allIds[i] : allIds;
       if (!isPopulatedObject(subdoc) && (!populateOptions.retainNullValues || subdoc != null) && !userSpecifiedTransform) {
         continue;
+      } else if (!populateOptions.retainNullValues && subdoc == null) {
+        continue;
       } else if (userSpecifiedTransform) {
         subdoc = transform(isPopulatedObject(subdoc) ? subdoc : null, _allIds);
       }


### PR DESCRIPTION
Fix #12739

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Avoid calling populate transform on null values

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
