### PR TITLE
chore(workflows/test): update deno version to 1.32

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.30.x
+          deno-version: v1.32.x
       - run: deno --version
       - run: npm install
       - name: Run Deno tests

--- a/test/deno.js
+++ b/test/deno.js
@@ -3,13 +3,6 @@
 import { createRequire } from "node:module";
 import process from "node:process";
 
-// Workaround for Mocha getting terminal width, which currently requires `--unstable`
-Object.defineProperty(process.stdout, 'getWindowSize', {
-  value: function() {
-    return [75, 40];
-  }
-});
-
 import { parse } from "https://deno.land/std/flags/mod.ts"
 const args = parse(Deno.args);
 

--- a/test/deno.js
+++ b/test/deno.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import { createRequire } from "https://deno.land/std@0.177.0/node/module.ts";
+import { createRequire } from "node:module";
+import process from "node:process";
 
 // Workaround for Mocha getting terminal width, which currently requires `--unstable`
 Object.defineProperty(process.stdout, 'getWindowSize', {


### PR DESCRIPTION
**Summary**

This PR updates the used deno version to 1.32, because 1.32.2 got a port of `node:zlib` implemented in rust (rather than a polyfill?), because it often resulted in `Error during unzip for /binary/mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz: Error: incorrect header check`

hopefully this fixes this problem for deno

[Example run](https://github.com/hasezoey/mongoose/actions/runs/4631765108/jobs/8195024293)