### PR TITLE
feat(index): added createInitialConnection option to Mongoose constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,11 @@ function Mongoose(options) {
     autoIndex: true,
     autoCreate: true
   }, options);
-  const conn = this.createConnection(); // default connection
-  conn.models = this.models;
+  const createInitialConnection = utils.getOption('createInitialConnection', this.options) ?? true;
+  if (createInitialConnection) {
+    const conn = this.createConnection(); // default connection
+    conn.models = this.models;
+  }
 
   if (this.options.pluralization) {
     this._pluralize = legacyPluralize;

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,8 @@ function Mongoose(options) {
     autoIndex: true,
     autoCreate: true
   }, options);
-  const createInitialConnection = utils.getOption('createInitialConnection', this.options) ?? true;
-  if (createInitialConnection) {
+  const createInitialConnection = utils.getOption('createInitialConnection', this.options);
+  if (createInitialConnection == null || createInitialConnection) {
     const conn = this.createConnection(); // default connection
     conn.models = this.models;
   }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1526,4 +1526,11 @@ describe('connections:', function() {
     const connectionIds = m.connections.map(c => c.id);
     assert.deepEqual(connectionIds, [1, 2, 3, 4, 5]);
   });
+
+  it('should not create default connection with createInitialConnection = false (gh-12965)', function() {
+    const m = new mongoose.Mongoose({
+      createInitialConnection: false
+    });
+    assert.deepEqual(m.connections.length, 0);
+  });
 });

--- a/types/mongooseoptions.d.ts
+++ b/types/mongooseoptions.d.ts
@@ -64,6 +64,13 @@ declare module 'mongoose' {
     cloneSchemas?: boolean;
 
     /**
+     * Set to `false` to disable the creation of the initial default connection.
+     *
+     * @default true
+     */
+    createInitialConnection?: boolean;
+
+    /**
      * If `true`, prints the operations mongoose sends to MongoDB to the console.
      * If a writable stream is passed, it will log to that stream, without colorization.
      * If a callback function is passed, it will receive the collection name, the method


### PR DESCRIPTION
closes #12965

**Summary**
If explicitly set to `false` the `createInitialConnection` option will disable the creation of the default initial connection.