### PR TITLE
fix: remove duplicated 'exists' method in Model interface in models.d.ts

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -473,13 +473,6 @@ declare module 'mongoose' {
       TRawDocType,
       'findOne'
     >;
-    exists(filter: FilterQuery<TRawDocType>): QueryWithHelpers<
-      { _id: InferId<TRawDocType> } | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TRawDocType,
-      'findOne'
-    >;
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find<ResultDoc = THydratedDocumentType>(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
This PR removes a duplicated method signature for `exists` in the `Model` interface within the `types/models.d.ts` file. The duplication does not add any functional value and could potentially lead to confusion. This change aims to clean up the code for better readability and maintenance.