### PR TITLE
Temporarily remove mongodb memory server from deno tests on 6.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,21 +78,23 @@ jobs:
   test-deno:
     runs-on: ubuntu-20.04
     name: Deno tests
-    env:
-      MONGOMS_VERSION: 6.0.0
-      MONGOMS_PREFER_GLOBAL_PATH: 1
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: 16
-      - name: Load MongoDB binary cache
-        id: cache-mongodb-binaries
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/mongodb-binaries
-          key: deno-${{ env.MONGOMS_VERSION }}
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.0.2
+      - name: Setup
+        run: |
+          wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz
+          tar xf mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz
+          mkdir -p ./data/db/27017 ./data/db/27000
+          printf "\ntimeout: 8000" >> ./.mocharc.yml
+          ./mongodb-linux-x86_64-ubuntu2004-6.0.0/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
+          sleep 2
+          mongod --version
+          echo `pwd`/mongodb-linux-x86_64-ubuntu2004-6.0.0/bin >> $GITHUB_PATH
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:

--- a/test/deno.js
+++ b/test/deno.js
@@ -14,7 +14,7 @@ const Mocha = require('mocha');
 const fs = require('fs');
 const path = require('path');
 
-const fixtures = require('./mocha-fixtures.js')
+// const fixtures = require('./mocha-fixtures.js');
 
 const mocha = new Mocha({
   timeout: 8000,
@@ -22,8 +22,8 @@ const mocha = new Mocha({
 });
 
 // the following is required because mocha somehow does not load "require" options and so needs to be manually set-up
-mocha.globalSetup(fixtures.mochaGlobalSetup);
-mocha.globalTeardown(fixtures.mochaGlobalTeardown);
+// mocha.globalSetup(fixtures.mochaGlobalSetup);
+// mocha.globalTeardown(fixtures.mochaGlobalTeardown);
 
 const testDir = 'test';
 

--- a/test/mocha-fixtures.js
+++ b/test/mocha-fixtures.js
@@ -48,9 +48,9 @@ module.exports.mochaGlobalSetup = async function mochaGlobalSetup() {
 
 module.exports.mochaGlobalTeardown = async function mochaGlobalTeardown() {
   if (mongoinstance) {
-    await mongoinstance.stop().catch(() => {});
+    await mongoinstance.stop();
   }
   if (mongorreplset) {
-    await mongorreplset.stop().catch(() => {});
+    await mongorreplset.stop();
   }
 };

--- a/test/mocha-fixtures.js
+++ b/test/mocha-fixtures.js
@@ -48,9 +48,9 @@ module.exports.mochaGlobalSetup = async function mochaGlobalSetup() {
 
 module.exports.mochaGlobalTeardown = async function mochaGlobalTeardown() {
   if (mongoinstance) {
-    await mongoinstance.stop();
+    await mongoinstance.stop().catch(() => {});
   }
   if (mongorreplset) {
-    await mongorreplset.stop();
+    await mongorreplset.stop().catch(() => {});
   }
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

@hasezoey FYI, I'm temporarily removing mongodb memory server from deno tests on 6.x branch because we've been experiencing some weird test failures, see:

1. Error 1: https://github.com/Automattic/mongoose/actions/runs/4853799889/jobs/8650382091
2. Error 2: https://github.com/Automattic/mongoose/actions/runs/4853740990/jobs/8650256294

I'd like to bring mongodb memory server back as soon as we can, but right now these test failures are blocking releasing 6.11.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
