### PR TITLE
fix: missing typings for option includeResultMetadata

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -16,7 +16,7 @@ import mongoose, {
 } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
-import { UpdateOneModel, ChangeStreamInsertDocument } from 'mongodb';
+import { UpdateOneModel, ChangeStreamInsertDocument, ObjectId } from 'mongodb';
 
 function rawDocSyntax(): void {
   interface ITest {
@@ -672,4 +672,26 @@ async function gh13705() {
 
   const findOneAndUpdateRes = await TestModel.findOneAndUpdate({}, {}, { lean: true });
   expectType<ExpectedLeanDoc | null>(findOneAndUpdateRes);
+}
+
+async function gh13746() {
+  const schema = new Schema({ name: String });
+  const TestModel = model('Test', schema);
+
+  type OkType = 0 | 1;
+
+  const findByIdAndUpdateRes = await TestModel.findByIdAndUpdate('0'.repeat(24), {}, { includeResultMetadata: true });
+  expectType<boolean | undefined>(findByIdAndUpdateRes.lastErrorObject?.updatedExisting);
+  expectType<ObjectId | undefined>(findByIdAndUpdateRes.lastErrorObject?.upserted);
+  expectType<OkType>(findByIdAndUpdateRes.ok);
+
+  const findOneAndReplaceRes = await TestModel.findOneAndReplace({ _id: '0'.repeat(24) }, {}, { includeResultMetadata: true });
+  expectType<boolean | undefined>(findOneAndReplaceRes.lastErrorObject?.updatedExisting);
+  expectType<ObjectId | undefined>(findOneAndReplaceRes.lastErrorObject?.upserted);
+  expectType<OkType>(findOneAndReplaceRes.ok);
+
+  const findOneAndUpdateRes = await TestModel.findOneAndUpdate({ _id: '0'.repeat(24) }, {}, { includeResultMetadata: true });
+  expectType<boolean | undefined>(findOneAndUpdateRes.lastErrorObject?.updatedExisting);
+  expectType<ObjectId | undefined>(findOneAndUpdateRes.lastErrorObject?.upserted);
+  expectType<OkType>(findOneAndUpdateRes.ok);
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -560,6 +560,11 @@ declare module 'mongoose' {
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,
       update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
+    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate'>;
+    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
+      id: mongodb.ObjectId | any,
+      update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate'>;
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
@@ -614,6 +619,11 @@ declare module 'mongoose' {
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,
       replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
+    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace'>;
+    findOneAndReplace<ResultDoc = THydratedDocumentType>(
+      filter: FilterQuery<TRawDocType>,
+      replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace'>;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
@@ -638,6 +648,11 @@ declare module 'mongoose' {
       filter: FilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { rawResult: true }
+    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate'>;
+    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
+      filter: FilterQuery<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate'>;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,


### PR DESCRIPTION
Fixes https://github.com/Automattic/mongoose/issues/13746

**Summary**
Typescript was complaining of missing types when I was using `includeResultMetadata`. So in this PR, I fixed that issue by adding the missing types for it.
