### PR TITLE
Updated the isIndexEqual function to take into account non-text index…

### DIFF
--- a/lib/helpers/indexes/isIndexEqual.js
+++ b/lib/helpers/indexes/isIndexEqual.js
@@ -28,15 +28,19 @@ module.exports = function isIndexEqual(key, options, dbIndex) {
   //   textIndexVersion: 3
   // }
   if (dbIndex.textIndexVersion != null) {
-    const weights = dbIndex.weights;
-    if (Object.keys(weights).length !== Object.keys(key).length) {
+    // If a compound index involves both text and non-text indexes, we want to extract both (gh-13136)
+    const weightsAndKeys = Object.assign({}, dbIndex.weights);
+    Object.keys(dbIndex.key)
+      .filter(function(key) { return !(key.startsWith('_fts'));})
+      .forEach(function(key) { weightsAndKeys[key] = dbIndex.key[key];});
+    if (Object.keys(weightsAndKeys).length !== Object.keys(key).length) {
       return false;
     }
-    for (const prop of Object.keys(weights)) {
+    for (const prop of Object.keys(weightsAndKeys)) {
       if (!(prop in key)) {
         return false;
       }
-      const weight = weights[prop];
+      const weight = weightsAndKeys[prop];
       if (weight !== get(options, 'weights.' + prop) && !(weight === 1 && get(options, 'weights.' + prop) == null)) {
         return false;
       }

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -673,7 +673,7 @@ describe('model', function() {
 
       const TestModel = db.model('Test', Test);
       TestModel.syncIndexes().then((results1) => {
-        assert.strictEqual(results1, []);
+        assert.deepEqual(results1, []);
         // second call to syncIndexes should return an empty array, representing 0 deleted indexes
         TestModel.syncIndexes().then((results2) => {
           assert.deepEqual(results2, []);

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -676,7 +676,7 @@ describe('model', function() {
         assert.strictEqual(results1, []);
         // second call to syncIndexes should return an empty array, representing 0 deleted indexes
         TestModel.syncIndexes().then((results2) => {
-          assert.strictEqual(results2, []);
+          assert.deepEqual(results2, []);
           done();
         });
       });


### PR DESCRIPTION
…es when checking compound indexes that include both text and non-text indexes

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This PR fixes https://github.com/Automattic/mongoose/issues/13136

