### PR TITLE
BREAKING CHANGE: avoid saving changes to de-selected paths

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1579,6 +1579,11 @@ Document.prototype.$__shouldModify = function(pathToMark, path, options, constru
   if (this.$isNew) {
     return true;
   }
+
+  if (!this.$__isSelected(path) && (!options || !options._forceModify)) {
+    return false;
+  }
+
   // Is path already modified? If so, always modify. We may unmark modified later.
   if (path in this.$__.activePaths.getStatePaths('modify')) {
     return true;

--- a/lib/helpers/timestamps/setDocumentTimestamps.js
+++ b/lib/helpers/timestamps/setDocumentTimestamps.js
@@ -21,6 +21,6 @@ module.exports = function setDocumentTimestamps(doc, timestampOption, currentTim
     if (doc.isNew && createdAt != null) {
       ts = doc.$__getValue(createdAt);
     }
-    doc.$set(updatedAt, ts);
+    doc.$set(updatedAt, ts, null, { _forceModify: true });
   }
 };


### PR DESCRIPTION
Fix #13145
Re: #13143
Re: #13062

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now Mongoose saves changes to de-selected paths, and skips `required` validation on those paths. That can be problematic in the following case:

```javascript
    const testSchema = new mongoose.Schema({
      name: { type: String, required: true },
      age: { type: Number, required: true, select: false },
      links: { type: String, required: true, select: false }
    });

    const Test = db.model('Test', testSchema);

    const { _id } = await Test.create({
      name: 'Test Testerson',
      age: 0,
      links: 'some init links'
    });

    let doc = await Test.findById(_id);
    doc.links = undefined;
    // `links` is now `undefined`, despite `required`
    await doc.save();
```

We've been considering making this change since [when we were working on Mongoose 5](https://github.com/Automattic/mongoose/issues/4651#issuecomment-258186695), and this issue continues to pop up every year or two; I think 8.0 is a good time to make this particular change.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
