### PR TITLE
chore: update node engine version to match mongodb's minimal

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "main": "./index.js",
   "types": "./types/index.d.ts",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.20.1"
   },
   "bugs": {
     "url": "https://github.com/Automattic/mongoose/issues/new"


### PR DESCRIPTION
**Summary**

This PR updates the engine-node version to match what mongodb has defined, because otherwise mongoose says to support a lower version than a library it uses

https://github.com/mongodb/node-mongodb-native/blob/ce8e69b6db0eb4c0b9271ce43e334d70b967d227/package.json#L102