### PR TITLE
perf: speed up creating maps of subdocuments

### DIFF
--- a/benchmarks/mapOfSubdocs.js
+++ b/benchmarks/mapOfSubdocs.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const mongoose = require('../');
+
+run().catch(err => {
+  console.error(err);
+  process.exit(-1);
+});
+
+async function run() {
+  await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_test', {
+    serverSelectionTimeoutMS: 5000
+  });
+
+  const minisMap = new mongoose.Schema(
+    {
+      //? Mini reference
+      mini: {
+        type: Map,
+        of: new mongoose.Schema({
+          //? Mini ID
+          miniID: { type: mongoose.Schema.Types.ObjectId, ref: 'Mini', required: true },
+          //? Timestamp as number
+          timestamp: { type: Number, required: true },
+        }),
+      },
+    },
+    //? Automatic creation of timestamps for creation and updating.
+    //? This will be created on the background by the package
+    { timestamps: true }
+  );
+  const MinisMap = mongoose.model('MinisMap', minisMap);
+  await MinisMap.init();
+  
+  const mini = new Map();
+  for (let i = 0; i < 2000; ++i) {
+    const miniID = new mongoose.Types.ObjectId();
+    mini.set(miniID, {
+      miniID,
+      timestamp: Math.floor(Math.random() * 1000000)
+    });
+  }
+
+  let loopStart = Date.now();
+
+  for (let k = 0; k < 10; k++) {
+    await MinisMap.create({ mini });
+  }
+
+  const results = {
+    'Average save time ms': (Date.now() - loopStart) / 10
+  };
+
+  console.log(JSON.stringify(results, null, '  '));
+}

--- a/lib/document.js
+++ b/lib/document.js
@@ -2221,9 +2221,8 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
       paths = paths.indexOf(' ') === -1 ? [paths] : paths.split(' ');
     }
 
-    const directModifiedPathsObj = this.$__.activePaths.getStatePaths('modify');
-    const directModifiedPaths = Object.keys(directModifiedPathsObj);
-    if (directModifiedPaths.length === 0) {
+    const directModifiedPathsObj = this.$__.activePaths.states.modify;
+    if (directModifiedPathsObj == null) {
       return false;
     }
     for (const path of paths) {
@@ -2237,6 +2236,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
       return !!~modified.indexOf(path);
     });
 
+    const directModifiedPaths = Object.keys(directModifiedPathsObj);
     return isModifiedChild || paths.some(function(path) {
       return directModifiedPaths.some(function(mod) {
         return mod === path || path.startsWith(mod + '.');
@@ -3324,10 +3324,7 @@ Document.prototype.$__reset = function reset() {
   let _this = this;
 
   // Skip for subdocuments
-  if (this.$isDocumentArrayElement || this.$isSingleNested) {
-    return this;
-  }
-  const subdocs = this.$getAllSubdocs();
+  const subdocs = this.$parent() === this ? this.$getAllSubdocs() : [];
   const resetArrays = new Set();
   for (const subdoc of subdocs) {
     const fullPathWithIndexes = subdoc.$__fullPathWithIndexes();

--- a/lib/document.js
+++ b/lib/document.js
@@ -2226,7 +2226,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
       return false;
     }
     for (const path of paths) {
-      if (directModifiedPathsObj.hasOwnProperty(path)) {
+      if (Object.prototype.hasOwnProperty.call(directModifiedPathsObj, path)) {
         return true;
       }
     }

--- a/lib/document.js
+++ b/lib/document.js
@@ -2217,14 +2217,21 @@ Document.prototype[documentModifiedPaths] = Document.prototype.modifiedPaths;
 
 Document.prototype.isModified = function(paths, modifiedPaths) {
   if (paths) {
-    const directModifiedPaths = Object.keys(this.$__.activePaths.getStatePaths('modify'));
-    if (directModifiedPaths.length === 0) {
-      return false;
-    }
-
     if (!Array.isArray(paths)) {
       paths = paths.indexOf(' ') === -1 ? [paths] : paths.split(' ');
     }
+
+    const directModifiedPathsObj = this.$__.activePaths.getStatePaths('modify');
+    const directModifiedPaths = Object.keys(directModifiedPathsObj);
+    if (directModifiedPaths.length === 0) {
+      return false;
+    }
+    for (const path of paths) {
+      if (directModifiedPathsObj.hasOwnProperty(path)) {
+        return true;
+      }
+    }
+
     const modified = modifiedPaths || this[documentModifiedPaths]();
     const isModifiedChild = paths.some(function(path) {
       return !!~modified.indexOf(path);
@@ -3317,7 +3324,10 @@ Document.prototype.$__reset = function reset() {
   let _this = this;
 
   // Skip for subdocuments
-  const subdocs = this.$parent() === this ? this.$getAllSubdocs() : [];
+  if (this.$isDocumentArrayElement || this.$isSingleNested) {
+    return this;
+  }
+  const subdocs = this.$getAllSubdocs();
   const resetArrays = new Set();
   for (const subdoc of subdocs) {
     const fullPathWithIndexes = subdoc.$__fullPathWithIndexes();

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -141,12 +141,12 @@ class MongooseMap extends Map {
     super.set(key, value);
 
     if (value != null && value.$isSingleNested) {
-      value.$basePath = this.$__path + '.' + key;
+      value.$basePath = fullPath;
     }
 
     const parent = this.$__parent;
     if (parent != null && parent.$__ != null && !deepEqual(value, priorVal)) {
-      parent.markModified(this.$__path + '.' + key);
+      parent.markModified(fullPath);
     }
   }
 

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -96,9 +96,9 @@ class MongooseMap extends Map {
       return;
     }
 
-    const fullPath = this.$__path + '.' + key;
+    let _fullPath;
     const populated = this.$__parent != null && this.$__parent.$__ ?
-      this.$__parent.$populated(fullPath, true) || this.$__parent.$populated(this.$__path, true) :
+      this.$__parent.$populated(this.$__path, true) :
       null;
     const priorVal = this.get(key);
 
@@ -127,11 +127,19 @@ class MongooseMap extends Map {
       }
     } else {
       try {
-        value = this.$__schemaType.
-          applySetters(value, this.$__parent, false, this.get(key), { path: fullPath });
+        const options = this.$__schemaType.$isMongooseDocumentArray ?
+          { path: fullPath.call(this) } :
+          null;
+        value = this.$__schemaType.applySetters(
+          value,
+          this.$__parent,
+          false,
+          this.get(key),
+          options
+        );
       } catch (error) {
         if (this.$__parent != null && this.$__parent.$__ != null) {
-          this.$__parent.invalidate(fullPath, error);
+          this.$__parent.invalidate(fullPath.call(this), error);
           return;
         }
         throw error;
@@ -141,12 +149,22 @@ class MongooseMap extends Map {
     super.set(key, value);
 
     if (value != null && value.$isSingleNested) {
-      value.$basePath = fullPath;
+      value.$basePath = fullPath.call(this);
     }
 
     const parent = this.$__parent;
     if (parent != null && parent.$__ != null && !deepEqual(value, priorVal)) {
-      parent.markModified(fullPath);
+      parent.markModified(fullPath.call(this));
+    }
+
+    // Delay calculating full path unless absolutely necessary, because string
+    // concatenation is a bottleneck re: #13171
+    function fullPath() {
+      if (_fullPath) {
+        return _fullPath;
+      }
+      _fullPath = this.$__path + '.' + key;
+      return _fullPath;
     }
   }
 

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -97,8 +97,9 @@ class MongooseMap extends Map {
     }
 
     let _fullPath;
-    const populated = this.$__parent != null && this.$__parent.$__ ?
-      this.$__parent.$populated(this.$__path, true) :
+    const parent = this.$__parent;
+    const populated = parent != null && parent.$__ && parent.$__.populated ?
+      parent.$populated(fullPath.call(this), true) || parent.$populated(this.$__path, true) :
       null;
     const priorVal = this.get(key);
 
@@ -127,7 +128,7 @@ class MongooseMap extends Map {
       }
     } else {
       try {
-        const options = this.$__schemaType.$isMongooseDocumentArray ?
+        const options = this.$__schemaType.$isMongooseDocumentArray || this.$__schemaType.$isSingleNested ?
           { path: fullPath.call(this) } :
           null;
         value = this.$__schemaType.applySetters(
@@ -148,11 +149,6 @@ class MongooseMap extends Map {
 
     super.set(key, value);
 
-    if (value != null && value.$isSingleNested) {
-      value.$basePath = fullPath.call(this);
-    }
-
-    const parent = this.$__parent;
     if (parent != null && parent.$__ != null && !deepEqual(value, priorVal)) {
       parent.markModified(fullPath.call(this));
     }

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -956,6 +956,7 @@ describe('Map', function() {
     });
     doc.myMap.set('abc', { myValue: 'some value' });
     const changes = doc.getChanges();
+
     assert.ok(!changes.$unset);
     assert.deepEqual(changes, { $set: { 'myMap.abc': { myValue: 'some value' } } });
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: #13191, #13271.

Benchmark from #13191 with 2000 documents, before this change:

```
Starting the process of mapping all minis and timing it
Iterating through all minis: 5.661ms
Sorting all minis: 1.368ms
Creating and populating Map of Minis: 0.4ms
Saving Map of Minis to MongoDB using Mongoose: 1.684s
Map Process: 1.692s
Saved Minis Map successfully!
```

After:

```
Starting the process of mapping all minis and timing it
Iterating through all minis: 6.554ms
Sorting all minis: 1.872ms
Creating and populating Map of Minis: 0.555ms
Saving Map of Minis to MongoDB using Mongoose: 315.028ms
Map Process: 324.444ms
Saved Minis Map successfully!
```

I would love to make this faster and will work on it some more, as well as adding a benchmark for this, but figured I'd add a PR first.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
