### PR TITLE
fix(query+timestamps): avoid sending `overwrite` and `timestamps` options to MongoDB

### DIFF
--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -98,8 +98,14 @@ module.exports = function setupTimestamps(schema, timestamps) {
     if (replaceOps.has(this.op) && this.getUpdate() == null) {
       this.setUpdate({});
     }
-    applyTimestampsToUpdate(now, createdAt, updatedAt, this.getUpdate(),
-      this.options, this.schema);
+    applyTimestampsToUpdate(
+      now,
+      createdAt,
+      updatedAt,
+      this.getUpdate(),
+      this._mongooseOptions,
+      this.schema
+    );
     applyTimestampsToChildren(now, this.getUpdate(), this.model.schema);
     next();
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -1606,7 +1606,14 @@ Query.prototype.setOptions = function(options, overwrite) {
     this._mongooseOptions.sanitizeFilter = options.sanitizeFilter;
     delete options.sanitizeFilter;
   }
-
+  if ('overwrite' in options) {
+    this._mongooseOptions.overwrite = options.overwrite;
+    delete options.overwrite;
+  }
+  if ('timestamps' in options) {
+    this._mongooseOptions.timestamps = options.timestamps;
+    delete options.timestamps;
+  }
   if ('defaults' in options) {
     this._mongooseOptions.defaults = options.defaults;
     // deleting options.defaults will cause 7287 to fail
@@ -1864,7 +1871,7 @@ Query.prototype._updateForExec = function() {
   while (i--) {
     const op = ops[i];
 
-    if (this.options.overwrite) {
+    if (this._mongooseOptions.overwrite) {
       ret[op] = update[op];
       continue;
     }
@@ -3786,7 +3793,7 @@ async function _updateThunk(op) {
   const options = this._optionsForExec(this.model);
 
   this._update = clone(this._update, options);
-  const isOverwriting = this.options.overwrite && !hasDollarKeys(this._update);
+  const isOverwriting = this._mongooseOptions.overwrite && !hasDollarKeys(this._update);
   if (isOverwriting) {
     if (op === 'updateOne' || op === 'updateMany') {
       throw new MongooseError('The MongoDB server disallows ' +
@@ -3795,7 +3802,7 @@ async function _updateThunk(op) {
     }
     this._update = new this.model(this._update, null, true);
   } else {
-    this._update = this._castUpdate(this._update, options.overwrite);
+    this._update = this._castUpdate(this._update, this._mongooseOptions.overwrite);
 
     if (this._update == null || Object.keys(this._update).length === 0) {
       return { acknowledged: false };

--- a/test/model.findOneAndReplace.test.js
+++ b/test/model.findOneAndReplace.test.js
@@ -4,6 +4,7 @@
  * Test dependencies.
  */
 
+const sinon = require('sinon');
 const start = require('./common');
 
 const assert = require('assert');
@@ -370,5 +371,25 @@ describe('model: findOneAndReplace:', function() {
 
     const doc = await Test.findById(entry);
     assert.strictEqual(doc.name, undefined);
+  });
+
+  it('does not send overwrite or timestamps option to MongoDB', async function() {
+    const testSchema = new Schema({
+      name: String
+    });
+    const Test = db.model('Test', testSchema);
+
+    sinon.stub(Test.collection, 'findOneAndReplace').callsFake(() => Promise.resolve({}));
+
+    await Test.findOneAndReplace(
+      { name: 'Test' },
+      {},
+      { timestamps: true }
+    );
+
+    assert.ok(Test.collection.findOneAndReplace.calledOnce);
+    const opts = Test.collection.findOneAndReplace.getCalls()[0].args[2];
+    assert.ok(!Object.keys(opts).includes('overwrite'));
+    assert.ok(!Object.keys(opts).includes('timestamps'));
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`overwrite` and `timestamps` aren't supported options on the MongoDB server, they're internal to Mongoose, so they should be stored under `_mongooseOptions`. Removing these options makes debug output cleaner and improves perf slightly.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
