### PR TITLE
fix(schema): handle recursive schemas in discriminator definitions

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -412,7 +412,9 @@ Schema.prototype._clone = function _clone(Constructor) {
   s.s.hooks = this.s.hooks.clone();
 
   s.tree = clone(this.tree);
-  s.paths = clone(this.paths);
+  s.paths = Object.fromEntries(
+    Object.entries(this.paths).map(([key, value]) => ([key, value.clone()]))
+  );
   s.nested = clone(this.nested);
   s.subpaths = clone(this.subpaths);
   for (const schemaType of Object.values(s.paths)) {

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -56,7 +56,7 @@ function SubdocumentPath(schema, path, options) {
   this.base = schema.base;
   SchemaType.call(this, path, options, 'Embedded');
 
-  if (schema._applyDiscriminators != null) {
+  if (schema._applyDiscriminators != null && !options?._skipApplyDiscriminators) {
     for (const disc of schema._applyDiscriminators.keys()) {
       this.discriminator(disc, schema._applyDiscriminators.get(disc));
     }
@@ -388,8 +388,11 @@ SubdocumentPath.prototype.toJSON = function toJSON() {
  */
 
 SubdocumentPath.prototype.clone = function() {
-  const options = Object.assign({}, this.options);
-  const schematype = new this.constructor(this.schema, this.path, options);
+  const schematype = new this.constructor(
+    this.schema,
+    this.path,
+    { ...this.options, _skipApplyDiscriminators: true }
+  );
   schematype.validators = this.validators.slice();
   if (this.requiredValidator !== undefined) {
     schematype.requiredValidator = this.requiredValidator;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3172,4 +3172,20 @@ describe('schema', function() {
     const res = await Test.findOne({ _id: { $eq: doc._id, $type: 'objectId' } });
     assert.equal(res.name, 'Test Testerson');
   });
+
+  it('handles recursive definitions in discriminators (gh-13978)', function() {
+    const base = new Schema({
+      type: { type: Number, required: true }
+    }, { discriminatorKey: 'type' });
+
+    const recursive = new Schema({
+      self: { type: base, required: true }
+    });
+
+    base.discriminator(1, recursive);
+    const TestModel = db.model('Test', base);
+
+    const doc = new TestModel({ type: 1, self: { type: 1 } });
+    assert.strictEqual(doc.self.type, 1);
+  });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3183,7 +3183,7 @@ describe('schema', function() {
     });
 
     base.discriminator(1, recursive);
-    const TestModel = db.model('Test', base);
+    const TestModel = db.model('gh13978', base);
 
     const doc = new TestModel({ type: 1, self: { type: 1 } });
     assert.strictEqual(doc.self.type, 1);


### PR DESCRIPTION
Fix #13978

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Deep cloning schema `paths` property causes issues when discriminator schema contains the main schema as a subdocument. This PR makes it so that we don't deep clone unnecessarily, just clone each `path` and avoid re-applying discriminators unnecessarily (discriminators are already copied in `SubdocumentPath.prototype.clone`)

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
