### PR TITLE
fix(schema): support 'ascending', 'asc', 'descending', 'desc' for index direction

### DIFF
--- a/lib/helpers/schema/getIndexes.js
+++ b/lib/helpers/schema/getIndexes.js
@@ -78,7 +78,15 @@ module.exports = function getIndexes(schema) {
           field[prefix + key] = 'text';
           delete options.text;
         } else {
-          const isDescendingIndex = Number(index) === -1;
+          let isDescendingIndex = false;
+          if (index === 'descending' || index === 'desc') {
+            isDescendingIndex = true;
+          } else if (index === 'ascending' || index === 'asc') {
+            isDescendingIndex = false;
+          } else {
+            isDescendingIndex = Number(index) === -1;
+          }
+
           field[prefix + key] = isDescendingIndex ? -1 : 1;
         }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2046,6 +2046,14 @@ Schema.prototype.index = function(fields, options) {
     utils.expires(options);
   }
 
+  for (const field of Object.keys(fields)) {
+    if (fields[field] === 'ascending' || fields[field] === 'asc') {
+      fields[field] = 1;
+    } else if (fields[field] === 'descending' || fields[field] === 'desc') {
+      fields[field] = -1;
+    }
+  }
+
   this._indexes.push([fields, options]);
   return this;
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -856,6 +856,21 @@ describe('schema', function() {
         assert.deepEqual(indexes[1][0], { prop2: 1 });
       });
 
+      it('using "ascending" and "descending" for order (gh-13725)', function() {
+        const testSchema = new Schema({
+          prop1: { type: String, index: 'ascending' },
+          prop2: { type: Number, index: 'descending' },
+          prop3: { type: String }
+        });
+        testSchema.index({ prop3: 'desc' }, { unique: true });
+
+        const indexes = testSchema.indexes();
+        assert.equal(indexes.length, 3);
+        assert.deepEqual(indexes[0][0], { prop1: 1 });
+        assert.deepEqual(indexes[1][0], { prop2: -1 });
+        assert.deepEqual(indexes[2][0], { prop3: -1 });
+      });
+
       it('with single nested doc (gh-6113)', function() {
         const pointSchema = new Schema({
           type: {
@@ -873,8 +888,6 @@ describe('schema', function() {
         assert.deepEqual(schema.indexes(), [
           [{ point: '2dsphere' }, { background: true }]
         ]);
-
-
       });
 
       it('with embedded discriminator (gh-6485)', function() {

--- a/test/types/mongo.test.ts
+++ b/test/types/mongo.test.ts
@@ -2,11 +2,6 @@ import * as mongoose from 'mongoose';
 import { expectType } from 'tsd';
 import * as bson from 'bson';
 
-<<<<<<< HEAD
-import GridFSBucket = mongoose.mongo.GridFSBucket;
-
-=======
->>>>>>> 6.x
 function gh12537() {
   const schema = new mongoose.Schema({ test: String });
   const model = mongoose.model('Test', schema);

--- a/types/augmentations.d.ts
+++ b/types/augmentations.d.ts
@@ -6,8 +6,4 @@ declare module 'bson' {
     /** Mongoose automatically adds a conveniency "_id" getter on the base ObjectId class */
     _id: this;
   }
-<<<<<<< HEAD
 }
-=======
-}
->>>>>>> 6.x

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -30,7 +30,7 @@ declare module 'mongoose' {
      OptionalPaths<DocDefinition, TSchemaOptions['typeKey']>)]: ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>;
    };
 
-  /**
+   /**
    * @summary Obtains document schema type from Schema instance.
    * @param {Schema} TSchema `typeof` a schema instance.
    * @example
@@ -39,7 +39,7 @@ declare module 'mongoose' {
    * // result
    * type UserType = {userName?: string}
    */
-  export type InferSchemaType<TSchema> = IfAny<TSchema, any, ObtainSchemaGeneric<TSchema, 'DocType'>>;
+   export type InferSchemaType<TSchema> = IfAny<TSchema, any, ObtainSchemaGeneric<TSchema, 'DocType'>>;
 
   /**
    * @summary Obtains schema Generic type by using generic alias.


### PR DESCRIPTION
Fix #13725

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Our TypeScript types say Mongoose supports 'ascending' and 'descending' as `IndexDirection`, but runtime behavior doesn't support that. I figure it is easy enough to add support to runtime behavior rather than removing the TypeScript types.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
