### PR TITLE
docs(source/api): fix "index.js" -> "mongoose.js" rename

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const md = require('marked');
 
 const files = [
-  'lib/index.js',
+  'lib/mongoose.js',
   'lib/schema.js',
   'lib/connection.js',
   'lib/document.js',


### PR DESCRIPTION
**Summary**

This PR fixes the documentation filemap, which was not done in 3ec26a0fa30e98736b859202832c5121a9ffb1c5 and so broke the website by having a empty api page