### PR TITLE
chore(generateSearch): move config missing error to require

### DIFF
--- a/scripts/generateSearch.js
+++ b/scripts/generateSearch.js
@@ -155,5 +155,7 @@ async function run() {
 
   console.log(results.map(res => res.url));
 
+  console.log(`Added ${contents.length} Content`);
+
   process.exit(0);
 }

--- a/scripts/generateSearch.js
+++ b/scripts/generateSearch.js
@@ -1,6 +1,14 @@
 'use strict';
 
-const config = require('../.config');
+let config;
+try {
+  config = require('../.config.js');
+} finally {
+  if (!config || !config.uri) {
+    console.error('No Config or config.URI given, please create a .config.js file with those values in the root of the repository');
+    process.exit(-1);
+  }
+}
 const cheerio = require('cheerio');
 const filemap = require('../docs/source');
 const fs = require('fs');
@@ -120,11 +128,6 @@ run().catch(async error => {
 });
 
 async function run() {
-  if (!config || !config.uri) {
-    console.error('No Config or config.URI given, please create a .config.js file with those values');
-    process.exit(-1);
-  }
-
   await mongoose.connect(config.uri, { dbName: 'mongoose', serverSelectionTimeoutMS: 5000 });
 
   // wait for the index to be created


### PR DESCRIPTION
This PR moves the Error message that was added in 0b7bbbbc23a2b79fb05defaef27f91efc54398bb to the require, where the actual error gets thrown if the config does not exist.

also adds a message on how much content was added.