### PR TITLE
test: allow more tests for deno

### DIFF
--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -887,10 +887,6 @@ describe('connections:', function() {
   });
 
   it('throws a MongooseServerSelectionError on server selection timeout (gh-8451)', function() {
-    if (typeof Deno !== 'undefined') {
-      // In Deno dns throws an uncatchable error here.
-      return this.skip();
-    }
     const opts = {
       serverSelectionTimeoutMS: 100
     };

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -235,7 +235,8 @@ describe('ValidationError', function() {
   describe('when user code defines a r/o Error#toJSON', function() {
     it('should not fail', function(done) {
       if (typeof Deno !== 'undefined') {
-        // Deno doesn't support child_process.fork
+        // Deno currently errors with:
+        // could not find npm package for 'file:///path/to/mongoose/test/isolated/project-has-error.toJSON.js'
         return this.skip();
       }
       this.timeout(10000);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -842,11 +842,6 @@ describe('mongoose module:', function() {
     });
 
     it('connect with url doesnt cause unhandled rejection (gh-6997)', async function() {
-      if (typeof Deno !== 'undefined') {
-        // In Deno dns throws an uncatchable error here.
-        return this.skip();
-      }
-
       const m = new mongoose.Mongoose();
       const _options = Object.assign({}, options, { serverSelectionTimeoutMS: 100 });
       const error = await m.connect('mongodb://doesnotexist:27009/test', _options).then(() => null, err => err);


### PR DESCRIPTION
**Summary**

This PR enables some tests to also run on deno again, they were originally disabled because deno did not support catching some errors, but they now work
also updates a message on why a test is disabled for deno currently
