### PR TITLE
type(query): changed `QueryOptions` lean type to `Record<string, any>`

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -109,7 +109,7 @@ declare module 'mongoose' {
     /**
      * If truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document.
      */
-    lean?: boolean | any;
+    lean?: boolean | Record<string, any>;
     limit?: number;
     maxTimeMS?: number;
     multi?: boolean;


### PR DESCRIPTION
Changed the `lean` attribute of `QueryOptions` to `boolean | Record<string, any>` to allow correct inference on a query return type.

closes #13142