### PR TITLE
chore(CHANGELOG): add missing entry for mongodb 5.18.1 upgrade for 7.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 7.5.0 / 2023-08-29
 ==================
+ * feat: use mongodb driver v5.18.1
  * feat: allow top level dollar keys with findOneAndUpdate(), update() for MongoDB 5 #13786
  * fix(document): make array getters avoid unintentionally modifying array, defer getters until index access instead #13774
  * feat: deprecate `overwrite` option for findOneAndUpdate() #13578


### PR DESCRIPTION
**Summary**

This PR adds a missing entry of noting that the mongodb driver had been updated for that version, because 2aa453cba40308307f6ce90fb7ee51aa45dbeac4 was not included in the changelog.

i have already updated the [github release](https://github.com/Automattic/mongoose/releases/tag/7.5.0) to include this notice
