### PR TITLE
docs(middleware): list `validate` as a potential query middleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -55,6 +55,7 @@ In query middleware functions, `this` refers to the query.
 * [update](api/query.html#query_Query-update)
 * [updateOne](api/query.html#query_Query-updateOne)
 * [updateMany](api/query.html#query_Query-updateMany)
+* [validate](validation.html#update-validators)
 
 Aggregate middleware is for `MyModel.aggregate()`.
 Aggregate middleware executes when you call `exec()` on an aggregate object.


### PR DESCRIPTION
Re: #12680

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12680 pointed out that we don't list 'validate' as a potential query middleware. This fixes the docs. Below is an example of using query middleware for `validate()`

```javascript
'use strict';

const mongoose = require('mongoose');

const schema = new mongoose.Schema({ name: String });

schema.pre('validate', () => {
  console.log('Regular pre validate');
});
schema.pre('validate', { query: true, document: false }, () => {
  console.log('Pre query validate');
});

const Test = mongoose.model('Test', schema);

run().catch(err => console.log(err));

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test');

  const doc = new Test();
  await doc.validate();

  console.log('----');
  await Test.updateOne({}, { name: 'bar' }).setOptions({ runValidators: true });
}
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
