### PR TITLE
types(query): make `lean()` flatten out inferred maps into Record<string, V>

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bson": "^5.0.1",
+    "bson": "^5.2.0",
     "kareem": "2.5.1",
-    "mongodb": "5.1.0",
+    "mongodb": "5.3.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",
     "ms": "2.1.3",

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -125,3 +125,21 @@ async function _11767() {
   // expectError(examFound2Obj.questions[0].populated);
   expectType<string[]>(examFound2Obj.questions[0].answers);
 }
+
+async function gh13010() {
+  const schema = new Schema({
+    name: { required: true, type: Map, of: String }
+  });
+
+  const CountryModel = model('Country', schema);
+
+  await CountryModel.create({
+    name: {
+      en: 'Croatia',
+      ru: 'Хорватия'
+    }
+  });
+
+  const country = await CountryModel.findOne().lean().orFail().exec();
+  expectType<Record<string, string>>(country.name);
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -560,13 +560,13 @@ declare module 'mongoose' {
   export type UpdateQuery<T> = _UpdateQuery<T> & AnyObject;
 
   export type FlattenMaps<T> = {
-    [K in keyof T]: T[K] extends Map<any, any>
-      ? AnyObject : T[K] extends TreatAsPrimitives
+    [K in keyof T]: T[K] extends Map<any, infer V>
+      ? Record<string, V> : T[K] extends TreatAsPrimitives
         ? T[K] : FlattenMaps<T[K]>;
   };
 
   export type actualPrimitives = string | boolean | number | bigint | symbol | null | undefined;
-  export type TreatAsPrimitives = actualPrimitives | NativeDate | RegExp | symbol | Error | BigInt | Types.ObjectId;
+  export type TreatAsPrimitives = actualPrimitives | NativeDate | RegExp | symbol | Error | BigInt | Types.ObjectId | Buffer | Function;
 
   export type SchemaDefinitionType<T> = T extends Document ? Omit<T, Exclude<keyof Document, '_id' | 'id' | '__v'>> : T;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -430,7 +430,7 @@ declare module 'mongoose' {
     j(val: boolean | null): this;
 
     /** Sets the lean option. */
-    lean<LeanResultType = ResultType extends any[] ? Require_id<RawDocType>[] : Require_id<RawDocType>>(val?: boolean | any): QueryWithHelpers<ResultType extends null ? LeanResultType | null : LeanResultType, DocType, THelpers, RawDocType>;
+    lean<LeanResultType = ResultType extends any[] ? Require_id<FlattenMaps<RawDocType>>[] : Require_id<FlattenMaps<RawDocType>>>(val?: boolean | any): QueryWithHelpers<ResultType extends null ? LeanResultType | null : LeanResultType, DocType, THelpers, RawDocType>;
 
     /** Specifies the maximum number of documents the query will return. */
     limit(val: number): this;


### PR DESCRIPTION
Fix #13010

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`lean()` queries never return maps, because Mongoose maps are stored as POJOs in MongoDB. This PR makes so that `lean()` uses `FlattenMaps` by default to replace maps in documents with their `Record<>` equivalent.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
