### PR TITLE
Avoid saving changes to non-modified paths

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -4,11 +4,12 @@ Before we get into the specifics of validation syntax, please keep the following
 
 - Validation is defined in the [SchemaType](schematypes.html)
 - Validation is [middleware](middleware.html). Mongoose registers validation as a `pre('save')` hook on every schema by default.
+- Validation always runs as the **first** `pre('save')` hook. This means that validation doesn't run on any changes you make in `pre('save')` hooks.
 - You can disable automatic validation before save by setting the [validateBeforeSave](guide.html#validateBeforeSave) option
-- You can manually run validation using `doc.validate(callback)` or `doc.validateSync()`
+- You can manually run validation using `doc.validate()` or `doc.validateSync()`
 - You can manually mark a field as invalid (causing validation to fail) by using [`doc.invalidate(...)`](api/document.html#document_Document-invalidate)
 - Validators are not run on undefined values. The only exception is the [`required` validator](api/schematype.html#schematype_SchemaType-required).
-- Validation is asynchronously recursive; when you call [Model#save](api/model.html#model_Model-save), sub-document validation is executed as well. If an error occurs, your [Model#save](api/model.html#model_Model-save) callback receives it
+- When you call [Model#save](api/model.html#model_Model-save), Mongoose also runs subdocument validation. If an error occurs, your [Model#save](api/model.html#model_Model-save) promise rejects
 - Validation is customizable
 
 ```javascript

--- a/lib/document.js
+++ b/lib/document.js
@@ -1590,6 +1590,11 @@ Document.prototype.$__shouldModify = function(pathToMark, path, options, constru
   if (this.$isNew) {
     return true;
   }
+
+  if (!this.$__isSelected(path) && (!options || !options._forceModify)) {
+    return false;
+  }
+
   // Is path already modified? If so, always modify. We may unmark modified later.
   if (path in this.$__.activePaths.getStatePaths('modify')) {
     return true;

--- a/lib/helpers/timestamps/setDocumentTimestamps.js
+++ b/lib/helpers/timestamps/setDocumentTimestamps.js
@@ -21,6 +21,6 @@ module.exports = function setDocumentTimestamps(doc, timestampOption, currentTim
     if (doc.isNew && createdAt != null) {
       ts = doc.$__getValue(createdAt);
     }
-    doc.$set(updatedAt, ts);
+    doc.$set(updatedAt, ts, null, { _forceModify: true });
   }
 };

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1240,16 +1240,6 @@ describe('document', function() {
     await user1.save();
     const user2 = await User.findById(user1).select('name').exec();
 
-    user2.req = undefined;
-    let err = await user2.save().then(() => null, err => err);
-    err = String(err);
-
-    const invalid = /Path `req` is required./.test(err);
-    assert.ok(invalid);
-
-    user2.req = 'it works again';
-    await user2.save();
-
     const user3 = await User.findById(user2).select('_id').exec();
     await user3.save();
   });
@@ -9453,7 +9443,7 @@ describe('document', function() {
     await doc.save();
 
     const fromDb = await Test.findById(doc._id);
-    assert.deepEqual(fromDb.toObject().arr, [{ val: 2 }, { val: 2 }]);
+    assert.deepEqual(fromDb.toObject().arr, [{ val: 1 }, { val: 2 }]);
   });
 
   it('ignore getters when diffing objects for change tracking (gh-9501)', async function() {
@@ -12219,6 +12209,29 @@ describe('document', function() {
     const fromDb = await Test.findById(test);
     assert.equal(fromDb.obj.subArr.length, 1);
     assert.equal(fromDb.obj.subArr[0].str, 'subArr.test1');
+  });
+
+  it('avoids saving changes to deselected paths (gh-13062)', async function() {
+    const testSchema = new mongoose.Schema({
+      name: { type: String, required: true },
+      age: { type: Number, required: true, select: false },
+      links: { type: String, required: true, select: false }
+    });
+
+    const Test = db.model('Test', testSchema);
+
+    const { _id } = await Test.create({
+      name: 'Test Testerson',
+      age: 0,
+      links: 'some init links'
+    });
+
+    const doc = await Test.findById(_id);
+    doc.links = undefined;
+    await doc.save();
+
+    const fromDb = await Test.findById(_id).select('+links');
+    assert.equal(fromDb.links, 'some init links');
   });
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13062 pointed out an issue similar to #5800, #9457, and #4651: Mongoose saves changes to non-selected paths. This is a bit of a gotcha, and something that we'd like to consider changing. What do you think of this change @hasezoey ? There are some minor changes to existing tests, so this change is a little risky.

Also made a change in the docs to highlight the gotcha that `pre('save')` changes don't go through validation in the `validation` docs.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
