### PR TITLE
fix(populate): correctly set `populatedModelSymbol` on documents populated using `Model.populate()`

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -540,6 +540,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
       // Used internally for checking what model was used to populate this
       // path.
       options[populateModelSymbol] = Model;
+      currentOptions[populateModelSymbol] = Model;
       available[modelName] = {
         model: Model,
         options: currentOptions,

--- a/lib/model.js
+++ b/lib/model.js
@@ -4264,7 +4264,7 @@ const excludeIdReg = /\s?-_id\s?/;
 const excludeIdRegGlobal = /\s?-_id\s?/g;
 
 function populate(model, docs, options, callback) {
-  const populateOptions = { ...options };
+  const populateOptions = options;
   if (options.strictPopulate == null) {
     if (options._localModel != null && options._localModel.schema._userProvidedOptions.strictPopulate != null) {
       populateOptions.strictPopulate = options._localModel.schema._userProvidedOptions.strictPopulate;

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -226,6 +226,9 @@ const methods = {
     if (populated && value !== null && value !== undefined) {
       // cast to the populated Models schema
       Model = populated.options[populateModelSymbol];
+      if (Model == null) {
+        throw new MongooseError('No populated model found for path `' + this[arrayPathSymbol] + '`. This is likely a bug in Mongoose, please report an issue on github.com/Automattic/mongoose.');
+      }
 
       // only objects are permitted so we can safely assume that
       // non-objects are to be interpreted as _id


### PR DESCRIPTION
Fix #13575

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A bit of a nasty issue: `populate()` relies on `getModelsMapForPopulate()` to set `populatedModelSymbol` on the passed in options to set the model being populated, so future calls know what model this path was populated with. But shallow cloning in `Model.populate()` breaks that.

I'd love to do some refactoring here, but will hold off for now because that can take a long time.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
