### PR TITLE
Perf improvements when creating arrays of primitives

### DIFF
--- a/lib/statemachine.js
+++ b/lib/statemachine.js
@@ -65,7 +65,11 @@ StateMachine.ctor = function() {
  */
 
 StateMachine.prototype._changeState = function _changeState(path, nextState) {
-  const prevBucket = this.states[this.paths[path]];
+  const prevState = this.paths[path];
+  if (prevState === nextState) {
+    return;
+  }
+  const prevBucket = this.states[prevState];
   if (prevBucket) delete prevBucket[path];
 
   this.paths[path] = nextState;

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -375,7 +375,7 @@ const methods = {
         atomics.$push = val;
       } else {
         if (val.length === 1) {
-          atomics.$push.$each.push(val);
+          atomics.$push.$each.push(val[0]);
         } else if (val.length < 10000) {
           atomics.$push.$each.push(...val);
         } else {

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -374,7 +374,13 @@ const methods = {
       if (val != null && utils.hasUserDefinedProperty(val, '$each')) {
         atomics.$push = val;
       } else {
-        atomics.$push.$each.push(val);
+        if (val.length < 10000) {
+          atomics.$push.$each.push(...val);
+        } else {
+          for (const v of val) {
+            atomics.$push.$each.push(v);
+          }
+        }
       }
     } else {
       atomics[op] = val;
@@ -711,7 +717,7 @@ const methods = {
           'with different `$position`');
       }
       atomic = values;
-      ret = [].push.apply(arr, values);
+      ret = _basePush.apply(arr, values);
     }
 
     this._registerAtomic('$push', atomic);

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -411,8 +411,7 @@ const methods = {
   addToSet() {
     _checkManualPopulation(this, arguments);
 
-    let values = [].map.call(arguments, this._mapCast, this);
-    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol]);
+    const values = [].map.call(arguments, this._mapCast, this);
     const added = [];
     let type = '';
     if (values[0] instanceof ArraySubdocument) {
@@ -423,7 +422,7 @@ const methods = {
       type = 'ObjectId';
     }
 
-    const rawValues = utils.isMongooseArray(values) ? values.__array : this;
+    const rawValues = utils.isMongooseArray(values) ? values.__array : values;
     const rawArray = utils.isMongooseArray(this) ? this.__array : this;
 
     rawValues.forEach(function(v) {
@@ -690,10 +689,7 @@ const methods = {
 
     _checkManualPopulation(this, values);
 
-    const parent = this[arrayParentSymbol];
     values = [].map.call(values, this._mapCast, this);
-    values = this[arraySchemaSymbol].applySetters(values, parent, undefined,
-      undefined, { skipDocumentArrayCast: true });
     let ret;
     const atomics = this[arrayAtomicsSymbol];
     this._markModified();
@@ -925,7 +921,6 @@ const methods = {
       values = arguments;
     } else {
       values = [].map.call(arguments, this._cast, this);
-      values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol]);
     }
 
     const arr = utils.isMongooseArray(this) ? this.__array : this;

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -374,7 +374,9 @@ const methods = {
       if (val != null && utils.hasUserDefinedProperty(val, '$each')) {
         atomics.$push = val;
       } else {
-        if (val.length < 10000) {
+        if (val.length === 1) {
+          atomics.$push.$each.push(val);
+        } else if (val.length < 10000) {
           atomics.$push.$each.push(...val);
         } else {
           for (const v of val) {

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -374,7 +374,7 @@ const methods = {
       if (val != null && utils.hasUserDefinedProperty(val, '$each')) {
         atomics.$push = val;
       } else {
-        atomics.$push.$each = atomics.$push.$each.concat(val);
+        atomics.$push.$each.push(val);
       }
     } else {
       atomics[op] = val;

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -1915,4 +1915,26 @@ describe('types array', function() {
       }
     });
   });
+
+  it('calls array setters (gh-11380)', function() {
+    let called = 0;
+    const Test = db.model('Test', new Schema({
+      intArr: [{
+        type: Number,
+        set: v => {
+          ++called;
+          return Math.floor(v);
+        }
+      }]
+    }));
+
+    assert.equal(called, 0);
+    const doc = new Test({ intArr: [3.14] });
+    assert.deepStrictEqual(doc.intArr, [3]);
+    assert.equal(called, 1);
+
+    doc.intArr.push(2.718);
+    assert.deepStrictEqual(doc.intArr, [3, 2]);
+    assert.equal(called, 2);
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: #11380, #13546. This one quick improvement of using `push()` instead of `concat()` already helps shave off maybe 10% off of #11380.

Before:

```
l100.avg=1140.53, total.avg=3175.7342
```

After:

```
l100.avg=1249.86, total.avg=2870.4085
```

Gonna work to see what other performance wins we can turn up.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
