### PR TITLE
types: make property names show up in intellisense for UpdateQuery

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -634,7 +634,7 @@ declare module 'mongoose' {
    * { age: 30 }
    * ```
    */
-  export type UpdateQuery<T> = _UpdateQuery<T> & AnyObject;
+  export type UpdateQuery<T> = AnyKeys<T> & _UpdateQuery<T> & AnyObject;
 
   /**
    * A more strict form of UpdateQuery that enforces updating only


### PR DESCRIPTION
Fix #14090

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I took a look, and with this changes it looks like intellisense picks up property names as well as update operators 
![image](https://github.com/Automattic/mongoose/assets/1620265/d1467b0a-59b1-43ad-91c0-61481399a21d)


<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
