### PR TITLE
fix(query): apply schema-level paths before calculating projection for findOneAndUpdate()

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2003,9 +2003,13 @@ Query.prototype._optionsForExec = function(model) {
     }
   }
 
-  const projection = this._fieldsForExec();
-  if (projection != null) {
-    options.projection = projection;
+  this._applyPaths();
+  if (this._fields != null) {
+    this._fields = this._castFields(this._fields);
+    const projection = this._fieldsForExec();
+    if (projection != null) {
+      options.projection = projection;
+    }
   }
 
   return options;
@@ -2258,10 +2262,6 @@ Query.prototype._find = wrapThunk(function(callback) {
 
   callback = _wrapThunkCallback(this, callback);
 
-  this._applyPaths();
-  this._fields = this._castFields(this._fields);
-
-  const fields = this._fieldsForExec();
   const mongooseOptions = this._mongooseOptions;
   const _this = this;
   const userProvidedFields = _this._userProvidedFields || {};
@@ -2275,6 +2275,10 @@ Query.prototype._find = wrapThunk(function(callback) {
     session: this && this.options && this.options.session || null,
     lean: mongooseOptions.lean || null
   });
+
+  const options = this._optionsForExec();
+  const filter = this._conditions;
+  const fields = options.projection;
 
   const cb = (err, docs) => {
     if (err) {
@@ -2317,8 +2321,6 @@ Query.prototype._find = wrapThunk(function(callback) {
     });
   };
 
-  const options = this._optionsForExec();
-  const filter = this._conditions;
 
   this._collection.collection.find(filter, options, (err, cursor) => {
     if (err != null) {
@@ -2531,8 +2533,6 @@ Query.prototype._findOne = wrapThunk(function(callback) {
     return null;
   }
 
-  this._applyPaths();
-  this._fields = this._castFields(this._fields);
   applyGlobalMaxTimeMS(this.options, this.model);
   applyGlobalDiskUse(this.options, this.model);
 
@@ -3852,17 +3852,6 @@ Query.prototype._findOneAndReplace = wrapThunk(function(callback) {
   const filter = this._conditions;
   const options = this._optionsForExec();
   convertNewToReturnDocument(options);
-  let fields = null;
-
-  this._applyPaths();
-  if (this._fields != null) {
-    options.projection = this._castFields(utils.clone(this._fields));
-    fields = options.projection;
-    if (fields instanceof Error) {
-      callback(fields);
-      return null;
-    }
-  }
 
   const runValidators = _getOption(this, 'runValidators', false);
   if (runValidators === false) {
@@ -3991,7 +3980,6 @@ Query.prototype._findAndModify = function(type, callback) {
   const model = this.model;
   const schema = model.schema;
   const _this = this;
-  let fields;
 
   const castedQuery = castQuery(this);
   if (castedQuery instanceof Error) {
@@ -4059,18 +4047,6 @@ Query.prototype._findAndModify = function(type, callback) {
 
     if (Array.isArray(opts.arrayFilters)) {
       opts.arrayFilters = removeUnusedArrayFilters(this._update, opts.arrayFilters);
-    }
-  }
-
-  this._applyPaths();
-  if (this._fields) {
-    this._fields = this._castFields(this._fields);
-    fields = this._fieldsForExec();
-    if (fields != null) {
-      opts.projection = fields;
-    }
-    if (opts.projection instanceof Error) {
-      return callback(opts.projection);
     }
   }
 
@@ -5442,6 +5418,9 @@ Query.prototype._castFields = function _castFields(fields) {
  */
 
 Query.prototype._applyPaths = function applyPaths() {
+  if (!this.model) {
+    return;
+  }
   this._fields = this._fields || {};
   helpers.applyPaths(this._fields, this.model.schema);
 
@@ -5500,9 +5479,6 @@ Query.prototype._applyPaths = function applyPaths() {
  */
 
 Query.prototype.cursor = function cursor(opts) {
-  this._applyPaths();
-  this._fields = this._castFields(this._fields);
-
   if (opts) {
     this.setOptions(opts);
   }

--- a/test/model.findOneAndReplace.test.js
+++ b/test/model.findOneAndReplace.test.js
@@ -371,7 +371,6 @@ describe('model: findOneAndReplace:', function() {
     const schema = new Schema({ name: String, age: { type: Number, select: false } });
     const Model = db.model('Test', schema);
 
-
     const doc = await Model.findOneAndReplace({}, { name: 'Jean-Luc Picard', age: 59 }, {
       upsert: true,
       returnOriginal: false

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1268,7 +1268,7 @@ describe('Query', function() {
       const q = new Query();
       q.hint(hint);
 
-      const options = q._optionsForExec({ schema: { options: {} } });
+      const options = q._optionsForExec();
       assert.equal(JSON.stringify(options), a);
       done();
     });


### PR DESCRIPTION
Fix #13340

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like this issue was introduced in https://github.com/Automattic/mongoose/pull/13059 . In order to correctly apply schema level projection, you need to call `this._applyPaths()`, and it looks like with #13059 `findOneAndReplace()` no longer calls `this._applyPaths()`.

With this change, we _only_ handle creating projection logic in `optionsForExec()`. Individual thunks are no longer responsible for calling `applyPaths()`, etc.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
