### PR TITLE
fix: handle casting `$elemMatch` underneath `$not` underneath another `$elemMatch`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,8 @@ module.exports = {
     '*.min.js',
     '**/docs/js/native.js',
     '!.*',
-    'node_modules'
+    'node_modules',
+    '.git'
   ],
   overrides: [
     {

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -309,8 +309,21 @@ module.exports = function cast(schema, obj, options, context) {
           while (k--) {
             $cond = ks[k];
             nested = val[$cond];
-
-            if ($cond === '$not') {
+            if ($cond === '$elemMatch') {
+              if (nested && schematype != null && schematype.schema != null) {
+                cast(schematype.schema, nested, options, context);
+              } else if (nested && schematype != null && schematype.$isMongooseArray) {
+                if (utils.isPOJO(nested) && nested.$not != null) {
+                  cast(schema, nested, options, context);
+                } else {
+                  val[$cond] = schematype.castForQuery(
+                    $cond,
+                    nested,
+                    context
+                  );
+                }
+              }
+            } else if ($cond === '$not') {
               if (nested && schematype) {
                 _keys = Object.keys(nested);
                 if (_keys.length && isOperator(_keys[0])) {
@@ -337,6 +350,7 @@ module.exports = function cast(schema, obj, options, context) {
                 context
               );
             }
+
           }
         }
       } else if (Array.isArray(val) && ['Buffer', 'Array'].indexOf(schematype.instance) === -1) {

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -754,6 +754,18 @@ describe('model query casting', function() {
         assert.strictEqual(doc.outerArray[0].innerArray[0], 'onetwothree');
       });
   });
+  it('should not throw a cast error when dealing with an array of an array of strings in combination with $elemMach and $not (gh-13880)', async function() {
+    const testSchema = new Schema({
+      arr: [[String]]
+    });
+    const Test = db.model('Test', testSchema);
+    const doc = new Test({ arr: [[1, 2, 3], [2, 3, 4]] });
+    await doc.save();
+    const query = { arr: { $elemMatch: { $not: { $elemMatch: { $eq: '1' } } } } };
+    const res = await Test.find(query);
+    assert(res);
+    assert(res[0].arr);
+  });
 });
 
 function _geojsonPoint(coordinates) {


### PR DESCRIPTION
Fix #13880

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A simpler solution than #13888, went for a different branch name and different PR because branch names that end in `.js` can make our current eslint config screw up your git state.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
