### PR TITLE
Remove direction to include virutals in toObject

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -374,8 +374,7 @@ console.log(axl.fullName); // Axl Rose
 If you use `toJSON()` or `toObject()` mongoose will *not* include virtuals
 by default. This includes the output of calling [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 on a Mongoose document, because [`JSON.stringify()` calls `toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description).
-Pass `{ virtuals: true }` to either
-[`toObject()`](api/document.html#document_Document-toObject) or [`toJSON()`](api/document.html#document_Document-toJSON).
+Pass `{ virtuals: true }` to [`toJSON()`](api/document.html#document_Document-toJSON).
 
 You can also add a custom setter to your virtual that will let you set both
 first name and last name via the `fullName` virtual.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -371,10 +371,34 @@ Now, mongoose will call your getter function every time you access the
 console.log(axl.fullName); // Axl Rose
 ```
 
-If you use `toJSON()` or `toObject()` mongoose will *not* include virtuals
-by default. This includes the output of calling [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
-on a Mongoose document, because [`JSON.stringify()` calls `toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description).
-Pass `{ virtuals: true }` to [`toJSON()`](api/document.html#document_Document-toJSON).
+If you use `toJSON()` or `toObject()` Mongoose will *not* include virtuals by default.
+Pass `{ virtuals: true }` to [`toJSON()`](api/document.html#document_Document-toJSON) or `toObject()` to include virtuals.
+
+```javascript
+// Convert `doc` to a POJO, with virtuals attached
+doc.toObject({ virtuals: true });
+
+// Equivalent:
+doc.toJSON({ virtuals: true });
+```
+
+The above caveat for `toJSON()` also includes the output of calling [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) on a Mongoose document, because [`JSON.stringify()` calls `toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description).
+To include virtuals in `JSON.stringify()` output, you can either call `toObject({ virtuals: true })` on the document before calling `JSON.stringify()`, or set the `toJSON: { virtuals: true }` option on your schema.
+
+```javascript
+// Explicitly add virtuals to `JSON.stringify()` output
+JSON.stringify(doc.toObject({ virtuals: true }));
+
+// Or, to automatically attach virtuals to `JSON.stringify()` output:
+const personSchema = new Schema({
+  name: {
+    first: String,
+    last: String
+  }
+}, {
+  toJSON: { virtuals: true } // <-- include virtuals in `JSON.stringify()`
+});
+```
 
 You can also add a custom setter to your virtual that will let you set both
 first name and last name via the `fullName` virtual.


### PR DESCRIPTION
Passing {virtuals: true} to toObject does not have the same effect as toJSON{ vrituals: true} Tested on Ubuntu 22.04 and Windows 10 using version "^6.9.2"


Can be replicated with the following model file:

```
const postSchema = new Schema(
  {
    text: String,
    username: String,
    comments: [{ type: Schema.Types.ObjectId, ref: 'comment' }],
  },
  {
    // replace with toJSON to revert to correct behavior
    toObject: {
      virtuals: true,
    },
  }
);

postSchema.virtual('commentCount').get(function () {
  return this.comments.length;
});

// Initialize our Post model
const Post = model('post', postSchema);
```

Please correct if I'm using this code erroneously

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Documentation directly states including virtuals can be achieved via the same process for both toJSON and toObject but `{ virtuals: true }` has no impact on toObject

**Examples**

toJSON response: 
```
{
		"_id": "643631713ac0c3db07a42df3",
		"text": " curabitur dolor purus ut ornare amet imsum elit lacinia blandit",
		"username": "Abaan",
		"comments": [
			"643631713ac0c3db07a42dee"
		],
		"commentCount": 1,
		"id": "643631713ac0c3db07a42df3"
},
```
toObject response:
```
{
		"_id": "643631713ac0c3db07a42df3",
		"text": " curabitur dolor purus ut ornare amet imsum elit lacinia blandit",
		"username": "Abaan",
		"comments": [
			"643631713ac0c3db07a42dee"
		]
},
```