### PR TITLE
fix(schema): make creating top-level virtual underneath subdocument equivalent to creating virtual on the subdocument

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2217,7 +2217,7 @@ Schema.prototype.virtual = function(name, options) {
     }
 
     // Workaround for gh-8198: if virtual is under document array, make a fake
-    // virtual. See gh-8210
+    // virtual. See gh-8210, gh-13189
     const parts = name.split('.');
     let cur = parts[0];
     for (let i = 0; i < parts.length - 1; ++i) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2224,7 +2224,7 @@ Schema.prototype.virtual = function(name, options) {
       if (this.paths[cur] == null) {
         continue;
       }
-      
+
       if (this.paths[cur].$isMongooseDocumentArray || this.paths[cur].$isSingleNested) {
         const remnant = parts.slice(i + 1).join('.');
         this.paths[cur].schema.virtual(remnant, options);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2221,7 +2221,11 @@ Schema.prototype.virtual = function(name, options) {
     const parts = name.split('.');
     let cur = parts[0];
     for (let i = 0; i < parts.length - 1; ++i) {
-      if (this.paths[cur] != null && this.paths[cur].$isMongooseDocumentArray) {
+      if (this.paths[cur] == null) {
+        continue;
+      }
+      
+      if (this.paths[cur].$isMongooseDocumentArray || this.paths[cur].$isSingleNested) {
         const remnant = parts.slice(i + 1).join('.');
         this.paths[cur].schema.virtual(remnant, options);
         break;

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -7941,12 +7941,12 @@ describe('model: populate:', function() {
           barId: { type: Schema.Types.ObjectId, ref: 'Test' },
           quantity: Number
         }],
-        child: {
+        child: new Schema({
           barId: {
             type: 'ObjectId',
             ref: 'Test'
           }
-        }
+        })
       });
       FooSchema.virtual('children.bar', {
         ref: 'Test',
@@ -7954,11 +7954,10 @@ describe('model: populate:', function() {
         foreignField: '_id',
         justOne: true
       });
-      FooSchema.virtual('child.bar', {
+      FooSchema.virtual('child.bars', {
         ref: 'Test',
         localField: 'child.barId',
-        foreignField: '_id',
-        justOne: true
+        foreignField: '_id'
       });
       const BarSchema = Schema({ name: String });
       const Foo = db.model('Test1', FooSchema);
@@ -7972,13 +7971,13 @@ describe('model: populate:', function() {
           barId: bar._id
         }
       });
-      const foo2 = await Foo.findById(foo._id).populate('children.bar child.bar');
+      const foo2 = await Foo.findById(foo._id).populate('children.bar child.bars');
       assert.equal(foo2.children[0].bar.name, 'bar');
-      assert.equal(foo2.child.bar.name, 'bar');
+      assert.equal(foo2.child.bars[0].name, 'bar');
 
       const asObject = foo2.toObject({ virtuals: true });
       assert.equal(asObject.children[0].bar.name, 'bar');
-      assert.equal(asObject.child.bar.name, 'bar');
+      assert.equal(asObject.child.bars[0].name, 'bar');
     });
 
     describe('gh-8247', function() {


### PR DESCRIPTION
Fix #13189
Re: #8210
Re: #8198

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Apply the fix for #8198 to single nested subdocuments, as opposed to just arrays. That looks like it fixes #13189, which highlights the same underlying issue as #8210.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
