### PR TITLE
chore: move mocha config from package.json to mocharc

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -2,3 +2,7 @@ reporter: spec # better to identify failing / slow tests than "dot"
 ui: bdd # explicitly setting, even though it is mocha default
 require:
   - test/mocha-fixtures.js
+extension:
+  - test.js
+watch-files:
+  - test/**/*.js

--- a/package.json
+++ b/package.json
@@ -130,14 +130,6 @@
   },
   "homepage": "https://mongoosejs.com",
   "browser": "./dist/browser.umd.js",
-  "mocha": {
-    "extension": [
-      "test.js"
-    ],
-    "watch-files": [
-      "test/**/*.js"
-    ]
-  },
   "config": {
     "mongodbMemoryServer": {
       "disablePostinstall": true


### PR DESCRIPTION
**Summary**

This PR moves the mocha config options in `package.json` to `.mocharc.yml`, this way mocha config is defined in one place only and we also dont need to ship that config (re #13946)
