### PR TITLE
fix(query): fix unexpected validation error when doing findOneAndReplace() with a nullish value

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -85,9 +85,11 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     val = ret[op];
     hasDollarKey = hasDollarKey || op.startsWith('$');
     const toUnset = {};
-    for (const key of Object.keys(val)) {
-      if (val[key] === undefined) {
-        toUnset[key] = 1;
+    if (val != null) {
+      for (const key of Object.keys(val)) {
+        if (val[key] === undefined) {
+          toUnset[key] = 1;
+        }
       }
     }
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4314,7 +4314,7 @@ describe('Query', function() {
     assert.strictEqual(found[0].title, 'burrito bowl');
   });
 
-  it('update operation should remove fields set to undefined (gh-12794)', async() => {
+  it('update operation should remove fields set to undefined (gh-12794) (gh-12821)', async function() {
     const m = new mongoose.Mongoose();
 
     await m.connect(start.uri);
@@ -4338,5 +4338,15 @@ describe('Query', function() {
     ).lean();
 
     assert.ok('title' in updatedDoc === false);
+
+    const replacedDoc = await Test.findOneAndReplace(
+      {
+        _id: doc._id
+      },
+      { title: undefined },
+      { returnOriginal: false }
+    ).lean();
+
+    assert.ok('title' in replacedDoc === false);
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

Fix #12821

**Summary**

#12797 missed a small edge case where `val` can be nullish.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
