### PR TITLE
fix(document): fix missing import and change wrong variable name

### DIFF
--- a/docs/typescript/query-helpers.md
+++ b/docs/typescript/query-helpers.md
@@ -29,7 +29,7 @@ The 2nd generic parameter, `TQueryHelpers`, should be an interface that contains
 Below is an example of creating a `ProjectModel` with a `byName` query helper.
 
 ```typescript
-import { HydratedDocument, Model, Query, Schema, model } from 'mongoose';
+import { HydratedDocument, Model, QueryWithHelpers, Schema, model, connect } from 'mongoose';
 
 interface Project {
   name?: string;
@@ -64,7 +64,7 @@ ProjectSchema.query.byName = function byName(
 };
 
 // 2nd param to `model()` is the Model class to return.
-const ProjectModel = model<Project, ProjectModelType>('Project', schema);
+const ProjectModel = model<Project, ProjectModelType>('Project', ProjectSchema);
 
 run().catch(err => console.log(err));
 


### PR DESCRIPTION
**Summary**

- I found some errors in the sample code of "Manually Typed Query Helpers"
    - https://mongoosejs.com/docs/typescript/query-helpers.html#manually-typed-query-helpers



**Examples**

```
lib/models/project2.ts:9:25 - error TS2304: Cannot find name 'QueryWithHelpers'.

9   byName(name: string): QueryWithHelpers<
                          ~~~~~~~~~~~~~~~~
lib/models/project2.ts:29:9 - error TS2304: Cannot find name 'QueryWithHelpers'.

29   this: QueryWithHelpers<any, HydratedDocument<Project>, ProjectQueryHelpers>,
           ~~~~~~~~~~~~~~~~
lib/models/project2.ts:36:66 - error TS2552: Cannot find name 'schema'. Did you mean 'Schema'?

36 const ProjectModel = model<Project, ProjectModelType>('Project', schema);
                                                                    ~~~~~~
lib/models/project2.ts:41:9 - error TS2304: Cannot find name 'connect'.

41   await connect('mongodb://127.0.0.1:27017/test');
           ~~~~~~~
```
