### PR TITLE
feat(schema): consistently add `.get()` function to all SchemaType classes

### DIFF
--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -347,6 +347,18 @@ SubdocumentPath.defaultOptions = {};
 
 SubdocumentPath.set = SchemaType.set;
 
+/**
+ * Attaches a getter for all SubdocumentPath instances
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SubdocumentPath.get = SchemaType.get;
+
 /*!
  * ignore
  */

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -170,6 +170,18 @@ SchemaArray.defaultOptions = {};
  */
 SchemaArray.set = SchemaType.set;
 
+/**
+ * Attaches a getter for all Array instances
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SchemaArray.get = SchemaType.get;
+
 /*!
  * Inherits from SchemaType.
  */

--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -63,6 +63,23 @@ SchemaBigInt._cast = castBigInt;
 SchemaBigInt.set = SchemaType.set;
 
 /**
+ * Attaches a getter for all BigInt instances
+ *
+ * #### Example:
+ *
+ *     // Convert bigints to numbers
+ *     mongoose.Schema.BigInt.get(v => v == null ? number : Number(v));
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SchemaBigInt.get = SchemaType.get;
+
+/**
  * Get/set the function used to cast arbitrary values to booleans.
  *
  * #### Example:

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -66,6 +66,25 @@ SchemaBoolean._cast = castBoolean;
 SchemaBoolean.set = SchemaType.set;
 
 /**
+ * Attaches a getter for all Boolean instances
+ *
+ * #### Example:
+ *
+ *     mongoose.Schema.Boolean.get(v => v === true ? 'yes' : 'no');
+ *
+ *     const Order = mongoose.model('Order', new Schema({ isPaid: Boolean }));
+ *     new Order({ isPaid: false }).isPaid; // 'no'
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SchemaBoolean.get = SchemaType.get;
+
+/**
  * Get/set the function used to cast arbitrary values to booleans.
  *
  * #### Example:

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -71,6 +71,26 @@ SchemaBuffer._checkRequired = v => !!(v && v.length);
 SchemaBuffer.set = SchemaType.set;
 
 /**
+ * Attaches a getter for all Buffer instances
+ *
+ * #### Example:
+ *
+ *     // Always convert to string when getting an ObjectId
+ *     mongoose.Schema.Types.Buffer.get(v => v.toString('hex'));
+ *
+ *     const Model = mongoose.model('Test', new Schema({ buf: Buffer } }));
+ *     typeof (new Model({ buf: Buffer.fromString('hello') }).buf); // 'string'
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SchemaBuffer.get = SchemaType.get;
+
+/**
  * Override the function the required validator uses to check whether a string
  * passes the `required` check.
  *

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -71,6 +71,26 @@ SchemaDate._cast = castDate;
 SchemaDate.set = SchemaType.set;
 
 /**
+ * Attaches a getter for all ObjectId instances
+ *
+ * #### Example:
+ *
+ *     // Always convert to string when getting an ObjectId
+ *     mongoose.Date.get(v => v.toString());
+ *
+ *     const Model = mongoose.model('Test', new Schema({ date: { type: Date, default: () => new Date() } }));
+ *     typeof (new Model({}).date); // 'string'
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SchemaDate.get = SchemaType.get;
+
+/**
  * Get/set the function used to cast arbitrary values to dates.
  *
  * #### Example:

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -67,6 +67,23 @@ Decimal128._cast = castDecimal128;
 Decimal128.set = SchemaType.set;
 
 /**
+ * Attaches a getter for all Decimal128 instances
+ *
+ * #### Example:
+ *
+ *     // Automatically convert Decimal128s to Numbers
+ *     mongoose.Schema.Decimal128.get(v => v == null ? v : Number(v));
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+Decimal128.get = SchemaType.get;
+
+/**
  * Get/set the function used to cast arbitrary values to decimals.
  *
  * #### Example:

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -37,7 +37,7 @@ let Subdocument;
  */
 
 function DocumentArrayPath(key, schema, options, schemaOptions) {
-  if (schema.options.timeseries) {
+  if (schema.options && schema.options.timeseries) {
     throw new InvalidSchemaOptionError(key, 'timeseries');
   }
   const schemaTypeIdOption = DocumentArrayPath.defaultOptions &&

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -605,6 +605,18 @@ DocumentArrayPath.defaultOptions = {};
 
 DocumentArrayPath.set = SchemaType.set;
 
+/**
+ * Attaches a getter for all DocumentArrayPath instances
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+DocumentArrayPath.get = SchemaType.get;
+
 /*!
  * Module exports.
  */

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -154,6 +154,26 @@ SchemaUUID._cast = function(value) {
 };
 
 /**
+ * Attaches a getter for all UUID instances.
+ *
+ * #### Example:
+ *
+ *     // Note that `v` is a string by default
+ *     mongoose.Schema.UUID.get(v => v.toUpperCase());
+ *
+ *     const Model = mongoose.model('Test', new Schema({ test: 'UUID' }));
+ *     new Model({ test: uuid.v4() }).test; // UUID with all uppercase
+ *
+ * @param {Function} getter
+ * @return {this}
+ * @function get
+ * @static
+ * @api public
+ */
+
+SchemaUUID.get = SchemaType.get;
+
+/**
  * Sets a default option for all UUID instances.
  *
  * #### Example:

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -198,6 +198,14 @@ describe('schematype', function() {
     });
   });
 
+  describe('get()', function() {
+    Object.values(mongoose.SchemaTypes).forEach(schemaType => {
+      it(`${schemaType.name} has a \`get\` method`, () => {
+        assert.strictEqual(typeof schemaType.get, 'function');
+      });
+    });
+  });
+
   describe('set()', function() {
     describe('SchemaType.set()', function() {
       it('SchemaType.set, is a function', () => {
@@ -205,18 +213,10 @@ describe('schematype', function() {
       });
     });
 
-    [
-      mongoose.SchemaTypes.String,
-      mongoose.SchemaTypes.Number,
-      mongoose.SchemaTypes.Boolean,
-      mongoose.SchemaTypes.Array,
-      mongoose.SchemaTypes.Buffer,
-      mongoose.SchemaTypes.Date,
-      mongoose.SchemaTypes.ObjectId,
-      mongoose.SchemaTypes.Mixed,
-      mongoose.SchemaTypes.Decimal128,
-      mongoose.SchemaTypes.Map
-    ].forEach((type) => {
+    const typesToTest = Object.values(mongoose.SchemaTypes).
+      filter(t => t.name !== 'SubdocumentPath' && t.name !== 'DocumentArrayPath');
+
+    typesToTest.forEach((type) => {
       it(type.name + ', when given a default option, set its', () => {
         // Act
         type.set('someRandomOption', true);


### PR DESCRIPTION
Re: #7156

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like some schematypes are missing the `get()` function to register a getter for all instances of the schematype. Only numbers, strings, and ObjectIds currently have that function. This came up in #7156 in the context of dates.

Not urgent because there is an easy workaround, but something we should ship for 7.3.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
