### PR TITLE
Close all connections in all tests, also change some tests to be working stand-alone

### DIFF
--- a/test/collection.capped.test.js
+++ b/test/collection.capped.test.js
@@ -19,12 +19,15 @@ const Schema = mongoose.Schema;
 describe('collections: capped:', function() {
   let db;
 
+  const connectionsToClose = [];
+
   before(function() {
     db = start();
   });
 
   after(async function() {
     await db.close();
+    await Promise.all(connectionsToClose.map((v) => v.close()));
   });
 
   it('schemas should have option size', function() {
@@ -52,6 +55,7 @@ describe('collections: capped:', function() {
 
   it('skips when setting autoCreate to false (gh-8566)', async function() {
     const db = start();
+    connectionsToClose.push(db);
     this.timeout(30000);
     await db.dropDatabase();
 

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -8,8 +8,15 @@ const assert = require('assert');
 const mongoose = start.mongoose;
 
 describe('collections:', function() {
+  const connectionsToClose = [];
+
+  after(async function() {
+    await Promise.all(connectionsToClose.map((v) => v.close()));
+  });
+
   it('should buffer commands until connection is established', function(done) {
     const db = mongoose.createConnection();
+    connectionsToClose.push(db);
     const collection = db.collection('test-buffering-collection');
     let connected = false;
     let insertedId = undefined;
@@ -43,6 +50,7 @@ describe('collections:', function() {
 
   it('returns a promise if buffering and no callback (gh-7676)', function(done) {
     const db = mongoose.createConnection();
+    connectionsToClose.push(db);
     const collection = db.collection('gh7676');
 
     const promise = collection.insertOne({ foo: 'bar' }, {})
@@ -145,6 +153,7 @@ describe('collections:', function() {
 
   it('buffers for sync methods (gh-10610)', function(done) {
     const db = mongoose.createConnection();
+    connectionsToClose.push(db);
     const collection = db.collection('gh10610');
 
     collection.find({}, {}, function(err, res) {

--- a/test/docs/cast.test.js
+++ b/test/docs/cast.test.js
@@ -23,6 +23,10 @@ describe('Cast Tutorial', function() {
     });
   });
 
+  after(async () => {
+    await mongoose.disconnect();
+  })
+
   it('get and set', async function() {
     const query = Character.find({ name: 'Jean-Luc Picard' });
     query.getFilter(); // `{ name: 'Jean-Luc Picard' }`

--- a/test/docs/date.test.js
+++ b/test/docs/date.test.js
@@ -5,7 +5,6 @@ const start = require('../common');
 
 describe('Date Tutorial', function() {
   let User;
-  // let db;
 
   const mongoose = new start.mongoose.Mongoose();
 
@@ -19,6 +18,10 @@ describe('Date Tutorial', function() {
 
     return mongoose.connect(start.uri);
   });
+
+  after(async () => {
+    await mongoose.disconnect();
+  })
 
   it('Example 1.2: casts strings to dates', function() {
     const user = new User({
@@ -83,7 +86,6 @@ describe('Date Tutorial', function() {
 
   describe('Example 1.3.1', function() {
     let Episode;
-    let db;
 
     before(async function() {
       const episodeSchema = new mongoose.Schema({
@@ -96,8 +98,7 @@ describe('Date Tutorial', function() {
           max: '1994-05-23'
         }
       });
-      db = await start().asPromise();
-      Episode = db.model('Episode', episodeSchema);
+      Episode = mongoose.model('Episode2', episodeSchema);
 
       await Episode.create([
         { title: 'Encounter at Farpoint', airedAt: '1987-09-28' },

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -39,6 +39,8 @@ describe('debug: shell', function() {
   const originalConsole = console.info;
   const originalDebugOption = mongoose.options.debug;
 
+  const connectionsToClose = [];
+
   before(function() {
     db = start();
     testModel = db.model('Test', testSchema);
@@ -57,6 +59,7 @@ describe('debug: shell', function() {
     console.info = originalConsole;
     mongoose.set('debug', originalDebugOption);
     await db.close();
+    await Promise.all(connectionsToClose.map((v) => v.close()))
   });
 
   it('no-shell', async function() {
@@ -75,12 +78,14 @@ describe('debug: shell', function() {
     const m = new mongoose.Mongoose();
     // `conn1` with active debug
     const conn1 = m.createConnection(start.uri);
+    connectionsToClose.push(conn1);
     conn1.set('debug', true);
     const testModel1 = conn1.model('Test', testSchema);
     await testModel1.create({ dob: new Date(), title: 'Connection 1' });
     const storedLog = lastLog;
     // `conn2` without debug
     const conn2 = m.createConnection(start.uri);
+    connectionsToClose.push(conn2);
     const testModel2 = conn2.model('Test', testSchema);
     await testModel2.create({ dob: new Date(), title: 'Connection 2' });
     // Last log should not have been overwritten

--- a/test/docs/findoneandupdate.test.js
+++ b/test/docs/findoneandupdate.test.js
@@ -26,6 +26,10 @@ describe('Tutorial: findOneAndUpdate()', function() {
     await Character.create({ name: 'Jean-Luc Picard' });
   });
 
+  after(async () => {
+    await mongoose.disconnect();
+  })
+
   it('basic case', async function() {
     // acquit:ignore:start
     await mongoose.model('Character').deleteMany({});

--- a/test/docs/getters-setters.test.js
+++ b/test/docs/getters-setters.test.js
@@ -17,6 +17,10 @@ describe('getters/setters', function() {
     mongoose.deleteModel(/.*/);
   });
 
+  after(async () => {
+    await mongoose.disconnect();
+  })
+
   describe('getters', function() {
     it('basic example', async function() {
       const userSchema = new Schema({

--- a/test/docs/lean.test.js
+++ b/test/docs/lean.test.js
@@ -21,6 +21,10 @@ describe('Lean Tutorial', function() {
     mongoose.deleteModel(/Group/);
   });
 
+  after(async () => {
+    await mongoose.disconnect();
+  })
+
   it('compare sizes lean vs not lean', async function() {
     // acquit:ignore:start
     if (typeof Deno !== 'undefined') {

--- a/test/docs/virtuals.test.js
+++ b/test/docs/virtuals.test.js
@@ -17,6 +17,10 @@ describe('Virtuals', function() {
     mongoose.deleteModel(/.*/);
   });
 
+  after(async () => {
+    await mongoose.disconnect();
+  })
+
   it('basic', async function() {
     const userSchema = mongoose.Schema({
       email: String

--- a/test/helpers/clone.test.js
+++ b/test/helpers/clone.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
 const clone = require('../../lib/helpers/clone');
 const symbols = require('../../lib/helpers/symbols');
 const ObjectId = require('../../lib/types/objectid');

--- a/test/helpers/indexes.getRelatedIndexes.test.js
+++ b/test/helpers/indexes.getRelatedIndexes.test.js
@@ -12,7 +12,10 @@ const {
 
 describe('getRelatedIndexes', () => {
   let db;
-  beforeEach(() => db = start());
+  before(() => db = start());
+  beforeEach(() => db.deleteModel(/.*/));
+  afterEach(() => require('../util').clearTestData(db));
+  afterEach(() => require('../util').stopRemainingOps(db));
   after(() => db.close());
 
   describe('getRelatedSchemaIndexes', () => {

--- a/test/helpers/indexes.isIndexEqual.test.js
+++ b/test/helpers/indexes.isIndexEqual.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
 const isIndexEqual = require('../../lib/helpers/indexes/isIndexEqual');
 
 describe('isIndexEqual', function() {

--- a/test/helpers/isMongooseObject.test.js
+++ b/test/helpers/isMongooseObject.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
 const isMongooseObject = require('../../lib/helpers/isMongooseObject');
 const MongooseArray = require('../../lib/types/array');
 

--- a/test/helpers/isSimpleValidator.test.js
+++ b/test/helpers/isSimpleValidator.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
 const isSimpleValidator = require('../../lib/helpers/isSimpleValidator');
 const MongooseDocumentArray = require('../../lib/types/DocumentArray');
 

--- a/test/helpers/populate.getSchemaTypes.test.js
+++ b/test/helpers/populate.getSchemaTypes.test.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const Schema = require('../../lib/schema');
 const assert = require('assert');
-const getSchemaTypes = require('../../lib/helpers/populate/getSchemaTypes');
+
 const mongoose = require('../common').mongoose;
+const Schema = require('../../lib/schema');
+const getSchemaTypes = require('../../lib/helpers/populate/getSchemaTypes');
 
 describe('getSchemaTypes', function() {
   it('handles embedded discriminators (gh-5970)', function() {

--- a/test/helpers/populate.getVirtual.test.js
+++ b/test/helpers/populate.getVirtual.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const Schema = require('../../lib/schema');
 const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
+const Schema = require('../../lib/schema');
 const getVirtual = require('../../lib/helpers/populate/getVirtual');
 
 describe('getVirtual', function() {

--- a/test/helpers/projection.applyProjection.test.js
+++ b/test/helpers/projection.applyProjection.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const applyProjection = require('../../lib/helpers/projection/applyProjection');
 const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
+const applyProjection = require('../../lib/helpers/projection/applyProjection');
 
 describe('applyProjection', function() {
   it('handles deep inclusive projections', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,6 +88,7 @@ describe('mongoose module:', function() {
     await User.findOne();
     assert.equal(written.length, 1);
     assert.ok(written[0].startsWith('users.findOne('));
+    await mongoose.disconnect();
   });
 
   it('{g,s}etting options', function() {
@@ -479,6 +480,7 @@ describe('mongoose module:', function() {
 
     assert.equal(doc.createdAt.valueOf(), date.valueOf());
     assert.equal(doc.updatedAt.valueOf(), date.valueOf());
+    await mongoose.disconnect();
   });
 
   it('isolates custom types between mongoose instances (gh-6933) (gh-7158)', function() {
@@ -758,6 +760,7 @@ describe('mongoose module:', function() {
     await Person.create({ name: 'Test1', favoriteMovie: movie._id });
     const entry = await Person.findOne().populate({ path: 'favoriteMovie' });
     assert(entry);
+    await mongoose.disconnect();
   });
   it('global `strictPopulate` works when true (gh-10694)', async function() {
     const mongoose = new Mongoose();
@@ -774,6 +777,7 @@ describe('mongoose module:', function() {
     await assert.rejects(async() => {
       await Person.findOne().populate({ path: 'favoriteGame' });
     }, { message: 'Cannot populate path `favoriteGame` because it is not in your schema. Set the `strictPopulate` option to false to override.' });
+    await mongoose.disconnect();
   });
   it('allows global `strictPopulate` to be overriden on specific queries set to true (gh-10694)', async function() {
     const mongoose = new Mongoose();
@@ -789,6 +793,7 @@ describe('mongoose module:', function() {
     await assert.rejects(async() => {
       await Person.findOne().populate({ path: 'favoriteGame', strictPopulate: true });
     }, { message: 'Cannot populate path `favoriteGame` because it is not in your schema. Set the `strictPopulate` option to false to override.' });
+    await mongoose.disconnect();
   });
   it('allows global `strictPopulate` to be overriden on specific queries set to false (gh-10694)', async function() {
     const mongoose = new Mongoose();
@@ -803,6 +808,7 @@ describe('mongoose module:', function() {
     await Person.create({ name: 'Test1', favoriteMovie: movie._id });
     const entry = await Person.findOne().populate({ path: 'favoriteMovie' });
     assert(entry);
+    await mongoose.disconnect();
   });
 
   describe('exports', function() {
@@ -871,6 +877,7 @@ describe('mongoose module:', function() {
       // lean is necessary to avoid defaults by casting
       const movie = await Movie.findOne({ title: 'Cloud Atlas' }).lean();
       assert.equal(movie.genre, 'Action');
+      await m.disconnect();
     });
 
     it('setting `setDefaultOnInsert` on operation has priority over base option (gh-9032)', async function() {
@@ -896,6 +903,7 @@ describe('mongoose module:', function() {
       // lean is necessary to avoid defaults by casting
       const movie = await Movie.findOne({ title: 'The Man From Earth' }).lean();
       assert.ok(!movie.genre);
+      await m.disconnect();
     });
     it('should prevent non-hexadecimal strings (gh-9996)', function() {
       const badIdString = 'z'.repeat(24);
@@ -970,6 +978,7 @@ describe('mongoose module:', function() {
         // Assert
         const optionsSentToMongo = nativeAggregateSpy.args[0][1];
         assert.strictEqual(optionsSentToMongo.allowDiskUse, undefined);
+        await m.disconnect();
       });
 
       it('works when set to `true` and no option provided', async() => {
@@ -992,6 +1001,7 @@ describe('mongoose module:', function() {
         // Assert
         const optionsSentToMongo = nativeAggregateSpy.args[0][1];
         assert.strictEqual(optionsSentToMongo.allowDiskUse, true);
+        await m.disconnect();
       });
       it('can be overridden by a specific query', async() => {
         // Arrange
@@ -1013,6 +1023,7 @@ describe('mongoose module:', function() {
         // Assert
         const optionsSentToMongo = nativeAggregateSpy.args[0][1];
         assert.equal(optionsSentToMongo.allowDiskUse, false);
+        await m.disconnect();
       });
     });
     describe('global `timestamps.createdAt.immutable` (gh-10139)', () => {
@@ -1097,6 +1108,7 @@ describe('mongoose module:', function() {
         title: 'The IDless master'
       });
       assert.equal(entry.id, undefined);
+      await m.disconnect();
     });
   });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -25,6 +25,8 @@ describe('Model', function() {
   let Comments;
   let BlogPost;
 
+  const connectionsToClose = [];
+
   beforeEach(() => db.deleteModel(/.*/));
 
   beforeEach(function() {
@@ -80,8 +82,9 @@ describe('Model', function() {
     db = start();
   });
 
-  after(function() {
-    db.close();
+  after(async function() {
+    await db.close();
+    await Promise.all(connectionsToClose.map(async(v) => /* v instanceof Promise ? (await v).close() : */ v.close()));
   });
 
   afterEach(() => util.clearTestData(db));
@@ -3720,6 +3723,7 @@ describe('Model', function() {
 
     it('with positional notation on path not existing in schema (gh-1048)', function(done) {
       const db = start();
+      connectionsToClose.push(db);
 
       const M = db.model('Test', Schema({ name: 'string' }));
       db.on('open', function() {
@@ -4332,6 +4336,7 @@ describe('Model', function() {
   it('save max bson size error with buffering (gh-3906)', async function() {
     this.timeout(10000);
     const db = start({ noErrorListener: true });
+    connectionsToClose.push(db);
     const Test = db.model('Test', { name: Object });
 
     const test = new Test({
@@ -4350,6 +4355,7 @@ describe('Model', function() {
   it('reports max bson size error in save (gh-3906)', async function() {
     this.timeout(10000);
     const db = await start({ noErrorListener: true });
+    connectionsToClose.push(db);
     const Test = db.model('Test', { name: Object });
 
     const test = new Test({
@@ -5336,6 +5342,7 @@ describe('Model', function() {
 
         it('watch() before connecting (gh-5964)', async function() {
           const db = start();
+          connectionsToClose.push(db);
 
           const MyModel = db.model('Test5964', new Schema({ name: String }));
 
@@ -5355,6 +5362,7 @@ describe('Model', function() {
 
         it('watch() close() prevents buffered watch op from running (gh-7022)', async function() {
           const db = start();
+          connectionsToClose.push(db);
           const MyModel = db.model('Test', new Schema({}));
           const changeStream = MyModel.watch();
           const ready = new global.Promise(resolve => {
@@ -5372,6 +5380,7 @@ describe('Model', function() {
 
         it('watch() close() closes the stream (gh-7022)', async function() {
           const db = await start();
+          connectionsToClose.push(db);
           const MyModel = db.model('Test', new Schema({ name: String }));
 
           await MyModel.init();
@@ -5422,6 +5431,7 @@ describe('Model', function() {
         it('startSession() before connecting', async function() {
 
           const db = start();
+          connectionsToClose.push(db);
 
           const MyModel = db.model('Test', new Schema({ name: String }));
 

--- a/test/query.middleware.test.js
+++ b/test/query.middleware.test.js
@@ -14,12 +14,15 @@ describe('query middleware', function() {
   let Author;
   let Publisher;
 
+  const connectionsToClose = [];
+
   before(function() {
     db = start();
   });
 
   after(async function() {
     await db.close();
+    await Promise.all(connectionsToClose.map((v) => v.close()));
   });
 
   const initializeData = function(done) {
@@ -81,7 +84,8 @@ describe('query middleware', function() {
       next();
     });
 
-    start();
+    const conn = start();
+    connectionsToClose.push(conn);
 
     initializeData(function(error) {
       assert.ifError(error);


### PR DESCRIPTION
**Summary**

This PR updates some tests / test files to close all connections that were opened, also changes some test files to be working stand-alone

though i am not really proud of some of the connection caching done with `connectionsToClose`

some more detailed notes:
- all test files *except* `connection.test.js` and `index.test.js` have been updated with `connectionsToClose` or a simple `mongoose.disconnect` instead of not closing the connections
- some spaces have been added between some tests
- many `test/helpers` test files have been updated to work when tested stand-alone (only testing a single test file)
- change some import order in `test/helpers` to be consistent across `test/helpers` test files
- some tests have been updated to use the existing connection instead of creating a new one (when it was not about using a new connection)

these changes are required for a follow-up PR i am doing to integrate MMS to the deno tests too (instead of manually downloading and starting mongodb), because otherwise it would fail with the following when the single-instance is stopped:

```txt
error: Uncaught Error: connect ECONNREFUSED 127.0.0.1:36683 - Local (undefined:undefined)
    Error.captureStackTrace(err);
          ^
    at __node_internal_captureLargerStackTrace (https://deno.land/std@0.171.0/node/internal/errors.ts:113:11)
    at __node_internal_exceptionWithHostPort (https://deno.land/std@0.171.0/node/internal/errors.ts:295:12)
    at TCPConnectWrap._afterConnect [as oncomplete] (https://deno.land/std@0.171.0/node/net.ts:369:16)
    at TCP.afterConnect (https://deno.land/std@0.171.0/node/internal_binding/connection_wrap.ts:71:11)
    at https://deno.land/std@0.171.0/node/internal_binding/tcp_wrap.ts:375:16
error Command failed with exit code 1.
```