### PR TITLE
upgrade to mongodb-memory-server 9.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.34.x
+          deno-version: v1.37.x
       - run: deno --version
       - run: npm install
       - name: Run Deno tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,17 +41,17 @@ jobs:
       matrix:
         node: [14, 16, 18, 20]
         os: [ubuntu-20.04, ubuntu-22.04]
-        mongodb: [4.4.22, 5.0.19, 6.0.9, 7.0.0]
+        mongodb: [4.4.28, 5.0.25, 6.0.14, 7.0.7]
         include:
           - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
-            mongodb: 5.0.14
+            mongodb: 5.0.25
             node: 16
             coverage: true
         exclude:
           - os: ubuntu-22.04 # exclude because there are no 4.x mongodb builds for 2204
-            mongodb: 4.4.22
+            mongodb: 4.4.28
           - os: ubuntu-22.04 # exclude because there are no 5.x mongodb builds for 2204
-            mongodb: 5.0.19
+            mongodb: 5.0.25
     name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongodb }} OS ${{ matrix.os }}
     env:
       MONGOMS_VERSION: ${{ matrix.mongodb }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Deno tests
     env:
-      MONGOMS_VERSION: 6.0.9
+      MONGOMS_VERSION: 6.0.14
       MONGOMS_PREFER_GLOBAL_PATH: 1
       FORCE_COLOR: true
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         node: [14, 16, 18, 20]
         os: [ubuntu-20.04, ubuntu-22.04]
-        mongodb: [4.4.22, 5.0.19, 6.0.9]
+        mongodb: [4.4.22, 5.0.19, 6.0.9, 7.0.0]
         include:
           - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
             mongodb: 5.0.14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         node: [14, 16, 18, 20]
         os: [ubuntu-20.04, ubuntu-22.04]
-        mongodb: [4.4.18, 5.0.14, 6.0.4]
+        mongodb: [4.4.22, 5.0.19, 6.0.9]
         include:
           - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
             mongodb: 5.0.14
@@ -49,9 +49,9 @@ jobs:
             coverage: true
         exclude:
           - os: ubuntu-22.04 # exclude because there are no 4.x mongodb builds for 2204
-            mongodb: 4.4.18
+            mongodb: 4.4.22
           - os: ubuntu-22.04 # exclude because there are no 5.x mongodb builds for 2204
-            mongodb: 5.0.14
+            mongodb: 5.0.19
     name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongodb }} OS ${{ matrix.os }}
     env:
       MONGOMS_VERSION: ${{ matrix.mongodb }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Deno tests
     env:
-      MONGOMS_VERSION: 6.0.4
+      MONGOMS_VERSION: 6.0.9
       MONGOMS_PREFER_GLOBAL_PATH: 1
       FORCE_COLOR: true
     steps:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mkdirp": "^3.0.1",
     "mocha": "10.2.0",
     "moment": "2.x",
-    "mongodb-memory-server": "9.1.8",
+    "mongodb-memory-server": "9.2.0",
     "ncp": "^2.0.0",
     "nyc": "15.1.0",
     "pug": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mkdirp": "^3.0.1",
     "mocha": "10.2.0",
     "moment": "2.x",
-    "mongodb-memory-server": "9.0.0",
+    "mongodb-memory-server": "9.1.8",
     "ncp": "^2.0.0",
     "nyc": "15.1.0",
     "pug": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mkdirp": "^3.0.1",
     "mocha": "10.2.0",
     "moment": "2.x",
-    "mongodb-memory-server": "8.15.1",
+    "mongodb-memory-server": "9.0.0",
     "ncp": "^2.0.0",
     "nyc": "15.1.0",
     "pug": "3.0.2",

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -27,7 +27,7 @@ describe('schema select option', function() {
 
   it('excluding paths through schematype', async function() {
     // data clearing is required for this test, because in deno some other test leaks a "_id: immutable" index
-    await require('./util').clearTestData(db);
+    await db.dropDatabase();
 
     const schema = new Schema({
       thin: Boolean,

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -26,6 +26,9 @@ describe('schema select option', function() {
   afterEach(() => require('./util').stopRemainingOps(db));
 
   it('excluding paths through schematype', async function() {
+    // data clearing is required for this test, because in deno some other test leaks a "_id: immutable" index
+    await require('./util').clearTestData(db);
+
     const schema = new Schema({
       thin: Boolean,
       name: { type: String, select: false },


### PR DESCRIPTION
**Summary**

This PR upgrades `mongodb-memory-server` to `9.0.0`(`-beta.2`), but also does:
- upgrade all used mongodb version's patch version
- add mongodb `7.0.0` as a test (because mms more probably supports it with 9.0.0)
- upgrade deno to 1.36 (because with the new mms version, 1.34 just gets stuck before even starting the server)

Currently known problems:
deno really does not like the new MMS (mongodb?) version, constant `Server selection timed out` and locally many test fail too.
also in a debug run in CI it seems like the server somehow has a lot of failed hearbeats, and i dont understand why

even when testing locally against a mongodb docker container (via `MONGOOSE_TEST_URI`), those same tests fail and the final error logged also is `Server selection timed out after 30000 ms`