### PR TITLE
test(fixtures): check md5 of archive downloaded

### DIFF
--- a/test/mocha-fixtures.js
+++ b/test/mocha-fixtures.js
@@ -27,6 +27,7 @@ module.exports.mochaGlobalSetup = async function mochaGlobalSetup() {
   let replseturi;
 
   process.env.RUNTIME_DOWNLOAD = '1'; // ensure MMS is able to download binaries in this context
+  process.env.MONGOMS_MD5_CHECK = '1';
 
   // set some options when running in a CI
   if (process.env.CI) {


### PR DESCRIPTION
**Summary**

This PR enables md5 checks on the archives downloaded by MMS, this is in hopes to narrow down deno zlib errors as corrupt downloads or zlib not working correctly on deno.

i could not get the error to reproduce locally and in the CI runs i did i could also not explicitly reproduce it, so i hope that this will help find a run over time