### PR TITLE
fix(document): handle calling `set()` underneath a strict: false subdocument path from the top-level document

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -26,6 +26,7 @@ const flattenObjectWithDottedPaths = require('./helpers/path/flattenObjectWithDo
 const get = require('./helpers/get');
 const getEmbeddedDiscriminatorPath = require('./helpers/document/getEmbeddedDiscriminatorPath');
 const getKeysInSchemaOrder = require('./helpers/schema/getKeysInSchemaOrder');
+const getSubdocumentStrictValue = require('./helpers/document/getSubdocumentStrictValue');
 const handleSpreadDoc = require('./helpers/document/handleSpreadDoc');
 const immediate = require('./helpers/immediate');
 const isDefiningProjection = require('./helpers/projection/isDefiningProjection');
@@ -52,6 +53,7 @@ const populateModelSymbol = require('./helpers/symbols').populateModelSymbol;
 const scopeSymbol = require('./helpers/symbols').scopeSymbol;
 const schemaMixedSymbol = require('./schema/symbols').schemaMixedSymbol;
 const parentPaths = require('./helpers/path/parentPaths');
+const getDeepestSubdocumentForPath = require('./helpers/document/getDeepestSubdocumentForPath');
 
 let DocumentArray;
 let MongooseArray;
@@ -1032,7 +1034,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
   let key;
   let prefix;
 
-  const strict = options && 'strict' in options
+  const userSpecifiedStrict = options && 'strict' in options;
+  let strict = userSpecifiedStrict
     ? options.strict
     : this.$__.strictMode;
 
@@ -1140,8 +1143,20 @@ Document.prototype.$set = function $set(path, val, type, options) {
   }
 
   let pathType = this.$__schema.pathType(path);
+  let parts = null;
   if (pathType === 'adhocOrUndefined') {
-    pathType = getEmbeddedDiscriminatorPath(this, path, { typeOnly: true });
+    parts = path.indexOf('.') === -1 ? [path] : path.split('.');
+    pathType = getEmbeddedDiscriminatorPath(this, parts, { typeOnly: true });
+  }
+  if (pathType === 'adhocOrUndefined' && !userSpecifiedStrict) {
+    // May be path underneath non-strict schema
+    if (parts == null) {
+      parts = path.indexOf('.') === -1 ? [path] : path.split('.');
+    }
+    const subdocStrict = getSubdocumentStrictValue(parts, this.$__schema);
+    if (subdocStrict !== undefined) {
+      strict = subdocStrict;
+    }
   }
 
   // Assume this is a Mongoose document that was copied into a POJO using
@@ -1204,7 +1219,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
   }
 
   let schema;
-  const parts = path.indexOf('.') === -1 ? [path] : path.split('.');
+  if (parts == null) {
+    parts = path.indexOf('.') === -1 ? [path] : path.split('.');
+  }
 
   // Might need to change path for top-level alias
   if (typeof this.$__schema.aliases[parts[0]] === 'string') {
@@ -1377,15 +1394,19 @@ Document.prototype.$set = function $set(path, val, type, options) {
       didPopulate = true;
     }
 
-    if (this.$__schema.singleNestedPaths[path] == null && (!refMatches || !schema.$isSingleNested || !val.$__)) {
+    if (!refMatches || !schema.$isSingleNested || !val.$__) {
       // If this path is underneath a single nested schema, we'll call the setter
       // later in `$__set()` because we don't take `_doc` when we iterate through
       // a single nested doc. That's to make sure we get the correct context.
       // Otherwise we would double-call the setter, see gh-7196.
+      let setterContext = this;
+      if (this.$__schema.singleNestedPaths[path] != null && parts.length > 1) {
+        setterContext = getDeepestSubdocumentForPath(this, parts, this.schema);
+      }
       if (options != null && options.overwriteImmutable) {
-        val = schema.applySetters(val, this, false, priorVal, { overwriteImmutable: true });
+        val = schema.applySetters(val, setterContext, false, priorVal, { overwriteImmutable: true });
       } else {
-        val = schema.applySetters(val, this, false, priorVal);
+        val = schema.applySetters(val, setterContext, false, priorVal);
       }
     }
 
@@ -1560,13 +1581,6 @@ Document.prototype.$__shouldModify = function(pathToMark, path, options, constru
     return true;
   }
 
-  // Re: the note about gh-7196, `val` is the raw value without casting or
-  // setters if the full path is under a single nested subdoc because we don't
-  // want to double run setters. So don't set it as modified. See gh-7264.
-  if (this.$__schema.singleNestedPaths[path] != null) {
-    return false;
-  }
-
   if (val === void 0 && !this.$__isSelected(path)) {
     // when a path is not selected in a query, its initial
     // value will be undefined.
@@ -1679,7 +1693,7 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
       } else if (obj[parts[i]] && obj[parts[i]] instanceof Embedded) {
         obj = obj[parts[i]];
       } else if (obj[parts[i]] && !Array.isArray(obj[parts[i]]) && obj[parts[i]].$isSingleNested) {
-        obj = obj[parts[i]];
+        obj = obj[parts[i]]._doc;
       } else if (obj[parts[i]] && Array.isArray(obj[parts[i]])) {
         obj = obj[parts[i]];
       } else {

--- a/lib/helpers/document/getDeepestSubdocumentForPath.js
+++ b/lib/helpers/document/getDeepestSubdocumentForPath.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = function getDeepestSubdocumentForPath(doc, parts, schema) {
+  let curPath = parts[0];
+  let curSchema = schema;
+  let subdoc = doc;
+  for (let i = 0; i < parts.length - 1; ++i) {
+    const curSchemaType = curSchema.path(curPath);
+    if (curSchemaType && curSchemaType.schema) {
+      subdoc = subdoc.get(curPath);
+      curSchema = curSchemaType.schema;
+      curPath = parts[i + 1];
+      if (subdoc == null) {
+        break;
+      }
+    } else {
+      curPath += '.' + parts[i + 1];
+    }
+  }
+
+  return subdoc;
+};

--- a/lib/helpers/document/getEmbeddedDiscriminatorPath.js
+++ b/lib/helpers/document/getEmbeddedDiscriminatorPath.js
@@ -15,7 +15,9 @@ const getSchemaDiscriminatorByValue = require('../discriminator/getSchemaDiscrim
 module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
   options = options || {};
   const typeOnly = options.typeOnly;
-  const parts = path.indexOf('.') === -1 ? [path] : path.split('.');
+  const parts = Array.isArray(path) ?
+    path :
+    (path.indexOf('.') === -1 ? [path] : path.split('.'));
   let schemaType = null;
   let type = 'adhocOrUndefined';
 

--- a/lib/helpers/document/getSubdocumentStrictValue.js
+++ b/lib/helpers/document/getSubdocumentStrictValue.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = function getSubdocumentStrictValue(parts, schema) {
+  if (parts.length === 1) {
+    return undefined;
+  }
+  let cur = parts[0];
+  let strict = undefined;
+  for (let i = 0; i < parts.length - 1; ++i) {
+    const curSchemaType = schema.path(cur);
+    if (curSchemaType && curSchemaType.schema) {
+      strict = curSchemaType.schema.options.strict;
+      schema = curSchemaType.schema;
+      cur = parts[i + 1];
+    } else {
+      cur += '.' + parts[i + 1];
+    }
+  }
+
+  return strict;
+};

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -739,6 +739,10 @@ Schema.prototype.add = function add(obj, prefix) {
         if (this._userProvidedOptions.typeKey) {
           childSchemaOptions.typeKey = this._userProvidedOptions.typeKey;
         }
+        // propagate 'strict' option to child schema
+        if (this._userProvidedOptions.strict != null) {
+          childSchemaOptions.strict = this._userProvidedOptions.strict;
+        }
 
         const _schema = new Schema(_typeDef, childSchemaOptions);
         _schema.$implicitlyCreated = true;
@@ -2057,6 +2061,24 @@ Schema.prototype.set = function(key, value, tags) {
       this.options[key] = value;
       this._userProvidedOptions[key] = this.options[key];
       break;
+  }
+
+  // Propagate `strict` and `strictQuery` changes down to implicitly created schemas
+  if (key === 'strict') {
+    for (const { schema } of this.childSchemas) {
+      if (!schema.$implicitlyCreated) {
+        continue;
+      }
+      schema.options.strict = value;
+    }
+  }
+  if (key === 'strictQuery') {
+    for (const { schema } of this.childSchemas) {
+      if (!schema.$implicitlyCreated) {
+        continue;
+      }
+      schema.options.strictQuery = value;
+    }
   }
 
   return this;

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -202,6 +202,7 @@ SchemaString.checkRequired = SchemaType.checkRequired;
  * @param {...String|Object} [args] enumeration values
  * @return {SchemaType} this
  * @see Customized Error Messages https://mongoosejs.com/docs/api/error.html#Error.messages
+ * @see Enums in JavaScript https://masteringjs.io/tutorials/fundamentals/enum
  * @api public
  */
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12079,6 +12079,25 @@ describe('document', function() {
     assert.equal(fromDb.obj.subArr.length, 1);
     assert.equal(fromDb.obj.subArr[0].str, 'subArr.test1');
   });
+
+  it('can set() from top-level on nested schema with strict: false (gh-13327)', async function() {
+    const testSchema = new Schema({
+      d: new Schema({}, {
+        strict: false,
+        _id: false
+      }
+      )
+    });
+    const Test = db.model('Test', testSchema);
+
+    const x = new Test();
+    x.set('d.x.y', 1);
+    assert.strictEqual(x.get('d.x.y'), 1);
+    await x.save();
+
+    const fromDb = await Test.findById(x._id).lean();
+    assert.equal(fromDb.d.x.y, 1);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Re: #13327

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13327 points out some interesting corner cases that pop up when calling `set()` on a top-level document. This PR addresses one of them: `x.set('d.x.y', 1);` where `d` is a single nested subdocument with no properties but `strict: false`.

To fix this, we needed to iron out a couple of issues:

1. We don't use subdocument strict when calling `set()` on top-level document
2. `set('strict', false)` doesn't bubble down to child schemas
3. Consistent single nested subdoc setter context without needing to rely on `$__set()` to get the correct context re: #7196 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
