### PR TITLE
fix(schema): `Schema.add` should add properties to schema's `.obj`

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -98,7 +98,7 @@ function Schema(obj, options) {
     return new Schema(obj, options);
   }
 
-  this.obj = obj;
+  this.obj = obj || {};
   this.paths = {};
   this.aliases = {};
   this.subpaths = {};
@@ -606,6 +606,15 @@ Schema.prototype.add = function add(obj, prefix) {
 
     const fullPath = prefix + key;
     const val = obj[key];
+
+    if (
+      this.obj &&
+      key !== '__v' &&
+      key !== '_id' &&
+      !(key in this.obj)
+    ) {
+      this.obj[key] = val;
+    }
 
     if (val == null) {
       throw new TypeError('Invalid value for schema path `' + fullPath +

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2913,4 +2913,12 @@ describe('schema', function() {
 
     assert.equal(schema._getSchema('child.testMap.foo.bar').instance, 'Mixed');
   });
+
+  it('Schema.add method should add properties to schema.obj object (gh-12799)', () => {
+    const schema = new Schema();
+
+    schema.add({ test: String });
+
+    assert.ok('test' in schema.obj === true);
+  });
 });


### PR DESCRIPTION
fix #12799 

**Summary**
Adding a property with the `Schema.add` method was not adding it to the `.obj` object of the schema.

**Examples**
```
const schema = new Schema();
schema.add({ test: String });
console.log(schema.obj); // Was undefined, now contains the `test` property
```