### PR TITLE
fix(schema): handle embedded discriminators defined using `Schema.prototype.discriminator()`

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -723,19 +723,6 @@ Schema.prototype.add = function add(obj, prefix) {
         for (const key in val[0].discriminators) {
           schemaType.discriminator(key, val[0].discriminators[key]);
         }
-      } else if (val[0] != null && val[0].instanceOfSchema && val[0]._applyDiscriminators instanceof Map) {
-        const applyDiscriminators = val[0]._applyDiscriminators;
-        const schemaType = this.path(prefix + key);
-        for (const disc of applyDiscriminators.keys()) {
-          schemaType.discriminator(disc, applyDiscriminators.get(disc));
-        }
-      }
-      else if (val != null && val.instanceOfSchema && val._applyDiscriminators instanceof Map) {
-        const applyDiscriminators = val._applyDiscriminators;
-        const schemaType = this.path(prefix + key);
-        for (const disc of applyDiscriminators.keys()) {
-          schemaType.discriminator(disc, applyDiscriminators.get(disc));
-        }
       }
     } else if (Object.keys(val).length < 1) {
       // Special-case: {} always interpreted as Mixed path so leaf at this node

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -55,6 +55,12 @@ function SubdocumentPath(schema, path, options) {
   this.$isSingleNested = true;
   this.base = schema.base;
   SchemaType.call(this, path, options, 'Embedded');
+
+  if (schema._applyDiscriminators != null) {
+    for (const disc of schema._applyDiscriminators.keys()) {
+      this.discriminator(disc, schema._applyDiscriminators.get(disc));
+    }
+  }
 }
 
 /*!

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -88,6 +88,12 @@ function DocumentArrayPath(key, schema, options, schemaOptions) {
 
   this.$embeddedSchemaType.caster = this.Constructor;
   this.$embeddedSchemaType.schema = this.schema;
+
+  if (schema._applyDiscriminators != null) {
+    for (const disc of schema._applyDiscriminators.keys()) {
+      this.discriminator(disc, schema._applyDiscriminators.get(disc));
+    }
+  }
 }
 
 /**

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12520,6 +12520,56 @@ describe('document', function() {
     await doc.save();
     assert.strictEqual(attachmentSchemaPreValidateCalls, 1);
   });
+
+  it('handles embedded discriminators defined using Schema.prototype.discriminator (gh-13898)', async function() {
+    const baseNestedDiscriminated = new Schema({
+      type: { type: Number, required: true }
+    }, { discriminatorKey: 'type' });
+
+    class BaseClass {
+      whoAmI() {
+        return 'I am baseNestedDiscriminated';
+      }
+    }
+    BaseClass.type = 1;
+
+    baseNestedDiscriminated.loadClass(BaseClass);
+
+    class NumberTyped extends BaseClass {
+      whoAmI() {
+        return 'I am NumberTyped';
+      }
+    }
+    NumberTyped.type = 3;
+
+    class StringTyped extends BaseClass {
+      whoAmI() {
+        return 'I am StringTyped';
+      }
+    }
+    StringTyped.type = 4;
+
+    baseNestedDiscriminated.discriminator(1, new Schema({}).loadClass(NumberTyped));
+    baseNestedDiscriminated.discriminator('3', new Schema({}).loadClass(StringTyped));
+
+    const containsNestedSchema = new Schema({
+      nestedDiscriminatedTypes: { type: [baseNestedDiscriminated], required: true }
+    });
+
+    class ContainsNested {
+      whoAmI() {
+        return 'I am ContainsNested';
+      }
+    }
+    containsNestedSchema.loadClass(ContainsNested);
+
+    const Test = db.model('Test', containsNestedSchema);
+    const instance = await Test.create({ type: 1, nestedDiscriminatedTypes: [{ type: 1 }, { type: '3' }] });
+    assert.deepStrictEqual(
+      instance.nestedDiscriminatedTypes.map(i => i.whoAmI()),
+      ['I am NumberTyped', 'I am StringTyped']
+    );
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #13898

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Using `schema.path('docArr').discriminator(...)` works fine, but not `docArrSchema.discriminator(...); const schema = new Schema({ docArr: [docArrSchema] })`. This PR makes it so that both syntaxes work.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
