### PR TITLE
docs(further_reading): remove style for "img"

### DIFF
--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -1,11 +1,6 @@
 # Further Reading
 
 <style>
-  img {
-    width: auto;
-    border: none;
-  }
-
   .pluralsight-link {
     float: left;
     margin-right: 0.5em;


### PR DESCRIPTION
**Summary**

This PR removes the extra style for `img`, which causes the "jobs" sidebar to break by having one really large image take all space