### PR TITLE
fix(model): make bulkSave() save changes in discriminator paths if calling bulkSave() on base model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3780,6 +3780,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
   }
 
   setDefaultOptions();
+  const discriminatorKey = this.schema.options.discriminatorKey;
 
   const writeOperations = documents.reduce((accumulator, document, i) => {
     if (!options.skipValidation) {
@@ -3809,6 +3810,12 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
       const changes = delta[1];
 
       _applyCustomWhere(document, where);
+
+      // Set the discriminator key, so bulk write casting knows which
+      // schema to use re: gh-13907
+      if (document[discriminatorKey] != null && !(discriminatorKey in where)) {
+        where[discriminatorKey] = document[discriminatorKey];
+      }
 
       document.$__version(where, delta);
       const writeOperation = { updateOne: { filter: where, update: changes } };

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6239,6 +6239,27 @@ describe('Model', function() {
       assert.equal(writeOperations.length, 3);
     });
 
+    it('saves changes in discriminators if calling `bulkSave()` on base model (gh-13907)', async() => {
+      const schema = new mongoose.Schema(
+        { value: String },
+        { discriminatorKey: 'type' }
+      );
+      const typeASchema = new mongoose.Schema({ aValue: String });
+      schema.discriminator('A', typeASchema);
+
+      const TestModel = db.model('Test', schema);
+      const testData = { value: 'initValue', type: 'A', aValue: 'initAValue' };
+      const doc = await TestModel.create(testData);
+
+      doc.value = 'updatedValue1';
+      doc.aValue = 'updatedValue2';
+      await TestModel.bulkSave([doc]);
+
+      const findDoc = await TestModel.findById(doc._id);
+      assert.strictEqual(findDoc.value, 'updatedValue1');
+      assert.strictEqual(findDoc.aValue, 'updatedValue2');
+    });
+
     it('accepts `timestamps: false` (gh-12059)', async() => {
       // Arrange
       const userSchema = new Schema({


### PR DESCRIPTION
Fix #13907

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Calling `bulkSave()` with the base model means `bulkSave()` only casts against the base model, ignoring discriminators. This PR fixes that by setting the discriminator key on the corresponding update for every document that has a discriminator key.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
