### PR TITLE
fix(schematype): fixed validation for required UUID field

### DIFF
--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -234,7 +234,7 @@ SchemaUUID.prototype.checkRequired = function checkRequired(value) {
   if (Buffer.isBuffer(value)) {
     value = binaryToString(value);
   }
-  return UUID_FORMAT.test(value);
+  return value != null && UUID_FORMAT.test(value);
 };
 
 /**

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -231,6 +231,9 @@ SchemaUUID.checkRequired = SchemaType.checkRequired;
  */
 
 SchemaUUID.prototype.checkRequired = function checkRequired(value) {
+  if (Buffer.isBuffer(value)) {
+    value = binaryToString(value);
+  }
   return UUID_FORMAT.test(value);
 };
 

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -1504,6 +1504,37 @@ describe('schema', function() {
         name: 'uuidRefName'
       });
       assert.ifError(uuidRef.validateSync());
+
+      const uuidRef2 = new UUIDRefModel({
+        _id: uuidv4(),
+        uuidNonRef: uuidv4(),
+        uuidRefNonRequired: uuidv4(),
+        name: 'uuidRefName'
+      });
+
+      const err2 = uuidRef2.validateSync();
+      assert.ok(err2);
+      assert.ok(err2.errors['uuidRef']);
+
+      const uuidRef3 = new UUIDRefModel({
+        _id: uuidv4(),
+        uuidRef: uuidv4(),
+        uuidRefNonRequired: uuidv4(),
+        name: 'uuidRefName'
+      });
+
+      const err3 = uuidRef3.validateSync();
+      assert.ok(err3);
+      assert.ok(err3.errors['uuidNonRef']);
+
+      const uuidRef4 = new UUIDRefModel({
+        _id: uuidv4(),
+        uuidRef: uuidv4(),
+        uuidNonRef: uuidv4(),
+        name: 'uuidRefName'
+      });
+
+      assert.ifError(uuidRef4.validateSync());
     });
   });
 });

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -9,6 +9,7 @@ const start = require('./common');
 const Promise = require('bluebird');
 const assert = require('assert');
 const random = require('./util').random;
+const { v4: uuidv4 } = require('uuid');
 
 const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
@@ -1472,6 +1473,37 @@ describe('schema', function() {
         // Assert
         assert.ifError(err);
       });
+    });
+
+    it('should validate required UUID fields correctly (gh-12991)', function() {
+      const uuidSchema = new mongoose.Schema({
+        _id: { type: mongoose.Schema.Types.UUID, required: true },
+        name: { type: mongoose.Schema.Types.String, required: true }
+      });
+
+      const uuidRefSchema = new mongoose.Schema({
+        _id: { type: mongoose.Schema.Types.UUID, required: true },
+        uuidRef: { type: mongoose.Schema.Types.UUID, ref: 'UUIDModel', required: true },
+        uuidNonRef: { type: mongoose.Schema.Types.UUID, required: true },
+        uuidRefNonRequired: { type: mongoose.Schema.Types.UUID, ref: 'UUIDModel' },
+        name: { type: mongoose.Schema.Types.String, required: true }
+      });
+
+      const UUIDModel = mongoose.model('UUIDModel', uuidSchema, 'uuids');
+
+      const UUIDRefModel = mongoose.model('UUIDRefModel', uuidRefSchema, 'uuidRefs');
+
+      const uuid = new UUIDModel({ _id: uuidv4(), name: 'uuidName' });
+      assert.ifError(uuid.validateSync());
+
+      const uuidRef = new UUIDRefModel({
+        _id: uuidv4(),
+        uuidRef: uuidv4(),
+        uuidNonRef: uuidv4(),
+        uuidRefNonRequired: uuidv4(),
+        name: 'uuidRefName'
+      });
+      assert.ifError(uuidRef.validateSync());
     });
   });
 });


### PR DESCRIPTION
closes #12991

**Summary**
Added conversion of buffered `UUID` values to pass the `checkRequired` test.