### PR TITLE
Handle `DocumentArray` in `FlattenMaps`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -596,7 +596,8 @@ declare module 'mongoose' {
   export type FlattenMaps<T> = {
     [K in keyof T]: T[K] extends Map<any, infer V>
       ? Record<string, V> : T[K] extends TreatAsPrimitives
-        ? T[K] : FlattenMaps<T[K]>;
+        ? T[K] : T[K] extends Types.DocumentArray<infer ItemType>
+          ? Types.DocumentArray<FlattenMaps<ItemType>> : FlattenMaps<T[K]>;
   };
 
   export type actualPrimitives = string | boolean | number | bigint | symbol | null | undefined;


### PR DESCRIPTION
Closes https://github.com/Automattic/mongoose/issues/13345

**Summary**

Since 7.1.0, `lean()` replaces `Map` in documents with their `Record<string, V>` equivalent by using `FlattenMaps`. Currently, `FlattenMaps` returns a type incompatible with `InferSchemaType` type when there is a property of `DocumentArray` type. This PR fixes it.

**Examples**

This won't produce compilation error:
```ts
import { model, Schema, InferSchemaType } from 'mongoose';
import { expectType } from 'tsd';

async function test() {
    const imageSchema = new Schema({
        url: { required: true, type: String }
    });

    const placeSchema = new Schema({
        images: { required: true, type: [imageSchema] },
    });

    type Place = InferSchemaType<typeof placeSchema>;

    const PlaceModel = model('Place', placeSchema);

    const place = await PlaceModel.findOne().lean().orFail().exec();
    expectAssignable<Place>(place);
}
```