### PR TITLE
fix(document): avoid setting array default if document array projected out by sibling projection

### DIFF
--- a/lib/helpers/document/applyDefaults.js
+++ b/lib/helpers/document/applyDefaults.js
@@ -32,7 +32,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
         }
       } else if (exclude === false && fields && !included) {
         const hasSubpaths = type.$isSingleNested || type.$isMongooseDocumentArray;
-        if (curPath in fields || (hasSubpaths && hasIncludedChildren != null && hasIncludedChildren[curPath])) {
+        if (curPath in fields || (j === len - 1 && hasSubpaths && hasIncludedChildren != null && hasIncludedChildren[curPath])) {
           included = true;
         } else if (hasIncludedChildren != null && !hasIncludedChildren[curPath]) {
           break;

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -93,15 +93,11 @@ describe('debug: shell', function() {
   });
 
   it('should avoid sending null session option with document ops (gh-13052)', async function() {
-    const m = new mongoose.Mongoose();
-    m.set('debug', true);
-    await m.connect(start.uri);
+    mongoose.set('debug', { shell: false });
     const schema = new Schema({ name: String });
-    const Test = m.model('gh_13052', schema);
+    const Test = db.model('gh_13052', schema);
 
     await Test.create({ name: 'foo' });
     assert.equal(false, lastLog.includes('session'));
-
-    await m.disconnect();
   });
 });

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -93,11 +93,20 @@ describe('debug: shell', function() {
   });
 
   it('should avoid sending null session option with document ops (gh-13052)', async function() {
-    mongoose.set('debug', { shell: false });
+    let args = [];
+    const m = new mongoose.Mongoose();
+    m.set('debug', function() {
+      args.push([...arguments]);
+    });
+    await m.connect(start.uri);
     const schema = new Schema({ name: String });
-    const Test = db.model('gh_13052', schema);
+    const Test = m.model('gh_13052', schema);
 
     await Test.create({ name: 'foo' });
-    assert.equal(false, lastLog.includes('session'));
+    assert.equal(args.length, 1);
+    assert.equal(args[0][1], 'insertOne');
+    assert.ok(!('session' in args[0][3]));
+
+    await m.disconnect();
   });
 });

--- a/test/docs/debug.test.js
+++ b/test/docs/debug.test.js
@@ -93,10 +93,15 @@ describe('debug: shell', function() {
   });
 
   it('should avoid sending null session option with document ops (gh-13052)', async function() {
+    const m = new mongoose.Mongoose();
+    m.set('debug', true);
+    await m.connect(start.uri);
     const schema = new Schema({ name: String });
-    const Test = db.model('gh_13052', schema);
+    const Test = m.model('gh_13052', schema);
 
     await Test.create({ name: 'foo' });
     assert.equal(false, lastLog.includes('session'));
+
+    await m.disconnect();
   });
 });

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12179,6 +12179,47 @@ describe('document', function() {
     doc.init({ properties: { foo: 'foo' } });
     assert.strictEqual(doc.properties.bar, undefined);
   });
+
+  it('avoids overwriting array with sibling projection (gh-13043)', async function() {
+    const testSchema = new mongoose.Schema({
+      str: 'string',
+      obj: {
+        subObj: {
+          str: 'string'
+        },
+        subArr: [{
+          str: 'string'
+        }]
+      },
+      arr: [{
+        str: 'string'
+      }]
+    });
+    const Test = db.model('Test', testSchema);
+    // Create one test document : obj.subArr[0].str === 'subArr.test1'
+    await Test.create({
+      str: 'test1',
+      obj: {
+        subObj: {
+          str: 'subObj.test1'
+        },
+        subArr: [{
+          str: 'subArr.test1'
+        }]
+      },
+      arr: [{ str: 'arr.test1' }]
+    });
+
+    const test = await Test.findOne({ str: 'test1' }, 'str obj.subObj');
+
+    // Update one property
+    test.str = test.str + ' - updated';
+    await test.save();
+
+    const fromDb = await Test.findById(test);
+    assert.equal(fromDb.obj.subArr.length, 1);
+    assert.equal(fromDb.obj.subArr[0].str, 'subArr.test1');
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12162,6 +12162,23 @@ describe('document', function() {
       { $pop: { arr: -1 }, $inc: { __v: 1 } }
     );
   });
+
+  it('avoids setting array default if document array projected out by sibling projection (gh-13003)', async function() {
+    const schema = new mongoose.Schema({
+      name: String,
+      arr: [String],
+      properties: {
+        foo: String,
+        bar: [{ baz: String, qux: Boolean }],
+        baz: String
+      }
+    });
+    const Test = db.model('Test', schema);
+
+    const doc = new Test({}, { 'properties.foo': 1 });
+    doc.init({ properties: { foo: 'foo' } });
+    assert.strictEqual(doc.properties.bar, undefined);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #13003

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Without this fix, `applyDefaults()` thinks it needs to apply defaults to all sibling properties of `properties.foo` when the projection is `{ 'properties.foo': 1 }`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
