### PR TITLE
docs(deprecations): quick fix for includeResultMetadata docs

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -30,7 +30,7 @@ const doc = await Test.findOneAndUpdate(
 const doc = await Test.findOneAndUpdate(
   { name: 'Test' },
   { name: 'Test Testerson' },
-  { includeResultMetadata: false }
+  { includeResultMetadata: true }
 );
 ```
 


### PR DESCRIPTION
Fix #13661

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix, #13661 points out that the deprecation docs flip `includeResultMetadata`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
