### PR TITLE
feat(schematype): merge rather than overwrite default schematype validators

### DIFF
--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -59,7 +59,19 @@ function SchemaType(path, options, instance) {
   const defaultOptionsKeys = Object.keys(defaultOptions);
 
   for (const option of defaultOptionsKeys) {
-    if (defaultOptions.hasOwnProperty(option) && !Object.prototype.hasOwnProperty.call(options, option)) {
+    if (option === 'validate') {
+      const defaultValidators = Array.isArray(defaultOptions.validate)
+        ? defaultOptions.validate
+        : defaultOptions.validate == null
+          ? []
+          : [defaultOptions.validate];
+      const specifiedValidators = Array.isArray(options.validate)
+        ? options.validate
+        : options.validate == null
+          ? []
+          : [options.validate];
+      options.validate = [...defaultValidators, ...specifiedValidators];
+    } else if (defaultOptions.hasOwnProperty(option) && !Object.prototype.hasOwnProperty.call(options, option)) {
       options[option] = defaultOptions[option];
     }
   }

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -60,17 +60,7 @@ function SchemaType(path, options, instance) {
 
   for (const option of defaultOptionsKeys) {
     if (option === 'validate') {
-      const defaultValidators = Array.isArray(defaultOptions.validate)
-        ? defaultOptions.validate
-        : defaultOptions.validate == null
-          ? []
-          : [defaultOptions.validate];
-      const specifiedValidators = Array.isArray(options.validate)
-        ? options.validate
-        : options.validate == null
-          ? []
-          : [options.validate];
-      options.validate = [...defaultValidators, ...specifiedValidators];
+      this.validate(defaultOptions.validate);
     } else if (defaultOptions.hasOwnProperty(option) && !Object.prototype.hasOwnProperty.call(options, option)) {
       options[option] = defaultOptions[option];
     }

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -210,11 +210,15 @@ describe('schematype', function() {
 
   it('merges default validators (gh-14070)', function() {
     class TestSchemaType extends mongoose.SchemaType {}
-    TestSchemaType.set('validate', v => typeof v === 'string');
+    TestSchemaType.set('validate', checkIfString);
 
     const schemaType = new TestSchemaType('test-path', {
-      validate: v => v.length === 2
+      validate: checkIfLength2
     });
+
+    assert.equal(schemaType.validators.length, 2);
+    assert.equal(schemaType.validators[0].validator, checkIfString);
+    assert.equal(schemaType.validators[1].validator, checkIfLength2);
 
     let err = schemaType.doValidateSync([1, 2]);
     assert.ok(err);
@@ -226,6 +230,13 @@ describe('schematype', function() {
 
     err = schemaType.doValidateSync('ab');
     assert.ifError(err);
+
+    function checkIfString(v) {
+      return typeof v === 'string';
+    }
+    function checkIfLength2(v) {
+      return v.length === 2;
+    }
   });
 
   describe('set()', function() {

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -208,6 +208,25 @@ describe('schematype', function() {
     });
   });
 
+  it('merges default validators (gh-14070)', function() {
+    class TestSchemaType extends mongoose.SchemaType {}
+    TestSchemaType.set('validate', v => typeof v === 'string');
+
+    const schemaType = new TestSchemaType();
+    schemaType.validate(v => v.length === 2);
+
+    let err = schemaType.doValidateSync([1, 2]);
+    assert.ok(err);
+    assert.equal(err.name, 'ValidatorError');
+
+    err = schemaType.doValidateSync('foo');
+    assert.ok(err);
+    assert.equal(err.name, 'ValidatorError');
+
+    err = schemaType.doValidateSync('ab');
+    assert.ifError(err);
+  });
+
   describe('set()', function() {
     describe('SchemaType.set()', function() {
       it('SchemaType.set, is a function', () => {

--- a/test/schematype.test.js
+++ b/test/schematype.test.js
@@ -212,8 +212,9 @@ describe('schematype', function() {
     class TestSchemaType extends mongoose.SchemaType {}
     TestSchemaType.set('validate', v => typeof v === 'string');
 
-    const schemaType = new TestSchemaType();
-    schemaType.validate(v => v.length === 2);
+    const schemaType = new TestSchemaType('test-path', {
+      validate: v => v.length === 2
+    });
 
     let err = schemaType.doValidateSync([1, 2]);
     assert.ok(err);


### PR DESCRIPTION
Fix #14070

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14070 makes a fair point that `validate` overwriting default schematype validators is a point of friction, and merging validators would make the default validator API much more useful. I figure it is reasonable to ship this with 8.1, what do you think @AbdelrahmanHafez @hasezoey ?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
