### PR TITLE
fix(array): pass-through all parameters

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -451,7 +451,7 @@ SchemaArray.prototype.$toObject = SchemaArray.prototype.toObject;
  * ignore
  */
 
-SchemaArray.prototype.discriminator = function(name, schema) {
+SchemaArray.prototype.discriminator = function(...args) {
   let arr = this;
   while (arr.$isMongooseArray && !arr.$isMongooseDocumentArray) {
     arr = arr.casterConstructor;
@@ -460,7 +460,7 @@ SchemaArray.prototype.discriminator = function(name, schema) {
         'a document array, ' + this.path + ' is a plain array');
     }
   }
-  return arr.discriminator(name, schema);
+  return arr.discriminator(...args);
 };
 
 /*!

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -2101,4 +2101,73 @@ describe('model', function() {
     await Square.create({ nested: { test: 'foo' } });
     assert.equal(subdocSaveCalls, 1);
   });
+
+  it('uses "value" over "name" for multi-dimensonal arrays (gh-13201)', function() {
+    const buildingSchema = new mongoose.Schema(
+      {
+        width: {
+          type: Number,
+          default: 100
+        },
+        type: {
+          type: String,
+          enum: ['G', 'S']
+        }
+      },
+      { discriminatorKey: 'type', _id: false }
+    );
+
+    const garageSchema = buildingSchema.clone();
+    garageSchema.add({
+      slotsForCars: {
+        type: Number,
+        default: 10
+      }
+    });
+
+    const summerSchema = buildingSchema.clone();
+    summerSchema.add({
+      distanceToLake: {
+        type: Number,
+        default: 100
+      }
+    });
+
+    const areaSchema = new mongoose.Schema({
+      buildings: {
+        type: [
+          [
+            {
+              type: buildingSchema
+            }
+          ]
+        ]
+      }
+    });
+
+    garageSchema.paths['type'].options.$skipDiscriminatorCheck = true;
+    summerSchema.paths['type'].options.$skipDiscriminatorCheck = true;
+    const path = areaSchema.path('buildings');
+
+    path.discriminator('Garage', garageSchema, 'G');
+    path.discriminator('Summer', summerSchema, 'S');
+
+    const AreaModel = mongoose.model('Area', areaSchema);
+
+    const area = new AreaModel({
+      buildings: [
+        [
+          { type: 'S', distanceToLake: 100 },
+          { type: 'G', slotsForCars: 20 }
+        ]
+      ]
+    });
+
+    assert.ok(area.buildings[0][0].distanceToLake);
+    assert.ok(area.buildings[0][1].slotsForCars);
+
+    const innerBuildingsPath = AreaModel.schema.path('buildings.$');
+    assert.ok(innerBuildingsPath.schemaOptions.type.discriminators.Garage);
+    assert.equal(innerBuildingsPath.schemaOptions.type.discriminators.Garage.discriminatorMapping.value, 'G');
+  });
 });


### PR DESCRIPTION
**Summary**

This PR changes `SchemaArray.discriminator` to pass-through all parameters to the `arr.discriminator` function

fixes #13201

fix should also be added to 7.x