### PR TITLE
docs(typescript): explain that virtuals inferred from schema only show up on Model, not raw document type

### DIFF
--- a/docs/typescript/virtuals.md
+++ b/docs/typescript/virtuals.md
@@ -16,9 +16,9 @@ const schema = new Schema(
     lastName: String,
   },
   {
-    virtuals:{
-      fullName:{
-        get(){
+    virtuals: {
+      fullName: {
+        get() {
           return `${this.firstName} ${this.lastName}`;
         }
         // virtual setter and options can be defined here as well.
@@ -28,7 +28,32 @@ const schema = new Schema(
 );
 ```
 
+Note that Mongoose does **not** include virtuals in the returned type from `InferSchemaType`.
+That is because `InferSchemaType` returns the "raw" document interface, which represents the structure of the data stored in MongoDB.
+
+```ts
+type User = InferSchemaType<typeof schema>;
+
+const user: User = {};
+// Property 'fullName' does not exist on type '{ firstName?: string | undefined; ... }'.
+user.fullName;
+```
+
+However, Mongoose **does** add the virtuals to the model type.
+
+```ts
+const UserModel = model('User', schema);
+
+const user = new UserModel({ firstName: 'foo' });
+// Works
+user.fullName;
+
+// Here's how to get the hydrated document type
+type UserDocument = ReturnType<(typeof UserModel)['hydrate']>;
+```
+
 ### Set virtuals type manually:
+
 You shouldn't define virtuals in your TypeScript [document interface](../typescript.html).
 Instead, you should define a separate interface for your virtuals, and pass this interface to `Model` and `Schema`.
 


### PR DESCRIPTION
Fix #12684

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Documentation related to where virtuals show up with automatically inferred schema types, and why they show up where they do. Also how to get the hydrated doc type. Because we didn't have a good link to answer @Jokero 's questions in #12684 

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
