### PR TITLE
fix(update): handle casting doubly nested arrays with $pullAll

### DIFF
--- a/lib/helpers/discriminator/mergeDiscriminatorSchema.js
+++ b/lib/helpers/discriminator/mergeDiscriminatorSchema.js
@@ -43,7 +43,8 @@ module.exports = function mergeDiscriminatorSchema(to, from, path) {
         // base schema has a given path as a single nested but discriminator schema
         // has the path as a document array, or vice versa (gh-9534)
         if ((from[key].$isSingleNested && to[key].$isMongooseDocumentArray) ||
-              (from[key].$isMongooseDocumentArray && to[key].$isSingleNested)) {
+              (from[key].$isMongooseDocumentArray && to[key].$isSingleNested) ||
+              (from[key].$isMongooseDocumentArrayElement && to[key].$isMongooseDocumentArrayElement)) {
           continue;
         } else if (from[key].instanceOfSchema) {
           if (to[key].instanceOfSchema) {

--- a/lib/schema/DocumentArrayElement.js
+++ b/lib/schema/DocumentArrayElement.js
@@ -1,0 +1,93 @@
+/*!
+ * Module dependencies.
+ */
+
+'use strict';
+
+const MongooseError = require('../error/mongooseError');
+const SchemaType = require('../schematype');
+const SubdocumentPath = require('./SubdocumentPath');
+const getConstructor = require('../helpers/discriminator/getConstructor');
+
+/**
+ * DocumentArrayElement SchemaType constructor.
+ *
+ * @param {String} path
+ * @param {Object} options
+ * @inherits SchemaType
+ * @api public
+ */
+
+function DocumentArrayElement(path, options) {
+  this.$parentSchemaType = options && options.$parentSchemaType;
+  if (!this.$parentSchemaType) {
+    throw new MongooseError('Cannot create DocumentArrayElement schematype without a parent');
+  }
+  delete options.$parentSchemaType;
+
+  SchemaType.call(this, path, options, 'DocumentArrayElement');
+
+  this.$isMongooseDocumentArrayElement = true;
+}
+
+/**
+ * This schema type's name, to defend against minifiers that mangle
+ * function names.
+ *
+ * @api public
+ */
+DocumentArrayElement.schemaName = 'DocumentArrayElement';
+
+DocumentArrayElement.defaultOptions = {};
+
+/*!
+ * Inherits from SchemaType.
+ */
+DocumentArrayElement.prototype = Object.create(SchemaType.prototype);
+DocumentArrayElement.prototype.constructor = DocumentArrayElement;
+
+/**
+ * Casts `val` for DocumentArrayElement.
+ *
+ * @param {Object} value to cast
+ * @api private
+ */
+
+DocumentArrayElement.prototype.cast = function(...args) {
+  return this.$parentSchemaType.cast(...args)[0];
+};
+
+/**
+ * Casts contents for queries.
+ *
+ * @param {String} $cond
+ * @param {any} [val]
+ * @api private
+ */
+
+DocumentArrayElement.prototype.doValidate = function(value, fn, scope, options) {
+  const Constructor = getConstructor(this.caster, value);
+
+  if (value && !(value instanceof Constructor)) {
+    value = new Constructor(value, scope, null, null, options && options.index != null ? options.index : null);
+  }
+
+  return SubdocumentPath.prototype.doValidate.call(this, value, fn, scope, options);
+};
+
+DocumentArrayElement.prototype.clone = function() {
+  this.options.$parentSchemaType = this.$parentSchemaType;
+  const ret = SchemaType.prototype.clone.apply(this, arguments);
+  delete this.options.$parentSchemaType;
+
+  ret.caster = this.caster;
+  ret.schema = this.schema;
+
+  return ret;
+};
+
+/*!
+ * Module exports.
+ */
+
+module.exports = DocumentArrayElement;

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -6,11 +6,11 @@
 
 const ArrayType = require('./array');
 const CastError = require('../error/cast');
+const DocumentArrayElement = require('./DocumentArrayElement');
 const EventEmitter = require('events').EventEmitter;
 const SchemaDocumentArrayOptions =
   require('../options/SchemaDocumentArrayOptions');
 const SchemaType = require('../schematype');
-const SubdocumentPath = require('./SubdocumentPath');
 const discriminator = require('../helpers/model/discriminator');
 const handleIdOption = require('../helpers/schema/handleIdOption');
 const handleSpreadDoc = require('../helpers/document/handleSpreadDoc');
@@ -74,25 +74,14 @@ function DocumentArrayPath(key, schema, options, schemaOptions) {
     });
   }
 
-  const parentSchemaType = this;
-  this.$embeddedSchemaType = new SchemaType(key + '.$', {
+  const $parentSchemaType = this;
+  this.$embeddedSchemaType = new DocumentArrayElement(key + '.$', {
     required: this &&
       this.schemaOptions &&
-      this.schemaOptions.required || false
+      this.schemaOptions.required || false,
+    $parentSchemaType
   });
-  this.$embeddedSchemaType.cast = function(value, doc, init) {
-    return parentSchemaType.cast(value, doc, init)[0];
-  };
-  this.$embeddedSchemaType.doValidate = function(value, fn, scope, options) {
-    const Constructor = getConstructor(this.caster, value);
 
-    if (value && !(value instanceof Constructor)) {
-      value = new Constructor(value, scope, null, null, options && options.index != null ? options.index : null);
-    }
-
-    return SubdocumentPath.prototype.doValidate.call(this, value, fn, scope, options);
-  };
-  this.$embeddedSchemaType.$isMongooseDocumentArrayElement = true;
   this.$embeddedSchemaType.caster = this.Constructor;
   this.$embeddedSchemaType.schema = this.schema;
 }

--- a/test/model.update.test.js
+++ b/test/model.update.test.js
@@ -3346,6 +3346,35 @@ describe('model: updateOne: ', function() {
     assert.equal(fromDb.children[0].name, 'Luke Skywalker');
   });
 
+  it('works with doubly nested arrays with $pullAll (gh-13190)', async function() {
+    const multiArraySchema = new Schema({
+      _id: false,
+      label: String,
+      arr: [Number]
+    });
+
+    const baseTestSchema = new Schema({
+      baseLabel: String,
+      mArr: [[multiArraySchema]]
+    });
+
+    const Test = db.model('Test', baseTestSchema);
+
+    const arrB = new Test({
+      baseLabel: 'testx',
+      mArr: [[{ label: 'testInner', arr: [1, 2, 3, 4] }]]
+    });
+    await arrB.save();
+    const res = await Test.updateOne(
+      { baseLabel: 'testx' },
+      { $pullAll: { 'mArr.0.0.arr': [1, 2] } }
+    );
+    assert.equal(res.modifiedCount, 1);
+
+    const { mArr } = await Test.findById(arrB).lean().orFail();
+    assert.deepStrictEqual(mArr, [[{ label: 'testInner', arr: [3, 4] }]]);
+  });
+
   describe('converts dot separated paths to nested structure (gh-10200)', () => {
     it('works with new Model(...)', () => {
       const Payment = getPaymentModel();


### PR DESCRIPTION
Fix #13190

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

The problem is that document array elements use the base SchemaType class, so `cast()` doesn't work after `clone()`. The current implementation is a bit hacky, so I added a `DocumentArrayElement` SchemaType so `clone()`-ed DocumentArrayElements get the correct `cast()` function.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
