### PR TITLE
chore: add `versionNumber` property to docs content for search

### DIFF
--- a/scripts/generateSearch.js
+++ b/scripts/generateSearch.js
@@ -31,7 +31,8 @@ const contentSchema = new mongoose.Schema({
   title: { type: String, required: true },
   body: { type: String, required: true },
   url: { type: String, required: true },
-  version: { type: String, required: true, default: version }
+  version: { type: String, required: true, default: version },
+  versionNumber: { type: Number, required: true, default: version.replace(/\.x$/, '') }
 });
 contentSchema.index({ title: 'text', body: 'text' });
 const Content = mongoose.model('Content', contentSchema, 'Content');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: [this comment](https://github.com/mongoosejs/backend/commit/378f7e27a2ae2379260047febddd699fe479c67a#r108335721), looks like our search backend isn't using Atlas search correctly. Unfortunately with the current `version` property being a string, we get the following error: `MongoServerError: "compound.must[0].equals.value" must be a boolean, objectId, number, or date` . Looks like there's no way for `$search` with `equals` to compare strings. So I added a `versionNumber` property.

We'll get rid of the `Content` model/s `version` property once we've merged the search changes and confirmed no issues.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
