### PR TITLE
Add guard to stop loadClass copying Document if Document is used as base of loaded class (same hack as implemented for Model already).

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -198,6 +198,8 @@ function Document(obj, fields, skipId, options) {
   applyQueue(this);
 }
 
+Document.prototype.$isMongooseDocumentPrototype = true;
+
 /**
  * Boolean flag specifying if the document is new. If you create a document
  * using `new`, this document will be considered "new". `$isNew` is how

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2290,9 +2290,11 @@ function _deletePath(schema, name) {
  * @param {Boolean} [virtualsOnly] if truthy, only pulls virtuals from the class, not methods or statics
  */
 Schema.prototype.loadClass = function(model, virtualsOnly) {
+  // Stop copying when hit certain base classes
   if (model === Object.prototype ||
       model === Function.prototype ||
-      model.prototype.hasOwnProperty('$isMongooseModelPrototype')) {
+      model.prototype.hasOwnProperty('$isMongooseModelPrototype') ||
+      model.prototype.hasOwnProperty('$isMongooseDocumentPrototype')) {
     return this;
   }
 


### PR DESCRIPTION
**Summary**
I want to set `Document` as the base class of a `loadClass` class so I can inherit its typings on `this` conveniently. There is a [guard condition hack in the code](https://github.com/Automattic/mongoose/blob/c77dd1bfbec6b551f0ba602b318bdd98f68c4aeb/lib/schema.js#L2291) to allow this for `Model` already. This PR just extends to guard condition to account for possibility Document is the base class. If  that didn't already exist I wouldn't PR this, but since it exists may as well account for Document too, in case people do that, and for consistency.

**Examples**
Something like this:

```
export class MyResourceMethods extends Document
{
  delete() {
    return this.remove();
  }
  async ping() {
    await this.updateOne({ $inc: { pingCount: 1 } });
    return { modified: true };
  }
 ...
}
```

If you want Typescript to know types for Document methods (updateOne, remove in example) you can either type `this` in every method or do the above. The above is more convenient.

Refs #12813.

