### PR TITLE
fix query cursor and middleware interaction

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -46,7 +46,6 @@ function QueryCursor(query, options) {
   this._transforms = [];
   this.model = model;
   this.options = options || {};
-
   model.hooks.execPre('find', query, (err) => {
     if (err != null) {
       _this._markError(err);
@@ -66,6 +65,7 @@ function QueryCursor(query, options) {
       // Max out the number of documents we'll populate in parallel at 5000.
       this.options._populateBatchSize = Math.min(this.options.batchSize, 5000);
     }
+    Object.assign(this.options, query._optionsForExec());
     model.collection.find(query._conditions, this.options, (err, cursor) => {
       if (err != null) {
         _this._markError(err);

--- a/lib/query.js
+++ b/lib/query.js
@@ -5021,6 +5021,7 @@ Query.prototype.cursor = function cursor(opts) {
   }
 
   const options = this._optionsForExec();
+
   try {
     this.cast(this.model);
   } catch (err) {

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -818,7 +818,8 @@ describe('QueryCursor', function() {
     await Test.create([{ a: 1, b: 1, c: 1 }, { a: 2, b: 2, c: 2 }]);
     const cursorMiddleSelect = [];
     let r;
-    let cursor = Test.find().select('-b').sort({ a: 1 }).cursor();
+    const cursor = Test.find().select('-b').sort({ a: 1 }).cursor();
+    // eslint-disable-next-line no-cond-assign
     while (r = await cursor.next()) {
       cursorMiddleSelect.push(r);
     }

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -805,6 +805,28 @@ describe('QueryCursor', function() {
     const docs = await Example.find().sort('foo');
     assert.deepStrictEqual(docs.map(d => d.foo), ['example1', 'example2']);
   });
+  it('should allow middleware to run before applying _optionsForExec() gh-13417', async function() {
+    const testSchema = new Schema({
+      a: Number,
+      b: Number,
+      c: Number
+    });
+    testSchema.pre('find', function() {
+      this.select('-c');
+    });
+    const Test = db.model('gh13417', testSchema);
+    await Test.create([{ a: 1, b: 1, c: 1 }, { a: 2, b: 2, c: 2 }]);
+    const cursorMiddleSelect = [];
+    let r;
+    let cursor = Test.find().select('-b').sort({ a: 1 }).cursor();
+    while (r = await cursor.next()) {
+      cursorMiddleSelect.push(r);
+    }
+    assert.equal(typeof cursorMiddleSelect[0].b, 'undefined');
+    assert.equal(typeof cursorMiddleSelect[1].b, 'undefined');
+    assert.equal(typeof cursorMiddleSelect[0].c, 'undefined');
+    assert.equal(typeof cursorMiddleSelect[1].c, 'undefined');
+  });
 });
 
 async function delay(ms) {


### PR DESCRIPTION
Cannot remove the options assignment in query.js as it causes test failures.

closes #13417 
