### PR TITLE
fix: account for null values when assigning `isNew` property

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1671,8 +1671,8 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
     val[arrayAtomicsBackupSymbol] = priorVal[arrayAtomicsBackupSymbol];
     if (utils.isMongooseDocumentArray(val)) {
       val.forEach(doc => {
-        if (doc) {
-          doc.isNew = false;
+        if (doc != null) {
+          doc.$isNew = false;
         }
       });
     }

--- a/lib/document.js
+++ b/lib/document.js
@@ -1670,7 +1670,11 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
     val[arrayAtomicsSymbol] = priorVal[arrayAtomicsSymbol];
     val[arrayAtomicsBackupSymbol] = priorVal[arrayAtomicsBackupSymbol];
     if (utils.isMongooseDocumentArray(val)) {
-      val.forEach(doc => { doc.isNew = false; });
+      val.forEach(doc => {
+        if (doc) {
+          doc.isNew = false;
+        }
+      });
     }
   }
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12448,6 +12448,36 @@ describe('document', function() {
     assert.equal(a.reward, 14055648105137340n);
     assert.equal(b.reward, 14055648105137340n);
   });
+  it('should allow null values in list in self assignment (gh-13859)', async function() {
+    const objSchema = new Schema({
+      date: Date,
+      value: Number
+    });
+
+    const testSchema = new Schema({
+      intArray: [Number],
+      strArray: [String],
+      objArray: [objSchema]
+    });
+    const Test = db.model('Test', testSchema);
+
+    const doc = new Test({
+      intArray: [1, 2, 3, null],
+      strArray: ['b', null, 'c'],
+      objArray: [
+        { date: new Date(1000), value: 1 },
+        null,
+        { date: new Date(3000), value: 3 }
+      ]
+    });
+    await doc.save();
+    doc.intArray = doc.intArray;
+    doc.strArray = doc.strArray;
+    doc.objArray = doc.objArray; // this is the trigger for the error
+    assert.ok(doc);
+    await doc.save();
+    assert.ok(doc);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
closes #13859 
