### PR TITLE
chore(workflows/test): force color

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
     env:
       MONGOMS_VERSION: ${{ matrix.mongodb }}
       MONGOMS_PREFER_GLOBAL_PATH: 1
+      FORCE_COLOR: true
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
@@ -91,6 +92,7 @@ jobs:
     env:
       MONGOMS_VERSION: 6.0.4
       MONGOMS_PREFER_GLOBAL_PATH: 1
+      FORCE_COLOR: true
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Setup node
@@ -117,6 +119,8 @@ jobs:
       - test
     runs-on: ubuntu-latest
     name: Replica Set tests
+    env:
+      FORCE_COLOR: true
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Setup node


### PR DESCRIPTION
**Summary**

This PR forces color for CI test output, which should make it easier to parse if there are problems (especially for something like debugging #13764)

Color is not enabled by default in github CI because (from what i can tell) it is detected as "not a tty"
