### PR TITLE
BREAKING CHANGE: stop using mquery for `updateX()`, `deleteX()`, `sort()`, always convert sort args to objects

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -37,6 +37,7 @@ const sanitizeFilter = require('./helpers/query/sanitizeFilter');
 const sanitizeProjection = require('./helpers/query/sanitizeProjection');
 const selectPopulatedFields = require('./helpers/query/selectPopulatedFields');
 const setDefaultsOnInsert = require('./helpers/setDefaultsOnInsert');
+const specialProperties = require('./helpers/specialProperties');
 const updateValidators = require('./helpers/updateValidators');
 const util = require('util');
 const utils = require('./utils');
@@ -2340,8 +2341,6 @@ Query.prototype.find = function(conditions) {
     this.error(new ObjectParameterError(conditions, 'filter', 'find'));
   }
 
-  Query.base.find.call(this);
-
   return this;
 };
 
@@ -2588,8 +2587,6 @@ Query.prototype.findOne = function(conditions, projection, options) {
   } else if (conditions != null) {
     this.error(new ObjectParameterError(conditions, 'filter', 'findOne'));
   }
-
-  Query.base.findOne.call(this);
 
   return this;
 };
@@ -2870,8 +2867,71 @@ Query.prototype.sort = function(arg) {
     throw new Error('sort() only takes 1 Argument');
   }
 
-  return Query.base.sort.call(this, arg);
+  if (this.options.sort == null) {
+    this.options.sort = {};
+  }
+  const sort = this.options.sort;
+  if (typeof arg === 'string') {
+    const properties = arg.indexOf(' ') === -1 ? [arg] : arg.split(' ');
+    for (let property of properties) {
+      const ascend = '-' == property[0] ? -1 : 1;
+      if (ascend === -1) {
+        property = property.slice(1);
+      }
+      if (specialProperties.has(property)) {
+        continue;
+      }
+      sort[property] = ascend;
+    }
+  } else if (Array.isArray(arg)) {
+    for (const pair of arg) {
+      if (!Array.isArray(pair)) {
+        throw new TypeError('Invalid sort() argument, must be array of arrays');
+      }
+      const key = '' + pair[0];
+      if (specialProperties.has(key)) {
+        continue;
+      }
+      sort[key] = _handleSortValue(pair[1], key);
+    }
+  } else if (typeof arg === 'object' && arg != null && !(arg instanceof Map)) {
+    for (const key of Object.keys(arg)) {
+      if (specialProperties.has(key)) {
+        continue;
+      }
+      sort[key] = _handleSortValue(arg[key], key);
+    }
+  } else if (arg instanceof Map) {
+    for (let key of arg.keys()) {
+      key = '' + key;
+      if (specialProperties.has(key)) {
+        continue;
+      }
+      sort[key] = _handleSortValue(arg.get(key), key);
+    }
+  } else if (arg != null) {
+    throw new TypeError('Invalid sort() argument. Must be a string, object, array, or map.');
+  }
+
+  return this;
 };
+
+/*!
+ * Convert sort values
+ */
+
+function _handleSortValue(val, key) {
+  if (val === 1 || val === 'asc' || val === 'ascending') {
+    return 1;
+  }
+  if (val === -1 || val === 'desc' || val === 'descending') {
+    return -1;
+  }
+  if (val?.$meta != null) {
+    return { $meta: val.$meta };
+  }
+  throw new TypeError('Invalid sort value: { ' + key + ': ' + val + ' }');
+}
 
 /**
  * Declare and/or execute this query as a `deleteOne()` operation. Works like
@@ -2920,8 +2980,6 @@ Query.prototype.deleteOne = function deleteOne(filter, options) {
   } else if (filter != null) {
     this.error(new ObjectParameterError(filter, 'filter', 'deleteOne'));
   }
-
-  Query.base.deleteOne.call(this);
 
   return this;
 };
@@ -2995,8 +3053,6 @@ Query.prototype.deleteMany = function(filter, options) {
   } else if (filter != null) {
     this.error(new ObjectParameterError(filter, 'filter', 'deleteMany'));
   }
-
-  Query.base.deleteMany.call(this);
 
   return this;
 };
@@ -4140,7 +4196,7 @@ function _update(query, op, filter, doc, options, callback) {
     return query;
   }
 
-  return Query.base[op].call(query, filter, void 0, options, callback);
+  return query;
 }
 
 /**
@@ -5028,7 +5084,9 @@ Query.prototype.tailable = function(val, opts) {
     }
   }
 
-  return Query.base.tailable.call(this, val);
+  this.options.tailable = arguments.length ? !!val : true;
+
+  return this;
 };
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -772,12 +772,9 @@ describe('Query', function() {
       query.sort({ a: 1, c: -1, b: 'asc', e: 'descending', f: 'ascending' });
       assert.deepEqual(query.options.sort, { a: 1, c: -1, b: 1, e: -1, f: 1 });
 
-      if (typeof global.Map !== 'undefined') {
-        query = new Query({});
-        query.sort(new global.Map().set('a', 1).set('b', 1));
-        assert.equal(query.options.sort.get('a'), 1);
-        assert.equal(query.options.sort.get('b'), 1);
-      }
+      query = new Query({});
+      query.sort(new Map().set('a', 1).set('b', 1));
+      assert.deepStrictEqual(query.options.sort, { a: 1, b: 1 });
 
       query = new Query({});
       let e;

--- a/test/query.toconstructor.test.js
+++ b/test/query.toconstructor.test.js
@@ -180,7 +180,7 @@ describe('Query:', function() {
       const query = Model.find().sort([['name', 1]]);
       const Query = query.toConstructor();
       const q = new Query();
-      assert.deepEqual(q.options.sort, [['name', 1]]);
+      assert.deepEqual(q.options.sort, { name: 1 });
     });
   });
 });


### PR DESCRIPTION
Re: #13617

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Unfortunately there's a lot of functionality duplicated between mongoose and mquery, so with #13617 we're moving towards moving this logic into mongoose for easier maintenance. The big change in this PR is `sort()`: we've moved sort handling into Mongoose, and we're making `options.sort` always an object. We're now converting `.sort([['a', 1]])` into `.sort({ a: 1 })`, rather than leaving it as `[['a', 1]]` under the hood. Keeping entries-style syntax internally is not necessary post ES2015, key order is still maintained, and that removes the need for us to handle edge cases like `.sort([['a', 1]]).sort({ b: 1 })`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
