### PR TITLE
feat(connection): add `Connection.prototype.removeDb()` for removing a related connection

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1418,6 +1418,29 @@ Connection.prototype.syncIndexes = async function syncIndexes(options = {}) {
  * @api public
  */
 
+/**
+ * Removes the database connection with the given name created with with `useDb()`.
+ *
+ * Throws an error if the database connection was not found.
+ *
+ * #### Example:
+ *
+ *     // Connect to `initialdb` first
+ *     const conn = await mongoose.createConnection('mongodb://127.0.0.1:27017/initialdb').asPromise();
+ *
+ *     // Creates an un-cached connection to `mydb`
+ *     const db = conn.useDb('mydb');
+ *
+ *     // Closes `db`, and removes `db` from `conn.relatedDbs` and `conn.otherDbs`
+ *     await conn.removeDb('mydb');
+ *
+ * @method removeDb
+ * @memberOf Connection
+ * @param {String} name The database name
+ * @return {Connection} this
+ * @api public
+ */
+
 /*!
  * Module exports.
  */

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -127,6 +127,44 @@ NativeConnection.prototype.useDb = function(name, options) {
 };
 
 /**
+ * Removes the database connection with the given name created with with `useDb()`.
+ *
+ * Throws an error if the database connection was not found.
+ *
+ * #### Example:
+ *
+ *     // Connect to `initialdb` first
+ *     const conn = await mongoose.createConnection('mongodb://127.0.0.1:27017/initialdb').asPromise();
+ *
+ *     // Creates an un-cached connection to `mydb`
+ *     const db = conn.useDb('mydb');
+ *
+ *     // Closes `db`, and removes `db` from `conn.relatedDbs` and `conn.otherDbs`
+ *     await conn.removeDb('mydb');
+ *
+ * @method removeDb
+ * @memberOf Connection
+ * @param {String} name The database name
+ * @return {Connection} this
+ */
+
+NativeConnection.prototype.removeDb = function removeDb(name) {
+  const dbs = this.otherDbs.filter(db => db.name === name);
+  if (!dbs.length) {
+    throw new MongooseError(`No connections to database "${name}" found`);
+  }
+
+  for (const db of dbs) {
+    db._closeCalled = true;
+    db._destroyCalled = true;
+    db._readyState = STATES.disconnected;
+    db.$wasForceClosed = true;
+  }
+  delete this.relatedDbs[name];
+  this.otherDbs = this.otherDbs.filter(db => db.name !== name);
+};
+
+/**
  * Closes the connection
  *
  * @param {Boolean} [force]

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -127,7 +127,7 @@ NativeConnection.prototype.useDb = function(name, options) {
 };
 
 /**
- * Removes the database connection with the given name created with with `useDb()`.
+ * Removes the database connection with the given name created with `useDb()`.
  *
  * Throws an error if the database connection was not found.
  *


### PR DESCRIPTION
Fix #11821

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now there's no clean way to close a `useDb()` connection, you have to reach into internals and remove the db from `relatedDbs`, etc. With this PR, `removeDb()` lets you permanently close a `useDb()` connection so it can be garbage collected: removes it from `relatedDbs`, `otherDbs`, and marks the db as force closed and destroyed, so any collection operations immediately error out.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
