### PR TITLE
feat(ts): Export MongooseError class

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports.Mixed = mongoose.Mixed;
 module.exports.Date = mongoose.Date;
 module.exports.Number = mongoose.Number;
 module.exports.Error = mongoose.Error;
+module.exports.MongooseError = mongoose.MongooseError;
 module.exports.now = mongoose.now;
 module.exports.CastError = mongoose.CastError;
 module.exports.SchemaTypeOptions = mongoose.SchemaTypeOptions;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1140,6 +1140,7 @@ Mongoose.prototype.Number = SchemaTypes.Number;
  */
 
 Mongoose.prototype.Error = require('./error/index');
+Mongoose.prototype.MongooseError = require('./error/mongooseError');
 
 /**
  * Mongoose uses this function to get the current time when setting

--- a/types/error.d.ts
+++ b/types/error.d.ts
@@ -6,7 +6,7 @@ declare module 'mongoose' {
   type CastError = Error.CastError;
   type SyncIndexesError = Error.SyncIndexesError;
 
-  class MongooseError extends global.Error {
+  export class MongooseError extends global.Error {
     constructor(msg: string);
 
     /** The type of error. "MongooseError" for generic errors. */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Exports the class `MongooseError` so it can be tested using `err instanceof MongooseError`

**Examples**

```ts
import mongoose from 'mongoose';

const Model = mongoose.model('model', new mongoose.Schema({ answer: Number }));

async function main() {
  const doc = new Model({ answer: 'not a number' });
  const err = doc.validateSync();

  console.log(err instanceof mongoose.Error); // true
  console.log(err instanceof mongoose.MongooseError); // true
  console.log(err instanceof mongoose.Error.ValidationError); // true
}

main();
```

Closes #13387 