### PR TITLE
fix Model.create failing when the last argument is falsy

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2796,9 +2796,15 @@ Model.findByIdAndRemove = function(id, options) {
  */
 
 Model.create = async function create(doc, options) {
-  if (typeof options === 'function' ||
-      typeof arguments[2] === 'function') {
+  const argumentsArray = Array.from(arguments);
+  const argumentsArrayAfterTheFirst = argumentsArray.slice(1);
+
+  if (argumentsArray.some(argument => typeof argument === 'function')) {
     throw new MongooseError('Model.create() no longer accepts a callback');
+  }
+
+  if (arguments.length > 1 && argumentsArrayAfterTheFirst.some(argument => !argument)) {
+    throw new MongooseError('Passed a falsy value to Model.create() after doc');
   }
 
   _checkContext(this, 'create');
@@ -2811,16 +2817,6 @@ Model.create = async function create(doc, options) {
     options = options != null && typeof options === 'object' ? options : {};
   } else {
     const last = arguments[arguments.length - 1];
-    const argumentsArray = Array.from(arguments);
-    const argumentsArrayAfterTheFirst = argumentsArray.slice(1);
-
-    if (argumentsArray.some(argument => typeof argument === 'function')) {
-      throw new MongooseError('Model.create() no longer accepts a callback');
-    }
-
-    if (arguments.length > 1 && argumentsArrayAfterTheFirst.some(argument => !argument)) {
-      throw new MongooseError('Passed a falsy value to Model.create() after doc');
-    }
 
     options = {};
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -861,10 +861,10 @@ function checkDivergentArray(doc, path, array) {
   // would be similarly destructive as we never received all
   // elements of the array and potentially would overwrite data.
   const check = pop.options.match ||
-      pop.options.options && utils.object.hasOwnProperty(pop.options.options, 'limit') || // 0 is not permitted
-      pop.options.options && pop.options.options.skip || // 0 is permitted
-      pop.options.select && // deselected _id?
-      (pop.options.select._id === 0 ||
+    pop.options.options && utils.object.hasOwnProperty(pop.options.options, 'limit') || // 0 is not permitted
+    pop.options.options && pop.options.options.skip || // 0 is permitted
+    pop.options.select && // deselected _id?
+    (pop.options.select._id === 0 ||
       /\s?-_id\s?/.test(pop.options.select));
 
   if (check) {
@@ -992,7 +992,7 @@ Model.prototype.$__where = function _where(where) {
 
 Model.prototype.deleteOne = async function deleteOne(options) {
   if (typeof options === 'function' ||
-      typeof arguments[1] === 'function') {
+    typeof arguments[1] === 'function') {
     throw new MongooseError('Model.prototype.deleteOne() no longer accepts a callback');
   }
 
@@ -1735,7 +1735,7 @@ function _ensureIndexes(model, options, callback) {
   function create() {
     if (options._automatic) {
       if (model.schema.options.autoIndex === false ||
-          (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
+        (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
         return done();
       }
     }
@@ -2797,7 +2797,7 @@ Model.findByIdAndRemove = function(id, options) {
 
 Model.create = async function create(doc, options) {
   if (typeof options === 'function' ||
-      typeof arguments[2] === 'function') {
+    typeof arguments[2] === 'function') {
     throw new MongooseError('Model.create() no longer accepts a callback');
   }
 
@@ -2812,9 +2812,14 @@ Model.create = async function create(doc, options) {
   } else {
     const last = arguments[arguments.length - 1];
     const argumentsArray = Array.from(arguments);
+    const argumentsArrayAfterTheFirst = Array.from(arguments).slice(1);
 
     if (argumentsArray.some(argument => typeof argument === 'function')) {
       throw new MongooseError('Model.create() no longer accepts a callback');
+    }
+
+    if (arguments.length > 1 && argumentsArrayAfterTheFirst.some(argument => !argument)) {
+      throw new MongooseError('Passed a falsy value to Model.create() after doc');
     }
 
     options = {};
@@ -2822,11 +2827,11 @@ Model.create = async function create(doc, options) {
     args = [...arguments];
 
     if (args.length === 2 &&
-        args[0] != null &&
-        args[1] != null &&
-        args[0].session == null &&
-        getConstructorName(last.session) === 'ClientSession' &&
-        !this.schema.path('session')) {
+      args[0] != null &&
+      args[1] != null &&
+      args[0].session == null &&
+      getConstructorName(last.session) === 'ClientSession' &&
+      !this.schema.path('session')) {
       // Probably means the user is running into the common mistake of trying
       // to use a spread to specify options, see gh-7535
       utils.warn('WARNING: to pass a `session` to `Model.create()` in ' +
@@ -3188,7 +3193,7 @@ Model.$__insertMany = function(arr, options, callback) {
         // `writeErrors` is a property reported by the MongoDB driver,
         // just not if there's only 1 error.
         if (error.writeErrors == null &&
-            (error.result && error.result.result && error.result.result.writeErrors) != null) {
+          (error.result && error.result.result && error.result.result.writeErrors) != null) {
           error.writeErrors = error.result.result.writeErrors;
         }
 
@@ -3357,7 +3362,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   _checkContext(this, 'bulkWrite');
 
   if (typeof options === 'function' ||
-      typeof arguments[2] === 'function') {
+    typeof arguments[2] === 'function') {
     throw new MongooseError('Model.bulkWrite() no longer accepts a callback');
   }
   options = options || {};
@@ -3909,9 +3914,9 @@ function _update(model, op, conditions, doc, options) {
   options = typeof options === 'function' ? options : clone(options);
 
   const versionKey = model &&
-  model.schema &&
-  model.schema.options &&
-  model.schema.options.versionKey || null;
+    model.schema &&
+    model.schema.options &&
+    model.schema.options.versionKey || null;
   _decorateUpdateWithVersionKey(doc, options, versionKey);
 
   return mq[op](conditions, doc, options);
@@ -4277,9 +4282,9 @@ function populate(model, docs, options, callback) {
     // to fail. So delay running lean transform until _after_
     // `_assign()`
     if (mod.options &&
-        mod.options.options &&
-        mod.options.options.lean &&
-        mod.options.options.lean.transform) {
+      mod.options.options &&
+      mod.options.options.lean &&
+      mod.options.options.lean.transform) {
       mod.options.options._leanTransform = mod.options.options.lean.transform;
       mod.options.options.lean = true;
     }
@@ -4408,8 +4413,8 @@ function _execPopulateQuery(mod, match, select, assignmentOpts, callback) {
   // field, that's the client's fault.
   for (const foreignField of mod.foreignField) {
     if (foreignField !== '_id' &&
-        query.selectedInclusively() &&
-        !isPathSelectedInclusive(query._fields, foreignField)) {
+      query.selectedInclusively() &&
+      !isPathSelectedInclusive(query._fields, foreignField)) {
       query.select(foreignField);
     }
   }
@@ -4765,7 +4770,7 @@ Model.__subclass = function subclass(conn, schema, collection) {
   Model.collection = Model.prototype.collection;
   Model.$__collection = Model.collection;
   // Errors handled internally, so ignore
-  Model.init().catch(() => {});
+  Model.init().catch(() => { });
   return Model;
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2811,15 +2811,15 @@ Model.create = async function create(doc, options) {
     options = options != null && typeof options === 'object' ? options : {};
   } else {
     const last = arguments[arguments.length - 1];
-    options = {};
-    if (typeof last === 'function' || (arguments.length > 1 && !last)) {
-      if (typeof options === 'function' ||
-          typeof arguments[2] === 'function') {
-        throw new MongooseError('Model.create() no longer accepts a callback');
-      }
-    } else {
-      args = [...arguments];
+    const argumentsArray = Array.from(arguments);
+
+    if (argumentsArray.some(argument => typeof argument === 'function')) {
+      throw new MongooseError('Model.create() no longer accepts a callback');
     }
+
+    options = {};
+
+    args = [...arguments];
 
     if (args.length === 2 &&
         args[0] != null &&

--- a/lib/model.js
+++ b/lib/model.js
@@ -861,10 +861,10 @@ function checkDivergentArray(doc, path, array) {
   // would be similarly destructive as we never received all
   // elements of the array and potentially would overwrite data.
   const check = pop.options.match ||
-    pop.options.options && utils.object.hasOwnProperty(pop.options.options, 'limit') || // 0 is not permitted
-    pop.options.options && pop.options.options.skip || // 0 is permitted
-    pop.options.select && // deselected _id?
-    (pop.options.select._id === 0 ||
+      pop.options.options && utils.object.hasOwnProperty(pop.options.options, 'limit') || // 0 is not permitted
+      pop.options.options && pop.options.options.skip || // 0 is permitted
+      pop.options.select && // deselected _id?
+      (pop.options.select._id === 0 ||
       /\s?-_id\s?/.test(pop.options.select));
 
   if (check) {
@@ -992,7 +992,7 @@ Model.prototype.$__where = function _where(where) {
 
 Model.prototype.deleteOne = async function deleteOne(options) {
   if (typeof options === 'function' ||
-    typeof arguments[1] === 'function') {
+      typeof arguments[1] === 'function') {
     throw new MongooseError('Model.prototype.deleteOne() no longer accepts a callback');
   }
 
@@ -1735,7 +1735,7 @@ function _ensureIndexes(model, options, callback) {
   function create() {
     if (options._automatic) {
       if (model.schema.options.autoIndex === false ||
-        (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
+          (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
         return done();
       }
     }
@@ -2797,7 +2797,7 @@ Model.findByIdAndRemove = function(id, options) {
 
 Model.create = async function create(doc, options) {
   if (typeof options === 'function' ||
-    typeof arguments[2] === 'function') {
+      typeof arguments[2] === 'function') {
     throw new MongooseError('Model.create() no longer accepts a callback');
   }
 
@@ -2812,7 +2812,7 @@ Model.create = async function create(doc, options) {
   } else {
     const last = arguments[arguments.length - 1];
     const argumentsArray = Array.from(arguments);
-    const argumentsArrayAfterTheFirst = Array.from(arguments).slice(1);
+    const argumentsArrayAfterTheFirst = argumentsArray.slice(1);
 
     if (argumentsArray.some(argument => typeof argument === 'function')) {
       throw new MongooseError('Model.create() no longer accepts a callback');
@@ -2827,11 +2827,11 @@ Model.create = async function create(doc, options) {
     args = [...arguments];
 
     if (args.length === 2 &&
-      args[0] != null &&
-      args[1] != null &&
-      args[0].session == null &&
-      getConstructorName(last.session) === 'ClientSession' &&
-      !this.schema.path('session')) {
+        args[0] != null &&
+        args[1] != null &&
+        args[0].session == null &&
+        getConstructorName(last.session) === 'ClientSession' &&
+        !this.schema.path('session')) {
       // Probably means the user is running into the common mistake of trying
       // to use a spread to specify options, see gh-7535
       utils.warn('WARNING: to pass a `session` to `Model.create()` in ' +
@@ -3193,7 +3193,7 @@ Model.$__insertMany = function(arr, options, callback) {
         // `writeErrors` is a property reported by the MongoDB driver,
         // just not if there's only 1 error.
         if (error.writeErrors == null &&
-          (error.result && error.result.result && error.result.result.writeErrors) != null) {
+            (error.result && error.result.result && error.result.result.writeErrors) != null) {
           error.writeErrors = error.result.result.writeErrors;
         }
 
@@ -3362,7 +3362,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   _checkContext(this, 'bulkWrite');
 
   if (typeof options === 'function' ||
-    typeof arguments[2] === 'function') {
+      typeof arguments[2] === 'function') {
     throw new MongooseError('Model.bulkWrite() no longer accepts a callback');
   }
   options = options || {};
@@ -3914,9 +3914,9 @@ function _update(model, op, conditions, doc, options) {
   options = typeof options === 'function' ? options : clone(options);
 
   const versionKey = model &&
-    model.schema &&
-    model.schema.options &&
-    model.schema.options.versionKey || null;
+  model.schema &&
+  model.schema.options &&
+  model.schema.options.versionKey || null;
   _decorateUpdateWithVersionKey(doc, options, versionKey);
 
   return mq[op](conditions, doc, options);
@@ -4282,9 +4282,9 @@ function populate(model, docs, options, callback) {
     // to fail. So delay running lean transform until _after_
     // `_assign()`
     if (mod.options &&
-      mod.options.options &&
-      mod.options.options.lean &&
-      mod.options.options.lean.transform) {
+        mod.options.options &&
+        mod.options.options.lean &&
+        mod.options.options.lean.transform) {
       mod.options.options._leanTransform = mod.options.options.lean.transform;
       mod.options.options.lean = true;
     }
@@ -4413,8 +4413,8 @@ function _execPopulateQuery(mod, match, select, assignmentOpts, callback) {
   // field, that's the client's fault.
   for (const foreignField of mod.foreignField) {
     if (foreignField !== '_id' &&
-      query.selectedInclusively() &&
-      !isPathSelectedInclusive(query._fields, foreignField)) {
+        query.selectedInclusively() &&
+        !isPathSelectedInclusive(query._fields, foreignField)) {
       query.select(foreignField);
     }
   }
@@ -4770,7 +4770,7 @@ Model.__subclass = function subclass(conn, schema, collection) {
   Model.collection = Model.prototype.collection;
   Model.$__collection = Model.collection;
   // Errors handled internally, so ignore
-  Model.init().catch(() => { });
+  Model.init().catch(() => {});
   return Model;
 };
 

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -115,22 +115,6 @@ describe('model', function() {
       assert.ok(endTime - startTime < 4 * 100); // serial: >= 4 * 100 parallel: < 4 * 100
     });
 
-    it('creates a document when options equals undefined (gh-13487)', async function() {
-      const posts = await B.create({ title: 'undefined options' }, undefined);
-      const post1 = posts[0];
-      assert.equal(post1.title, 'undefined options');
-    });
-
-    it('creates multiple document when options equals undefined (gh-13487)', async function() {
-      const posts = await B.create({ title: 'Post1' }, { title: 'Post2' }, undefined);
-
-      const post1 = posts[0];
-      const post2 = posts[1];
-
-      assert.equal(post1.title, 'Post1');
-      assert.equal(post2.title, 'Post2');
-    });
-
     describe('callback is optional', function() {
       it('with one doc', async function() {
         const doc = await B.create({ title: 'optional callback' });

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -115,6 +115,22 @@ describe('model', function() {
       assert.ok(endTime - startTime < 4 * 100); // serial: >= 4 * 100 parallel: < 4 * 100
     });
 
+    it('creates a document when options equals undefined (gh-13487)', async function() {
+      const posts = await B.create({ title: 'undefined options' }, undefined);
+      const post1 = posts[0];
+      assert.equal(post1.title, 'undefined options');
+    });
+
+    it('creates multiple document when options equals undefined (gh-13487)', async function() {
+      const posts = await B.create({ title: 'Post1' }, { title: 'Post2' }, undefined);
+
+      const post1 = posts[0];
+      const post2 = posts[1];
+
+      assert.equal(post1.title, 'Post1');
+      assert.equal(post2.title, 'Post2');
+    });
+
     describe('callback is optional', function() {
       it('with one doc', async function() {
         const doc = await B.create({ title: 'optional callback' });


### PR DESCRIPTION
**Summary**

Related to  #13487 

You shouldn't be able to pass falsy values to `Model.create()` after doc because it will create a document with empty values (fails schema validation later on)

Added better error handling

The code only checks if `options(second argument)` and third arguments are callbacks  and doesn't take `last` into consideration 

**Examples**

 cases like 

`
const user = await User.create(
  { name: 'user 1' },
  { name: 'user 2' },
  { name: 'user 3' },
  () => console.log('test'),
  { name: 'not created' }
)
`
would pass this validation (fails later on)

and a case like `const user = await User.create(() => console.log('test'))` throws the same `cannot read length of undefined` error instead of throwing no callbacks error

