### PR TITLE
fix(model): avoid TypeError if insertMany() fails with error that does not have `writeErrors` property

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3234,16 +3234,19 @@ Model.$__insertMany = function(arr, options, callback) {
         }
 
         // `insertedDocs` is a Mongoose-specific property
+        const hasWriteErrors = error && error.writeErrors;
         const erroredIndexes = new Set((error && error.writeErrors || []).map(err => err.index));
 
-        for (let i = 0; i < error.writeErrors.length; ++i) {
-          const originalIndex = validDocIndexToOriginalIndex.get(error.writeErrors[i].index);
-          error.writeErrors[i] = {
-            ...error.writeErrors[i],
-            index: originalIndex
-          };
-          if (!ordered) {
-            results[originalIndex] = error.writeErrors[i];
+        if (error.writeErrors != null) {
+          for (let i = 0; i < error.writeErrors.length; ++i) {
+            const originalIndex = validDocIndexToOriginalIndex.get(error.writeErrors[i].index);
+            error.writeErrors[i] = {
+              ...error.writeErrors[i],
+              index: originalIndex
+            };
+            if (!ordered) {
+              results[originalIndex] = error.writeErrors[i];
+            }
           }
         }
 
@@ -3260,7 +3263,7 @@ Model.$__insertMany = function(arr, options, callback) {
         let firstErroredIndex = -1;
         error.insertedDocs = docAttributes.
           filter((doc, i) => {
-            const isErrored = erroredIndexes.has(i);
+            const isErrored = !hasWriteErrors || erroredIndexes.has(i);
 
             if (ordered) {
               if (firstErroredIndex > -1) {


### PR DESCRIPTION
Fix #13531

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This issue is a bit tricky to test, but the idea is that, in the `insertMany()` error handler, the `error` may not necessarily have a `writeErrors` property. I was able to repro with the following script by shutting down my MongoDB server in the 10 seconds between "Sleep" and "Executing".

```javascript
'use strict';

const mongoose = require('mongoose');

run().catch(err => console.log(err));

async function run() {
  await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_test', { serverSelectionTimeoutMS: 5000 });
  const Test = mongoose.model('Test', mongoose.Schema({ name: String }));
  await Test.init();

  console.log('Sleep');
  await new Promise(resolve => setTimeout(resolve, 10000));

  console.log('Executing');
  await Test.insertMany([{ name: 'foo' }]);
  console.log('Done');
}
```

With this change, we'll assume that all documents failed to insert if there's an error with no `writeErrors` property.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
