### PR TITLE
fix(document): avoid triggering setter when initializing `Model.prototype.collection` to allow defining `collection` as a schema path name

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4759,8 +4759,6 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
 
   schema._preCompile();
 
-  model.prototype.$__setSchema(schema);
-
   const _userProvidedOptions = schema._userProvidedOptions || {};
 
   const collectionOptions = {
@@ -4773,13 +4771,16 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
     collectionOptions.autoCreate = schema.options.autoCreate;
   }
 
-  model.prototype.collection = connection.collection(
+  const collection = connection.collection(
     collectionName,
     collectionOptions
   );
 
-  model.prototype.$collection = model.prototype.collection;
-  model.prototype[modelCollectionSymbol] = model.prototype.collection;
+  model.prototype.collection = collection;
+  model.prototype.$collection = collection;
+  model.prototype[modelCollectionSymbol] = collection;
+
+  model.prototype.$__setSchema(schema);
 
   // apply methods and statics
   applyMethods(model, schema);
@@ -4788,8 +4789,8 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   applyStaticHooks(model, schema.s.hooks, schema.statics);
 
   model.schema = model.prototype.$__schema;
-  model.collection = model.prototype.collection;
-  model.$__collection = model.collection;
+  model.collection = collection;
+  model.$__collection = collection;
 
   // Create custom query constructor
   model.Query = function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12600,6 +12600,18 @@ describe('document', function() {
       ['I am NumberTyped', 'I am StringTyped']
     );
   });
+
+  it('can use `collection` as schema name (gh-13956)', async function() {
+    const schema = new mongoose.Schema({ name: String, collection: String });
+    const Test = db.model('Test', schema);
+
+    const doc = await Test.create({ name: 'foo', collection: 'bar' });
+    assert.strictEqual(doc.collection, 'bar');
+    doc.collection = 'baz';
+    await doc.save();
+    const { collection } = await Test.findById(doc);
+    assert.strictEqual(collection, 'baz');
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #13956

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now get the following error when you try to use `collection` as a schema path name:

```
$ node gh-13956.js 
TypeError: Cannot read properties of undefined (reading 'Symbol(mongoose#Document#scope)')
    at Model.set [as collection] (/home/val/Workspace/MongoDB/mongoose/lib/helpers/document/compile.js:205:32)
    at Function.compile (/home/val/Workspace/MongoDB/mongoose/lib/model.js:4776:30)
    at Mongoose._model (/home/val/Workspace/MongoDB/mongoose/lib/index.js:620:27)
    at Mongoose.model (/home/val/Workspace/MongoDB/mongoose/lib/index.js:579:27)
    at run (/home/val/Workspace/MongoDB/troubleshoot-mongoose/gh-13956.js:11:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This PR fixes that, you can now use `collection` as a schema name, albeit still with the "`collection` is a reserved schema pathname and may break some functionality." warning.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
