### PR TITLE
types(model): fix type of options of Model.aggregate

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -11,7 +11,8 @@ import {
   HydratedDocument,
   HydratedDocumentFromSchema,
   Query,
-  UpdateWriteOpResult
+  UpdateWriteOpResult,
+  AggregateOptions
 } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
@@ -568,4 +569,10 @@ function gh12573ModelAny() {
   expectType<any>(doc);
   const { fieldA } = doc;
   expectType<any>(fieldA);
+}
+
+function aggregateOptionsTest() {
+  const TestModel = model('test', new Schema({}));
+  const options: AggregateOptions = {};
+  TestModel.aggregate(undefined, options);
 }

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -4,67 +4,7 @@ declare module 'mongoose' {
   /** Extract generic type from Aggregate class */
   type AggregateExtract<P> = P extends Aggregate<infer T> ? T : never;
 
-  interface AggregateOptions extends
-    SessionOption {
-    /**
-     * If true, the MongoDB server will use the hard drive to store data during this aggregation.
-     */
-    allowDiskUse?: boolean;
-    /**
-     * Applicable only if you specify the $out or $merge aggregation stages.
-     *
-     * Enables db.collection.aggregate() to bypass document validation during the operation. This lets you insert documents that do not meet the validation requirements.
-     */
-    bypassDocumentValidation?: boolean;
-    /**
-     * The BSON-serializer will check if keys are valid
-     */
-    collation?: mongodb.CollationOptions;
-    /**
-     * Users can specify an arbitrary string to help trace the operation through the database profiler, currentOp, and logs.
-     */
-    comment?: string;
-    /**
-     *  Specifies the initial batch size for the cursor. The value of the cursor field is a document with the field batchSize.
-     */
-    cursor?: { batchSize?: number; };
-
-    /**
-     * Specifies to return the information on the processing of the pipeline. See Return Information on Aggregation Pipeline Operation for an example.
-     *
-     * Not available in multi-document transactions.
-     */
-    explain?: mongodb.ExplainVerbosityLike;
-    /**
-     * The index to use for the aggregation. The index is on the initial collection/view against which the aggregation is run.
-     */
-    hint?: string | AnyObject;
-    /**
-     * Specifies a document with a list of variables. This allows you to improve command readability by separating the variables from the query text.
-     */
-    let?: AnyObject;
-    /**
-     * Specifies a time limit in milliseconds for processing operations on a cursor. If you do not specify a value for maxTimeMS, operations will not time out. A value of 0 explicitly specifies the default unbounded behavior.
-     *
-     * @see https://docs.mongodb.com/manual/reference/operator/meta/maxTimeMS/
-     */
-    maxTimeMS?: number;
-    /**
-     * Return BSON filled buffers from operations.
-     */
-    raw?: boolean;
-    /**
-     * Specifies the read concern.
-     */
-    readConcern?: mongodb.ReadConcernLike;
-    /**
-     * The preferred read preference.
-     */
-    readPreference?: mongodb.ReadPreferenceLike;
-    /**
-     * Specifies the write concern.
-     */
-    writeConcern?: mongodb.WriteConcern;
+  interface AggregateOptions extends Omit<mongodb.AggregateOptions, 'session'>, SessionOption {
     [key: string]: any;
   }
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -140,7 +140,7 @@ declare module 'mongoose' {
     >
     > & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
-    aggregate<R = any>(pipeline?: PipelineStage[], options?: mongodb.AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
+    aggregate<R = any>(pipeline?: PipelineStage[], options?: AggregateOptions, callback?: Callback<R[]>): Aggregate<Array<R>>;
     aggregate<R = any>(pipeline: PipelineStage[], callback?: Callback<R[]>): Aggregate<Array<R>>;
 
     /** Base Mongoose instance the model uses. */


### PR DESCRIPTION
**Summary**

This change adjusts the type of the `options` parameter of `Model.aggregate` to be the `AggregateOptions` type from mongoose, instead of the one from mongodb. The aggregate method just passes this parameter on to `Aggregate.option`, which is already typed to accept the `AggregateOptions` type from mongoose, so this seems like the correct choice.

The 2 types mostly seem to be compatible anyways, but there is a small inconsistency that makes them incompatible: `mongodb.AggregateOptions` specifies that the `session` property may be a `ClientSession`, or `undefined` (but not `null`), while the `AggregateOptions` type from mongoose also allows `null`. So maybe that also should simply be aligned.