### PR TITLE
docs(middleware): clarify that `doc.deleteOne()` doesn't run query middleware currently

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -97,12 +97,14 @@ Here are the possible strings that can be passed to `pre()`
 All middleware types support pre and post hooks.
 How pre and post hooks work is described in more detail below.
 
-**Note:** Mongoose registers `updateOne` and
-`deleteOne` middleware on `Query#updateOne()` and `Query#deleteOne()` by default.
-This means that both `doc.updateOne()` and `Model.updateOne()` trigger
-`updateOne` hooks, but `this` refers to a query, not a document. To register
-`updateOne` or `deleteOne` middleware as document middleware, use
-`schema.pre('updateOne', { document: true, query: false })`.
+**Note:** Mongoose registers `updateOne` middleware on `Query.prototype.updateOne()` by default.
+This means that both `doc.updateOne()` and `Model.updateOne()` trigger `updateOne` hooks, but `this` refers to a query, not a document.
+To register `updateOne` middleware as document middleware, use `schema.pre('updateOne', { document: true, query: false })`.
+
+**Note:** Like `updateOne`, Mongoose registers `deleteOne` middleware on `Query.prototype.deleteOne` by default.
+That means that `Model.deleteOne()` will trigger `deleteOne` hooks, and `this` will refer to a query.
+However, `doc.deleteOne()` does **not** fire `deleteOne` query middleware for legacy reasons.
+To register `deleteOne` middleware as document middleware, use `schema.pre('deleteOne', { document: true, query: false })`.
 
 **Note:** The [`create()`](./api/model.html#model_Model-create) function fires `save()` hooks.
 


### PR DESCRIPTION
Fix #13669

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Middleware docs don't make it clear that `doc.deleteOne()` currently doesn't run query middleware. We're fixing this in #13660. Can't fix this in 7.x because we have tests that assert on this behavior. So add a section to the docs, and make sure to make a note of the breaking change in 8.x.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
