### PR TITLE
types(schema): support `required: { isRequired: true }` syntax in schema definition

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1139,7 +1139,10 @@ function gh13514() {
   const schema = new Schema({
     email: {
       type: String,
-      required: [true, 'email is required']
+      required: {
+        isRequired: true,
+        message: 'Email is required'
+      } as const
     }
   });
   const Test = model('Test', schema);

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1134,3 +1134,16 @@ function maps() {
   expectType<Map<string, number>>(doc.myMap);
   expectType<number | undefined>(doc.myMap!.get('answer'));
 }
+
+function gh13514() {
+  const schema = new Schema({
+    email: {
+      type: String,
+      required: [true, 'email is required']
+    }
+  });
+  const Test = model('Test', schema);
+
+  const doc = new Test({ email: 'bar' });
+  const str: string = doc.email;
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -86,7 +86,7 @@ type IsPathDefaultUndefined<PathType> = PathType extends { default: undefined } 
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  */
 type IsPathRequired<P, TypeKey extends string = DefaultTypeKey> =
-  P extends { required: true | [true, string | undefined] } | ArrayConstructor | any[]
+  P extends { required: true | [true, string | undefined] | { isRequired: true } } | ArrayConstructor | any[]
     ? true
     : P extends { required: boolean }
       ? P extends { required: false }


### PR DESCRIPTION
Re: #13514

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

One potential workaround for #13514 is using object syntax for defining `required`, because the following works fine:

```javascript
new Schema({
  email: {
    type: String,
    required: { isRequired: true, message: 'Email is required' }
  }
});
```

But we don't currently support that in TypeScript. This PR adds support for the `required: { isRequired: true }` syntax. Unfortunately doesn't help very much with #13514.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
