### PR TITLE
type: add types for includeResultMetadata

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -32,7 +32,9 @@ declare module 'mongoose' {
     PopulateOption,
     SessionOption {
     limit?: number;
+    // @deprecated, use includeResultMetadata instead
     rawResult?: boolean;
+    includeResultMetadata?: boolean;
     ordered?: boolean;
     lean?: boolean;
     throwOnValidationError?: boolean;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -124,9 +124,14 @@ declare module 'mongoose' {
     overwriteDiscriminatorKey?: boolean;
     projection?: ProjectionType<DocType>;
     /**
+     * @deprecated use includeResultMetadata instead.
      * if true, returns the raw result from the MongoDB driver
      */
     rawResult?: boolean;
+    /**
+     * if ture, includes meta data for the result from the MongoDB driver
+     */
+    includeResultMetadata?: boolean;
     readPreference?: string | mongodb.ReadPreferenceMode;
     /**
      * An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.


### PR DESCRIPTION
adds types for includeResultMetadata (see  https://mongoosejs.com/docs/deprecations.html#rawresult) and sets rawResult as deprecated.

related to #13954 
