### PR TITLE
fix(types): change "bulkWrite" to not be strict by default and allow overwriting

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -352,6 +352,50 @@ async function gh12277() {
   ]);
 }
 
+async function overwriteBulkWriteContents() {
+  type DocumentType<T> = Document<any, any, T> & T;
+
+  interface BaseModelClassDoc {
+    firstname: string;
+  }
+
+  const baseModelClassSchema = new Schema({
+    firstname: String
+  });
+
+  const BaseModel = model<BaseModelClassDoc>('test', baseModelClassSchema);
+
+  expectError(BaseModel.bulkWrite<{ testy: string }>([
+    {
+      insertOne: {
+        document: {
+          test: 'hello'
+        }
+      }
+    }
+  ]));
+
+  BaseModel.bulkWrite<{ testy: string }>([
+    {
+      insertOne: {
+        document: {
+          testy: 'hello'
+        }
+      }
+    }
+  ]);
+
+  BaseModel.bulkWrite([
+    {
+      insertOne: {
+        document: {
+          randomPropertyNotInTypes: 'hello'
+        }
+      }
+    }
+  ]);
+}
+
 export function autoTypedModel() {
   const AutoTypedSchema = autoTypedSchema();
   const AutoTypedModel = model('AutoTypeModel', AutoTypedSchema);

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -162,12 +162,12 @@ declare module 'mongoose' {
      * if you use `create()`) because with `bulkWrite()` there is only one network
      * round trip to the MongoDB server.
      */
-    bulkWrite(
-      writes: Array<mongodb.AnyBulkWriteOperation<T extends Document ? any : (T extends {} ? T : any)>>,
+    bulkWrite<DocContents = T>(
+      writes: Array<mongodb.AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
       options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions & { ordered: false }
     ): Promise<mongodb.BulkWriteResult & { mongoose?: { validationErrors: Error[] } }>;
-    bulkWrite(
-      writes: Array<mongodb.AnyBulkWriteOperation<T extends Document ? any : (T extends {} ? T : any)>>,
+    bulkWrite<DocContents = T>(
+      writes: Array<mongodb.AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
       options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions
     ): Promise<mongodb.BulkWriteResult>;
 


### PR DESCRIPTION
**Summary**

This PR modifies `Model.bulkWrite` to be overwrite-able and not be strict by default (i am not quite sure if it is wanted)

this changes `bulkWrite` to be more in-line with functions like `create` & `insertMany`