### PR TITLE
Add fullPath to ValidatorProps

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1305,6 +1305,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
 
     const validatorProperties = isSimpleValidator(v) ? Object.assign({}, v) : clone(v);
     validatorProperties.path = options && options.path ? options.path : path;
+    validatorProperties.fullPath = this.$fullPath;
     validatorProperties.value = value;
 
     if (validator instanceof RegExp) {
@@ -1426,6 +1427,7 @@ SchemaType.prototype.doValidateSync = function(value, scope, options) {
     const validator = v.validator;
     const validatorProperties = isSimpleValidator(v) ? Object.assign({}, v) : clone(v);
     validatorProperties.path = options && options.path ? options.path : path;
+    validatorProperties.fullPath = this.$fullPath;
     validatorProperties.value = value;
     let ok = false;
 

--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -4,6 +4,7 @@ declare module 'mongoose' {
 
   interface ValidatorProps {
     path: string;
+    fullPath: string;
     value: any;
   }
 


### PR DESCRIPTION
When using a custom validator function in sub-schemas it's currently impossible to retrieve corresponding field in the schema and thus, access info like `ref` or `refPath`.

### Summary

I just add a new field to `ValidatorOptions` called `fullPath` retrieved from `this.$fullPath` before the call of the validator function.

### Examples

```js
const { Schema, models, model } = require("mongoose");

const User = model("User", {email:  String});

const metaSchema = new Schema({
    user: {
        type: Schema.Types.ObjectId,
        ref: "User",
        validate: {
            async validator(_id, props) {
                // here context is lost if we don't have the fullPath field
                // because retrieving current nested field options is impossible using path
                // as depth related information is no longer available
                const ref = this.schema.path(props.fullPath)?.options?.ref;
                const model = models[ref];
                return (await model.exists({ _id }).exec()) !== null;
            }
        }
    }
});

const Foo = model("Foo", {meta: {type: metaSchema}});

const user = await User.create({email: "example@email.com"});

// Works using `fullPath` but will fail if only `path` is available
await Foo.create({meta: {user: user._id}}); 

// Validation Error as expected
await Foo.create({meta: {user: "e175cac316a79afdd0ad3afb"}}); 
```
