### PR TITLE
fix: handle update validators and single nested doc with numberic paths

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2577,7 +2577,7 @@ Schema.prototype._getSchema = function(path) {
               if (parts[p] === '$' || isArrayFilter(parts[p])) {
                 if (p + 1 === parts.length) {
                   // comments.$
-                  return foundschema;
+                  return foundschema.$embeddedSchemaType;
                 }
                 // comments.$.comments.$.title
                 ret = search(parts.slice(p + 1), foundschema.schema);

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3069,6 +3069,22 @@ describe('model: updateOne: ', function() {
     const doc = await Test.findById(_id);
     assert.equal(doc.$myKey, 'gh13786');
   });
+  it('works with update validators and single nested doc with numberic paths (gh-13977)', async function() {
+    const subdoc = new mongoose.Schema({
+      1: { type: String, required: true, validate: () => true }
+    });
+    const schema = new mongoose.Schema({ subdoc });
+    const Test = db.model('Test', schema);
+
+    const _id = new mongoose.Types.ObjectId();
+    await Test.updateOne(
+      { _id },
+      { subdoc: { 1: 'foobar' } },
+      { upsert: true, runValidators: true }
+    );
+    const doc = await Test.findById(_id);
+    assert.equal(doc.subdoc['1'], 'foobar');
+  });
 });
 
 async function delay(ms) {


### PR DESCRIPTION
Fix #13977

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix: looks like `schema._getPath()` just returns the array path when called with `arr.$`, which seems incorrect, and causes update validators to try to pass a string value to `SingleNested.prototype.doValidate()` in #13977. Tests pass with this change, so I think this fix is reasonable.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
