### PR TITLE
Revert "typescript: Allow null for optional document fields"

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -466,7 +466,7 @@ function gh12100() {
   const TestModel = model('test', schema_with_string_id);
   const obj = new TestModel();
 
-  expectType<string | null>(obj._id);
+  expectType<string>(obj._id);
 })();
 
 (async function gh12094() {

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -411,7 +411,7 @@ async function gh12342_manual() {
 
 async function gh12342_auto() {
   interface Project {
-    name?: string | null, stars?: number | null
+    name?: string, stars?: number
   }
 
   const ProjectSchema = new Schema({

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -372,50 +372,50 @@ export function autoTypedSchema() {
   }
 
   type TestSchemaType = {
-    string1?: string | null;
-    string2?: string | null;
-    string3?: string | null;
-    string4?: string | null;
+    string1?: string;
+    string2?: string;
+    string3?: string;
+    string4?: string;
     string5: string;
-    number1?: number | null;
-    number2?: number | null;
-    number3?: number | null;
-    number4?: number | null;
+    number1?: number;
+    number2?: number;
+    number3?: number;
+    number4?: number;
     number5: number;
-    date1?: Date | null;
-    date2?: Date | null;
-    date3?: Date | null;
-    date4?: Date | null;
+    date1?: Date;
+    date2?: Date;
+    date3?: Date;
+    date4?: Date;
     date5: Date;
-    buffer1?: Buffer | null;
-    buffer2?: Buffer | null;
-    buffer3?: Buffer | null;
-    buffer4?: Buffer | null;
-    boolean1?: boolean | null;
-    boolean2?: boolean | null;
-    boolean3?: boolean | null;
-    boolean4?: boolean | null;
+    buffer1?: Buffer;
+    buffer2?: Buffer;
+    buffer3?: Buffer;
+    buffer4?: Buffer;
+    boolean1?: boolean;
+    boolean2?: boolean;
+    boolean3?: boolean;
+    boolean4?: boolean;
     boolean5: boolean;
-    mixed1?: any | null;
-    mixed2?: any | null;
-    mixed3?: any | null;
-    objectId1?: Types.ObjectId | null;
-    objectId2?: Types.ObjectId | null;
-    objectId3?: Types.ObjectId | null;
-    customSchema?: Int8 | null;
-    map1?: Map<string, string> | null;
-    map2?: Map<string, number> | null;
+    mixed1?: any;
+    mixed2?: any;
+    mixed3?: any;
+    objectId1?: Types.ObjectId;
+    objectId2?: Types.ObjectId;
+    objectId3?: Types.ObjectId;
+    customSchema?: Int8;
+    map1?: Map<string, string>;
+    map2?: Map<string, number>;
     array1: string[];
     array2: any[];
     array3: any[];
     array4: any[];
     array5: any[];
     array6: string[];
-    array7?: string[] | null;
-    array8?: string[] | null;
-    decimal1?: Types.Decimal128 | null;
-    decimal2?: Types.Decimal128 | null;
-    decimal3?: Types.Decimal128 | null;
+    array7?: string[];
+    array8?: string[];
+    decimal1?: Types.Decimal128;
+    decimal2?: Types.Decimal128;
+    decimal3?: Types.Decimal128;
   };
 
   const TestSchema = new Schema({
@@ -552,17 +552,17 @@ export function autoTypedSchema() {
 export type AutoTypedSchemaType = {
   schema: {
     userName: string;
-    description?: string | null;
+    description?: string;
     nested?: {
       age: number;
-      hobby?: string | null
-    } | null,
-    favoritDrink?: 'Tea' | 'Coffee' | null,
+      hobby?: string
+    },
+    favoritDrink?: 'Tea' | 'Coffee',
     favoritColorMode: 'dark' | 'light'
-    friendID?: Types.ObjectId | null;
+    friendID?: Types.ObjectId;
     nestedArray: Types.DocumentArray<{
       date: Date;
-      messages?: number | null;
+      messages?: number;
     }>
   }
   , statics: {
@@ -639,7 +639,7 @@ function gh12003() {
 
   expectType<'type'>({} as ObtainSchemaGeneric<typeof BaseSchema, 'TSchemaOptions'>['typeKey']);
 
-  expectType<{ name?: string | null }>({} as BaseSchemaType);
+  expectType<{ name?: string }>({} as BaseSchemaType);
 }
 
 function gh11987() {
@@ -675,7 +675,7 @@ function gh12030() {
     }
   ]>;
   expectType<{
-    username?: string | null
+    username?: string
   }[]>({} as A);
 
   type B = ObtainDocumentType<{
@@ -687,13 +687,13 @@ function gh12030() {
   }>;
   expectType<{
     users: {
-      username?: string | null
+      username?: string
     }[];
   }>({} as B);
 
   expectType<{
     users: {
-      username?: string | null
+      username?: string
     }[];
   }>({} as InferSchemaType<typeof Schema1>);
 
@@ -715,7 +715,7 @@ function gh12030() {
   expectType<{
     users: Types.DocumentArray<{
       credit: number;
-      username?: string | null;
+      username?: string;
     }>;
   }>({} as InferSchemaType<typeof Schema3>);
 
@@ -724,7 +724,7 @@ function gh12030() {
     data: { type: { role: String }, default: {} }
   });
 
-  expectType<{ data: { role?: string | null } }>({} as InferSchemaType<typeof Schema4>);
+  expectType<{ data: { role?: string } }>({} as InferSchemaType<typeof Schema4>);
 
   const Schema5 = new Schema({
     data: { type: { role: Object }, default: {} }
@@ -749,7 +749,7 @@ function gh12030() {
     track?: {
       backupCount: number;
       count: number;
-    } | null;
+    };
   }>({} as InferSchemaType<typeof Schema6>);
 
 }
@@ -826,7 +826,7 @@ function gh12450() {
   });
 
   expectType<{
-    user?: Types.ObjectId | null;
+    user?: Types.ObjectId;
   }>({} as InferSchemaType<typeof ObjectIdSchema>);
 
   const Schema2 = new Schema({
@@ -841,14 +841,14 @@ function gh12450() {
     decimalValue: { type: Schema.Types.Decimal128 }
   });
 
-  expectType<{ createdAt: Date, decimalValue?: Types.Decimal128 | null }>({} as InferSchemaType<typeof Schema3>);
+  expectType<{ createdAt: Date, decimalValue?: Types.Decimal128 }>({} as InferSchemaType<typeof Schema3>);
 
   const Schema4 = new Schema({
     createdAt: { type: Date },
     decimalValue: { type: Schema.Types.Decimal128 }
   });
 
-  expectType<{ createdAt?: Date | null, decimalValue?: Types.Decimal128 | null }>({} as InferSchemaType<typeof Schema4>);
+  expectType<{ createdAt?: Date, decimalValue?: Types.Decimal128 }>({} as InferSchemaType<typeof Schema4>);
 }
 
 function gh12242() {
@@ -872,7 +872,7 @@ function testInferTimestamps() {
   // an error "Parameter type { createdAt: Date; updatedAt: Date; name?: string | undefined; }
   // is not identical to argument type { createdAt: NativeDate; updatedAt: NativeDate; } &
   // { name?: string | undefined; }"
-  expectType<{ createdAt: Date, updatedAt: Date } & { name?: string | null }>({} as WithTimestamps);
+  expectType<{ createdAt: Date, updatedAt: Date } & { name?: string }>({} as WithTimestamps);
 
   const schema2 = new Schema({
     name: String
@@ -898,25 +898,25 @@ function gh12431() {
   });
 
   type Example = InferSchemaType<typeof testSchema>;
-  expectType<{ testDate?: Date | null, testDecimal?: Types.Decimal128 | null }>({} as Example);
+  expectType<{ testDate?: Date, testDecimal?: Types.Decimal128 }>({} as Example);
 }
 
 async function gh12593() {
   const testSchema = new Schema({ x: { type: Schema.Types.UUID } });
 
   type Example = InferSchemaType<typeof testSchema>;
-  expectType<{ x?: Buffer | null }>({} as Example);
+  expectType<{ x?: Buffer }>({} as Example);
 
   const Test = model('Test', testSchema);
 
   const doc = await Test.findOne({ x: '4709e6d9-61fd-435e-b594-d748eb196d8f' }).orFail();
-  expectType<Buffer | undefined | null>(doc.x);
+  expectType<Buffer | undefined>(doc.x);
 
   const doc2 = new Test({ x: '4709e6d9-61fd-435e-b594-d748eb196d8f' });
-  expectType<Buffer | undefined | null>(doc2.x);
+  expectType<Buffer | undefined>(doc2.x);
 
   const doc3 = await Test.findOne({}).orFail().lean();
-  expectType<Buffer | undefined | null>(doc3.x);
+  expectType<Buffer | undefined>(doc3.x);
 
   const arrSchema = new Schema({ arr: [{ type: Schema.Types.UUID }] });
 
@@ -982,7 +982,7 @@ function gh12611() {
   expectType<{
     description: string;
     skills: Types.ObjectId[];
-    anotherField?: string | null;
+    anotherField?: string;
   }>({} as Props);
 }
 

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -26,13 +26,8 @@ declare module 'mongoose' {
    */
    type ObtainDocumentType<DocDefinition, EnforcedDocType = any, TSchemaOptions extends Record<any, any> = DefaultSchemaOptions> =
    IsItRecordAndNotAny<EnforcedDocType> extends true ? EnforcedDocType : {
-     [K in keyof (
-       RequiredPaths<DocDefinition, TSchemaOptions['typeKey']> &
-       OptionalPaths<DocDefinition, TSchemaOptions['typeKey']>
-     )]:
-     IsPathRequired<DocDefinition[K], TSchemaOptions['typeKey']> extends true ?
-       ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>:
-       ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']> | null;
+     [K in keyof (RequiredPaths<DocDefinition, TSchemaOptions['typeKey']> &
+     OptionalPaths<DocDefinition, TSchemaOptions['typeKey']>)]: ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>;
    };
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Probably best to defer the change from #12781 until our 7.0 release. The change seemed easy enough, but then we got bit by test failures in master that we didn't notice until after we merged our PR for 6.9. This change may require users to update method return signatures and do other additional work, so it is likely a bit too big of a change for a minor release.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
