### PR TITLE
fix(query): respect query-level `strict` option on `findOneAndReplace()`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3608,22 +3608,39 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
     throw this.error();
   }
 
+  if ('strict' in this.options) {
+    this._mongooseOptions.strict = this.options.strict;
+    delete this.options.strict;
+  }
+
   const filter = this._conditions;
   const options = this._optionsForExec();
   this._applyTranslateAliases(options);
   convertNewToReturnDocument(options);
 
+  const modelOpts = { skipId: true };
+  if ('strict' in this._mongooseOptions) {
+    modelOpts.strict = this._mongooseOptions.strict;
+  }
+
   const runValidators = _getOption(this, 'runValidators', false);
   if (runValidators === false) {
     try {
-      this._update = this._castUpdate(this._update, true);
+      const update = new this.model(this._update, null, modelOpts);
+      if (update.$__.validationError) {
+        throw update.$__.validationError;
+      }
+      this._update = update.toBSON();
     } catch (err) {
+      if (err instanceof ValidationError) {
+        throw err;
+      }
       const validationError = new ValidationError();
       validationError.errors[err.path] = err;
       throw validationError;
     }
 
-    let res = await this._collection.collection.findOneAndReplace(filter, this._update || {}, options);
+    let res = await this._collection.collection.findOneAndReplace(filter, this._update, options);
 
     for (const fn of this._transforms) {
       res = fn(res);
@@ -3640,16 +3657,20 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
     });
   }
 
-
-  let castedDoc = new this.model(this._update, null, true);
-  this._update = castedDoc;
-  await castedDoc.validate();
-
-  if (castedDoc.toBSON) {
-    castedDoc = castedDoc.toBSON();
+  try {
+    const castedDoc = new this.model(this._update, null, modelOpts);
+    this._update = castedDoc.toBSON();
+    await castedDoc.validate();
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      throw err;
+    }
+    const validationError = new ValidationError();
+    validationError.errors[err.path] = err;
+    throw validationError;
   }
 
-  let res = await this._collection.collection.findOneAndReplace(filter, castedDoc, options);
+  let res = await this._collection.collection.findOneAndReplace(filter, this._update, options);
 
   for (const fn of this._transforms) {
     res = fn(res);

--- a/lib/query.js
+++ b/lib/query.js
@@ -3624,43 +3624,15 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
   }
 
   const runValidators = _getOption(this, 'runValidators', false);
-  if (runValidators === false) {
-    try {
-      const update = new this.model(this._update, null, modelOpts);
-      if (update.$__.validationError) {
-        throw update.$__.validationError;
-      }
-      this._update = update.toBSON();
-    } catch (err) {
-      if (err instanceof ValidationError) {
-        throw err;
-      }
-      const validationError = new ValidationError();
-      validationError.errors[err.path] = err;
-      throw validationError;
-    }
-
-    let res = await this._collection.collection.findOneAndReplace(filter, this._update, options);
-
-    for (const fn of this._transforms) {
-      res = fn(res);
-    }
-
-    const doc = res.value;
-    return new Promise((resolve, reject) => {
-      this._completeOne(doc, res, _wrapThunkCallback(this, (err, res) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(res);
-      }));
-    });
-  }
 
   try {
-    const castedDoc = new this.model(this._update, null, modelOpts);
-    this._update = castedDoc.toBSON();
-    await castedDoc.validate();
+    const update = new this.model(this._update, null, modelOpts);
+    if (runValidators) {
+      await update.validate();
+    } else if (update.$__.validationError) {
+      throw update.$__.validationError;
+    }
+    this._update = update.toBSON();
   } catch (err) {
     if (err instanceof ValidationError) {
       throw err;
@@ -3677,7 +3649,6 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
   }
 
   const doc = res.value;
-
   return new Promise((resolve, reject) => {
     this._completeOne(doc, res, _wrapThunkCallback(this, (err, res) => {
       if (err) {


### PR DESCRIPTION
Fix #13507

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`findOneAndReplace()` isn't respecting query `strict` option right now. This change fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
