### PR TITLE
types(model): support calling `Model.validate()` with `pathsToSkip` option

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -751,3 +751,11 @@ function gh13957() {
   const repository = new RepositoryBase<ITest>(TestModel);
   expectType<Promise<ITest[]>>(repository.insertMany([{ name: 'test' }]));
 }
+
+async function gh14003() {
+  const schema = new Schema({ name: String });
+  const TestModel = model('Test', schema);
+
+  await TestModel.validate({ name: 'foo' }, ['name']);
+  await TestModel.validate({ name: 'foo' }, { pathsToSkip: ['name'] });
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -461,8 +461,11 @@ declare module 'mongoose' {
 
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
     validate(): Promise<void>;
-    validate(optional: any): Promise<void>;
-    validate(optional: any, pathsToValidate: PathsToValidate): Promise<void>;
+    validate(obj: any): Promise<void>;
+    validate(
+      obj: any,
+      pathsOrOptions: PathsToValidate | { pathsToSkip?: PathsToValidate }
+    ): Promise<void>;
 
     /** Watches the underlying collection for changes using [MongoDB change streams](https://www.mongodb.com/docs/manual/changeStreams/). */
     watch<ResultType extends mongodb.Document = any, ChangeType extends mongodb.ChangeStreamDocument = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions & { hydrate?: boolean }): mongodb.ChangeStream<ResultType, ChangeType>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -462,10 +462,8 @@ declare module 'mongoose' {
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
     validate(): Promise<void>;
     validate(obj: any): Promise<void>;
-    validate(
-      obj: any,
-      pathsOrOptions: PathsToValidate | { pathsToSkip?: PathsToValidate }
-    ): Promise<void>;
+    validate(obj: any, pathsOrOptions: PathsToValidate): Promise<void>;
+    validate(obj: any, pathsOrOptions: { pathsToSkip?: pathsToSkip }): Promise<void>;
 
     /** Watches the underlying collection for changes using [MongoDB change streams](https://www.mongodb.com/docs/manual/changeStreams/). */
     watch<ResultType extends mongodb.Document = any, ChangeType extends mongodb.ChangeStreamDocument = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions & { hydrate?: boolean }): mongodb.ChangeStream<ResultType, ChangeType>;


### PR DESCRIPTION
Re: #14003

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

While #14003 looks like a non-issue, it did lead us to find that TS types don't support calling `Model.validate()` with a `pathsToSkip` option

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
