### PR TITLE
test(query): remove unnecessary query test code

### DIFF
--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1373,7 +1373,7 @@ describe('Query', function() {
   });
 
   describe('setOptions', function() {
-    it('works', async function() {
+    it('works', function() {
       const q = new Query();
       q.setOptions({ thing: 'cat' });
       q.setOptions({ populate: ['fans'] });
@@ -1397,16 +1397,6 @@ describe('Query', function() {
       assert.equal(q.options.hint.index2, -1);
       assert.equal(q.options.readPreference.mode, 'secondary');
       assert.equal(q.options.readPreference.tags[0].dc, 'eu');
-
-      const Product = db.model('Product', productSchema);
-      const [, doc2] = await Product.create([
-        { numbers: [3, 4, 5] },
-        { strings: 'hi there'.split(' '), w: 'majority' }
-      ]);
-
-      const docs = await Product.find().setOptions({ limit: 1, sort: { _id: -1 }, read: 'n' });
-      assert.equal(docs.length, 1);
-      assert.equal(docs[0].id, doc2.id);
     });
 
     it('populate as array in options (gh-4446)', function() {


### PR DESCRIPTION
Fix #13970

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The test failure in #13970 is because [read preference 'nearest' doesn't distinguish between primaries and secondaries](https://www.mongodb.com/docs/manual/core/read-preference/#mongodb-readmode-nearest), so in theory the query can fetch data from a secondary before data has replicated to it.

Either way, the test code is unnecessary now, this logic dates back to 2012 in https://github.com/Automattic/mongoose/commit/205a709c4e69c759709e3113f7de4f0859f1ddd4. It doesn't actually test whether the read preference is sent, and would be less flakey if read preference wasn't sent to the server. And the behavior it tries to cover is covered in other tests.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
