### PR TITLE
fix(schema): fix dangling reference to virtual in `tree` after `removeVirtual()`

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2357,6 +2357,11 @@ Schema.prototype.removeVirtual = function(path) {
     for (const virtual of path) {
       delete this.paths[virtual];
       delete this.virtuals[virtual];
+      if (virtual.indexOf('.') !== -1) {
+        mpath.unset(virtual, this.tree);
+      } else {
+        delete this.tree[virtual];
+      }
     }
   }
   return this;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2988,9 +2988,13 @@ describe('schema', function() {
     assert.ok(schema.virtuals.foo);
     schema.removeVirtual('foo');
     assert.ok(!schema.virtuals.foo);
+    assert.ok(!schema.tree.foo);
+
+    schema.virtual('foo').get(v => v || 99);
+
     const Test = db.model('gh-8397', schema);
     const doc = new Test({ name: 'Test' });
-    assert.equal(doc.foo, undefined);
+    assert.equal(doc.foo, 99);
   });
 
   it('should allow deleting multiple virtuals gh-8397', async function() {


### PR DESCRIPTION
Fix #13085

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`removeVirtual()` still leaves a dangling reference to the virtual type, this PR fixes that. With this fix, #13085 can correctly redeclare virtuals.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
