### PR TITLE
chore: add strict populate as exported error

### DIFF
--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -205,7 +205,7 @@ MongooseError.MongooseServerSelectionError = require('./serverSelection');
 MongooseError.DivergentArrayError = require('./divergentArray');
 
 /**
- * Thrown when your try to pass values to model contrtuctor that
+ * Thrown when your try to pass values to model constructor that
  * were not specified in schema or change immutable properties when
  * `strict` mode is `"throw"`
  *
@@ -215,3 +215,14 @@ MongooseError.DivergentArrayError = require('./divergentArray');
  */
 
 MongooseError.StrictModeError = require('./strict');
+
+/**
+ * An instance of this error class will be returned when mongoose failed to
+ * populate with a path that is not existing.
+ *
+ * @api public
+ * @memberOf Error
+ * @static
+ */
+
+MongooseError.StrictPopulateError = require('./strictPopulate');

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -9,6 +9,7 @@ const start = require('./common');
 const assert = require('assert');
 const utils = require('../lib/utils');
 const util = require('./util');
+const MongooseError = require('../lib/error/mongooseError');
 
 const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
@@ -10965,6 +10966,7 @@ describe('model: populate:', function() {
     assert.equal(person.stories[0].title, 'Casino Royale');
   });
 
+
   describe('strictPopulate', function() {
     it('reports full path when throwing `strictPopulate` error with deep populate (gh-10923)', async function() {
       const L2 = db.model('Test', new Schema({ name: String }));
@@ -11001,6 +11003,7 @@ describe('model: populate:', function() {
         then(() => null, err => err);
       assert.ok(err);
       assert.ok(err.message.includes('strictPopulate'), err.message);
+      assert.ok(err instanceof MongooseError.StrictPopulateError);
     });
 
     it('allows overwriting localField and foreignField when populating a virtual gh-6963', async function() {

--- a/types/error.d.ts
+++ b/types/error.d.ts
@@ -129,5 +129,10 @@ declare module 'mongoose' {
 
       constructor(doc: Document, currentVersion: number, modifiedPaths: Array<string>);
     }
+
+    export class StrictPopulateError extends MongooseError {
+      name: 'StrictPopulateError';
+      path: string;
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Add and export `StrictPopulateError` class so it can be used by ts/esm modules

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
```javascript
import { MongooseError } from 'mongoose';

const err = new MongooseError.StrictPopulateError('test')

if(err instanceof MongooseError.StrictPopulateError){
  // do something
}
``` 

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
