### PR TITLE
fix(subdocument): add back `remove()` function

### DIFF
--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -358,7 +358,20 @@ Subdocument.prototype.$__removeFromParent = function() {
 };
 
 /**
- * Null-out this subdoc
+ * Remove this subdoc from its parent. Does **not** trigger any middleware.
+ *
+ * @param {Object} [options]
+ * @param {Function} [callback] optional callback for compatibility with Document.prototype.remove
+ */
+
+Subdocument.prototype.remove = function remove() {
+  this.$__removeFromParent();
+  return this;
+};
+
+/**
+ * Removes this subdoc from its parent, and fires 'deleteOne' middleware
+ * when the parent document is saved.
  *
  * @param {Object} [options]
  * @param {Function} [callback] optional callback for compatibility with Document.prototype.remove


### PR DESCRIPTION
Fix #13284

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We removed `remove()` from top-level documents, which in turn removed it from subdocuments. But it is still useful to be able to remove subdocuments from top-level documents and arrays, so I added this function back, with the caveat that it doesn't fire any middleware.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
