### PR TITLE
docs(typescript): add notes about virtual context to Mongoose 6 migration and TypeScript virtuals docs

### DIFF
--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -511,3 +511,22 @@ The following legacy types have been removed:
 * `HookDoneFunction`
 * `SchemaTypeOpts`
 * `ConnectionOptions`
+
+Mongoose 6 infers the document's type for `this` in virtual getters and setters.
+In Mongoose 5.x, `this` would be `any` in the following code.
+
+```ts
+schema.virtual('myVirtual').get(function() {
+  this; // any in Mongoose 5.x
+});
+```
+
+In Mongoose 6, `this` will be set to the document type.
+
+```ts
+const schema = new Schema({ name: String });
+
+schema.virtual('myVirtual').get(function() {
+  this.name; // string
+});
+```

--- a/docs/typescript/virtuals.md
+++ b/docs/typescript/virtuals.md
@@ -83,3 +83,19 @@ schema.virtual('fullName').get(function() {
   return `${this.firstName} ${this.lastName}`;
 });
 ```
+
+### Override the Type of `this` in Your Virtual
+
+In case the value of `this` in your virtual is incorrect for some reason, you can always override it using the generic parameter to `virtual()`.
+
+```ts
+interface MyCustomUserDocumentType {
+  firstName: string;
+  lastName: string;
+  myMethod(): string;
+}
+
+schema.virtual<MyCustomUserDocumentType>('fullName').get(function() {
+  return this.method(); // returns string
+});
+```


### PR DESCRIPTION
Fix #12806

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Couple of quick notes in the docs re: #12806. Mostly make a note of a potentially breaking change, and also highlight the `virtual<MyTypeHere>` escape hatch for when types are not quite right.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
