### PR TITLE
fix(connection): disable createConnection buffering if autoCreate option is changed

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1341,7 +1341,10 @@ Model.init = function init(callback) {
 
   this.schema.emit('init', this);
 
-  if (this.$init != null) {
+  const autoCreate = utils.getOption('autoCreate',
+    this.schema.options, this.db.config, this.db.base.options);
+
+  if (this.$init != null && this.$autoCreate === autoCreate) {
     if (callback) {
       this.$init.then(() => callback(), err => callback(err));
       return null;
@@ -1349,10 +1352,10 @@ Model.init = function init(callback) {
     return this.$init;
   }
 
+  this.$autoCreate = autoCreate;
+
   const Promise = PromiseProvider.get();
   const autoIndex = utils.getOption('autoIndex',
-    this.schema.options, this.db.config, this.db.base.options);
-  const autoCreate = utils.getOption('autoCreate',
     this.schema.options, this.db.config, this.db.base.options);
 
   const _ensureIndexes = autoIndex ?

--- a/lib/model.js
+++ b/lib/model.js
@@ -60,9 +60,11 @@ const modifiedPaths = require('./helpers/update/modifiedPaths');
 const parallelLimit = require('./helpers/parallelLimit');
 const parentPaths = require('./helpers/path/parentPaths');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
+const promiseOrCallback = require('./helpers/promiseOrCallback');
 const pushNestedArrayPaths = require('./helpers/model/pushNestedArrayPaths');
 const removeDeselectedForeignField = require('./helpers/populate/removeDeselectedForeignField');
 const setDottedPath = require('./helpers/path/setDottedPath');
+const STATES = require('./connectionstate');
 const util = require('util');
 const utils = require('./utils');
 
@@ -1341,18 +1343,13 @@ Model.init = function init(callback) {
 
   this.schema.emit('init', this);
 
-  const autoCreate = utils.getOption('autoCreate',
-    this.schema.options, this.db.config, this.db.base.options);
-
-  if (this.$init != null && this.$autoCreate === autoCreate) {
+  if (this.$init != null) {
     if (callback) {
       this.$init.then(() => callback(), err => callback(err));
       return null;
     }
     return this.$init;
   }
-
-  this.$autoCreate = autoCreate;
 
   const Promise = PromiseProvider.get();
   const autoIndex = utils.getOption('autoIndex',
@@ -1361,9 +1358,33 @@ Model.init = function init(callback) {
   const _ensureIndexes = autoIndex ?
     cb => this.ensureIndexes({ _automatic: true }, cb) :
     cb => cb();
-  const _createCollection = autoCreate ?
-    cb => this.createCollection({}, cb) :
-    cb => cb();
+
+  const model = this;
+  const _wrapCollHelper = function(fn) {
+    return function(cb) {
+      const conn = model.db;
+
+      return promiseOrCallback(cb, cb => {
+        immediate(() => {
+          if ((conn.readyState === STATES.connecting || conn.readyState === STATES.disconnected) && conn._shouldBufferCommands()) {
+            conn._queue.push({ fn: fn, ctx: conn, args: [cb] });
+          } else {
+            try {
+              fn.apply(conn, [cb]);
+            } catch (err) {
+              return cb(err);
+            }
+          }
+        });
+      });
+    };
+  };
+  const _createCollection = _wrapCollHelper(function _createCollection(cb) {
+    const autoCreate = utils.getOption('autoCreate',
+      model.schema.options, model.db.config, model.db.base.options);
+    if (autoCreate) model.createCollection({}, cb);
+    else cb();
+  });
 
   this.$init = new Promise((resolve, reject) => {
     _createCollection(error => {

--- a/lib/model.js
+++ b/lib/model.js
@@ -60,7 +60,6 @@ const modifiedPaths = require('./helpers/update/modifiedPaths');
 const parallelLimit = require('./helpers/parallelLimit');
 const parentPaths = require('./helpers/path/parentPaths');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
-const promiseOrCallback = require('./helpers/promiseOrCallback');
 const pushNestedArrayPaths = require('./helpers/model/pushNestedArrayPaths');
 const removeDeselectedForeignField = require('./helpers/populate/removeDeselectedForeignField');
 const setDottedPath = require('./helpers/path/setDottedPath');
@@ -1354,39 +1353,30 @@ Model.init = function init(callback) {
   }
 
   const Promise = PromiseProvider.get();
-  const autoIndex = utils.getOption('autoIndex',
-    this.schema.options, this.db.config, this.db.base.options);
-
-  const _ensureIndexes = autoIndex ?
-    cb => this.ensureIndexes({ _automatic: true }, cb) :
-    cb => cb();
 
   const model = this;
-  const _wrapCollHelper = function(fn) {
-    return function(cb) {
-      const conn = model.db;
-
-      return promiseOrCallback(cb, cb => {
-        immediate(() => {
-          if ((conn.readyState === STATES.connecting || conn.readyState === STATES.disconnected) && conn._shouldBufferCommands()) {
-            conn._queue.push({ fn: fn, ctx: conn, args: [cb] });
-          } else {
-            try {
-              fn.apply(conn, [cb]);
-            } catch (err) {
-              return cb(err);
-            }
-          }
-        });
-      });
-    };
-  };
-  const _createCollection = _wrapCollHelper(function _createCollection(cb) {
-    const autoCreate = utils.getOption('autoCreate',
+  const _ensureIndexes = function(cb) {
+    const autoIndex = utils.getOption('autoIndex',
       model.schema.options, model.db.config, model.db.base.options);
-    if (autoCreate) model.createCollection({}, cb);
+    if (autoIndex) model.ensureIndexes({ _automatic: true }, cb);
     else cb();
-  });
+  };
+  const _createCollection = function(cb) {
+    const conn = model.db;
+
+    if ((conn.readyState === STATES.connecting || conn.readyState === STATES.disconnected) && conn._shouldBufferCommands()) {
+      conn._queue.push({ fn: _createCollection, ctx: conn, args: [cb] });
+    } else {
+      try {
+        const autoCreate = utils.getOption('autoCreate',
+          model.schema.options, model.db.config, model.db.base.options);
+        if (autoCreate) model.createCollection({}, cb);
+        else cb();
+      } catch (err) {
+        return cb(err);
+      }
+    }
+  };
 
   this.$init = new Promise((resolve, reject) => {
     _createCollection(error => {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1526,4 +1526,23 @@ describe('connections:', function() {
     const connectionIds = m.connections.map(c => c.id);
     assert.deepEqual(connectionIds, [1, 2, 3, 4, 5]);
   });
+
+  it('with autoCreate = false after schema create (gh-12940)', async function() {
+    const m = new mongoose.Mongoose();
+
+    const schema = new Schema({ name: String }, {
+      collation: { locale: 'en_US', strength: 1 },
+      collection: 'gh12940_Conn'
+    });
+    const Model = m.model('gh12940_Conn', schema);
+
+    await m.connect(start.uri, {
+      autoCreate: false
+    });
+
+    await Model.init();
+
+    const res = await m.connection.db.listCollections().toArray();
+    assert.ok(!res.map(c => c.name).includes('gh12940_Conn'));
+  });
 });


### PR DESCRIPTION
fix #12940

**Summary**
Avoid usage of cached `createCollection` callback if `autoCreate` option value has changed.
