### PR TITLE
fix(document): allow calling `$model()` with no args for TypeScript

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1060,40 +1060,45 @@ Model.prototype.$__deleteOne = function $__deleteOne(options, cb) {
 };
 
 /**
- * Returns another Model instance.
+ * Returns the model instance used to create this document if no `name` specified.
+ * If `name` specified, returns the model with the given `name`.
  *
  * #### Example:
  *
- *     const doc = new Tank;
- *     await doc.model('User').findById(id);
+ *     const doc = new Tank({});
+ *     doc.$model() === Tank; // true
+ *     await doc.$model('User').findById(id);
  *
- * @param {String} name model name
- * @method model
- * @api public
- * @return {Model}
- */
-
-Model.prototype.model = function model(name) {
-  return this[modelDbSymbol].model(name);
-};
-
-/**
- * Returns another Model instance.
- *
- * #### Example:
- *
- *     const doc = new Tank;
- *     await doc.model('User').findById(id);
- *
- * @param {String} name model name
+ * @param {String} [name] model name
  * @method $model
  * @api public
  * @return {Model}
  */
 
 Model.prototype.$model = function $model(name) {
+  if (arguments.length === 0) {
+    return this.constructor;
+  }
   return this[modelDbSymbol].model(name);
 };
+
+/**
+ * Returns the model instance used to create this document if no `name` specified.
+ * If `name` specified, returns the model with the given `name`.
+ *
+ * #### Example:
+ *
+ *     const doc = new Tank({});
+ *     doc.$model() === Tank; // true
+ *     await doc.$model('User').findById(id);
+ *
+ * @param {String} [name] model name
+ * @method model
+ * @api public
+ * @return {Model}
+ */
+
+Model.prototype.model = Model.prototype.$model;
 
 /**
  * Returns a document with `_id` only if at least one document exists in the database that matches

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12521,6 +12521,14 @@ describe('document', function() {
     assert.strictEqual(attachmentSchemaPreValidateCalls, 1);
   });
 
+  it('returns constructor if using $model() with no args (gh-13878)', async function() {
+    const testSchema = new Schema({ name: String });
+    const Test = db.model('Test', testSchema);
+
+    const doc = new Test();
+    assert.strictEqual(doc.$model(), Test);
+  });
+
   it('avoids creating separate subpaths entry for every element in array (gh-13874)', async function() {
     const tradeSchema = new mongoose.Schema({ tradeId: Number, content: String });
 

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -302,6 +302,7 @@ function gh13878() {
   const User = model('User', schema);
   const user = new User({ name: 'John', age: 30 });
   expectType<typeof User>(user.$model());
+  expectType<typeof User>(user.model());
 }
 
 function gh13094() {

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -294,6 +294,16 @@ function gh12290() {
   user.isDirectModified('name');
 }
 
+function gh13878() {
+  const schema = new Schema({
+    name: String,
+    age: Number
+  });
+  const User = model('User', schema);
+  const user = new User({ name: 'John', age: 30 });
+  expectType<typeof User>(user.$model());
+}
+
 function gh13094() {
   type UserDocumentNever = HydratedDocument<{ name: string }, Record<string, never>>;
 

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -75,6 +75,7 @@ declare module 'mongoose' {
 
     /** Returns the model with the given name on this document's associated connection. */
     $model<ModelType = Model<unknown>>(name: string): ModelType;
+    $model<ModelType = Model<DocType>>(): ModelType;
 
     /**
      * A string containing the current operation that Mongoose is executing

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -192,6 +192,10 @@ declare module 'mongoose' {
     markModified<T extends keyof DocType>(path: T, scope?: any): void;
     markModified(path: string, scope?: any): void;
 
+    /** Returns the model with the given name on this document's associated connection. */
+    model<ModelType = Model<unknown>>(name: string): ModelType;
+    model<ModelType = Model<DocType>>(): ModelType;
+
     /** Returns the list of paths that have been modified. */
     modifiedPaths(options?: { includeChildren?: boolean }): Array<string>;
 


### PR DESCRIPTION
Fix #13878

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

TypeScript doesn't allow specifying a type for the `constructor` property, so right now there's no ergonomic way to get the model associated with a document in TypeScript. Need to use `as`. This PR makes it so that you can do `doc.$model()`. Requires a small runtime change, Mongoose doesn't currently support calling `doc.$model()` without args.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
