### PR TITLE
fix(connection): add stub implementation of `doClose` to base connection class

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1054,6 +1054,16 @@ Connection.prototype._close = function(force, destroy, callback) {
 };
 
 /**
+ * Abstract method that drivers must implement.
+ * 
+ * @api private
+ */
+
+Connection.prototype.doClose = function() {
+  throw new Error('Connection#doClose unimplemented by driver');
+};
+
+/**
  * Called when the connection closes
  *
  * @api private

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1055,7 +1055,7 @@ Connection.prototype._close = function(force, destroy, callback) {
 
 /**
  * Abstract method that drivers must implement.
- * 
+ *
  * @api private
  */
 


### PR DESCRIPTION
Fix #12971

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick detail that shouldn't affect any prod code. But #12971 does point out that our base connection class doesn't have a `doClose()` method, but calls `this.doClose()`. The built-in MongoDB driver layer does have a `doClose()`, but there's no indication to anyone building a new driver that they need to implement that, and if you instantiate a new connection directly (which you shouldn't do) you'll get an error about `doClose()` not being a function.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
