### PR TITLE
test(model): make test covering `init()` errors on index build failures more robust

### DIFF
--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -256,19 +256,23 @@ describe('model', function() {
 
     it('error should emit on the model', async function() {
       const schema = new Schema({ name: { type: String } });
-      const Test = db.model('Test', schema);
-
+      const Test = db.model('Test', schema, 'Test');
+      await Test.init();
       await Test.create({ name: 'hi' }, { name: 'hi' });
 
-      Test.schema.index({ name: 1 }, { unique: true });
-      Test.schema.index({ other: 1 });
+      const Test2 = db.model(
+        'Test2',
+        new Schema({
+          name: {
+            type: String,
+            unique: true
+          }
+        }),
+        'Test'
+      );
 
-      const err = await Test.ensureIndexes().then(() => null, err => err);
-
+      const err = await Test2.init().then(() => null, err => err);
       assert.ok(/E11000 duplicate key error/.test(err.message), err);
-
-      delete Test.$init;
-      await Test.init().catch(() => {});
     });
 
     it('when one index creation errors', async function() {


### PR DESCRIPTION
Fix #13171

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I don't have a good explanation for the root cause of this test flaking. But we shouldn't rely on modifying the Test model's schema indexes after compiling, that seems brittle. With this change, we instead create a separate model that points to the same collection, and ensure that model's index builds fail.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
