### PR TITLE
types: correctly handle `pre('deleteOne', { document: true })`

### DIFF
--- a/test/types/middleware.test.ts
+++ b/test/types/middleware.test.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Model, Document, SaveOptions, Query, Aggregate, HydratedDocument, PreSaveMiddlewareFunction } from 'mongoose';
-import { expectError, expectType, expectNotType } from 'tsd';
+import { expectError, expectType, expectNotType, expectAssignable } from 'tsd';
 
 const preMiddlewareFn: PreSaveMiddlewareFunction<Document> = function(next, opts) {
   this.$markValid('name');
@@ -171,5 +171,15 @@ function gh11257() {
 
   schema.pre('updateOne', { document: false, query: true }, function() {
     this.find();
+  });
+}
+
+function gh13601() {
+  const testSchema = new Schema({
+    name: String
+  });
+
+  testSchema.pre('deleteOne', { document: true }, function() {
+    expectAssignable<Document>(this);
   });
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -378,11 +378,22 @@ declare module 'mongoose' {
     pre<T = never>(method: MongooseQueryOrDocumentMiddleware | MongooseQueryOrDocumentMiddleware[] | RegExp, options: SchemaPreOptions & { document: false, query: false }, fn: PreMiddlewareFunction<T>): this;
     pre<T = never>(method: MongooseDistinctQueryMiddleware|MongooseDistinctQueryMiddleware[], options: SchemaPreOptions & { document: boolean, query: false }, fn: PreMiddlewareFunction<T>): this;
     pre<T = never>(method: MongooseDistinctDocumentMiddleware | MongooseDistinctDocumentMiddleware[] | RegExp, options: SchemaPreOptions & { document: false, query: boolean }, fn: PreMiddlewareFunction<T>): this;
+    // this = Union of Document and Query, could be called with any of them
+    pre<T = THydratedDocumentType | Query<any, any>>(
+      method: MongooseQueryAndDocumentMiddleware | MongooseQueryAndDocumentMiddleware[] | RegExp,
+      options: SchemaPreOptions & { document: true, query: true },
+      fn: PreMiddlewareFunction<T>
+    ): this;
     // this = Document
     pre<T = THydratedDocumentType>(method: 'save', fn: PreSaveMiddlewareFunction<T>): this;
     pre<T = THydratedDocumentType>(method: 'save', options: SchemaPreOptions, fn: PreSaveMiddlewareFunction<T>): this;
     pre<T = THydratedDocumentType>(method: MongooseDistinctDocumentMiddleware|MongooseDistinctDocumentMiddleware[], fn: PreMiddlewareFunction<T>): this;
     pre<T = THydratedDocumentType>(method: MongooseDistinctDocumentMiddleware|MongooseDistinctDocumentMiddleware[], options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
+    pre<T = THydratedDocumentType>(
+      method: MongooseQueryAndDocumentMiddleware | MongooseQueryAndDocumentMiddleware[] | RegExp,
+      options: SchemaPreOptions & { document: true },
+      fn: PreMiddlewareFunction<T>
+    ): this;
     pre<T = THydratedDocumentType>(method: MongooseQueryOrDocumentMiddleware | MongooseQueryOrDocumentMiddleware[] | RegExp, options: SchemaPreOptions & { document: true, query: false }, fn: PreMiddlewareFunction<T>): this;
     // this = Query
     pre<T = Query<any, any>>(method: MongooseDefaultQueryMiddleware|MongooseDefaultQueryMiddleware[], fn: PreMiddlewareFunction<T>): this;


### PR DESCRIPTION
Fix #13601

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`pre('deleteOne', { document: true })` fails to compile currently, which is a bit problematic. Looks like the current TS types require `{ document: true, query: false }`, which isn't correct.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
