### PR TITLE
types(model): make InsertManyResult consistent with return type of insertMany

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -717,10 +717,10 @@ function gh13904() {
   interface ITest {
     name?: string;
   }
-  const Test = model<ITest>("Test", schema);
+  const Test = model<ITest>('Test', schema);
 
   expectAssignable<Promise<InsertManyResult<ITest>>>(Test.insertMany(
-    [{ name: "test" }],
+    [{ name: 'test' }],
     {
       ordered: false,
       rawResult: true

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -9,6 +9,7 @@ import mongoose, {
   CallbackError,
   HydratedDocument,
   HydratedDocumentFromSchema,
+  InsertManyResult,
   Query,
   UpdateWriteOpResult,
   AggregateOptions,
@@ -708,4 +709,21 @@ async function gh13746() {
   expectType<boolean | undefined>(findOneAndUpdateRes.lastErrorObject?.updatedExisting);
   expectType<ObjectId | undefined>(findOneAndUpdateRes.lastErrorObject?.upserted);
   expectType<OkType>(findOneAndUpdateRes.ok);
+}
+
+function gh13904() {
+  const schema = new Schema({ name: String });
+
+  interface ITest {
+    name?: string;
+  }
+  const Test = model<ITest>("Test", schema);
+
+  expectAssignable<Promise<InsertManyResult<ITest>>>(Test.insertMany(
+    [{ name: "test" }],
+    {
+      ordered: false,
+      rawResult: true
+    }
+  ));
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -375,7 +375,7 @@ declare module 'mongoose' {
       options: InsertManyOptions & { ordered: false; rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<DocContents>> & {
       mongoose: {
-        validationErrors: Error[];
+        validationErrors: (CastError | Error.ValidatorError)[];
         results: Array<
           Error |
           Object |

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -374,7 +374,7 @@ declare module 'mongoose' {
       options: InsertManyOptions & { ordered: false; rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<TRawDocType>> & {
       mongoose: {
-        validationErrors: Error[];
+        validationErrors: (CastError | Error.ValidatorError)[];
         results: Array<
           Error |
           Object |


### PR DESCRIPTION
Fix #13904

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like just an inconsistency in typedefs, result of `insertMany()` should be assignable to Mongoose's `InsertManyResult`, but currently isn't.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
