### PR TITLE
Doc: Updated callback method for Model.findOne()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2111,16 +2111,8 @@ Model.findById = function findById(id, projection, options) {
  *     await Adventure.findOne({ country: 'Croatia' }).exec();
  *
  *     // Model.findOne() no longer accepts a callback
- *     Adventure.findOne({ country: 'Croatia' }, function (err, adventure) {});
- * 
- *     // Instead use
- *     Adventure.findOne({ country: 'Croatia' })
- *     .then((adventure)=>{
- *     })
- *     .catch((err)=>{
- *     });
  *
- *     // select only the adventures name and length
+ *     // Select only the adventures name and length
  *     await Adventure.findOne({ country: 'Croatia' }, 'name length').exec();
  *
  * @param {Object} [conditions]

--- a/lib/model.js
+++ b/lib/model.js
@@ -2110,8 +2110,15 @@ Model.findById = function findById(id, projection, options) {
  *     // Find one adventure whose `country` is 'Croatia', otherwise `null`
  *     await Adventure.findOne({ country: 'Croatia' }).exec();
  *
- *     // using callback
+ *     // Model.findOne() no longer accepts a callback
  *     Adventure.findOne({ country: 'Croatia' }, function (err, adventure) {});
+ * 
+ *     // Instead use
+ *     Adventure.findOne({ country: 'Croatia' })
+ *     .then((adventure)=>{
+ *     })
+ *     .catch((err)=>{
+ *     });
  *
  *     // select only the adventures name and length
  *     await Adventure.findOne({ country: 'Croatia' }, 'name length').exec();


### PR DESCRIPTION
The official documentation was not updated, it shows that Model.findOne() uses callback, which is not accepted now.
The Change updates the document with updated method for Model.findOne().

fixes #13095