### PR TITLE
fix(document): make array getters avoid unintentionally modifying array, defer getters until index access instead

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4091,6 +4091,14 @@ function applyGetters(self, json, options) {
       if (ii === last) {
         const val = self.$get(path);
         branch[part] = clone(val, options);
+        if (Array.isArray(branch[part]) && schema.paths[path].$embeddedSchemaType) {
+          for (let i = 0; i < branch[part].length; ++i) {
+            branch[part][i] = schema.paths[path].$embeddedSchemaType.applyGetters(
+              branch[part][i],
+              self
+            );
+          }
+        }
       } else if (v == null) {
         if (part in cur) {
           branch[part] = v;

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -289,13 +289,6 @@ SchemaArray.prototype.applyGetters = function(value, scope) {
   }
 
   const ret = SchemaType.prototype.applyGetters.call(this, value, scope);
-  if (Array.isArray(ret)) {
-    const rawValue = utils.isMongooseArray(ret) ? ret.__array : ret;
-    const len = rawValue.length;
-    for (let i = 0; i < len; ++i) {
-      rawValue[i] = this.caster.applyGetters(rawValue[i], scope);
-    }
-  }
   return ret;
 };
 

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -90,6 +90,9 @@ function MongooseArray(values, path, doc, schematype) {
       if (mongooseArrayMethods.hasOwnProperty(prop)) {
         return mongooseArrayMethods[prop];
       }
+      if (typeof prop === 'string' && numberRE.test(prop) && schematype?.$embeddedSchemaType != null) {
+        return schematype.$embeddedSchemaType.applyGetters(__array[prop], doc);
+      }
 
       return __array[prop];
     },

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12387,7 +12387,7 @@ describe('document', function() {
     assert.equal(oneUser.hobbies[0], 'swimming');
     assert.equal(oneUser.hobbies[0], 'swimming');
   });
-    
+
   it('sets defaults on subdocs with subdoc projection (gh-13720)', async function() {
     const subSchema = new mongoose.Schema({
       propertyA: { type: String, default: 'A' },

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -5564,6 +5564,7 @@ describe('document', function() {
       const Test = db.model('Test', testSchema);
 
       const doc = new Test({ arr: [new mongoose.Types.ObjectId()] });
+      assert.equal(called, 0);
       assert.deepEqual(doc.toObject({ getters: true }).arr, [42]);
       assert.equal(called, 1);
     });
@@ -5581,7 +5582,6 @@ describe('document', function() {
       });
 
       const Test = db.model('Test', testSchema);
-
 
       let doc = await Test.create({ arr: [new mongoose.Types.ObjectId()] });
       assert.equal(called, 1);
@@ -12341,6 +12341,51 @@ describe('document', function() {
     const test2 = {};
     assert.strictEqual(test2.constructor.polluted, undefined);
     assert.strictEqual(Object.polluted, undefined);
+  });
+
+  it('does not modify array when calling getters (gh-13748)', async function() {
+    // create simple setter to add a sufix
+    const addSufix = (name) => {
+      return name + '-sufix';
+    };
+
+    // create simple gettrer to remove last 6 letters (should be "-sufix")
+    const removeSufix = (name) => {
+      return ('' + name).slice(0, -6);
+    };
+
+    const userSchema = new mongoose.Schema(
+      {
+        name: String,
+        age: Number,
+        profession: {
+          type: String,
+          get: removeSufix,
+          set: addSufix
+        },
+        hobbies: [{ type: String, get: removeSufix, set: addSufix }]
+      },
+      {
+        toObject: { getters: true },
+        toJSON: { getters: true }
+      }
+    );
+    const User = db.model('User', userSchema);
+
+    const usr = await User.create({
+      name: 'John',
+      age: 18,
+      profession: 'teacher',
+      hobbies: ['swimming', 'football']
+    });
+
+    const oneUser = await User.findById(usr._id).orFail();
+    assert.equal(oneUser.profession, 'teacher');
+    assert.equal(oneUser.profession, 'teacher');
+    assert.equal(oneUser.profession, 'teacher');
+    assert.equal(oneUser.hobbies[0], 'swimming');
+    assert.equal(oneUser.hobbies[0], 'swimming');
+    assert.equal(oneUser.hobbies[0], 'swimming');
   });
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13748 points out that accessing `user.hobbies` actually modifies the `hobbies` array if there's a getter on elements of the `hobbies` array. That is a problem. To fix that, I moved the logic for applying getters from `SchemaArray.prototype.applyGetters()`, which is also called when you access `user.hobbies`, and into the top-level `applyGetters()` function, which is only called by `toObject()` and `toJSON()`.

As a side effect, in order to avoid breaking Schema UUID tests, we instead need to apply getters on index access. So `user.hobbies[0]` will fire getters on `hobbies.0`, but not modify `hobbies`. That's what the changes to `types/array/index.js` are for.

Still to investigate: it looks like `oneUser.get('hobbies.0')` double calls getters with this PR. Worth checking before merging.

Also need to think about whether to merge this in 7.5, or wait for 8.0. The `types/array/index.js` changes seem a bit too heavy for a patch release.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
