### PR TITLE
Update migrating_to_7.md to include Model.countDocuments

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -100,6 +100,7 @@ They always return promises.
 - `Model.aggregate`
 - `Model.bulkWrite`
 - `Model.cleanIndexes`
+- `Model.countDocuments`
 - `Model.create`
 - `Model.createCollection`
 - `Model.createIndexes`


### PR DESCRIPTION
**Summary**
`Model.countDocuments` also removed the option for callbacks, but is not mentioned in the migration document
