### PR TITLE
fix: avoid applying map property getters when saving

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -640,7 +640,7 @@ exports.getValue = function(path, obj, map) {
 const mapGetterOptions = Object.freeze({ getters: false });
 
 function getValueLookup(obj, part) {
-  const _from = obj && obj._doc ? obj._doc : obj;
+  const _from = obj?._doc || obj;
   return _from instanceof Map ?
     _from.get(part, mapGetterOptions) :
     _from[part];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -630,8 +630,22 @@ function _populateObj(obj) {
  */
 
 exports.getValue = function(path, obj, map) {
-  return mpath.get(path, obj, '_doc', map);
+  return mpath.get(path, obj, getValueLookup, map);
 };
+
+/*!
+ * ignore
+ */
+
+const mapGetterOptions = Object.freeze({ getters: false });
+
+function getValueLookup(obj, part) {
+  const _from = obj && obj._doc ? obj._doc : obj;
+  obj = _from instanceof Map ?
+    _from.get(part, mapGetterOptions) :
+    _from[part];
+  return obj;
+}
 
 /**
  * Sets the value of `obj` at the given `path`.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -641,10 +641,9 @@ const mapGetterOptions = Object.freeze({ getters: false });
 
 function getValueLookup(obj, part) {
   const _from = obj && obj._doc ? obj._doc : obj;
-  obj = _from instanceof Map ?
+  return _from instanceof Map ?
     _from.get(part, mapGetterOptions) :
     _from[part];
-  return obj;
 }
 
 /**


### PR DESCRIPTION
Fix #13657

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, `save()` will actually apply getters on map paths when updating an existing doc. That's why the test case from #13657 shows maps of uuids getting saved as strings. This PR fixes that by making it so that `getValue()`, Mongoose's internal way to "get dotted path without Mongoose internals", always passes `getters: false` to `map.get()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
