### PR TITLE
Fix Typescript definition of schema.discriminator to allow strings.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -260,7 +260,7 @@ declare module 'mongoose' {
     /** Returns a copy of this schema */
     clone<T = this>(): T;
 
-    discriminator<DisSchema = Schema>(name: string, schema: DisSchema): this;
+    discriminator<DisSchema = Schema>(name: string | number, schema: DisSchema): this;
 
     /** Returns a new schema that has the picked `paths` from this schema. */
     pick<T = this>(paths: string[], options?: SchemaOptions): T;


### PR DESCRIPTION
**Summary**

Schema.discriminator accepts only strings, even though other discriminator functions (e.g Schema.Types.Array) accept number | string

**Examples**

```javascript
baseSchema.discriminator(1, derivedSchema);
```
would give compile error, even though numbers as discriminators do work.