### PR TITLE
refactor: avoid using callbacks for internal `deleteOne()` and `find()` calls

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -84,24 +84,32 @@ function QueryCursor(query, options) {
       this.options._populateBatchSize = Math.min(this.options.batchSize, 5000);
     }
     Object.assign(this.options, query._optionsForExec());
-    model.collection.find(query._conditions, this.options, (err, cursor) => {
-      if (err != null) {
-        this._markError(err);
-        this.listeners('error').length > 0 && this.emit('error', this._error);
-        return;
-      }
-
-      if (this._error) {
-        cursor.close(function() {});
-        this.listeners('error').length > 0 && this.emit('error', this._error);
-      }
-      this.cursor = cursor;
-      this.emit('cursor', cursor);
-    });
+    if (model.collection._shouldBufferCommands() && model.collection.buffer) {
+      model.collection.queue.push([
+        () => _getRawCursor(query, this)
+      ]);
+    } else {
+      _getRawCursor(query, this);
+    }
   });
 }
 
 util.inherits(QueryCursor, Readable);
+
+/*!
+ * ignore
+ */
+
+function _getRawCursor(query, queryCursor) {
+  try {
+    const cursor = query.model.collection.find(query._conditions, queryCursor.options);
+    queryCursor.cursor = cursor;
+    queryCursor.emit('cursor', cursor);
+  } catch (err) {
+    queryCursor._markError(err);
+    queryCursor.listeners('error').length > 0 && queryCursor.emit('error', queryCursor._error);
+  }
+}
 
 /**
  * Necessary to satisfy the Readable API

--- a/lib/model.js
+++ b/lib/model.js
@@ -1046,16 +1046,18 @@ Model.prototype.$__deleteOne = function $__deleteOne(options, cb) {
     options.session = session;
   }
 
-  this[modelCollectionSymbol].deleteOne(where, options, err => {
-    if (!err) {
+  this[modelCollectionSymbol].deleteOne(where, options).then(
+    () => {
       this.$__.isDeleted = true;
       this.$emit('deleteOne', this);
       this.constructor.emit('deleteOne', this);
       return cb(null, this);
+    },
+    err => {
+      this.$__.isDeleted = false;
+      cb(err);
     }
-    this.$__.isDeleted = false;
-    cb(err);
-  });
+  );
 };
 
 /**

--- a/test/query.toconstructor.test.js
+++ b/test/query.toconstructor.test.js
@@ -162,9 +162,9 @@ describe('Query:', function() {
       });
 
       const Test = db.model('Test', schema);
+      await Test.deleteMany({});
       const test = new Test({ name: 'Romero' });
       const Q = Test.findOne({}).toConstructor();
-
 
       await test.save();
       const doc = await Q();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

There are a couple of places where we still use internal callback calls, which caused some trouble when implementing the in-memory-driver. This doesn't seem to cause any bugs, but we shouldn't rely on callbacks at all given that the MongoDB driver no longer supports them.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
