### PR TITLE
fix(model): make Model.bulkWrite() with empty array and ordered false not throw an error

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3796,6 +3796,10 @@ Model.bulkWrite = function(ops, options, callback) {
     function completeUnorderedValidation() {
       validOps = validOps.sort().map(index => ops[index]);
 
+      if (validOps.length === 0) {
+        return cb(null, getDefaultBulkwriteResult());
+      }
+
       this.$__collection.bulkWrite(validOps, options, (error, res) => {
         if (error) {
           if (validationErrors.length > 0) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7856,9 +7856,32 @@ describe('Model', function() {
     const userSchema = new Schema({ name: String });
     const User = db.model('User', userSchema);
 
-    const err = await User.bulkWrite([], { ordered: false }).then(() => null, err => err);
-    assert.ok(err);
-    assert.equal(err.name, 'MongoInvalidArgumentError');
+    const res = await User.bulkWrite([], { ordered: false });
+    assert.deepEqual(
+      res,
+      {
+        result: {
+          ok: 1,
+          writeErrors: [],
+          writeConcernErrors: [],
+          insertedIds: [],
+          nInserted: 0,
+          nUpserted: 0,
+          nMatched: 0,
+          nModified: 0,
+          nRemoved: 0,
+          upserted: []
+        },
+        insertedCount: 0,
+        matchedCount: 0,
+        modifiedCount: 0,
+        deletedCount: 0,
+        upsertedCount: 0,
+        upsertedIds: {},
+        insertedIds: {},
+        n: 0
+      }
+    );
   });
 
   it('allows calling `create()` after `bulkWrite()` (gh-9350)', async function() {


### PR DESCRIPTION
Fix #13664

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

@JavaScriptBach is right that the fact that `bulkWrite([], { ordered: false })` throwing an error is a bit of a rough patch in the API. Especially since `bulkWrite([])` (no `ordered: false`) does not throw an error.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
