### PR TITLE
fix(types/query): remove "update" function

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -594,9 +594,6 @@ declare module 'mongoose' {
     /** Converts this query to a customized, reusable query constructor with all arguments and options retained. */
     toConstructor<RetType = typeof Query>(): RetType;
 
-    /** Declare and/or execute this query as an update() operation. */
-    update(filter?: FilterQuery<DocType>, update?: UpdateQuery<DocType> | UpdateWithAggregationPipeline, options?: QueryOptions<DocType> | null): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType>;
-
     /**
      * Declare and/or execute this query as an updateMany() operation. Same as
      * `update()`, except MongoDB will update _all_ documents that match


### PR DESCRIPTION
**Summary**

This PR removes the function `update` from the query types, because it has been removed for 7.0 in runtime

re #12955
re #13039