### PR TITLE
fix(types): handle `Record<string, never>` as value for HydratedDocument TOverrides parameter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,10 +46,11 @@
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/indent": [
-          "error",
+          "warn",
           2,
           {
-            "SwitchCase": 1
+            "SwitchCase": 1,
+            "ignoredNodes": ["TSTypeParameterInstantiation"]
           }
         ],
         "@typescript-eslint/prefer-optional-chain": "error",

--- a/.npmignore
+++ b/.npmignore
@@ -46,3 +46,5 @@ webpack.base.config.js
 
 notes.md
 list.out
+
+eslintrc.json

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -293,3 +293,22 @@ function gh12290() {
   user.isDirectModified('name age');
   user.isDirectModified('name');
 }
+
+function gh13094() {
+  type UserDocumentNever = HydratedDocument<{ name: string }, Record<string, never>>;
+
+  const doc: UserDocumentNever = null as any;
+  expectType<string>(doc.name);
+
+  // The following currently fails.
+  /* type UserDocumentUnknown = HydratedDocument<{ name: string }, Record<string, unknown>>;
+
+  const doc2: UserDocumentUnknown = null as any;
+  expectType<string>(doc2.name); */
+
+  // The following currently fails.
+  /* type UserDocumentAny = HydratedDocument<{ name: string }, Record<string, any>>;
+
+  const doc3: UserDocumentAny = null as any;
+  expectType<string>(doc3.name); */
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -139,12 +139,14 @@ declare module 'mongoose' {
     TOverrides = {},
     TQueryHelpers = {}
   > = IfAny<
-  DocType,
-  any,
-  Document<unknown, TQueryHelpers, DocType> & MergeType<
-  Require_id<DocType>,
-  IfAny<TOverrides, {}>
-  >
+    DocType,
+    any,
+    Document<unknown, TQueryHelpers, DocType> & MergeType<
+      Require_id<DocType>,
+      TOverrides extends Record<string, never> ?
+        {} :
+        IfAny<TOverrides, {}>
+    >
   >;
   export type HydratedSingleSubdocument<DocType, TOverrides = {}> = Types.Subdocument<unknown> & Require_id<DocType> & TOverrides;
   export type HydratedArraySubdocument<DocType, TOverrides = {}> = Types.ArraySubdocument<unknown> & Require_id<DocType> & TOverrides;


### PR DESCRIPTION
Fix #13094

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

I applied @hasezoey 's suggested fix for #13094. We can avoid `Record<string, never>` as a special case, because the only value that matches that is empty object `{}`. But avoiding `Record<string, any>` or `Record<string, unknown>` is hard because it seems like _any_ object extends from `Record<string, any>`, and there's no good way to check if a type is a record type, or at least if a type is an object with known keys.

I'm open to suggestions for better ways to fix this. But this should be enough to unblock.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
