### PR TITLE
chore(deno): change to start mocha fixtures before mocha

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,23 +78,21 @@ jobs:
   test-deno:
     runs-on: ubuntu-20.04
     name: Deno tests
+    env:
+      MONGOMS_VERSION: 6.0.0
+      MONGOMS_PREFER_GLOBAL_PATH: 1
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: 16
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.0.2
-      - name: Setup
-        run: |
-          wget -q https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz
-          tar xf mongodb-linux-x86_64-ubuntu2004-6.0.0.tgz
-          mkdir -p ./data/db/27017 ./data/db/27000
-          printf "\ntimeout: 8000" >> ./.mocharc.yml
-          ./mongodb-linux-x86_64-ubuntu2004-6.0.0/bin/mongod --setParameter ttlMonitorSleepSecs=1 --fork --dbpath ./data/db/27017 --syslog --port 27017
-          sleep 2
-          mongod --version
-          echo `pwd`/mongodb-linux-x86_64-ubuntu2004-6.0.0/bin >> $GITHUB_PATH
+      - name: Load MongoDB binary cache
+        id: cache-mongodb-binaries
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: deno-${{ env.MONGOMS_VERSION }}
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -5,3 +5,4 @@ rules:
   no-self-assign: off
 ignorePatterns:
   - deno.js
+  - deno*.js

--- a/test/deno_mocha.js
+++ b/test/deno_mocha.js
@@ -1,0 +1,54 @@
+'use strict';
+
+import { createRequire } from "node:module";
+import process from "node:process";
+
+// Workaround for Mocha getting terminal width, which currently requires `--unstable`
+Object.defineProperty(process.stdout, 'getWindowSize', {
+  value: function() {
+    return [75, 40];
+  }
+});
+
+import { parse } from "https://deno.land/std/flags/mod.ts"
+const args = parse(Deno.args);
+
+Error.stackTraceLimit = 100;
+
+const require = createRequire(import.meta.url);
+
+const Mocha = require('mocha');
+const fs = require('fs');
+const path = require('path');
+
+// const fixtures = require('./mocha-fixtures.js')
+
+const mocha = new Mocha({
+  timeout: 8000,
+  ...(args.g ? { fgrep: '' + args.g } : {})
+});
+
+// the following is required because mocha somehow does not load "require" options and so needs to be manually set-up
+// mocha.globalSetup(fixtures.mochaGlobalSetup);
+// mocha.globalTeardown(fixtures.mochaGlobalTeardown);
+
+const testDir = 'test';
+
+const files = fs.readdirSync(testDir).
+  concat(fs.readdirSync(path.join(testDir, 'docs')).map(file => path.join('docs', file))).
+  concat(fs.readdirSync(path.join(testDir, 'helpers')).map(file => path.join('helpers', file)));
+
+const ignoreFiles = new Set(['browser.test.js']);
+
+for (const file of files) {
+  if (!file.endsWith('.test.js') || ignoreFiles.has(file)) {
+    continue;
+  }
+
+  mocha.addFile(path.join(testDir, file));
+}
+
+mocha.run(function(failures) {
+  process.exitCode = failures ? 1 : 0;  // exit with non-zero status if there were failures
+  process.exit(process.exitCode);
+});

--- a/test/mocha-fixtures.js
+++ b/test/mocha-fixtures.js
@@ -3,6 +3,12 @@
 const mms = require('mongodb-memory-server');
 
 /*
+
+Note: dont use any mocha-specific things in this file, it may or may not be called without mocha (see deno.js)
+
+*/
+
+/*
  * Default MMS mongodb version is used, unless MONGOMS_VERSION is set (which is set with the matrix in test.yml for CI)
  */
 


### PR DESCRIPTION
**Summary**

This PR changes the deno test to start the fixtures before mocha and to start mocha in a child-process, to workaround the issue about connections still being open at the end of the test suite

only downsides are that deno permissions will have to be set via the `args` array in the code now, because i dont know of a way to start a child deno process with the same permissions

re https://github.com/Automattic/mongoose/pull/13349#issuecomment-1531194531

also reverts #13349

PS: this is basically just a workaround, not fixing the actual issue
