### PR TITLE
Handle null objects in arrays during populate operations

### DIFF
--- a/lib/helpers/populate/markArraySubdocsPopulated.js
+++ b/lib/helpers/populate/markArraySubdocsPopulated.js
@@ -38,7 +38,9 @@ module.exports = function markArraySubdocsPopulated(doc, populated) {
 
       if (utils.isMongooseDocumentArray(val)) {
         for (let j = 0; j < val.length; ++j) {
-          val[j].populated(rest, item._docs[id] == null ? void 0 : item._docs[id][j], item);
+          if(val[j]){
+            val[j].populated(rest, item._docs[id] == null ? void 0 : item._docs[id][j], item);
+          }
         }
         break;
       }


### PR DESCRIPTION
**Summary**

An exception handling mechanism has been introduced to prevent Mongoose from attempting to populate null objects within an array. This fix prevents application crashes that occur when null elements are present within an array in a document.

Prior to this fix, when encountering a null object within an array, the code would attempt to populate the null object and consequently crash. Null objects in arrays can be present in various scenarios, such as incomplete or inconsistent data.

With this fix in place, if a null object is found within an array, it will not attempt to be populated, ensuring the application's stability in such cases.

**Examples**

Consider a MongoDB document with a `founders` field designed to be an array of objects:

```javascript
founders: [
    {
      legal_form: { type: mongoose.Schema.Types.ObjectId, ref: "Legal_Form" },
      name: String,
      identification_code: String,
      ownership_percentage: Number,
    },
]
```

And the database contains a document where the `founders` field has a null object:

```javascript
[
  {
    name: 'name',
    identification_code: 'id_code',
    ownership_percentage: 51.5,
    _id: new ObjectId("63e1fc49d4ff7ce99a3a3faf")
  },
  null
]
```

Previously, this would throw the following error: `TypeError: Cannot read properties of null (reading 'populated')`.  Now, with the fix in place, Mongoose will successfully populate the non-null objects and simply ignore the null ones, preventing the `TypeError`.
