### PR TITLE
fix(document): handle MongoDB Long when casting BigInts

### DIFF
--- a/lib/cast/bigint.js
+++ b/lib/cast/bigint.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { Long } = require('bson');
 
 /**
  * Given a value, cast it to a BigInt, or throw an `Error` if the value
@@ -21,6 +22,10 @@ module.exports = function castBigInt(val) {
   }
   if (typeof val === 'bigint') {
     return val;
+  }
+
+  if (val instanceof Long) {
+    return val.toBigInt();
   }
 
   if (typeof val === 'string' || typeof val === 'number') {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12436,6 +12436,18 @@ describe('document', function() {
     const fromDb = await Test.findById(x._id).lean();
     assert.equal(fromDb._id, 1);
   });
+  it('handles bigint (gh-13791)', async function() {
+    const testSchema = new mongoose.Schema({
+      n: Number,
+      reward: BigInt
+    });
+    const Test = db.model('Test', testSchema);
+
+    const a = await Test.create({ n: 1, reward: 14055648105137340n });
+    const b = await Test.findOne({ n: 1 });
+    assert.equal(a.reward, 14055648105137340n);
+    assert.equal(b.reward, 14055648105137340n);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #13791

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

By default, MongoDB Node driver returns BigInts as a BSON Long, but Mongoose doesn't know how to cast BigInts to Longs. This PR fixes that

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
