### PR TITLE
docs(middleware): clarify that query middleware applies to document by default

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -407,6 +407,28 @@ schema.pre('deleteOne', { query: true, document: false }, function() {
 });
 ```
 
+Mongoose also has both query and document hooks for `validate()`.
+Unlike `deleteOne` and `updateOne`, `validate` middleware applies to `Document.prototype.validate` by default.
+
+```javascript
+const schema = new mongoose.Schema({ name: String });
+schema.pre('validate', function() {
+  console.log('Document validate');
+});
+schema.pre('validate', { query: true, document: false }, function() {
+  console.log('Query validate');
+});
+const Test = mongoose.model('Test', schema);
+
+const doc = new Test({ name: 'foo' });
+
+// Prints "Document validate"
+await doc.validate();
+
+// Prints "Query validate"
+await Test.find().validate();
+```
+
 <h2 id="notes"><a href="#notes">Notes on findAndUpdate() and Query Middleware</a></h2>
 
 Pre and post `save()` hooks are **not** executed on `update()`,


### PR DESCRIPTION
Fix #13713

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We don't explain that `validate` hooks apply to document middleware by default anywhere, this PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
