### PR TITLE
refactor(connection): get database name without using mongodb node driver internals

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -349,7 +349,7 @@ function _setClient(conn, client, options, dbName) {
     client.s.options.hosts &&
     client.s.options.hosts[0] &&
     client.s.options.hosts[0].port || void 0;
-  conn.name = dbName != null ? dbName : client && client.s && client.s.options && client.s.options.dbName || void 0;
+  conn.name = dbName != null ? dbName : db.databaseName;
   conn._closeCalled = client._closeCalled;
 
   const _handleReconnect = () => {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Minor tweak: currently we access MongoDB Node driver internals to get the current database name, this PR uses `databaseName`, which is part of the MongoDB Node driver's public API

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
