### PR TITLE
fix(query): avoid sending unnecessary empty projection to MongoDB server

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1876,6 +1876,12 @@ Query.prototype.setUpdate = function(val) {
  */
 
 Query.prototype._fieldsForExec = function() {
+  if (this._fields == null) {
+    return null;
+  }
+  if (Object.keys(this._fields).length === 0) {
+    return null;
+  }
   return utils.clone(this._fields);
 };
 
@@ -1996,6 +2002,12 @@ Query.prototype._optionsForExec = function(model) {
       delete options.wtimeout;
     }
   }
+
+  const projection = this._fieldsForExec();
+  if (projection != null) {
+    options.projection = projection;
+  }
+
   return options;
 };
 
@@ -2306,7 +2318,6 @@ Query.prototype._find = wrapThunk(function(callback) {
   };
 
   const options = this._optionsForExec();
-  options.projection = this._fieldsForExec();
   const filter = this._conditions;
 
   this._collection.collection.find(filter, options, (err, cursor) => {
@@ -2525,8 +2536,10 @@ Query.prototype._findOne = wrapThunk(function(callback) {
   applyGlobalMaxTimeMS(this.options, this.model);
   applyGlobalDiskUse(this.options, this.model);
 
-  // don't pass in the conditions because we already merged them in
-  Query.base.findOne.call(this, {}, (err, doc) => {
+  const conds = this._conditions;
+  const options = this._optionsForExec();
+
+  this._collection.findOne(conds, options, (err, doc) => {
     if (err) {
       callback(err);
       return null;
@@ -4038,10 +4051,12 @@ Query.prototype._findAndModify = function(type, callback) {
   }
 
   this._applyPaths();
-
   if (this._fields) {
-    fields = utils.clone(this._fields);
-    opts.projection = this._castFields(fields);
+    this._fields = this._castFields(this._fields);
+    fields = this._fieldsForExec();
+    if (fields != null) {
+      opts.projection = fields;
+    }
     if (opts.projection instanceof Error) {
       return callback(opts.projection);
     }
@@ -5469,14 +5484,12 @@ Query.prototype._applyPaths = function applyPaths() {
 Query.prototype.cursor = function cursor(opts) {
   this._applyPaths();
   this._fields = this._castFields(this._fields);
-  this.setOptions({ projection: this._fieldsForExec() });
+
   if (opts) {
     this.setOptions(opts);
   }
 
-  const options = Object.assign({}, this._optionsForExec(), {
-    projection: this.projection()
-  });
+  const options = this._optionsForExec();
   try {
     this.cast(this.model);
   } catch (err) {


### PR DESCRIPTION
Fix #13050

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now we always send `projection` option to the MongoDB server, even if `projection` is an empty object. This is a bit clunky for numerous reasons: perf, messy logs, etc. With this change, we won't send `projection` if it is an empty object.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

No projections in below script:

```javascript
'use strict';
  
const mongoose = require('mongoose');
mongoose.set('debug', true);

run().catch(err => console.log(err));

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test');
  const schema = new mongoose.Schema({ name: String });
  const Test = mongoose.model('Test', schema);

  await Test.findOne();

  await Test.find();

  await Test.findOneAndUpdate({}, { name: 'bar' });
}
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
