### PR TITLE
add type def for Aggreaget#model without arguments

### DIFF
--- a/test/types/aggregate.test.ts
+++ b/test/types/aggregate.test.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Document, Expression, PipelineStage, Types } from 'mongoose';
+import { Schema, model, Document, Expression, PipelineStage, Types, Model, Aggregate } from 'mongoose';
 import { expectType } from 'tsd';
 
 const schema: Schema = new Schema({ name: { type: 'String' } });
@@ -8,6 +8,7 @@ interface ITest extends Document {
 }
 
 const Test = model<ITest>('Test', schema);
+const AnotherTest = model<ITest>('AnotherTest', schema);
 
 Test.aggregate([{ $match: { name: 'foo' } }]).exec().then((res: any) => console.log(res));
 
@@ -60,6 +61,10 @@ async function run() {
   expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 'desc' }));
   expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: 'descending' }));
   expectType<ITest[]>(await Test.aggregate<ITest>().sort({ name: { $meta: 'textScore' } }));
+
+  // Aggregate.prototype.model()
+  expectType<Model<any>>(Test.aggregate<ITest>().model());
+  expectType<Aggregate<ITest[]>>(Test.aggregate<ITest>().model(AnotherTest));
 }
 
 function gh12017_1() {

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -167,6 +167,11 @@ declare module 'mongoose' {
     model(model: Model<any>): this;
 
     /**
+     * Returns the current model bound to this aggregate object
+     */
+    model(): Model<any>;
+
+    /**
      * Append a new $near operator to this aggregation pipeline
      * @param arg $near operator contents
      */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

add missing type definition for `Aggregate.prototype.model` function that can be used for set or get Model from an Aggregate object.

According to mongoose documentation `Aggregate.prototype.model` can be used in two ways:

```js
      const aggregate = MyModel.aggregate([{ $match: { answer: 42 } }]);
      aggregate.model() === MyModel; // true
 
      // Change the model. There's rarely any reason to do this.
      aggregate.model(SomeOtherModel);
      aggregate.model() === SomeOtherModel; // true

```

...to get the aggregation object model and to set it.

But `types/aggregate.d.ts` is missing type definition for the get case of `Aggregate.prototype.model` function

This PR aims to fix this.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
