### PR TITLE
BREAKING CHANGE: copy schema options when merging schemas using `new Schema()` or `Schema.prototype.add()`

### DIFF
--- a/lib/helpers/schema/merge.js
+++ b/lib/helpers/schema/merge.js
@@ -15,6 +15,13 @@ module.exports = function merge(s1, s2, skipConflictingPaths) {
   s1.method(s2.methods);
   s1.static(s2.statics);
 
+  for (const [option, value] of Object.entries(s2._userProvidedOptions)) {
+    if (!(option in s1._userProvidedOptions)) {
+      s1._userProvidedOptions[option] = value;
+      s1.options[option] = value;
+    }
+  }
+
   for (const query in s2.query) {
     s1.query[query] = s2.query[query];
   }

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1391,8 +1391,24 @@ describe('schema', function() {
       assert.ok(s.path('created'));
       assert.ok(s.path('name'));
       assert.ok(!s.options.id);
+    });
 
+    it('copies options from array of schemas', function() {
+      const baseSchema = new Schema({ created: Date }, { id: true, toJSON: { virtuals: true } });
+      const s = new Schema([baseSchema, { name: String }]);
 
+      assert.ok(s.path('created'));
+      assert.ok(s.path('name'));
+      assert.ok(s.options.id);
+      assert.deepEqual(s.options.toJSON, { virtuals: true });
+      assert.strictEqual(s.options.toObject, undefined);
+
+      s.add(new Schema({}, { toObject: { getters: true } }));
+      assert.ok(s.path('created'));
+      assert.ok(s.path('name'));
+      assert.ok(s.options.id);
+      assert.deepEqual(s.options.toJSON, { virtuals: true });
+      assert.deepEqual(s.options.toObject, { getters: true });
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

A neat change/feature that was recently requested: if using `schema1.add(schema2)` and `schema1` doesn't have a `toJSON` or `toObject` option set, use schema2's `toJSON` and `toObject` options.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
