### PR TITLE
chore(workflows/test): update deno version to 1.34

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.33.x
+          deno-version: v1.34.x
       - run: deno --version
       - run: npm install
       - name: Run Deno tests


### PR DESCRIPTION
**Summary**

This PR updates the deno version used by the test, because seemingly deno 1.33 does not correctly parse http response headers, which makes `mongodb-memory-server` fail, 1.34 has it fixed

This fix should likely also be backported to 6.x, because the tests there are also failing

Example run: https://github.com/hasezoey/mongoose/actions/runs/5175446536/jobs/9323041413

*the tests failing only happens on branches that have no mongo binary cache yet (like new branches)