### PR TITLE
Improve search generation script

### DIFF
--- a/docs/search.js
+++ b/docs/search.js
@@ -40,7 +40,7 @@ for (const [filename, file] of Object.entries(filemap)) {
         const content = new Content({
           title: `API: ${prop.string}`,
           body: prop.description,
-          url: `api.html#${prop.anchorId}`
+          url: `api/${_class.fileName}.html#${prop.anchorId}`
         });
         const err = content.validateSync();
         if (err != null) {

--- a/docs/search.js
+++ b/docs/search.js
@@ -16,6 +16,8 @@ markdown.setOptions({
   }
 });
 
+mongoose.set('strictQuery', false);
+
 // 5.13.5 -> 5.x, 6.8.2 -> 6.x, etc.
 version = version.slice(0, version.indexOf('.')) + '.x';
 

--- a/docs/search.js
+++ b/docs/search.js
@@ -114,7 +114,12 @@ for (const filename of files) {
   }
 }
 
-run().catch(error => console.error(error.stack));
+run().catch(async error => {
+  console.error(error.stack);
+
+  // ensure the script exists in case of error
+  await mongoose.disconnect();
+});
 
 async function run() {
   await mongoose.connect(config.uri, { dbName: 'mongoose' });

--- a/docs/search.js
+++ b/docs/search.js
@@ -124,6 +124,9 @@ run().catch(async error => {
 async function run() {
   await mongoose.connect(config.uri, { dbName: 'mongoose' });
 
+  // wait for the index to be created
+  await Content.init();
+
   await Content.deleteMany({ version });
   for (const content of contents) {
     if (version === '6.x') {

--- a/docs/search.js
+++ b/docs/search.js
@@ -31,10 +31,8 @@ contentSchema.index({ title: 'text', body: 'text' });
 const Content = mongoose.model('Content', contentSchema, 'Content');
 
 const contents = [];
-const files = Object.keys(filemap);
 
-for (const filename of files) {
-  const file = filemap[filename];
+for (const [filename, file] of Object.entries(filemap)) {
   if (file.api) {
     // API docs are special, raw content is in the `docs` property
     for (const _class of file.docs) {

--- a/docs/search.js
+++ b/docs/search.js
@@ -44,7 +44,7 @@ for (const [filename, file] of Object.entries(filemap)) {
         });
         const err = content.validateSync();
         if (err != null) {
-          console.log(content);
+          console.error(content);
           throw err;
         }
         contents.push(content);
@@ -122,6 +122,11 @@ run().catch(async error => {
 });
 
 async function run() {
+  if (!config || !config.uri) {
+    console.error('No Config or config.URI given, please create a .config.js file with those values');
+    process.exit(-1);
+  }
+
   await mongoose.connect(config.uri, { dbName: 'mongoose' });
 
   // wait for the index to be created

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "docs:checkout:gh-pages": "git checkout gh-pages",
     "docs:checkout:legacy": "git checkout 5.x",
     "docs:generate": "node ./scripts/website.js",
-    "docs:generate:search": "node docs/search.js",
+    "docs:generate:search": "node ./scripts/generateSearch.js",
     "docs:merge:stable": "git merge master",
     "docs:merge:legacy": "git merge 5.x",
     "docs:test": "npm run docs:generate && npm run docs:generate:search",

--- a/scripts/generateSearch.js
+++ b/scripts/generateSearch.js
@@ -2,7 +2,7 @@
 
 const config = require('../.config');
 const cheerio = require('cheerio');
-const filemap = require('./source');
+const filemap = require('../docs/source');
 const fs = require('fs');
 const pug = require('pug');
 const mongoose = require('../');
@@ -107,7 +107,7 @@ for (const [filename, file] of Object.entries(filemap)) {
         body: html,
         url: `${filename.replace('.pug', '.html').replace(/^docs/, '')}#${el.prop('id')}`
       });
-  
+
       content.validateSync();
       contents.push(content);
     });
@@ -137,7 +137,7 @@ async function run() {
     if (version === '6.x') {
       let url = content.url.startsWith('/') ? content.url : `/${content.url}`;
       if (!url.startsWith('/docs')) {
-        url = '/docs'  + url;
+        url = '/docs' + url;
       }
       content.url = url;
     } else {


### PR DESCRIPTION
**Summary**

This PR aims to improve the search generation script, by doing:
- move the script from `/docs` to `/scripts` (because it is not a browser script)
- disconnect on error (had it hanging for me)
- add useful error when no config is found
- change to use `/docs/api/file.html` over `/docs/api.html` (re https://github.com/Automattic/mongoose/pull/12223#issuecomment-1428470684 & https://github.com/Automattic/mongoose/issues/13033)
- use `Object.entries` over creating a one-time use array
- disable `strictQuery` warning
