### PR TITLE
fix: Remove count() from TypeScript definitions

### DIFF
--- a/types/middlewares.d.ts
+++ b/types/middlewares.d.ts
@@ -5,7 +5,7 @@ declare module 'mongoose' {
   type MongooseDistinctDocumentMiddleware = 'save' | 'init' | 'validate';
   type MongooseDocumentMiddleware = MongooseDistinctDocumentMiddleware | MongooseQueryAndDocumentMiddleware;
 
-  type MongooseDistinctQueryMiddleware = 'count' | 'estimatedDocumentCount' | 'countDocuments' | 'deleteMany' | 'distinct' | 'find' | 'findOne' | 'findOneAndDelete' | 'findOneAndReplace' | 'findOneAndUpdate' | 'replaceOne' | 'updateMany';
+  type MongooseDistinctQueryMiddleware = 'estimatedDocumentCount' | 'countDocuments' | 'deleteMany' | 'distinct' | 'find' | 'findOne' | 'findOneAndDelete' | 'findOneAndReplace' | 'findOneAndUpdate' | 'replaceOne' | 'updateMany';
   type MongooseDefaultQueryMiddleware = MongooseDistinctQueryMiddleware | 'updateOne' | 'deleteOne';
   type MongooseQueryMiddleware = MongooseDistinctQueryMiddleware | MongooseQueryAndDocumentMiddleware;
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -201,15 +201,6 @@ declare module 'mongoose' {
     /** Collection the model uses. */
     collection: Collection;
 
-    /** Creates a `count` query: counts the number of documents that match `filter`. */
-    count(filter?: FilterQuery<TRawDocType>): QueryWithHelpers<
-      number,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TRawDocType,
-      'count'
-    >;
-
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
       filter?: FilterQuery<TRawDocType>,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -259,15 +259,6 @@ declare module 'mongoose' {
     /** Specifies the `comment` option. */
     comment(val: string): this;
 
-    /** Specifies this query as a `count` query. */
-    count(criteria?: FilterQuery<DocType>): QueryWithHelpers<
-      number,
-      DocType,
-      THelpers,
-      RawDocType,
-      'count'
-    >;
-
     /** Specifies this query as a `countDocuments` query. */
     countDocuments(
       criteria?: FilterQuery<DocType>,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

After https://github.com/Automattic/mongoose/pull/13618 was merged, the now missing `count()` function was not removed from the types.

cc @IslandRhythms 
