### PR TITLE
Fix Deno tests

### DIFF
--- a/test/deno.js
+++ b/test/deno.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { createRequire } from "https://deno.land/std/node/module.ts";
+import { createRequire } from "https://deno.land/std@0.177.0/node/module.ts";
 
 // Workaround for Mocha getting terminal width, which currently requires `--unstable`
 Object.defineProperty(process.stdout, 'getWindowSize', {

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -91,4 +91,12 @@ describe('debug: shell', function() {
     // Last log should not have been overwritten
     assert.equal(storedLog, lastLog);
   });
+
+  it('should avoid sending null session option with document ops (gh-13052)', async function() {
+    const schema = new Schema({ name: String });
+    const Test = db.model('gh_13052', schema);
+
+    await Test.create({ name: 'foo' });
+    assert.equal(false, lastLog.includes('session'));
+  });
 });

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -91,12 +91,4 @@ describe('debug: shell', function() {
     // Last log should not have been overwritten
     assert.equal(storedLog, lastLog);
   });
-
-  it('should avoid sending null session option with document ops (gh-13052)', async function() {
-    const schema = new Schema({ name: String });
-    const Test = db.model('gh_13052', schema);
-
-    await Test.create({ name: 'foo' });
-    assert.equal(false, lastLog.includes('session'));
-  });
 });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -109,6 +109,7 @@ describe('Model', function() {
 
     const doc = await Test.findOne();
 
+    console.log('Found', doc);
     assert.ok('last_name' in doc);
     assert.ok('_id' in doc);
     assert.ok('first_name' in doc._id);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -94,6 +94,7 @@ describe('Model', function() {
         some: String
       }
     }));
+    await Test.deleteMany();
     const t = new Test({
       _id: {
         first_name: 'Daniel',
@@ -109,7 +110,6 @@ describe('Model', function() {
 
     const doc = await Test.findOne();
 
-    console.log('Found', doc);
     assert.ok('last_name' in doc);
     assert.ok('_id' in doc);
     assert.ok('first_name' in doc._id);

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const setDocumentTimestamps = require('../lib/helpers/timestamps/setDocumentTimestamps');
 const start = require('./common');
 
 const assert = require('assert');
@@ -76,21 +77,13 @@ describe('types.subdocument', function() {
         testString: 'Test 1'
       }]
     });
-    let id;
-    return thingy.save().
-      then(function() {
-        id = thingy._id;
-      }).
-      then(function() {
-        const thingy2 = {
-          subArray: [{
-            testString: 'Test 2'
-          }]
-        };
-        return Thing.updateOne({
-          _id: id
-        }, { $set: thingy2 });
-      });
+
+    const now = new Date();
+    setDocumentTimestamps(thingy, undefined, () => now, 'createdAt', 'updatedAt');
+    assert.equal(thingy.createdAt.valueOf(), now.valueOf());
+    assert.equal(thingy.updatedAt.valueOf(), now.valueOf());
+    assert.strictEqual(thingy.subArray[0].createdAt, undefined);
+    assert.strictEqual(thingy.subArray[0].updatedAt, undefined);
   });
 
   describe('#isModified', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #13061. Turns out there was some stale data in the 'tests' collection that this test was picking up, below is the doc:

```
Found <ref *1> model {
  "$__": InternalCache {
    activePaths: StateMachine { paths: { __v: "init" }, states: { init: [Object] } },
    skipId: true,
    getters: { _id: Document { first_name: [Getter/Setter], age: [Getter/Setter] } },
    nestedPath: "_id",
    [Symbol("mongoose#Document#scope")]: [Circular *1]
  },
  "$isNew": false,
  _doc: {
    _id: ObjectId {
      [Symbol(id)]: Buffer(12) [
         99, 244, 221, 196,  76,
        238,  72, 239,  52, 185,
        255, 124
      ]
    },
    doc_embed: {},
    subArray: [ { testString: "Test 2", _id: [Object] } ],
    createdAt: 2023-02-21T15:05:40.101Z,
    updatedAt: 2023-02-21T15:05:40.115Z,
    __v: 0
  }
}
```

Looks like this is due to `types.subdocument.test.js` not properly cleaning up after itself. I fixed that test, and also added a little extra cleanup in the failing test.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
