### PR TITLE
BREAKING CHANGE: make `Model.validate()` use `Model.castObject()` to cast, and return casted copy of object instead of modifying in place

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4064,7 +4064,7 @@ Model.aggregate = function aggregate(pipeline, options) {
  * @param {Object} obj
  * @param {Object|Array|String} pathsOrOptions
  * @param {Object} [context]
- * @return {Promise|undefined}
+ * @return {Promise<Object>} casted and validated copy of `obj` if validation succeeded
  * @api public
  */
 
@@ -4123,8 +4123,19 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
     pushNestedArrayPaths(paths, val, path);
   }
 
-  let remaining = paths.length;
   let error = null;
+  paths = new Set(paths);
+
+  try {
+    obj = this.castObject(obj);
+  } catch (err) {
+    error = err;
+    for (const key of Object.keys(error.errors || {})) {
+      paths.delete(key);
+    }
+  }
+
+  let remaining = paths.size;
 
   return new Promise((resolve, reject) => {
     for (const path of paths) {
@@ -4140,20 +4151,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
         cur = cur[pieces[i]];
       }
 
-      let val = get(obj, path, void 0);
-
-      if (val != null) {
-        try {
-          val = schemaType.cast(val);
-          cur[pieces[pieces.length - 1]] = val;
-        } catch (err) {
-          error = error || new ValidationError();
-          error.addError(path, err);
-
-          _checkDone();
-          continue;
-        }
-      }
+      const val = get(obj, path, void 0);
 
       schemaType.doValidate(val, err => {
         if (err) {
@@ -4169,7 +4167,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
         if (error) {
           reject(error);
         } else {
-          resolve();
+          resolve(obj);
         }
       }
     }


### PR DESCRIPTION
Fix #12668

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`Model.validate()` currently modifies the passed in object for casting purposes, which is inconsistent with how `Model.castObject()` works and can leave the passed-in object in a half-casted state if there's a cast error. This PR makes `Model.validate()` use `Model.castObject()` to create a casted copy of `obj`, and run validation on all paths that successfully casted.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
