### PR TITLE
fix(query): handles validation errors when updating required fields to undefined

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -87,7 +87,7 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     const toUnset = {};
     if (val != null) {
       for (const key of Object.keys(val)) {
-        if (val[key] === undefined) {
+        if (val[key] === undefined && !schema.requiredPaths().includes(key)) {
           toUnset[key] = 1;
         }
       }


### PR DESCRIPTION
fix #12930

**Summary**
#12794 didn't handle the case of an update to `undefined` of a `required` field.