### PR TITLE
types(schema): handle `type: Schema.Types.Map` in TypeScript

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1123,3 +1123,14 @@ function gh13534() {
   const doc = new Test({ myId: '0'.repeat(24) });
   expectType<Types.ObjectId>(doc.myId);
 }
+
+function maps() {
+  const schema = new Schema({
+    myMap: { type: Schema.Types.Map, of: Number, required: true }
+  });
+  const Test = model('Test', schema);
+
+  const doc = new Test({ myMap: { answer: 42 } });
+  expectType<Map<string, number>>(doc.myMap);
+  expectType<number | undefined>(doc.myMap!.get('answer'));
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -218,10 +218,11 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
                                         PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
                                           IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
                                             PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
-                                              PathValueType extends ArrayConstructor ? any[] :
-                                                PathValueType extends typeof Schema.Types.Mixed ? any:
-                                                  IfEquals<PathValueType, ObjectConstructor> extends true ? any:
-                                                    IfEquals<PathValueType, {}> extends true ? any:
-                                                      PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
-                                                        PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, { typeKey: TypeKey }> :
-                                                          unknown;
+                                              IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
+                                                PathValueType extends ArrayConstructor ? any[] :
+                                                  PathValueType extends typeof Schema.Types.Mixed ? any:
+                                                    IfEquals<PathValueType, ObjectConstructor> extends true ? any:
+                                                      IfEquals<PathValueType, {}> extends true ? any:
+                                                        PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+                                                          PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, { typeKey: TypeKey }> :
+                                                            unknown;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Ran into a small issue where `InferSchemaType` ends up interpretting `myMap: { type: Schema.Types.Map, of: Number, required: true }` as a boolean. This fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
