### PR TITLE
feat: allow top level dollar keys with findOneAndUpdate(), update()

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -14,6 +14,24 @@ const schemaMixedSymbol = require('../../schema/symbols').schemaMixedSymbol;
 const setDottedPath = require('../path/setDottedPath');
 const utils = require('../../utils');
 
+const mongodbUpdateOperators = new Set([
+  '$currentDate',
+  '$inc',
+  '$min',
+  '$max',
+  '$mul',
+  '$rename',
+  '$set',
+  '$setOnInsert',
+  '$unset',
+  '$addToSet',
+  '$pop',
+  '$pull',
+  '$push',
+  '$pullAll',
+  '$bit'
+]);
+
 /**
  * Casts an update op based on the given schema
  *
@@ -58,7 +76,7 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
   while (i--) {
     const op = ops[i];
     // if overwrite is set, don't do any of the special $set stuff
-    if (op[0] !== '$' && !overwrite) {
+    if (!mongodbUpdateOperators.has(op) && !overwrite) {
       // fix up $set sugar
       if (!ret.$set) {
         if (obj.$set) {
@@ -88,7 +106,7 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     if (val &&
         typeof val === 'object' &&
         !Buffer.isBuffer(val) &&
-        (!overwrite || hasDollarKey)) {
+        (!overwrite || mongodbUpdateOperators.has(op))) {
       walkUpdatePath(schema, val, op, options, context, filter);
     } else if (overwrite && ret && typeof ret === 'object') {
       walkUpdatePath(schema, ret, '$set', options, context, filter);
@@ -540,7 +558,7 @@ function castUpdateVal(schema, val, op, $conditional, context, path) {
     return Boolean(val);
   }
 
-  if (/^\$/.test($conditional)) {
+  if (mongodbUpdateOperators.has($conditional)) {
     return schema.castForQuery(
       $conditional,
       val,

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3051,6 +3051,18 @@ describe('model: updateOne: ', function() {
       await Person.updateOne({ name: 'Anakin' }, { name: 'The Chosen One' }).orFail();
     }, { message: 'No document found for query "{ name: \'Anakin\' }" on model "gh-11620"' });
   });
+  it('updateOne with top level key that starts with $ (gh-13786)', async function() {
+    const schema = new mongoose.Schema({
+      $myKey: String
+    });
+
+    const Test = db.model('Test', schema);
+
+    const _id = new mongoose.Types.ObjectId();
+    await Test.updateOne({ _id }, { $myKey: 'gh13786' }, { upsert: true });
+    const doc = await Test.findById(_id);
+    assert.equal(doc.$myKey, 'gh13786');
+  });
 });
 
 async function delay(ms) {

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3052,6 +3052,11 @@ describe('model: updateOne: ', function() {
     }, { message: 'No document found for query "{ name: \'Anakin\' }" on model "gh-11620"' });
   });
   it('updateOne with top level key that starts with $ (gh-13786)', async function() {
+    const [major] = await start.mongodVersion();
+    if (major < 5) {
+      return this.skip();
+    }
+
     const schema = new mongoose.Schema({
       $myKey: String
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, MongoDB allows storing top-level keys that start with $, but our `castUpdate()` function doesn't allow top-level dollar keys.

```javascript
'use strict';
  
const mongoose = require('mongoose');
mongoose.set('debug', true);

void async function main() {
  await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_test');
  //await mongoose.connection.dropDatabase();

  await mongoose.connection.collection('test').insertOne({ $set: [1,2, 3, 4] });
  console.log(await mongoose.connection.collection('test').find().toArray());
  console.log('Done');
}();
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
