### PR TITLE
fix(model): make `bulkSave()` persist changes that happen in pre('save') middleware

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3565,10 +3565,8 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
  * @param {Boolean} [options.j=true] If false, disable [journal acknowledgement](https://www.mongodb.com/docs/manual/reference/write-concern/#j-option)
  *
  */
-Model.bulkSave = async function(documents, options) {
+Model.bulkSave = async function bulkSave(documents, options) {
   options = options || {};
-
-  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options.timestamps });
 
   if (options.timestamps != null) {
     for (const document of documents) {
@@ -3585,6 +3583,8 @@ Model.bulkSave = async function(documents, options) {
   }
 
   await Promise.all(documents.map(buildPreSavePromise));
+
+  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options.timestamps });
 
   const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, options).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12500,7 +12500,7 @@ describe('document', function() {
 
     assert.equal(updatedPerson?._age, 61);
   });
-    
+
   it('handles default embedded discriminator values (gh-13835)', async function() {
     const childAbstractSchema = new Schema(
       { kind: { type: Schema.Types.String, enum: ['concreteKind'], required: true, default: 'concreteKind' } },


### PR DESCRIPTION
Fix #13799

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13799 points out that property changes in `pre('save')` hooks don't get saved if you're using `bulkSave()`. That is inconsistent with plain old `save()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
