### PR TITLE
test(model): make timeseries test more durable by avoiding autoIndex and drop/init race

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6916,10 +6916,12 @@ describe('Model', function() {
           granularity: 'hours'
         },
         autoCreate: false,
+        autoIndex: false,
         expireAfterSeconds: 86400
       });
 
-      const Test = db.model('Test', schema);
+      const Test = db.model('Test', schema, 'Test');
+      await Test.init();
 
       await Test.collection.drop().catch(() => {});
       await Test.createCollection();


### PR DESCRIPTION
Fix #12643

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I haven't been able to repro the flakey test locally, but I have some guesses about why this test is flaking. 1) `autoIndex` isn't disabled, so that could somehow be causing an incorrect collection to be created, 2) not waiting for `init()` before dropping. Either way, these two changes should make the test more robust.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
