### PR TITLE
fix(model): ensure consistent ordering of validation errors in `insertMany()` with `ordered: false` and `rawResult: true`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3411,7 +3411,8 @@ Model.$__insertMany = function(arr, options, callback) {
   }
 
   const validationErrors = [];
-  const toExecute = arr.map(doc =>
+  const validationErrorsToOriginalOrder = new Map();
+  const toExecute = arr.map((doc, index) =>
     callback => {
       if (!(doc instanceof _this)) {
         try {
@@ -3437,6 +3438,7 @@ Model.$__insertMany = function(arr, options, callback) {
           // failed. It's up to the next function to filter out all failed models
           if (ordered === false) {
             validationErrors.push(error);
+            validationErrorsToOriginalOrder.set(error, index);
             return callback(null, null);
           }
           return callback(error);
@@ -3454,10 +3456,24 @@ Model.$__insertMany = function(arr, options, callback) {
     const docAttributes = docs.filter(function(doc) {
       return doc != null;
     });
+
+    // Make sure validation errors are in the same order as the
+    // original documents, so if both doc1 and doc2 both fail validation,
+    // `Model.insertMany([doc1, doc2])` will always have doc1's validation
+    // error before doc2's. Re: gh-12791.
+    if (validationErrors.length > 0) {
+      validationErrors.sort((err1, err2) => {
+        return validationErrorsToOriginalOrder.get(err1) - validationErrorsToOriginalOrder.get(err2);
+      });
+    }
+
     // Quickly escape while there aren't any valid docAttributes
     if (docAttributes.length === 0) {
       if (rawResult) {
         const res = {
+          acknowledged: true,
+          insertedCount: 0,
+          insertedIds: {},
           mongoose: {
             validationErrors: validationErrors
           }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3452,10 +3452,20 @@ Model.$__insertMany = function(arr, options, callback) {
       callback(error, null);
       return;
     }
+
+    const originalDocIndex = new Map();
+    const validDocIndexToOriginalIndex = new Map();
+    for (let i = 0; i < docs.length; ++i) {
+      originalDocIndex.set(docs[i], i);
+    }
+
     // We filter all failed pre-validations by removing nulls
     const docAttributes = docs.filter(function(doc) {
       return doc != null;
     });
+    for (let i = 0; i < docAttributes.length; ++i) {
+      validDocIndexToOriginalIndex.set(i, originalDocIndex.get(docAttributes[i]));
+    }
 
     // Make sure validation errors are in the same order as the
     // original documents, so if both doc1 and doc2 both fail validation,
@@ -3506,6 +3516,13 @@ Model.$__insertMany = function(arr, options, callback) {
         // `insertedDocs` is a Mongoose-specific property
         const erroredIndexes = new Set((error && error.writeErrors || []).map(err => err.index));
 
+        for (let i = 0; i < error.writeErrors.length; ++i) {
+          error.writeErrors[i] = {
+            ...error.writeErrors[i],
+            index: validDocIndexToOriginalIndex.get(error.writeErrors[i].index)
+          };
+        }
+
         let firstErroredIndex = -1;
         error.insertedDocs = docAttributes.
           filter((doc, i) => {
@@ -3528,6 +3545,12 @@ Model.$__insertMany = function(arr, options, callback) {
             _setIsNew(doc, false);
             return doc;
           });
+
+        if (rawResult && ordered === false) {
+          error.mongoose = {
+            validationErrors: validationErrors
+          };
+        }
 
         callback(error, null);
         return;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4753,7 +4753,7 @@ describe('Model', function() {
       });
     });
 
-    it('insertMany() validation error with ordered true when all documents are invalid (', function(done) {
+    it('insertMany() validation error with ordered true when all documents are invalid', function(done) {
       const schema = new Schema({
         name: { type: String, required: true }
       });


### PR DESCRIPTION
Re: #12791

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12791 points out a few issues with our error reporting with `create()` and `insertMany()`. We do have a workaround using `insertMany()`, but the workaround does have a potential flaw: currently, `res.mongoose.validationErrors` can report validation errors in any order.

Specifically, the validation errors are in the order that the errors occur, not in the order of the original documents passed in. So if `doc1` and `doc2` both fail validation, `const res = await Model.insertMany([doc1, doc2], { ordered: false, rawResult: true })` can end up with doc2's validation error before doc1's in `res.mongoose.validationErrors` if doc1's validation takes longer than doc2's.

With this change, `res.mongoose.validationErrors` will always be in the same order as the documents passed in. So doc1's validation error will always be before doc2's. So to check whether a document at index `i` was actually inserted, you need to check if `i in res.insertedIds`. To check if there was a MongoDB-specific write error, check if `!(i in res.insertedIds)` 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
