### PR TITLE
fix(document): apply setters on resulting value when calling Document.prototype.$inc()

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1783,18 +1783,22 @@ Document.prototype.$inc = function $inc(path, val) {
     return this;
   }
 
+  const currentValue = this.$__getValue(path) || 0;
+  let valToSet = currentValue + val;
+  let valToInc = val;
+
   try {
     val = castNumber(val);
+    valToSet = schemaType.applySetters(currentValue + val, this);
+    valToInc = valToSet - currentValue;
   } catch (err) {
     this.invalidate(path, new MongooseError.CastError('number', val, path, err));
   }
 
-  const currentValue = this.$__getValue(path) || 0;
-
   this.$__.primitiveAtomics = this.$__.primitiveAtomics || {};
-  this.$__.primitiveAtomics[path] = { $inc: val };
+  this.$__.primitiveAtomics[path] = { $inc: valToInc };
   this.markModified(path);
-  this.$__setValue(path, currentValue + val);
+  this.$__setValue(path, valToSet);
 
   return this;
 };

--- a/lib/document.js
+++ b/lib/document.js
@@ -18,7 +18,6 @@ const ValidatorError = require('./error/validator');
 const VirtualType = require('./virtualtype');
 const $__hasIncludedChildren = require('./helpers/projection/hasIncludedChildren');
 const promiseOrCallback = require('./helpers/promiseOrCallback');
-const castNumber = require('./cast/number');
 const applyDefaults = require('./helpers/document/applyDefaults');
 const cleanModifiedSubpaths = require('./helpers/document/cleanModifiedSubpaths');
 const compile = require('./helpers/document/compile').compile;
@@ -1784,21 +1783,25 @@ Document.prototype.$inc = function $inc(path, val) {
   }
 
   const currentValue = this.$__getValue(path) || 0;
-  let valToSet = currentValue + val;
+  let shouldSet = false;
+  let valToSet = null;
   let valToInc = val;
 
   try {
-    val = castNumber(val);
+    val = schemaType.cast(val);
     valToSet = schemaType.applySetters(currentValue + val, this);
     valToInc = valToSet - currentValue;
+    shouldSet = true;
   } catch (err) {
     this.invalidate(path, new MongooseError.CastError('number', val, path, err));
   }
 
-  this.$__.primitiveAtomics = this.$__.primitiveAtomics || {};
-  this.$__.primitiveAtomics[path] = { $inc: valToInc };
-  this.markModified(path);
-  this.$__setValue(path, valToSet);
+  if (shouldSet) {
+    this.$__.primitiveAtomics = this.$__.primitiveAtomics || {};
+    this.$__.primitiveAtomics[path] = { $inc: valToInc };
+    this.markModified(path);
+    this.$__setValue(path, valToSet);
+  }
 
   return this;
 };

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11688,7 +11688,7 @@ describe('document', function() {
 
         doc.$inc('counter', 3);
         assert.deepEqual(called, [2, 5]);
-        assert.equal(doc.counter, 5);
+        assert.equal(doc.counter, 2);
         const err = await doc.save().then(() => null, err => err);
         assert.ok(err);
         assert.ok(err.errors['counter']);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11669,7 +11669,7 @@ describe('document', function() {
         assert.equal(res.counter, 3.14);
       });
 
-      it('sets value even if setter fails (gh-13158)', async function() {
+      it('avoids updating value if setter fails (gh-13158)', async function() {
         const called = [];
         const Test2 = db.model('Test2', Schema({
           counter: {


### PR DESCRIPTION
Fix #13158

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Document.prototype.$inc() doesn't call setters right now, which is a little strange given that `findOneAndUpdate()` with `$inc` does call setters.

The biggest wrinkle here is that we're calling setters on the _resulting value_, not the value passed in to `$inc`. So `$inc('balance', 4)` will call setters with `balance = 6 + 4` if `balance` was originally 6. I think this is slightly better because setters are often used for rounding, and we want to make sure devs that are using `$inc()` instead of `+=` don't run into unexpected binary floating point precision issues.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
