### PR TITLE
fix(schema): make `Schema.prototype.clone()` avoid creating different copies of subdocuments and single nested paths underneath single nested paths

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -409,7 +409,25 @@ Schema.prototype._clone = function _clone(Constructor) {
   s.paths = utils.clone(this.paths);
   s.nested = utils.clone(this.nested);
   s.subpaths = utils.clone(this.subpaths);
-  s.singleNestedPaths = utils.clone(this.singleNestedPaths);
+  for (const schemaType of Object.values(s.paths)) {
+    if (schemaType.$isSingleNested) {
+      const path = schemaType.path;
+      for (const key of Object.keys(schemaType.schema.paths)) {
+        s.singleNestedPaths[path + '.' + key] = schemaType.schema.paths[key];
+      }
+      for (const key of Object.keys(schemaType.schema.singleNestedPaths)) {
+        s.singleNestedPaths[path + '.' + key] =
+          schemaType.schema.singleNestedPaths[key];
+      }
+      for (const key of Object.keys(schemaType.schema.subpaths)) {
+        s.singleNestedPaths[path + '.' + key] =
+          schemaType.schema.subpaths[key];
+      }
+      for (const key of Object.keys(schemaType.schema.nested)) {
+        s.singleNestedPaths[path + '.' + key] = 'nested';
+      }
+    }
+  }
   s.childSchemas = gatherChildSchemas(s);
 
   s.virtuals = utils.clone(this.virtuals);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2022,6 +2022,21 @@ describe('schema', function() {
         const test2 = test.clone();
         assert.equal(test2.localTest(), 42);
       });
+
+      it('avoids creating duplicate array constructors when cloning doc array underneath subdoc (gh-13626)', function() {
+        const schema = new mongoose.Schema({
+          config: {
+            type: new mongoose.Schema({
+              attributes: [{ value: 'Mixed' }]
+            })
+          }
+        }).clone();
+
+        assert.strictEqual(
+          schema.paths['config'].schema.paths['attributes'].Constructor,
+          schema.singleNestedPaths['config.attributes'].Constructor
+        );
+      });
     });
 
     it('childSchemas prop (gh-5695)', function(done) {


### PR DESCRIPTION
Re: #13626

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13626 is one of those issues where doing the "5 whys" exercise takes you down a very deep rabbit hole. There are a few issues that came together to form the issue reported in #13626. The one addressed in this PR is that `Schema.prototype.clone()` unintentionally creates duplicate constructors for subdocuments and document arrays that are nested underneath a subdocument path.

```javascript
new Schema({
  docArr1: [{ name: String }] // unaffected
  subdoc1: new Schema({
    docArr2: [{ name: String }], // affected
    subdoc2: new Schema({ name: String }) // affected
  });
}).clone();
```

The issue is that `Schema.prototype.clone()` first uses `utils.clone()` to clone the schema's paths, and then clone the single nested paths:

```javascript
s.paths = utils.clone(this.paths);
s.singleNestedPaths = utils.clone(this.singleNestedPaths);
```

`clone()` calls `SchemaType.prototype.clone()`, on each schema type it finds. This means that, after cloning `singleNestedPaths`, `paths['subdoc1'].schema.paths['subdoc2']` will not be the same as `singleNestedPaths['subdoc1.subdoc2']`. They will be distinct clones of the original schema's `singleNestedPaths['subdoc1.subdoc2']`.

Fix is to re-assemble `singleNestedPaths` from the cloned schemas' `paths`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
