### PR TITLE
docs(transactions): added example for `Connection.transaction()` method

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -46,7 +46,20 @@ The changes in that document are not persisted to MongoDB.
 The `Connection#transaction()` function informs Mongoose change tracking that the `save()` was rolled back, and marks all fields that were changed in the transaction as modified.
 
 ```javascript
-[require:transactions.*can save document after aborted transaction]
+const doc = new Person({ name: 'Will Riker' });
+
+await db.transaction(async function setRank(session) {
+    doc.name = 'Captain';
+    await doc.save({ session });
+    doc.isNew; // false
+
+    // Throw an error to abort the transaction
+    throw new Error('Oops!');
+}, { readPreference: 'primary' }).catch(() => {});
+
+// true, `transaction()` reset the document's state because the
+// transaction was aborted.
+doc.isNew;
 ```
 
 <h2 id="with-mongoose-documents-and-save"><a href="#with-mongoose-documents-and-save">With Mongoose Documents and <code>save()</code></a></h2>

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -76,7 +76,6 @@ describe('transactions', function() {
     // acquit:ignore:start
     const Customer = db.model('Customer_withTrans', new Schema({ name: String }));
     // acquit:ignore:end
-
     let session = null;
     return Customer.createCollection().
       then(() => Customer.startSession()).


### PR DESCRIPTION
fix #12934

**Summary**
Added an example substituting the broken link in the `Connection.transaction()` method documentation and removed an empty first line from the `withTransaction` method example.