### PR TITLE
fix(cursor): handle calling `skipMiddlewareFunction()` in pre('find') middleware with cursors

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -8,6 +8,7 @@ const MongooseError = require('../error/mongooseError');
 const Readable = require('stream').Readable;
 const eachAsync = require('../helpers/cursor/eachAsync');
 const helpers = require('../queryhelpers');
+const kareem = require('kareem');
 const immediate = require('../helpers/immediate');
 const util = require('util');
 
@@ -39,6 +40,7 @@ function QueryCursor(query, options) {
   Readable.call(this, { autoDestroy: true, objectMode: true });
 
   this.cursor = null;
+  this.skipped = false;
   this.query = query;
   const _this = this;
   const model = query.model;
@@ -48,6 +50,23 @@ function QueryCursor(query, options) {
   this.options = options || {};
   model.hooks.execPre('find', query, (err) => {
     if (err != null) {
+      if (err instanceof kareem.skipWrappedFunction) {
+        const resultValue = err.args[0];
+        if (resultValue != null && (!Array.isArray(resultValue) || resultValue.length)) {
+          const err = new MongooseError(
+            'Cannot `skipMiddlewareFunction()` with a value when using ' +
+            '`.find().cursor()`, value must be nullish or empty array, got "' +
+            util.inspect(resultValue) +
+            '".'
+          );
+          _this._markError(err);
+          _this.listeners('error').length > 0 && _this.emit('error', err);
+          return;
+        }
+        this.skipped = true;
+        _this.emit('cursor', null);
+        return;
+      }
       _this._markError(err);
       _this.listeners('error').length > 0 && _this.emit('error', err);
       return;
@@ -393,6 +412,9 @@ function _next(ctx, cb) {
       callback(ctx._error);
     });
   }
+  if (ctx.skipped) {
+    return immediate(() => callback(null, null));
+  }
 
   if (ctx.cursor) {
     if (ctx.query._mongooseOptions.populate && !ctx._pop) {
@@ -448,6 +470,9 @@ function _next(ctx, cb) {
     ctx.once('cursor', function(cursor) {
       ctx.removeListener('error', cb);
       if (cursor == null) {
+        if (ctx.skipped) {
+          return cb(null, null);
+        }
         return;
       }
       _next(ctx, cb);

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -832,7 +832,7 @@ describe('QueryCursor', function() {
   it('handles skipMiddlewareFunction() (gh-13411)', async function() {
     const schema = new mongoose.Schema({ name: String });
 
-    schema.pre('find', async () => {
+    schema.pre('find', async() => {
       throw mongoose.skipMiddlewareFunction();
     });
 

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -828,6 +828,50 @@ describe('QueryCursor', function() {
     assert.equal(typeof cursorMiddleSelect[0].c, 'undefined');
     assert.equal(typeof cursorMiddleSelect[1].c, 'undefined');
   });
+
+  it('handles skipMiddlewareFunction() (gh-13411)', async function() {
+    const schema = new mongoose.Schema({ name: String });
+
+    schema.pre('find', async () => {
+      throw mongoose.skipMiddlewareFunction();
+    });
+
+    const Movie = db.model('Movie', schema);
+
+    await Movie.deleteMany({});
+    await Movie.create([
+      { name: 'Kickboxer' },
+      { name: 'Ip Man' },
+      { name: 'Enter the Dragon' }
+    ]);
+
+    const arr = [];
+    await Movie.find({}).cursor().eachAsync(doc => arr.push(doc.name));
+    assert.strictEqual(arr.length, 0);
+  });
+
+  it('throws if calling skipMiddlewareFunction() with non-empty array (gh-13411)', async function() {
+    const schema = new mongoose.Schema({ name: String });
+
+    schema.pre('find', (next) => {
+      next(mongoose.skipMiddlewareFunction([{ name: 'bar' }]));
+    });
+
+    const Movie = db.model('Movie', schema);
+
+    await Movie.deleteMany({});
+    await Movie.create([
+      { name: 'Kickboxer' },
+      { name: 'Ip Man' },
+      { name: 'Enter the Dragon' }
+    ]);
+
+    const err = await Movie.find().cursor().
+      eachAsync(() => {}).
+      then(() => null, err => err);
+    assert.ok(err);
+    assert.ok(err.message.includes('skipMiddlewareFunction'), err.message);
+  });
 });
 
 async function delay(ms) {


### PR DESCRIPTION
Fix #13411

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently, `skipMiddlewareFunction()` in `pre('find')` middleware causes an error if you're using cursors. With this change, it is now fine to call `skipMiddlewareFunction()` in pre('find') middleware with cursors with no parameters; or with `null`, `undefined`, or empty array `[]`.

The reason why we don't support passing an array of documents is that it would be tricky to rewrite current cursor logic to use arrays. We may consider this for the future if there's demand.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
