### PR TITLE
Types: Add inline comment to to tell the default value of the runValidator flag in the queryOptions types

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -136,6 +136,10 @@ declare module 'mongoose' {
      * Another alias for the `new` option. `returnOriginal` is deprecated so this should be used.
      */
     returnDocument?: 'before' | 'after';
+    /**
+     * Set to true to enable `update validators`
+     * (https://mongoosejs.com/docs/validation.html#update-validators). Defaults to false.
+     */
     runValidators?: boolean;
     /* Set to `true` to automatically sanitize potentially unsafe user-generated query projections */
     sanitizeProjection?: boolean;


### PR DESCRIPTION
**Summary**

I ran into a small issue when using a function like `findOneAndUpdate` or `updateMany`, the `runValidator` flag in the `queryOptions` interface is optional but has no information about the default value.
