### PR TITLE
feat: support generating custom cast error message with a function

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -109,17 +109,33 @@ thrown.
 
 ## Cast Errors
 
-Before running validators, Mongoose attempts to coerce values to the
-correct type. This process is called *casting* the document. If
-casting fails for a given path, the `error.errors` object will contain
-a `CastError` object.
+Before running validators, Mongoose attempts to coerce values to the correct type. This process is called *casting* the document.
+If casting fails for a given path, the `error.errors` object will contain a `CastError` object.
 
-Casting runs before validation, and validation does not run if casting
-fails. That means your custom validators may assume `v` is `null`,
-`undefined`, or an instance of the type specified in your schema.
+Casting runs before validation, and validation does not run if casting fails.
+That means your custom validators may assume `v` is `null`, `undefined`, or an instance of the type specified in your schema.
 
 ```acquit
 [require:Cast Errors]
+```
+
+By default, Mongoose cast error messages look like `Cast to Number failed for value "pie" at path "numWheels"`.
+You can overwrite Mongoose's default cast error message by the `cast` option on your SchemaType to a string as follows.
+
+```acquit
+[require:Cast Error Message Overwrite]
+```
+
+Mongoose's cast error message templating supports the following parameters:
+
+- `{PATH}`: the path that failed to cast
+- `{VALUE}`: a string representation of the value that failed to cast
+- `{KIND}`: the type that Mongoose attempted to cast to, like `'String'` or `'Number'`
+
+You can also define a function that Mongoose will call to get the cast error message as follows.
+
+```acquit
+[require:Cast Error Message Function Overwrite]
 ```
 
 ## Global SchemaType Validation

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -128,9 +128,9 @@ You can overwrite Mongoose's default cast error message by the `cast` option on 
 
 Mongoose's cast error message templating supports the following parameters:
 
-- `{PATH}`: the path that failed to cast
-- `{VALUE}`: a string representation of the value that failed to cast
-- `{KIND}`: the type that Mongoose attempted to cast to, like `'String'` or `'Number'`
+* `{PATH}`: the path that failed to cast
+* `{VALUE}`: a string representation of the value that failed to cast
+* `{KIND}`: the type that Mongoose attempted to cast to, like `'String'` or `'Number'`
 
 You can also define a function that Mongoose will call to get the cast error message as follows.
 

--- a/lib/error/cast.js
+++ b/lib/error/cast.js
@@ -20,10 +20,9 @@ class CastError extends MongooseError {
   constructor(type, value, path, reason, schemaType) {
     // If no args, assume we'll `init()` later.
     if (arguments.length > 0) {
-      const stringValue = getStringValue(value);
       const valueType = getValueType(value);
       const messageFormat = getMessageFormat(schemaType);
-      const msg = formatMessage(null, type, stringValue, path, messageFormat, valueType, reason);
+      const msg = formatMessage(null, type, value, path, messageFormat, valueType, reason);
       super(msg);
       this.init(type, value, path, reason, schemaType);
     } else {
@@ -77,7 +76,7 @@ class CastError extends MongooseError {
    */
   setModel(model) {
     this.model = model;
-    this.message = formatMessage(model, this.kind, this.stringValue, this.path,
+    this.message = formatMessage(model, this.kind, this.value, this.path,
       this.messageFormat, this.valueType);
   }
 }
@@ -111,10 +110,8 @@ function getValueType(value) {
 }
 
 function getMessageFormat(schemaType) {
-  const messageFormat = schemaType &&
-  schemaType.options &&
-  schemaType.options.cast || null;
-  if (typeof messageFormat === 'string') {
+  const messageFormat = schemaType && schemaType._castErrorMessage || null;
+  if (typeof messageFormat === 'string' || typeof messageFormat === 'function') {
     return messageFormat;
   }
 }
@@ -123,8 +120,9 @@ function getMessageFormat(schemaType) {
  * ignore
  */
 
-function formatMessage(model, kind, stringValue, path, messageFormat, valueType, reason) {
-  if (messageFormat != null) {
+function formatMessage(model, kind, value, path, messageFormat, valueType, reason) {
+  if (typeof messageFormat === 'string') {
+    const stringValue = getStringValue(value);
     let ret = messageFormat.
       replace('{KIND}', kind).
       replace('{VALUE}', stringValue).
@@ -134,7 +132,10 @@ function formatMessage(model, kind, stringValue, path, messageFormat, valueType,
     }
 
     return ret;
+  } else if (typeof messageFormat === 'function') {
+    return messageFormat(value, path, model, kind);
   } else {
+    const stringValue = getStringValue(value);
     const valueTypeMsg = valueType ? ' (type ' + valueType + ')' : '';
     let ret = 'Cast to ' + kind + ' failed for value ' +
       stringValue + valueTypeMsg + ' at path "' + path + '"';

--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -6,7 +6,7 @@
  *     const mongoose = require('mongoose');
  *     mongoose.Error.messages.String.enum  = "Your custom message for {PATH}.";
  *
- * As you might have noticed, error messages support basic templating
+ * Error messages support basic templating. Mongoose will replace the following strings with the corresponding value.
  *
  * - `{PATH}` is replaced with the invalid document path
  * - `{VALUE}` is replaced with the invalid value

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -82,7 +82,11 @@ function SchemaType(path, options, instance) {
   const keys = Object.keys(this.options);
   for (const prop of keys) {
     if (prop === 'cast') {
-      this.castFunction(this.options[prop]);
+      if (Array.isArray(this.options[prop])) {
+        this.castFunction.apply(this, this.options[prop]);
+      } else {
+        this.castFunction(this.options[prop]);
+      }
       continue;
     }
     if (utils.hasUserDefinedProperty(this.options, prop) && typeof this[prop] === 'function') {
@@ -255,14 +259,24 @@ SchemaType.cast = function cast(caster) {
  * @api public
  */
 
-SchemaType.prototype.castFunction = function castFunction(caster) {
+SchemaType.prototype.castFunction = function castFunction(caster, message) {
   if (arguments.length === 0) {
     return this._castFunction;
   }
+
   if (caster === false) {
     caster = this.constructor._defaultCaster || (v => v);
   }
-  this._castFunction = caster;
+  if (typeof caster === 'string') {
+    this._castErrorMessage = caster;
+    return this._castFunction;
+  }
+  if (caster != null) {
+    this._castFunction = caster;
+  }
+  if (message != null) {
+    this._castErrorMessage = message;
+  }
 
   return this._castFunction;
 };

--- a/test/docs/validation.test.js
+++ b/test/docs/validation.test.js
@@ -384,6 +384,53 @@ describe('validation docs', function() {
     // acquit:ignore:end
   });
 
+  it('Cast Error Message Overwrite', function() {
+    const vehicleSchema = new mongoose.Schema({
+      numWheels: {
+        type: Number,
+        cast: '{VALUE} is not a number'
+      }
+    });
+    const Vehicle = db.model('Vehicle', vehicleSchema);
+
+    const doc = new Vehicle({ numWheels: 'pie' });
+    const err = doc.validateSync();
+
+    err.errors['numWheels'].name; // 'CastError'
+    // "pie" is not a number
+    err.errors['numWheels'].message;
+    // acquit:ignore:start
+    assert.equal(err.errors['numWheels'].name, 'CastError');
+    assert.equal(err.errors['numWheels'].message,
+      '"pie" is not a number');
+    db.deleteModel(/Vehicle/);
+    // acquit:ignore:end
+  });
+
+  /* eslint-disable no-unused-vars */
+  it('Cast Error Message Function Overwrite', function() {
+    const vehicleSchema = new mongoose.Schema({
+      numWheels: {
+        type: Number,
+        cast: [null, (value, path, model, kind) => `"${value}" is not a number`]
+      }
+    });
+    const Vehicle = db.model('Vehicle', vehicleSchema);
+
+    const doc = new Vehicle({ numWheels: 'pie' });
+    const err = doc.validateSync();
+
+    err.errors['numWheels'].name; // 'CastError'
+    // "pie" is not a number
+    err.errors['numWheels'].message;
+    // acquit:ignore:start
+    assert.equal(err.errors['numWheels'].name, 'CastError');
+    assert.equal(err.errors['numWheels'].message,
+      '"pie" is not a number');
+    db.deleteModel(/Vehicle/);
+    // acquit:ignore:end
+  });
+
   it('Global SchemaType Validation', async function() {
     // Add a custom validator to all strings
     mongoose.Schema.Types.String.set('validate', v => v == null || v > 0);

--- a/test/docs/validation.test.js
+++ b/test/docs/validation.test.js
@@ -14,6 +14,8 @@ describe('validation docs', function() {
     });
   });
 
+  beforeEach(() => db.deleteModel(/Vehicle/));
+
   after(async function() {
     await db.close();
   });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -208,8 +208,8 @@ describe('Model', function() {
       describe('defaults', function() {
         it('to a non-empty array', function() {
           const DefaultArraySchema = new Schema({
-            arr: { type: Array, cast: String, default: ['a', 'b', 'c'] },
-            single: { type: Array, cast: String, default: ['a'] }
+            arr: { type: Array, default: ['a', 'b', 'c'] },
+            single: { type: Array, default: ['a'] }
           });
           const DefaultArray = db.model('Test', DefaultArraySchema);
           const arr = new DefaultArray();
@@ -223,7 +223,7 @@ describe('Model', function() {
 
         it('empty', function() {
           const DefaultZeroCardArraySchema = new Schema({
-            arr: { type: Array, cast: String, default: [] },
+            arr: { type: Array, default: [] },
             auto: [Number]
           });
           const DefaultZeroCardArray = db.model('Test', DefaultZeroCardArraySchema);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2396,6 +2396,25 @@ describe('schema', function() {
       assert.ok(threw);
     });
 
+    it('with function cast error format', function() {
+      const schema = Schema({
+        num: {
+          type: Number,
+          cast: [null, value => `${value} isn't a number`]
+        }
+      });
+
+      let threw = false;
+      try {
+        schema.path('num').cast('horseradish');
+      } catch (err) {
+        threw = true;
+        assert.equal(err.name, 'CastError');
+        assert.equal(err.message, 'horseradish isn\'t a number');
+      }
+      assert.ok(threw);
+    });
+
     it('with objectids', function() {
       const schema = Schema({
         userId: {

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -64,10 +64,10 @@ declare module 'mongoose' {
 
     /** Allows overriding casting logic for this individual path. If a string, the given string overwrites Mongoose's default cast error message. */
     cast?: string |
-      boolean |
-      ((value: any) => T) |
-      [(value: any) => T, string] |
-      [((value: any) => T) | null, (value: any, path: string, model: Model<T>, kind: string) => string];
+    boolean |
+    ((value: any) => T) |
+    [(value: any) => T, string] |
+    [((value: any) => T) | null, (value: any, path: string, model: Model<T>, kind: string) => string];
 
     /**
      * If true, attach a required validator to this path, which ensures this path

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -67,7 +67,7 @@ declare module 'mongoose' {
     boolean |
     ((value: any) => T) |
     [(value: any) => T, string] |
-    [((value: any) => T) | null, (value: any, path: string, model: Model<T>, kind: string) => string];
+    [((value: any) => T) | null, (value: any, path: string, model: Model<any>, kind: string) => string];
 
     /**
      * If true, attach a required validator to this path, which ensures this path

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -63,7 +63,11 @@ declare module 'mongoose' {
     validate?: SchemaValidator<T> | AnyArray<SchemaValidator<T>>;
 
     /** Allows overriding casting logic for this individual path. If a string, the given string overwrites Mongoose's default cast error message. */
-    cast?: string;
+    cast?: string |
+      boolean |
+      ((value: any) => T) |
+      [(value: any) => T, string] |
+      [((value: any) => T) | null, (value: any, path: string, model: Model<T>, kind: string) => string];
 
     /**
      * If true, attach a required validator to this path, which ensures this path


### PR DESCRIPTION
Fix #3162

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We do already have support for custom error messages, but that is using strings with template variables, like `cast: '{VALUE} is not a number'`.

 With this PR, we'll also support "cast: [null, value => `${value} is not a number`]" as a supported syntax to create a custom error message. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
