### PR TITLE
[6.x] add `cursor.eachAsync` index parameter

### DIFF
--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -1,4 +1,5 @@
 import { Schema, model, Document, Types } from 'mongoose';
+import { expectType } from 'tsd';
 
 const schema: Schema = new Schema({ name: { type: 'String' } });
 
@@ -13,7 +14,7 @@ Test.find().cursor().eachAsync(async(doc: ITest) => console.log(doc.name)).
 
 Test.find().cursor().
   eachAsync(async(doc: ITest, i) => {
-    expectType<Types.ObjectId>(doc._id);
+    expectType<any>(doc._id);
     expectType<number>(i);
   }).
   then(() => console.log('Done!'));

--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -10,3 +10,10 @@ const Test = model<ITest>('Test', schema);
 
 Test.find().cursor().eachAsync(async(doc: ITest) => console.log(doc.name)).
   then(() => console.log('Done!'));
+
+Test.find().cursor().
+  eachAsync(async(doc: ITest, i) => {
+    expectType<Types.ObjectId>(doc._id);
+    expectType<number>(i);
+  }).
+  then(() => console.log('Done!'));

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -39,10 +39,10 @@ declare module 'mongoose' {
      * will wait for the promise to resolve before iterating on to the next one.
      * Returns a promise that resolves when done.
      */
-    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions & { batchSize: number }, callback: CallbackWithoutResult): void;
-    eachAsync(fn: (doc: DocType) => any, options: EachAsyncOptions, callback: CallbackWithoutResult): void;
-    eachAsync(fn: (doc: DocType[]) => any, options: EachAsyncOptions & { batchSize: number }): Promise<void>;
-    eachAsync(fn: (doc: DocType) => any, options?: EachAsyncOptions): Promise<void>;
+    eachAsync(fn: (doc: DocType[], index: number) => any, options: EachAsyncOptions & { batchSize: number }, callback: CallbackWithoutResult): void;
+    eachAsync(fn: (doc: DocType, index: number) => any, options: EachAsyncOptions, callback: CallbackWithoutResult): void;
+    eachAsync(fn: (doc: DocType[], index: number) => any, options: EachAsyncOptions & { batchSize: number }): Promise<void>;
+    eachAsync(fn: (doc: DocType, index: number) => any, options?: EachAsyncOptions): Promise<void>;
 
     /**
      * Registers a transform function which subsequently maps documents retrieved


### PR DESCRIPTION
**Summary**

This PR is a backport of #13153 for 6.x

fixes #13152