### PR TITLE
refactor(cursor): use arrow functions instead of `_this` throughout

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -42,7 +42,6 @@ function QueryCursor(query, options) {
   this.cursor = null;
   this.skipped = false;
   this.query = query;
-  const _this = this;
   const model = query.model;
   this._mongooseOptions = {};
   this._transforms = [];
@@ -59,16 +58,16 @@ function QueryCursor(query, options) {
             util.inspect(resultValue) +
             '".'
           );
-          _this._markError(err);
-          _this.listeners('error').length > 0 && _this.emit('error', err);
+          this._markError(err);
+          this.listeners('error').length > 0 && this.emit('error', err);
           return;
         }
         this.skipped = true;
-        _this.emit('cursor', null);
+        this.emit('cursor', null);
         return;
       }
-      _this._markError(err);
-      _this.listeners('error').length > 0 && _this.emit('error', err);
+      this._markError(err);
+      this.listeners('error').length > 0 && this.emit('error', err);
       return;
     }
     this._transforms = this._transforms.concat(query._transforms.slice());
@@ -87,17 +86,17 @@ function QueryCursor(query, options) {
     Object.assign(this.options, query._optionsForExec());
     model.collection.find(query._conditions, this.options, (err, cursor) => {
       if (err != null) {
-        _this._markError(err);
-        _this.listeners('error').length > 0 && _this.emit('error', _this._error);
+        this._markError(err);
+        this.listeners('error').length > 0 && this.emit('error', this._error);
         return;
       }
 
-      if (_this._error) {
+      if (this._error) {
         cursor.close(function() {});
-        _this.listeners('error').length > 0 && _this.emit('error', _this._error);
+        this.listeners('error').length > 0 && this.emit('error', this._error);
       }
-      _this.cursor = cursor;
-      _this.emit('cursor', cursor);
+      this.cursor = cursor;
+      this.emit('cursor', cursor);
     });
   });
 }
@@ -113,21 +112,20 @@ util.inherits(QueryCursor, Readable);
  */
 
 QueryCursor.prototype._read = function() {
-  const _this = this;
-  _next(this, function(error, doc) {
+  _next(this, (error, doc) => {
     if (error) {
-      return _this.emit('error', error);
+      return this.emit('error', error);
     }
     if (!doc) {
-      _this.push(null);
-      _this.cursor.close(function(error) {
+      this.push(null);
+      this.cursor.close(function(error) {
         if (error) {
-          return _this.emit('error', error);
+          return this.emit('error', error);
         }
       });
       return;
     }
-    _this.push(doc);
+    this.push(doc);
   });
 };
 
@@ -223,9 +221,8 @@ QueryCursor.prototype.close = async function close() {
  */
 
 QueryCursor.prototype.rewind = function() {
-  const _this = this;
-  _waitForCursor(this, function() {
-    _this.cursor.rewind();
+  _waitForCursor(this, () => {
+    this.cursor.rewind();
   });
   return this;
 };
@@ -281,14 +278,13 @@ QueryCursor.prototype.next = async function next() {
  */
 
 QueryCursor.prototype.eachAsync = function(fn, opts, callback) {
-  const _this = this;
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
   }
   opts = opts || {};
 
-  return eachAsync(function(cb) { return _next(_this, cb); }, fn, opts, callback);
+  return eachAsync((cb) => _next(this, cb), fn, opts, callback);
 };
 
 /**
@@ -312,9 +308,8 @@ QueryCursor.prototype.options;
  */
 
 QueryCursor.prototype.addCursorFlag = function(flag, value) {
-  const _this = this;
-  _waitForCursor(this, function() {
-    _this.cursor.addCursorFlag(flag, value);
+  _waitForCursor(this, () => {
+    this.cursor.addCursorFlag(flag, value);
   });
   return this;
 };
@@ -521,13 +516,12 @@ function _populateBatch() {
   if (!this.ctx._batchDocs.length) {
     return this.callback(null, null);
   }
-  const _this = this;
   this.ctx.query.model.populate(this.ctx._batchDocs, this.ctx._pop).then(
     () => {
-      _nextDoc(_this.ctx, _this.ctx._batchDocs.shift(), _this.ctx._pop, _this.callback);
+      _nextDoc(this.ctx, this.ctx._batchDocs.shift(), this.ctx._pop, this.callback);
     },
     err => {
-      _this.callback(err);
+      this.callback(err);
     }
   );
 }


### PR DESCRIPTION
Re: #13436 comments

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: @hasezoey 's comments on #13436. Update `QueryCursor` class to use [arrow functions](https://masteringjs.io/tutorials/fundamentals/arrow) and `this` consistently, rather than relying on `_this`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
