### PR TITLE
Index: Fix index alias object key position

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2037,11 +2037,9 @@ Schema.prototype.index = function(fields, options) {
   }
   for (const key in fields) {
     if (this.aliases[key]) {
-      fields[this.aliases[key]] = fields[key];
-      delete fields[key];
+      fields = utils.renameObjKey(fields, key, this.aliases[key]);
     }
   }
-
   for (const field of Object.keys(fields)) {
     if (fields[field] === 'ascending' || fields[field] === 'asc') {
       fields[field] = 1;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -964,6 +964,29 @@ exports.each = function(arr, fn) {
   }
 };
 
+/**
+ * Rename an object key, while preserving its position in the object
+ *
+ * @param {Object} oldObj
+ * @param {String|Number} oldKey
+ * @param {String|Number} newKey
+ * @api private
+ */
+exports.renameObjKey = function (oldObj, oldKey, newKey) {
+  const keys = Object.keys(oldObj);
+  return keys.reduce(
+    (acc, val) => {
+      if (val === oldKey) {
+        acc[newKey] = oldObj[oldKey];
+      } else {
+        acc[val] = oldObj[val];
+      }
+      return acc;
+    },
+    {} as Record<string, unknown>
+  );
+}
+
 /*!
  * ignore
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -983,7 +983,7 @@ exports.renameObjKey = function (oldObj, oldKey, newKey) {
       }
       return acc;
     },
-    {} as Record<string, unknown>
+    {}
   );
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -972,7 +972,7 @@ exports.each = function(arr, fn) {
  * @param {String|Number} newKey
  * @api private
  */
-exports.renameObjKey = function (oldObj, oldKey, newKey) {
+exports.renameObjKey = function(oldObj, oldKey, newKey) {
   const keys = Object.keys(oldObj);
   return keys.reduce(
     (acc, val) => {
@@ -985,7 +985,7 @@ exports.renameObjKey = function (oldObj, oldKey, newKey) {
     },
     {}
   );
-}
+};
 
 /*!
  * ignore


### PR DESCRIPTION
**Summary**

This pr fixes an issue index object order when it has aliases, it rename the key from the alias to the original field and maintain it's position in the object as entered by user.


**Examples**

```

const UserSchema = new Schema(
  {
    n: {
      type: String,
      alias: 'name',
    },
    age: {
      type: Number,
    }
  }
)

UserSchema.index({ name: 1, age: -1 });

// The current behavior will generate index object like this 
// original fields { name: 1, age: -1 }
// after replacing the name alias with original field  { age: -1, n: 1 } ❌ 

The fix in this PR will make it work as intended and preserve the object key order
{ n: 1, age: -1 } ✅ 

```

This issue exist in version 7 and version 8 and would great to merge this PR in both versions.

Thank you! 