### PR TITLE
fix(documentarray): set correct document array path if making map of document arrays

### DIFF
--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -416,6 +416,8 @@ DocumentArrayPath.prototype.cast = function(value, doc, init, prev, options) {
 
   options = options || {};
 
+  const path = options.path || this.path;
+
   if (!Array.isArray(value)) {
     if (!init && !DocumentArrayPath.options.castNonArrays) {
       throw new CastError('DocumentArray', value, this.path, null, this);
@@ -423,7 +425,7 @@ DocumentArrayPath.prototype.cast = function(value, doc, init, prev, options) {
     // gh-2442 mark whole array as modified if we're initializing a doc from
     // the db and the path isn't an array in the document
     if (!!doc && init) {
-      doc.markModified(this.path);
+      doc.markModified(path);
     }
     return this.cast([value], doc, init, prev, options);
   }
@@ -431,7 +433,7 @@ DocumentArrayPath.prototype.cast = function(value, doc, init, prev, options) {
   // We need to create a new array, otherwise change tracking will
   // update the old doc (gh-4449)
   if (!options.skipDocumentArrayCast || utils.isMongooseDocumentArray(value)) {
-    value = new MongooseDocumentArray(value, this.path, doc);
+    value = new MongooseDocumentArray(value, path, doc);
   }
 
   if (prev != null) {
@@ -439,7 +441,7 @@ DocumentArrayPath.prototype.cast = function(value, doc, init, prev, options) {
   }
 
   if (options.arrayPathIndex != null) {
-    value[arrayPathSymbol] = this.path + '.' + options.arrayPathIndex;
+    value[arrayPathSymbol] = path + '.' + options.arrayPathIndex;
   }
 
   const rawArray = utils.isMongooseDocumentArray(value) ? value.__array : value;

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -762,4 +762,22 @@ describe('types.documentarray', function() {
 
     assert.ok(doc.subDocArray[0]._id instanceof mongoose.Types.ObjectId);
   });
+
+  it('gets correct path when underneath map (gh-12997)', function() {
+    const mapArraySchema = Schema({
+      myMap: {
+        type: Map,
+        of: [Schema({ name: String })]
+      }
+    });
+
+    const Model = db.model('Test', mapArraySchema);
+    const doc = new Model({
+      myMap: {
+        foo: [{ name: 'bar' }]
+      }
+    });
+
+    assert.equal(doc.myMap.get('foo').$path(), 'myMap.foo');
+  });
 });


### PR DESCRIPTION
Fix #12997

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We made some changes in https://github.com/Automattic/mongoose/issues/9811 to support modified paths when you have a map of subdocuments, but looks like those changes weren't correctly applied to maps of document arrays. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
