### PR TITLE
Avoid storing a separate entry in schema `subpaths` for every element in an array

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1017,7 +1017,7 @@ Schema.prototype.path = function(path, obj) {
 
     // subpaths?
     return /\.\d+\.?.*$/.test(path)
-      ? getPositionalPath(this, path)
+      ? getPositionalPath(this, path, cleanPath)
       : undefined;
   }
 
@@ -1634,7 +1634,7 @@ Schema.prototype.pathType = function(path) {
   }
 
   if (/\.\d+\.|\.\d+$/.test(path)) {
-    return getPositionalPathType(this, path);
+    return getPositionalPathType(this, path, cleanPath);
   }
   return 'adhocOrUndefined';
 };
@@ -1678,7 +1678,7 @@ Schema.prototype.setupTimestamp = function(timestamps) {
  * @api private
  */
 
-function getPositionalPathType(self, path) {
+function getPositionalPathType(self, path, cleanPath) {
   const subpaths = path.split(/\.(\d+)\.|\.(\d+)$/).filter(Boolean);
   if (subpaths.length < 2) {
     return self.paths.hasOwnProperty(subpaths[0]) ?
@@ -1729,7 +1729,7 @@ function getPositionalPathType(self, path) {
     val = val.schema.path(subpath);
   }
 
-  self.subpaths[path] = val;
+  self.subpaths[cleanPath] = val;
   if (val) {
     return 'real';
   }
@@ -1744,9 +1744,9 @@ function getPositionalPathType(self, path) {
  * ignore
  */
 
-function getPositionalPath(self, path) {
-  getPositionalPathType(self, path);
-  return self.subpaths[path];
+function getPositionalPath(self, path, cleanPath) {
+  getPositionalPathType(self, path, cleanPath);
+  return self.subpaths[cleanPath];
 }
 
 /**
@@ -2637,6 +2637,9 @@ Schema.prototype._getSchema = function(path) {
     if (parts[i] === '$' || isArrayFilter(parts[i])) {
       // Re: gh-5628, because `schema.path()` doesn't take $ into account.
       parts[i] = '0';
+    }
+    if (/^\d+$/.test(parts[i])) {
+      parts[i] = '$';
     }
   }
   return search(parts, _this);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -37,6 +37,8 @@ const isPOJO = utils.isPOJO;
 
 let id = 0;
 
+const numberRE = /^\d+$/;
+
 /**
  * Schema constructor.
  *
@@ -2638,7 +2640,7 @@ Schema.prototype._getSchema = function(path) {
       // Re: gh-5628, because `schema.path()` doesn't take $ into account.
       parts[i] = '0';
     }
-    if (/^\d+$/.test(parts[i])) {
+    if (numberRE.test(parts[i])) {
       parts[i] = '$';
     }
   }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12550,7 +12550,7 @@ describe('document', function() {
 
     assert.equal(Object.keys(TestModel.schema.subpaths).length, 3);
   });
-    
+
   it('handles embedded discriminators defined using Schema.prototype.discriminator (gh-13898)', async function() {
     const baseNestedDiscriminated = new Schema({
       type: { type: Number, required: true }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In fix for #3265, we made it so that we store an entry in `subpaths` for every element in an array, presumably to help make it easier to look up array paths. With a little bit of changes, it turns out this is unnecessary; and, as #13874 pointed out, adding an entry to `subpaths` for every element in an array can be considered a memory leak.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
