### PR TITLE
Move all MongoDB-specific connection logic into driver layer, add `createClient()` method to handle creating MongoClient

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -736,7 +736,7 @@ Connection.prototype.openUri = async function openUri(uri, options) {
     throw err;
   }
 
-  this.$initialConnection = this.createClient(this, uri, options).
+  this.$initialConnection = this.createClient(uri, options).
     then(() => this).
     catch(err => {
       this.readyState = STATES.disconnected;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,10 +16,7 @@ const clone = require('./helpers/clone');
 const driver = require('./driver');
 const get = require('./helpers/get');
 const immediate = require('./helpers/immediate');
-const mongodb = require('mongodb');
-const pkg = require('../package.json');
 const utils = require('./utils');
-const processConnectionOptions = require('./helpers/processConnectionOptions');
 const CreateCollectionsError = require('./error/createCollectionsError');
 
 const arrayAtomicsSymbol = require('./helpers/symbols').arrayAtomicsSymbol;
@@ -739,7 +736,7 @@ Connection.prototype.openUri = async function openUri(uri, options) {
     throw err;
   }
 
-  this.$initialConnection = _createMongoClient(this, uri, options).
+  this.$initialConnection = this.createClient(this, uri, options).
     then(() => this).
     catch(err => {
       this.readyState = STATES.disconnected;
@@ -794,184 +791,6 @@ function _handleConnectionErrors(err) {
   }
 
   return err;
-}
-
-/*!
- * ignore
- */
-
-async function _createMongoClient(conn, uri, options) {
-  if (typeof uri !== 'string') {
-    throw new MongooseError('The `uri` parameter to `openUri()` must be a ' +
-      `string, got "${typeof uri}". Make sure the first parameter to ` +
-      '`mongoose.connect()` or `mongoose.createConnection()` is a string.');
-  }
-
-  if (conn._destroyCalled) {
-    throw new MongooseError(
-      'Connection has been closed and destroyed, and cannot be used for re-opening the connection. ' +
-      'Please create a new connection with `mongoose.createConnection()` or `mongoose.connect()`.'
-    );
-  }
-
-  if (conn.readyState === STATES.connecting || conn.readyState === STATES.connected) {
-    if (conn._connectionString !== uri) {
-      throw new MongooseError('Can\'t call `openUri()` on an active connection with ' +
-        'different connection strings. Make sure you aren\'t calling `mongoose.connect()` ' +
-        'multiple times. See: https://mongoosejs.com/docs/connections.html#multiple_connections');
-    }
-  }
-
-  options = processConnectionOptions(uri, options);
-
-  if (options) {
-
-    const autoIndex = options.config && options.config.autoIndex != null ?
-      options.config.autoIndex :
-      options.autoIndex;
-    if (autoIndex != null) {
-      conn.config.autoIndex = autoIndex !== false;
-      delete options.config;
-      delete options.autoIndex;
-    }
-
-    if ('autoCreate' in options) {
-      conn.config.autoCreate = !!options.autoCreate;
-      delete options.autoCreate;
-    }
-
-    if ('sanitizeFilter' in options) {
-      conn.config.sanitizeFilter = options.sanitizeFilter;
-      delete options.sanitizeFilter;
-    }
-
-    // Backwards compat
-    if (options.user || options.pass) {
-      options.auth = options.auth || {};
-      options.auth.username = options.user;
-      options.auth.password = options.pass;
-
-      conn.user = options.user;
-      conn.pass = options.pass;
-    }
-    delete options.user;
-    delete options.pass;
-
-    if (options.bufferCommands != null) {
-      conn.config.bufferCommands = options.bufferCommands;
-      delete options.bufferCommands;
-    }
-  } else {
-    options = {};
-  }
-
-  conn._connectionOptions = options;
-  const dbName = options.dbName;
-  if (dbName != null) {
-    conn.$dbName = dbName;
-  }
-  delete options.dbName;
-
-  if (!utils.hasUserDefinedProperty(options, 'driverInfo')) {
-    options.driverInfo = {
-      name: 'Mongoose',
-      version: pkg.version
-    };
-  }
-
-  conn.readyState = STATES.connecting;
-  conn._connectionString = uri;
-
-  let client;
-  try {
-    client = new mongodb.MongoClient(uri, options);
-  } catch (error) {
-    conn.readyState = STATES.disconnected;
-    throw error;
-  }
-  conn.client = client;
-
-  client.setMaxListeners(0);
-  await client.connect();
-
-  _setClient(conn, client, options, dbName);
-
-  for (const db of conn.otherDbs) {
-    _setClient(db, client, {}, db.name);
-  }
-  return conn;
-}
-
-/*!
- * ignore
- */
-
-function _setClient(conn, client, options, dbName) {
-  const db = dbName != null ? client.db(dbName) : client.db();
-  conn.db = db;
-  conn.client = client;
-  conn.host = client &&
-    client.s &&
-    client.s.options &&
-    client.s.options.hosts &&
-    client.s.options.hosts[0] &&
-    client.s.options.hosts[0].host || void 0;
-  conn.port = client &&
-    client.s &&
-    client.s.options &&
-    client.s.options.hosts &&
-    client.s.options.hosts[0] &&
-    client.s.options.hosts[0].port || void 0;
-  conn.name = dbName != null ? dbName : client && client.s && client.s.options && client.s.options.dbName || void 0;
-  conn._closeCalled = client._closeCalled;
-
-  const _handleReconnect = () => {
-    // If we aren't disconnected, we assume this reconnect is due to a
-    // socket timeout. If there's no activity on a socket for
-    // `socketTimeoutMS`, the driver will attempt to reconnect and emit
-    // this event.
-    if (conn.readyState !== STATES.connected) {
-      conn.readyState = STATES.connected;
-      conn.emit('reconnect');
-      conn.emit('reconnected');
-      conn.onOpen();
-    }
-  };
-
-  const type = client &&
-  client.topology &&
-  client.topology.description &&
-  client.topology.description.type || '';
-
-  if (type === 'Single') {
-    client.on('serverDescriptionChanged', ev => {
-      const newDescription = ev.newDescription;
-      if (newDescription.type === 'Unknown') {
-        conn.readyState = STATES.disconnected;
-      } else {
-        _handleReconnect();
-      }
-    });
-  } else if (type.startsWith('ReplicaSet')) {
-    client.on('topologyDescriptionChanged', ev => {
-      // Emit disconnected if we've lost connectivity to the primary
-      const description = ev.newDescription;
-      if (conn.readyState === STATES.connected && description.type !== 'ReplicaSetWithPrimary') {
-        // Implicitly emits 'disconnected'
-        conn.readyState = STATES.disconnected;
-      } else if (conn.readyState === STATES.disconnected && description.type === 'ReplicaSetWithPrimary') {
-        _handleReconnect();
-      }
-    });
-  }
-
-  conn.onOpen();
-
-  for (const i in conn.collections) {
-    if (utils.object.hasOwnProperty(conn.collections, i)) {
-      conn.collections[i].onOpen();
-    }
-  }
 }
 
 /**
@@ -1526,26 +1345,16 @@ Connection.prototype.getClient = function getClient() {
  * @return {Connection} this
  */
 
-Connection.prototype.setClient = function setClient(client) {
-  if (!(client instanceof mongodb.MongoClient)) {
-    throw new MongooseError('Must call `setClient()` with an instance of MongoClient');
-  }
-  if (this.readyState !== STATES.disconnected) {
-    throw new MongooseError('Cannot call `setClient()` on a connection that is already connected.');
-  }
-  if (client.topology == null) {
-    throw new MongooseError('Cannot call `setClient()` with a MongoClient that you have not called `connect()` on yet.');
-  }
+Connection.prototype.setClient = function setClient() {
+  throw new MongooseError('Connection#setClient not implemented by driver');
+};
 
-  this._connectionString = client.s.url;
-  _setClient(this, client, {}, client.s.options.dbName);
+/*!
+ * Called internally by `openUri()` to create a MongoClient instance.
+ */
 
-  for (const model of Object.values(this.models)) {
-    // Errors handled internally, so safe to ignore error
-    model.init().catch(function $modelInitNoop() {});
-  }
-
-  return this;
+Connection.prototype.createClient = function createClient() {
+  throw new MongooseError('Connection#createClient not implemented by driver');
 };
 
 /**

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -163,22 +163,22 @@ NativeConnection.prototype.doClose = async function doClose(force) {
  * ignore
  */
 
-NativeConnection.prototype.createClient = async function createClient(conn, uri, options) {
+NativeConnection.prototype.createClient = async function createClient(uri, options) {
   if (typeof uri !== 'string') {
     throw new MongooseError('The `uri` parameter to `openUri()` must be a ' +
       `string, got "${typeof uri}". Make sure the first parameter to ` +
       '`mongoose.connect()` or `mongoose.createConnection()` is a string.');
   }
 
-  if (conn._destroyCalled) {
+  if (this._destroyCalled) {
     throw new MongooseError(
       'Connection has been closed and destroyed, and cannot be used for re-opening the connection. ' +
       'Please create a new connection with `mongoose.createConnection()` or `mongoose.connect()`.'
     );
   }
 
-  if (conn.readyState === STATES.connecting || conn.readyState === STATES.connected) {
-    if (conn._connectionString !== uri) {
+  if (this.readyState === STATES.connecting || this.readyState === STATES.connected) {
+    if (this._connectionString !== uri) {
       throw new MongooseError('Can\'t call `openUri()` on an active connection with ' +
         'different connection strings. Make sure you aren\'t calling `mongoose.connect()` ' +
         'multiple times. See: https://mongoosejs.com/docs/connections.html#multiple_connections');
@@ -193,18 +193,18 @@ NativeConnection.prototype.createClient = async function createClient(conn, uri,
       options.config.autoIndex :
       options.autoIndex;
     if (autoIndex != null) {
-      conn.config.autoIndex = autoIndex !== false;
+      this.config.autoIndex = autoIndex !== false;
       delete options.config;
       delete options.autoIndex;
     }
 
     if ('autoCreate' in options) {
-      conn.config.autoCreate = !!options.autoCreate;
+      this.config.autoCreate = !!options.autoCreate;
       delete options.autoCreate;
     }
 
     if ('sanitizeFilter' in options) {
-      conn.config.sanitizeFilter = options.sanitizeFilter;
+      this.config.sanitizeFilter = options.sanitizeFilter;
       delete options.sanitizeFilter;
     }
 
@@ -214,24 +214,24 @@ NativeConnection.prototype.createClient = async function createClient(conn, uri,
       options.auth.username = options.user;
       options.auth.password = options.pass;
 
-      conn.user = options.user;
-      conn.pass = options.pass;
+      this.user = options.user;
+      this.pass = options.pass;
     }
     delete options.user;
     delete options.pass;
 
     if (options.bufferCommands != null) {
-      conn.config.bufferCommands = options.bufferCommands;
+      this.config.bufferCommands = options.bufferCommands;
       delete options.bufferCommands;
     }
   } else {
     options = {};
   }
 
-  conn._connectionOptions = options;
+  this._connectionOptions = options;
   const dbName = options.dbName;
   if (dbName != null) {
-    conn.$dbName = dbName;
+    this.$dbName = dbName;
   }
   delete options.dbName;
 
@@ -242,27 +242,27 @@ NativeConnection.prototype.createClient = async function createClient(conn, uri,
     };
   }
 
-  conn.readyState = STATES.connecting;
-  conn._connectionString = uri;
+  this.readyState = STATES.connecting;
+  this._connectionString = uri;
 
   let client;
   try {
     client = new mongodb.MongoClient(uri, options);
   } catch (error) {
-    conn.readyState = STATES.disconnected;
+    this.readyState = STATES.disconnected;
     throw error;
   }
-  conn.client = client;
+  this.client = client;
 
   client.setMaxListeners(0);
   await client.connect();
 
-  _setClient(conn, client, options, dbName);
+  _setClient(this, client, options, dbName);
 
-  for (const db of conn.otherDbs) {
+  for (const db of this.otherDbs) {
     _setClient(db, client, {}, db.name);
   }
-  return conn;
+  return this;
 };
 
 /*!

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -5,8 +5,13 @@
 'use strict';
 
 const MongooseConnection = require('../../connection');
+const MongooseError = require('../../error/index');
 const STATES = require('../../connectionstate');
+const mongodb = require('mongodb');
+const pkg = require('../../../package.json');
+const processConnectionOptions = require('../../helpers/processConnectionOptions');
 const setTimeout = require('../../helpers/timers').setTimeout;
+const utils = require('../../utils');
 
 /**
  * A [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) connection implementation.
@@ -153,6 +158,210 @@ NativeConnection.prototype.doClose = async function doClose(force) {
 
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+NativeConnection.prototype.createClient = async function createClient(conn, uri, options) {
+  if (typeof uri !== 'string') {
+    throw new MongooseError('The `uri` parameter to `openUri()` must be a ' +
+      `string, got "${typeof uri}". Make sure the first parameter to ` +
+      '`mongoose.connect()` or `mongoose.createConnection()` is a string.');
+  }
+
+  if (conn._destroyCalled) {
+    throw new MongooseError(
+      'Connection has been closed and destroyed, and cannot be used for re-opening the connection. ' +
+      'Please create a new connection with `mongoose.createConnection()` or `mongoose.connect()`.'
+    );
+  }
+
+  if (conn.readyState === STATES.connecting || conn.readyState === STATES.connected) {
+    if (conn._connectionString !== uri) {
+      throw new MongooseError('Can\'t call `openUri()` on an active connection with ' +
+        'different connection strings. Make sure you aren\'t calling `mongoose.connect()` ' +
+        'multiple times. See: https://mongoosejs.com/docs/connections.html#multiple_connections');
+    }
+  }
+
+  options = processConnectionOptions(uri, options);
+
+  if (options) {
+
+    const autoIndex = options.config && options.config.autoIndex != null ?
+      options.config.autoIndex :
+      options.autoIndex;
+    if (autoIndex != null) {
+      conn.config.autoIndex = autoIndex !== false;
+      delete options.config;
+      delete options.autoIndex;
+    }
+
+    if ('autoCreate' in options) {
+      conn.config.autoCreate = !!options.autoCreate;
+      delete options.autoCreate;
+    }
+
+    if ('sanitizeFilter' in options) {
+      conn.config.sanitizeFilter = options.sanitizeFilter;
+      delete options.sanitizeFilter;
+    }
+
+    // Backwards compat
+    if (options.user || options.pass) {
+      options.auth = options.auth || {};
+      options.auth.username = options.user;
+      options.auth.password = options.pass;
+
+      conn.user = options.user;
+      conn.pass = options.pass;
+    }
+    delete options.user;
+    delete options.pass;
+
+    if (options.bufferCommands != null) {
+      conn.config.bufferCommands = options.bufferCommands;
+      delete options.bufferCommands;
+    }
+  } else {
+    options = {};
+  }
+
+  conn._connectionOptions = options;
+  const dbName = options.dbName;
+  if (dbName != null) {
+    conn.$dbName = dbName;
+  }
+  delete options.dbName;
+
+  if (!utils.hasUserDefinedProperty(options, 'driverInfo')) {
+    options.driverInfo = {
+      name: 'Mongoose',
+      version: pkg.version
+    };
+  }
+
+  conn.readyState = STATES.connecting;
+  conn._connectionString = uri;
+
+  let client;
+  try {
+    client = new mongodb.MongoClient(uri, options);
+  } catch (error) {
+    conn.readyState = STATES.disconnected;
+    throw error;
+  }
+  conn.client = client;
+
+  client.setMaxListeners(0);
+  await client.connect();
+
+  _setClient(conn, client, options, dbName);
+
+  for (const db of conn.otherDbs) {
+    _setClient(db, client, {}, db.name);
+  }
+  return conn;
+};
+
+/*!
+ * ignore
+ */
+
+NativeConnection.prototype.setClient = function setClient(client) {
+  if (!(client instanceof mongodb.MongoClient)) {
+    throw new MongooseError('Must call `setClient()` with an instance of MongoClient');
+  }
+  if (this.readyState !== STATES.disconnected) {
+    throw new MongooseError('Cannot call `setClient()` on a connection that is already connected.');
+  }
+  if (client.topology == null) {
+    throw new MongooseError('Cannot call `setClient()` with a MongoClient that you have not called `connect()` on yet.');
+  }
+
+  this._connectionString = client.s.url;
+  _setClient(this, client, {}, client.s.options.dbName);
+
+  for (const model of Object.values(this.models)) {
+    // Errors handled internally, so safe to ignore error
+    model.init().catch(function $modelInitNoop() {});
+  }
+
+  return this;
+};
+
+/*!
+ * ignore
+ */
+
+function _setClient(conn, client, options, dbName) {
+  const db = dbName != null ? client.db(dbName) : client.db();
+  conn.db = db;
+  conn.client = client;
+  conn.host = client &&
+    client.s &&
+    client.s.options &&
+    client.s.options.hosts &&
+    client.s.options.hosts[0] &&
+    client.s.options.hosts[0].host || void 0;
+  conn.port = client &&
+    client.s &&
+    client.s.options &&
+    client.s.options.hosts &&
+    client.s.options.hosts[0] &&
+    client.s.options.hosts[0].port || void 0;
+  conn.name = dbName != null ? dbName : client && client.s && client.s.options && client.s.options.dbName || void 0;
+  conn._closeCalled = client._closeCalled;
+
+  const _handleReconnect = () => {
+    // If we aren't disconnected, we assume this reconnect is due to a
+    // socket timeout. If there's no activity on a socket for
+    // `socketTimeoutMS`, the driver will attempt to reconnect and emit
+    // this event.
+    if (conn.readyState !== STATES.connected) {
+      conn.readyState = STATES.connected;
+      conn.emit('reconnect');
+      conn.emit('reconnected');
+      conn.onOpen();
+    }
+  };
+
+  const type = client &&
+  client.topology &&
+  client.topology.description &&
+  client.topology.description.type || '';
+
+  if (type === 'Single') {
+    client.on('serverDescriptionChanged', ev => {
+      const newDescription = ev.newDescription;
+      if (newDescription.type === 'Unknown') {
+        conn.readyState = STATES.disconnected;
+      } else {
+        _handleReconnect();
+      }
+    });
+  } else if (type.startsWith('ReplicaSet')) {
+    client.on('topologyDescriptionChanged', ev => {
+      // Emit disconnected if we've lost connectivity to the primary
+      const description = ev.newDescription;
+      if (conn.readyState === STATES.connected && description.type !== 'ReplicaSetWithPrimary') {
+        // Implicitly emits 'disconnected'
+        conn.readyState = STATES.disconnected;
+      } else if (conn.readyState === STATES.disconnected && description.type === 'ReplicaSetWithPrimary') {
+        _handleReconnect();
+      }
+    });
+  }
+
+  conn.onOpen();
+
+  for (const i in conn.collections) {
+    if (utils.object.hasOwnProperty(conn.collections, i)) {
+      conn.collections[i].onOpen();
+    }
+  }
+}
 
 
 /*!

--- a/test/timestamps.test.js
+++ b/test/timestamps.test.js
@@ -608,12 +608,13 @@ describe('timestamps', function() {
     });
 
     it('should change updatedAt when findOneAndUpdate', async function() {
+      await Cat.deleteMany({});
       await Cat.create({ name: 'test123' });
       let doc = await Cat.findOne({ name: 'test123' });
       const old = doc.updatedAt;
+      await new Promise(resolve => setTimeout(resolve, 10));
       doc = await Cat.findOneAndUpdate({ name: 'test123' }, { $set: { hobby: 'fish' } }, { new: true });
-      assert.ok(doc.updatedAt.getTime() > old.getTime());
-
+      assert.ok(doc.updatedAt.getTime() > old.getTime(), `Expected ${doc.updatedAt} > ${old}`);
     });
 
     it('insertMany with createdAt off (gh-6381)', async function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Pulling in some work we started on with #4292 work (see [vkarpov15/gh-4292 branch](https://github.com/Automattic/mongoose/tree/vkarpov15/gh-4292)). One of the annoying pain points in building the in-memory driver was that we couldn't import Mongoose's `Connection` class without importing all of MongoDB. The driver layer is supposed to abstract that out, but connections have a bunch of MongoDB references that should really be in the driver layer.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
