### PR TITLE
Allow this typing in validator functions

### DIFF
--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -2,32 +2,32 @@ declare module 'mongoose' {
 
   type SchemaValidator<T> = RegExp | [RegExp, string] | Function | [Function, string] | ValidateOpts<T> | ValidateOpts<T>[];
 
-  interface ValidatorProps {
+  interface ValidatorProps<T> {
     path: string;
-    value: any;
+    value: T;
   }
 
-  interface ValidatorMessageFn {
-    (props: ValidatorProps): string;
+  interface ValidatorMessageFn<T> {
+    (props: ValidatorProps<T>): string;
   }
 
-  interface ValidateFn<T> {
-    (value: T, props?: ValidatorProps & Record<string, any>): boolean;
+  interface ValidateFn<T, M = Model<unknown>> {
+    (this: M, value: T, props?: ValidatorProps<T> & Record<string, any>): boolean;
   }
 
-  interface LegacyAsyncValidateFn<T> {
-    (value: T, done: (result: boolean) => void): void;
+  interface LegacyAsyncValidateFn<T, M = Model<unknown>> {
+    (this: M, value: T, done: (result: boolean) => void): void;
   }
 
-  interface AsyncValidateFn<T> {
-    (value: T, props?: ValidatorProps & Record<string, any>): Promise<boolean>;
+  interface AsyncValidateFn<T, M = Model<unknown>> {
+    (this: M, value: T, props?: ValidatorProps<T> & Record<string, any>): Promise<boolean>;
   }
 
-  interface ValidateOpts<T> {
+  interface ValidateOpts<T, M = Model<unknown>> {
     msg?: string;
-    message?: string | ValidatorMessageFn;
+    message?: string | ValidatorMessageFn<T>;
     type?: string;
-    validator: ValidateFn<T> | LegacyAsyncValidateFn<T> | AsyncValidateFn<T>;
+    validator: ValidateFn<T, M> | LegacyAsyncValidateFn<T, M> | AsyncValidateFn<T, M>;
     propsParameter?: boolean;
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Improve ability to type validator functions by allowing to define the `this` keyword. This avoid type errors when using `this` in the function body.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```ts
export const refExists: ValidateOpts<Types.ObjectId> = {
	async validator(_id: Types.ObjectId, props: ValidatorProps & Record<string, unknown>): Promise<boolean> {
		const self = this.constructor as Model<unknown>;
		const {ref} = self.schema.paths[props.path].options;
		const model = models[ref as string];

		return await model.exists({_id}).exec() !== null;
	},
	message: 'REF_ID_DOES_NOT_EXISTS',
	propsParameter: true,
};
```
return the following error on this.constructor;

> any
> Unsafe member access .constructor on an `any` value. `this` is typed as `any`.
> You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.eslint[@typescript-eslint/no-unsafe-member-access](https://typescript-eslint.io/rules/no-unsafe-member-access)