### PR TITLE
chore(dev-deps): remove bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "axios": "1.1.3",
     "babel-loader": "8.2.5",
     "benchmark": "2.1.4",
-    "bluebird": "3.7.2",
     "broken-link-checker": "^0.7.8",
     "buffer": "^5.6.0",
     "cheerio": "1.0.0-rc.12",


### PR DESCRIPTION
**Summary**

This PR removes the dev-dependency `bluebird`, because i could not find any reference to it still being used (the only reference is a codeblock in `migrate_to_7.md`)
