### PR TITLE
fix(collection): handle creating model when connection disconnected with bufferCommands = false

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -43,9 +43,7 @@ Object.setPrototypeOf(NativeCollection.prototype, MongooseCollection.prototype);
  */
 
 NativeCollection.prototype.onOpen = function() {
-  if (this.collection == null) {
-    this.collection = this.conn.db.collection(this.name);
-  }
+  this.collection = this.conn.db.collection(this.name);
   MongooseCollection.prototype.onOpen.call(this);
   return this.collection;
 };

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -43,11 +43,11 @@ Object.setPrototypeOf(NativeCollection.prototype, MongooseCollection.prototype);
  */
 
 NativeCollection.prototype.onOpen = function() {
-  const _this = this;
-
-  _this.collection = _this.conn.db.collection(_this.name);
-  MongooseCollection.prototype.onOpen.call(_this);
-  return _this.collection;
+  if (this.collection == null) {
+    this.collection = this.conn.db.collection(this.name);
+  }
+  MongooseCollection.prototype.onOpen.call(this);
+  return this.collection;
 };
 
 /**
@@ -58,6 +58,25 @@ NativeCollection.prototype.onOpen = function() {
 
 NativeCollection.prototype.onClose = function(force) {
   MongooseCollection.prototype.onClose.call(this, force);
+};
+
+/**
+ * Helper to get the collection, in case `this.collection` isn't set yet.
+ * May happen if `bufferCommands` is false and created the model when
+ * Mongoose was disconnected.
+ *
+ * @api private
+ */
+
+NativeCollection.prototype._getCollection = function _getCollection() {
+  if (this.collection) {
+    return this.collection;
+  }
+  if (this.conn.db != null) {
+    this.collection = this.conn.db.collection(this.name);
+    return this.collection;
+  }
+  return null;
 };
 
 /*!
@@ -74,7 +93,7 @@ const syncCollectionMethods = { watch: true, find: true, aggregate: true };
 
 function iter(i) {
   NativeCollection.prototype[i] = function() {
-    const collection = this.collection;
+    const collection = this._getCollection();
     const args = Array.from(arguments);
     const _this = this;
     const globalDebug = _this &&

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1470,4 +1470,23 @@ describe('connections:', function() {
 
     assert.equal(m.connection.model('Test2'), Test2);
   });
+
+  it('creates collection if creating model while connection is disconnected with bufferCommands=false', async function() {
+    const m = new mongoose.Mongoose();
+    m.set('bufferCommands', false);
+    const conn = await m.createConnection(start.uri, { bufferCommands: false }).asPromise();
+    conn.client.emit('serverDescriptionChanged', { newDescription: { type: 'Unknown' } });
+
+    const Test = conn.model('Test', new Schema({ name: String }));
+
+    const [res] = await Promise.all([
+      Test.findOne().exec(),
+      new Promise.resolve(resolve => setTimeout(resolve, 100)).then(() => {
+        conn.client.emit('serverDescriptionChanged', { newDescription: { type: 'Single' } });
+      })
+    ]);
+    assert.equal(res, null);
+
+    await m.disconnect();
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If you create a new model while Mongoose is disconnected, and `bufferCommands` is false, you'll get the following error:

```
MongooseError: Cannot call `tests.findOne()` before initial connection is complete if `bufferCommands = false`. Make sure you `await mongoose.connect()` if you have `bufferCommands = false`.
```

That is unexpected. You should never get that error after calling `mongoose.connect()`, even with `bufferCommands` disabled.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
