### PR TITLE
Add Path generic

### DIFF
--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -366,7 +366,7 @@ async function gh13070() {
   const child = model<IChild>('Child', childSchema);
 
   const doc = await parent.findOne();
-  await child.populate<{child: IChild}>(doc, 'child');
+  await child.populate<{ child: IChild }>(doc, 'child');
 
 
 }

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -365,7 +365,7 @@ async function gh13070() {
   const Parent = model<IParent>('Parent', parentSchema);
   const Child = model<IChild>('Child', childSchema);
 
-  const doc = await Parent.findOne();
+  const doc = await Parent.findOne().orFail();
   const doc2 = await Child.populate<{ child: IChild }>(doc, 'child');
-  const name: string = doc.child.name;
+  const name: string = doc2.child.name;
 }

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -362,11 +362,10 @@ async function gh13070() {
       parent: { type: Schema.Types.ObjectId, ref: 'Parent', required: true }
     });
 
-  const parent = model<IParent>('Parent', parentSchema);
-  const child = model<IChild>('Child', childSchema);
+  const Parent = model<IParent>('Parent', parentSchema);
+  const Child = model<IChild>('Child', childSchema);
 
-  const doc = await parent.findOne();
-  await child.populate<{ child: IChild }>(doc, 'child');
-
-
+  const doc = await Parent.findOne();
+  const doc2 = await Child.populate<{ child: IChild }>(doc, 'child');
+  const name: string = doc.child.name;
 }

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -339,3 +339,34 @@ function gh12136() {
   }
 
 }
+
+async function gh13070() {
+  interface IParent {
+    name: string;
+    child: Types.ObjectId;
+  }
+  interface IChild {
+    name: string;
+    parent: Types.ObjectId;
+  }
+
+  const parentSchema = new Schema(
+    {
+      name: { type: String, required: true },
+      child: { type: Schema.Types.ObjectId, ref: 'Child', required: true }
+    });
+
+  const childSchema = new Schema(
+    {
+      name: { type: String, required: true },
+      parent: { type: Schema.Types.ObjectId, ref: 'Parent', required: true }
+    });
+
+  const parent = model<IParent>('Parent', parentSchema);
+  const child = model<IChild>('Child', childSchema);
+
+  const doc = await parent.findOne();
+  await child.populate<{child: IChild}>(doc, 'child');
+
+
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -303,7 +303,8 @@ declare module 'mongoose' {
       callback?: Callback<(HydratedDocument<T, TMethodsAndOverrides, TVirtuals>)[]>): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
     populate(doc: any, options: PopulateOptions | Array<PopulateOptions> | string,
       callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-
+    populate<Paths={}>(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string): Promise<MergeType<this, Paths>>;
+    populate<Paths={}>(docs: any, options: PopulateOptions | Array<PopulateOptions> | string, callback?: Callback<MergeType<this, Paths>>): void;
 
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
     validate(callback?: CallbackWithoutResult): Promise<void>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -299,12 +299,22 @@ declare module 'mongoose' {
     modelName: string;
 
     /** Populates document references. */
-    populate(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string,
-      callback?: Callback<(HydratedDocument<T, TMethodsAndOverrides, TVirtuals>)[]>): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
-    populate(doc: any, options: PopulateOptions | Array<PopulateOptions> | string,
-      callback?: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-    populate<Paths={}>(docs: Array<any>, options: PopulateOptions | Array<PopulateOptions> | string): Promise<MergeType<this, Paths>>;
-    populate<Paths={}>(docs: any, options: PopulateOptions | Array<PopulateOptions> | string, callback?: Callback<MergeType<this, Paths>>): void;
+    populate(
+      docs: Array<any>,
+      options: PopulateOptions | Array<PopulateOptions> | string
+    ): Promise<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>;
+    populate(
+      doc: any,
+      options: PopulateOptions | Array<PopulateOptions> | string,
+    ): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+    populate<Paths>(
+      docs: Array<any>,
+      options: PopulateOptions | Array<PopulateOptions> | string
+    ): Promise<MergeType<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, Paths>[]>;
+    populate<Paths>(
+      doc: AnyObject,
+      options: PopulateOptions | Array<PopulateOptions> | string
+    ): Promise<MergeType<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, Paths>>;
 
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
     validate(callback?: CallbackWithoutResult): Promise<void>;


### PR DESCRIPTION
It wasn't yelling at me.

Also, while working on this issue I noticed the populate section is more focused on query population than calling `Model.populate()`. Maybe we should include a small section about that function since we have a section titled `Populate` in the docs.
