### PR TITLE
fix(timestamps): set timestamps on empty `replaceOne()`

### DIFF
--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -7,6 +7,11 @@ const handleTimestampOption = require('../schema/handleTimestampOption');
 const setDocumentTimestamps = require('./setDocumentTimestamps');
 const symbols = require('../../schema/symbols');
 
+const replaceOps = new Set([
+  'replaceOne',
+  'findOneAndReplace'
+]);
+
 module.exports = function setupTimestamps(schema, timestamps) {
   const childHasTimestamp = schema.childSchemas.find(withTimestamp);
   function withTimestamp(s) {
@@ -90,7 +95,7 @@ module.exports = function setupTimestamps(schema, timestamps) {
       currentTime() :
       this.model.base.now();
     // Replacing with null update should still trigger timestamps
-    if (this.op === 'findOneAndReplace' && this.getUpdate() == null) {
+    if (replaceOps.has(this.op) && this.getUpdate() == null) {
       this.setUpdate({});
     }
     applyTimestampsToUpdate(now, createdAt, updatedAt, this.getUpdate(),

--- a/test/timestamps.test.js
+++ b/test/timestamps.test.js
@@ -548,6 +548,19 @@ describe('timestamps', function() {
       assert.ok(doc.createdAt.getTime() === doc.updatedAt.getTime());
     });
 
+    it('sets timestamps on replaceOne (gh-9951)', async function() {
+      await Cat.deleteMany({});
+      const { _id } = await Cat.create({ name: 'notexistname' });
+      await Cat.replaceOne({ name: 'notexistname' }, {});
+      const docs = await Cat.find({});
+      assert.equal(docs.length, 1);
+      const [doc] = docs;
+      assert.equal(doc._id.toHexString(), _id.toHexString());
+      assert.ok(doc.createdAt);
+      assert.ok(doc.updatedAt);
+      assert.ok(doc.createdAt.getTime() === doc.updatedAt.getTime());
+    });
+
     it('should change updatedAt when save', async function() {
       const doc = await Cat.findOne({ name: 'newcat' });
       const old = doc.updatedAt;


### PR DESCRIPTION
Re: #9951
Re: #13170

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I noticed when working on #13170 that the fix for #9951 only applies to `findOneAndReplace()`, not `replaceOne()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
