### PR TITLE
types(documentarray): fixed type of DocumentArray constructor parameter

### DIFF
--- a/test/types/docArray.test.ts
+++ b/test/types/docArray.test.ts
@@ -33,4 +33,47 @@ function gh13087() {
   }
 
   expectError(new Types.DocumentArray<Book>([1, 2, 3]));
+
+  const locationSchema = new Schema(
+    {
+      type: {
+        required: true,
+        type: String,
+        enum: ['Point']
+      },
+      coordinates: {
+        required: true,
+        type: [Number] // [longitude, latitude]
+      }
+    },
+    { _id: false }
+  );
+
+  const pointSchema = new Schema({
+    name: { required: true, type: String },
+    location: { required: true, type: locationSchema }
+  });
+
+  const routeSchema = new Schema({
+    points: { type: [pointSchema] }
+  });
+
+  type Route = InferSchemaType<typeof routeSchema>;
+
+  function getTestRouteData(): Route {
+    return {
+      points: new Types.DocumentArray([
+        { name: 'Test', location: { type: 'Point', coordinates: [1, 2] } }
+      ])
+    };
+  }
+
+  const { points } = getTestRouteData();
+  expectType<Types.DocumentArray<{
+    name: string;
+    location: {
+      type: 'Point';
+      coordinates: number[];
+    };
+  }>>(points);
 }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -61,7 +61,7 @@ declare module 'mongoose' {
 
     class DocumentArray<T> extends Types.Array<T extends Types.Subdocument ? T : Types.Subdocument<InferId<T>> & T> {
       /** DocumentArray constructor */
-      constructor(values: (AnyKeys<T> & AnyObject)[]);
+      constructor(values: AnyObject[]);
 
       isMongooseDocumentArray: true;
 


### PR DESCRIPTION
**Summary**
As a result of [this feedback](https://github.com/Automattic/mongoose/issues/13087#issuecomment-1470729163), fixes the bug introduced by #13089 changing the type of `DocumentArray` constructor's parameter to `AnyObject[]`.

Closes #13087
