### PR TITLE
types: support `mongoose.Schema.ObjectId` as alias for `mongoose.Schema.Types.ObjectId`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1113,3 +1113,13 @@ function gh12882() {
     }[]
   }>({} as rTArrType);
 }
+
+function gh13534() {
+  const schema = new Schema({
+    myId: { type: Schema.ObjectId, required: true }
+  });
+  const Test = model('Test', schema);
+
+  const doc = new Test({ myId: '0'.repeat(24) });
+  expectType<Types.ObjectId>(doc.myId);
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -430,6 +430,8 @@ declare module 'mongoose' {
 
     /** Returns the virtual type with the given `name`. */
     virtualpath<T = THydratedDocumentType>(name: string): VirtualType<T> | null;
+
+    static ObjectId: typeof Schema.Types.ObjectId;
   }
 
   export type NumberSchemaDefinition = typeof Number | 'number' | 'Number' | typeof Schema.Types.Number;


### PR DESCRIPTION
Fix #13534

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Works fine at runtime, just TypeScript types don't support it. Causes some confusion, see #13534 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
