### PR TITLE
fix(document): avoid double-calling array getters when using `.get('arr.0')`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -640,7 +640,10 @@ exports.getValue = function(path, obj, map) {
 const mapGetterOptions = Object.freeze({ getters: false });
 
 function getValueLookup(obj, part) {
-  const _from = obj?._doc || obj;
+  let _from = obj?._doc || obj;
+  if (_from != null && _from.isMongooseArrayProxy) {
+    _from = _from.__array;
+  }
   return _from instanceof Map ?
     _from.get(part, mapGetterOptions) :
     _from[part];

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12386,6 +12386,10 @@ describe('document', function() {
     assert.equal(oneUser.hobbies[0], 'swimming');
     assert.equal(oneUser.hobbies[0], 'swimming');
     assert.equal(oneUser.hobbies[0], 'swimming');
+
+    assert.equal(oneUser.get('hobbies.0'), 'swimming');
+    assert.equal(oneUser.get('hobbies.0'), 'swimming');
+    assert.equal(oneUser.get('hobbies.0'), 'swimming');
   });
 
   it('sets defaults on subdocs with subdoc projection (gh-13720)', async function() {


### PR DESCRIPTION
Re: #13748
Re: #13774

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Missed a spot when I merged #13748, but followed up on it and fix it with this PR.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
