### PR TITLE
docs: add list of known incompatible npm packages

### DIFF
--- a/docs/incompatible_packages.md
+++ b/docs/incompatible_packages.md
@@ -1,0 +1,4 @@
+The following npm packages are known to be incompatible with Mongoose:
+
+- [collections](https://www.npmjs.com/package/collections): polluted globals cause issues with the MongoDB Node driver's URL parser. See [GitHub issue 12671](https://github.com/Automattic/mongoose/issues/12671#issuecomment-1374942680). This affects any [package that depends on collections](https://www.npmjs.com/package/collections?activeTab=dependents).
+- [excel-export](https://www.npmjs.com/package/excel-export): has dependency on `collections`

--- a/docs/source/index.js
+++ b/docs/source/index.js
@@ -63,6 +63,7 @@ exports['docs/jobs.pug'] = {
 };
 exports['docs/change-streams.md'] = { title: 'MongoDB Change Streams in NodeJS with Mongoose', markdown: true };
 exports['docs/lodash.md'] = { title: 'Using Mongoose with Lodash', markdown: true };
+exports['docs/incompatible_packages.md'] = { title: 'Known Incompatible npm Packages', markdown: true };
 
 for (const props of Object.values(exports)) {
   props.jobs = jobs;


### PR DESCRIPTION
Fix #12671

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12671 is an issue with another npm package that adds some global properties which break an upstream dependency of Mongoose. It would be nice to have a list of known incompatible packages in our docs.

On a side note, it would be great to know which npm packages modify global state.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
