### PR TITLE
chore(npmignore): ignore newer files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -47,4 +47,12 @@ webpack.base.config.js
 notes.md
 list.out
 
-eslintrc.json
+# config files
+lgtm.yml
+.mocharc.yml
+.eslintrc.js
+.markdownlint-cli2.cjs
+
+# scripts
+scripts/
+tools/

--- a/.npmignore
+++ b/.npmignore
@@ -52,6 +52,7 @@ lgtm.yml
 .mocharc.yml
 .eslintrc.js
 .markdownlint-cli2.cjs
+tsconfig.json
 
 # scripts
 scripts/


### PR DESCRIPTION
**Summary**

This PR updates the `.npmignore` to include some files which were added since the last touch to npmignore, mainly:
- transition from `eslintrc.json` to `.eslintrc.js`
- addition of markdownlint-cli
- addition of lgtm
- move of scripts to `scripts`
- addition of `.mocharc.yml`

also excluded `tools/`, because to my knowledge these are not meant to be shipped, another exclude is `tsconfig.json`

see https://unpkg.com/browse/mongoose@7.6.0/ for context