### PR TITLE
feat(query): add `translateAliases` option to automatically call translate aliases on query fields

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1939,6 +1939,8 @@ Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
               // Recursively translate nested queries
               fields[key][i] = this.translateAliases(fields[key][i]);
             }
+          } else {
+            this.translateAliases(fields[key]);
           }
         }
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1855,20 +1855,24 @@ Model.discriminators;
  *
  * #### Example:
  *
- *     Character
- *       .find(Character.translateAliases({
- *         '名': 'Eddard Stark' // Alias for 'name'
- *       })
- *       .exec(function(err, characters) {})
+ *     await Character.find(Character.translateAliases({
+ *        '名': 'Eddard Stark' // Alias for 'name'
+ *     });
+ *
+ * By default, `translateAliases()` overwrites raw fields with aliased fields.
+ * So if `n` is an alias for `name`, `{ n: 'alias', name: 'raw' }` will resolve to `{ name: 'alias' }`.
+ * However, you can set the `errorOnDuplicates` option to throw an error if there are potentially conflicting paths.
+ * The `translateAliases` option for queries uses `errorOnDuplicates`.
  *
  * #### Note:
  *
  * Only translate arguments of object type anything else is returned raw
  *
  * @param {Object} fields fields/conditions that may contain aliased keys
+ * @param {Boolean} [errorOnDuplicates] if true, throw an error if there's both a key and an alias for that key in `fields`
  * @return {Object} the translated 'pure' fields/conditions
  */
-Model.translateAliases = function translateAliases(fields) {
+Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
   _checkContext(this, 'translateAliases');
 
   const translate = (key, value) => {
@@ -1880,6 +1884,9 @@ Model.translateAliases = function translateAliases(fields) {
       const name = fieldKeys[i];
       if (currentSchema && currentSchema.aliases[name]) {
         alias = currentSchema.aliases[name];
+        if (errorOnDuplicates && alias in fields) {
+          throw new MongooseError(`Provided object has both field "${name}" and its alias "${alias}"`);
+        }
         // Alias found,
         translated.push(alias);
       } else {
@@ -1961,6 +1968,7 @@ Model.translateAliases = function translateAliases(fields) {
  *
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @api public
  */
@@ -1995,6 +2003,7 @@ Model.deleteOne = function deleteOne(conditions, options) {
  *
  * @param {Object} conditions
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @api public
  */
@@ -2036,6 +2045,7 @@ Model.deleteMany = function deleteMany(conditions, options) {
  * @param {Object|ObjectId} filter
  * @param {Object|String|String[]} [projection] optional fields to return, see [`Query.prototype.select()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.select())
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see field selection https://mongoosejs.com/docs/api/query.html#Query.prototype.select()
  * @see query casting https://mongoosejs.com/docs/tutorials/query_casting.html
@@ -2124,6 +2134,7 @@ Model.findById = function findById(id, projection, options) {
  * @param {Object} [conditions]
  * @param {Object|String|String[]} [projection] optional fields to return, see [`Query.prototype.select()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.select())
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see field selection https://mongoosejs.com/docs/api/query.html#Query.prototype.select()
  * @see lean queries https://mongoosejs.com/docs/tutorials/lean.html
@@ -2317,7 +2328,7 @@ Model.$where = function $where() {
 };
 
 /**
- * Issues a mongodb findAndModify update command.
+ * Issues a mongodb findOneAndUpdate command.
  *
  * Finds a matching document, updates it according to the `update` arg, passing any `options`, and returns the found document (if any) to the callback. The query executes if `callback` is passed else a Query object is returned.
  *
@@ -2369,6 +2380,7 @@ Model.$where = function $where() {
  * @param {Boolean} [options.runValidators] if true, runs [update validators](https://mongoosejs.com/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema
  * @param {Boolean} [options.setDefaultsOnInsert=true] If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Tutorial https://mongoosejs.com/docs/tutorials/findoneandupdate.html
  * @see mongodb https://www.mongodb.com/docs/manual/reference/command/findAndModify/
@@ -2429,7 +2441,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
 }
 
 /**
- * Issues a mongodb findAndModify update command by a document's _id field.
+ * Issues a mongodb findOneAndUpdate command by a document's _id field.
  * `findByIdAndUpdate(id, ...)` is equivalent to `findOneAndUpdate({ _id: id }, ...)`.
  *
  * Finds a matching document, updates it according to the `update` arg,
@@ -2487,6 +2499,7 @@ function _decorateUpdateWithVersionKey(update, options, versionKey) {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Boolean} [options.new=false] if true, return the modified document rather than the original
  * @param {Object|String} [options.select] sets the document fields to return.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Model.findOneAndUpdate https://mongoosejs.com/docs/api/model.html#Model.findOneAndUpdate()
  * @see mongodb https://www.mongodb.com/docs/manual/reference/command/findAndModify/
@@ -2547,6 +2560,7 @@ Model.findByIdAndUpdate = function(id, update, options) {
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @api public
  */
@@ -2582,6 +2596,7 @@ Model.findOneAndDelete = function(conditions, options) {
  * @param {Object|Number|String} id value of `_id` to query by
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Model.findOneAndRemove https://mongoosejs.com/docs/api/model.html#Model.findOneAndRemove()
  * @see mongodb https://www.mongodb.com/docs/manual/reference/command/findAndModify/
@@ -2625,6 +2640,7 @@ Model.findByIdAndDelete = function(id, options) {
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @api public
  */
@@ -2649,7 +2665,7 @@ Model.findOneAndReplace = function(filter, replacement, options) {
 };
 
 /**
- * Issue a mongodb findAndModify remove command.
+ * Issue a mongodb findOneAndRemove command.
  *
  * Finds a matching document, removes it, and returns the found document (if any).
  *
@@ -2682,6 +2698,7 @@ Model.findOneAndReplace = function(filter, replacement, options) {
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.select] sets the document fields to return.
  * @param {Number} [options.maxTimeMS] puts a time limit on the query - requires mongodb >= 2.6.0
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see mongodb https://www.mongodb.com/docs/manual/reference/command/findAndModify/
  * @api public
@@ -2707,7 +2724,7 @@ Model.findOneAndRemove = function(conditions, options) {
 };
 
 /**
- * Issue a mongodb findAndModify remove command by a document's _id field. `findByIdAndRemove(id, ...)` is equivalent to `findOneAndRemove({ _id: id }, ...)`.
+ * Issue a mongodb findOneAndRemove command by a document's _id field. `findByIdAndRemove(id, ...)` is equivalent to `findOneAndRemove({ _id: id }, ...)`.
  *
  * Finds a matching document, removes it, and returns the found document (if any).
  *
@@ -2729,6 +2746,7 @@ Model.findOneAndRemove = function(conditions, options) {
  * @param {Object|String} [options.sort] if multiple docs are found by the conditions, sets the sort order to choose which doc to update.
  * @param {Boolean} [options.rawResult] if true, returns the [raw result from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html)
  * @param {Object|String} [options.select] sets the document fields to return.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Model.findOneAndRemove https://mongoosejs.com/docs/api/model.html#Model.findOneAndRemove()
  * @see mongodb https://www.mongodb.com/docs/manual/reference/command/findAndModify/
@@ -3739,6 +3757,7 @@ Model.hydrate = function(obj, projection, options) {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](https://mongoosejs.com/docs/guide.html#writeConcern)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see MongoDB docs https://www.mongodb.com/docs/manual/reference/command/update/#update-command-output
@@ -3777,6 +3796,7 @@ Model.updateMany = function updateMany(conditions, doc, options) {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](https://mongoosejs.com/docs/guide.html#writeConcern)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see MongoDB docs https://www.mongodb.com/docs/manual/reference/command/update/#update-command-output
@@ -3813,6 +3833,7 @@ Model.updateOne = function updateOne(conditions, doc, options) {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](https://mongoosejs.com/docs/guide.html#writeConcern)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query}
  * @see Query docs https://mongoosejs.com/docs/queries.html
  * @see UpdateResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/UpdateResult.html

--- a/lib/query.js
+++ b/lib/query.js
@@ -2662,7 +2662,7 @@ Query.prototype._applyTranslateAliases = function _applyTranslateAliases(options
     return;
   }
 
-  if (this.model && this.model.schema && Object.keys(this.model.schema.aliases).length > 0) {
+  if (this.model?.schema?.aliases && Object.keys(this.model.schema.aliases).length > 0) {
     this.model.translateAliases(this._conditions, true);
     this.model.translateAliases(options.projection, true);
     this.model.translateAliases(this._update, true);

--- a/lib/query.js
+++ b/lib/query.js
@@ -154,6 +154,18 @@ Query.prototype = new mquery();
 Query.prototype.constructor = Query;
 Query.base = mquery.prototype;
 
+/*!
+ * Overwrite mquery's `_distinct`, because Mongoose uses that name
+ * to store the field to apply distinct on.
+ */
+
+Object.defineProperty(Query.prototype, '_distinct', {
+  configurable: true,
+  writable: true,
+  enumerable: true,
+  value: undefined
+});
+
 /**
  * Flag to opt out of using `$geoWithin`.
  *
@@ -1618,6 +1630,11 @@ Query.prototype.setOptions = function(options, overwrite) {
     this._mongooseOptions.defaults = options.defaults;
     // deleting options.defaults will cause 7287 to fail
   }
+  if ('translateAliases' in options) {
+    this._mongooseOptions.translateAliases = options.translateAliases;
+    delete options.translateAliases;
+  }
+
   if (options.lean == null && this.schema && 'lean' in this.schema.options) {
     this._mongooseOptions.lean = this.schema.options.lean;
   }
@@ -2237,6 +2254,9 @@ Query.prototype._find = async function _find() {
   });
 
   const options = this._optionsForExec();
+
+  this._applyTranslateAliases(options);
+
   const filter = this._conditions;
   const fields = options.projection;
 
@@ -2486,6 +2506,8 @@ Query.prototype._findOne = async function _findOne() {
 
   const options = this._optionsForExec();
 
+  this._applyTranslateAliases(options);
+
   // don't pass in the conditions because we already merged them in
   const doc = await this._collection.collection.findOne(this._conditions, options);
   return new Promise((resolve, reject) => {
@@ -2582,8 +2604,11 @@ Query.prototype._count = async function _count() {
   applyGlobalMaxTimeMS(this.options, this.model);
   applyGlobalDiskUse(this.options, this.model);
 
-  const conds = this._conditions;
   const options = this._optionsForExec();
+
+  this._applyTranslateAliases(options);
+
+  const conds = this._conditions;
 
   return this._collection.collection.count(conds, options);
 };
@@ -2609,10 +2634,41 @@ Query.prototype._countDocuments = async function _countDocuments() {
   applyGlobalMaxTimeMS(this.options, this.model);
   applyGlobalDiskUse(this.options, this.model);
 
-  const conds = this._conditions;
   const options = this._optionsForExec();
 
+  this._applyTranslateAliases(options);
+
+  const conds = this._conditions;
+
   return this._collection.collection.countDocuments(conds, options);
+};
+
+/*!
+ * If `translateAliases` option is set, call `Model.translateAliases()`
+ * on the following query properties: filter, projection, update, distinct.
+ */
+
+Query.prototype._applyTranslateAliases = function _applyTranslateAliases(options) {
+  let applyTranslateAliases = false;
+  if ('translateAliases' in this._mongooseOptions) {
+    applyTranslateAliases = this._mongooseOptions.translateAliases;
+  } else if (this?.model?.schema?._userProvidedOptions?.translateAliases != null) {
+    applyTranslateAliases = this.model.schema._userProvidedOptions.translateAliases;
+  } else if (this?.model?.base?.options?.translateAliases != null) {
+    applyTranslateAliases = this.model.base.options.translateAliases;
+  }
+  if (!applyTranslateAliases) {
+    return;
+  }
+
+  if (this.model && this.model.schema && Object.keys(this.model.schema.aliases).length > 0) {
+    this.model.translateAliases(this._conditions);
+    this.model.translateAliases(options.projection);
+    this.model.translateAliases(this._update);
+    if (this._distinct != null && this.model.schema.aliases[this._distinct] != null) {
+      this._distinct = this.model.schema.aliases[this._distinct];
+    }
+  }
 };
 
 /**
@@ -2796,6 +2852,7 @@ Query.prototype.__distinct = async function __distinct() {
   applyGlobalDiskUse(this.options, this.model);
 
   const options = this._optionsForExec();
+  this._applyTranslateAliases(options);
 
   return this._collection.collection.
     distinct(this._distinct, this._conditions, options);
@@ -2955,6 +3012,7 @@ Query.prototype._deleteOne = async function _deleteOne() {
   }
 
   const options = this._optionsForExec();
+  this._applyTranslateAliases(options);
 
   return this._collection.collection.deleteOne(this._conditions, options);
 };
@@ -3032,6 +3090,7 @@ Query.prototype._deleteMany = async function _deleteMany() {
   }
 
   const options = this._optionsForExec();
+  this._applyTranslateAliases(options);
 
   return this._collection.collection.deleteMany(this._conditions, options);
 };
@@ -3234,6 +3293,7 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   applyGlobalDiskUse(this.options, this.model);
 
   const opts = this._optionsForExec(this.model);
+  this._applyTranslateAliases(opts);
 
   if ('strict' in opts) {
     this._mongooseOptions.strict = opts.strict;
@@ -3427,6 +3487,7 @@ Query.prototype._findOneAndDelete = async function _findOneAndDelete() {
 
   const filter = this._conditions;
   const options = this._optionsForExec();
+  this._applyTranslateAliases(options);
   let fields = null;
 
   this._applyPaths();
@@ -3560,6 +3621,7 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
 
   const filter = this._conditions;
   const options = this._optionsForExec();
+  this._applyTranslateAliases(options);
   convertNewToReturnDocument(options);
 
   const runValidators = _getOption(this, 'runValidators', false);
@@ -3787,6 +3849,7 @@ async function _updateThunk(op) {
 
   const castedQuery = this._conditions;
   const options = this._optionsForExec(this.model);
+  this._applyTranslateAliases(options);
 
   this._update = clone(this._update, options);
   const isOverwriting = this._mongooseOptions.overwrite && !hasDollarKeys(this._update);

--- a/lib/query.js
+++ b/lib/query.js
@@ -2542,6 +2542,7 @@ Query.prototype._findOne = async function _findOne() {
  * @param {Object} [filter] mongodb selector
  * @param {Object} [projection] optional fields to return
  * @param {Object} [options] see [`setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query} this
  * @see findOne https://www.mongodb.com/docs/manual/reference/method/db.collection.findOne/
  * @see Query.select https://mongoosejs.com/docs/api/query.html#Query.prototype.select()
@@ -2662,9 +2663,9 @@ Query.prototype._applyTranslateAliases = function _applyTranslateAliases(options
   }
 
   if (this.model && this.model.schema && Object.keys(this.model.schema.aliases).length > 0) {
-    this.model.translateAliases(this._conditions);
-    this.model.translateAliases(options.projection);
-    this.model.translateAliases(this._update);
+    this.model.translateAliases(this._conditions, true);
+    this.model.translateAliases(options.projection, true);
+    this.model.translateAliases(this._update, true);
     if (this._distinct != null && this.model.schema.aliases[this._distinct] != null) {
       this._distinct = this.model.schema.aliases[this._distinct];
     }
@@ -3202,6 +3203,7 @@ function prepareDiscriminatorCriteria(query) {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.returnOriginal=null] An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @see Tutorial https://mongoosejs.com/docs/tutorials/findoneandupdate.html
  * @see findAndModify command https://www.mongodb.com/docs/manual/reference/command/findAndModify/
  * @see ModifyResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html
@@ -3557,6 +3559,7 @@ Query.prototype._findOneAndDelete = async function _findOneAndDelete() {
  * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.returnOriginal=null] An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @return {Query} this
  * @api public
  */
@@ -3990,6 +3993,7 @@ Query.prototype._replaceOne = async function _replaceOne() {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](https://mongoosejs.com/docs/guide.html#writeConcern)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
  * @see Model.update https://mongoosejs.com/docs/api/model.html#Model.update()
@@ -4058,6 +4062,7 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](https://mongoosejs.com/docs/guide.html#writeConcern)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
+ @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
  * @see Model.update https://mongoosejs.com/docs/api/model.html#Model.update()
@@ -4124,6 +4129,7 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * @param {Boolean} [options.upsert=false] if true, and no documents found, insert a new document
  * @param {Object} [options.writeConcern=null] sets the [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/) for replica sets. Overrides the [schema-level write concern](https://mongoosejs.com/docs/guide.html#writeConcern)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Does nothing if schema-level timestamps are not set.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
  * @param {Function} [callback] params are (error, writeOpResult)
  * @return {Query} this
  * @see Model.update https://mongoosejs.com/docs/api/model.html#Model.update()

--- a/lib/query.js
+++ b/lib/query.js
@@ -2652,9 +2652,9 @@ Query.prototype._applyTranslateAliases = function _applyTranslateAliases(options
   let applyTranslateAliases = false;
   if ('translateAliases' in this._mongooseOptions) {
     applyTranslateAliases = this._mongooseOptions.translateAliases;
-  } else if (this?.model?.schema?._userProvidedOptions?.translateAliases != null) {
+  } else if (this.model?.schema?._userProvidedOptions?.translateAliases != null) {
     applyTranslateAliases = this.model.schema._userProvidedOptions.translateAliases;
-  } else if (this?.model?.base?.options?.translateAliases != null) {
+  } else if (this.model?.base?.options?.translateAliases != null) {
     applyTranslateAliases = this.model.base.options.translateAliases;
   }
   if (!applyTranslateAliases) {

--- a/lib/validoptions.js
+++ b/lib/validoptions.js
@@ -30,7 +30,8 @@ const VALID_OPTIONS = Object.freeze([
   'strictPopulate',
   'strictQuery',
   'toJSON',
-  'toObject'
+  'toObject',
+  'translateAliases'
 ]);
 
 module.exports = VALID_OPTIONS;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -6731,7 +6731,7 @@ describe('document', function() {
       documentArray: [new Schema({})]
     }, { versionKey: false });
 
-    let Test = db.model('Test', schema);
+    const Test = db.model('Test', schema);
 
     const doc = new Test({
       _id: new mongoose.Types.ObjectId('0'.repeat(24)),

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3666,6 +3666,70 @@ describe('Query', function() {
 
   });
 
+  it('translateAliases option (gh-7511)', async function() {
+    const testSchema = new Schema({
+      name: {
+        type: String,
+        alias: 'n'
+      },
+      age: {
+        type: Number
+      }
+    });
+    const Test = db.model('Test', testSchema);
+    await Test.create({ name: 'foo', age: 99 });
+
+    let res = await Test.findOne({ n: 'foo' }, { n: 1 }, { translateAliases: true });
+    assert.equal(res.name, 'foo');
+    assert.strictEqual(res.age, void 0);
+
+    res = await Test.find({ n: 'foo' }, { n: 1 }, { translateAliases: true });
+    assert.equal(res.length, 1);
+    assert.equal(res[0].name, 'foo');
+    assert.strictEqual(res[0].age, void 0);
+
+    res = await Test.countDocuments({ n: 'foo' }, { translateAliases: true });
+    assert.strictEqual(res, 1);
+
+    res = await Test.distinct('n').setOptions({ translateAliases: true });
+    assert.deepStrictEqual(res, ['foo']);
+
+    res = await Test.findOneAndUpdate(
+      { n: 'foo' },
+      { n: 'bar' },
+      { returnDocument: 'after', translateAliases: true }
+    );
+    assert.strictEqual(res.name, 'bar');
+
+    res = await Test.updateOne(
+      { n: 'bar' },
+      { n: 'baz' },
+      { translateAliases: true }
+    );
+    assert.strictEqual(res.modifiedCount, 1);
+
+    res = await Test.deleteMany({ n: 'baz' }, { translateAliases: true });
+    assert.deepStrictEqual(res.deletedCount, 1);
+  });
+
+  it('schema level translateAliases option (gh-7511)', async function() {
+    const testSchema = new Schema({
+      name: {
+        type: String,
+        alias: 'n'
+      },
+      age: {
+        type: Number
+      }
+    }, { translateAliases: true });
+    const Test = db.model('Test', testSchema);
+    await Test.deleteMany({});
+    await Test.create({ name: 'foo', age: 99 });
+
+    const res = await Test.findOne({ n: 'foo' });
+    assert.equal(res.name, 'foo');
+  });
+
   describe('set()', function() {
     it('overwrites top-level keys if setting to undefined (gh-12155)', function() {
       const testSchema = new mongoose.Schema({

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3703,14 +3703,14 @@ describe('Query', function() {
 
     res = await Test.updateOne(
       { n: 'bar' },
-      { n: 'baz' },
+      { $set: { age: 44 }, n: 'baz' },
       { translateAliases: true }
     );
     assert.strictEqual(res.modifiedCount, 1);
 
     res = await Test.updateOne(
-      { n: 'baz' },
-      { name: 'qux' },
+      { name: 'baz' },
+      { $set: { n: 'qux' } },
       { translateAliases: true }
     );
     assert.strictEqual(res.modifiedCount, 1);

--- a/types/mongooseoptions.d.ts
+++ b/types/mongooseoptions.d.ts
@@ -202,5 +202,11 @@ declare module 'mongoose' {
      * @default { transform: true, flattenDecimals: true }
      */
     toObject?: ToObjectOptions;
+
+    /**
+     * If `true`, convert any aliases in filter, projection, update, and distinct
+     * to their database property names. Defaults to false.
+     */
+    translateAliases?: boolean;
   }
 }

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -161,6 +161,11 @@ declare module 'mongoose' {
      * timestamps. Does nothing if schema-level timestamps are not set.
      */
     timestamps?: boolean | QueryTimestampsConfig;
+    /**
+     * If `true`, convert any aliases in filter, projection, update, and distinct
+     * to their database property names. Defaults to false.
+     */
+    translateAliases?: boolean;
     upsert?: boolean;
     useBigInt64?: boolean;
     writeConcern?: mongodb.WriteConcern;


### PR DESCRIPTION
Fix #7511
Fix #8678

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Add `translateAliases` option on query, schema, and global level to apply `Model.translateAliases()` on all query fields automatically: `filter`, `projection`, `update`, and `distinct`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
