### PR TITLE
fix(ChangeStream): correctly handle `hydrate` option when using change stream as stream instead of iterator

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -83,6 +83,9 @@ class ChangeStream extends EventEmitter {
         if (ev === 'error' && this.closed) {
           return;
         }
+        if (data != null && data.fullDocument != null && this.options && this.options.hydrate) {
+          data.fullDocument = this.options.model.hydrate(data.fullDocument);
+        }
         this.emit(ev, data);
       });
     });

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11017,7 +11017,7 @@ describe('model: populate:', function() {
     const peopleList = await Person.find().
       sort({ firstName: 1 }).
       populate({ path: 'nationality', match: { desc: 'Spain' } });
-    assert.deepStrictEqual(peopleList.map(p => p.nationality?.key), [undefined, 'ES', undefined]);
+    assert.deepStrictEqual(peopleList.map(p => p.nationality.key), [undefined, 'ES', undefined]);
 
   });
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11017,8 +11017,10 @@ describe('model: populate:', function() {
     const peopleList = await Person.find().
       sort({ firstName: 1 }).
       populate({ path: 'nationality', match: { desc: 'Spain' } });
-    assert.deepStrictEqual(peopleList.map(p => p.nationality.key), [undefined, 'ES', undefined]);
-
+    assert.deepStrictEqual(
+      peopleList.map(p => p.personality ? p.nationality.key : undefined),
+      [undefined, 'ES', undefined]
+    );
   });
 
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11018,7 +11018,7 @@ describe('model: populate:', function() {
       sort({ firstName: 1 }).
       populate({ path: 'nationality', match: { desc: 'Spain' } });
     assert.deepStrictEqual(
-      peopleList.map(p => p.personality ? p.nationality.key : undefined),
+      peopleList.map(p => p.nationality ? p.nationality.key : undefined),
       [undefined, 'ES', undefined]
     );
   });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5364,6 +5364,32 @@ describe('Model', function() {
           assert.equal(changeData.fullDocument.get('name'), 'Tony Stark');
         });
 
+        it('fullDocument with immediate watcher and hydrate (gh-14049)', async function() {
+          const MyModel = db.model('Test', new Schema({ name: String }));
+
+          const doc = await MyModel.create({ name: 'Ned Stark' });
+
+          const changes = [];
+          const p = new Promise((resolve) => {
+            MyModel.watch([], {
+              fullDocument: 'updateLookup',
+              hydrate: true
+            }).on('change', change => {
+              changes.push(change);
+              resolve(change);
+            });
+          });
+
+          await MyModel.updateOne({ _id: doc._id }, { name: 'Tony Stark' });
+
+          const changeData = await p;
+          assert.equal(changeData.operationType, 'update');
+          assert.equal(changeData.fullDocument._id.toHexString(),
+            doc._id.toHexString());
+          assert.ok(changeData.fullDocument.$__);
+          assert.equal(changeData.fullDocument.get('name'), 'Tony Stark');
+        });
+
         it('respects discriminators (gh-11007)', async function() {
           const BaseModel = db.model('Test', new Schema({ name: String }));
           const ChildModel = BaseModel.discriminator('Test1', new Schema({ email: String }));

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5369,13 +5369,11 @@ describe('Model', function() {
 
           const doc = await MyModel.create({ name: 'Ned Stark' });
 
-          const changes = [];
           const p = new Promise((resolve) => {
             MyModel.watch([], {
               fullDocument: 'updateLookup',
               hydrate: true
             }).on('change', change => {
-              changes.push(change);
               resolve(change);
             });
           });


### PR DESCRIPTION
Fix #14049

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Missed a spot when handling the `hydrate` option for change streams: works fine when you use change streams as an iterator with `next()`, but doesn't work with `on()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
