### PR TITLE
fix(connection): handles unique autoincrement ID for connections

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -72,7 +72,7 @@ function Connection(base) {
   if (typeof base === 'undefined' || !base.connections.length) {
     this.id = 0;
   } else {
-    this.id = base.connections.length;
+    this.id = base.nextConnectionId;
   }
   this._queue = [];
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ const objectIdHexRegexp = /^[0-9A-Fa-f]{24}$/;
  */
 function Mongoose(options) {
   this.connections = [];
+  this.nextConnectionId = 0;
   this.models = {};
   this.events = new EventEmitter();
   this.__driver = driver.get();
@@ -345,6 +346,7 @@ Mongoose.prototype.createConnection = function(uri, options, callback) {
     options = null;
   }
   _mongoose.connections.push(conn);
+  _mongoose.nextConnectionId++;
   _mongoose.events.emit('createConnection', conn);
 
   if (arguments.length > 0) {
@@ -788,6 +790,27 @@ Mongoose.prototype.__defineSetter__('connection', function(v) {
  */
 
 Mongoose.prototype.connections;
+
+/**
+ * An integer containing the value of the next connection id. Calling
+ * [`createConnection()`](#mongoose_Mongoose-createConnection) increments
+ * this value.
+ *
+ * #### Example:
+ *
+ *     const mongoose = require('mongoose');
+ *     mongoose.createConnection(); // id `1`, `nextConnectionId` becomes `2`
+ *     mongoose.createConnection(); // id `2`, `nextConnectionId` becomes `3`
+ *     mongoose.connections[0].destroy() // Removes connection with id `1`
+ *     mongoose.createConnection(); // id `3`, `nextConnectionId` becomes `4`
+ *
+ * @memberOf Mongoose
+ * @instance
+ * @property {Number} nextConnectionId
+ * @api private
+ */
+
+Mongoose.prototype.nextConnectionId;
 
 /**
  * The Mongoose Aggregate constructor

--- a/lib/index.js
+++ b/lib/index.js
@@ -799,10 +799,10 @@ Mongoose.prototype.connections;
  * #### Example:
  *
  *     const mongoose = require('mongoose');
+ *     mongoose.createConnection(); // id `0`, `nextConnectionId` becomes `1`
  *     mongoose.createConnection(); // id `1`, `nextConnectionId` becomes `2`
+ *     mongoose.connections[0].destroy() // Removes connection with id `0`
  *     mongoose.createConnection(); // id `2`, `nextConnectionId` becomes `3`
- *     mongoose.connections[0].destroy() // Removes connection with id `1`
- *     mongoose.createConnection(); // id `3`, `nextConnectionId` becomes `4`
  *
  * @memberOf Mongoose
  * @instance

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1514,4 +1514,16 @@ describe('connections:', function() {
 
     await m.disconnect();
   });
+
+  it('should create connections with unique IDs also if one has been destroyed (gh-12966)', function() {
+    const m = new mongoose.Mongoose();
+    m.createConnection();
+    m.createConnection();
+    m.connections[0].destroy();
+    m.createConnection();
+    m.createConnection();
+    m.createConnection();
+    const connectionIds = m.connections.map(c => c.id);
+    assert.deepEqual(connectionIds, [1, 2, 3, 4, 5]);
+  });
 });


### PR DESCRIPTION
fix #12966

**Summary**
Added `nextConnectionId` counter to keep track of auto-increment IDs for new connections.