### PR TITLE
fix: Document.prototype.isModified support for a string of keys as first parameter

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2216,7 +2216,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
     }
 
     if (typeof paths === 'string') {
-      paths = [paths];
+      paths = paths.indexOf(' ') === -1 ? [paths] : paths.split(' ');
     }
 
     for (const path of paths) {

--- a/test/document.modified.test.js
+++ b/test/document.modified.test.js
@@ -165,6 +165,23 @@ describe('document modified', function() {
       assert.equal(post.isModified('title'), false);
     });
 
+    it('should support passing a string of keys separated by a blank space as the first argument', function() {
+      const post = new BlogPost();
+      post.init({
+        title: 'Test',
+        slug: 'test',
+        date: new Date()
+      });
+
+      assert.equal(post.isModified('title'), false);
+      post.set('title', 'modified title');
+      assert.equal(post.isModified('title'), true);
+      assert.equal(post.isModified('slug'), false);
+      assert.equal(post.isModified('title slug'), true);
+    });
+
+
+
     describe('on DocumentArray', function() {
       it('work', function() {
         const post = new BlogPost();


### PR DESCRIPTION
**Summary**

This pull request should fix the  issue [#13667](https://github.com/Automattic/mongoose/issues/13667). 
The error was caused in a recent change of the Document.isModified method, to resolve it I returned the paths variable declaration as it was before that change.  

**Examples**

These pictures show the repro script provided in the original issue running with and without the changes

![after](https://github.com/Automattic/mongoose/assets/41962288/90e66b57-d019-45b1-8069-825283bfdfce)

![before](https://github.com/Automattic/mongoose/assets/41962288/8ab0a318-805e-440a-8d2e-092719479e0d)