### PR TITLE
types(models): allow specifying `timestamps` as inline option for bulkWrite() operations

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -796,3 +796,52 @@ async function gh14026() {
 
   expectType<string[]>(await TestModel.distinct('bar'));
 }
+
+async function gh14072() {
+  type Test = {
+    _id: mongoose.Types.ObjectId;
+    num: number;
+    created_at: number;
+    updated_at: number;
+  };
+
+  const schema = new mongoose.Schema<Test>(
+    {
+      num: { type: Number },
+      created_at: { type: Number },
+      updated_at: { type: Number }
+    },
+    {
+      timestamps: {
+        createdAt: 'created_at',
+        updatedAt: 'updated_at',
+        currentTime: () => new Date().valueOf() / 1000
+      }
+    }
+  );
+
+  const M = mongoose.model<Test>('Test', schema);
+  const bulkWriteArray = [
+    {
+      insertOne: {
+        document: { num: 3 }
+      }
+    },
+    {
+      updateOne: {
+        filter: { num: 6 },
+        update: { num: 8 },
+        timestamps: false
+      }
+    },
+    {
+      updateMany: {
+        filter: { num: 5 },
+        update: { num: 10 },
+        timestamps: false
+      }
+    }
+  ];
+
+  await M.bulkWrite(bulkWriteArray);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -26,6 +26,12 @@ declare module 'mongoose' {
   interface MongooseBulkWriteOptions {
     skipValidation?: boolean;
     throwOnValidationError?: boolean;
+    timestamps?: boolean;
+  }
+
+  interface MongooseBulkWritePerWriteOptions {
+    timestamps?: boolean;
+    strict?: boolean;
   }
 
   interface InsertManyOptions extends
@@ -183,11 +189,17 @@ declare module 'mongoose' {
      * round trip to the MongoDB server.
      */
     bulkWrite<DocContents = TRawDocType>(
-      writes: Array<mongodb.AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
+      writes: Array<
+        mongodb.AnyBulkWriteOperation<
+          DocContents extends mongodb.Document ? DocContents : any
+        > & MongooseBulkWritePerWriteOptions>,
       options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions & { ordered: false }
     ): Promise<mongodb.BulkWriteResult & { mongoose?: { validationErrors: Error[] } }>;
     bulkWrite<DocContents = TRawDocType>(
-      writes: Array<mongodb.AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
+      writes: Array<
+        mongodb.AnyBulkWriteOperation<
+          DocContents extends mongodb.Document ? DocContents : any
+        > & MongooseBulkWritePerWriteOptions>,
       options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions
     ): Promise<mongodb.BulkWriteResult>;
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -32,6 +32,8 @@ declare module 'mongoose' {
   interface MongooseBulkWritePerWriteOptions {
     timestamps?: boolean;
     strict?: boolean;
+    session?: ClientSession;
+    skipValidation?: boolean;
   }
 
   interface InsertManyOptions extends


### PR DESCRIPTION
Fix #14072

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

You can set options like `timestamps` and `strict` on individual bulkWrite operations, that's handled in `castBulkWrite()`. This PR lets you set those options in TypeScript

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
