### PR TITLE
Don't allow Model.create() with keys that don't exist in the schema

### DIFF
--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -120,10 +120,6 @@ export function autoTypedModelConnection() {
 
   (async() => {
   // Model-functions-test
-  // Create should works with arbitrary objects.
-    const randomObject = await AutoTypedModel.create({ unExistKey: 'unExistKey', description: 'st' });
-    expectType<AutoTypedSchemaType['schema']['userName']>(randomObject.userName);
-
     const testDoc1 = await AutoTypedModel.create({ userName: 'M0_0a' });
     expectType<AutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
     expectType<AutoTypedSchemaType['schema']['description']>(testDoc1.description);

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -138,7 +138,7 @@ async function gh11117(): Promise<void> {
 
   const fooModel = model('foos', fooSchema);
 
-  const items = await fooModel.create<Foo>([
+  const items = await fooModel.create([
     {
       someId: new Types.ObjectId(),
       someDate: new Date(),

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -355,10 +355,6 @@ export function autoTypedModel() {
 
   (async() => {
   // Model-functions-test
-  // Create should works with arbitrary objects.
-    const randomObject = await AutoTypedModel.create({ unExistKey: 'unExistKey', description: 'st' });
-    expectType<AutoTypedSchemaType['schema']['userName']>(randomObject.userName);
-
     const testDoc1 = await AutoTypedModel.create({ userName: 'M0_0a' });
     expectType<AutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
     expectType<AutoTypedSchemaType['schema']['description']>(testDoc1.description);

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -185,12 +185,12 @@ declare module 'mongoose' {
     countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
     /** Creates a new document or documents */
-    create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, options?: SaveOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, callback: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): void;
-    create<DocContents = AnyKeys<T>>(doc: DocContents | T): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-    create<DocContents = AnyKeys<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
+    create(docs: Array<T | AnyKeys<T>>, options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create(docs: Array<T | AnyKeys<T>>, options?: SaveOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create(docs: Array<T | AnyKeys<T>>, callback: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): void;
+    create(doc: AnyKeys<T> | T): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+    create(...docs: Array<T | AnyKeys<T>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create(doc: T | AnyKeys<T>, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
 
     /**
      * Create the collection for this model. By default, if no indexes are specified,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Currently the Mongoose types allow to call `MyModel.create()` while specifying attributes that don't exist in the schema. This removes a lot of the benefits of static type-checking, as discussed in https://github.com/Automattic/mongoose/issues/10302.

This PR disallows nonexistent attributes without requiring the user to manually specify the type on every create call. It is not backwards compatible but I think it's a better default for people using TypeScript and is worth including in Mongoose 7. Thoughts?

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

Updated tests.
