### PR TITLE
docs(layout): fix "Schemas" not being highlighted when currently on page

### DIFF
--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -53,7 +53,7 @@ html(lang='en')
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/guides.html`, class=outputUrl === `${versions.versionedPath}/docs/guides.html` ? 'selected' : '') Guides
                 ul.pure-menu-list
                   li.pure-menu-item.sub-item
-                    a.pure-menu-link(href=`${versions.versionedPath}/docs/guide.html`, class=outputUrl === `${versions.versionedPath}/docs/schemas.html` ? 'selected' : '') Schemas
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/guide.html`, class=outputUrl === `${versions.versionedPath}/docs/guide.html` ? 'selected' : '') Schemas
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/schematypes.html`, class=outputUrl === `${versions.versionedPath}/docs/schematypes.html` ? 'selected' : '') SchemaTypes
                   li.pure-menu-item.sub-item


### PR DESCRIPTION
**Summary**

This PR fixes `Schemas` entry in the documentation sidebar not being highlighted while being on the page

re #13314
