### PR TITLE
fix(model): avoid sending null session option with document operations

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -283,8 +283,10 @@ Model.prototype.$__handleSave = function(options, callback) {
   if ('checkKeys' in options) {
     saveOptions.checkKeys = options.checkKeys;
   }
-  if (!saveOptions.hasOwnProperty('session')) {
-    saveOptions.session = this.$session();
+
+  const session = this.$session();
+  if (!saveOptions.hasOwnProperty('session') && session != null) {
+    saveOptions.session = session;
   }
 
   if (this.$isNew) {

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -91,4 +91,12 @@ describe('debug: shell', function() {
     // Last log should not have been overwritten
     assert.equal(storedLog, lastLog);
   });
+
+  it('should avoid sending null session option with document ops (gh-13052)', async function() {
+    const schema = new Schema({ name: String });
+    const Test = db.model('gh_13052', schema);
+
+    await Test.create({ name: 'foo' });
+    assert.equal(false, lastLog.includes('session'));
+  });
 });


### PR DESCRIPTION
closes #13052