### PR TITLE
fix(QueryCursor): avoid double-applying schema paths so you can include `select: false` fields with `+` projection using cursors

### DIFF
--- a/lib/cursor/QueryCursor.js
+++ b/lib/cursor/QueryCursor.js
@@ -34,7 +34,7 @@ const util = require('util');
  * @api public
  */
 
-function QueryCursor(query, options) {
+function QueryCursor(query) {
   // set autoDestroy=true because on node 12 it's by default false
   // gh-10902 need autoDestroy to destroy correctly and emit 'close' event
   Readable.call(this, { autoDestroy: true, objectMode: true });
@@ -46,7 +46,7 @@ function QueryCursor(query, options) {
   this._mongooseOptions = {};
   this._transforms = [];
   this.model = model;
-  this.options = options || {};
+  this.options = {};
   model.hooks.execPre('find', query, (err) => {
     if (err != null) {
       if (err instanceof kareem.skipWrappedFunction) {
@@ -70,20 +70,18 @@ function QueryCursor(query, options) {
       this.listeners('error').length > 0 && this.emit('error', err);
       return;
     }
+    Object.assign(this.options, query._optionsForExec());
     this._transforms = this._transforms.concat(query._transforms.slice());
     if (this.options.transform) {
-      this._transforms.push(options.transform);
+      this._transforms.push(this.options.transform);
     }
     // Re: gh-8039, you need to set the `cursor.batchSize` option, top-level
     // `batchSize` option doesn't work.
     if (this.options.batchSize) {
-      this.options.cursor = options.cursor || {};
-      this.options.cursor.batchSize = options.batchSize;
-
       // Max out the number of documents we'll populate in parallel at 5000.
       this.options._populateBatchSize = Math.min(this.options.batchSize, 5000);
     }
-    Object.assign(this.options, query._optionsForExec());
+
     if (model.collection._shouldBufferCommands() && model.collection.buffer) {
       model.collection.queue.push([
         () => _getRawCursor(query, this)

--- a/lib/query.js
+++ b/lib/query.js
@@ -5043,15 +5043,13 @@ Query.prototype.cursor = function cursor(opts) {
     this.setOptions(opts);
   }
 
-  const options = this._optionsForExec();
-
   try {
     this.cast(this.model);
   } catch (err) {
-    return (new QueryCursor(this, options))._markError(err);
+    return (new QueryCursor(this))._markError(err);
   }
 
-  return new QueryCursor(this, options);
+  return new QueryCursor(this);
 };
 
 // the rest of these are basically to support older Mongoose syntax with mquery


### PR DESCRIPTION
Fix #13773

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Bug fix, double applying `this._optionsForExec()` means projections lose `+age` projections that override `age: { select: false }` in schema. This double-applying only happens with `.cursor()` right now.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
