### PR TITLE
Fix v6 docs link

### DIFF
--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -52,7 +52,7 @@ html(lang='en')
                 a(href="#").pure-menu-link Version #{package.version}
                 ul.pure-menu-children
                   li.pure-menu-item
-                    a.pure-menu-link(href="/docs/6.x") Version #{package.latest6x}
+                    a.pure-menu-link(href="/docs/v6") Version #{package.latest6x}
                   li.pure-menu-item
                     a.pure-menu-link(href="/docs/5.x") Version #{package.latest5x}
               li.pure-menu-item.search


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Broken link on the website

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

Current link to v6 docs lead to a 404
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/868423/221982218-ce9d7651-8aef-4ac4-b19f-892f1ecc3389.png">

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
