### PR TITLE
fix(model): make bulkWrite casting respect global setDefaultsOnInsert

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -20,6 +20,8 @@ const setDefaultsOnInsert = require('../setDefaultsOnInsert');
 
 module.exports = function castBulkWrite(originalModel, op, options) {
   const now = originalModel.base.now();
+
+  const globalSetDefaultsOnInsert = originalModel.base.options.setDefaultsOnInsert;
   if (op['insertOne']) {
     return (callback) => {
       const model = decideModelByObject(originalModel, op['insertOne']['document']);
@@ -69,7 +71,10 @@ module.exports = function castBulkWrite(originalModel, op, options) {
           applyTimestampsToChildren(now, op['updateOne']['update'], model.schema);
         }
 
-        if (op['updateOne'].setDefaultsOnInsert !== false) {
+        const shouldSetDefaultsOnInsert = op['updateOne'].setDefaultsOnInsert == null ?
+          globalSetDefaultsOnInsert :
+          op['updateOne'].setDefaultsOnInsert;
+        if (shouldSetDefaultsOnInsert !== false) {
           setDefaultsOnInsert(op['updateOne']['filter'], model.schema, op['updateOne']['update'], {
             setDefaultsOnInsert: true,
             upsert: op['updateOne'].upsert
@@ -106,7 +111,11 @@ module.exports = function castBulkWrite(originalModel, op, options) {
         const schema = model.schema;
         const strict = options.strict != null ? options.strict : model.schema.options.strict;
 
-        if (op['updateMany'].setDefaultsOnInsert !== false) {
+        const shouldSetDefaultsOnInsert = op['updateMany'].setDefaultsOnInsert == null ?
+          globalSetDefaultsOnInsert :
+          op['updateMany'].setDefaultsOnInsert;
+
+        if (shouldSetDefaultsOnInsert !== false) {
           setDefaultsOnInsert(op['updateMany']['filter'], model.schema, op['updateMany']['update'], {
             setDefaultsOnInsert: true,
             upsert: op['updateMany'].upsert


### PR DESCRIPTION
Fix #13823

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`mongoose.set('setDefaultsOnInsert', false)` doesn't disable setDefaultsOnInsert for `bulkWrite()`, this PR fixes that

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
