### PR TITLE
types(models): add cleaner type definitions for `insertMany()` with no generics to prevent errors when using `insertMany()` in generic classes

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -709,3 +709,27 @@ async function gh13746() {
   expectType<ObjectId | undefined>(findOneAndUpdateRes.lastErrorObject?.upserted);
   expectType<OkType>(findOneAndUpdateRes.ok);
 }
+
+function gh13957() {
+  class RepositoryBase<T> {
+    protected model: mongoose.Model<T>;
+
+    constructor(schemaModel: mongoose.Model<T>) {
+      this.model = schemaModel;
+    }
+
+    // Testing that the following compiles successfully
+    async insertMany(elems: T[]): Promise<T[]> {
+      elems = await this.model.insertMany(elems);
+      return elems;
+    }
+  }
+
+  interface ITest {
+    name?: string
+  }
+  const schema = new Schema({ name: String });
+  const TestModel = model('Test', schema);
+  const repository = new RepositoryBase<ITest>(TestModel);
+  expectType<Promise<ITest[]>>(repository.insertMany([{ name: 'test' }]));
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -362,6 +362,34 @@ declare module 'mongoose' {
     init(): Promise<THydratedDocumentType>;
 
     /** Inserts one or more new documents as a single `insertMany` call to the MongoDB server. */
+    insertMany(
+      docs: Array<TRawDocType>
+    ): Promise<Array<THydratedDocumentType>>;
+    insertMany(
+      docs: Array<TRawDocType>,
+      options: InsertManyOptions & { lean: true; }
+    ): Promise<Array<Require_id<TRawDocType>>>;
+    insertMany(
+      doc: Array<TRawDocType>,
+      options: InsertManyOptions & { ordered: false; rawResult: true; }
+    ): Promise<mongodb.InsertManyResult<Require_id<TRawDocType>> & {
+      mongoose: {
+        validationErrors: Error[];
+        results: Array<
+          Error |
+          Object |
+          THydratedDocumentType
+        >
+      }
+    }>;
+    insertMany(
+      docs: Array<TRawDocType>,
+      options: InsertManyOptions & { lean: true, rawResult: true; }
+    ): Promise<mongodb.InsertManyResult<Require_id<TRawDocType>>>;
+    insertMany(
+      docs: Array<TRawDocType>,
+      options: InsertManyOptions & { rawResult: true; }
+    ): Promise<mongodb.InsertManyResult<Require_id<THydratedDocumentType>>>;
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>,
       options: InsertManyOptions & { lean: true; }


### PR DESCRIPTION
Fix #13957

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Something in the way `insertMany()` generics are structured causes the errors in #13957. Adding `insertMany()` overrides that have no generics fixes that, which seems like a reasonable approach.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
