### PR TITLE
fix(schema): propagate strictQuery to implicitly created schemas for embedded discriminators

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1250,6 +1250,9 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
         if (options.hasOwnProperty('strict')) {
           childSchemaOptions.strict = options.strict;
         }
+        if (options.hasOwnProperty('strictQuery')) {
+          childSchemaOptions.strictQuery = options.strictQuery;
+        }
 
         if (this._userProvidedOptions.hasOwnProperty('_id')) {
           childSchemaOptions._id = this._userProvidedOptions._id;

--- a/test/schema.documentarray.test.js
+++ b/test/schema.documentarray.test.js
@@ -75,6 +75,15 @@ describe('schema.documentarray', function() {
     done();
   });
 
+  it('propagates strictQuery to implicitly created schemas (gh-12796)', function() {
+    const schema = new Schema({
+      arr: [{ name: String }]
+    }, { strictQuery: 'throw' });
+
+    assert.equal(schema.childSchemas.length, 1);
+    assert.equal(schema.childSchemas[0].schema.options.strictQuery, 'throw');
+  });
+
   it('supports set with array of document arrays (gh-7799)', function() {
     const subSchema = new Schema({
       title: String


### PR DESCRIPTION
Fix #12796

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The root cause of #12796 is that we don't propagate `strictQuery` to implicitly created schemas like we do `strict`. So if global `strictQuery` is false, but the implicitly created schema's `strictQuery` is true. That gets even more confusing because embedded discriminator schemas do pick up the global `strictQuery` default, so with global `strictQuery = false` you get an error every time you create an embedded discriminator.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
