### PR TITLE
docs(deprecations): fix typo in includeResultMetadata deprecation docs

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -9,7 +9,7 @@ cause any problems for your application. Please [report any issues on GitHub](ht
 
 To fix all deprecation warnings, follow the below steps:
 
-* Replace `rawResult: true` with `includeResultMetadata: false` in `findOneAndUpdate()`, `findOneAndReplace()`, `findOneAndDelete()` calls.
+* Replace `rawResult: true` with `includeResultMetadata: true` in `findOneAndUpdate()`, `findOneAndReplace()`, `findOneAndDelete()` calls.
 
 Read below for more a more detailed description of each deprecation warning.
 


### PR DESCRIPTION
Fix #13844

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick typo fix that #13844 pointed out

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
