### PR TITLE
Correctly infer types on document arrays

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1071,7 +1071,7 @@ function gh12882() {
   expectType<{
     fooArray: string[]
   }>({} as rTArrString);
-  // Array of object with key named "type"
+  // Readonly array of object with key named "type"
   const rArrType = new Schema({
     fooArray: {
       type: [{

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1031,9 +1031,20 @@ function gh12882() {
     }
   });
   type tArrString = InferSchemaType<typeof arrString>;
+  // Array of numbers using string definition
+  const arrNum = new Schema({
+    fooArray: {
+      type: [{
+        type: 'Number',
+        required: true
+      }],
+      required: true
+    }
+  });
+  type tArrNum = InferSchemaType<typeof arrNum>;
   expectType<{
-    fooArray: string[]
-  }>({} as tArrString);
+    fooArray: number[]
+  }>({} as tArrNum);
   // Array of object with key named "type"
   const arrType = new Schema({
     fooArray: {
@@ -1071,6 +1082,20 @@ function gh12882() {
   expectType<{
     fooArray: string[]
   }>({} as rTArrString);
+  // Readonly array of numbers using string definition
+  const rArrNum = new Schema({
+    fooArray: {
+      type: [{
+        type: 'Number',
+        required: true
+      }] as const,
+      required: true
+    }
+  });
+  type rTArrNum = InferSchemaType<typeof rArrNum>;
+  expectType<{
+    fooArray: number[]
+  }>({} as rTArrNum);
   // Readonly array of object with key named "type"
   const rArrType = new Schema({
     fooArray: {

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1057,7 +1057,41 @@ function gh12882() {
       foo: number;
     }[]
   }>({} as tArrType);
-
-  type faaaa = StringConstructor extends Function ? string: number;
-  type fbbb = { type: String } extends Function ? string : number;
+  // Readonly array of strings
+  const rArrString = new Schema({
+    fooArray: {
+      type: [{
+        type: String,
+        required: true
+      }] as const,
+      required: true
+    }
+  });
+  type rTArrString = InferSchemaType<typeof rArrString>;
+  expectType<{
+    fooArray: string[]
+  }>({} as rTArrString);
+  // Array of object with key named "type"
+  const rArrType = new Schema({
+    fooArray: {
+      type: [{
+        type: {
+          type: String,
+          required: true
+        },
+        foo: {
+          type: Number,
+          required: true
+        }
+      }] as const,
+      required: true
+    }
+  });
+  type rTArrType = InferSchemaType<typeof rArrType>;
+  expectType<{
+    fooArray: {
+      type: string;
+      foo: number;
+    }[]
+  }>({} as rTArrType);
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1018,3 +1018,46 @@ function gh12869() {
   type Example = InferSchemaType<typeof dbExample>;
   expectType<'foo' | 'bar'>({} as Example['active']);
 }
+
+function gh12882() {
+  // Array of strings
+  const arrString = new Schema({
+    fooArray: {
+      type: [{
+        type: String,
+        required: true
+      }],
+      required: true
+    }
+  });
+  type tArrString = InferSchemaType<typeof arrString>;
+  expectType<{
+    fooArray: string[]
+  }>({} as tArrString);
+  // Array of object with key named "type"
+  const arrType = new Schema({
+    fooArray: {
+      type: [{
+        type: {
+          type: String,
+          required: true
+        },
+        foo: {
+          type: Number,
+          required: true
+        }
+      }],
+      required: true
+    }
+  });
+  type tArrType = InferSchemaType<typeof arrType>;
+  expectType<{
+    fooArray: {
+      type: string;
+      foo: number;
+    }[]
+  }>({} as tArrType);
+
+  type faaaa = StringConstructor extends Function ? string: number;
+  type fbbb = { type: String } extends Function ? string : number;
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -1,4 +1,3 @@
-import { OperationTime } from 'mongodb';
 import {
   Schema,
   InferSchemaType,

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -2,7 +2,6 @@ import { OperationTime } from 'mongodb';
 import {
   Schema,
   InferSchemaType,
-  ScalarSchemaDefinition,
   SchemaType,
   SchemaTypeOptions,
   TypeKeyBaseType,
@@ -154,17 +153,15 @@ type OptionalPaths<T, TypeKey extends string = DefaultTypeKey> = {
 
 /**
  * @summary Obtains schema Path type.
- * @description Obtains Path type by calling {@link ResolvePathType} OR by calling {@link InferSchemaType} if path of schema type.
+ * @description Obtains Path type by separating path type from other options and calling {@link ResolvePathType}
  * @param {PathValueType} PathValueType Document definition path type.
  * @param {TypeKey} TypeKey A generic refers to document definition.
  */
-type ObtainDocumentPathType<PathValueType, TypeKey extends string = DefaultTypeKey> = PathValueType extends Schema<any>
-  ? InferSchemaType<PathValueType>
-  : ResolvePathType<
-  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
-  PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {},
-  TypeKey
-  >;
+type ObtainDocumentPathType<PathValueType, TypeKey extends string = DefaultTypeKey> = ResolvePathType<
+PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
+PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {},
+TypeKey
+>;
 
 /**
  * @param {T} T A generic refers to string path enums.
@@ -183,16 +180,21 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
   PathValueType extends Schema ? InferSchemaType<PathValueType> :
     PathValueType extends (infer Item)[] ?
       IfEquals<Item, never, any[], Item extends Schema ?
-        Types.DocumentArray<ObtainDocumentPathType<Item, TypeKey>> :
+        // If Item is a schema, infer its type.
+        Types.DocumentArray<InferSchemaType<Item>> :
         Item extends Record<TypeKey, any>?
           Item[TypeKey] extends Function ?
+            // If Item has a type key that's callable, it must be a scalar,
+            // so we can directly obtain its path type.
             ObtainDocumentPathType<Item, TypeKey>[] :
+            // If the type key isn't callable, then this is an array of objects, in which case
+            // we need to call ObtainDocumentType to correctly infer its type.
             ObtainDocumentType<Item, any, { typeKey: TypeKey }>[]:
           ObtainDocumentPathType<Item, TypeKey>[]
       >:
       PathValueType extends ReadonlyArray<infer Item> ?
         IfEquals<Item, never, any[], Item extends Schema ?
-          Types.DocumentArray<ObtainDocumentPathType<Item, TypeKey>> :
+          Types.DocumentArray<InferSchemaType<Item>> :
           Item extends Record<TypeKey, any> ?
             Item[TypeKey] extends Function ?
               ObtainDocumentPathType<Item, TypeKey>[] :

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -182,8 +182,8 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
         // If Item is a schema, infer its type.
         Types.DocumentArray<InferSchemaType<Item>> :
         Item extends Record<TypeKey, any>?
-          Item[TypeKey] extends Function ?
-            // If Item has a type key that's callable, it must be a scalar,
+          Item[TypeKey] extends Function | String ?
+            // If Item has a type key that's a string or a callable, it must be a scalar,
             // so we can directly obtain its path type.
             ObtainDocumentPathType<Item, TypeKey>[] :
             // If the type key isn't callable, then this is an array of objects, in which case
@@ -195,7 +195,7 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
         IfEquals<Item, never, any[], Item extends Schema ?
           Types.DocumentArray<InferSchemaType<Item>> :
           Item extends Record<TypeKey, any> ?
-            Item[TypeKey] extends Function ?
+            Item[TypeKey] extends Function | String ?
               ObtainDocumentPathType<Item, TypeKey>[] :
               ObtainDocumentType<Item, any, { typeKey: TypeKey }>[]:
             ObtainDocumentPathType<Item, TypeKey>[]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Fix #12882.

The key insight here is that arrays of scalars and arrays of objects have different type inference logic. For example:

1. `type: [{type: String, required: true}]` is an array of strings.
2. `type: [{type: "String", required: true}]` is also an array of strings.
3. `type: [{type: {foo: {type: String}, required: true}]` is an array of objects that contains a field named `type`. Note here that `type` must be interpreted as a real key, not a type key. 

So if we have an array, we need to check if it's an array of scalars or objects. This is done as follows:
1. If the object has a type key that isn't callable and isn't a string, it's an object, so we need to call `ObtainDocumentType` to make sure that its keys are interpreted correctly. (i.e. if the object has a key called `type`, this is a real key, not a type key)
2. In all other cases, we continue to assume that the array is a scalar.

**Examples**

Adds tests.
