### PR TITLE
types(schema): avoid circular constraint in TSchemaOptions with --incremental by deferring `ResolveSchemaOptions<>`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -10,7 +10,7 @@ import {
   Query,
   model,
   HydratedDocument,
-  SchemaOptions,
+  ResolveSchemaOptions,
   ObtainDocumentType,
   ObtainSchemaGeneric
 } from 'mongoose';
@@ -634,7 +634,8 @@ function gh12003() {
 
   type BaseSchemaType = InferSchemaType<typeof BaseSchema>;
 
-  expectType<'type'>({} as ObtainSchemaGeneric<typeof BaseSchema, 'TSchemaOptions'>['typeKey']);
+  type TSchemaOptions = ResolveSchemaOptions<ObtainSchemaGeneric<typeof BaseSchema, 'TSchemaOptions'>>;
+  expectType<'type'>({} as TSchemaOptions['typeKey']);
 
   expectType<{ name?: string }>({} as BaseSchemaType);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -211,15 +211,21 @@ declare module 'mongoose' {
     TQueryHelpers = {},
     TVirtuals = {},
     TStaticMethods = {},
-    TSchemaOptions extends ResolveSchemaOptions<TSchemaOptions> = DefaultSchemaOptions,
-    DocType extends ApplySchemaOptions<ObtainDocumentType<DocType, EnforcedDocType, TSchemaOptions>, TSchemaOptions> = ApplySchemaOptions<ObtainDocumentType<any, EnforcedDocType, TSchemaOptions>, TSchemaOptions>,
+    TSchemaOptions = DefaultSchemaOptions,
+    DocType extends ApplySchemaOptions<
+      ObtainDocumentType<DocType, EnforcedDocType, ResolveSchemaOptions<TSchemaOptions>>,
+      ResolveSchemaOptions<TSchemaOptions>
+    > = ApplySchemaOptions<
+      ObtainDocumentType<any, EnforcedDocType, ResolveSchemaOptions<TSchemaOptions>>,
+      ResolveSchemaOptions<TSchemaOptions>
+    >,
     THydratedDocumentType = HydratedDocument<FlatRecord<DocType>, TVirtuals & TInstanceMethods>
   >
     extends events.EventEmitter {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<FlatRecord<DocType>, TInstanceMethods, TQueryHelpers, TStaticMethods, TVirtuals, THydratedDocumentType> | TSchemaOptions);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<FlatRecord<DocType>, TInstanceMethods, TQueryHelpers, TStaticMethods, TVirtuals, THydratedDocumentType> | ResolveSchemaOptions<TSchemaOptions>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -46,7 +46,7 @@ declare module 'mongoose' {
    * @param {TSchema} TSchema A generic of schema type instance.
    * @param {alias} alias Targeted generic alias.
    */
-   type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TSchemaOptions' | 'DocType'> =
+  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TSchemaOptions' | 'DocType'> =
    TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TStaticMethods, infer TSchemaOptions, infer DocType>
      ? {
        EnforcedDocType: EnforcedDocType;
@@ -60,8 +60,7 @@ declare module 'mongoose' {
      }[alias]
      : unknown;
 
-  // Without Omit, this gives us a "Type parameter 'TSchemaOptions' has a circular constraint."
-  type ResolveSchemaOptions<T> = Omit<MergeType<DefaultSchemaOptions, T>, 'fakepropertyname'>;
+  type ResolveSchemaOptions<T> = MergeType<DefaultSchemaOptions, T>;
 
   type ApplySchemaOptions<T, O = DefaultSchemaOptions> = ResolveTimestamps<T, O>;
 


### PR DESCRIPTION
Fix #13129

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like the `Omit<>` trick we did to avoid TS complaining about circular constraints doesn't work if you set the `incremental` option in TypeScript 4.9+. With this change `TSchemaOptions` no longer references itself, so no more circular constraints. We just wrap `TSchemaOptions` in `ResolveSchemaOptions` whenever we use it in the schema class.

I wish there was some reasonable way to test this, but the issue doesn't seem to show up in tsd, so our only option would be to manually run a particular version of tsc with `--incremental` on a script. And I don't think that's necessary, seems easy enough to eyeball that this particular change removes the circular constraint.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
