### PR TITLE
fix(document): avoid unmarking modified on nested path if no initial value stored and already modified

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1204,6 +1204,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
         this.invalidate(path, new MongooseError.CastError('Object', val, path));
         return this;
       }
+      const wasModified = this.$isModified(path);
       const hasInitialVal = this.$__.savedState != null && this.$__.savedState.hasOwnProperty(path);
       if (this.$__.savedState != null && !this.$isNew && !this.$__.savedState.hasOwnProperty(path)) {
         const initialVal = this.$__getValue(path);
@@ -1228,7 +1229,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
       for (const key of keys) {
         this.$set(path + '.' + key, val[key], constructing, options);
       }
-      if (priorVal != null && utils.deepEqual(hasInitialVal ? this.$__.savedState[path] : priorVal, val)) {
+      if (priorVal != null &&
+          (!wasModified || hasInitialVal) &&
+          utils.deepEqual(hasInitialVal ? this.$__.savedState[path] : priorVal, val)) {
         this.unmarkModified(path);
       } else {
         this.markModified(path);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -9239,6 +9239,49 @@ describe('document', function() {
     assert.ok(foo.isModified('subdoc.bar'));
   });
 
+  it('does not unmark modified if there is no initial value (gh-9396)', async function() {
+    const IClientSchema = new Schema({
+      jwt: {
+        token_crypt: { type: String, template: false, maxSize: 8 * 1024 },
+        token_salt: { type: String, template: false }
+      }
+    });
+
+    const encrypt = function(doc, path, value) {
+      doc.set(path + '_crypt', value + '_crypt');
+      doc.set(path + '_salt', value + '_salt');
+    };
+
+    const decrypt = function(doc, path) {
+      return doc.get(path + '_crypt').replace('_crypt', '');
+    };
+
+    IClientSchema.virtual('jwt.token')
+      .get(function() {
+        return decrypt(this, 'jwt.token');
+      })
+      .set(function(value) {
+        encrypt(this, 'jwt.token', value);
+      });
+
+
+    const iclient = db.model('Test', IClientSchema);
+    const test = new iclient({
+      jwt: {
+        token: 'firstToken'
+      }
+    });
+
+    await test.save();
+    const entry = await iclient.findById(test._id).orFail();
+    entry.set('jwt.token', 'secondToken');
+    entry.set(entry.toJSON());
+    await entry.save();
+
+    const { jwt } = await iclient.findById(test._id).orFail();
+    assert.strictEqual(jwt.token, 'secondToken');
+  });
+
   it('correctly tracks saved state for deeply nested objects (gh-10773) (gh-9396)', async function() {
     const PaymentSchema = Schema({ status: String }, { _id: false });
     const OrderSchema = new Schema({


### PR DESCRIPTION
Fix #14022

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14022 comes down to Mongoose calling `unmarkModified()` if you set a nested path to the same value after modifying it. Which is fine if we have `savedState`, which stores the last state that we successfully called `save()` with. But problematic if we're just relying on `priorVal`, which contains the value of `path` before we set it. With this PR, if we don't have `savedState` and the path is already modified, we won't `unmarkModified()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
