### PR TITLE
types(model): aligned `watch()` type for mongodb 4.6.0

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -17,7 +17,7 @@ import {
 } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
-import { UpdateOneModel } from 'mongodb';
+import { UpdateOneModel, ChangeStreamInsertDocument } from 'mongodb';
 
 function rawDocSyntax(): void {
   interface ITest {
@@ -566,4 +566,15 @@ async function gh13151() {
   expectType<ITest & { _id: Types.ObjectId } | null>(test);
   if (!test) return;
   expectType<ITest & { _id: Types.ObjectId }>(test);
+}
+
+function gh13206() {
+  interface ITest {
+    name: string;
+  }
+  const TestSchema = new Schema({ name: String });
+  const TestModel = model<ITest>('Test', TestSchema);
+  TestModel.watch<ITest, ChangeStreamInsertDocument<ITest>>([], { fullDocument: 'updateLookup' }).on('change', (change) => {
+    expectType<ChangeStreamInsertDocument<ITest>>(change);
+  });
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -382,7 +382,7 @@ declare module 'mongoose' {
     validate(optional: any, pathsToValidate: PathsToValidate): Promise<void>;
 
     /** Watches the underlying collection for changes using [MongoDB change streams](https://www.mongodb.com/docs/manual/changeStreams/). */
-    watch<ResultType extends mongodb.Document = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions & { hydrate?: boolean }): mongodb.ChangeStream<ResultType>;
+    watch<ResultType extends mongodb.Document = any, ChangeType extends mongodb.ChangeStreamDocument = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions & { hydrate?: boolean }): mongodb.ChangeStream<ResultType, ChangeType>;
 
     /** Adds a `$where` clause to this query */
     $where(argument: string | Function): QueryWithHelpers<Array<THydratedDocumentType>, THydratedDocumentType, TQueryHelpers, TRawDocType>;


### PR DESCRIPTION
**Summary**
You can now specify the custom type for the top-level document returned in a `change` event.
This aligns with the changes introduced in [MongoDB 4.6.0](https://github.com/mongodb/node-mongodb-native/releases/tag/v4.6.0).

**Example**
```
TestModel.watch<ITest, ChangeStreamInsertDocument<ITest>>([]).on('change', (change) => {
    console.log(change.fullDocument); // TS won't complain
});
```

Closes #13206