### PR TITLE
test(aggregate): increase timeout for a "beforeEach" hook

### DIFF
--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -614,6 +614,7 @@ describe('aggregate: ', function() {
 
   describe('exec', function() {
     beforeEach(async function() {
+      this.timeout(4000); // double the default of 2 seconds
       await setupData(db);
     });
 


### PR DESCRIPTION
**Summary**

This PR increases the timeout for a `beforeEach` hook to 4 seconds (from a default of 2 seconds), in the hopes that test fail less with `Error: Timeout of 2000ms exceeded.`

see https://github.com/hasezoey/mongoose/actions/runs/3989840214/jobs/6842753284 as example