### PR TITLE
fix(query+populate): add `refPath` to projection by default, unless explicitly excluded

### DIFF
--- a/lib/helpers/query/selectPopulatedFields.js
+++ b/lib/helpers/query/selectPopulatedFields.js
@@ -21,11 +21,24 @@ module.exports = function selectPopulatedFields(fields, userProvidedFields, popu
       } else if (userProvidedFields[path] === 0) {
         delete fields[path];
       }
+
+      const refPath = populateOptions[path]?.refPath;
+      if (typeof refPath === 'string') {
+        if (!isPathInFields(userProvidedFields, refPath)) {
+          fields[refPath] = 1;
+        } else if (userProvidedFields[refPath] === 0) {
+          delete fields[refPath];
+        }
+      }
     }
   } else if (isExclusive(fields)) {
     for (const path of paths) {
       if (userProvidedFields[path] == null) {
         delete fields[path];
+      }
+      const refPath = populateOptions[path]?.refPath;
+      if (typeof refPath === 'string' && userProvidedFields[refPath] == null) {
+        delete fields[refPath];
       }
     }
   }

--- a/test/helpers/query.selectPopulatedFields.test.js
+++ b/test/helpers/query.selectPopulatedFields.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('assert');
+const selectPopulatedFields = require('../../lib/helpers/query/selectPopulatedFields');
+
+describe('selectPopulatedFields', function() {
+  it('selects refPath', function() {
+    const fields = { name: 1 };
+    const userProvidedFields = { name: 1 };
+    const populateOptions = {
+      parent: {
+        refPath: 'parentModel'
+      }
+    };
+    selectPopulatedFields(fields, userProvidedFields, populateOptions);
+    assert.deepStrictEqual(fields, {
+      name: 1,
+      parent: 1,
+      parentModel: 1
+    });
+  });
+
+  it('adds refPath to projection if not deselected by user in exclusive projection', function() {
+    const fields = { name: 0, parentModel: 0 };
+    const userProvidedFields = { name: 0 };
+    const populateOptions = {
+      parent: {
+        refPath: 'parentModel'
+      }
+    };
+    selectPopulatedFields(fields, userProvidedFields, populateOptions);
+    assert.deepStrictEqual(fields, {
+      name: 0
+    });
+  });
+});


### PR DESCRIPTION
Fix mongodb-js/mongoose-autopopulate#96

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In order to `populate()` correctly, we need the field referenced by `refPath`. We already project in populated fields by default, so adding `refPath` unless explicitly excluded is reasonable.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
