### PR TITLE
set default value for _update when no update object is provided and versionKey is set to false

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3809,14 +3809,14 @@ function _completeManyLean(schema, docs, path, opts) {
  */
 
 Query.prototype._mergeUpdate = function(doc) {
-  if (doc == null || (typeof doc === 'object' && Object.keys(doc).length === 0)) {
-    this._update = {};
-    return;
-  }
-
   if (!this._update) {
     this._update = Array.isArray(doc) ? [] : {};
   }
+
+  if (doc == null || (typeof doc === 'object' && Object.keys(doc).length === 0)) {
+    return;
+  }
+
   if (doc instanceof Query) {
     if (Array.isArray(this._update)) {
       throw new Error('Cannot mix array and object updates');

--- a/lib/query.js
+++ b/lib/query.js
@@ -3810,6 +3810,7 @@ function _completeManyLean(schema, docs, path, opts) {
 
 Query.prototype._mergeUpdate = function(doc) {
   if (doc == null || (typeof doc === 'object' && Object.keys(doc).length === 0)) {
+    this._update = {};
     return;
   }
 

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -2184,4 +2184,20 @@ describe('model: findOneAndUpdate:', function() {
       /Cannot set `rawResult` option when `includeResultMetadata` is false/
     );
   });
+
+  it('successfully runs findOneAndUpdate with no update and versionKey set to false (gh-13783)', async function() {
+    const exampleSchema = new mongoose.Schema({
+      name: String
+    }, { versionKey: false });
+
+    const ExampleModel = db.model('Example', exampleSchema);
+
+    const document = await ExampleModel.findOneAndUpdate(
+      { name: 'test' },
+      {},
+      { upsert: true, returnDocument: 'after', returnOriginal: false }
+    );
+    assert.ok(document);
+    assert.ok(document.name, 'test');
+  });
 });


### PR DESCRIPTION
**Summary**

Fixes #13783

When calling `findOneAndUpdate` with no update query the `_decorateUpdateWithVersionKey` function adds `'$setOnInsert': { __v: 0 }` to the update doc so it passes the `_mergeUpdate` first check which then sets the `_update` to `{}` but with `versionKey` set to `false` the update doc length is 0 so the `_mergeUpdate` function returns early

this PR set a value of empty object to the `_update` property even when `Object.keys(doc).length === 0` so it's defined 
