### PR TITLE
fix(populate): merge instead of overwrite when `match` is on `_id`

### DIFF
--- a/lib/helpers/populate/createPopulateQueryFilter.js
+++ b/lib/helpers/populate/createPopulateQueryFilter.js
@@ -3,6 +3,7 @@
 const SkipPopulateValue = require('./SkipPopulateValue');
 const parentPaths = require('../path/parentPaths');
 const { trusted } = require('../query/trusted');
+const hasDollarKeys = require('../query/hasDollarKeys');
 
 module.exports = function createPopulateQueryFilter(ids, _match, _foreignField, model, skipInvalidIds) {
   const match = _formatMatch(_match);
@@ -13,6 +14,11 @@ module.exports = function createPopulateQueryFilter(ids, _match, _foreignField, 
     if (foreignField !== '_id' || !match['_id']) {
       ids = _filterInvalidIds(ids, foreignSchemaType, skipInvalidIds);
       match[foreignField] = trusted({ $in: ids });
+    } else if (foreignField === '_id' && match['_id']) {
+      const userSpecifiedMatch = hasDollarKeys(match[foreignField]) ?
+        match[foreignField] :
+        { $eq: match[foreignField] };
+      match[foreignField] = { ...trusted({ $in: ids }), ...userSpecifiedMatch };
     }
 
     const _parentPaths = parentPaths(foreignField);
@@ -37,6 +43,11 @@ module.exports = function createPopulateQueryFilter(ids, _match, _foreignField, 
         const foreignSchemaType = model.schema.path(foreignField);
         ids = _filterInvalidIds(ids, foreignSchemaType, skipInvalidIds);
         $or.push({ [foreignField]: { $in: ids } });
+      } else if (foreignField === '_id' && match['_id']) {
+        const userSpecifiedMatch = hasDollarKeys(match[foreignField]) ?
+          match[foreignField] :
+          { $eq: match[foreignField] };
+        match[foreignField] = { ...trusted({ $in: ids }), ...userSpecifiedMatch };
       }
     }
   }


### PR DESCRIPTION
Fix #12834

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12834 points out that `match` on `_id` overwrites rather than merges. Which is not a very good API design, because any custom `match` that specifies `_id` will overwrite the `_id` filter specified by `populate()`. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
