### PR TITLE
fix(cast): remove empty conditions after strict applied

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -64,11 +64,18 @@ module.exports = function cast(schema, obj, options, context) {
       if (!Array.isArray(val)) {
         throw new CastError('Array', val, path);
       }
-      for (let k = 0; k < val.length; ++k) {
+      for (let k = val.length - 1; k >= 0; k--) {
         if (val[k] == null || typeof val[k] !== 'object') {
           throw new CastError('Object', val[k], path + '.' + k);
         }
         val[k] = cast(schema, val[k], options, context);
+        if (Object.keys(val[k]).length === 0) {
+          val.splice(k, 1);
+        }
+      }
+
+      if (val.length === 0) {
+        delete obj[path];
       }
     } else if (path === '$where') {
       type = typeof val;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
with `strictQuery true`, a query likes:
```js
{$or: [{notInSchema: 'any'}, {age: {$gt: 18}}]}
```
will become
```js
{$or: [{}, {age: {$gt: 18}}]}
```
and `{}` will match every documents

this pull will 
+ remove empty object `{}` from conditions

then 
+ if conditions is an empty array, remove it

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
