### PR TITLE
types(document): correct return type for `doc.deleteOne()` re: Mongoose 8 breaking change

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -9,6 +9,7 @@ import {
   HydratedSingleSubdocument,
   DefaultSchemaOptions
 } from 'mongoose';
+import { DeleteResult } from 'mongodb';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { autoTypedModel } from './models.test';
 import { autoTypedModelConnection } from './connection.test';
@@ -39,7 +40,9 @@ const Test = model<ITest>('Test', schema);
 void async function main() {
   const doc = await Test.findOne().orFail();
 
-  expectType<Promise<TestDocument>>(doc.deleteOne());
+  expectType<DeleteResult>(await doc.deleteOne());
+  expectType<TestDocument | null>(await doc.deleteOne().findOne());
+  expectType<{ _id: Types.ObjectId, name?: string } | null>(await doc.deleteOne().findOne().lean());
 }();
 
 

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -108,7 +108,13 @@ declare module 'mongoose' {
     db: Connection;
 
     /** Removes this document from the db. */
-    deleteOne(options?: QueryOptions): Promise<this>;
+    deleteOne(options?: QueryOptions): QueryWithHelpers<
+      mongodb.DeleteResult,
+      this,
+      TQueryHelpers,
+      DocType,
+      'deleteOne'
+    >;
 
     /**
      * Takes a populated field and returns it to its unpopulated state. If called with


### PR DESCRIPTION
Fix #14081

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

TypeScript types for `doc.deleteOne()` still return `Promise<this>`. This PR makes `doc.deleteOne()` correctly return a `QueryWithHelpers` with correct types.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
