### PR TITLE
fix: export mongodb types more robustly

### DIFF
--- a/test/types/mongo.test.ts
+++ b/test/types/mongo.test.ts
@@ -1,0 +1,4 @@
+import * as mongoose from 'mongoose';
+import { expectType } from 'tsd';
+
+import GridFSBucket = mongoose.mongo.GridFSBucket;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,7 +105,7 @@ declare module 'mongoose' {
   export function setDriver(driver: any): Mongoose;
 
   /** The node-mongodb-native driver Mongoose uses. */
-  export const mongo: typeof mongodb;
+  export { mongodb as mongo };
 
   /** Declares a global plugin executed on all Schemas. */
   export function plugin(fn: (schema: Schema, opts?: any) => void, opts?: any): Mongoose;


### PR DESCRIPTION
**Summary**

Mongoose exposes its underlying `mongodb` import via the `mongo` export. However, if you use `import * as mongoose from 'mongoose'` syntax then `mongoose.mongo.X` becomes untyped. By using an alias export instead, the types are preserved, even when importing like that.

**Examples**

See the test I added.
