### PR TITLE
docs: fix link to lean api

### DIFF
--- a/docs/tutorials/lean.md
+++ b/docs/tutorials/lean.md
@@ -1,6 +1,6 @@
 # Faster Mongoose Queries With Lean
 
-The [lean option](../query.html#query_Query-lean) tells Mongoose to skip
+The [lean option](../api.html#query_Query-lean) tells Mongoose to skip
 [hydrating](../model.html#model_Model-hydrate) the result documents. This
 makes queries faster and less memory intensive, but the result documents are
 plain old JavaScript objects (POJOs), **not** [Mongoose documents](../documents.html).

--- a/docs/tutorials/lean.md
+++ b/docs/tutorials/lean.md
@@ -1,6 +1,6 @@
 # Faster Mongoose Queries With Lean
 
-The [lean option](../api.html#query_Query-lean) tells Mongoose to skip
+The [lean option](../api/query.html#query_Query-lean) tells Mongoose to skip
 [hydrating](../model.html#model_Model-hydrate) the result documents. This
 makes queries faster and less memory intensive, but the result documents are
 plain old JavaScript objects (POJOs), **not** [Mongoose documents](../documents.html).


### PR DESCRIPTION
This PR fixes a broken link in the docs.

Expected: https://mongoosejs.com/docs/api.html#query_Query-lean
Actual: https://mongoosejs.com/docs/query.html#query_Query-lean