### PR TITLE
Fix discriminator type field update for custom discriminator model name

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -5100,7 +5100,9 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
   if (this._mongooseOptions.overwriteDiscriminatorKey &&
       obj[discriminatorKey] != null &&
       baseSchema.discriminators) {
-    const _schema = baseSchema.discriminators[obj[discriminatorKey]];
+    const _schema = Object.values(baseSchema.discriminators).find(
+      discriminator => discriminator.discriminatorMapping.value === obj[discriminatorKey]
+    );
     if (_schema != null) {
       schema = _schema;
     }

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -3288,10 +3288,10 @@ describe('model: updateOne: ', function() {
       const baseModel = db.model('Test', baseSchema);
 
       const aSchema = Schema({ aThing: Number }, { _id: false, id: false });
-      const aModel = baseModel.discriminator('A', aSchema);
+      const aModel = baseModel.discriminator('discriminator-A', aSchema, 'A');
 
       const bSchema = new Schema({ bThing: String }, { _id: false, id: false });
-      const bModel = baseModel.discriminator('B', bSchema);
+      const bModel = baseModel.discriminator('discriminator-B', bSchema, 'B');
 
       // Model is created as a type A
       let doc = await baseModel.create({ type: 'A', aThing: 1 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Mongoose requires unique model names, so to avoid conflicts when using discriminators, you use 3 parameter syntax: `model.discriminator(modelName, schema, discriminatorKeyValue)`.
When updating a document using e.g. `updateOne`, you're allowed to change discriminator key value when you provide `overwriteDiscriminatorKey`.
But the code responsible for updating the discriminator type was relying on `modelName` being equal to `discriminatorKeyValue`, which may not be the case if you use custom model name for your discriminator.

`Schema.discriminators` are indexed by model name and the code was using update value for `discriminatorKey`.

**Examples**

I modified an existing test to make it fail, then fixed it.

I'm not sure if I should keep the original test as is and add a new one, but the difference is just 2 lines - the model names for discriminators.
