### PR TITLE
fix(cursor): bubble up resumeTokenChanged event from change streams

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -10,6 +10,12 @@ const EventEmitter = require('events').EventEmitter;
  * ignore
  */
 
+const driverChangeStreamEvents = ['close', 'change', 'end', 'error', 'resumeTokenChanged'];
+
+/*!
+ * ignore
+ */
+
 class ChangeStream extends EventEmitter {
   constructor(changeStreamThunk, pipeline, options) {
     super();
@@ -52,7 +58,7 @@ class ChangeStream extends EventEmitter {
           this.closed = true;
         });
 
-        ['close', 'change', 'end', 'error'].forEach(ev => {
+        driverChangeStreamEvents.forEach(ev => {
           this.driverChangeStream.on(ev, data => {
             // Sometimes Node driver still polls after close, so
             // avoid any uncaught exceptions due to closed change streams
@@ -75,7 +81,7 @@ class ChangeStream extends EventEmitter {
       this.closed = true;
     });
 
-    ['close', 'change', 'end', 'error'].forEach(ev => {
+    driverChangeStreamEvents.forEach(ev => {
       this.driverChangeStream.on(ev, data => {
         // Sometimes Node driver still polls after close, so
         // avoid any uncaught exceptions due to closed change streams

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3404,7 +3404,7 @@ describe('Model', function() {
         let listener;
 
         before(function() {
-          if (!process.env.REPLICA_SET) {
+          if (!process.env.REPLICA_SET && !process.env.START_REPLICA_SET) {
             this.skip();
           }
         });
@@ -3434,6 +3434,20 @@ describe('Model', function() {
           assert.equal(changeData.operationType, 'insert');
           assert.equal(changeData.fullDocument._id.toHexString(),
             doc._id.toHexString());
+        });
+
+        it('bubbles up resumeTokenChanged events (gh-13607)', async function() {
+          const MyModel = db.model('Test', new Schema({ name: String }));
+
+          const resumeTokenChangedEvent = new Promise(resolve => {
+            changeStream = MyModel.watch();
+            listener = data => resolve(data);
+            changeStream.once('resumeTokenChanged', listener);
+          });
+
+          await MyModel.create({ name: 'test' });
+          const { _data } = await resumeTokenChangedEvent;
+          assert.ok(_data);
         });
 
         it('using next() and hasNext() (gh-11527)', async function() {


### PR DESCRIPTION
Fix #13607

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

It looks like MongoDB driver change streams emit a resumeTokenChanged event that Mongoose change streams aren't propagating. This PR fixes that, and also makes it so that change stream tests run in CI.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
