### PR TITLE
fix(model): add `results` property to unordered `insertMany()` to make it easy to identify exactly which documents were inserted

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3371,7 +3371,7 @@ Model.startSession = function() {
  * @param {Array|Object|*} doc(s)
  * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#insertMany)
  * @param {Boolean} [options.ordered=true] if true, will fail fast on the first error encountered. If false, will insert all the documents it can and report errors later. An `insertMany()` with `ordered = false` is called an "unordered" `insertMany()`.
- * @param {Boolean} [options.rawResult=false] if false, the returned promise resolves to the documents that passed mongoose document validation. If `true`, will return the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/InsertManyResult.html) with a `mongoose` property that contains `validationErrors` if this is an unordered `insertMany`.
+ * @param {Boolean} [options.rawResult=false] if false, the returned promise resolves to the documents that passed mongoose document validation. If `true`, will return the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/InsertManyResult.html) with a `mongoose` property that contains `validationErrors` and `results` if this is an unordered `insertMany`.
  * @param {Boolean} [options.lean=false] if `true`, skips hydrating and validating the documents. This option is useful if you need the extra performance, but Mongoose won't validate the documents before inserting.
  * @param {Number} [options.limit=null] this limits the number of documents being processed (validation/casting) by mongoose in parallel, this does **NOT** send the documents in batches to MongoDB. Use this option if you're processing a large number of documents and your app is running out of memory.
  * @param {String|Object|Array} [options.populate=null] populates the result documents. This option is a no-op if `rawResult` is set.
@@ -3534,19 +3534,20 @@ Model.$__insertMany = function(arr, options, callback) {
         const erroredIndexes = new Set((error && error.writeErrors || []).map(err => err.index));
 
         for (let i = 0; i < error.writeErrors.length; ++i) {
+          const originalIndex = validDocIndexToOriginalIndex.get(error.writeErrors[i].index);
           error.writeErrors[i] = {
             ...error.writeErrors[i],
-            index: validDocIndexToOriginalIndex.get(error.writeErrors[i].index)
+            index: originalIndex
           };
           if (!ordered) {
-            results[validDocIndexToOriginalIndex.get(error.writeErrors[i].index)] = error.writeErrors[i];
+            results[originalIndex] = error.writeErrors[i];
           }
         }
 
         if (!ordered) {
           for (let i = 0; i < results.length; ++i) {
             if (results[i] === void 0) {
-              results[i] = docAttributes[i];
+              results[i] = docs[i];
             }
           }
 
@@ -3594,10 +3595,17 @@ Model.$__insertMany = function(arr, options, callback) {
 
       if (rawResult) {
         if (ordered === false) {
+          for (let i = 0; i < results.length; ++i) {
+            if (results[i] === void 0) {
+              results[i] = docs[i];
+            }
+          }
+
           // Decorate with mongoose validation errors in case of unordered,
           // because then still do `insertMany()`
           res.mongoose = {
-            validationErrors: validationErrors
+            validationErrors: validationErrors,
+            results: results
           };
         }
         return callback(null, res);

--- a/lib/model.js
+++ b/lib/model.js
@@ -3427,6 +3427,7 @@ Model.$__insertMany = function(arr, options, callback) {
 
   const validationErrors = [];
   const validationErrorsToOriginalOrder = new Map();
+  const results = ordered ? null : new Array(arr.length);
   const toExecute = arr.map((doc, index) =>
     callback => {
       if (!(doc instanceof _this)) {
@@ -3454,6 +3455,7 @@ Model.$__insertMany = function(arr, options, callback) {
           if (ordered === false) {
             validationErrors.push(error);
             validationErrorsToOriginalOrder.set(error, index);
+            results[index] = error;
             return callback(null, null);
           }
           return callback(error);
@@ -3536,6 +3538,19 @@ Model.$__insertMany = function(arr, options, callback) {
             ...error.writeErrors[i],
             index: validDocIndexToOriginalIndex.get(error.writeErrors[i].index)
           };
+          if (!ordered) {
+            results[validDocIndexToOriginalIndex.get(error.writeErrors[i].index)] = error.writeErrors[i];
+          }
+        }
+
+        if (!ordered) {
+          for (let i = 0; i < results.length; ++i) {
+            if (results[i] === void 0) {
+              results[i] = docAttributes[i];
+            }
+          }
+
+          error.results = results;
         }
 
         let firstErroredIndex = -1;
@@ -3563,7 +3578,8 @@ Model.$__insertMany = function(arr, options, callback) {
 
         if (rawResult && ordered === false) {
           error.mongoose = {
-            validationErrors: validationErrors
+            validationErrors: validationErrors,
+            results: results
           };
         }
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4857,6 +4857,12 @@ describe('Model', function() {
       assert.ok(!res.mongoose.validationErrors[0].errors['year']);
       assert.ok(res.mongoose.validationErrors[1].errors['year']);
       assert.ok(!res.mongoose.validationErrors[1].errors['name']);
+
+      assert.equal(res.mongoose.results.length, 3);
+      assert.ok(res.mongoose.results[0].errors['name']);
+      assert.ok(res.mongoose.results[1].errors['year']);
+      assert.ok(res.mongoose.results[2].$__);
+      assert.equal(res.mongoose.results[2].name, 'The Empire Strikes Back');
     });
 
     it('insertMany() validation error with ordered false and rawResult for mixed write and validation error (gh-12791)', async function() {
@@ -4886,6 +4892,13 @@ describe('Model', function() {
       assert.ok(!err.mongoose.validationErrors[0].errors['year']);
       assert.ok(err.mongoose.validationErrors[1].errors['year']);
       assert.ok(!err.mongoose.validationErrors[1].errors['name']);
+
+      assert.equal(err.mongoose.results.length, 4);
+      assert.ok(err.mongoose.results[0].errors['name']);
+      assert.ok(err.mongoose.results[1].errors['year']);
+      assert.ok(err.mongoose.results[2].$__);
+      assert.equal(err.mongoose.results[2].name, 'The Empire Strikes Back');
+      assert.ok(err.mongoose.results[3].err);
     });
 
     it('insertMany() populate option (gh-9720)', async function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4570,6 +4570,11 @@ describe('Model', function() {
       const error = await Movie.insertMany(arr, { ordered: false }).then(() => null, err => err);
 
       assert.equal(error.message.indexOf('E11000'), 0);
+      assert.equal(error.results.length, 3);
+      assert.equal(error.results[0].name, 'Star Wars');
+      assert.ok(error.results[1].err);
+      assert.ok(error.results[1].err.errmsg.includes('E11000'));
+      assert.equal(error.results[2].name, 'The Empire Strikes Back');
       const docs = await Movie.find({}).sort({ name: 1 }).exec();
 
       assert.equal(docs.length, 2);
@@ -4676,6 +4681,11 @@ describe('Model', function() {
       assert.equal(err.insertedDocs.length, 2);
       assert.equal(err.insertedDocs[0].code, 'test');
       assert.equal(err.insertedDocs[1].code, 'HARD');
+
+      assert.equal(err.results.length, 3);
+      assert.ok(err.results[0].err.errmsg.includes('E11000'));
+      assert.equal(err.results[1].code, 'test');
+      assert.equal(err.results[2].code, 'HARD');
 
       await Question.deleteMany({});
       await Question.create({ code: 'MEDIUM', text: '123' });

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -87,11 +87,11 @@ async function insertManyTest() {
     foo: string;
   }
 
-  const TestSchema = new Schema<ITest & Document>({
+  const TestSchema = new Schema<ITest>({
     foo: { type: String, required: true }
   });
 
-  const Test = connection.model<ITest & Document>('Test', TestSchema);
+  const Test = connection.model<ITest>('Test', TestSchema);
 
   Test.insertMany([{ foo: 'bar' }]).then(async res => {
     res.length;
@@ -99,6 +99,9 @@ async function insertManyTest() {
 
   const res = await Test.insertMany([{ foo: 'bar' }], { rawResult: true });
   expectType<ObjectId>(res.insertedIds[0]);
+
+  const res2 = await Test.insertMany([{ foo: 'bar' }], { ordered: false, rawResult: true });
+  expectAssignable<Error | Object | ReturnType<(typeof Test)['hydrate']>>(res2.mongoose.results[0]);
 }
 
 function schemaStaticsWithoutGenerics() {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -288,6 +288,15 @@ declare module 'mongoose' {
     insertMany<DocContents = T>(doc: DocContents, callback: Callback<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>): void;
 
     insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, Require_id<T>>>>;
+    insertMany<DocContents = T>(
+      doc: DocContents,
+      options: InsertManyOptions & { ordered: false; rawResult: true; }
+    ): Promise<mongodb.InsertManyResult<T> & {
+      mongoose: {
+        validationErrors: Error[];
+        results: Array<Error | Object | HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>
+      }
+    }>;
     insertMany<DocContents = T>(docs: Array<DocContents | T>, options: InsertManyOptions & { rawResult: true; }): Promise<mongodb.InsertManyResult<T>>;
     insertMany<DocContents = T>(docs: Array<DocContents | T>): Promise<Array<HydratedDocument<MergeType<MergeType<T, DocContents>, Require_id<T>>, TMethodsAndOverrides, TVirtuals>>>;
     insertMany<DocContents = T>(doc: DocContents, options: InsertManyOptions & { lean: true; }): Promise<Array<MergeType<MergeType<T, DocContents>, Require_id<T>>>>;


### PR DESCRIPTION
Fix #12791

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12791 pointed out that it is still very tricky to figure out exactly which documents were inserted if you're using `insertMany()` with `ordered: false`. That's because the document can either 1) fail Mongoose validation, 2) fail because of a MongoDB server error, 3) succeed. And the results for (1), (2), and (3) are all in separate properties, which means you need to do some stitching to figure out exactly what happened with a particular document.

With this PR, if there were any errors, there will be a `results` property on the error (or `res.mongoose.results` if you're using `rawResult: true`) that contains an array which has either 1) the document if the document was successfully inserted, 2) the MongoDB write error if the write failed, 3) the Mongoose validation error if the document failed validation. The index in the `results` array corresponds to the index of the original document in `arr` in the `Model.insertMany(arr)` call, so this should make it easy to determine if an individual document succeeded or not in `insertMany()`. Just check `error.results[i] instanceof mongoose.Document`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
