### PR TITLE
types(model+query): correctly remove count from TypeScript types to reflect removal of runtime support

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -72,7 +72,7 @@ Test.find({}, {}, { populate: { path: 'child', model: ChildModel, match: true } 
 
 Test.find().byName('test').byName('test2').orFail().exec().then(console.log);
 
-Test.count({ name: /Test/ }).exec().then((res: number) => console.log(res));
+Test.countDocuments({ name: /Test/ }).exec().then((res: number) => console.log(res));
 Test.findOne({ 'docs.id': 42 }).exec().then(console.log);
 
 // ObjectId casting

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -201,15 +201,6 @@ declare module 'mongoose' {
     /** Collection the model uses. */
     collection: Collection;
 
-    /** Creates a `count` query: counts the number of documents that match `filter`. */
-    count(filter?: FilterQuery<TRawDocType>): QueryWithHelpers<
-      number,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TRawDocType,
-      'count'
-    >;
-
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
       filter?: FilterQuery<TRawDocType>,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -259,15 +259,6 @@ declare module 'mongoose' {
     /** Specifies the `comment` option. */
     comment(val: string): this;
 
-    /** Specifies this query as a `count` query. */
-    count(criteria?: FilterQuery<DocType>): QueryWithHelpers<
-      number,
-      DocType,
-      THelpers,
-      RawDocType,
-      'count'
-    >;
-
     /** Specifies this query as a `countDocuments` query. */
     countDocuments(
       criteria?: FilterQuery<DocType>,


### PR DESCRIPTION
Fix #14062

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like we didn't fully remove `count()` from TS types when removing runtime support, this PR fixes that

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
