### PR TITLE
Mongodb v4.13 Memoryleak fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "^4.7.0",
     "kareem": "2.5.1",
-    "mongodb": "4.13.0",
+    "mongodb": "4.14.0",
     "mpath": "0.9.0",
     "mquery": "4.0.3",
     "ms": "2.1.3",


### PR DESCRIPTION
**Summary**

According to https://www.mongodb.com/docs/drivers/node/current/whats-new/#what-s-new-in-4.14, `mongodb@4.13` has a memoryleak which is fixed in `mongodb@4.14`. Naturally they recommend to upgrade to 4.14

Other than that, the 4.14 version seems to only have "Deprecated methods and options that reference the legacy Logger." so the upgrade should be a no-brainer
