### PR TITLE
feat(populate): pass virtual to `match` function to allow merging match options

### DIFF
--- a/docs/populate.md
+++ b/docs/populate.md
@@ -727,6 +727,29 @@ AuthorSchema.virtual('posts', {
 });
 ```
 
+You can overwrite the `match` option when calling `populate()` as follows.
+
+```javascript
+// Overwrite the `match` option specified in `AuthorSchema.virtual()` for this
+// single `populate()` call.
+await Author.findOne().populate({ path: posts, match: {} });
+```
+
+You can also set the `match` option to a function in your `populate()` call.
+If you want to merge your `populate()` match option, rather than overwriting, use the following.
+
+```javascript
+await Author.findOne().populate({
+  path: posts,
+  // Add `isDeleted: false` to the virtual's default `match`, so the `match`
+  // option would be `{ tags: author.favoriteTags, isDeleted: false }`
+  match: (author, virtual) => ({
+    ...virtual.options.match(author),
+    isDeleted: false
+  })
+});
+```
+
 <h2 id="populating-maps"><a href="#populating-maps">Populating Maps</a></h2>
 
 [Maps](schematypes.html#maps) are a type that represents an object with arbitrary

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -436,13 +436,13 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
     data.justOne = justOne;
 
     // `match`
-    let match = get(options, 'match', null) ||
-      get(data, 'virtual.options.match', null) ||
+    const baseMatch = get(data, 'virtual.options.match', null) ||
       get(data, 'virtual.options.options.match', null);
+    let match = get(options, 'match', null) || baseMatch;
 
     let hasMatchFunction = typeof match === 'function';
     if (hasMatchFunction) {
-      match = match.call(doc, doc);
+      match = match.call(doc, doc, data.virtual);
     }
 
     if (Array.isArray(localField) && Array.isArray(foreignField) && localField.length === foreignField.length) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2192,6 +2192,7 @@ Schema.prototype.indexes = function() {
  * @param {Boolean|Function} [options.justOne=false] Only works with populate virtuals. If [truthy](https://masteringjs.io/tutorials/fundamentals/truthy), will be a single doc or `null`. Otherwise, the populate virtual will be an array.
  * @param {Boolean} [options.count=false] Only works with populate virtuals. If [truthy](https://masteringjs.io/tutorials/fundamentals/truthy), this populate virtual will contain the number of documents rather than the documents themselves when you `populate()`.
  * @param {Function|null} [options.get=null] Adds a [getter](https://mongoosejs.com/docs/tutorials/getters-setters.html) to this virtual to transform the populated doc.
+ * @param {Object|Function} [options.match=null] Apply a default [`match` option to populate](https://mongoosejs.com/docs/populate.html#match), adding an additional filter to the populate query.
  * @return {VirtualType}
  */
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -512,7 +512,7 @@ declare module 'mongoose' {
     count?: boolean;
 
     /** Add an extra match condition to `populate()`. */
-    match?: FilterQuery<any> | Function;
+    match?: FilterQuery<any> | ((doc: Record<string, any>, virtual?: this) => Record<string, any> | null);
 
     /** Add a default `limit` to the `populate()` query. */
     limit?: number;


### PR DESCRIPTION
Fix #12443

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#12443 asks for a way to merge `match` options when populated rather than overwriting. Instead of adding yet another new option, I added a new parameter to `match()` function: the virtual definition. That makes it easy to append the virtual `match` to any custom match you want to add.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
