### PR TITLE
fix(query): avoid executing transforms if query wasn't executed

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2786,7 +2786,7 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
-  let paths = shouldValidateModifiedOnly ?
+  const paths = shouldValidateModifiedOnly ?
     pathDetails[0].filter((path) => this.$isModified(path)) :
     pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
@@ -2986,7 +2986,7 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
-  let paths = shouldValidateModifiedOnly ?
+  const paths = shouldValidateModifiedOnly ?
     pathDetails[0].filter((path) => this.$isModified(path)) :
     pathDetails[0];
   const skipSchemaValidators = pathDetails[1];

--- a/lib/query.js
+++ b/lib/query.js
@@ -4319,16 +4319,16 @@ Query.prototype.exec = async function exec(op) {
   try {
     await _executePreHooks(this);
     res = await this[thunk]();
+
+    for (const fn of this._transforms) {
+      res = fn(res);
+    }
   } catch (err) {
     if (err instanceof Kareem.skipWrappedFunction) {
       res = err.args[0];
     } else {
       error = err;
     }
-  }
-
-  for (const fn of this._transforms) {
-    res = fn(res);
   }
 
   res = await _executePostHooks(this, res, error);


### PR DESCRIPTION
Fix #13165

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Some of the refactoring we did to switch `exec()` to async/await created a quirk where we still execute query transforms even if the query errored out. This leads to odd consequences like throwing a `DocumentNotFoundError` if `findOne()` throws a cast error, even though Mongoose didn't execute a query.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
