### PR TITLE
types: avoid unnecessary MergeType<> if TOverrides not set, clean up statics and insertMany() type issues

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,4 +1,3 @@
-import { ObjectId } from 'bson';
 import {
   Schema,
   Document,
@@ -77,7 +76,7 @@ async function insertManyTest() {
   });
 
   const res = await Test.insertMany([{ foo: 'bar' }], { rawResult: true });
-  expectType<ObjectId>(res.insertedIds[0]);
+  expectType<Types.ObjectId>(res.insertedIds[0]);
 
   const res2 = await Test.insertMany([{ foo: 'bar' }], { ordered: false, rawResult: true });
   expectAssignable<Error | Object | ReturnType<(typeof Test)['hydrate']>>(res2.mongoose.results[0]);
@@ -621,4 +620,22 @@ function gh13206() {
   TestModel.watch<ITest, ChangeStreamInsertDocument<ITest>>([], { fullDocument: 'updateLookup' }).on('change', (change) => {
     expectType<ChangeStreamInsertDocument<ITest>>(change);
   });
+}
+
+function gh13529() {
+  interface ResourceDoc {
+    foo: string;
+  }
+
+  type ResourceIdT<ResourceIdField extends string> = {
+    [key in ResourceIdField]: string;
+  };
+  type ResourceDocWithId<ResourceIdField extends string> = ResourceDoc & ResourceIdT<ResourceIdField>;
+
+  function test<
+    ResourceType extends string,
+    DocT extends ResourceDocWithId<`${ResourceType}Id`>>(dbModel: Model<DocT>) {
+    const resourceDoc = new dbModel();
+    resourceDoc.foo = 'bar';
+  }
 }

--- a/test/types/virtuals.test.ts
+++ b/test/types/virtuals.test.ts
@@ -1,4 +1,4 @@
-import { Document, Model, Schema, model, InferSchemaType, FlatRecord, ObtainSchemaGeneric } from 'mongoose';
+import { Document, Model, Schema, model, InferSchemaType, ObtainSchemaGeneric } from 'mongoose';
 import { expectType } from 'tsd';
 
 interface IPerson {
@@ -90,7 +90,7 @@ function gh11543() {
 async function autoTypedVirtuals() {
   type AutoTypedSchemaType = InferSchemaType<typeof testSchema>;
   type VirtualsType = { domain: string };
-  type InferredDocType = FlatRecord<AutoTypedSchemaType & ObtainSchemaGeneric<typeof testSchema, 'TVirtuals'>>;
+  type InferredDocType = AutoTypedSchemaType & ObtainSchemaGeneric<typeof testSchema, 'TVirtuals'>;
 
   const testSchema = new Schema({
     email: {
@@ -118,7 +118,7 @@ async function autoTypedVirtuals() {
   const doc = new TestModel();
   expectType<string>(doc.domain);
 
-  expectType<FlatRecord<AutoTypedSchemaType & VirtualsType >>({} as InferredDocType);
+  expectType<AutoTypedSchemaType & VirtualsType>({} as InferredDocType);
 
   const doc2 = await TestModel.findOne().orFail();
   expectType<string>(doc2.domain);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -143,9 +143,13 @@ declare module 'mongoose' {
     any,
     TOverrides extends Record<string, never> ?
       Document<unknown, TQueryHelpers, DocType> & Require_id<DocType> :
-      Document<unknown, TQueryHelpers, DocType> & MergeType<
-        Require_id<DocType>,
-        IfAny<TOverrides, {}>
+      IfAny<
+        TOverrides,
+        Document<unknown, TQueryHelpers, DocType> & Require_id<DocType>,
+        Document<unknown, TQueryHelpers, DocType> & MergeType<
+          Require_id<DocType>,
+          TOverrides
+        >
       >
   >;
   export type HydratedSingleSubdocument<DocType, TOverrides = {}> = Types.Subdocument<unknown> & Require_id<DocType> & TOverrides;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -225,13 +225,13 @@ declare module 'mongoose' {
       ObtainDocumentType<any, EnforcedDocType, ResolveSchemaOptions<TSchemaOptions>>,
       ResolveSchemaOptions<TSchemaOptions>
     >,
-    THydratedDocumentType = HydratedDocument<FlatRecord<DocType>, TVirtuals & TInstanceMethods>
+    THydratedDocumentType = HydratedDocument<DocType, TVirtuals & TInstanceMethods>
   >
     extends events.EventEmitter {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<FlatRecord<DocType>, TInstanceMethods, TQueryHelpers, TStaticMethods, TVirtuals, THydratedDocumentType> | ResolveSchemaOptions<TSchemaOptions>);
+    constructor(definition?: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | DocType, options?: SchemaOptions<DocType, TInstanceMethods, TQueryHelpers, TStaticMethods, TVirtuals, THydratedDocumentType> | ResolveSchemaOptions<TSchemaOptions>);
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>> | Schema, prefix?: string): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -141,12 +141,12 @@ declare module 'mongoose' {
   > = IfAny<
     DocType,
     any,
-    Document<unknown, TQueryHelpers, DocType> & MergeType<
-      Require_id<DocType>,
-      TOverrides extends Record<string, never> ?
-        {} :
+    TOverrides extends Record<string, never> ?
+      Document<unknown, TQueryHelpers, DocType> & Require_id<DocType> :
+      Document<unknown, TQueryHelpers, DocType> & MergeType<
+        Require_id<DocType>,
         IfAny<TOverrides, {}>
-    >
+      >
   >;
   export type HydratedSingleSubdocument<DocType, TOverrides = {}> = Types.Subdocument<unknown> & Require_id<DocType> & TOverrides;
   export type HydratedArraySubdocument<DocType, TOverrides = {}> = Types.ArraySubdocument<unknown> & Require_id<DocType> & TOverrides;
@@ -212,7 +212,7 @@ declare module 'mongoose' {
 
   export class Schema<
     EnforcedDocType = any,
-    M = Model<EnforcedDocType, any, any, any>,
+    TModelType = Model<EnforcedDocType, any, any, any>,
     TInstanceMethods = {},
     TQueryHelpers = {},
     TVirtuals = {},
@@ -311,7 +311,7 @@ declare module 'mongoose' {
     pathType(path: string): string;
 
     /** Registers a plugin for this schema. */
-    plugin<PFunc extends PluginFunction<DocType, M, any, any, any, any>, POptions extends Parameters<PFunc>[1] = Parameters<PFunc>[1]>(fn: PFunc, opts?: POptions): this;
+    plugin<PFunc extends PluginFunction<DocType, TModelType, any, any, any, any>, POptions extends Parameters<PFunc>[1] = Parameters<PFunc>[1]>(fn: PFunc, opts?: POptions): this;
 
     /** Defines a post hook for the model. */
 
@@ -320,7 +320,7 @@ declare module 'mongoose' {
     post<T = Query<any, any>>(method: MongooseQueryMiddleware | MongooseQueryMiddleware[] | RegExp, options: SchemaPostOptions & { errorHandler: true }, fn: ErrorHandlingMiddlewareWithOption<T>): this;
     post<T = THydratedDocumentType>(method: MongooseDocumentMiddleware | MongooseDocumentMiddleware[] | RegExp, options: SchemaPostOptions & { errorHandler: true }, fn: ErrorHandlingMiddlewareWithOption<T>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPostOptions & { errorHandler: true }, fn: ErrorHandlingMiddlewareWithOption<T, Array<any>>): this;
-    post<T = M>(method: 'insertMany' | RegExp, options: SchemaPostOptions & { errorHandler: true }, fn: ErrorHandlingMiddlewareWithOption<T>): this;
+    post<T = TModelType>(method: 'insertMany' | RegExp, options: SchemaPostOptions & { errorHandler: true }, fn: ErrorHandlingMiddlewareWithOption<T>): this;
 
     // this = never since it never happens
     post<T = never>(method: MongooseQueryOrDocumentMiddleware | MongooseQueryOrDocumentMiddleware[] | RegExp, options: SchemaPostOptions & { document: false, query: false }, fn: PostMiddlewareFunction<never, never>): this;
@@ -358,14 +358,14 @@ declare module 'mongoose' {
     // method aggregate and insertMany with PostMiddlewareFunction
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: PostMiddlewareFunction<T, Array<AggregateExtract<T>>>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, Array<AggregateExtract<T>>>): this;
-    post<T = M>(method: 'insertMany' | RegExp, fn: PostMiddlewareFunction<T, T>): this;
-    post<T = M>(method: 'insertMany' | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, T>): this;
+    post<T = TModelType>(method: 'insertMany' | RegExp, fn: PostMiddlewareFunction<T, T>): this;
+    post<T = TModelType>(method: 'insertMany' | RegExp, options: SchemaPostOptions, fn: PostMiddlewareFunction<T, T>): this;
 
     // method aggregate and insertMany with ErrorHandlingMiddlewareFunction
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: ErrorHandlingMiddlewareFunction<T, Array<any>>): this;
     post<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T, Array<any>>): this;
-    post<T = M>(method: 'insertMany' | RegExp, fn: ErrorHandlingMiddlewareFunction<T>): this;
-    post<T = M>(method: 'insertMany' | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T>): this;
+    post<T = TModelType>(method: 'insertMany' | RegExp, fn: ErrorHandlingMiddlewareFunction<T>): this;
+    post<T = TModelType>(method: 'insertMany' | RegExp, options: SchemaPostOptions, fn: ErrorHandlingMiddlewareFunction<T>): this;
 
     /** Defines a pre hook for the model. */
     // this = never since it never happens
@@ -390,8 +390,8 @@ declare module 'mongoose' {
     pre<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: PreMiddlewareFunction<T>): this;
     pre<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
     /* method insertMany */
-    pre<T = M>(method: 'insertMany' | RegExp, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;
-    pre<T = M>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;
+    pre<T = TModelType>(method: 'insertMany' | RegExp, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;
+    pre<T = TModelType>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;
 
     /** Object of currently defined query helpers on this schema. */
     query: TQueryHelpers;
@@ -413,11 +413,12 @@ declare module 'mongoose' {
 
     /** Adds static "class" methods to Models compiled from this schema. */
     static<K extends keyof TStaticMethods>(name: K, fn: TStaticMethods[K]): this;
-    static(obj: { [F in keyof TStaticMethods]: TStaticMethods[F] } & { [name: string]: (this: M, ...args: any[]) => any }): this;
-    static(name: string, fn: (this: M, ...args: any[]) => any): this;
+    static(obj: { [F in keyof TStaticMethods]: TStaticMethods[F] } & { [name: string]: (this: TModelType, ...args: any[]) => any }): this;
+    static(name: string, fn: (this: TModelType, ...args: any[]) => any): this;
 
     /** Object of currently defined statics on this schema. */
-    statics: { [F in keyof TStaticMethods]: TStaticMethods[F] } & { [name: string]: (this: M, ...args: any[]) => any };
+    statics: { [F in keyof TStaticMethods]: TStaticMethods[F] } &
+      { [name: string]: (this: TModelType, ...args: any[]) => unknown };
 
     /** Creates a virtual type with the given name. */
     virtual<T = HydratedDocument<DocType, TVirtuals & TInstanceMethods, TQueryHelpers>>(

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -336,46 +336,47 @@ declare module 'mongoose' {
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>,
       options: InsertManyOptions & { lean: true; }
-    ): Promise<Array<MergeType<MergeType<TRawDocType, DocContents>, Require_id<TRawDocType>>>>;
+    ): Promise<Array<Require_id<DocContents>>>;
     insertMany<DocContents = TRawDocType>(
-      doc: DocContents,
+      docs: DocContents | TRawDocType,
+      options: InsertManyOptions & { lean: true; }
+    ): Promise<Array<Require_id<DocContents>>>;
+    insertMany<DocContents = TRawDocType>(
+      doc: DocContents | TRawDocType,
       options: InsertManyOptions & { ordered: false; rawResult: true; }
-    ): Promise<mongodb.InsertManyResult<TRawDocType> & {
+    ): Promise<mongodb.InsertManyResult<Require_id<DocContents>> & {
       mongoose: {
         validationErrors: Error[];
         results: Array<
           Error |
           Object |
-          HydratedDocument<
-            MergeType<
-              MergeType<TRawDocType, DocContents>,
-              Require_id<TRawDocType>
-            >
-          >
+          MergeType<THydratedDocumentType, DocContents>
         >
       }
     }>;
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>,
       options: InsertManyOptions & { rawResult: true; }
-    ): Promise<mongodb.InsertManyResult<TRawDocType>>;
+    ): Promise<mongodb.InsertManyResult<Require_id<DocContents>>>;
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>
-    ): Promise<Array<HydratedDocument<MergeType<MergeType<TRawDocType, DocContents>, Require_id<TRawDocType>>, TVirtuals & TInstanceMethods, TQueryHelpers>>>;
+    ): Promise<Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>>;
     insertMany<DocContents = TRawDocType>(
       doc: DocContents,
       options: InsertManyOptions & { lean: true; }
-    ): Promise<Array<MergeType<MergeType<TRawDocType, DocContents>, Require_id<TRawDocType>>>>;
+    ): Promise<Array<Require_id<DocContents>>>;
     insertMany<DocContents = TRawDocType>(
       doc: DocContents,
       options: InsertManyOptions & { rawResult: true; }
-    ): Promise<mongodb.InsertManyResult<TRawDocType>>;
+    ): Promise<mongodb.InsertManyResult<Require_id<DocContents>>>;
     insertMany<DocContents = TRawDocType>(
       doc: DocContents,
       options: InsertManyOptions
-    ): Promise<Array<HydratedDocument<MergeType<MergeType<TRawDocType, DocContents>, Require_id<TRawDocType>>, TVirtuals & TInstanceMethods, TQueryHelpers>>>;
-    insertMany<DocContents = TRawDocType>(doc: DocContents): Promise<
-    Array<HydratedDocument<MergeType<MergeType<TRawDocType, DocContents>, Require_id<TRawDocType>>, TVirtuals & TInstanceMethods, TQueryHelpers>>
+    ): Promise<Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>>;
+    insertMany<DocContents = TRawDocType>(
+      doc: DocContents
+    ): Promise<
+      Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>
     >;
 
     /** The name of the model */

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -204,10 +204,10 @@ declare module 'mongoose' {
      * Model Statics methods.
      */
     statics?: IfEquals<
-    TStaticMethods,
-    {},
-    Record<any, (this: Model<DocType>, ...args: any) => unknown>,
-    TStaticMethods
+      TStaticMethods,
+      {},
+      { [name: string]: (this: Model<DocType>, ...args: any[]) => unknown },
+      { [F in keyof TStaticMethods]: TStaticMethods[F] }
     >
 
     /**

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -14,13 +14,20 @@ declare module 'mongoose' {
 
   type MergeType<A, B> = Omit<A, keyof B> & B;
 
+  /**
+   * @summary Converts Unions to one record "object".
+   * @description It makes intellisense dialog box easier to read as a single object instead of showing that in multiple object unions.
+   * @param {T} T The type to be converted.
+   */
+  type FlatRecord<T> = { [K in keyof T]: T[K] };
+
    /**
- * @summary Checks if a type is "Record" or "any".
- * @description It Helps to check if user has provided schema type "EnforcedDocType"
- * @param {T} T A generic type to be checked.
- * @returns true if {@link T} is Record OR false if {@link T} is of any type.
- */
-type IsItRecordAndNotAny<T> = IfEquals<T, any, false, T extends Record<any, any> ? true : false>;
+    * @summary Checks if a type is "Record" or "any".
+    * @description It Helps to check if user has provided schema type "EnforcedDocType"
+    * @param {T} T A generic type to be checked.
+    * @returns true if {@link T} is Record OR false if {@link T} is of any type.
+    */
+  type IsItRecordAndNotAny<T> = IfEquals<T, any, false, T extends Record<any, any> ? true : false>;
 
 /**
  * @summary Checks if two types are identical.

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -14,13 +14,6 @@ declare module 'mongoose' {
 
   type MergeType<A, B> = Omit<A, keyof B> & B;
 
-  /**
-   * @summary Converts Unions to one record "object".
-   * @description It makes intellisense dialog box easier to read as a single object instead of showing that in multiple object unions.
-   * @param {T} T The type to be converted.
-   */
-   type FlatRecord<T> = { [K in keyof T]: T[K] };
-
    /**
  * @summary Checks if a type is "Record" or "any".
  * @description It Helps to check if user has provided schema type "EnforcedDocType"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13529 points out some issues with `MergeType`, this PR makes it so that we avoid using `MergeType` in `HydratedDocument<>` where possible.

However, for a future release, we should remove HydratedDocument, and instead rely on inferring the hydrated document type from the schema. Inferring HydratedDocument type from the raw document type isn't possible in general, and relies on `Omit<>`, which is super brittle in TypeScript - breaks on private/protected fields, unions with generics, and other cases.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
