### PR TITLE
fix(types): add insertMany array overload with options

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -82,6 +82,20 @@ async function insertManyTest() {
   expectAssignable<Error | Object | ReturnType<(typeof Test)['hydrate']>>(res2.mongoose.results[0]);
 }
 
+function gh13930() {
+  interface ITest {
+    foo: string;
+  }
+
+  const TestSchema = new Schema<ITest>({
+    foo: { type: String, required: true }
+  });
+
+  const Test = connection.model<ITest>('Test', TestSchema);
+
+  Test.insertMany<{foo: string}>([{ foo: 'bar' }], { });
+}
+
 function gh10074() {
   interface IDog {
     breed: string;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -401,6 +401,10 @@ declare module 'mongoose' {
       options: InsertManyOptions
     ): Promise<Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>>;
     insertMany<DocContents = TRawDocType>(
+      docs: Array<DocContents | TRawDocType>,
+      options: InsertManyOptions
+    ): Promise<Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>>;
+    insertMany<DocContents = TRawDocType>(
       doc: DocContents
     ): Promise<
       Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
This solves a typescript problem we are having with using options and insertMany, issue https://github.com/Automattic/mongoose/issues/13930. In this PR I have added an additional overload when inserting an array with options.
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
See the test case and bug report for examples
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
