### PR TITLE
fix(update): avoid applying defaults on query filter when upserting with empty update

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -126,7 +126,8 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
       Object.keys(filter).length > 0) {
     // Trick the driver into allowing empty upserts to work around
     // https://github.com/mongodb/node-mongodb-native/pull/2490
-    return { $setOnInsert: filter };
+    // Shallow clone to avoid passing defaults in re: gh-13962
+    return { $setOnInsert: { ...filter } };
   }
   return ret;
 };

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -2200,4 +2200,21 @@ describe('model: findOneAndUpdate:', function() {
     assert.ok(document);
     assert.equal(document.name, 'test');
   });
+
+  it('skips adding defaults to filter when passing empty update (gh-13962)', async function() {
+    const schema = new Schema({
+      myField: Number,
+      defaultField: { type: String, default: 'default' }
+    }, { versionKey: false });
+    const Test = db.model('Test', schema);
+
+    await Test.create({ myField: 1, defaultField: 'some non-default value' });
+
+    const updated = await Test.findOneAndUpdate(
+      { myField: 1 },
+      {},
+      { upsert: true, returnDocument: 'after' }
+    );
+    assert.equal(updated.defaultField, 'some non-default value');
+  });
 });


### PR DESCRIPTION
Fix #13962

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13962 points out an issue: we pass `filter` by reference when adding a `$setOnInsert` to prevent MongoDB from complaining about empty updates, but then `setDefaultsOnInsert` can modify that filter. This PR fixes that bug by making sure we shallow clone `filter`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
