### PR TITLE
types(schematypes): add missing BigInt SchemaType

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1177,3 +1177,9 @@ function gh13702() {
   const schema = new Schema({ name: String });
   expectType<[IndexDefinition, IndexOptions][]>(schema.indexes());
 }
+
+function gh13780() {
+  const schema = new Schema({ num: Schema.Types.BigInt });
+  type InferredType = InferSchemaType<typeof schema>;
+  expectType<bigint | undefined>(null as unknown as InferredType['num']);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -215,14 +215,16 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
                                   PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 ? Types.Decimal128 :
                                     IfEquals<PathValueType, Schema.Types.Decimal128> extends true ? Types.Decimal128 :
                                       IfEquals<PathValueType, Types.Decimal128> extends true ? Types.Decimal128 :
-                                        PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
-                                          IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
-                                            PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
-                                              IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
-                                                PathValueType extends ArrayConstructor ? any[] :
-                                                  PathValueType extends typeof Schema.Types.Mixed ? any:
-                                                    IfEquals<PathValueType, ObjectConstructor> extends true ? any:
-                                                      IfEquals<PathValueType, {}> extends true ? any:
-                                                        PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
-                                                          PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, { typeKey: TypeKey }> :
-                                                            unknown;
+                                        IfEquals<PathValueType, Schema.Types.BigInt> extends true ? bigint :
+                                          PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt ? bigint :
+                                            PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
+                                              IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
+                                                PathValueType extends MapConstructor ? Map<string, ResolvePathType<Options['of']>> :
+                                                  IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
+                                                    PathValueType extends ArrayConstructor ? any[] :
+                                                      PathValueType extends typeof Schema.Types.Mixed ? any:
+                                                        IfEquals<PathValueType, ObjectConstructor> extends true ? any:
+                                                          IfEquals<PathValueType, {}> extends true ? any:
+                                                            PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+                                                              PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, { typeKey: TypeKey }> :
+                                                                unknown;

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -311,6 +311,14 @@ declare module 'mongoose' {
         enum(vals: string[] | number[]): this;
       }
 
+      class BigInt extends SchemaType {
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: 'BigInt';
+
+        /** Default options for this SchemaType */
+        defaultOptions: Record<string, any>;
+      }
+
       class Boolean extends SchemaType {
         /** This schema type's name, to defend against minifiers that mangle function names. */
         static schemaName: 'Boolean';


### PR DESCRIPTION
Fix #13780

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13780 points out that accessing `mongoose.Schema.Types.BigInt` throws a compiler error in TypeScript. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
