### PR TITLE
types(aggregate): allow object syntax for `$mergeObjects`

### DIFF
--- a/test/types/aggregate.test.ts
+++ b/test/types/aggregate.test.ts
@@ -136,3 +136,19 @@ function gh12311() {
     }
   };
 }
+
+function gh13060() {
+  const schema = new Schema({ status: String });
+  const documentModel = model('Document', schema);
+
+  documentModel.aggregate([{
+    $group: {
+      _id: '$_id',
+      merged: {
+        $mergeObjects: {
+          status: '$status'
+        }
+      }
+    }
+  }]);
+}

--- a/types/expressions.d.ts
+++ b/types/expressions.d.ts
@@ -1793,7 +1793,7 @@ declare module 'mongoose' {
        * @version 3.6
        * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#mongodb-expression-exp.-mergeObjects
        */
-      $mergeObjects: ObjectExpression | ObjectExpression[] | ArrayExpression;
+      $mergeObjects: ObjectExpression | ObjectExpression[] | ArrayExpression | Record<string, string>;
     }
 
     export interface SetField {


### PR DESCRIPTION
Fix #13060

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

More info here: https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#syntax . Technically you can only use `$mergeObjects: Record<string, string>` if using `$mergeObjects` in a [$bucket](https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/#mongodb-pipeline-pipe.-bucket), [$bucketAuto](https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/#mongodb-pipeline-pipe.-bucketAuto), or [$group](https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#mongodb-pipeline-pipe.-group) stage accumulator, but implementing that is complex and likely not worth the effort.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
