### PR TITLE
BREAKING CHANGE: Safer types for `Model.distinct` and `Query.distinct`.

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -295,8 +295,9 @@ async function gh11306(): Promise<void> {
   // 3. Create a Model.
   const MyModel = model<User>('User', schema);
 
-  expectType<any[]>(await MyModel.distinct('name'));
-  expectType<string[]>(await MyModel.distinct<string>('name'));
+  expectType<unknown[]>(await MyModel.distinct('notThereInSchema'));
+  expectType<string[]>(await MyModel.distinct('name'));
+  expectType<number[]>(await MyModel.distinct<'overrideTest', number>('overrideTest'));
 }
 
 function autoTypedQuery() {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -443,8 +443,11 @@ declare module 'mongoose' {
     translateAliases(raw: any): any;
 
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
-    distinct<ReturnType = any>(field: string, filter?: FilterQuery<TRawDocType>): QueryWithHelpers<
-      Array<ReturnType>,
+    distinct<DocKey extends string, ResultType = unknown>(
+      field: DocKey,
+      filter?: FilterQuery<TRawDocType>
+    ): QueryWithHelpers<
+      Array<DocKey extends keyof TRawDocType ? TRawDocType[DocKey] : ResultType>,
       THydratedDocumentType,
       TQueryHelpers,
       TRawDocType,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -317,10 +317,10 @@ declare module 'mongoose' {
     deleteOne(): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne'>;
 
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
-    distinct<ReturnType = any>(
-      field: string,
+    distinct<DocKey extends string, ResultType = unknown>(
+      field: DocKey,
       filter?: FilterQuery<DocType>
-    ): QueryWithHelpers<Array<ReturnType>, DocType, THelpers, RawDocType, 'distinct'>;
+    ): QueryWithHelpers<Array<DocKey extends keyof DocType ? DocType[DocKey] : ResultType>, DocType, THelpers, RawDocType, 'distinct'>;
 
     /** Specifies a `$elemMatch` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     elemMatch<K = string>(path: K, val: any): this;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

W.r.t issue https://github.com/Automattic/mongoose/issues/11306

This PR improves the type safety for the return type of `Model#distinct` and `Query#distinct`. It should behave more like Mongodb does, i.e., if you give something that isn't a key on the document, you would still get an empty array or maybe something `unknown[]`. If you _do_ give the correct key from the schema, you'll get a type safe result.

**Note:** This is not a backwards compatible change, as pointed out here: https://github.com/Automattic/mongoose/issues/11306#issuecomment-1705526596

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

The changes to the tests should be good enough examples. Can add more here if required.