### PR TITLE
fix(connection): retain modified status for documents created outside a transaction during transaction retries

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -563,6 +563,10 @@ function _resetSessionDocuments(session) {
       doc.$__.activePaths.states.modify = {};
     }
     for (const path of state.modifiedPaths) {
+      const currentState = doc.$__.activePaths.paths[path];
+      if (currentState != null) {
+        delete doc.$__.activePaths[currentState][path];
+      }
       doc.$__.activePaths.paths[path] = 'modify';
       doc.$__.activePaths.states.modify[path] = true;
     }

--- a/lib/document.js
+++ b/lib/document.js
@@ -53,6 +53,7 @@ const scopeSymbol = require('./helpers/symbols').scopeSymbol;
 const schemaMixedSymbol = require('./schema/symbols').schemaMixedSymbol;
 const parentPaths = require('./helpers/path/parentPaths');
 const getDeepestSubdocumentForPath = require('./helpers/document/getDeepestSubdocumentForPath');
+const sessionNewDocuments = require('./helpers/symbols').sessionNewDocuments;
 
 let DocumentArray;
 let MongooseArray;
@@ -1474,7 +1475,14 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
     this.$__set(pathToMark, path, options, constructing, parts, schema, val, priorVal);
 
-    if (savedState != null && savedState.hasOwnProperty(savedStatePath) && utils.deepEqual(val, savedState[savedStatePath])) {
+    if (savedState != null &&
+        savedState.hasOwnProperty(savedStatePath) &&
+        this.$__.session &&
+        this.$__.session[sessionNewDocuments] &&
+        this.$__.session[sessionNewDocuments].has(this) &&
+        this.$__.session[sessionNewDocuments].get(this).modifiedPaths &&
+        !this.$__.session[sessionNewDocuments].get(this).modifiedPaths.has(savedStatePath) &&
+        utils.deepEqual(val, savedState[savedStatePath])) {
       this.unmarkModified(path);
     }
   }

--- a/lib/document.js
+++ b/lib/document.js
@@ -1475,13 +1475,15 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
     this.$__set(pathToMark, path, options, constructing, parts, schema, val, priorVal);
 
+    const isInTransaction = !!this.$__.session?.transaction;
+    const isModifiedWithinTransaction = this.$__.session &&
+      this.$__.session[sessionNewDocuments] &&
+      this.$__.session[sessionNewDocuments].has(this) &&
+      this.$__.session[sessionNewDocuments].get(this).modifiedPaths &&
+      !this.$__.session[sessionNewDocuments].get(this).modifiedPaths.has(savedStatePath);
     if (savedState != null &&
         savedState.hasOwnProperty(savedStatePath) &&
-        this.$__.session &&
-        this.$__.session[sessionNewDocuments] &&
-        this.$__.session[sessionNewDocuments].has(this) &&
-        this.$__.session[sessionNewDocuments].get(this).modifiedPaths &&
-        !this.$__.session[sessionNewDocuments].get(this).modifiedPaths.has(savedStatePath) &&
+        (!isInTransaction || isModifiedWithinTransaction) &&
         utils.deepEqual(val, savedState[savedStatePath])) {
       this.unmarkModified(path);
     }

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -396,4 +396,29 @@ describe('transactions', function() {
     assert.equal(docs.length, 1);
     assert.equal(docs[0].name, 'test');
   });
+
+  it('transaction() retains modified status for documents created outside the transaction (gh-13973)', async function() {
+    db.deleteModel(/Test/);
+    const Test = db.model('Test', Schema({ status: String }));
+
+    await Test.createCollection();
+    await Test.deleteMany({});
+
+    const { _id } = await Test.create({ status: 'test' });
+    const doc = await Test.findById(_id);
+
+    let i = 0;
+    await db.transaction(async(session) => {
+      doc.status = 'test2';
+      assert.ok(doc.$isModified('status'));
+      await doc.save({ session });
+      if (++i < 3) {
+        throw new mongoose.mongo.MongoServerError({
+          errorLabels: ['TransientTransactionError']
+        });
+      }
+    });
+
+    assert.equal(i, 3);
+  });
 });

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -397,7 +397,7 @@ describe('transactions', function() {
     assert.equal(docs[0].name, 'test');
   });
 
-  it('transaction() retains modified status for documents created outside the transaction (gh-13973)', async function() {
+  it('transaction() retains modified status for documents created outside of the transaction then modified inside the transaction (gh-13973)', async function() {
     db.deleteModel(/Test/);
     const Test = db.model('Test', Schema({ status: String }));
 


### PR DESCRIPTION
Fix #13973

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13973 points out that, due to the fact that we store the document's initial `savedState` during the first transaction operation, this can lead to us calling `unmarkModified()` unintentionally. Right now `$__set()` calls `unmarkModified()` if the document's `savedState` says that the value hasn't changed from the initial value. However, we also need to check if this is a transaction retry and the transaction says the document was already modified before the transaction started.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
