### PR TITLE
Allow virtuals to be invoked in the definition of other virtuals

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -353,7 +353,7 @@ declare module 'mongoose' {
     statics: { [F in keyof TStaticMethods]: TStaticMethods[F] } & { [name: string]: (this: M, ...args: any[]) => any };
 
     /** Creates a virtual type with the given name. */
-    virtual<T = HydratedDocument<DocType, TInstanceMethods>>(
+    virtual<T = HydratedDocument<DocType, TInstanceMethods, TVirtuals>>(
       name: keyof TVirtuals | string,
       options?: VirtualTypeOptions<T, DocType>
     ): VirtualType<T>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I sometimes use virtuals in the definition of other virtuals in my Mongoose schemas. This change allows virtuals to invoke other virtuals in TypeScript.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

I have this code:

```typescript
userSchema.virtual("tier").get(function() {
	// ...
	candidate = this.programModel?.tier_override;
	// ...
});
```

In this code, `programModel` is a virtual. However, compiling this code gives me an error:

```
src/user_model.ts:208:19 - error TS2339: Property 'programModel' does not exist on type 'Document<unknown, any, IUser> & IUser & Required<{ _id: ObjectId; }> & IUserMethods'.

208  candidate = this.programModel?.tier_override;
                      ~~~~~~~~~~~~
```

This PR fixes the error.

I have my virtuals defined in their own interface:

```typescript
interface IUserVirtuals {
	// ...
	tier: string;
	programModel: IProgram | null | undefined;
	// ...
}
```

I use the following type shortcuts:

```typescript
type UserModel = Mongoose.Model<IUser, {}, IUserMethods, IUserVirtuals>;
type UserSchema = Mongoose.Schema<IUser, UserModel, IUserMethods, {}, IUserVirtuals>;
type HydratedUser = Mongoose.HydratedDocument<IUser, IUserMethods, IUserVirtuals>;
```

The two `{}` are stand-ins for `TQueryHelpers`, which I don't currently use.