### PR TITLE
Enhance Mongoose Typings with SearchMeta Interface for Atlas Search

### DIFF
--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -241,7 +241,7 @@ declare module 'mongoose' {
     }
 
     export interface SearchMeta {
-      /** [`$search` reference](https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/) */
+      /** [`$searchMeta` reference](https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#mongodb-pipeline-pipe.-searchMeta) */
       $searchMeta: {
         index?: string;
         highlight?: {

--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -28,6 +28,7 @@ declare module 'mongoose' {
     | PipelineStage.ReplaceWith
     | PipelineStage.Sample
     | PipelineStage.Search
+    | PipelineStage.SearchMeta
     | PipelineStage.Set
     | PipelineStage.SetWindowFields
     | PipelineStage.Skip
@@ -228,6 +229,20 @@ declare module 'mongoose' {
     export interface Search {
       /** [`$search` reference](https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/) */
       $search: {
+        index?: string;
+        highlight?: {
+          /** [`highlightPath` reference](https://docs.atlas.mongodb.com/atlas-search/path-construction/#multiple-field-search) */
+          path: string | string[] | { value: string, multi: string };
+          maxCharsToExamine?: number;
+          maxNumPassages?: number;
+        };
+        [operator: string]: any;
+      }
+    }
+
+    export interface SearchMeta {
+      /** [`$search` reference](https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/) */
+      $searchMeta: {
         index?: string;
         highlight?: {
           /** [`highlightPath` reference](https://docs.atlas.mongodb.com/atlas-search/path-construction/#multiple-field-search) */


### PR DESCRIPTION
Add search meta
**Summary:**
This pull request extends the Mongoose module typings by incorporating the SearchMeta interface. This addition offers better type definitions for developers leveraging MongoDB Atlas Search, ensuring that their implementations are more type-safe and adhere to the expected structure.

**Motivation:**
With MongoDB Atlas Search gaining traction, many developers are harnessing its full-text search capabilities within their Mongoose-based applications. By providing detailed type definitions, we can simplify their development process, prevent type-related errors, and encourage best practices.

**Key Features:**

Introduced the SearchMeta interface that encapsulates the $searchMeta aggregation pipeline stage.
Included annotations for the possible properties within this stage, such as index, highlight, and their respective sub-properties.
Provided direct links to official MongoDB documentation for easy reference.


**Examples:**
For a developer implementing the Atlas Search with Mongoose, they can now expect type suggestions and checks for the $searchMeta stage:

```
const searchAggregation = [
    {
        $searchMeta: {
            index: 'myIndex',
            highlight: {
                path: ['field1', 'field2'],
                maxCharsToExamine: 150
            }
        }
    }
];
```
With these typings in place, incorrect implementations, such as an invalid property in $searchMeta, will be flagged by TypeScript, offering a more reliable development experience.

Note: For contributors, while updating documentation, please refer to the corresponding .pug files rather than directly editing .html files.