### PR TITLE
Speed up get on top-level properties by 10x

### DIFF
--- a/benchmarks/get.js
+++ b/benchmarks/get.js
@@ -1,40 +1,72 @@
 'use strict';
 
-const get = require('../lib/helpers/get');
+const mongoose = require('../');
 
-let obj;
+run().catch(err => {
+  console.error(err);
+  process.exit(-1);
+});
 
-// Single string
-obj = {};
+async function run() {
+  const schema = new mongoose.Schema({
+    field1: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field2: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field3: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field4: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field5: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field6: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field7: {type: String, default: Math.random().toString(36).slice(2, 16)},
+    field8: {type: String, default: Math.random().toString(36).slice(2, 16)},
+  }, { versionKey: false });
+  const TestModel = mongoose.model('Test', schema);
+  
+  let tests = [];
+  for (let i = 0; i < 10000; i++) {
+    tests.push(new TestModel());
+  }
 
-let start = Date.now();
-for (let i = 0; i < 10000000; ++i) {
-  get(obj, 'test', null);
+  let loopStart = Date.now();
+
+  // run loop with mongoose objects
+  for (let k = 0; k < 100; k++) {
+    for (let test of tests) {
+      test.field1;
+      test.field2;
+      test.field3;
+      test.field4;
+      test.field5;
+      test.field6;
+      test.field7;
+      test.field8;
+    }
+  }
+
+  const results = {
+    'Model loop ms': Date.now() - loopStart
+  };
+
+  const plainTests = [];
+  for (let test of tests) {
+    plainTests.push(test.toObject());
+  }
+
+  loopStart = Date.now();
+
+  // run loop with plain objects
+  for (let k = 0; k < 100; k++) {
+    for (let test of plainTests) {
+      test.field1;
+      test.field2;
+      test.field3;
+      test.field4;
+      test.field5;
+      test.field6;
+      test.field7;
+      test.field8;
+    }
+  }
+
+  results['POJO loop ms'] = Date.now() - loopStart;
+
+  console.log(JSON.stringify(results, null, '  '));
 }
-console.log('Single string', Date.now() - start);
-
-// Array of length 1
-obj = {};
-start = Date.now();
-let arr = ['test'];
-for (let i = 0; i < 10000000; ++i) {
-  get(obj, arr, null);
-}
-console.log('Array of length 1', Date.now() - start);
-
-// String with dots
-obj = { a: { b: 1 } };
-start = Date.now();
-for (let i = 0; i < 10000000; ++i) {
-  get(obj, 'a.b', null);
-}
-console.log('String with dots', Date.now() - start);
-
-// Multi element array
-obj = { a: { b: 1 } };
-start = Date.now();
-arr = ['a', 'b'];
-for (let i = 0; i < 10000000; ++i) {
-  get(obj, arr, null);
-}
-console.log('Multi element array', Date.now() - start);

--- a/lib/document.js
+++ b/lib/document.js
@@ -723,6 +723,9 @@ Document.prototype.$__init = function(doc, opts) {
 function init(self, obj, doc, opts, prefix) {
   prefix = prefix || '';
 
+  if (obj.$__ != null) {
+    obj = obj._doc;
+  }
   const keys = Object.keys(obj);
   const len = keys.length;
   let schemaType;
@@ -1842,12 +1845,14 @@ Document.prototype.$__setValue = function(path, val) {
 
 Document.prototype.get = function(path, type, options) {
   let adhoc;
-  options = options || {};
+  if (options == null) {
+    options = {};
+  }
   if (type) {
     adhoc = this.$__schema.interpretAsType(path, type, this.$__schema.options);
   }
 
-  let schema = this.$__path(path);
+  let schema = this.$__path(path, options.noDottedPath);
   if (schema == null) {
     schema = this.$__schema.virtualpath(path);
   }
@@ -1860,7 +1865,7 @@ Document.prototype.get = function(path, type, options) {
   if (schema instanceof VirtualType) {
     return schema.applyGetters(void 0, this);
   }
-  const hasDot = path.indexOf('.') !== -1;
+  const hasDot = !options.noDottedPath && path.indexOf('.') !== -1;
   let obj = this._doc;
 
   if (hasDot) {
@@ -1925,14 +1930,14 @@ Document.prototype.$get = Document.prototype.get;
  * @instance
  */
 
-Document.prototype.$__path = function(path) {
+Document.prototype.$__path = function(path, noDottedPath) {
   const adhocs = this.$__.adhocPaths;
   const adhocType = adhocs && adhocs.hasOwnProperty(path) ? adhocs[path] : null;
 
   if (adhocType) {
     return adhocType;
   }
-  return this.$__schema.path(path);
+  return this.$__schema.path(path, undefined, noDottedPath);
 };
 
 /**

--- a/lib/document.js
+++ b/lib/document.js
@@ -15,7 +15,6 @@ const Schema = require('./schema');
 const StrictModeError = require('./error/strict');
 const ValidationError = require('./error/validation');
 const ValidatorError = require('./error/validator');
-const VirtualType = require('./virtualtype');
 const $__hasIncludedChildren = require('./helpers/projection/hasIncludedChildren');
 const promiseOrCallback = require('./helpers/promiseOrCallback');
 const applyDefaults = require('./helpers/document/applyDefaults');
@@ -1851,50 +1850,59 @@ Document.prototype.get = function(path, type, options) {
   if (type) {
     adhoc = this.$__schema.interpretAsType(path, type, this.$__schema.options);
   }
+  const noDottedPath = options.noDottedPath;
 
-  let schema = this.$__path(path, options.noDottedPath);
+  // Fast path if we know we're just accessing top-level path on the document:
+  // just get the schema path, avoid `$__path()` because that does string manipulation
+  let schema = noDottedPath ? this.$__schema.paths[path] : this.$__path(path);
   if (schema == null) {
     schema = this.$__schema.virtualpath(path);
+
+    if (schema != null) {
+      return schema.applyGetters(void 0, this);
+    }
   }
-  if (schema instanceof MixedSchema) {
+
+  if (noDottedPath) {
+    let obj = this._doc[path];
+    if (adhoc) {
+      obj = adhoc.cast(obj);
+    }
+    if (schema != null) {
+      return schema.applyGetters(obj, this);
+    }
+    return obj;
+  }
+
+  if (schema != null && schema.instance === 'Mixed') {
     const virtual = this.$__schema.virtualpath(path);
     if (virtual != null) {
       schema = virtual;
     }
   }
-  if (schema instanceof VirtualType) {
-    return schema.applyGetters(void 0, this);
-  }
-  const hasDot = !options.noDottedPath && path.indexOf('.') !== -1;
+
+  const hasDot = path.indexOf('.') !== -1;
   let obj = this._doc;
 
-  if (hasDot) {
-    const pieces = path.split('.');
-    // Might need to change path for top-level alias
-    if (typeof this.$__schema.aliases[pieces[0]] === 'string') {
-      pieces[0] = this.$__schema.aliases[pieces[0]];
+  const pieces = hasDot ? path.split('.') : [path];
+  // Might need to change path for top-level alias
+  if (typeof this.$__schema.aliases[pieces[0]] === 'string') {
+    pieces[0] = this.$__schema.aliases[pieces[0]];
+  }
+
+  for (let i = 0, l = pieces.length; i < l; i++) {
+    if (obj && obj._doc) {
+      obj = obj._doc;
     }
 
-    for (let i = 0, l = pieces.length; i < l; i++) {
-      if (obj && obj._doc) {
-        obj = obj._doc;
-      }
-
-      if (obj == null) {
-        obj = void 0;
-      } else if (obj instanceof Map) {
-        obj = obj.get(pieces[i], { getters: false });
-      } else if (i === l - 1) {
-        obj = utils.getValue(pieces[i], obj);
-      } else {
-        obj = obj[pieces[i]];
-      }
-    }
-  } else {
-    if (typeof this.$__schema.aliases[path] === 'string') {
-      obj = obj[this.$__schema.aliases[path]];
+    if (obj == null) {
+      obj = void 0;
+    } else if (obj instanceof Map) {
+      obj = obj.get(pieces[i], { getters: false });
+    } else if (i === l - 1) {
+      obj = utils.getValue(pieces[i], obj);
     } else {
-      obj = obj[path];
+      obj = obj[pieces[i]];
     }
   }
 
@@ -1930,14 +1938,14 @@ Document.prototype.$get = Document.prototype.get;
  * @instance
  */
 
-Document.prototype.$__path = function(path, noDottedPath) {
+Document.prototype.$__path = function(path) {
   const adhocs = this.$__.adhocPaths;
   const adhocType = adhocs && adhocs.hasOwnProperty(path) ? adhocs[path] : null;
 
   if (adhocType) {
     return adhocType;
   }
-  return this.$__schema.path(path, undefined, noDottedPath);
+  return this.$__schema.path(path);
 };
 
 /**

--- a/lib/document.js
+++ b/lib/document.js
@@ -1857,31 +1857,39 @@ Document.prototype.get = function(path, type, options) {
       schema = virtual;
     }
   }
-  const pieces = path.indexOf('.') === -1 ? [path] : path.split('.');
-  let obj = this._doc;
-
   if (schema instanceof VirtualType) {
     return schema.applyGetters(void 0, this);
   }
+  const hasDot = path.indexOf('.') !== -1;
+  let obj = this._doc;
 
-  // Might need to change path for top-level alias
-  if (typeof this.$__schema.aliases[pieces[0]] === 'string') {
-    pieces[0] = this.$__schema.aliases[pieces[0]];
-  }
-
-  for (let i = 0, l = pieces.length; i < l; i++) {
-    if (obj && obj._doc) {
-      obj = obj._doc;
+  if (hasDot) {
+    const pieces = path.split('.');
+    // Might need to change path for top-level alias
+    if (typeof this.$__schema.aliases[pieces[0]] === 'string') {
+      pieces[0] = this.$__schema.aliases[pieces[0]];
     }
 
-    if (obj == null) {
-      obj = void 0;
-    } else if (obj instanceof Map) {
-      obj = obj.get(pieces[i], { getters: false });
-    } else if (i === l - 1) {
-      obj = utils.getValue(pieces[i], obj);
+    for (let i = 0, l = pieces.length; i < l; i++) {
+      if (obj && obj._doc) {
+        obj = obj._doc;
+      }
+
+      if (obj == null) {
+        obj = void 0;
+      } else if (obj instanceof Map) {
+        obj = obj.get(pieces[i], { getters: false });
+      } else if (i === l - 1) {
+        obj = utils.getValue(pieces[i], obj);
+      } else {
+        obj = obj[pieces[i]];
+      }
+    }
+  } else {
+    if (typeof this.$__schema.aliases[path] === 'string') {
+      obj = obj[this.$__schema.aliases[path]];
     } else {
-      obj = obj[pieces[i]];
+      obj = obj[path];
     }
   }
 

--- a/lib/helpers/document/compile.js
+++ b/lib/helpers/document/compile.js
@@ -24,6 +24,10 @@ const _isEmptyOptions = Object.freeze({
   transform: false
 });
 
+const noDottedPathGetOptions = Object.freeze({
+  noDottedPath: true
+});
+
 /**
  * Compiles schemas.
  * @param {Object} tree
@@ -64,6 +68,7 @@ function defineKey({ prop, subprops, prototype, prefix, options }) {
   Document = Document || require('../../document');
   const path = (prefix ? prefix + '.' : '') + prop;
   prefix = prefix || '';
+  const useGetOptions = prefix ? Object.freeze({}) : noDottedPathGetOptions;
 
   if (subprops) {
     Object.defineProperty(prototype, prop, {
@@ -188,7 +193,12 @@ function defineKey({ prop, subprops, prototype, prefix, options }) {
       enumerable: true,
       configurable: true,
       get: function() {
-        return this[getSymbol].call(this.$__[scopeSymbol] || this, path);
+        return this[getSymbol].call(
+          this.$__[scopeSymbol] || this,
+          path,
+          null,
+          useGetOptions
+        );
       },
       set: function(v) {
         this.$set.call(this.$__[scopeSymbol] || this, path, v);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -933,12 +933,9 @@ reserved.collection = 1;
  * @api public
  */
 
-Schema.prototype.path = function(path, obj, noDottedPath) {
-  // Convert to '.$' to check subpaths re: gh-6405
+Schema.prototype.path = function(path, obj) {
   if (obj === undefined) {
-    if (noDottedPath) {
-      return this.paths[path];
-    }
+    // Convert to '.$' to check subpaths re: gh-6405
     const cleanPath = _pathToPositionalSyntax(path);
     let schematype = _getPath(this, path, cleanPath);
     if (schematype != null) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -933,10 +933,13 @@ reserved.collection = 1;
  * @api public
  */
 
-Schema.prototype.path = function(path, obj) {
+Schema.prototype.path = function(path, obj, noDottedPath) {
   // Convert to '.$' to check subpaths re: gh-6405
-  const cleanPath = _pathToPositionalSyntax(path);
   if (obj === undefined) {
+    if (noDottedPath) {
+      return this.paths[path];
+    }
+    const cleanPath = _pathToPositionalSyntax(path);
     let schematype = _getPath(this, path, cleanPath);
     if (schematype != null) {
       return schematype;

--- a/test/deno.js
+++ b/test/deno.js
@@ -12,6 +12,8 @@ Object.defineProperty(process.stdout, 'getWindowSize', {
 import { parse } from "https://deno.land/std/flags/mod.ts"
 const args = parse(Deno.args);
 
+Error.stackTraceLimit = 100;
+
 const require = createRequire(import.meta.url);
 
 const Mocha = require('mocha');

--- a/test/virtualtype.test.js
+++ b/test/virtualtype.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const VirtualType = require('../lib/virtualtype');
 const assert = require('assert');
+const start = require('./common');
 
 describe('VirtualType', function() {
   describe('clone', function() {
     it('copies path and options correctly (gh-8587)', function() {
       const opts = { ref: 'User', localField: 'userId', foreignField: '_id' };
-      const virtual = new VirtualType(Object.assign({}, opts), 'users');
+      const virtual = new start.mongoose.VirtualType(Object.assign({}, opts), 'users');
 
       const clone = virtual.clone();
       assert.equal(clone.path, 'users');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`doc.myProp` does a lot of unnecessary string manipulation and comparisons. This PR trims off a bunch of the unnecessary work.

Before:

```
$ node ./benchmarks/get.js 
{
  "Model loop ms": 2011,
  "POJO loop ms": 7
}
```

After:

```
$ node ./benchmarks/get.js 
{
  "Model loop ms": 206,
  "POJO loop ms": 8
}
```

Not really sure how much faster we can make this, Mongoose will always be slower than a plain old property access because we need to support getters, etc. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
