### PR TITLE
docs: add brief note on TypeScript generic usage for embedded discriminator `path()` calls

### DIFF
--- a/docs/discriminators.md
+++ b/docs/discriminators.md
@@ -53,3 +53,27 @@ To update a document's discriminator key, use `findOneAndUpdate()` or `updateOne
 ```acquit
 [require:use overwriteDiscriminatorKey to change discriminator key]
 ```
+
+## Embedded discriminators in arrays
+
+You can also define discriminators on embedded document arrays.
+Embedded discriminators are different because the different discriminator types are stored in the same document array (within a document) rather than the same collection.
+In other words, embedded discriminators let you store subdocuments matching different schemas in the same array.
+
+As a general best practice, make sure you declare any hooks on your schemas **before** you use them.
+You should **not** call `pre()` or `post()` after calling `discriminator()`.
+
+```acquit
+[require:Embedded discriminators in arrays]
+```
+
+## Single nested discriminators
+
+You can also define discriminators on single nested subdocuments, similar to how you can define discriminators on arrays of subdocuments.
+
+As a general best practice, make sure you declare any hooks on your schemas **before** you use them.
+You should **not** call `pre()` or `post()` after calling `discriminator()`.
+
+```acquit
+[require:Single nested discriminators]
+```

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -273,6 +273,7 @@ describe('discriminator docs', function() {
     const batchSchema = new Schema({ events: [eventSchema] });
 
     // `batchSchema.path('events')` gets the mongoose `DocumentArray`
+    // For TypeScript, use `schema.path<Schema.Types.DocumentArray>('events')`
     const docArray = batchSchema.path('events');
 
     // The `events` array can contain 2 different types of events, a
@@ -391,6 +392,7 @@ describe('discriminator docs', function() {
     const shapeSchema = Schema({ name: String }, { discriminatorKey: 'kind' });
     const schema = Schema({ shape: shapeSchema });
 
+    // For TypeScript, use `schema.path<Schema.Types.Subdocument>('shape').discriminator(...)`
     schema.path('shape').discriminator('Circle', Schema({ radius: String }));
     schema.path('shape').discriminator('Square', Schema({ side: Number }));
 


### PR DESCRIPTION
Re: #10435

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Added back embedded discriminator docs, with a couple of comments on `path()` generic requirement for TypeScript.

I'll take another look and see if we can maybe remove the need to do `schema.path<Schema.Types.Subdocument>` and just have Mongoose infer the type correctly.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
