### PR TITLE
feat(query): remove all references to option "snapshot"

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -963,27 +963,6 @@ Query.prototype.skip = function skip(v) {
  */
 
 /**
- * Specifies this query as a `snapshot` query.
- *
- * #### Example:
- *
- *     query.snapshot(); // true
- *     query.snapshot(true);
- *     query.snapshot(false);
- *
- * #### Note:
- *
- * Cannot be used with `distinct()`
- *
- * @method snapshot
- * @memberOf Query
- * @instance
- * @see snapshot https://docs.mongodb.org/manual/reference/operator/snapshot/
- * @return {Query} this
- * @api public
- */
-
-/**
  * Sets query hints.
  *
  * #### Example:
@@ -1572,7 +1551,6 @@ Query.prototype.getOptions = function() {
  * - [readPreference](https://docs.mongodb.org/manual/applications/replication/#read-preference)
  * - [hint](https://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24hint)
  * - [comment](https://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24comment)
- * - [snapshot](https://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bsnapshot%28%29%7D%7D)
  * - [maxscan](https://docs.mongodb.org/v3.2/reference/operator/meta/maxScan/#metaOp._S_maxScan)
  *
  * The following options are only for write operations: `update()`, `updateOne()`, `updateMany()`, `replaceOne()`, `findOneAndUpdate()`, and `findByIdAndUpdate()`:

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1385,15 +1385,6 @@ describe('Query', function() {
       });
     });
 
-    describe('snapshot', function() {
-      it('works', function(done) {
-        const query = new Query({});
-        query.snapshot(true);
-        assert.equal(query.options.snapshot, true);
-        done();
-      });
-    });
-
     describe('batchSize', function() {
       it('works', function(done) {
         const query = new Query({});

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -147,7 +147,6 @@ declare module 'mongoose' {
     sanitizeFilter?: boolean;
     setDefaultsOnInsert?: boolean;
     skip?: number;
-    snapshot?: any;
     sort?: any;
     /** overwrites the schema's strict mode option */
     strict?: boolean | string;
@@ -605,9 +604,6 @@ declare module 'mongoose' {
     /** Specifies a `$slice` projection for an array. */
     slice(path: string, val: number | Array<number>): this;
     slice(val: number | Array<number>): this;
-
-    /** Specifies this query as a `snapshot` query. */
-    snapshot(val?: boolean): this;
 
     /** Sets the sort order. If an object is passed, values allowed are `asc`, `desc`, `ascending`, `descending`, `1`, and `-1`. */
     sort(arg?: string | { [key: string]: SortOrder | { $meta: 'textScore' } } | [string, SortOrder][] | undefined | null): this;


### PR DESCRIPTION
**Summary**

This PR removes the query option `snapshot`, which i could not find any documentation about it anymore (even for mongodb (db) 3.6), i could only find things for `readconcern: "snapshot"`

Note: this PR does not touch the read-concern option