### PR TITLE
fix(query): convert findOneAndUpdate to findOneAndReplace when overwrite set for backwards compat with Mongoose 6

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3281,6 +3281,12 @@ Query.prototype.findOneAndUpdate = function(filter, doc, options) {
  */
 
 Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
+  // For backwards compability with Mongoose 6 re: #13550
+  if (this._mongooseOptions.overwrite) {
+    this.op = 'findOneAndReplace';
+    return this._findOneAndReplace();
+  }
+
   this._castConditions();
 
   _castArrayFilters(this);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4104,4 +4104,14 @@ describe('Query', function() {
       await Error.find().sort('-');
     }, { message: 'Invalid field "" passed to sort()' });
   });
+  it('converts findOneAndUpdate to findOneAndReplace if overwrite set (gh-13550)', async function() {
+    const testSchema = new Schema({
+      name: { type: String }
+    });
+
+    const Test = db.model('Test', testSchema);
+    const q = Test.findOneAndUpdate({}, { name: 'bar' }, { overwrite: true });
+    await q.exec();
+    assert.equal(q.op, 'findOneAndReplace');
+  });
 });


### PR DESCRIPTION
Fix #13550

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In Mongoose 6, `findOneAndUpdate()` with `overwrite: true` was converted into `findOneAndReplace()`. Looks like that behavior got lost in some of our callback refactoring work for Mongoose 7. This PR adds that behavior back.

What do you think about deprecating the `overwrite` option? It is no longer necessary with `findOneAndReplace()`, and is a potential source of confusion.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
