### PR TITLE
fix(query): revert breaking changes introduced by #12797

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -84,14 +84,6 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     const op = ops[i];
     val = ret[op];
     hasDollarKey = hasDollarKey || op.startsWith('$');
-    const toUnset = {};
-    if (val != null) {
-      for (const key of Object.keys(val)) {
-        if (val[key] === undefined) {
-          toUnset[key] = 1;
-        }
-      }
-    }
 
     if (val &&
         typeof val === 'object' &&
@@ -108,10 +100,6 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
 
     if (op.startsWith('$') && utils.isEmptyObject(val)) {
       delete ret[op];
-      if (op === '$set' && !utils.isEmptyObject(toUnset)) {
-        // Unset all undefined values
-        ret['$unset'] = toUnset;
-      }
     }
   }
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4314,42 +4314,6 @@ describe('Query', function() {
     assert.strictEqual(found[0].title, 'burrito bowl');
   });
 
-  it('update operation should remove fields set to undefined (gh-12794) (gh-12821)', async function() {
-    const m = new mongoose.Mongoose();
-
-    await m.connect(start.uri);
-
-    const schema = new mongoose.Schema({ title: String });
-
-    const Test = m.model('test', schema);
-
-    const doc = await Test.create({
-      title: 'test'
-    });
-
-    assert.strictEqual(doc.title, 'test');
-
-    const updatedDoc = await Test.findOneAndUpdate(
-      {
-        _id: doc._id
-      },
-      { title: undefined },
-      { returnOriginal: false }
-    ).lean();
-
-    assert.ok('title' in updatedDoc === false);
-
-    const replacedDoc = await Test.findOneAndReplace(
-      {
-        _id: doc._id
-      },
-      { title: undefined },
-      { returnOriginal: false }
-    ).lean();
-
-    assert.ok('title' in replacedDoc === false);
-  });
-
   it('handles $elemMatch with nested schema (gh-12902)', async function() {
     const bioSchema = new Schema({
       name: { type: String }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4314,6 +4314,32 @@ describe('Query', function() {
     assert.strictEqual(found[0].title, 'burrito bowl');
   });
 
+  it('update operation should not remove fields set to undefined (gh-12930)', async function() {
+    const m = new mongoose.Mongoose();
+
+    await m.connect(start.uri);
+
+    const schema = new mongoose.Schema({ title: String });
+
+    const Test = m.model('test', schema);
+
+    const doc = await Test.create({
+      title: 'test'
+    });
+
+    assert.strictEqual(doc.title, 'test');
+
+    const updatedDoc = await Test.findOneAndUpdate(
+      {
+        _id: doc._id
+      },
+      { title: undefined },
+      { returnOriginal: false }
+    ).lean();
+
+    assert.strictEqual(updatedDoc.title, 'test');
+  });
+
   it('handles $elemMatch with nested schema (gh-12902)', async function() {
     const bioSchema = new Schema({
       name: { type: String }


### PR DESCRIPTION
closes #12930

**Summary**
As a result of [this](https://github.com/Automattic/mongoose/issues/12930#issuecomment-1416503984) conversation, #12797 introduced breaking changes.
This PR revert them (as well as the fix of #12826) to the previous behavior.

Update queries now do not remove fields set to `undefined`.