### PR TITLE
chore(scripts/website): fix script to correctly parse "-rc" like versions

### DIFF
--- a/scripts/website.js
+++ b/scripts/website.js
@@ -90,7 +90,8 @@ let filteredTags = [];
  * @returns number array or undefined
  */
 function parseVersion(str) {
-  const versionReg = /^v?(\d+)\.(\d+)\.(\d+)$/i;
+  // there is no ending "$", because of "rc"-like versions
+  const versionReg = /^v?(\d+)\.(\d+)\.(\d+)/i;
 
   const match = versionReg.exec(str);
 
@@ -105,12 +106,23 @@ function parseVersion(str) {
     return parsed;
   }
 
+  // special case, to not log a warning
+  if (str === "test") {
+    return undefined;
+  }
+
+  console.log(`Failed to parse version! got: ${str}`);
+
   return undefined;
 }
 
+/**
+ * Get versions from git tags and put them into {@link filteredTags}
+ */
 function getVersions() {
   // get all tags from git
-  const res = childProcess.execSync("git tag").toString();
+  // "trim" is used to remove the ending new-line
+  const res = childProcess.execSync("git tag").toString().trim();
 
   filteredTags = res.split('\n')
   // map all gotten tags if they match the regular expression


### PR DESCRIPTION
**Summary**

This PR fixes the website script to correctly build for `rc`-like versions by just not reading past the last digit. (also fixed legacy `alpha` releases)
Also includes some extra fixes:
- print string that failed to parse
- trim childprocess output (remove last empty-newline)
- ignore git tag `test`

example of a failed run: https://github.com/Automattic/mongoose/actions/runs/6632207139/job/18017384534 (c28cffea0a47ce07a4b154d4435eacfbc72c56d7)
