### PR TITLE
docs: rework several code examples that still use callbacks

### DIFF
--- a/docs/async-await.md
+++ b/docs/async-await.md
@@ -11,27 +11,7 @@ This is especially helpful for avoiding callback hell when executing multiple as
 Each of the three functions below retrieves a record from the database, updates it, and prints the updated record to the console.
 
 ```javascript
-// Works.
-function callbackUpdate() {
-  MyModel.findOne({ firstName: 'franklin', lastName: 'roosevelt' }, function(err, doc) {
-    if (err) {
-      handleError(err);
-    }
-
-    doc.middleName = 'delano';
-
-    doc.save(function(err, updatedDoc) {
-      if (err) {
-        handleError(err);
-      }
-
-      // Final logic is 2 callbacks deep
-      console.log(updatedDoc);
-    });
-  });
-}
-
-// Better.
+// Using promise chaining
 function thenUpdate() {
   MyModel.findOne({ firstName: 'franklin', lastName: 'roosevelt' })
     .then(function(doc) {
@@ -44,7 +24,7 @@ function thenUpdate() {
     });
 }
 
-// Best?
+// Using async/await
 async function awaitUpdate() {
   try {
     const doc = await MyModel.findOne({

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -79,9 +79,8 @@ const schema = new mongoose.Schema({
 });
 const Model = db.model('Test', schema);
 
-Model.create([{ name: 'Val' }, { name: 'Val' }], function(err) {
-  console.log(err); // No error, unless index was already built
-});
+// No error, unless index was already built
+await Model.create([{ name: 'Val' }, { name: 'Val' }]);
 ```
 
 However, if you wait for the index to build using the `Model.on('index')` event, attempts to save duplicates will correctly error.
@@ -92,21 +91,12 @@ const schema = new mongoose.Schema({
 });
 const Model = db.model('Test', schema);
 
-Model.on('index', function(err) { // <-- Wait for model's indexes to finish
-  assert.ifError(err);
-  Model.create([{ name: 'Val' }, { name: 'Val' }], function(err) {
-    console.log(err);
-  });
-});
-
-// Promise based alternative. `init()` returns a promise that resolves
-// when the indexes have finished building successfully. The `init()`
+// Wait for model's indexes to finish. The `init()`
 // function is idempotent, so don't worry about triggering an index rebuild.
-Model.init().then(function() {
-  Model.create([{ name: 'Val' }, { name: 'Val' }], function(err) {
-    console.log(err);
-  });
-});
+await Model.init();
+
+// Throws a duplicate key error
+await Model.create([{ name: 'Val' }, { name: 'Val' }]);
 ```
 
 MongoDB persists indexes, so you only need to rebuild indexes if you're starting

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -532,11 +532,10 @@ schema.post('update', function(error, res, next) {
 });
 
 const people = [{ name: 'Axl Rose' }, { name: 'Slash' }];
-Person.create(people, function(error) {
-  Person.update({ name: 'Slash' }, { $set: { name: 'Axl Rose' } }, function(error) {
-    // `error.message` will be "There was a duplicate key error"
-  });
-});
+await Person.create(people); function(error) {
+
+// Throws "There was a duplicate key error"
+await Person.update({ name: 'Slash' }, { $set: { name: 'Axl Rose' } });
 ```
 
 Error handling middleware can transform an error, but it can't remove the

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -532,7 +532,7 @@ schema.post('update', function(error, res, next) {
 });
 
 const people = [{ name: 'Axl Rose' }, { name: 'Slash' }];
-await Person.create(people); function(error) {
+await Person.create(people);
 
 // Throws "There was a duplicate key error"
 await Person.update({ name: 'Slash' }, { $set: { name: 'Axl Rose' } });

--- a/lib/model.js
+++ b/lib/model.js
@@ -3045,8 +3045,10 @@ Model.startSession = function() {
  *
  * #### Example:
  *
- *     const arr = [{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }];
- *     Movies.insertMany(arr, function(error, docs) {});
+ *     await Movies.insertMany([
+ *       { name: 'Star Wars' },
+ *       { name: 'The Empire Strikes Back' }
+ *     ]);
  *
  * @param {Array|Object|*} doc(s)
  * @param {Object} [options] see the [mongodb driver options](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#insertMany)

--- a/test/model.insertMany.test.js
+++ b/test/model.insertMany.test.js
@@ -26,8 +26,7 @@ describe('insertMany()', function() {
     const Movie = db.model('Movie', schema);
     const start = Date.now();
 
-    const arr = [{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }];
-    return Movie.insertMany(arr).
+    return Movie.insertMany([{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }]).
       then(docs => {
         assert.equal(docs.length, 2);
         assert.ok(!docs[0].isNew);
@@ -93,8 +92,7 @@ describe('insertMany()', function() {
     }, { timestamps: true });
     const Movie = db.model('Movie', schema);
 
-    const arr = [{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }];
-    let docs = await Movie.insertMany(arr);
+    let docs = await Movie.insertMany([{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }]);
     assert.equal(docs.length, 2);
     assert.ok(!docs[0].isNew);
     assert.ok(!docs[1].isNew);
@@ -299,8 +297,7 @@ describe('insertMany()', function() {
     });
     const Movie = db.model('Movie', schema);
 
-    const arr = [{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }];
-    let docs = await Movie.insertMany(arr);
+    let docs = await Movie.insertMany([{ name: 'Star Wars' }, { name: 'The Empire Strikes Back' }]);
     assert.equal(docs.length, 2);
     assert.equal(calledPre, 2);
     assert.equal(calledPost, 1);


### PR DESCRIPTION
Fix #13616

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13616 pointed out one example in our docs that still uses callbacks. That's a problem now that 7.x dropped support for callbacks. I also found a few other spots where we still use callbacks in the docs, this PR fixes those.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
