### PR TITLE
6.x should still support node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "main": "./index.js",
   "types": "./types/index.d.ts",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=12.0.0"
   },
   "bugs": {
     "url": "https://github.com/Automattic/mongoose/issues/new"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

@vkarpov15 I think the bump to node 14 minimum was accidental, this reverts mongoose 6.x to still be supported on node 12.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
