### PR TITLE
types(query):  `returnDocument` type safety

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -304,9 +304,18 @@ async function gh11602(): Promise<void> {
     returnDocument: 'after',
     rawResult: true
   });
+
   expectError(updateResult.lastErrorObject?.modifiedCount);
   expectType<boolean | undefined>(updateResult.lastErrorObject?.updatedExisting);
   expectType<ObjectId | undefined>(updateResult.lastErrorObject?.upserted);
+
+  Model.findOneAndUpdate({}, {}, { returnDocument: 'before' });
+  Model.findOneAndUpdate({}, {}, { returnDocument: 'after' });
+  Model.findOneAndUpdate({}, {}, { returnDocument: undefined });
+  Model.findOneAndUpdate({}, {}, {});
+  expectError(Model.findOneAndUpdate({}, {}, {
+    returnDocument: 'not-before-or-after'
+  }));
 }
 
 function autoTypedQuery() {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -136,7 +136,7 @@ declare module 'mongoose' {
     /**
      * Another alias for the `new` option. `returnOriginal` is deprecated so this should be used.
      */
-    returnDocument?: string;
+    returnDocument?: 'before' | 'after';
     runValidators?: boolean;
     /* Set to `true` to automatically sanitize potentially unsafe user-generated query projections */
     sanitizeProjection?: boolean;


### PR DESCRIPTION
This PR sets type safety `returnDocument` type as `'before' | 'after'` instead of accepting any `string`.