### PR TITLE
types(schema): correct return type for `Schema.prototype.indexes()`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1,19 +1,21 @@
 import {
   Schema,
   Document,
+  HydratedDocument,
+  IndexDefinition,
+  IndexOptions,
+  InferSchemaType,
+  InsertManyOptions,
+  ObtainDocumentType,
+  ObtainSchemaGeneric,
+  ResolveSchemaOptions,
   SchemaDefinition,
   SchemaTypeOptions,
   Model,
-  Types,
-  InferSchemaType,
   SchemaType,
+  Types,
   Query,
-  model,
-  HydratedDocument,
-  ResolveSchemaOptions,
-  ObtainDocumentType,
-  ObtainSchemaGeneric,
-  InsertManyOptions
+  model
 } from 'mongoose';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
@@ -1169,4 +1171,9 @@ function gh13633() {
   schema.pre('insertMany', function(next, docs, options) {
     expectType<(InsertManyOptions & { lean?: boolean }) | undefined>(options);
   });
+}
+
+function gh13702() {
+  const schema = new Schema({ name: String });
+  expectType<[IndexDefinition, IndexOptions][]>(schema.indexes());
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -278,7 +278,7 @@ declare module 'mongoose' {
      * Returns a list of indexes that this schema declares, via `schema.index()`
      * or by `index: true` in a path's options.
      */
-    indexes(): Array<IndexDefinition>;
+    indexes(): Array<[IndexDefinition, IndexOptions]>;
 
     /** Gets a schema option. */
     get<K extends keyof SchemaOptions>(key: K): SchemaOptions[K];


### PR DESCRIPTION
Fix #13702

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Just a quick types fix. Current return value doesn't accurately reflect runtime behavior.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
