### PR TITLE
BREAKING CHANGE: remove castForQueryWrapper and _castForQuery on schematype, make castForQuery not rely on $conditional being optional

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -12,6 +12,7 @@ you should be aware of when migrating from Mongoose 6.x to Mongoose 7.x.
 If you're still on Mongoose 5.x, please read the [Mongoose 5.x to 6.x migration guide](migrating_to_6.html) and upgrade to Mongoose 6.x first.
 
 * [`strictQuery`](#strictquery)
+* [Removed `castForQueryWrapper()`, updated `castForQuery()` signature](#removed-castforquerywrapper-updated-castforquery-signature)
 
 <h3 id="strictquery"><a href="#strictquery">`strictQuery`</a></h3>
 
@@ -25,4 +26,30 @@ const MyModel = mongoose.model('Test', mySchema);
 const docs = await MyModel.find({ notInSchema: 1 });
 // Empty array in Mongoose 7. In Mongoose 6, this would contain all documents in MyModel
 docs;
+```
+
+<h3 id="removed-castforquerywrapper"><a href="#removed-castforquerywrapper">Removed <code>castForQueryWrapper, updated <code>castForQuery()</code> signature</code></a></h3>
+
+Mongoose now always calls SchemaType `castForQuery()` method with 3 arguments: `$conditional`, `value`, and `context`.
+If you've implemented a custom schema type that defines its own `castForQuery()` method, you need to update the method as follows.
+
+```javascript
+// Mongoose 6.x format:
+MySchemaType.prototype.castForQuery = function($conditional, value) {
+  if (arguments.length === 2) {
+    // Handle casting value with `$conditional` - $eq, $in, $not, etc.
+  } else {
+    value = $conditional;
+    // Handle casting `value` with no conditional
+  }
+};
+
+// Mongoose 7.x format
+MySchemaType.prototype.castForQuery = function($conditional, value, context) {
+  if ($conditional != null) {
+    // Handle casting value with `$conditional` - $eq, $in, $not, etc.
+  } else {
+    // Handle casting `value` with no conditional
+  }
+};
 ```

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -185,16 +185,18 @@ module.exports = function cast(schema, obj, options, context) {
             let value = val[geo];
 
             if (val.$maxDistance != null) {
-              val.$maxDistance = numbertype.castForQueryWrapper({
-                val: val.$maxDistance,
-                context: context
-              });
+              val.$maxDistance = numbertype.castForQuery(
+                null,
+                val.$maxDistance,
+                context
+              );
             }
             if (val.$minDistance != null) {
-              val.$minDistance = numbertype.castForQueryWrapper({
-                val: val.$minDistance,
-                context: context
-              });
+              val.$minDistance = numbertype.castForQuery(
+                null,
+                val.$minDistance,
+                context
+              );
             }
 
             if (geo === '$within') {
@@ -216,16 +218,18 @@ module.exports = function cast(schema, obj, options, context) {
                 value.$geometry && typeof value.$geometry.type === 'string' &&
                 Array.isArray(value.$geometry.coordinates)) {
               if (value.$maxDistance != null) {
-                value.$maxDistance = numbertype.castForQueryWrapper({
-                  val: value.$maxDistance,
-                  context: context
-                });
+                value.$maxDistance = numbertype.castForQuery(
+                  null,
+                  value.$maxDistance,
+                  context
+                );
               }
               if (value.$minDistance != null) {
-                value.$minDistance = numbertype.castForQueryWrapper({
-                  val: value.$minDistance,
-                  context: context
-                });
+                value.$minDistance = numbertype.castForQuery(
+                  null,
+                  value.$minDistance,
+                  context
+                );
               }
               if (isMongooseObject(value.$geometry)) {
                 value.$geometry = value.$geometry.toObject({
@@ -283,10 +287,11 @@ module.exports = function cast(schema, obj, options, context) {
         any$conditionals = Object.keys(val).some(isOperator);
 
         if (!any$conditionals) {
-          obj[path] = schematype.castForQueryWrapper({
-            val: val,
-            context: context
-          });
+          obj[path] = schematype.castForQuery(
+            null,
+            val,
+            context
+          );
         } else {
           const ks = Object.keys(val);
           let $cond;
@@ -302,27 +307,27 @@ module.exports = function cast(schema, obj, options, context) {
                 _keys = Object.keys(nested);
                 if (_keys.length && isOperator(_keys[0])) {
                   for (const key in nested) {
-                    nested[key] = schematype.castForQueryWrapper({
-                      $conditional: key,
-                      val: nested[key],
-                      context: context
-                    });
+                    nested[key] = schematype.castForQuery(
+                      key,
+                      nested[key],
+                      context
+                    );
                   }
                 } else {
-                  val[$cond] = schematype.castForQueryWrapper({
-                    $conditional: $cond,
-                    val: nested,
-                    context: context
-                  });
+                  val[$cond] = schematype.castForQuery(
+                    $cond,
+                    nested,
+                    context
+                  );
                 }
                 continue;
               }
             } else {
-              val[$cond] = schematype.castForQueryWrapper({
-                $conditional: $cond,
-                val: nested,
-                context: context
-              });
+              val[$cond] = schematype.castForQuery(
+                $cond,
+                nested,
+                context
+              );
             }
           }
         }
@@ -331,18 +336,20 @@ module.exports = function cast(schema, obj, options, context) {
         const valuesArray = val;
 
         for (const _val of valuesArray) {
-          casted.push(schematype.castForQueryWrapper({
-            val: _val,
-            context: context
-          }));
+          casted.push(schematype.castForQuery(
+            null,
+            _val,
+            context
+          ));
         }
 
         obj[path] = { $in: casted };
       } else {
-        obj[path] = schematype.castForQueryWrapper({
-          val: val,
-          context: context
-        });
+        obj[path] = schematype.castForQuery(
+          null,
+          val,
+          context
+        );
       }
     }
   }
@@ -356,7 +363,7 @@ function _cast(val, numbertype, context) {
       if (Array.isArray(item) || isObject(item)) {
         return _cast(item, numbertype, context);
       }
-      val[i] = numbertype.castForQueryWrapper({ val: item, context: context });
+      val[i] = numbertype.castForQuery(null, item, context);
     });
   } else {
     const nearKeys = Object.keys(val);

--- a/lib/helpers/query/castFilterPath.js
+++ b/lib/helpers/query/castFilterPath.js
@@ -7,10 +7,11 @@ module.exports = function castFilterPath(query, schematype, val) {
   const any$conditionals = Object.keys(val).some(isOperator);
 
   if (!any$conditionals) {
-    return schematype.castForQueryWrapper({
-      val: val,
-      context: ctx
-    });
+    return schematype.castForQuery(
+      null,
+      val,
+      ctx
+    );
   }
 
   const ks = Object.keys(val);
@@ -26,27 +27,27 @@ module.exports = function castFilterPath(query, schematype, val) {
         const _keys = Object.keys(nested);
         if (_keys.length && isOperator(_keys[0])) {
           for (const key of Object.keys(nested)) {
-            nested[key] = schematype.castForQueryWrapper({
-              $conditional: key,
-              val: nested[key],
-              context: ctx
-            });
+            nested[key] = schematype.castForQuery(
+              key,
+              nested[key],
+              ctx
+            );
           }
         } else {
-          val[$cond] = schematype.castForQueryWrapper({
-            $conditional: $cond,
-            val: nested,
-            context: ctx
-          });
+          val[$cond] = schematype.castForQuery(
+            $cond,
+            nested,
+            ctx
+          );
         }
         continue;
       }
     } else {
-      val[$cond] = schematype.castForQueryWrapper({
-        $conditional: $cond,
-        val: nested,
-        context: ctx
-      });
+      val[$cond] = schematype.castForQuery(
+        $cond,
+        nested,
+        ctx
+      );
     }
   }
 

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -263,7 +263,7 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
           if (schematype != null && schematype.$isSingleNested) {
             const _strict = strict == null ? schematype.schema.options.strict : strict;
             try {
-              obj[key] = schematype.castForQuery(val, context, { strict: _strict });
+              obj[key] = schematype.castForQuery(null, val, context, { strict: _strict });
             } catch (error) {
               aggregatedError = _appendError(error, context, key, aggregatedError);
             }
@@ -532,10 +532,11 @@ function castUpdateVal(schema, val, op, $conditional, context, path) {
     }
     if (op === '$inc') {
       // Support `$inc` with long, int32, etc. (gh-4283)
-      return schema.castForQueryWrapper({
-        val: val,
-        context: context
-      });
+      return schema.castForQuery(
+        null,
+        val,
+        context
+      );
     }
     try {
       return castNumber(val);
@@ -551,21 +552,25 @@ function castUpdateVal(schema, val, op, $conditional, context, path) {
   }
 
   if (/^\$/.test($conditional)) {
-    return schema.castForQueryWrapper({
-      $conditional: $conditional,
-      val: val,
-      context: context
-    });
+    return schema.castForQuery(
+      $conditional,
+      val,
+      context
+    );
   }
 
   if (overwriteOps[op]) {
-    return schema.castForQueryWrapper({
-      val: val,
-      context: context,
-      $skipQueryCastForUpdate: val != null && schema.$isMongooseArray && schema.$fullPath != null && !schema.$fullPath.match(/\d+$/),
-      $applySetters: schema[schemaMixedSymbol] != null
-    });
+    const skipQueryCastForUpdate = val != null && schema.$isMongooseArray && schema.$fullPath != null && !schema.$fullPath.match(/\d+$/);
+    const applySetters = schema[schemaMixedSymbol] != null;
+    if (skipQueryCastForUpdate || applySetters) {
+      return schema.applySetters(val, context);
+    }
+    return schema.castForQuery(
+      null,
+      val,
+      context
+    );
   }
 
-  return schema.castForQueryWrapper({ val: val, context: context });
+  return schema.castForQuery(null, val, context);
 }

--- a/lib/helpers/update/castArrayFilters.js
+++ b/lib/helpers/update/castArrayFilters.js
@@ -102,7 +102,7 @@ function _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilt
       if (typeof filter[key] === 'object') {
         filter[key] = castFilterPath(query, schematype, filter[key]);
       } else {
-        filter[key] = schematype.castForQuery(filter[key]);
+        filter[key] = schematype.castForQuery(null, filter[key]);
       }
     }
   }

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -117,8 +117,8 @@ function _createConstructor(schema, baseClass) {
  * @api private
  */
 
-SubdocumentPath.prototype.$conditionalHandlers.$geoWithin = function handle$geoWithin(val) {
-  return { $geometry: this.castForQuery(val.$geometry) };
+SubdocumentPath.prototype.$conditionalHandlers.$geoWithin = function handle$geoWithin(val, context) {
+  return { $geometry: this.castForQuery(null, val.$geometry, context) };
 };
 
 /*!
@@ -194,22 +194,21 @@ SubdocumentPath.prototype.cast = function(val, doc, init, priorVal, options) {
  * @api private
  */
 
-SubdocumentPath.prototype.castForQuery = function($conditional, val, options) {
+SubdocumentPath.prototype.castForQuery = function($conditional, val, context, options) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
       throw new Error('Can\'t use ' + $conditional);
     }
     return handler.call(this, val);
   }
-  val = $conditional;
   if (val == null) {
     return val;
   }
 
   if (this.options.runSetters) {
-    val = this._applySetters(val);
+    val = this._applySetters(val, context);
   }
 
   const Constructor = getConstructor(this.caster, val);

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -478,6 +478,68 @@ SchemaArray.prototype.clone = function() {
   return schematype;
 };
 
+SchemaArray.prototype._castForQuery = function(val, context) {
+  let Constructor = this.casterConstructor;
+
+  if (val &&
+      Constructor.discriminators &&
+      Constructor.schema &&
+      Constructor.schema.options &&
+      Constructor.schema.options.discriminatorKey) {
+    if (typeof val[Constructor.schema.options.discriminatorKey] === 'string' &&
+        Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]]) {
+      Constructor = Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]];
+    } else {
+      const constructorByValue = getDiscriminatorByValue(Constructor.discriminators, val[Constructor.schema.options.discriminatorKey]);
+      if (constructorByValue) {
+        Constructor = constructorByValue;
+      }
+    }
+  }
+
+  const proto = this.casterConstructor.prototype;
+  const protoCastForQuery = proto && proto.castForQuery;
+  const protoCast = proto && proto.cast;
+  const constructorCastForQuery = Constructor.castForQuery;
+  const caster = this.caster;
+
+  if (Array.isArray(val)) {
+    this.setters.reverse().forEach(setter => {
+      val = setter.call(this, val, this);
+    });
+    val = val.map(function(v) {
+      if (utils.isObject(v) && v.$elemMatch) {
+        return v;
+      }
+      if (protoCastForQuery) {
+        v = protoCastForQuery.call(caster, null, v, context);
+        return v;
+      } else if (protoCast) {
+        v = protoCast.call(caster, v);
+        return v;
+      } else if (constructorCastForQuery) {
+        v = constructorCastForQuery.call(caster, null, v, context);
+        return v;
+      }
+      if (v != null) {
+        v = new Constructor(v);
+        return v;
+      }
+      return v;
+    });
+  } else if (protoCastForQuery) {
+    val = protoCastForQuery.call(caster, null, val, context);
+  } else if (protoCast) {
+    val = protoCast.call(caster, val);
+  } else if (constructorCastForQuery) {
+    val = constructorCastForQuery.call(caster, null, val, context);
+  } else if (val != null) {
+    val = new Constructor(val);
+  }
+
+  return val;
+};
+
 /**
  * Casts values for queries.
  *
@@ -486,74 +548,23 @@ SchemaArray.prototype.clone = function() {
  * @api private
  */
 
-SchemaArray.prototype.castForQuery = function($conditional, value) {
+SchemaArray.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  let val;
 
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
 
     if (!handler) {
       throw new Error('Can\'t use ' + $conditional + ' with Array.');
     }
 
-    val = handler.call(this, value);
+    return handler.call(this, val, context);
   } else {
-    val = $conditional;
-    let Constructor = this.casterConstructor;
-
-    if (val &&
-        Constructor.discriminators &&
-        Constructor.schema &&
-        Constructor.schema.options &&
-        Constructor.schema.options.discriminatorKey) {
-      if (typeof val[Constructor.schema.options.discriminatorKey] === 'string' &&
-          Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]]) {
-        Constructor = Constructor.discriminators[val[Constructor.schema.options.discriminatorKey]];
-      } else {
-        const constructorByValue = getDiscriminatorByValue(Constructor.discriminators, val[Constructor.schema.options.discriminatorKey]);
-        if (constructorByValue) {
-          Constructor = constructorByValue;
-        }
-      }
-    }
-
-    const proto = this.casterConstructor.prototype;
-    let method = proto && (proto.castForQuery || proto.cast);
-    if (!method && Constructor.castForQuery) {
-      method = Constructor.castForQuery;
-    }
-    const caster = this.caster;
-
-    if (Array.isArray(val)) {
-      this.setters.reverse().forEach(setter => {
-        val = setter.call(this, val, this);
-      });
-      val = val.map(function(v) {
-        if (utils.isObject(v) && v.$elemMatch) {
-          return v;
-        }
-        if (method) {
-          v = method.call(caster, v);
-          return v;
-        }
-        if (v != null) {
-          v = new Constructor(v);
-          return v;
-        }
-        return v;
-      });
-    } else if (method) {
-      val = method.call(caster, val);
-    } else if (val != null) {
-      val = new Constructor(val);
-    }
+    return this._castForQuery(val, context);
   }
-
-  return val;
 };
 
-function cast$all(val) {
+function cast$all(val, context) {
   if (!Array.isArray(val)) {
     val = [val];
   }
@@ -571,17 +582,17 @@ function cast$all(val) {
     return cast(this.casterConstructor.schema, o)[this.path];
   }, this);
 
-  return this.castForQuery(val);
+  return this.castForQuery(null, val, context);
 }
 
-function cast$elemMatch(val) {
+function cast$elemMatch(val, context) {
   const keys = Object.keys(val);
   const numKeys = keys.length;
   for (let i = 0; i < numKeys; ++i) {
     const key = keys[i];
     const value = val[key];
     if (isOperator(key) && value != null) {
-      val[key] = this.castForQuery(key, value);
+      val[key] = this.castForQuery(key, value, context);
     }
   }
 
@@ -648,9 +659,9 @@ handle.$gt =
 handle.$gte =
 handle.$lt =
 handle.$lte =
-handle.$ne =
 handle.$not =
-handle.$regex = SchemaArray.prototype.castForQuery;
+handle.$regex =
+handle.$ne = SchemaArray.prototype._castForQuery;
 
 // `$in` is special because you can also include an empty array in the query
 // like `$in: [1, []]`, see gh-5913

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -221,19 +221,19 @@ SchemaBoolean.$conditionalHandlers =
  * @api private
  */
 
-SchemaBoolean.prototype.castForQuery = function($conditional, val) {
+SchemaBoolean.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = SchemaBoolean.$conditionalHandlers[$conditional];
 
     if (handler) {
       return handler.call(this, val);
     }
 
-    return this._castForQuery(val);
+    return this.applySetters(null, val, context);
   }
 
-  return this._castForQuery($conditional);
+  return this.applySetters(val, context);
 };
 
 /**

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -224,8 +224,8 @@ SchemaBuffer.prototype.subtype = function(subtype) {
 /*!
  * ignore
  */
-function handleSingle(val) {
-  return this.castForQuery(val);
+function handleSingle(val, context) {
+  return this.castForQuery(null, val, context);
 }
 
 SchemaBuffer.prototype.$conditionalHandlers =
@@ -248,17 +248,16 @@ SchemaBuffer.prototype.$conditionalHandlers =
  * @api private
  */
 
-SchemaBuffer.prototype.castForQuery = function($conditional, val) {
+SchemaBuffer.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
       throw new Error('Can\'t use ' + $conditional + ' with Buffer.');
     }
     return handler.call(this, val);
   }
-  val = $conditional;
-  const casted = this._castForQuery(val);
+  const casted = this.applySetters(val, context);
   return casted ? casted.toObject({ transform: false, virtuals: false }) : casted;
 };
 

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -383,9 +383,9 @@ SchemaDate.prototype.$conditionalHandlers =
  * @api private
  */
 
-SchemaDate.prototype.castForQuery = function($conditional, val) {
-  if (arguments.length !== 2) {
-    return this._castForQuery($conditional);
+SchemaDate.prototype.castForQuery = function($conditional, val, context) {
+  if ($conditional == null) {
+    return this.applySetters(val, context);
   }
 
   const handler = this.$conditionalHandlers[$conditional];

--- a/lib/schema/mixed.js
+++ b/lib/schema/mixed.js
@@ -119,10 +119,7 @@ Mixed.prototype.cast = function(val) {
  */
 
 Mixed.prototype.castForQuery = function($cond, val) {
-  if (arguments.length === 2) {
-    return val;
-  }
-  return $cond;
+  return val;
 };
 
 /*!

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -418,16 +418,16 @@ SchemaNumber.prototype.$conditionalHandlers =
  * @api private
  */
 
-SchemaNumber.prototype.castForQuery = function($conditional, val) {
+SchemaNumber.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
       throw new CastError('number', val, this.path, null, this);
     }
-    return handler.call(this, val);
+    return handler.call(this, val, context);
   }
-  val = this._castForQuery($conditional);
+  val = this.applySetters(val, context);
   return val;
 };
 

--- a/lib/schema/operators/geospatial.js
+++ b/lib/schema/operators/geospatial.js
@@ -34,7 +34,7 @@ function cast$near(val) {
       'with a $geometry property');
   }
 
-  return SchemaArray.prototype.castForQuery.call(this, val);
+  return SchemaArray.prototype.castForQuery.call(this, null, val);
 }
 
 function cast$geometry(val, self) {

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -608,21 +608,21 @@ SchemaString.prototype.cast = function(value, doc, init) {
  * ignore
  */
 
-function handleSingle(val) {
-  return this.castForQuery(val);
+function handleSingle(val, context) {
+  return this.castForQuery(null, val, context);
 }
 
 /*!
  * ignore
  */
 
-function handleArray(val) {
+function handleArray(val, context) {
   const _this = this;
   if (!Array.isArray(val)) {
-    return [this.castForQuery(val)];
+    return [this.castForQuery(null, val, context)];
   }
   return val.map(function(m) {
-    return _this.castForQuery(m);
+    return _this.castForQuery(null, m, context);
   });
 }
 
@@ -670,21 +670,21 @@ Object.defineProperty(SchemaString.prototype, '$conditionalHandlers', {
  * @api private
  */
 
-SchemaString.prototype.castForQuery = function($conditional, val) {
+SchemaString.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
       throw new Error('Can\'t use ' + $conditional + ' with String.');
     }
-    return handler.call(this, val);
+    return handler.call(this, val, context);
   }
-  val = $conditional;
+
   if (Object.prototype.toString.call(val) === '[object RegExp]' || isBsonType(val, 'BSONRegExp')) {
     return val;
   }
 
-  return this._castForQuery(val);
+  return this.applySetters(val, context);
 };
 
 /*!

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -310,15 +310,15 @@ utils.options(SchemaType.prototype.$conditionalHandlers, {
  * @api private
  */
 
-SchemaUUID.prototype.castForQuery = function($conditional, val) {
+SchemaUUID.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler)
       throw new Error('Can\'t use ' + $conditional + ' with UUID.');
-    return handler.call(this, val);
+    return handler.call(this, val, context);
   } else {
-    return this.cast($conditional);
+    return this.cast(val);
   }
 };
 

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1539,21 +1539,21 @@ SchemaType.prototype._castRef = function _castRef(value, doc, init) {
  * ignore
  */
 
-function handleSingle(val) {
-  return this.castForQuery(val);
+function handleSingle(val, context) {
+  return this.castForQuery(null, val, context);
 }
 
 /*!
  * ignore
  */
 
-function handleArray(val) {
+function handleArray(val, context) {
   const _this = this;
   if (!Array.isArray(val)) {
-    return [this.castForQuery(val)];
+    return [this.castForQuery(null, val, context)];
   }
   return val.map(function(m) {
-    return _this.castForQuery(m);
+    return _this.castForQuery(null, m, context);
   });
 }
 
@@ -1563,16 +1563,16 @@ function handleArray(val) {
  * @api private
  */
 
-function handle$in(val) {
+function handle$in(val, context) {
   const _this = this;
   if (!Array.isArray(val)) {
-    return [this.castForQuery(val)];
+    return [this.castForQuery(null, val, context)];
   }
   return val.map(function(m) {
     if (Array.isArray(m) && m.length === 0) {
       return m;
     }
-    return _this.castForQuery(m);
+    return _this.castForQuery(null, m, context);
   });
 }
 
@@ -1591,62 +1591,26 @@ SchemaType.prototype.$conditionalHandlers = {
 };
 
 /**
- * Wraps `castForQuery` to handle context
- * @param {Object} params
- * @instance
- * @api private
- */
-
-SchemaType.prototype.castForQueryWrapper = function(params) {
-  this.$$context = params.context;
-  if ('$conditional' in params) {
-    const ret = this.castForQuery(params.$conditional, params.val);
-    this.$$context = null;
-    return ret;
-  }
-  if (params.$skipQueryCastForUpdate || params.$applySetters) {
-    const ret = this._castForQuery(params.val);
-    this.$$context = null;
-    return ret;
-  }
-
-  const ret = this.castForQuery(params.val);
-  this.$$context = null;
-  return ret;
-};
-
-/**
  * Cast the given value with the given optional query operator.
  *
  * @param {String} [$conditional] query operator, like `$eq` or `$in`
  * @param {Any} val
+ * @param {Query} context
  * @return {Any}
  * @api private
  */
 
-SchemaType.prototype.castForQuery = function($conditional, val) {
+SchemaType.prototype.castForQuery = function($conditional, val, context) {
   let handler;
-  if (arguments.length === 2) {
+  if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
       throw new Error('Can\'t use ' + $conditional);
     }
-    return handler.call(this, val);
+    return handler.call(this, val, context);
   }
-  val = $conditional;
-  return this._castForQuery(val);
-};
 
-/**
- * Internal switch for runSetters
- *
- * @param {Any} val
- * @return {Any}
- * @api private
- */
-
-SchemaType.prototype._castForQuery = function(val) {
-  return this.applySetters(val, this.$$context);
+  return this.applySetters(val, context);
 };
 
 /**

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -137,20 +137,14 @@ describe('model query casting', function() {
     });
   });
 
-  it('casts $in values of arrays with single item instead of array (jrl-3238)', function(done) {
+  it('casts $in values of arrays with single item instead of array (gh-3238)', async function() {
     const post = new BlogPostB();
     const id = post._id.toString();
 
-    post.save(function(err) {
-      assert.ifError(err);
+    await post.save();
 
-      BlogPostB.findOne({ _id: { $in: id } }, function(err, doc) {
-        assert.ifError(err);
-
-        assert.equal(doc._id.toString(), id);
-        done();
-      });
-    });
+    const doc = await BlogPostB.findOne({ _id: { $in: id } });
+    assert.equal(doc._id.toString(), id);
   });
 
   it('casts $nin values of arrays (gh-232)', function(done) {

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -1586,7 +1586,7 @@ describe('model: querying:', function() {
     });
   });
 
-  it('mixed types with $elemMatch (gh-591)', function(done) {
+  it('mixed types with $elemMatch (gh-591)', async function() {
     const S = new Schema({ a: [{}], b: Number });
     const M = db.model('Test', S);
 
@@ -1594,27 +1594,19 @@ describe('model: querying:', function() {
     m.a = [1, 2, { name: 'Frodo' }, 'IDK', { name: 100 }];
     m.b = 10;
 
-    m.save(function(err) {
-      assert.ifError(err);
+    await m.save();
 
-      M.find({ a: { name: 'Frodo' }, b: '10' }, function(err, docs) {
-        assert.ifError(err);
-        assert.equal(docs[0].a.length, 5);
-        assert.equal(docs[0].b.valueOf(), 10);
+    let docs = await M.find({ a: { name: 'Frodo' }, b: '10' });
+    assert.equal(docs[0].a.length, 5);
+    assert.equal(docs[0].b.valueOf(), 10);
 
-        const query = {
-          a: {
-            $elemMatch: { name: 100 }
-          }
-        };
-
-        M.find(query, function(err, docs) {
-          assert.ifError(err);
-          assert.equal(docs[0].a.length, 5);
-          done();
-        });
-      });
-    });
+    const query = {
+      a: {
+        $elemMatch: { name: 100 }
+      }
+    };
+    docs = await M.find(query);
+    assert.equal(docs[0].a.length, 5);
   });
 
   describe('$all', function() {

--- a/test/types.number.test.js
+++ b/test/types.number.test.js
@@ -23,7 +23,7 @@ describe('types.number', function() {
 
   it('a null number should castForQuery to null', function(done) {
     const n = new SchemaNumber();
-    assert.strictEqual(n.castForQuery(null), null);
+    assert.strictEqual(n.castForQuery(null, null), null);
     done();
   });
 
@@ -104,7 +104,7 @@ describe('types.number', function() {
     const n = new SchemaNumber();
     let err;
     try {
-      n.castForQuery({ somePath: { $x: 43 } });
+      n.castForQuery(null, { somePath: { $x: 43 } });
     } catch (e) {
       err = e;
     }


### PR DESCRIPTION
Fix #12914

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We created the `castForQueryWrapper` abstraction in https://github.com/Automattic/mongoose/commit/69e286a831d885533380e69e6fff3e93318c6cb9 to avoid potentially breaking custom schematype implementations by adding a 3rd param, because `castForQuery()` historically has relied on checking argument length to check if `$conditional` is set or not. But the castForQueryWrapper abstraction is a bit messy and makes it hard to write custom schematypes.

With this PR, `castForQuery()` now always takes 3 arguments, including the context. And, if you don't want to specify `$conditional`, you should pass null.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
