### PR TITLE
feat(query): remove all references to option "maxScan"

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -52,9 +52,7 @@ const queryOptionMethods = new Set([
   'j',
   'lean',
   'limit',
-  'maxScan',
   'maxTimeMS',
-  'maxscan',
   'populate',
   'projection',
   'read',
@@ -906,25 +904,6 @@ Query.prototype.skip = function skip(v) {
 };
 
 /**
- * Specifies the maxScan option.
- *
- * #### Example:
- *
- *     query.maxScan(100);
- *
- * #### Note:
- *
- * Cannot be used with `distinct()`
- *
- * @method maxScan
- * @memberOf Query
- * @instance
- * @param {Number} val
- * @see maxScan https://docs.mongodb.org/manual/reference/operator/maxScan/
- * @api public
- */
-
-/**
  * Specifies the batchSize option.
  *
  * #### Example:
@@ -1573,7 +1552,6 @@ Query.prototype.getOptions = function() {
  * - [hint](https://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24hint)
  * - [comment](https://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24comment)
  * - [snapshot](https://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bsnapshot%28%29%7D%7D)
- * - [maxscan](https://docs.mongodb.org/v3.2/reference/operator/meta/maxScan/#metaOp._S_maxScan)
  *
  * The following options are only for write operations: `update()`, `updateOne()`, `updateMany()`, `replaceOne()`, `findOneAndUpdate()`, and `findByIdAndUpdate()`:
  *
@@ -5530,18 +5508,6 @@ Query.prototype.cursor = function cursor(opts) {
 };
 
 // the rest of these are basically to support older Mongoose syntax with mquery
-
-/**
- * _DEPRECATED_ Alias of `maxScan`
- *
- * @deprecated
- * @see maxScan #query_Query-maxScan
- * @method maxscan
- * @memberOf Query
- * @instance
- */
-
-Query.prototype.maxscan = Query.base.maxScan;
 
 /**
  * Sets the tailable option (for use with capped collections).

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1311,15 +1311,6 @@ describe('Query', function() {
   // Advanced Query options
 
   describe('options', function() {
-    describe('maxscan', function() {
-      it('works', function(done) {
-        const query = new Query({});
-        query.maxscan(100);
-        assert.equal(query.options.maxScan, 100);
-        done();
-      });
-    });
-
     describe('slaveOk', function() {
       it('works', function(done) {
         let query = new Query({});

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -112,7 +112,6 @@ declare module 'mongoose' {
     lean?: boolean | any;
     limit?: number;
     maxTimeMS?: number;
-    maxscan?: number;
     multi?: boolean;
     multipleCastError?: boolean;
     /**
@@ -472,9 +471,6 @@ declare module 'mongoose' {
     /** Specifies an `$maxDistance` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     maxDistance(path: string, val: number): this;
     maxDistance(val: number): this;
-
-    /** Specifies the maxScan option. */
-    maxScan(val: number): this;
 
     /**
      * Sets the [maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS/)


### PR DESCRIPTION
**Summary**

This PR removes all references to query option `maxScan`, which [has been removed from the driver in 4.0](https://github.com/mongodb/node-mongodb-native/commit/0e6375a22fc3d1f4ce10846b98dafaa65044ef6d) and has been removed from [mongodb's (db) side since 4.2](https://www.mongodb.com/docs/v4.0/reference/method/cursor.maxScan/#cursor.maxScan) (and deprecated since 4.0)

PS: i am not quite sure if this *should* be removed already, because version 4.0 and 4.2 are still supported by the driver (but the options have been removed from the driver) and from what i can tell mongoose matches the drivers support of mongodb (db) versions