### PR TITLE
chore: bump bson to match mongodb@5.9.0 exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bson": "^5.4.0",
+    "bson": "^5.5.0",
     "kareem": "2.5.1",
     "mongodb": "5.9.0",
     "mpath": "0.9.0",


### PR DESCRIPTION
**Summary**

This PR bumps the `bson` dependency to match the installed `mongodb`'s one, because otherwise some package managers (example yarn-v1) will install *the old* bson for mongoose and *the new* bson for mongodb driver, causing confusing test failures.

i noticed this while trying to install mongoose@7.6.0 for typegoose

context: https://unpkg.com/browse/mongodb@5.9.0/package.json#L28

<details>
<summary>Some test failure examples from typegoose</summary>

```txt
 FAIL  test/tests/ref.test.ts (5.488 s)
  ● check reference with buffer _id

    Expected "refFieldBuffer" to be "mongoose.Types.Buffer | Buffer"

      171 |   const { _id: refBufferId } = await RefTestModel.create({ refFieldBuffer: _id1 });
      172 |   const { refFieldBuffer } = await RefTestModel.findById(refBufferId).orFail().exec();
    > 173 |   assertion(isRefType(refFieldBuffer, Buffer), new Error('Expected "refFieldBuffer" to be "mongoose.Types.Buffer | Buffer"'));
          |                                                ^
      174 |   expect(_id1.equals(refFieldBuffer)).toEqual(true);
      175 |   const { _id: refArrayId } = await RefTestModel.create({ refArrayBuffer: [_id1, _id2] });
      176 |   const { refArrayBuffer } = await RefTestModel.findById(refArrayId).orFail().exec();

      at Object.<anonymous> (test/tests/ref.test.ts:173:48)

  ● check typeguards

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      220 |   expect(Array.isArray(foundPopulated.refArrayString)).toBe(true);
      221 |   expect(Array.isArray(foundPopulated.refArrayNumber)).toBe(true);
    > 222 |   expect(Array.isArray(foundPopulated.refArrayBuffer)).toBe(true);
          |                                                        ^
      223 |
      224 |   expect(foundPopulated.refArray!.length).toEqual(2);
      225 |   expect(foundPopulated.refArrayString!.length).toEqual(2);

      at Object.<anonymous> (test/tests/ref.test.ts:222:56)

  ● Reference-Maps should work and be populated

    expect(received).toBeInstanceOf(expected)

    Expected constructor: ObjectId
    Received constructor: ObjectId

      422 |
      423 |   found.mapped.forEach((v) => {
    > 424 |     expect(v).toBeInstanceOf(mongoose.Types.ObjectId);
          |               ^
      425 |   });
      426 |
      427 |   await found.populate('mapped.$*');

      at test/tests/ref.test.ts:424:15
          at MongooseMap.forEach (<anonymous>)
      at Object.<anonymous> (test/tests/ref.test.ts:423:16)

```

</details>