### PR TITLE
BREAKING CHANGE: merge `$and`, `$or` conditions in query filters

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2359,6 +2359,15 @@ Query.prototype.merge = function(source) {
     // if source has a feature, apply it to ourselves
 
     if (source._conditions) {
+      opts.omit = {};
+      if (this._conditions?.$and && source._conditions.$and) {
+        opts.omit['$and'] = true;
+        this._conditions.$and = this._conditions.$and.concat(source._conditions.$and);
+      }
+      if (this._conditions?.$or && source._conditions.$or) {
+        opts.omit['$or'] = true;
+        this._conditions.$or = this._conditions.$or.concat(source._conditions.$or);
+      }
       utils.merge(this._conditions, source._conditions, opts);
     }
 
@@ -2388,6 +2397,16 @@ Query.prototype.merge = function(source) {
     utils.merge(this._conditions, { _id: source }, opts);
 
     return this;
+  }
+
+  opts.omit = {};
+  if (this._conditions?.$and && source.$and) {
+    opts.omit['$and'] = true;
+    this._conditions.$and = this._conditions.$and.concat(source.$and);
+  }
+  if (this._conditions?.$or && source.$or) {
+    opts.omit['$or'] = true;
+    this._conditions.$or = this._conditions.$or.concat(source.$or);
   }
 
   // plain object

--- a/lib/query.js
+++ b/lib/query.js
@@ -2360,11 +2360,11 @@ Query.prototype.merge = function(source) {
 
     if (source._conditions) {
       opts.omit = {};
-      if (this._conditions?.$and && source._conditions.$and) {
+      if (this._conditions && this._conditions.$and && source._conditions.$and) {
         opts.omit['$and'] = true;
         this._conditions.$and = this._conditions.$and.concat(source._conditions.$and);
       }
-      if (this._conditions?.$or && source._conditions.$or) {
+      if (this._conditions && this._conditions.$or && source._conditions.$or) {
         opts.omit['$or'] = true;
         this._conditions.$or = this._conditions.$or.concat(source._conditions.$or);
       }
@@ -2400,11 +2400,11 @@ Query.prototype.merge = function(source) {
   }
 
   opts.omit = {};
-  if (this._conditions?.$and && source.$and) {
+  if (this._conditions && this._conditions.$and && source.$and) {
     opts.omit['$and'] = true;
     this._conditions.$and = this._conditions.$and.concat(source.$and);
   }
-  if (this._conditions?.$or && source.$or) {
+  if (this._conditions && this._conditions.$or && source.$or) {
     opts.omit['$or'] = true;
     this._conditions.$or = this._conditions.$or.concat(source.$or);
   }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4323,4 +4323,22 @@ describe('Query', function() {
 
     assert.strictEqual(books.length, 0);
   });
+
+  it('merges $and, $or conditions (gh-12944)', function() {
+    const Test = db.model('Test', new Schema({ tags: [String] }));
+
+    let q = Test.find({ $and: [{ tags: 'a' }] });
+    q.find({ $and: [{ tags: 'b' }] });
+    q.find({ $and: [{ tags: 'c' }] });
+
+    assert.deepEqual(q.getFilter(), {
+      $and: [{ tags: 'a' }, { tags: 'b' }, { tags: 'c' }]
+    });
+
+    q = Test.find({ $or: [{ tags: 'a' }] });
+    q.find({ $or: [{ tags: 'b' }] });
+    assert.deepEqual(q.getFilter(), {
+      $or: [{ tags: 'a' }, { tags: 'b' }]
+    });
+  });
 });


### PR DESCRIPTION
Fix #12944

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`find({ $and: [{ foo: 'bar' }] }).find({ $and: [{ foo: 'baz' }] })` currently overwrites instead of merges `$and`. This PR changes that, so chaining concatenates `$and`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
