### PR TITLE
types(model+query): unpack arrays in distinct return type

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -781,4 +781,11 @@ async function gh14026() {
 
   const distinctBar = await FooModel.distinct('bar');
   expectType<string[]>(distinctBar);
+
+  const TestModel = mongoose.model(
+    'Test',
+    new mongoose.Schema({ bar: [String] })
+  );
+
+  expectType<string[]>(await TestModel.distinct('bar'));
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -771,3 +771,14 @@ function gh13897() {
   expectType<Date>(doc.createdAt);
   expectError(new Document<IDocument>({ name: 'foo' }));
 }
+
+async function gh14026() {
+  interface Foo {
+    bar: string[];
+  }
+
+  const FooModel = mongoose.model<Foo>('Foo', new mongoose.Schema<Foo>({ bar: [String] }));
+
+  const distinctBar = await FooModel.distinct('bar');
+  expectType<string[]>(distinctBar);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -481,7 +481,7 @@ declare module 'mongoose' {
       field: DocKey,
       filter?: FilterQuery<TRawDocType>
     ): QueryWithHelpers<
-      Array<DocKey extends keyof TRawDocType ? TRawDocType[DocKey] : ResultType>,
+      Array<DocKey extends keyof TRawDocType ? Unpacked<TRawDocType[DocKey]> : ResultType>,
       THydratedDocumentType,
       TQueryHelpers,
       TRawDocType,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -320,7 +320,7 @@ declare module 'mongoose' {
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
       filter?: FilterQuery<DocType>
-    ): QueryWithHelpers<Array<DocKey extends keyof DocType ? DocType[DocKey] : ResultType>, DocType, THelpers, RawDocType, 'distinct'>;
+    ): QueryWithHelpers<Array<DocKey extends keyof DocType ? Unpacked<DocType[DocKey]> : ResultType>, DocType, THelpers, RawDocType, 'distinct'>;
 
     /** Specifies a `$elemMatch` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     elemMatch<K = string>(path: K, val: any): this;


### PR DESCRIPTION
Fix #14026

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`Unpack<T>` returns the array element type if `T` is an array, or `T` otherwise. We already use `Unpacked<>` in some similar cases, like async iterators for `aggregate()`. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
