### PR TITLE
fix(schema): make bulkWrite updateOne() and updateMany() respect timestamps option when set by merging schemas

### DIFF
--- a/lib/helpers/schema/merge.js
+++ b/lib/helpers/schema/merge.js
@@ -19,8 +19,7 @@ module.exports = function merge(s1, s2, skipConflictingPaths) {
 
   for (const [option, value] of Object.entries(s2._userProvidedOptions)) {
     if (!(option in s1._userProvidedOptions)) {
-      s1._userProvidedOptions[option] = value;
-      s1.options[option] = value;
+      s1.set(option, value);
     }
   }
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3960,7 +3960,6 @@ describe('Model', function() {
 
         const M = db.model('Test', schema);
 
-
         await M.create({ num: 42 });
 
         await new Promise((resolve) => setTimeout(resolve, 10));
@@ -3978,7 +3977,29 @@ describe('Model', function() {
         assert.ok(doc.createdAt.valueOf() >= now.valueOf());
         assert.ok(doc.updatedAt);
         assert.ok(doc.updatedAt.valueOf() >= now.valueOf());
+      });
 
+      it('with timestamps from merged schema (gh-13409)', async function() {
+        const schema = new Schema({ num: Number });
+        schema.add(new Schema({}, { timestamps: true }));
+
+        const M = db.model('Test', schema);
+
+        await M.create({ num: 42 });
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const now = Date.now();
+
+        await M.bulkWrite([{
+          updateOne: {
+            filter: { num: 42 },
+            update: { num: 100 }
+          }
+        }]);
+
+        const doc = await M.findOne({ num: 100 });
+        assert.ok(doc.updatedAt);
+        assert.ok(doc.updatedAt.valueOf() >= now.valueOf());
       });
 
       it('with child timestamps (gh-7032)', async function() {


### PR DESCRIPTION
Fix #13409

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`castBulkWrite()` relies on `schema.$timestamps`, which is only set if you explicitly go through `.set()` rather than setting `.options.timestamps`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
