### PR TITLE
fix(debug): avoid putting virtuals and getters in debug output

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -9,6 +9,7 @@ const MongooseError = require('../../error/mongooseError');
 const Collection = require('mongodb').Collection;
 const ObjectId = require('../../types/objectid');
 const getConstructorName = require('../../helpers/getConstructorName');
+const internalToObjectOptions = require('../../options').internalToObjectOptions;
 const stream = require('stream');
 const util = require('util');
 
@@ -377,7 +378,7 @@ function format(obj, sub, color, shell) {
   }
 
   const clone = require('../../helpers/clone');
-  let x = clone(obj, { transform: false });
+  let x = clone(obj, internalToObjectOptions);
   const constructorName = getConstructorName(x);
 
   if (constructorName === 'Binary') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I was losing my mind for a bit figuring out why I was seeing a virtual in my debug output, even though I was passing a [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) into `updateOne()`. Turns out that debug output will run virtuals and getters by default on document arrays, which doesn't accurately reflect the data passed into the mongodb driver.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
