### PR TITLE
update docs to reflect change from commit 760fa73

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3918,7 +3918,7 @@ Document.prototype.$toObject = function(options, json) {
  *
  * @param {Object} [options]
  * @param {Boolean} [options.getters=false] if true, apply all getters, including virtuals
- * @param {Boolean} [options.virtuals=false] if true, apply virtuals, including aliases. Use `{ getters: true, virtuals: false }` to just apply getters, not virtuals
+ * @param {Boolean|Object} [options.virtuals=false] if true, apply virtuals, including aliases. Use `{ getters: true, virtuals: false }` to just apply getters, not virtuals. An object of the form `{ pathsToSkip: ['someVirtual'] }` may also be used to omit specific virtuals.
  * @param {Boolean} [options.aliases=true] if `options.virtuals = true`, you can set `options.aliases = false` to skip applying aliases. This option is a no-op if `options.virtuals = false`.
  * @param {Boolean} [options.minimize=true] if true, omit any empty objects from the output
  * @param {Function|null} [options.transform=null] if set, mongoose will call this function to allow you to transform the returned object


### PR DESCRIPTION
Found this commit [0] while I was looking for a way to omit specific virtuals using toObject/toJSON, then noticed it wasn't in the api docs. Added an extra sentence to the doc to make it clear that this is an option.

First time contributing, let me know if there's anything else I can add.

[0] [760fa73](https://github.com/Automattic/mongoose/commit/760fa73b1f6fdb6ed5c7d1c8641a56803ffd530a)


