### PR TITLE
Correctly infer string enums on const arrays

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -982,3 +982,23 @@ function gh12782() {
 function gh12816() {
   const schema = new Schema({}, { overwriteModels: true });
 }
+
+function gh12869() {
+  const dbExampleConst = new Schema(
+    {
+      active: { type: String, enum: ["foo", "bar"] as const, required: true }
+    }
+  );
+
+  type ExampleConst = InferSchemaType<typeof dbExampleConst>;
+  expectType<"foo" | "bar">({} as ExampleConst['active']);
+
+  const dbExample = new Schema(
+    {
+      active: { type: String, enum: ["foo", "bar"], required: true }
+    }
+  );
+
+  type Example = InferSchemaType<typeof dbExample>;
+  expectType<"foo" | "bar">({} as Example['active']);
+}

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -986,19 +986,19 @@ function gh12816() {
 function gh12869() {
   const dbExampleConst = new Schema(
     {
-      active: { type: String, enum: ["foo", "bar"] as const, required: true }
+      active: { type: String, enum: ['foo', 'bar'] as const, required: true }
     }
   );
 
   type ExampleConst = InferSchemaType<typeof dbExampleConst>;
-  expectType<"foo" | "bar">({} as ExampleConst['active']);
+  expectType<'foo' | 'bar'>({} as ExampleConst['active']);
 
   const dbExample = new Schema(
     {
-      active: { type: String, enum: ["foo", "bar"], required: true }
+      active: { type: String, enum: ['foo', 'bar'], required: true }
     }
   );
 
   type Example = InferSchemaType<typeof dbExample>;
-  expectType<"foo" | "bar">({} as Example['active']);
+  expectType<'foo' | 'bar'>({} as Example['active']);
 }

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -162,7 +162,7 @@ type ObtainDocumentPathType<PathValueType, TypeKey extends string = DefaultTypeK
  * @param {T} T A generic refers to string path enums.
  * @returns Path enum values type as literal strings or string.
  */
-type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends (infer E)[] ? E : T extends { values: any } ? PathEnumOrString<T['values']> : string;
+type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends ReadonlyArray<infer E> ? E : T extends { values: any } ? PathEnumOrString<T['values']> : string;
 
 /**
  * @summary Resolve path type by returning the corresponding type.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fixes #12869
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Not a TypeScript expert, but I followed the example in #12463 and added a test case demonstrating this change works. I think what is happening here is that a readonly array cannot extend a regular array, so our types here need to use ReadonlyArray to handle both const and regular arrays.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
