### PR TITLE
chore(workflows/stale): update close message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days'
-          close-issue-message: "This issue was closed because it has been inactive for 19 days since being marked as stale."
+          close-issue-message: "This issue was closed because it has been inactive for 19 days and has been marked as stale."
           days-before-stale: 14
           days-before-close: 5
           any-of-labels: can't reproduce,help,needs clarification


### PR DESCRIPTION
**Summary**

This PR updates the stale close message, because it is not actually "19 days since stale label" but "19 days since no activity"

Example: https://github.com/Automattic/mongoose/issues/13017#issuecomment-1475044901