### PR TITLE
docs: fix `pre` element overflow in home page

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -46,6 +46,7 @@ pre {
   background: #eee;
   padding: 5px;
   border-radius: 3px;
+  overflow-x: auto;
 }
 code {
   color: #333;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
When browsing through the docs of mongoose, I opened it's home page and noticed a horizontal overflow, caused by the `pre` element in the first code snippet, hence I thought of fixing it.

**Examples**
Previously (having overflow issue): 

![image](https://github.com/Automattic/mongoose/assets/101876769/72d6add9-2e59-4807-9eed-4cb2f8c9f7a2)

Now (fixed overflow issue):

![image](https://github.com/Automattic/mongoose/assets/101876769/d6cca67b-af9f-4acc-9765-8814f0d3303b)

