### PR TITLE
fix(getModelMapForPopulate): mention model name in error

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -390,7 +390,7 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
 
     if (!localField || !foreignField) {
       return new MongooseError('If you are populating a virtual, you must set the ' +
-        'localField and foreignField options' + ` (Model: ${model.modelName})`);
+        `localField and foreignField options (Model: ${model.modelName})`);
     }
 
     if (typeof localField === 'function') {

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -390,7 +390,7 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
 
     if (!localField || !foreignField) {
       return new MongooseError('If you are populating a virtual, you must set the ' +
-        'localField and foreignField options');
+        'localField and foreignField options' + ` (Model: ${model.modelName})`);
     }
 
     if (typeof localField === 'function') {

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -389,8 +389,7 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
     let foreignField = virtual.options.foreignField;
 
     if (!localField || !foreignField) {
-      return new MongooseError('If you are populating a virtual, you must set the ' +
-        `localField and foreignField options (Model: ${model.modelName})`);
+      return new MongooseError(`Cannot populate virtual \`${options.path}\` on model \`${model.modelName}\`, because options \`localField\` and / or \`foreignField\` are missing`);
     }
 
     if (typeof localField === 'function') {

--- a/test/helpers/getModelsMapForPopulate.test.js
+++ b/test/helpers/getModelsMapForPopulate.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('assert');
+const start = require('../common');
+const util = require('../util');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('getModelsMapForPopulate', function() {
+  let db;
+
+  beforeEach(() => db.deleteModel(/.*/));
+
+  before(function() {
+    db = start();
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  afterEach(() => util.clearTestData(db));
+  afterEach(() => util.stopRemainingOps(db));
+
+  it('should error on missing options on populate', async function() {
+    const sch = new Schema({
+      test: mongoose.Schema.Types.ObjectId
+    }, {
+      virtuals: {
+        someVirtual: {}
+      }
+    });
+
+    const model = db.model('Test', sch);
+
+    const doc = await model.create({ test: new mongoose.Types.ObjectId() });
+
+    await assert.rejects(() => model.findById(doc._id).populate('someVirtual').exec(), /If you are populating a virtual, you must set the localField and foreignField options \(Model: Test\)/);
+  });
+});

--- a/test/helpers/getModelsMapForPopulate.test.js
+++ b/test/helpers/getModelsMapForPopulate.test.js
@@ -36,6 +36,6 @@ describe('getModelsMapForPopulate', function() {
 
     const doc = await model.create({ test: new mongoose.Types.ObjectId() });
 
-    await assert.rejects(() => model.findById(doc._id).populate('someVirtual').exec(), /If you are populating a virtual, you must set the localField and foreignField options \(Model: Test\)/);
+    await assert.rejects(() => model.findById(doc._id).populate('someVirtual').exec(), /Cannot populate virtual `someVirtual` on model `Test`, because options `localField` and \/ or `foreignField` are missing/);
   });
 });


### PR DESCRIPTION
**Summary**

This PR adds the model name to a error, it is probably not the best method for debugging which model the problem is, but better than not mentioning it.
also adds a test-file for the the helper because i was unsure where to add the test

fixes #13406
