### PR TITLE
fix(document): handle default values for discriminator key with embedded discriminators

### DIFF
--- a/lib/helpers/discriminator/getConstructor.js
+++ b/lib/helpers/discriminator/getConstructor.js
@@ -9,7 +9,10 @@ const getDiscriminatorByValue = require('./getDiscriminatorByValue');
 
 module.exports = function getConstructor(Constructor, value, defaultDiscriminatorValue) {
   const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  const discriminatorValue = (value != null && value[discriminatorKey]) || defaultDiscriminatorValue;
+  let discriminatorValue = (value != null && value[discriminatorKey]);
+  if (discriminatorValue == null) {
+    discriminatorValue = defaultDiscriminatorValue;
+  }
   if (Constructor.discriminators &&
       discriminatorValue != null) {
     if (Constructor.discriminators[discriminatorValue]) {

--- a/lib/helpers/discriminator/getConstructor.js
+++ b/lib/helpers/discriminator/getConstructor.js
@@ -7,15 +7,15 @@ const getDiscriminatorByValue = require('./getDiscriminatorByValue');
  * @api private
  */
 
-module.exports = function getConstructor(Constructor, value) {
+module.exports = function getConstructor(Constructor, value, defaultDiscriminatorValue) {
   const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (value != null &&
-      Constructor.discriminators &&
-      value[discriminatorKey] != null) {
-    if (Constructor.discriminators[value[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[value[discriminatorKey]];
+  const discriminatorValue = (value != null && value[discriminatorKey]) || defaultDiscriminatorValue;
+  if (Constructor.discriminators &&
+      discriminatorValue != null) {
+    if (Constructor.discriminators[discriminatorValue]) {
+      Constructor = Constructor.discriminators[discriminatorValue];
     } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor.discriminators, value[discriminatorKey]);
+      const constructorByValue = getDiscriminatorByValue(Constructor.discriminators, discriminatorValue);
       if (constructorByValue) {
         Constructor = constructorByValue;
       }

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -161,7 +161,9 @@ SubdocumentPath.prototype.cast = function(val, doc, init, priorVal, options) {
     throw new ObjectExpectedError(this.path, val);
   }
 
-  const Constructor = getConstructor(this.caster, val);
+  const discriminatorKeyPath = this.schema.path(this.schema.options.discriminatorKey);
+  const defaultDiscriminatorValue = discriminatorKeyPath == null ? null : discriminatorKeyPath.getDefault(doc);
+  const Constructor = getConstructor(this.caster, val, defaultDiscriminatorValue);
 
   let subdoc;
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12478,6 +12478,33 @@ describe('document', function() {
     await doc.save();
     assert.ok(doc);
   });
+
+  it('handles default embedded discriminator values (gh-13835)', async function() {
+    const childAbstractSchema = new Schema(
+      { kind: { type: Schema.Types.String, enum: ['concreteKind'], required: true, default: 'concreteKind' } },
+      { discriminatorKey: 'kind', _id: false }
+    );
+    const childConcreteSchema = new Schema({ concreteProp: { type: Number, required: true } });
+
+    const parentSchema = new Schema(
+      {
+        child: {
+          type: childAbstractSchema,
+          required: true
+        }
+      },
+      { _id: false }
+    );
+
+    parentSchema.path('child').discriminator('concreteKind', childConcreteSchema);
+
+    const ParentModel = db.model('Test', parentSchema);
+
+    const parent = new ParentModel({ child: { concreteProp: 123 } });
+    assert.strictEqual(parent.child.concreteProp, 123);
+    assert.strictEqual(parent.get('child.concreteProp'), 123);
+    assert.strictEqual(parent.toObject().child.concreteProp, 123);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #13835

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently, Mongoose doesn't pick up default values for the discriminator key when creating a new subdocument. The default value doesn't get set until after Mongoose decides which constructor to use. So this PR makes Mongoose check for default values on the discriminator key when initializing a subdocument.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
