### PR TITLE
Added logic back to pull in strict option from schema

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4575,6 +4575,15 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
     upsert = this.options.upsert;
   }
 
+  let strict;
+  if ('strict' in this.options) {
+    strict = this.options.strict;
+  } else if (schema && schema.options) {
+    strict = schema.options.strict;
+  } else {
+    strict = true;
+  }
+
   const filter = this._conditions;
   if (schema != null &&
       utils.hasUserDefinedProperty(filter, schema.options.discriminatorKey) &&
@@ -4589,7 +4598,7 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
 
   return castUpdate(schema, obj, {
     overwrite: overwrite,
-    strict: this._mongooseOptions.strict,
+    strict: strict,
     upsert: upsert,
     arrayFilters: this.options.arrayFilters,
     overwriteDiscriminatorKey: this._mongooseOptions.overwriteDiscriminatorKey

--- a/lib/query.js
+++ b/lib/query.js
@@ -4576,8 +4576,8 @@ Query.prototype._castUpdate = function _castUpdate(obj, overwrite) {
   }
 
   let strict;
-  if ('strict' in this.options) {
-    strict = this.options.strict;
+  if ('strict' in this._mongooseOptions) {
+    strict = this._mongooseOptions.strict;
   } else if (schema && schema.options) {
     strict = schema.options.strict;
   } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I wanted to add this logic back into the Query from 5.x
https://github.com/Automattic/mongoose/blob/5.x/lib/query.js#L4686

I am not sure why this was removed in 6.x and 7.x but I would like the `strict` parameter to persist from the Schema.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
