### PR TITLE
fix(query): correctly pass context when casting `$elemMatch`

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -387,7 +387,8 @@ function getStrictQuery(queryOptions, schemaUserProvidedOptions, schemaOptions, 
   if ('strict' in schemaUserProvidedOptions) {
     return schemaUserProvidedOptions.strict;
   }
-  const mongooseOptions = context.mongooseCollection &&
+  const mongooseOptions = context &&
+    context.mongooseCollection &&
     context.mongooseCollection.conn &&
     context.mongooseCollection.conn.base &&
     context.mongooseCollection.conn.base.options;

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -557,17 +557,17 @@ function cast$all(val) {
     val = [val];
   }
 
-  val = val.map(function(v) {
+  val = val.map((v) => {
     if (!utils.isObject(v)) {
       return v;
     }
     if (v.$elemMatch != null) {
-      return { $elemMatch: cast(this.casterConstructor.schema, v.$elemMatch) };
+      return { $elemMatch: cast(this.casterConstructor.schema, v.$elemMatch, null, this && this.$$context) };
     }
 
     const o = {};
     o[this.path] = v;
-    return cast(this.casterConstructor.schema, o)[this.path];
+    return cast(this.casterConstructor.schema, o, null, this && this.$$context)[this.path];
   }, this);
 
   return this.castForQuery(val);
@@ -598,10 +598,10 @@ function cast$elemMatch(val) {
   if (discriminatorKey != null &&
       val[discriminatorKey] != null &&
       discriminators[val[discriminatorKey]] != null) {
-    return cast(discriminators[val[discriminatorKey]], val);
+    return cast(discriminators[val[discriminatorKey]], val, null, this && this.$$context);
   }
 
-  return cast(this.casterConstructor.schema, val);
+  return cast(this.casterConstructor.schema, val, null, this && this.$$context);
 }
 
 const handle = SchemaArray.prototype.$conditionalHandlers = {};
@@ -622,7 +622,7 @@ function createLogicalQueryOperatorHandler(op) {
 
     const ret = [];
     for (const obj of val) {
-      ret.push(cast(this.casterConstructor.schema, obj));
+      ret.push(cast(this.casterConstructor.schema, obj, null, this && this.$$context));
     }
 
     return ret;

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4349,4 +4349,38 @@ describe('Query', function() {
 
     assert.ok('title' in replacedDoc === false);
   });
+
+  it('handles $elemMatch with nested schema (gh-12902)', async function() {
+    const bioSchema = new Schema({
+      name: { type: String }
+    });
+
+    const Book = db.model('book', new Schema({
+      name: String,
+      authors: [{
+        bio: bioSchema
+      }]
+    }));
+
+    await new Book({
+      name: 'Mongoose Fundamentals',
+      authors: [{
+        bio: {
+          name: 'Foo Bar'
+        }
+      }]
+    }).save();
+
+    const books = await Book.find({
+      name: 'Mongoose Fundamentals',
+      authors: {
+        $elemMatch: {
+          'bio.name': { $in: ['Foo Bar'] },
+          'bio.location': 'Mandurah' // Not in schema
+        }
+      }
+    });
+
+    assert.strictEqual(books.length, 1);
+  });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2452,7 +2452,7 @@ describe('schema', function() {
     assert.ok(!schema.virtuals.id);
   });
 
-  describe('mongoose.set(`strictQuery`, value); (gh-6658)', function() {
+  describe.skip('mongoose.set(`strictQuery`, value); (gh-6658)', function() {
     let strictQueryOriginalValue;
 
     this.beforeEach(() => strictQueryOriginalValue = mongoose.get('strictQuery'));

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2452,18 +2452,14 @@ describe('schema', function() {
     assert.ok(!schema.virtuals.id);
   });
 
-  describe.skip('mongoose.set(`strictQuery`, value); (gh-6658)', function() {
-    let strictQueryOriginalValue;
-
-    this.beforeEach(() => strictQueryOriginalValue = mongoose.get('strictQuery'));
-    this.afterEach(() => mongoose.set('strictQuery', strictQueryOriginalValue));
-
+  describe('mongoose.set(`strictQuery`, value); (gh-6658)', function() {
     it('setting `strictQuery` on base sets strictQuery to schema (gh-6658)', function() {
       // Arrange
-      mongoose.set('strictQuery', 'some value');
+      const m = new mongoose.Mongoose();
+      m.set('strictQuery', 'some value');
 
       // Act
-      const schema = new Schema();
+      const schema = new m.Schema();
 
       // Assert
       assert.equal(schema.get('strictQuery'), 'some value');
@@ -2471,10 +2467,11 @@ describe('schema', function() {
 
     it('`strictQuery` set on base gets overwritten by option set on schema (gh-6658)', function() {
       // Arrange
-      mongoose.set('strictQuery', 'base option');
+      const m = new mongoose.Mongoose();
+      m.set('strictQuery', 'base option');
 
       // Act
-      const schema = new Schema({}, { strictQuery: 'schema option' });
+      const schema = new m.Schema({}, { strictQuery: 'schema option' });
 
       // Assert
       assert.equal(schema.get('strictQuery'), 'schema option');


### PR DESCRIPTION
Fix #12902
Re: #12909

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A more complete fix for #12902 than #12909. I also added the suggestion from #12909, but better to also fix the underlying issue, which is that we aren't correctly passing the Query as context when casting a `$elemMatch`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
