### PR TITLE
fix(query): allow deselecting discriminator key

### DIFF
--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -325,7 +325,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
     // If set to 0, we're explicitly excluding the discriminator key. Can't do this for all fields,
     // because we have tests that assert that using `-path` to exclude schema-level `select: true`
     // fields counts as an exclusive projection. See gh-11546
-    if (exclude && type.selected && path === schema.options.discriminatorKey && fields[path] != null && !fields[path]) {
+    if (!exclude && type.selected && path === schema.options.discriminatorKey && fields[path] != null && !fields[path]) {
       delete fields[path];
       return;
     }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4170,4 +4170,15 @@ describe('Query', function() {
     await q.exec();
     assert.equal(q.op, 'findOneAndReplace');
   });
+
+  it('allows deselecting discriminator key (gh-13679)', async function() {
+    const testSchema = new Schema({ name: String });
+    const Test = db.model('Test', testSchema);
+    const Test2 = Test.discriminator('Test2', new Schema({ test: String }));
+
+    const { _id } = await Test2.create({ name: 'test1', test: 'test2' });
+    const { name, __t } = await Test.findById(_id).select({ __t: 0 });
+    assert.strictEqual(name, 'test1');
+    assert.strictEqual(__t, undefined);
+  });
 });


### PR DESCRIPTION
Fix #13679

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The flipped sign is because "excude === true" means a projection that explicitly excludes fields, like `{ name: 0, age: 0 }`. The case on L308 is looking to capture the case where the user does something like `{ name: 1, __t: 0 }` as a way to explicitly exclude `__t`, which is included by default. So `if (!exclude)` is correct, and happens to fix the bug in #13679 as well

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
