### PR TITLE
fix(query): handle `$round` in `$expr` as array

### DIFF
--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -119,13 +119,10 @@ function _castExpression(val, schema, strictQuery) {
   }
   if (val.$round) {
     const $round = val.$round;
-    if (!Array.isArray($round) || $round.length !== 2) {
+    if (!Array.isArray($round) || $round.length < 1 || $round.length > 2) {
       throw new CastError('Array', $round, '$round');
     }
-    val.$round = [
-      castNumberOperator($round[0], schema, strictQuery),
-      castNumberOperator($round[1], schema, strictQuery)
-    ];
+    val.$round = $round.map(v => castNumberOperator(v, schema, strictQuery));
   }
 
   _omitUndefined(val);

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -29,7 +29,6 @@ const arithmeticOperatorNumber = new Set([
   '$floor',
   '$ln',
   '$log10',
-  '$round',
   '$sqrt',
   '$sin',
   '$cos',
@@ -117,6 +116,16 @@ function _castExpression(val, schema, strictQuery) {
   }
   if (val.$size) {
     val.$size = castNumberOperator(val.$size, schema, strictQuery);
+  }
+  if (val.$round) {
+    const $round = val.$round;
+    if (!Array.isArray($round) || $round.length !== 2) {
+      throw new CastError('Array', $round, '$round');
+    }
+    val.$round = [
+      castNumberOperator($round[0], schema, strictQuery),
+      castNumberOperator($round[1], schema, strictQuery)
+    ];
   }
 
   _omitUndefined(val);

--- a/test/helpers/query.cast$expr.test.js
+++ b/test/helpers/query.cast$expr.test.js
@@ -112,7 +112,10 @@ describe('castexpr', function() {
   it('casts $round (gh-13881)', function() {
     const testSchema = new Schema({ value: Number });
 
-    const res = cast$expr({ $eq: [{ $round: ['$value', '00'] }, 2] }, testSchema);
+    let res = cast$expr({ $eq: [{ $round: ['$value', '00'] }, 2] }, testSchema);
     assert.deepStrictEqual(res, { $eq: [{ $round: ['$value', 0] }, 2] });
+
+    res = cast$expr({ $eq: [{ $round: ['$value'] }, 2] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: [{ $round: ['$value'] }, 2] });
   });
 });

--- a/test/helpers/query.cast$expr.test.js
+++ b/test/helpers/query.cast$expr.test.js
@@ -108,4 +108,11 @@ describe('castexpr', function() {
     const res = cast$expr({ $not: { $in: ['42', '$nums'] } }, testSchema);
     assert.deepStrictEqual(res, { $not: { $in: [42, '$nums'] } });
   });
+
+  it('casts $round (gh-13881)', function() {
+    const testSchema = new Schema({ value: Number });
+
+    const res = cast$expr({ $eq: [{ $round: ['$value', '00'] }, 2] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: [{ $round: ['$value', 0] }, 2] });
+  });
 });


### PR DESCRIPTION
Fix #13881

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

[`$round` syntax takes an array, not a number](https://www.mongodb.com/docs/manual/reference/operator/aggregation/round/). This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
