### PR TITLE
fix(update): allow setting paths with dots under non-strict paths

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -360,7 +360,7 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
         try {
           if (prefix.length === 0 || key.indexOf('.') === -1) {
             obj[key] = castUpdateVal(schematype, val, op, key, context, prefix + key);
-          } else {
+          } else if (isStrict !== false || schematype != null) {
             // Setting a nested dotted path that's in the schema. We don't allow paths with '.' in
             // a schema, so replace the dotted path with a nested object to avoid ending up with
             // dotted properties in the updated object. See (gh-10200)

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -2121,4 +2121,26 @@ describe('model: findOneAndUpdate:', function() {
     assert.equal(res.name, 'Test');
     assert.equal(res.nickName, 'Quiz');
   });
+
+  it('allows setting paths with dots in non-strict paths (gh-13434) (gh-10200)', async function() {
+    const testSchema = new mongoose.Schema({
+      name: String,
+      info: Object
+    }, { strict: false });
+    const Test = db.model('Test', testSchema);
+
+    const doc = await Test.findOneAndUpdate(
+      {},
+      {
+        name: 'Test Testerson',
+        info: { 'second.name': 'Quiz' },
+        info2: { 'second.name': 'Quiz' }
+      },
+      { new: true, upsert: true }
+    ).lean();
+
+    assert.ok(doc);
+    assert.equal(doc.info['second.name'], 'Quiz');
+    assert.equal(doc.info2['second.name'], 'Quiz');
+  });
 });


### PR DESCRIPTION
Fix #13434
Re: #10200

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

One of @AbdelrahmanHafez 's early issues #10200 pops up :) we shouldn't apply `setDottedPaths()` if schema is not strict and we don't have a schematype, because MongoDB supports storing paths with dots now.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
