### PR TITLE
docs(navbar-search): add missing variable

### DIFF
--- a/docs/js/navbar-search.js
+++ b/docs/js/navbar-search.js
@@ -1,3 +1,5 @@
+var defaultVersion = '6.x';
+
 (function() {
   var versionFromUrl = window.location.pathname.match(/^\/docs\/(\d+\.x)/);
   var version = versionFromUrl ? versionFromUrl[1] : defaultVersion;


### PR DESCRIPTION
**Summary**

This PR is for fixing what c3384bcd1dc60fa15b57f41931bac9d9c99fc6e2 introduced (a missing variable), which makes the search via the navbar impossible (because the script never actually runs)

re #12830

fixes the following current error:
```txt
Uncaught ReferenceError: defaultVersion is not defined
    <anonymous> https://mongoosejs.com/docs/js/navbar-search.js:3
    <anonymous> https://mongoosejs.com/docs/js/navbar-search.js:18
[navbar-search.js:3:17](https://mongoosejs.com/docs/js/navbar-search.js)
    <anonymous> https://mongoosejs.com/docs/js/navbar-search.js:3
    <anonymous> https://mongoosejs.com/docs/js/navbar-search.js:18
```