### PR TITLE
types(lean): added omit for `ArraySubdocument` type in `LeanType` declaration

### DIFF
--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Document, LeanDocument, Types, BaseDocumentType, DocTypeFromUnion, DocTypeFromGeneric } from 'mongoose';
+import { Schema, model, Document, LeanDocument, Types, BaseDocumentType, DocTypeFromUnion, DocTypeFromGeneric, LeanType } from 'mongoose';
 import { expectError, expectNotType, expectType } from 'tsd';
 
 const schema: Schema = new Schema({ name: { type: 'String' } });
@@ -233,4 +233,14 @@ async function _11767() {
   // expectError(examFound2Obj.questions.$pop);
   // expectError(examFound2Obj.questions[0].populated);
   expectType<string[]>(examFound2Obj.questions[0].answers);
+}
+
+async function gh12859() {
+  interface TestInterface {
+    example: String;
+  }
+
+  type ArraySubdocumentType = Types.ArraySubdocument<TestInterface>;
+  type leanType = LeanType<ArraySubdocumentType>;
+  expectType<Omit<LeanDocument<ArraySubdocumentType>, 'parentArray' | 'ownerDocument' | 'parent'>>({} as leanType);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -558,8 +558,9 @@ declare module 'mongoose' {
   export type LeanType<T> =
     0 extends (1 & T) ? T : // any
       T extends TreatAsPrimitives ? T : // primitives
-        T extends Types.Subdocument ? Omit<LeanDocument<T>, '$isSingleNested' | 'ownerDocument' | 'parent'> :
-          LeanDocument<T>; // Documents and everything else
+        T extends Types.ArraySubdocument ? Omit<LeanDocument<T>, 'parentArray' | 'ownerDocument' | 'parent'> :
+          T extends Types.Subdocument ? Omit<LeanDocument<T>, '$isSingleNested' | 'ownerDocument' | 'parent'> :
+            LeanDocument<T>; // Documents and everything else
 
   export type LeanArray<T extends unknown[]> = T extends unknown[][] ? LeanArray<T[number]>[] : LeanType<T[number]>[];
 


### PR DESCRIPTION
Fixes #12859