### PR TITLE
fix: fixed types to allow string in interfaces for ObjectId in schemas

### DIFF
--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -41,7 +41,7 @@ declare module 'mongoose' {
 
   class SchemaTypeOptions<T> {
     type?:
-    T extends string ? StringSchemaDefinition :
+    T extends string ? StringSchemaDefinition | ObjectIdSchemaDefinition :
       T extends number ? NumberSchemaDefinition :
         T extends boolean ? BooleanSchemaDefinition :
           T extends NativeDate ? DateSchemaDefinition :


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Allowing string in interfaces for ObjectId in schemas.
Fixes #13288 
