### PR TITLE
fix(query): remove unnecessary check for atomic operators in findOneAndReplace()

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3587,9 +3587,6 @@ Query.prototype.findOneAndReplace = function(filter, replacement, options) {
   }
 
   if (replacement != null) {
-    if (hasDollarKeys(replacement)) {
-      throw new Error('The replacement document must not contain atomic operators.');
-    }
     this._mergeUpdate(replacement);
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This error check is both brittle and unnecessary. Unnecessary because the MongoDB driver already throws `MongoInvalidArgumentError: Replacement document must not contain atomic operators`. Brittle because it doesn't take into account chaining, like `.findOneAndReplace().set({ $push: 'foo' })`. I also don't like how this check uses vanilla `Error` rather than `MongooseError`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
