### PR TITLE
types: augment bson.ObjectId instead of adding on own type

### DIFF
--- a/test/types/mongo.test.ts
+++ b/test/types/mongo.test.ts
@@ -1,4 +1,19 @@
 import * as mongoose from 'mongoose';
 import { expectType } from 'tsd';
+import * as bson from 'bson';
 
 import GridFSBucket = mongoose.mongo.GridFSBucket;
+
+function gh12537() {
+  const schema = new mongoose.Schema({ test: String });
+  const model = mongoose.model('Test', schema);
+
+  const doc = new model({});
+
+  const v = new bson.ObjectId('somehex');
+  expectType<string>(v._id.toHexString());
+
+  doc._id = new bson.ObjectId('somehex');
+}
+
+gh12537();

--- a/types/augmentations.d.ts
+++ b/types/augmentations.d.ts
@@ -1,0 +1,9 @@
+// this import is required so that types get merged instead of completely overwritten
+import 'bson';
+
+declare module 'bson' {
+  interface ObjectId {
+    /** Mongoose automatically adds a conveniency "_id" getter on the base ObjectId class */
+    _id: this;
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@
 /// <reference path="./validation.d.ts" />
 /// <reference path="./inferschematype.d.ts" />
 /// <reference path="./virtuals.d.ts" />
+/// <reference path="./augmentations.d.ts" />
 
 declare class NativeDate extends global.Date { }
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -80,7 +80,6 @@ declare module 'mongoose' {
     }
 
     class ObjectId extends mongodb.ObjectId {
-      _id: this;
     }
 
     class Subdocument<IdType = any> extends Document<IdType> {


### PR DESCRIPTION
fixes #12537

**Summary**

This PR changes the `Types.ObjectId` to not have its own `_id` declaration anymore but augment `bson.ObjectId` directly