### PR TITLE
types(document): correct return type for `Model.prototype.deleteOne()`: promise, not query

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -39,7 +39,7 @@ const Test = model<ITest>('Test', schema);
 void async function main() {
   const doc = await Test.findOne().orFail();
 
-  expectType<Query<any, TestDocument>>(doc.deleteOne());
+  expectType<Promise<TestDocument>>(doc.deleteOne());
 }();
 
 

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -107,7 +107,7 @@ declare module 'mongoose' {
     db: Connection;
 
     /** Removes this document from the db. */
-    deleteOne(options?: QueryOptions): QueryWithHelpers<any, this, TQueryHelpers>;
+    deleteOne(options?: QueryOptions): Promise<this>;
 
     /**
      * Takes a populated field and returns it to its unpopulated state. If called with


### PR DESCRIPTION
Fix #13223

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

As implemented, `doc.deleteOne()` returns a promise, not a query. We could either update the `deleteOne()` implementation to match `updateOne()`, which _does_ return a query; or we update the TypeScript types. I think changing the TS types is the way to go, because it is less backwards breaking. But we should consider changing `doc.deleteOne()` to return a query in the next major release.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
