### PR TITLE
fix(query): allow deselecting discriminator key using `-` syntax

### DIFF
--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -199,6 +199,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
       // projection if `name` has schema-level `select: true`.
       if ((!type || !type.selected) || exclude !== false) {
         fields[path] = 0;
+        exclude = true;
       } else if (type && type.selected && exclude === false) {
         // Make a note of minus paths that are overwriting paths that are
         // included by default.

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4171,8 +4171,8 @@ describe('Query', function() {
     assert.equal(q.op, 'findOneAndReplace');
   });
 
-  it('allows deselecting discriminator key (gh-13679)', async function() {
-    const testSchema = new Schema({ name: String });
+  it('allows deselecting discriminator key (gh-13760) (gh-13679)', async function() {
+    const testSchema = new Schema({ name: String, age: Number });
     const Test = db.model('Test', testSchema);
     const Test2 = Test.discriminator('Test2', new Schema({ test: String }));
 
@@ -4180,5 +4180,13 @@ describe('Query', function() {
     const { name, __t } = await Test.findById(_id).select({ __t: 0 });
     assert.strictEqual(name, 'test1');
     assert.strictEqual(__t, undefined);
+
+    let doc = await Test.findById(_id).select({ __t: 0, age: 0 });
+    assert.strictEqual(doc.name, 'test1');
+    assert.strictEqual(doc.__t, undefined);
+
+    doc = await Test.findById(_id).select(['-__t', '-age']);
+    assert.strictEqual(doc.name, 'test1');
+    assert.strictEqual(doc.__t, undefined);
   });
 });


### PR DESCRIPTION
Fix #13760

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The issue is that, if using only `-` paths, `applyPaths()` doesn't set the correct value for `exclude` because all minus paths are stripped out until we sort through the schema to tell if this is deselecting a default selected path from the schema or not.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
