### PR TITLE
fix(schema): recursively copy schemas from different modules when calling `new Schema()`

### DIFF
--- a/lib/helpers/schema/merge.js
+++ b/lib/helpers/schema/merge.js
@@ -9,7 +9,9 @@ module.exports = function merge(s1, s2, skipConflictingPaths) {
     }
     pathsToAdd[key] = s2.tree[key];
   }
-  s1.add(pathsToAdd);
+  s1.options._isMerging = true;
+  s1.add(pathsToAdd, null);
+  delete s1.options._isMerging;
 
   s1.callQueue = s1.callQueue.concat(s2.callQueue);
   s1.method(s2.methods);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1285,12 +1285,16 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
     // new Schema({ path: [new Schema({ ... })] })
     if (cast && cast.instanceOfSchema) {
       if (!(cast instanceof Schema)) {
-        throw new TypeError('Schema for array path `' + path +
-          '` is from a different copy of the Mongoose module. ' +
-          'Please make sure you\'re using the same version ' +
-          'of Mongoose everywhere with `npm list mongoose`. If you are still ' +
-          'getting this error, please add `new Schema()` around the path: ' +
-          `${path}: new Schema(...)`);
+        if (this.options._isMerging) {
+          cast = new Schema(cast);
+        } else {
+          throw new TypeError('Schema for array path `' + path +
+            '` is from a different copy of the Mongoose module. ' +
+            'Please make sure you\'re using the same version ' +
+            'of Mongoose everywhere with `npm list mongoose`. If you are still ' +
+            'getting this error, please add `new Schema()` around the path: ' +
+            `${path}: new Schema(...)`);
+        }
       }
       return new MongooseTypes.DocumentArray(path, cast, obj);
     }
@@ -1298,12 +1302,16 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
         cast[options.typeKey] &&
         cast[options.typeKey].instanceOfSchema) {
       if (!(cast[options.typeKey] instanceof Schema)) {
-        throw new TypeError('Schema for array path `' + path +
-          '` is from a different copy of the Mongoose module. ' +
-          'Please make sure you\'re using the same version ' +
-          'of Mongoose everywhere with `npm list mongoose`. If you are still ' +
-          'getting this error, please add `new Schema()` around the path: ' +
-          `${path}: new Schema(...)`);
+        if (this.options._isMerging) {
+          cast[options.typeKey] = new Schema(cast[options.typeKey]);
+        } else {
+          throw new TypeError('Schema for array path `' + path +
+            '` is from a different copy of the Mongoose module. ' +
+            'Please make sure you\'re using the same version ' +
+            'of Mongoose everywhere with `npm list mongoose`. If you are still ' +
+            'getting this error, please add `new Schema()` around the path: ' +
+            `${path}: new Schema(...)`);
+        }
       }
       return new MongooseTypes.DocumentArray(path, cast[options.typeKey], obj, cast);
     }


### PR DESCRIPTION
Fix #13275

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, you can call `new Schema()` on a schema from a different copy of the Mongoose module to "copy" the schema over to use the local Mongoose module's schema class. But that doesn't apply to child schemas. This PR makes it so that child schemas also merge correctly.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
