### PR TITLE
fix(types): add "options" parameter for single "create" call

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -11,7 +11,8 @@ import {
   HydratedDocument,
   HydratedDocumentFromSchema,
   Query,
-  UpdateWriteOpResult
+  UpdateWriteOpResult,
+  SaveOptions
 } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
@@ -568,4 +569,12 @@ function gh12573ModelAny() {
   expectType<any>(doc);
   const { fieldA } = doc;
   expectType<any>(fieldA);
+}
+
+function gh12877() {
+  const TestModel = model('Test', new Schema({}));
+
+  const objToInsert = {};
+  const options: SaveOptions = {};
+  TestModel.create(objToInsert, options);
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -188,9 +188,10 @@ declare module 'mongoose' {
     create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
     create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, options?: SaveOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
     create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, callback: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): void;
-    create<DocContents = AnyKeys<T>>(doc: DocContents | T): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-    create<DocContents = AnyKeys<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create<DocContents = AnyKeys<T>>(doc: DocContents | T, options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+    create<DocContents = AnyKeys<T>>(doc: T | DocContents, options?: SaveOptions, callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
     create<DocContents = AnyKeys<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
+    create<DocContents = AnyKeys<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
 
     /**
      * Create the collection for this model. By default, if no indexes are specified,


### PR DESCRIPTION
**Summary**

This PR adds the `options` parameter to single `Model.create()` calls
This PR also moves the `...docs: Array<T | DocContents>` overload as the last option

fixes #12877