### PR TITLE
fix(schema): avoid propagating `toObject.transform` and `toJSON.transform` option to implicitly created schemas

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -748,10 +748,10 @@ Schema.prototype.add = function add(obj, prefix) {
           childSchemaOptions.strict = this._userProvidedOptions.strict;
         }
         if (this._userProvidedOptions.toObject != null) {
-          childSchemaOptions.toObject = this._userProvidedOptions.toObject;
+          childSchemaOptions.toObject = utils.omit(this._userProvidedOptions.toObject, ['transform']);
         }
         if (this._userProvidedOptions.toJSON != null) {
-          childSchemaOptions.toJSON = this._userProvidedOptions.toJSON;
+          childSchemaOptions.toJSON = utils.omit(this._userProvidedOptions.toJSON, ['transform']);
         }
 
         const _schema = new Schema(_typeDef, childSchemaOptions);
@@ -1346,10 +1346,10 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
           childSchemaOptions.strictQuery = options.strictQuery;
         }
         if (options.hasOwnProperty('toObject')) {
-          childSchemaOptions.toObject = options.toObject;
+          childSchemaOptions.toObject = utils.omit(options.toObject, ['transform']);
         }
         if (options.hasOwnProperty('toJSON')) {
-          childSchemaOptions.toJSON = options.toJSON;
+          childSchemaOptions.toJSON = utils.omit(options.toJSON, ['transform']);
         }
 
         if (this._userProvidedOptions.hasOwnProperty('_id')) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1006,7 +1006,7 @@ describe('document', function() {
       assert.equal(foundAlicJson.name, 'Alic');
     });
     it('should propogate toJSON to implicitly created schemas (gh-13599) (gh-13325)', async function() {
-      let transformCalls = [];
+      const transformCalls = [];
       const userSchema = Schema({
         firstName: String,
         company: {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -794,7 +794,7 @@ describe('document', function() {
     });
 
     it('should propogate toObject to implicitly created schemas (gh-13599) (gh-13325)', async function() {
-      let transformCalls = [];
+      const transformCalls = [];
       const userSchema = Schema({
         firstName: String,
         company: {


### PR DESCRIPTION
Fix #13599

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13599 pointed out that we introduced a potentially breaking change in #13396: `transform()` option propagates to implicitly created schemas, which means existing `transform` functions need to account that they'll run on subdocuments. This PR undoes that backwards breaking change by explicitly omitting `transform` from the `toJSON` and `toObject` options propagated down to implicitly created schemas.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
