### PR TITLE
Fix "near" aggregation operator input type

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -360,13 +360,12 @@ Aggregate.prototype.project = function(arg) {
  * #### Example:
  *
  *     aggregate.near({
- *       near: [40.724, -73.997],
+ *       near: { type: 'Point', coordinates: [40.724, -73.997] },
  *       distanceField: "dist.calculated", // required
  *       maxDistance: 0.008,
  *       query: { type: "public" },
  *       includeLocs: "dist.location",
- *       uniqueDocs: true,
- *       num: 5
+ *       spherical: true,
  *     });
  *
  * @see $geoNear https://docs.mongodb.org/manual/reference/aggregation/geoNear/

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -171,11 +171,8 @@ declare module 'mongoose' {
      */
     model(): Model<any>;
 
-    /**
-     * Append a new $near operator to this aggregation pipeline
-     * @param arg $near operator contents
-     */
-    near(arg: { near?: number[]; distanceField: string; maxDistance?: number; query?: Record<string, any>; includeLocs?: string; num?: number; uniqueDocs?: boolean }): this;
+    /** Appends a new $geoNear operator to this aggregate pipeline. */
+    near(arg: PipelineStage.GeoNear['$geoNear']): this;
 
     /** Returns the current pipeline */
     pipeline(): PipelineStage[];

--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -120,7 +120,11 @@ declare module 'mongoose' {
         minDistance?: number;
         query?: AnyObject;
         spherical?: boolean;
-        uniqueDocs?: boolean;
+        /**
+         * Deprecated. Use only with MondoDB below 4.2 (removed in 4.2)
+         * @deprecated
+         */
+        num?: number;
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The current input parameter type for `near` aggregation operator does not reflect what MongoDB actually supports since version `4.0` (https://www.mongodb.com/docs/v4.0/reference/operator/aggregation/geoNear/). `4.0` is minimum supported version by Mongoose `^6.0.0` (https://mongoosejs.com/docs/compatibility.html).

I've switched to the correct (already existing) interface, removed `uniqueDocs` property (which has no effect since MongoDB `2.6`) and added `num` property supported in MongoDB `4.0.x` but removed in `4.2`.

**Examples**

Without these changes, I cannot, for example, use GeoJSON point:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/434135/214920174-1aed35fc-27a3-4a1a-aef5-db5ab67cbd19.png">

