### PR TITLE
fix(query): handle non-string discriminator key values in query

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -118,9 +118,17 @@ module.exports = function cast(schema, obj, options, context) {
             discriminatorKey != null &&
             pathLastHalf !== discriminatorKey) {
             const discriminatorVal = get(obj, pathFirstHalf + '.' + discriminatorKey);
-            if (discriminatorVal != null) {
-              schematype = _schematype.schema.discriminators[discriminatorVal].
-                path(pathLastHalf);
+            const discriminators = _schematype.schema.discriminators;
+            if (typeof discriminatorVal === 'string' && discriminators[discriminatorVal] != null) {
+
+              schematype = discriminators[discriminatorVal].path(pathLastHalf);
+            } else if (discriminatorVal != null &&
+              Object.keys(discriminatorVal).length === 1 &&
+              Array.isArray(discriminatorVal.$in) &&
+              discriminatorVal.$in.length === 1 &&
+              typeof discriminatorVal.$in[0] === 'string' &&
+              discriminators[discriminatorVal.$in[0]] != null) {
+              schematype = discriminators[discriminatorVal.$in[0]].path(pathLastHalf);
             }
           }
         }

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -193,4 +193,34 @@ describe('cast: ', function() {
       name: 'foo'
     });
   });
+
+  it('handles $in with discriminators if $in has exactly 1 element (gh-13492)', function() {
+    const itemStateFooSchema = new Schema({
+      fieldFoo: String
+    });
+
+    const itemSchema = new Schema({
+      state: new Schema(
+        {
+          field: String
+        },
+        {
+          discriminatorKey: 'type'
+        }
+      )
+    });
+
+    itemSchema.path('state').discriminator('FOO', itemStateFooSchema);
+
+    const res = cast(itemSchema, {
+      'state.type': {
+        $in: ['FOO']
+      },
+      'state.fieldFoo': 44
+    });
+    assert.deepStrictEqual(res, {
+      'state.type': { $in: ['FOO'] },
+      'state.fieldFoo': '44'
+    });
+  });
 });


### PR DESCRIPTION
Fix #13492

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Current casting logic doesn't account for non-string values for the discriminator key. With this change, Mongoose won't error out on non-string discriminator key values, and will also handle `$in` in the limited case where there's only 1 element.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
