### PR TITLE
fix(populate): set populated docs in correct order when populating virtual underneath doc array with justOne

### DIFF
--- a/lib/helpers/populate/assignRawDocsToIdStructure.js
+++ b/lib/helpers/populate/assignRawDocsToIdStructure.js
@@ -32,9 +32,13 @@ const kHasArray = Symbol('mongoose#assignRawDocsToIdStructure#hasArray');
  */
 
 function assignRawDocsToIdStructure(rawIds, resultDocs, resultOrder, options, recursed) {
-  // honor user specified sort order
+  // honor user specified sort order, unless we're populating a single
+  // virtual underneath an array (e.g. populating `employees.mostRecentShift` where
+  // `mostRecentShift` is a virtual with `justOne`)
   const newOrder = [];
-  const sorting = options.sort && rawIds.length > 1;
+  const sorting = options.isVirtual && options.justOne && rawIds.length > 1
+    ? false :
+    options.sort && rawIds.length > 1;
   const nullIfNotFound = options.$nullIfNotFound;
   let doc;
   let sid;

--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -19,7 +19,8 @@ module.exports = function assignVals(o) {
   // `o.options` contains options explicitly listed in `populateOptions`, like
   // `match` and `limit`.
   const populateOptions = Object.assign({}, o.options, userOptions, {
-    justOne: o.justOne
+    justOne: o.justOne,
+    isVirtual: o.isVirtual
   });
   populateOptions.$nullIfNotFound = o.isVirtual;
   const populatedModel = o.populatedModel;


### PR DESCRIPTION
Fix #14018

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The issue is that Mongoose uses the `sort` order when assigning populated documents, which is incorrect in the case where you have virtual populate with `justOne`. In the `justOne` case, the `sort` just determines the documents you get back; the order in which the documents are assigned should be matched up by document id, not just using the sort order.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
