### PR TITLE
types: allow accessing `options` from pre middleware

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -12,7 +12,8 @@ import {
   HydratedDocument,
   ResolveSchemaOptions,
   ObtainDocumentType,
-  ObtainSchemaGeneric
+  ObtainSchemaGeneric,
+  InsertManyOptions
 } from 'mongoose';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
@@ -1149,4 +1150,23 @@ function gh13514() {
 
   const doc = new Test({ email: 'bar' });
   const str: string = doc.email;
+}
+
+function gh13633() {
+  const schema = new Schema({ name: String });
+
+  schema.pre('updateOne', { document: true, query: false }, function(next) {
+  });
+
+  schema.pre('updateOne', { document: true, query: false }, function(next, options) {
+    expectType<Record<string, any> | undefined>(options);
+  });
+
+  schema.post('save', function(res, next) {
+  });
+  schema.pre('insertMany', function(next, docs) {
+  });
+  schema.pre('insertMany', function(next, docs, options) {
+    expectType<(InsertManyOptions & { lean?: boolean }) | undefined>(options);
+  });
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -406,8 +406,25 @@ declare module 'mongoose' {
     pre<T extends Aggregate<any>>(method: 'aggregate' | RegExp, fn: PreMiddlewareFunction<T>): this;
     pre<T extends Aggregate<any>>(method: 'aggregate' | RegExp, options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
     /* method insertMany */
-    pre<T = TModelType>(method: 'insertMany' | RegExp, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;
-    pre<T = TModelType>(method: 'insertMany' | RegExp, options: SchemaPreOptions, fn: (this: T, next: (err?: CallbackError) => void, docs: any | Array<any>) => void | Promise<void>): this;
+    pre<T = TModelType>(
+      method: 'insertMany' | RegExp,
+      fn: (
+        this: T,
+        next: (err?: CallbackError) => void,
+        docs: any | Array<any>,
+        options?: InsertManyOptions & { lean?: boolean }
+      ) => void | Promise<void>
+    ): this;
+    pre<T = TModelType>(
+      method: 'insertMany' | RegExp,
+      options: SchemaPreOptions,
+      fn: (
+        this: T,
+        next: (err?: CallbackError) => void,
+        docs: any | Array<any>,
+        options?: InsertManyOptions & { lean?: boolean }
+      ) => void | Promise<void>
+    ): this;
 
     /** Object of currently defined query helpers on this schema. */
     query: TQueryHelpers;

--- a/types/middlewares.d.ts
+++ b/types/middlewares.d.ts
@@ -31,8 +31,16 @@ declare module 'mongoose' {
   type SchemaPreOptions = MiddlewareOptions;
   type SchemaPostOptions = MiddlewareOptions;
 
-  type PreMiddlewareFunction<ThisType = any> = (this: ThisType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void>;
-  type PreSaveMiddlewareFunction<ThisType = any> = (this: ThisType, next: CallbackWithoutResultAndOptionalError, opts: SaveOptions) => void | Promise<void>;
+  type PreMiddlewareFunction<ThisType = any> = (
+    this: ThisType,
+    next: CallbackWithoutResultAndOptionalError,
+    opts?: Record<string, any>
+  ) => void | Promise<void>;
+  type PreSaveMiddlewareFunction<ThisType = any> = (
+    this: ThisType,
+    next: CallbackWithoutResultAndOptionalError,
+    opts: SaveOptions
+  ) => void | Promise<void>;
   type PostMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, res: ResType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void>;
   type ErrorHandlingMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: CallbackWithoutResultAndOptionalError) => void;
   type ErrorHandlingMiddlewareWithOption<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType | null, next: CallbackWithoutResultAndOptionalError) => void | Promise<void>;


### PR DESCRIPTION
Fix #13633

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

TypeScript types don't support `options` param for document and model middleware currently. This PR adds that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
