### PR TITLE
fix(document): make array `$shift()` use `$pop` instead of overwriting array

### DIFF
--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -137,12 +137,13 @@ const methods = {
     this._markModified();
 
     // only allow shifting once
-    if (this._shifted) {
+    const __array = this.__array;
+    if (__array._shifted) {
       return;
     }
-    this._shifted = true;
+    __array._shifted = true;
 
-    return [].shift.call(this);
+    return [].shift.call(__array);
   },
 
   /**

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12148,6 +12148,20 @@ describe('document', function() {
     assert.equal(rawDoc.referenced.refOriginal, 'hello');
     assert.equal(rawDoc.referenced.refAnother, 'goodbye');
   });
+
+  it('$shift() triggers $pop', function() {
+    const Test = db.model('Test', mongoose.Schema({
+      arr: [String]
+    }, { autoCreate: false, autoIndex: false }));
+
+    const doc = Test.hydrate({ arr: ['a', 'b', 'c'] });
+    doc.arr.$shift();
+
+    assert.deepStrictEqual(
+      doc.getChanges(),
+      { $pop: { arr: -1 }, $inc: { __v: 1 } }
+    );
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like in Mongoose 6.0.0, our switch to using proxies for arrays broke some internal behavior for `$shift()`. The TLDR; is that `$shift()` mistakenly always becomes a `$set`, as opposed to a `$pop`, since 6.0.0. Which may have performance implications for large arrays.

This issue was happening because 1) setting `_shifted` on the array proxy triggers a `$set`, and 2) calling `shift()` on an array proxy also triggers a `$set`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
