### PR TITLE
feat(query): delay converting documents into POJOs until query execution, allow querying subdocuments with defaults disabled

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -10,12 +10,12 @@ const Types = require('./schema/index');
 const cast$expr = require('./helpers/query/cast$expr');
 const castTextSearch = require('./schema/operators/text');
 const get = require('./helpers/get');
-const getConstructorName = require('./helpers/getConstructorName');
 const getSchemaDiscriminatorByValue = require('./helpers/discriminator/getSchemaDiscriminatorByValue');
 const isOperator = require('./helpers/query/isOperator');
 const util = require('util');
 const isObject = require('./helpers/isObject');
 const isMongooseObject = require('./helpers/isMongooseObject');
+const utils = require('./utils');
 
 const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
 
@@ -291,7 +291,7 @@ module.exports = function cast(schema, obj, options, context) {
         }
       } else if (val == null) {
         continue;
-      } else if (getConstructorName(val) === 'Object') {
+      } else if (utils.isPOJO(val)) {
         any$conditionals = Object.keys(val).some(isOperator);
 
         if (!any$conditionals) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -24,6 +24,7 @@ const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminato
 const hasDollarKeys = require('./helpers/query/hasDollarKeys');
 const helpers = require('./queryhelpers');
 const immediate = require('./helpers/immediate');
+const internalToObjectOptions = require('./options').internalToObjectOptions;
 const isExclusive = require('./helpers/projection/isExclusive');
 const isInclusive = require('./helpers/projection/isInclusive');
 const isPathSelectedInclusive = require('./helpers/projection/isPathSelectedInclusive');
@@ -2319,8 +2320,6 @@ Query.prototype.find = function(conditions) {
 
   this.op = 'find';
 
-  conditions = utils.toObject(conditions);
-
   if (mquery.canMerge(conditions)) {
     this.merge(conditions);
 
@@ -2392,6 +2391,8 @@ Query.prototype.merge = function(source) {
     utils.merge(this._conditions, { _id: source }, opts);
 
     return this;
+  } else if (source && source.$__) {
+    source = source.toObject(internalToObjectOptions);
   }
 
   opts.omit = {};
@@ -2560,9 +2561,6 @@ Query.prototype.findOne = function(conditions, projection, options) {
   this.op = 'findOne';
   this._validateOp();
 
-  // make sure we don't send in the whole Document to merge()
-  conditions = utils.toObject(conditions);
-
   if (options) {
     this.setOptions(options);
   }
@@ -2726,8 +2724,6 @@ Query.prototype.count = function(filter) {
   this.op = 'count';
   this._validateOp();
 
-  filter = utils.toObject(filter);
-
   if (mquery.canMerge(filter)) {
     this.merge(filter);
   }
@@ -2822,8 +2818,6 @@ Query.prototype.countDocuments = function(conditions, options) {
   this.op = 'countDocuments';
   this._validateOp();
 
-  conditions = utils.toObject(conditions);
-
   if (mquery.canMerge(conditions)) {
     this.merge(conditions);
   }
@@ -2886,7 +2880,6 @@ Query.prototype.distinct = function(field, conditions) {
 
   this.op = 'distinct';
   this._validateOp();
-  conditions = utils.toObject(conditions);
 
   if (mquery.canMerge(conditions)) {
     this.merge(conditions);
@@ -2981,8 +2974,6 @@ Query.prototype.deleteOne = function deleteOne(filter, options) {
   this.op = 'deleteOne';
   this.setOptions(options);
 
-  filter = utils.toObject(filter);
-
   if (mquery.canMerge(filter)) {
     this.merge(filter);
 
@@ -3057,8 +3048,6 @@ Query.prototype.deleteMany = function(filter, options) {
   }
   this.setOptions(options);
   this.op = 'deleteMany';
-
-  filter = utils.toObject(filter);
 
   if (mquery.canMerge(filter)) {
     this.merge(filter);
@@ -4170,7 +4159,6 @@ function _update(query, op, filter, doc, options, callback) {
   // make sure we don't send in the whole Document to merge()
   query.op = op;
   query._validateOp();
-  filter = utils.toObject(filter);
   doc = doc || {};
 
   // strict is an option used in the update checking, make sure it gets set

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -212,11 +212,15 @@ SubdocumentPath.prototype.castForQuery = function($conditional, val, context, op
     return val;
   }
 
+  const Constructor = getConstructor(this.caster, val);
+  if (val instanceof Constructor) {
+    return val;
+  }
+
   if (this.options.runSetters) {
     val = this._applySetters(val, context);
   }
 
-  const Constructor = getConstructor(this.caster, val);
   const overrideStrict = options != null && options.strict != null ?
     options.strict :
     void 0;

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4104,4 +4104,34 @@ describe('Query', function() {
       await Error.find().sort('-');
     }, { message: 'Invalid field "" passed to sort()' });
   });
+  it('allows executing a find() with a subdocument with defaults disabled (gh-13512)', async function() {
+    const schema = mongoose.Schema({
+      title: String,
+      bookHolder: mongoose.Schema({
+        isReading: Boolean,
+        tags: [String]
+      })
+    });
+    const Test = db.model('Test', schema);
+
+    const BookHolder = schema.path('bookHolder').caster;
+
+    await Test.collection.insertOne({
+      title: 'test-defaults-disabled',
+      bookHolder: { isReading: true }
+    });
+
+    // Create a new BookHolder subdocument, skip applying defaults
+    // Otherwise, default `[]` for `tags` would cause this query to
+    // return no results.
+    const bookHolder = new BookHolder(
+      { isReading: true },
+      null,
+      null,
+      { defaults: false }
+    );
+    const doc = await Test.findOne({ bookHolder });
+    assert.ok(doc);
+    assert.equal(doc.title, 'test-defaults-disabled');
+  });
 });


### PR DESCRIPTION
Fix #13512

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

This change has a bit wider of a surface area than I'd like, but it should be good for performance and developer experience. The problem in #13512 is that Mongoose converts any query filters to POJOs first, and then recasts subdocument path POJOs back into subdocuments, before converting them to POJOs again; and loses the original settings so there's no way to execute a query on a subdocument path without applying defaults.

With this change, Mongoose will only convert documents in query filters to POJOs once, using the `toBSON()` function. Besides fixing #13512, this should make Mongoose faster in cases where you have subdocuments in query filters.

The only potential risk is that we're copying documents as POJOs somewhere. That's why I had to add `source = source.toObject(internalToObjectOptions);`.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
