### PR TITLE
fix: accessing discriminator schema with null

### DIFF
--- a/lib/helpers/query/getEmbeddedDiscriminatorPath.js
+++ b/lib/helpers/query/getEmbeddedDiscriminatorPath.js
@@ -75,7 +75,11 @@ module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, p
         continue;
       }
 
-      const discriminatorSchema = getDiscriminatorByValue(schematype.caster.discriminators, discriminatorKey).schema;
+      const discriminator = getDiscriminatorByValue(schematype.caster.discriminators, discriminatorKey);
+      const discriminatorSchema = discriminator && discriminator.schema;
+      if (discriminatorSchema == null) {
+        continue;
+      }
 
       const rest = parts.slice(i + 1).join('.');
       schematype = discriminatorSchema.path(rest);

--- a/test/helpers/query.castUpdate.test.js
+++ b/test/helpers/query.castUpdate.test.js
@@ -5,11 +5,37 @@ const assert = require('assert');
 const castUpdate = require('../../lib/helpers/query/castUpdate');
 
 describe('castUpdate', function() {
-  it('avoids adding `$each` if `$addToSet` on mixed array (gh-11284)', function() {
+  it('avoids adding `$each` if `$addToSet` on mixed array (gh-11284)', function () {
     const schema = new Schema({ test: [] });
     const obj = { $addToSet: { test: [1, 2, 3] } };
 
     const res = castUpdate(schema, obj);
     assert.deepEqual(res, { $addToSet: { test: [1, 2, 3] } });
+  });
+
+  it('casts the update correctly when target discriminator type is missing', function() {
+    const shapeSchema = Schema({ name: String }, { discriminatorKey: 'kind' });
+    const schema = Schema({ shape: shapeSchema });
+
+    schema
+      .path('shape')
+      .discriminator(
+        'gh8378_Circle',
+        Schema({ radius: String, color: String })
+      );
+
+    // schema
+    //   .path('shape')
+    //   .discriminator('gh8378_Square', Schema({ side: Number, color: String }));
+
+    const toBeUpdated = {
+      'shape.name': 'aName',
+      'shape.kind': 'gh8378_Square',
+      'shape.side': 4,
+      'shape.color': 'white'
+    };
+
+    const res = castUpdate(schema, { $set: toBeUpdated });
+    assert.deepEqual(res, { $set: toBeUpdated });
   });
 });

--- a/test/helpers/query.castUpdate.test.js
+++ b/test/helpers/query.castUpdate.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const castUpdate = require('../../lib/helpers/query/castUpdate');
 
 describe('castUpdate', function() {
-  it('avoids adding `$each` if `$addToSet` on mixed array (gh-11284)', function () {
+  it('avoids adding `$each` if `$addToSet` on mixed array (gh-11284)', function() {
     const schema = new Schema({ test: [] });
     const obj = { $addToSet: { test: [1, 2, 3] } };
 

--- a/test/model.findByIdAndUpdate.test.js
+++ b/test/model.findByIdAndUpdate.test.js
@@ -69,8 +69,8 @@ describe('model: findByIdAndUpdate:', function() {
 
     schema.path('shape').discriminator('gh8378_Circle',
       Schema({ radius: String, color: String }));
-    // schema.path('shape').discriminator('gh8378_Square',
-    //   Schema({ side: Number, color: String }));
+    schema.path('shape').discriminator('gh8378_Square',
+      Schema({ side: Number, color: String }));
 
     const MyModel = db.model('Test', schema);
 
@@ -89,11 +89,11 @@ describe('model: findByIdAndUpdate:', function() {
       'shape.name': 'after',
       'shape.side': 4,
       'shape.color': 'white'
-    }, { new: true });
+    }, { new: true, overwriteDiscriminatorKey: true });
 
     assert.equal(doc.shape.kind, 'gh8378_Square');
     assert.equal(doc.shape.name, 'after');
-    assert.equal(doc.shape.side, 4); // this assertion is failing, this property is not updated
+    assert.equal(doc.shape.side, 4);
     assert.equal(doc.shape.color, 'white');
   });
 });

--- a/test/model.findByIdAndUpdate.test.js
+++ b/test/model.findByIdAndUpdate.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * Test dependencies.
+ */
+
+const start = require('./common');
+
+const assert = require('assert');
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+const util = require('./util');
+
+describe('model: findByIdAndUpdate:', function() {
+  let db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  beforeEach(() => db.deleteModel(/.*/));
+  afterEach(() => util.clearTestData(db));
+  afterEach(() => require('./util').stopRemainingOps(db));
+
+  it('returns the edited document with previous and target discriminators types defined', async function() {
+    const shapeSchema = Schema({ name: String }, { discriminatorKey: 'kind' });
+    const schema = Schema({ shape: shapeSchema });
+
+    schema.path('shape').discriminator('gh8378_Circle',
+      Schema({ radius: String, color: String }));
+    schema.path('shape').discriminator('gh8378_Square',
+      Schema({ side: Number, color: String }));
+
+    const MyModel = db.model('Test', schema);
+
+
+    let doc = await MyModel.create({
+      shape: {
+        kind: 'gh8378_Circle',
+        name: 'before',
+        radius: 5,
+        color: 'red'
+      }
+    });
+
+    doc = await MyModel.findByIdAndUpdate(doc._id, {
+      'shape.kind': 'gh8378_Square',
+      'shape.name': 'after',
+      'shape.side': 4,
+      'shape.color': 'white'
+    }, { new: true });
+    console.log('doc');
+    console.log(doc);
+    console.log('doc');
+
+    assert.equal(doc.shape.kind, 'gh8378_Square');
+    assert.equal(doc.shape.name, 'after');
+    assert.equal(doc.shape.side, 4);
+    assert.equal(doc.shape.color, 'white');
+  });
+
+  it('returns the edited document with only previous discriminator type defined', async function() {
+    const shapeSchema = Schema({ name: String }, { discriminatorKey: 'kind' });
+    const schema = Schema({ shape: shapeSchema });
+
+    schema.path('shape').discriminator('gh8378_Circle',
+      Schema({ radius: String, color: String }));
+    // schema.path('shape').discriminator('gh8378_Square',
+    //   Schema({ side: Number, color: String }));
+
+    const MyModel = db.model('Test', schema);
+
+
+    let doc = await MyModel.create({
+      shape: {
+        kind: 'gh8378_Circle',
+        name: 'before',
+        radius: 5,
+        color: 'red'
+      }
+    });
+
+    doc = await MyModel.findByIdAndUpdate(doc._id, {
+      'shape.kind': 'gh8378_Square',
+      'shape.name': 'after',
+      'shape.side': 4,
+      'shape.color': 'white'
+    }, { new: true });
+
+    assert.equal(doc.shape.kind, 'gh8378_Square');
+    assert.equal(doc.shape.name, 'after');
+    assert.equal(doc.shape.side, 4); // this assertion is failing, this property is not updated
+    assert.equal(doc.shape.color, 'white');
+  });
+});


### PR DESCRIPTION
**Summary**

while trying to use findByIdAndUpdate on a document where its schema uses discriminator. I faced the same error here, https://github.com/Automattic/mongoose/issues/8837

looking at this PR, https://github.com/Automattic/mongoose/pull/8878. Trying to simulate the same fix for this case.

The error (Cannot read properties of null (reading 'schema') stack that I received was, 
```
'TypeError: Cannot read properties of null (reading 'schema')  
 at getEmbeddedDiscriminatorPath (/node_modules/mongoose/lib/helpers/query/getEmbeddedDiscriminatorPath.js:78:110)   
 at walkUpdatePath (/node_modules/mongoose/lib/helpers/query/castUpdate.js:328:22)   
 at castUpdate (/node_modules/mongoose/lib/query.js:4419:28)   
 at processTicksAndRejections (node:internal/process/task_queues:95:5)   
```

This error happens when the update includes a change in the discriminator type, and that (new) type is not defined as a discriminator. What's expected is to return a validation error instead of an exception.

Version used, "mongoose": "^7.4.2",