### PR TITLE
fix(document): call pre('validate') hooks when modifying a path underneath triply nested subdoc

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1694,6 +1694,13 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
     if (last) {
       if (obj instanceof Map) {
         obj.set(parts[i], val);
+      } else if (obj.$isSingleNested) {
+        if (!(parts[i] in obj)) {
+          obj[parts[i]] = val;
+          obj._doc[parts[i]] = val;
+        } else {
+          obj._doc[parts[i]] = val;
+        }
       } else {
         obj[parts[i]] = val;
       }
@@ -1705,7 +1712,7 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
       } else if (value && value instanceof Embedded) {
         obj = value;
       } else if (value && !Array.isArray(value) && value.$isSingleNested) {
-        obj = value._doc;
+        obj = value;
       } else if (value && Array.isArray(value)) {
         obj = value;
       } else if (value == null) {
@@ -2650,7 +2657,7 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
   const modifiedPaths = doc.modifiedPaths();
   for (const subdoc of subdocs) {
     if (subdoc.$basePath) {
-      const fullPathToSubdoc = subdoc.$__fullPathWithIndexes();
+      const fullPathToSubdoc = subdoc.$isSingleNested ? subdoc.$__pathRelativeToParent() : subdoc.$__fullPathWithIndexes();
 
       // Remove child paths for now, because we'll be validating the whole
       // subdoc.

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12212,6 +12212,8 @@ describe('document', function() {
 
     const x = new Test();
     x.set('d.x.y', 1);
+    assert.strictEqual(x.d.x.y, 1);
+    assert.deepStrictEqual(x.get('d.x'), { y: 1 });
     assert.strictEqual(x.get('d.x.y'), 1);
     await x.save();
 
@@ -12526,6 +12528,25 @@ describe('document', function() {
     assert.strictEqual(parent.child.concreteProp, 123);
     assert.strictEqual(parent.get('child.concreteProp'), 123);
     assert.strictEqual(parent.toObject().child.concreteProp, 123);
+  });
+
+  it('fires pre validate hooks on 4 level single nested subdocs (gh-13876)', async function() {
+    let attachmentSchemaPreValidateCalls = 0;
+    const attachmentSchema = new Schema({ name: String });
+    attachmentSchema.pre('validate', () => { ++attachmentSchemaPreValidateCalls; });
+
+    const richImageSchema = new Schema({ attachment: { type: attachmentSchema, required: false } });
+    const brandingSchema = new Schema({ logo: richImageSchema });
+    const instanceSchema = new Schema({ branding: brandingSchema });
+    const TestModel = db.model('Test', instanceSchema);
+
+    const instance = await TestModel.create({ branding: { logo: {} } });
+    assert.strictEqual(attachmentSchemaPreValidateCalls, 0);
+    const doc = await TestModel.findById(instance._id);
+
+    doc.set('branding.logo.attachment', { name: 'coolLogo' });
+    await doc.save();
+    assert.strictEqual(attachmentSchemaPreValidateCalls, 1);
   });
 });
 

--- a/test/query.middleware.test.js
+++ b/test/query.middleware.test.js
@@ -359,7 +359,7 @@ describe('query middleware', function() {
     assert.equal(postCount, 1);
   });
 
-  it('error handlers XYZ (gh-2284)', async function() {
+  it('error handlers (gh-2284)', async function() {
     const testSchema = new Schema({ title: { type: String, unique: true } });
 
     testSchema.post('updateOne', function(error, res, next) {


### PR DESCRIPTION
Fix #13876

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: #13339. A couple related issues:

1. If setting a path underneath a single nested subdoc, need to be careful to set on both `doc` and `doc._doc` if there isn't a setter for the path (for example, with `strict: false`).
2. When running `_getPathsToValidate()` underneath a single nested subdoc, need to get paths relative to parent.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
