### PR TITLE
Backport to 6.x: correctly handle global applyPluginsToChildSchemas option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -718,7 +718,9 @@ Mongoose.prototype._applyPlugins = function(schema, options) {
 
   options = options || {};
   options.applyPluginsToDiscriminators = _mongoose.options && _mongoose.options.applyPluginsToDiscriminators || false;
-  options.applyPluginsToChildSchemas = typeof (_mongoose.options && _mongoose.options.applyPluginsToDiscriminators) === 'boolean' ? _mongoose.options.applyPluginsToDiscriminators : true;
+  options.applyPluginsToChildSchemas = typeof (_mongoose.options && _mongoose.options.applyPluginsToChildSchemas) === 'boolean' ?
+    _mongoose.options.applyPluginsToChildSchemas :
+    true;
   applyPlugins(schema, _mongoose.plugins, options, '$globalPluginsApplied');
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -430,6 +430,25 @@ describe('mongoose module:', function() {
     return Promise.resolve();
   });
 
+  it('global plugins with applyPluginsToChildSchemas (gh-13887)', function() {
+    const m = new Mongoose();
+    m.set('applyPluginsToChildSchemas', false);
+
+    const called = [];
+    m.plugin(function(s) {
+      called.push(s);
+    });
+
+    const schema = new m.Schema({
+      subdoc: new m.Schema({ name: String }),
+      arr: [new m.Schema({ name: String })]
+    });
+
+    m.model('Test', schema);
+    assert.equal(called.length, 1);
+    assert.ok(called.indexOf(schema) !== -1);
+  });
+
   it('global plugins recompile schemas (gh-7572)', function() {
     function helloPlugin(schema) {
       schema.virtual('greeting').get(() => 'hello');


### PR DESCRIPTION
Fix #13887 for 6.x

**Summary**

This PR backports #13911 for 6.x
