### PR TITLE
fix(schemaoptions.d.ts): add option "overwriteModels" as a schema option

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -978,3 +978,7 @@ function gh12782() {
     test: string
   }>({} as Props);
 }
+
+function gh12816() {
+  const schema = new Schema({}, { overwriteModels: true });
+}

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -213,6 +213,12 @@ declare module 'mongoose' {
      * Virtual paths.
      */
     virtuals?: SchemaOptionsVirtualsPropertyType<DocType, TVirtuals, TInstanceMethods>,
+
+    /**
+     * Set to `true` to default to overwriting models with the same name when calling `mongoose.model()`, as opposed to throwing an `OverwriteModelError`.
+     * @default false
+     */
+    overwriteModels?: boolean;
   }
 
   interface DefaultSchemaOptions {


### PR DESCRIPTION
**Summary**

This PR adds the schema option `overwriteModels` to the types

fixes #12816