### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Models are defined through the `Schema` interface.
 
 ```js
 const Schema = mongoose.Schema;
-const ObjectId = Schema.ObjectId;
+const ObjectId = Schema.Types.ObjectId;
 
 const BlogPost = new Schema({
   author: ObjectId,


### PR DESCRIPTION
While upgrading from mongoose 6.x to 7.x i noticed mongoose.Schema.ObjectId has been changed to mongoose.Schema.Types.ObjectId so update the readme to reflect this change

