### PR TITLE
6.x/populate.md: fix edit whoopsie scrapping a line, and setting half of this doc in unclosed code tag

### DIFF
--- a/docs/populate.md
+++ b/docs/populate.md
@@ -487,7 +487,8 @@ const events = await Event.
 ```
 
 <h2 id="dynamic-ref"><a href="#dynamic-ref">Dynamic References via <code>refPath</code></a></h2>
-<code>
+
+Mongoose can also populate from multiple collections based on the value
 of a property in the document. Let's say you're building a schema for
 storing comments. A user may comment on either a blog post or a product.
 


### PR DESCRIPTION
See https://mongoosejs.com/docs/6.x/docs/populate.html#dynamic-ref

![whoopsie_2023-10-05-14:17:32](https://github.com/Automattic/mongoose/assets/522085/d048dfbb-c688-43db-9e06-cd7aed23e773)

Line restored from master, https://github.com/Automattic/mongoose/blob/d5964cdeeb278bf55b656fcf0217233b41e1e9ef/docs/populate.md?plain=1#L472-L474