### PR TITLE
feat(aggregate): add `Aggregate.prototype.finally()` to be consistent with Promise API for TypeScript

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1094,7 +1094,7 @@ Aggregate.prototype.then = function(resolve, reject) {
 };
 
 /**
- * Executes the query returning a `Promise` which will be
+ * Executes the aggregation returning a `Promise` which will be
  * resolved with either the doc(s) or rejected with the error.
  * Like [`.then()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.then), but only takes a rejection handler.
  * Compatible with `await`.
@@ -1106,6 +1106,21 @@ Aggregate.prototype.then = function(resolve, reject) {
 
 Aggregate.prototype.catch = function(reject) {
   return this.exec().then(null, reject);
+};
+
+/**
+ * Executes the aggregate returning a `Promise` which will be
+ * resolved with `.finally()` chained.
+ *
+ * More about [Promise `finally()` in JavaScript](https://thecodebarbarian.com/using-promise-finally-in-node-js.html).
+ *
+ * @param {Function} [onFinally]
+ * @return {Promise}
+ * @api public
+ */
+
+Aggregate.prototype.finally = function(onFinally) {
+  return this.exec().finally(onFinally);
 };
 
 /**

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -16,6 +16,9 @@ declare module 'mongoose' {
      */
     [Symbol.asyncIterator](): AsyncIterableIterator<Unpacked<ResultType>>;
 
+    // Returns a string representation of this aggregation.
+    [Symbol.toStringTag]: string;
+
     options: AggregateOptions;
 
     /**
@@ -72,6 +75,12 @@ declare module 'mongoose' {
 
     /** Appends a new $fill operator to this aggregate pipeline */
     fill(arg: PipelineStage.Fill['$fill']): this;
+
+    /**
+     * Executes the aggregation returning a `Promise` which will be
+     * resolved with `.finally()` chained.
+     */
+    finally: Promise<ResultType>['finally'];
 
     /** Appends new custom $graphLookup operator(s) to this aggregate pipeline, performing a recursive search on a collection. */
     graphLookup(options: PipelineStage.GraphLookup['$graphLookup']): this;


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Ran into this issue earlier: using `Model.aggregate()` in a place where a promise is expected, like `assert.rejects()`, TypeScript reports an error because Aggregate doesn't have `finally()` or `[toStringTag]`.

```
Argument of type 'Aggregate<any[]>' is not assignable to parameter of type 'Promise<unknown> | (() => Promise<unknown>)'.
      Type 'Aggregate<any[]>' is missing the following properties from type 'Promise<unknown>': finally, [Symbol.toStringTag]
```

We already have `[toStringTag]` and `finally()` on Query, so would be nice to have them on Aggregate as well.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
