### PR TITLE
types: allow overwriting `Paths` in `select()` to tell TypeScript which fields are projected

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -475,3 +475,14 @@ async function gh13142() {
   if (!blog) return;
   expectType<Pick<Blog, Extract<keyof { content: 1 }, keyof Blog>>>(blog);
 }
+
+async function gh13224() {
+  const userSchema = new Schema({ name: String, age: Number });
+  const UserModel = model('User', userSchema);
+
+  const u = await UserModel.findOne().select<{ name: string }>(['name']).orFail();
+  expectType<string>(u.name);
+  expectError(u.age);
+
+  expectError(UserModel.findOne().select<{ notInSchema: string }>(['name']).orFail());
+}

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -622,7 +622,15 @@ declare module 'mongoose' {
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'replaceOne'>;
 
     /** Specifies which document fields to include or exclude (also known as the query "projection") */
-    select(arg: string | string[] | Record<string, number | boolean | object>): this;
+    select<Paths extends { [P in keyof ResultType]?: any } = {}>(
+      arg: string | string[] | Record<string, number | boolean | object>
+    ): QueryWithHelpers<
+      UnpackedIntersection<{}, Paths>,
+      DocType,
+      THelpers,
+      UnpackedIntersection<{}, Paths>,
+      QueryOp
+    >;
 
     /** Determines if field selection has been made. */
     selected(): boolean;


### PR DESCRIPTION
Fix #13224

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick improvement for TypeScript users using `select()`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
