### PR TITLE
fix(model): avoid hanging on empty `bulkWrite()` with ordered: false

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3472,18 +3472,22 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
     let validOps = [];
     let validationErrors = [];
     const results = [];
-    for (let i = 0; i < validations.length; ++i) {
-      validations[i]((err) => {
-        if (err == null) {
-          validOps.push(i);
-        } else {
-          validationErrors.push({ index: i, error: err });
-          results[i] = err;
-        }
-        if (--remaining <= 0) {
-          completeUnorderedValidation.call(this);
-        }
-      });
+    if (remaining === 0) {
+      completeUnorderedValidation.call(this);
+    } else {
+      for (let i = 0; i < validations.length; ++i) {
+        validations[i]((err) => {
+          if (err == null) {
+            validOps.push(i);
+          } else {
+            validationErrors.push({ index: i, error: err });
+            results[i] = err;
+          }
+          if (--remaining <= 0) {
+            completeUnorderedValidation.call(this);
+          }
+        });
+      }
     }
 
     validationErrors = validationErrors.

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5923,6 +5923,15 @@ describe('Model', function() {
 
   });
 
+  it('Model.bulkWrite(...) does not hang with empty array and ordered: false (gh-13664)', async function() {
+    const userSchema = new Schema({ name: String });
+    const User = db.model('User', userSchema);
+
+    const err = await User.bulkWrite([], { ordered: false }).then(() => null, err => err);
+    assert.ok(err);
+    assert.equal(err.name, 'MongoInvalidArgumentError');
+  });
+
   it('allows calling `create()` after `bulkWrite()` (gh-9350)', async function() {
     const schema = Schema({ foo: Boolean });
     const Model = db.model('Test', schema);


### PR DESCRIPTION
Fix #13664

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like if `bulkWrite()` is empty and `ordered: false`, we never hit the `if (--remaining <= 0)` check, so `bulkWrite()` hangs forever. Fixed in this PR, but likely worth doing some refactoring to switch to using async functions rather than callbacks internally within `bulkWrite()` to avoid this sort of issue.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
