### PR TITLE
fix(document): save newly set defaults underneath single nested subdocuments

### DIFF
--- a/lib/helpers/document/applyDefaults.js
+++ b/lib/helpers/document/applyDefaults.js
@@ -78,7 +78,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
 
             if (typeof def !== 'undefined') {
               doc_[piece] = def;
-              doc.$__.activePaths.default(p);
+              applyChangeTracking(doc, p);
             }
           } else if (included) {
             // selected field
@@ -91,7 +91,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
 
             if (typeof def !== 'undefined') {
               doc_[piece] = def;
-              doc.$__.activePaths.default(p);
+              applyChangeTracking(doc, p);
             }
           }
         } else {
@@ -104,7 +104,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
 
           if (typeof def !== 'undefined') {
             doc_[piece] = def;
-            doc.$__.activePaths.default(p);
+            applyChangeTracking(doc, p);
           }
         }
       } else {
@@ -113,3 +113,14 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
     }
   }
 };
+
+/*!
+ * ignore
+ */
+
+function applyChangeTracking(doc, fullPath) {
+  doc.$__.activePaths.default(fullPath);
+  if (doc.$isSubdocument && doc.$isSingleNested && doc.$parent() != null) {
+    doc.$parent().$__.activePaths.default(doc.$__pathRelativeToParent(fullPath));
+  }
+}

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12110,6 +12110,44 @@ describe('document', function() {
     assert.equal(existingTest.isModified(), true);
     assert.equal(existingTest.modifiedPaths().length, 1);
   });
+
+  it('saves single nested subdoc defaults (gh-12905)', async function() {
+    const nestedSchema = new mongoose.Schema({
+      refOriginal: String,
+      refAnother: {
+        type: String,
+        default: () => 'goodbye'
+      }
+    });
+    const testSchema = new mongoose.Schema({
+      original: String,
+      another: {
+        type: String,
+        default: 'hello'
+      },
+      referenced: {
+        type: nestedSchema,
+        default: () => ({})
+      }
+    });
+    const Test = db.model('Test', testSchema);
+
+    const _id = new mongoose.Types.ObjectId();
+    await Test.collection.insertOne({
+      _id,
+      original: 'foo',
+      referenced: { refOriginal: 'hello' }
+    });
+
+    const doc = await Test.findById(_id);
+    assert.equal(doc.referenced.refOriginal, 'hello');
+    assert.equal(doc.referenced.refAnother, 'goodbye');
+
+    await doc.save();
+    const rawDoc = await Test.findById(_id).lean();
+    assert.equal(rawDoc.referenced.refOriginal, 'hello');
+    assert.equal(rawDoc.referenced.refAnother, 'goodbye');
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #12905

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If `applyDefaults()` creates a default underneath a single nested subdocument when loading from MongoDB, a subsequent `save()` won't save that default. This is a quick fix that handles that particular case. It won't handle nested subdocuments, or subdocuments underneath arrays, because that's proven to be a bit trickier. However, this PR should be enough to unblock OP from #12905 with minimal risk, and we can improve change tracking in this case later.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
