### PR TITLE
fix(model): include inspect output in `castBulkWrite()` error

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const MongooseError = require('../../error/mongooseError');
 const getDiscriminatorByValue = require('../../helpers/discriminator/getDiscriminatorByValue');
 const applyTimestampsToChildren = require('../update/applyTimestampsToChildren');
 const applyTimestampsToUpdate = require('../update/applyTimestampsToUpdate');
 const cast = require('../../cast');
 const castUpdate = require('../query/castUpdate');
+const { inspect } = require('util');
 const setDefaultsOnInsert = require('../setDefaultsOnInsert');
 
 /**
@@ -212,7 +214,8 @@ module.exports = function castBulkWrite(originalModel, op, options) {
     };
   } else {
     return (callback) => {
-      callback(new Error('Invalid op passed to `bulkWrite()`'), null);
+      const error = new MongooseError(`Invalid op passed to \`bulkWrite()\`: ${inspect(op)}`);
+      callback(error, null);
     };
   }
 };

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3945,7 +3945,14 @@ describe('Model', function() {
 
         const doc = await Parent.findOne();
         assert.ok(doc.children[0].updatedAt.valueOf() > end);
+      });
 
+      it('throws readable error if invalid op', async function() {
+        const Test = db.model('Test', Schema({ name: String }));
+        await assert.rejects(
+          () => Test.bulkWrite([Promise.resolve(42)]),
+          'MongooseError: Invalid op passed to `bulkWrite()`: Promise { 42 }'
+        );
       });
 
       it('with timestamps and replaceOne (gh-5708)', async function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, the current error message on an invalid bulk write op "Invalid op passed to `bulkWrite()`" doesn't provide any insight as to what the invalid op was. `inspect()` output provides a little extra info to make this issue easier to debug.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
