### PR TITLE
feat(model): add create option "immediateError"

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2802,7 +2802,7 @@ Model.findByIdAndRemove = function(id, options) {
  * @param {Array|Object} docs Documents to insert, as a spread or array
  * @param {Object} [options] Options passed down to `save()`. To specify `options`, `docs` **must** be an array, not a spread. See [Model.save](https://mongoosejs.com/docs/api/model.html#Model.prototype.save()) for available options.
  * @param {Boolean} [options.ordered] saves the docs in series rather than parallel.
- * @param {Boolean} [options.immediateError] If a Error occurs, throw the error immediately, instead of collecting in a result, default: true (backwards compatability)
+ * @param {Boolean} [options.aggregateErrors] Aggregate Errors instead of throwing the first one that occurs. Default: false
  * @return {Promise}
  * @api public
  */
@@ -2859,9 +2859,9 @@ Model.create = async function create(doc, options) {
     return Array.isArray(doc) ? [] : null;
   }
   let res = [];
-  const immediateError = typeof options.immediateError === 'boolean' ? options.immediateError : true;
+  const immediateError = typeof options.aggregateErrors === 'boolean' ? !options.aggregateErrors : true;
 
-  delete options.immediateError; // dont pass on the option to "$save"
+  delete options.aggregateErrors; // dont pass on the option to "$save"
 
   if (options.ordered) {
     for (let i = 0; i < args.length; i++) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -2802,6 +2802,7 @@ Model.findByIdAndRemove = function(id, options) {
  *
  * @param {Array|Object} docs Documents to insert, as a spread or array
  * @param {Object} [options] Options passed down to `save()`. To specify `options`, `docs` **must** be an array, not a spread. See [Model.save](https://mongoosejs.com/docs/api/model.html#Model.prototype.save()) for available options.
+ * @param {Boolean} [options.immediateError] If a Error occurs, throw the error immediately, instead of collecting in a result, default: true (backwards compatability)
  * @return {Promise}
  * @api public
  */
@@ -2858,27 +2859,41 @@ Model.create = async function create(doc, options) {
     return Array.isArray(doc) ? [] : null;
   }
   let res = [];
+  const immediateError = typeof options.immediateError === 'boolean' ? options.immediateError : true;
+
+  delete options.immediateError; // dont pass on the option to "$save"
+
   if (options.ordered) {
     for (let i = 0; i < args.length; i++) {
-      const doc = args[i];
-      const Model = this.discriminators && doc[discriminatorKey] != null ?
-        this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
-        this;
-      if (Model == null) {
-        throw new MongooseError(`Discriminator "${doc[discriminatorKey]}" not ` +
+      try {
+        const doc = args[i];
+        const Model = this.discriminators && doc[discriminatorKey] != null ?
+          this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
+          this;
+        if (Model == null) {
+          throw new MongooseError(`Discriminator "${doc[discriminatorKey]}" not ` +
           `found for model "${this.modelName}"`);
-      }
-      let toSave = doc;
-      if (!(toSave instanceof Model)) {
-        toSave = new Model(toSave);
-      }
+        }
+        let toSave = doc;
+        if (!(toSave instanceof Model)) {
+          toSave = new Model(toSave);
+        }
 
-      await toSave.$save(options);
-      res.push(toSave);
+        await toSave.$save(options);
+        res.push(toSave);
+      } catch (err) {
+        if (!immediateError) {
+          res.push(err);
+        } else {
+          throw err;
+        }
+      }
     }
     return res;
   } else {
-    res = await Promise.all(args.map(async doc => {
+    // ".bind(Promise)" is required, otherwise results in "TypeError: Promise.allSettled called on non-object"
+    const promiseType = !immediateError ? Promise.allSettled.bind(Promise) : Promise.all.bind(Promise);
+    let p = promiseType(args.map(async doc => {
       const Model = this.discriminators && doc[discriminatorKey] != null ?
         this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
         this;
@@ -2896,6 +2911,13 @@ Model.create = async function create(doc, options) {
 
       return toSave;
     }));
+
+    // chain the mapper, only if "allSettled" is used
+    if (!immediateError) {
+      p = p.then(presult => presult.map(v => v.status === 'fulfilled' ? v.value : v.reason));
+    }
+
+    res = await p;
   }
 
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -479,7 +479,6 @@ function generateVersionError(doc, modifiedPaths) {
  *     newProduct === product; // true
  *
  * @param {Object} [options] options optional options
- * @param {Boolean} [options.ordered] saves the docs in series rather than parallel.
  * @param {Session} [options.session=null] the [session](https://www.mongodb.com/docs/manual/reference/server-sessions/) associated with this save operation. If not specified, defaults to the [document's associated session](https://mongoosejs.com/docs/api/document.html#Document.prototype.session()).
  * @param {Object} [options.safe] (DEPRECATED) overrides [schema's safe option](https://mongoosejs.com/docs/guide.html#safe). Use the `w` option instead.
  * @param {Boolean} [options.validateBeforeSave] set to false to save without validating.
@@ -2802,6 +2801,7 @@ Model.findByIdAndRemove = function(id, options) {
  *
  * @param {Array|Object} docs Documents to insert, as a spread or array
  * @param {Object} [options] Options passed down to `save()`. To specify `options`, `docs` **must** be an array, not a spread. See [Model.save](https://mongoosejs.com/docs/api/model.html#Model.prototype.save()) for available options.
+ * @param {Boolean} [options.ordered] saves the docs in series rather than parallel.
  * @param {Boolean} [options.immediateError] If a Error occurs, throw the error immediately, instead of collecting in a result, default: true (backwards compatability)
  * @return {Promise}
  * @api public

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -198,7 +198,7 @@ describe('model', function() {
         assert.equal(docs.length, 5);
       });
 
-      it('should return the first error immediately if "immediateError" is not explicitly set (ordered)', async function() {
+      it('should return the first error immediately if "aggregateErrors" is not explicitly set (ordered)', async function() {
         const testSchema = new Schema({ name: { type: String, required: true } });
 
         const TestModel = db.model('gh1731-1', testSchema);
@@ -208,12 +208,12 @@ describe('model', function() {
         assert.ok(res instanceof mongoose.Error.ValidationError);
       });
 
-      it('should not return errors immediately if "immediateError" is "false" (ordered)', async function() {
+      it('should not return errors immediately if "aggregateErrors" is "true" (ordered)', async function() {
         const testSchema = new Schema({ name: { type: String, required: true } });
 
         const TestModel = db.model('gh1731-2', testSchema);
 
-        const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { ordered: true, immediateError: false });
+        const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { ordered: true, aggregateErrors: true });
 
         assert.equal(res.length, 3);
         assert.ok(res[0] instanceof mongoose.Document);
@@ -222,7 +222,7 @@ describe('model', function() {
       });
     });
 
-    it('should return the first error immediately if "immediateError" is not explicitly set', async function() {
+    it('should return the first error immediately if "aggregateErrors" is not explicitly set', async function() {
       const testSchema = new Schema({ name: { type: String, required: true } });
 
       const TestModel = db.model('gh1731-3', testSchema);
@@ -232,12 +232,12 @@ describe('model', function() {
       assert.ok(res instanceof mongoose.Error.ValidationError);
     });
 
-    it('should not return errors immediately if "immediateError" is "false"', async function() {
+    it('should not return errors immediately if "aggregateErrors" is "true"', async function() {
       const testSchema = new Schema({ name: { type: String, required: true } });
 
       const TestModel = db.model('gh1731-4', testSchema);
 
-      const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { immediateError: false });
+      const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { aggregateErrors: true });
 
       assert.equal(res.length, 3);
       assert.ok(res[0] instanceof mongoose.Document);

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -197,6 +197,52 @@ describe('model', function() {
         const docs = await Test.find();
         assert.equal(docs.length, 5);
       });
+
+      it('should return the first error immediately if "immediateError" is not explicitly set (ordered)', async function() {
+        const testSchema = new Schema({ name: { type: String, required: true } });
+
+        const TestModel = db.model('gh1731-1', testSchema);
+
+        const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { ordered: true }).then(null).catch(err => err);
+
+        assert.ok(res instanceof mongoose.Error.ValidationError);
+      });
+
+      it('should not return errors immediately if "immediateError" is "false" (ordered)', async function() {
+        const testSchema = new Schema({ name: { type: String, required: true } });
+
+        const TestModel = db.model('gh1731-2', testSchema);
+
+        const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { ordered: true, immediateError: false });
+
+        assert.equal(res.length, 3);
+        assert.ok(res[0] instanceof mongoose.Document);
+        assert.ok(res[1] instanceof mongoose.Error.ValidationError);
+        assert.ok(res[2] instanceof mongoose.Document);
+      });
+    });
+
+    it('should return the first error immediately if "immediateError" is not explicitly set', async function() {
+      const testSchema = new Schema({ name: { type: String, required: true } });
+
+      const TestModel = db.model('gh1731-3', testSchema);
+
+      const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], {}).then(null).catch(err => err);
+
+      assert.ok(res instanceof mongoose.Error.ValidationError);
+    });
+
+    it('should not return errors immediately if "immediateError" is "false"', async function() {
+      const testSchema = new Schema({ name: { type: String, required: true } });
+
+      const TestModel = db.model('gh1731-4', testSchema);
+
+      const res = await TestModel.create([{ name: 'test' }, {}, { name: 'another' }], { immediateError: false });
+
+      assert.equal(res.length, 3);
+      assert.ok(res[0] instanceof mongoose.Document);
+      assert.ok(res[1] instanceof mongoose.Error.ValidationError);
+      assert.ok(res[2] instanceof mongoose.Document);
     });
   });
 });

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Types, CallbackError } from 'mongoose';
+import { Schema, model, Types, HydratedDocument } from 'mongoose';
 import { expectError, expectType } from 'tsd';
 
 const schema = new Schema({ name: { type: 'String' } });
@@ -118,3 +118,10 @@ Test.insertMany({ _id: new Types.ObjectId('000000000000000000000000'), name: 'te
   (await Test.create([{ name: 'test' }]))[0];
   (await Test.create({ name: 'test' }))._id;
 })();
+
+async function createWithAggregateErrors() {
+  expectType<(HydratedDocument<ITest>)[]>(await Test.create([{}]));
+  expectType<(HydratedDocument<ITest> | Error)[]>(await Test.create([{}], { aggregateErrors: true }));
+}
+
+createWithAggregateErrors();

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -221,6 +221,7 @@ declare module 'mongoose' {
     >;
 
     /** Creates a new document or documents */
+    create<DocContents = AnyKeys<TRawDocType>>(docs: Array<TRawDocType | DocContents>, options: CreateOptions & { aggregateErrors: true }): Promise<(THydratedDocumentType | Error)[]>;
     create<DocContents = AnyKeys<TRawDocType>>(docs: Array<TRawDocType | DocContents>, options?: CreateOptions): Promise<THydratedDocumentType[]>;
     create<DocContents = AnyKeys<TRawDocType>>(doc: DocContents | TRawDocType): Promise<THydratedDocumentType>;
     create<DocContents = AnyKeys<TRawDocType>>(...docs: Array<TRawDocType | DocContents>): Promise<THydratedDocumentType[]>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -133,7 +133,7 @@ declare module 'mongoose' {
 
   interface CreateOptions extends SaveOptions {
     ordered?: boolean;
-    immediateError?: boolean;
+    aggregateErrors?: boolean;
   }
 
   interface RemoveOptions extends SessionOption, Omit<mongodb.DeleteOptions, 'session'> {}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -132,6 +132,10 @@ declare module 'mongoose' {
     wtimeout?: number;
   }
 
+  interface CreateOptions extends SaveOptions {
+    immediateError?: boolean;
+  }
+
   interface RemoveOptions extends SessionOption, Omit<mongodb.DeleteOptions, 'session'> {}
 
   const Model: Model<any>;
@@ -217,7 +221,7 @@ declare module 'mongoose' {
     >;
 
     /** Creates a new document or documents */
-    create<DocContents = AnyKeys<TRawDocType>>(docs: Array<TRawDocType | DocContents>, options?: SaveOptions): Promise<THydratedDocumentType[]>;
+    create<DocContents = AnyKeys<TRawDocType>>(docs: Array<TRawDocType | DocContents>, options?: CreateOptions): Promise<THydratedDocumentType[]>;
     create<DocContents = AnyKeys<TRawDocType>>(doc: DocContents | TRawDocType): Promise<THydratedDocumentType>;
     create<DocContents = AnyKeys<TRawDocType>>(...docs: Array<TRawDocType | DocContents>): Promise<THydratedDocumentType[]>;
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -123,7 +123,6 @@ declare module 'mongoose' {
     SessionOption {
     checkKeys?: boolean;
     j?: boolean;
-    ordered?: boolean;
     safe?: boolean | WriteConcern;
     timestamps?: boolean | QueryTimestampsConfig;
     validateBeforeSave?: boolean;
@@ -133,6 +132,7 @@ declare module 'mongoose' {
   }
 
   interface CreateOptions extends SaveOptions {
+    ordered?: boolean;
     immediateError?: boolean;
   }
 


### PR DESCRIPTION
**Summary**

This PR adds option `immediateError` to `create`, to not throw on the first error encountered and instead add the error to the result list (only applicable if the input is a array)

Default: `true` for backwards compatibility (current master behavior)

works with both `ordered: false` and `ordered: true`

Result of `immediateError: false`:

```ts
const result = await Model.create([{ test: "yes" }, {}, { test: "no" }], { immediateError: false });
// index 0 is the "test: yes" document
// index 1 is a error instance
// index 2 is the "test: no" document
```

is this implementation OK or should it maybe be split into returning a object of values and errors or some other way?

also moves option `ordered` from "SaveOptions" (on .save) to "CreateOptions" (to .create) because from what i can tell, the option `ordered` has no effect on `.save` itself

fixes #1731