### PR TITLE
fix(populate): handle multiple spaces when specifying paths to populate using space-delimited paths

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,6 +31,9 @@ exports.isMongooseDocumentArray = isMongooseDocumentArray.isMongooseDocumentArra
 exports.registerMongooseArray = isMongooseArray.registerMongooseArray;
 exports.registerMongooseDocumentArray = isMongooseDocumentArray.registerMongooseDocumentArray;
 
+const oneSpaceRE = /\s/;
+const manySpaceRE = /\s+/;
+
 /**
  * Produces a collection name from model `name`. By default, just returns
  * the model name
@@ -572,8 +575,8 @@ exports.populate = function populate(path, select, model, match, options, subPop
   function makeSingles(arr) {
     const ret = [];
     arr.forEach(function(obj) {
-      if (/[\s]/.test(obj.path)) {
-        const paths = obj.path.split(' ');
+      if (oneSpaceRE.test(obj.path)) {
+        const paths = obj.path.split(manySpaceRE);
         paths.forEach(function(p) {
           const copy = Object.assign({}, obj);
           copy.path = p;
@@ -592,9 +595,9 @@ function _populateObj(obj) {
   if (Array.isArray(obj.populate)) {
     const ret = [];
     obj.populate.forEach(function(obj) {
-      if (/[\s]/.test(obj.path)) {
+      if (oneSpaceRE.test(obj.path)) {
         const copy = Object.assign({}, obj);
-        const paths = copy.path.split(' ');
+        const paths = copy.path.split(manySpaceRE);
         paths.forEach(function(p) {
           copy.path = p;
           ret.push(exports.populate(copy)[0]);
@@ -609,7 +612,7 @@ function _populateObj(obj) {
   }
 
   const ret = [];
-  const paths = obj.path.split(' ');
+  const paths = oneSpaceRE.test(obj.path) ? obj.path.split(manySpaceRE) : [obj.path];
   if (obj.options != null) {
     obj.options = clone(obj.options);
   }


### PR DESCRIPTION
Fix #13951

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, `populate('user  fans')` will fail with a StrictPopulateError because of the extra space. I think it is sufficiently reasonable to split by multiple spaces, so `populate('user  fans')` is equivalent to `populate('user fans')`. This may cause issues in cases where path names have whitespace characters, but given that it isn't currently possible to populate a space-delimited path anyway, I don't think that is concerning.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
