### PR TITLE
Update website sidebar to be better use-able

### DIFF
--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -292,7 +292,6 @@ pre {
     top: 0px;
     left: 0;
     background-color: #eee;
-    font-size: 10px; /* change this value to increase/decrease button size */
     z-index: 10;
     width: 2em;
     height: 3px;
@@ -304,28 +303,11 @@ pre {
     background: #ddd;
   }
 
-  .menu-link span {
-    position: relative;
-    display: block;
-  }
-
-  .menu-link span,
-  .menu-link span:before,
-  .menu-link span:after {
-    background-color: #333;
-    width: 100%;
-    height: 0.2em;
-  }
-
-  .menu-link span:before,
-  .menu-link span:after {
-    position: absolute;
-    margin-top: -0.6em;
-    content: " ";
-  }
-
-  .menu-link span:after {
-    margin-top: 0.6em;
+  #menuLink {
+    width: 40px;
+    height: 40px;
+    padding: 2.5px;
+    color: rgb(0,0,0);
   }
 
   .active {

--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -91,6 +91,12 @@ pre code {
   padding-bottom: 2px;
 }
 
+/* change sub-item lists to be more dense */
+.sub-item > .pure-menu-link {
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
 .pure-menu-link:hover, .pure-menu-link.selected {
   background-color: rgba(0,0,0, 0.1);
 }

--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -82,13 +82,13 @@ pre code {
 }
 
 .pure-menu-item {
-  height: 28px;
   font-size: 12pt;
   padding-top: 0px;
 }
 
 .pure-menu-link {
   padding-top: 2px;
+  padding-bottom: 2px;
 }
 
 .pure-menu-link:hover, .pure-menu-link.selected {
@@ -96,7 +96,6 @@ pre code {
 }
 
 li.sub-item {
-  height: 23px;
   font-size: 11pt;
   margin-left: 15px;
 }
@@ -209,6 +208,10 @@ pre {
 
 .pure-menu-link.selected {
   font-weight: bold;
+}
+
+.pure-menu-item:not(:first-child), .pure-menu-item.sub-item {
+  margin-top: 2px;
 }
 
 /* Mobile */
@@ -327,7 +330,12 @@ pre {
 }
 
 .pure-menu-item:last-of-type {
-  padding-bottom: 20px;
+  padding-bottom: 5px;
+}
+
+/* dont add padding if it also has other elements (like a sub-list) */
+.pure-menu-link:not(:last-child) {
+  padding-bottom: 0px;
 }
 
 /* CPM ads */

--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -92,7 +92,7 @@ pre code {
 }
 
 /* change sub-item lists to be more dense */
-.sub-item > .pure-menu-link {
+.sub-item > .pure-menu-link, .tertiary-item > .pure-menu-link {
   padding-top: 0px;
   padding-bottom: 0px;
 }
@@ -107,7 +107,6 @@ li.sub-item {
 }
 
 li.tertiary-item {
-  height: 23px;
   font-size: 11pt;
   margin-left: 30px;
 }
@@ -216,7 +215,7 @@ pre {
   font-weight: bold;
 }
 
-.pure-menu-item:not(:first-child), .pure-menu-item.sub-item {
+.pure-menu-item:not(:first-child), .pure-menu-item.sub-item, .pure-menu-item.tertiary-item {
   margin-top: 2px;
 }
 

--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -245,7 +245,7 @@ pre {
 
   #menu {
     display: none;
-    position: absolute;
+    position: fixed;
     top: 45px;
     border-top: 1px solid #ddd;
     border-right: 1px solid #ddd;
@@ -263,6 +263,9 @@ pre {
     height: 45px;
     background-color: #eee;
     border-bottom: 1px solid #ddd;
+    position: sticky;
+    top: 0;
+    z-index: 1;
   }
 
   #logo {

--- a/docs/css/mongoose5.css
+++ b/docs/css/mongoose5.css
@@ -91,6 +91,10 @@ pre code {
   padding-top: 2px;
 }
 
+.pure-menu-link:hover, .pure-menu-link.selected {
+  background-color: rgba(0,0,0, 0.1);
+}
+
 li.sub-item {
   height: 23px;
   font-size: 11pt;

--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -58,27 +58,30 @@ html(lang='en')
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/schematypes.html`, class=outputUrl === `${versions.versionedPath}/docs/schematypes.html` ? 'selected' : '') SchemaTypes
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/connections.html`, class=outputUrl === `${versions.versionedPath}/docs/connections.html` ? 'selected' : '') Connections
-                  - if ([`${versions.versionedPath}/docs/connections`, `${versions.versionedPath}/docs/tutorials/ssl`].some(path => outputUrl.startsWith(path)))
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/ssl.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/ssl.html` ? 'selected' : '') SSL Connections
+                    - if ([`${versions.versionedPath}/docs/connections`, `${versions.versionedPath}/docs/tutorials/ssl`].some(path => outputUrl.startsWith(path)))
+                      ul.pure-menu-list
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/ssl.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/ssl.html` ? 'selected' : '') SSL Connections
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/models.html`, class=outputUrl === `${versions.versionedPath}/docs/models.html` ? 'selected' : '') Models
-                  - if ([`${versions.versionedPath}/docs/models`, `${versions.versionedPath}/docs/change-streams`].some(path => outputUrl.startsWith(path)))
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/change-streams.html`, class=outputUrl === `${versions.versionedPath}/docs/change-streams.html` ? 'selected' : '') Change Streams
+                    - if ([`${versions.versionedPath}/docs/models`, `${versions.versionedPath}/docs/change-streams`].some(path => outputUrl.startsWith(path)))
+                      ul.pure-menu-list
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/change-streams.html`, class=outputUrl === `${versions.versionedPath}/docs/change-streams.html` ? 'selected' : '') Change Streams
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/documents.html`, class=outputUrl === `${versions.versionedPath}/docs/documents.html` ? 'selected' : '') Documents
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/subdocs.html`, class=outputUrl === `${versions.versionedPath}/docs/subdocs.html` ? 'selected' : '') Subdocuments
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/queries.html`, class=outputUrl === `${versions.versionedPath}/docs/queries.html` ? 'selected' : '') Queries
-                  - if ([`${versions.versionedPath}/docs/queries`, `${versions.versionedPath}/docs/tutorials/findoneandupdate`, `${versions.versionedPath}/docs/tutorials/lean`, `${versions.versionedPath}/docs/tutorials/query_casting`].some(path => outputUrl.startsWith(path)))
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/query_casting.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/query_casting.html` ? 'selected' : '') Query Casting
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/findoneandupdate.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/findoneandupdate.html` ? 'selected' : '') findOneAndUpdate
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/lean.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/lean.html` ? 'selected' : '') The Lean Option
+                    - if ([`${versions.versionedPath}/docs/queries`, `${versions.versionedPath}/docs/tutorials/findoneandupdate`, `${versions.versionedPath}/docs/tutorials/lean`, `${versions.versionedPath}/docs/tutorials/query_casting`].some(path => outputUrl.startsWith(path)))
+                      ul.pure-menu-list
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/query_casting.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/query_casting.html` ? 'selected' : '') Query Casting
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/findoneandupdate.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/findoneandupdate.html` ? 'selected' : '') findOneAndUpdate
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/lean.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/lean.html` ? 'selected' : '') The Lean Option
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/validation.html`, class=outputUrl === `${versions.versionedPath}/docs/validation.html` ? 'selected' : '') Validation
                   li.pure-menu-item.sub-item
@@ -95,17 +98,18 @@ html(lang='en')
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/transactions.html`, class=outputUrl === `${versions.versionedPath}/docs/transactions.html` ? 'selected' : '') Transactions
                   li.pure-menu-item.sub-item
                     a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript.html` ? 'selected' : '') TypeScript
-                  - if (outputUrl.startsWith(`${versions.versionedPath}/docs/typescript`))
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/schemas.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/schemas.html` ? 'selected' : '') Schemas
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/statics-and-methods.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/statics-and-methods.html` ? 'selected' : '') Statics
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/query-helpers.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/query-helpers.html` ? 'selected' : '') Query Helpers
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/populate.html` ? 'selected' : '') Populate
-                    li.pure-menu-item.tertiary-item
-                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/subdocuments.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/subdocuments.html` ? 'selected' : '') Subdocuments
+                    - if (outputUrl.startsWith(`${versions.versionedPath}/docs/typescript`))
+                      ul.pure-menu-list
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/schemas.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/schemas.html` ? 'selected' : '') Schemas
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/statics-and-methods.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/statics-and-methods.html` ? 'selected' : '') Statics
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/query-helpers.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/query-helpers.html` ? 'selected' : '') Query Helpers
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/populate.html` ? 'selected' : '') Populate
+                        li.pure-menu-item.tertiary-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/subdocuments.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/subdocuments.html` ? 'selected' : '') Subdocuments
               li.pure-menu-item
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/api/mongoose.html`, class=outputUrl === `${versions.versionedPath}/docs/api/mongoose.html` ? 'selected' : '') API
                 ul.pure-menu-list

--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -51,80 +51,82 @@ html(lang='en')
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/index.html`, class=outputUrl === `${versions.versionedPath}/docs/index.html` ? 'selected' : '') Quick Start
               li.pure-menu-item
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/guides.html`, class=outputUrl === `${versions.versionedPath}/docs/guides.html` ? 'selected' : '') Guides
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/guide.html`, class=outputUrl === `${versions.versionedPath}/docs/schemas.html` ? 'selected' : '') Schemas
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/schematypes.html`, class=outputUrl === `${versions.versionedPath}/docs/schematypes.html` ? 'selected' : '') SchemaTypes
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/connections.html`, class=outputUrl === `${versions.versionedPath}/docs/connections.html` ? 'selected' : '') Connections
-              - if ([`${versions.versionedPath}/docs/connections`, `${versions.versionedPath}/docs/tutorials/ssl`].some(path => outputUrl.startsWith(path)))
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/ssl.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/ssl.html` ? 'selected' : '') SSL Connections
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/models.html`, class=outputUrl === `${versions.versionedPath}/docs/models.html` ? 'selected' : '') Models
-              - if ([`${versions.versionedPath}/docs/models`, `${versions.versionedPath}/docs/change-streams`].some(path => outputUrl.startsWith(path)))
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/change-streams.html`, class=outputUrl === `${versions.versionedPath}/docs/change-streams.html` ? 'selected' : '') Change Streams
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/documents.html`, class=outputUrl === `${versions.versionedPath}/docs/documents.html` ? 'selected' : '') Documents
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/subdocs.html`, class=outputUrl === `${versions.versionedPath}/docs/subdocs.html` ? 'selected' : '') Subdocuments
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/queries.html`, class=outputUrl === `${versions.versionedPath}/docs/queries.html` ? 'selected' : '') Queries
-              - if ([`${versions.versionedPath}/docs/queries`, `${versions.versionedPath}/docs/tutorials/findoneandupdate`, `${versions.versionedPath}/docs/tutorials/lean`, `${versions.versionedPath}/docs/tutorials/query_casting`].some(path => outputUrl.startsWith(path)))
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/query_casting.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/query_casting.html` ? 'selected' : '') Query Casting
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/findoneandupdate.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/findoneandupdate.html` ? 'selected' : '') findOneAndUpdate
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/lean.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/lean.html` ? 'selected' : '') The Lean Option
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/validation.html`, class=outputUrl === `${versions.versionedPath}/docs/validation.html` ? 'selected' : '') Validation
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/middleware.html`, class=outputUrl === `${versions.versionedPath}/docs/middleware.html` ? 'selected' : '') Middleware
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/populate.html` ? 'selected' : '') Populate
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/discriminators.html`, class=outputUrl === `${versions.versionedPath}/docs/discriminators.html` ? 'selected' : '') Discriminators
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/plugins.html`, class=outputUrl === `${versions.versionedPath}/docs/plugins.html` ? 'selected' : '') Plugins
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/timestamps.html`, class=outputUrl === `${versions.versionedPath}/docs/timestamps.html` ? 'selected' : '') Timestamps
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/transactions.html`, class=outputUrl === `${versions.versionedPath}/docs/transactions.html` ? 'selected' : '') Transactions
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript.html` ? 'selected' : '') TypeScript
-              - if (outputUrl.startsWith(`${versions.versionedPath}/docs/typescript`))
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/schemas.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/schemas.html` ? 'selected' : '') Schemas
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/statics-and-methods.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/statics-and-methods.html` ? 'selected' : '') Statics
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/query-helpers.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/query-helpers.html` ? 'selected' : '') Query Helpers
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/populate.html` ? 'selected' : '') Populate
-                li.pure-menu-item.tertiary-item
-                  a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/subdocuments.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/subdocuments.html` ? 'selected' : '') Subdocuments
+                ul.pure-menu-list
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/guide.html`, class=outputUrl === `${versions.versionedPath}/docs/schemas.html` ? 'selected' : '') Schemas
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/schematypes.html`, class=outputUrl === `${versions.versionedPath}/docs/schematypes.html` ? 'selected' : '') SchemaTypes
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/connections.html`, class=outputUrl === `${versions.versionedPath}/docs/connections.html` ? 'selected' : '') Connections
+                  - if ([`${versions.versionedPath}/docs/connections`, `${versions.versionedPath}/docs/tutorials/ssl`].some(path => outputUrl.startsWith(path)))
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/ssl.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/ssl.html` ? 'selected' : '') SSL Connections
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/models.html`, class=outputUrl === `${versions.versionedPath}/docs/models.html` ? 'selected' : '') Models
+                  - if ([`${versions.versionedPath}/docs/models`, `${versions.versionedPath}/docs/change-streams`].some(path => outputUrl.startsWith(path)))
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/change-streams.html`, class=outputUrl === `${versions.versionedPath}/docs/change-streams.html` ? 'selected' : '') Change Streams
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/documents.html`, class=outputUrl === `${versions.versionedPath}/docs/documents.html` ? 'selected' : '') Documents
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/subdocs.html`, class=outputUrl === `${versions.versionedPath}/docs/subdocs.html` ? 'selected' : '') Subdocuments
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/queries.html`, class=outputUrl === `${versions.versionedPath}/docs/queries.html` ? 'selected' : '') Queries
+                  - if ([`${versions.versionedPath}/docs/queries`, `${versions.versionedPath}/docs/tutorials/findoneandupdate`, `${versions.versionedPath}/docs/tutorials/lean`, `${versions.versionedPath}/docs/tutorials/query_casting`].some(path => outputUrl.startsWith(path)))
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/query_casting.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/query_casting.html` ? 'selected' : '') Query Casting
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/findoneandupdate.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/findoneandupdate.html` ? 'selected' : '') findOneAndUpdate
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/tutorials/lean.html`, class=outputUrl === `${versions.versionedPath}/docs/tutorials/lean.html` ? 'selected' : '') The Lean Option
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/validation.html`, class=outputUrl === `${versions.versionedPath}/docs/validation.html` ? 'selected' : '') Validation
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/middleware.html`, class=outputUrl === `${versions.versionedPath}/docs/middleware.html` ? 'selected' : '') Middleware
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/populate.html` ? 'selected' : '') Populate
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/discriminators.html`, class=outputUrl === `${versions.versionedPath}/docs/discriminators.html` ? 'selected' : '') Discriminators
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/plugins.html`, class=outputUrl === `${versions.versionedPath}/docs/plugins.html` ? 'selected' : '') Plugins
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/timestamps.html`, class=outputUrl === `${versions.versionedPath}/docs/timestamps.html` ? 'selected' : '') Timestamps
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/transactions.html`, class=outputUrl === `${versions.versionedPath}/docs/transactions.html` ? 'selected' : '') Transactions
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript.html` ? 'selected' : '') TypeScript
+                  - if (outputUrl.startsWith(`${versions.versionedPath}/docs/typescript`))
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/schemas.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/schemas.html` ? 'selected' : '') Schemas
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/statics-and-methods.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/statics-and-methods.html` ? 'selected' : '') Statics
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/query-helpers.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/query-helpers.html` ? 'selected' : '') Query Helpers
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/populate.html` ? 'selected' : '') Populate
+                    li.pure-menu-item.tertiary-item
+                      a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/subdocuments.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/subdocuments.html` ? 'selected' : '') Subdocuments
               li.pure-menu-item
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/api/mongoose.html`, class=outputUrl === `${versions.versionedPath}/docs/api/mongoose.html` ? 'selected' : '') API
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/mongoose.html`, class=outputUrl === `${versions.versionedPath}/docs/api/mongoose.html` ? 'selected' : '') Mongoose
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/schema.html`, class=outputUrl === `${versions.versionedPath}/docs/api/schema.html` ? 'selected' : '') Schema
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/connection.html`, class=outputUrl === `${versions.versionedPath}/docs/api/connection.html` ? 'selected' : '') Connection
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/document.html`, class=outputUrl === `${versions.versionedPath}/docs/api/document.html` ? 'selected' : '') Document
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/model.html`, class=outputUrl === `${versions.versionedPath}/docs/api/model.html` ? 'selected' : '') Model
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/query.html`, class=outputUrl === `${versions.versionedPath}/docs/api/query.html` ? 'selected' : '') Query
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/aggregate.html`, class=outputUrl === `${versions.versionedPath}/docs/api/aggregate.html` ? 'selected' : '') Aggregate
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/schematype.html`, class=outputUrl === `${versions.versionedPath}/docs/api/schematype.html` ? 'selected' : '') SchemaType
-              li.pure-menu-item.sub-item
-                a.pure-menu-link(href=`${versions.versionedPath}/docs/api/virtualtype.html`, class=outputUrl === `${versions.versionedPath}/docs/api/virtualtype.html` ? 'selected' : '') VirtualType
+                ul.pure-menu-list
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/mongoose.html`, class=outputUrl === `${versions.versionedPath}/docs/api/mongoose.html` ? 'selected' : '') Mongoose
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/schema.html`, class=outputUrl === `${versions.versionedPath}/docs/api/schema.html` ? 'selected' : '') Schema
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/connection.html`, class=outputUrl === `${versions.versionedPath}/docs/api/connection.html` ? 'selected' : '') Connection
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/document.html`, class=outputUrl === `${versions.versionedPath}/docs/api/document.html` ? 'selected' : '') Document
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/model.html`, class=outputUrl === `${versions.versionedPath}/docs/api/model.html` ? 'selected' : '') Model
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/query.html`, class=outputUrl === `${versions.versionedPath}/docs/api/query.html` ? 'selected' : '') Query
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/aggregate.html`, class=outputUrl === `${versions.versionedPath}/docs/api/aggregate.html` ? 'selected' : '') Aggregate
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/schematype.html`, class=outputUrl === `${versions.versionedPath}/docs/api/schematype.html` ? 'selected' : '') SchemaType
+                  li.pure-menu-item.sub-item
+                    a.pure-menu-link(href=`${versions.versionedPath}/docs/api/virtualtype.html`, class=outputUrl === `${versions.versionedPath}/docs/api/virtualtype.html` ? 'selected' : '') VirtualType
               li.pure-menu-item
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/migrating_to_7.html`, class=outputUrl === `${versions.versionedPath}/docs/migrating_to_7.html` ? 'selected' : '') Migration Guide
               li.pure-menu-item

--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -22,7 +22,7 @@ html(lang='en')
       #layout
         #mobile-menu
           a#menuLink.menu-link(href='#menu')
-            span
+            <svg width="100%" height="100%" viewBox="0 0 30 30" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M4 7h22M4 15h22M4 23h22"></path></svg>
           #mobile-logo-container
             a(href="/")
               img#logo(src=`${versions.versionedPath}/docs/images/mongoose5_62x30_transparent.png`)

--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -28,7 +28,7 @@ html(lang='en')
               img#logo(src=`${versions.versionedPath}/docs/images/mongoose5_62x30_transparent.png`)
               span.logo-text mongoose
         #menu
-          .pure-menu
+          nav.pure-menu
             #logo-container.pure-menu-heading
               a(href="/")
                 img#logo(src=`${versions.versionedPath}/docs/images/mongoose5_62x30_transparent.png`)


### PR DESCRIPTION
**Summary**

This PR (mainly) updates the documentation side-bar to be better use-able, things include:
- replace `span` hamburger menu-hack with a svg
- change the container element for `#menu > .pure-menu` to be a `nav` instead of implicit `div`
- change sub-lists to be their own lists (plus css changes necessary)
- show indications of what element in the side-bar is currently hovered over (and use the same effect for the current page)
- change the mobile-menu (logo) header and sidebar to be sticky / fixed, so it can be accessed at any scroll level

re #13314

<details>
<summary>Screenshots</summary>

old active & hover:
![original_active_and_hover](https://user-images.githubusercontent.com/10911626/234038605-7b71557d-ab5a-416e-b7ea-6a87ac2ca582.png)

new active & hover:
![new_active_and_hover](https://user-images.githubusercontent.com/10911626/234038611-dd8f6c8b-f5bd-4e28-8bbc-16f9d38ed5cd.png)

old mobile + scroll:
![orig_mobile](https://user-images.githubusercontent.com/10911626/234039373-d3dffe75-5a04-43c0-8470-05f42c4f445c.png)

new mobile + scroll:
![new_mobile](https://user-images.githubusercontent.com/10911626/234039407-becb0f5a-dfe1-4423-b232-dcc2fb480eb4.png)

</details>

PS: these changes should make it easier to change the lists (secondary & tertiary lists) to be made collapsible 

PPS: these changes also work great with things like dark-reader