### PR TITLE
fix(schema): avoid creating unnecessary clone of schematype in nested array so nested document arrays use correct constructor

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1122,15 +1122,14 @@ Schema.prototype.path = function(path, obj) {
       if (_schemaType.$isMongooseDocumentArray) {
         _schemaType.$embeddedSchemaType._arrayPath = arrayPath;
         _schemaType.$embeddedSchemaType._arrayParentPath = path;
-        _schemaType = _schemaType.$embeddedSchemaType.clone();
+        _schemaType = _schemaType.$embeddedSchemaType;
       } else {
         _schemaType.caster._arrayPath = arrayPath;
         _schemaType.caster._arrayParentPath = path;
-        _schemaType = _schemaType.caster.clone();
+        _schemaType = _schemaType.caster;
       }
 
-      _schemaType.path = arrayPath;
-      toAdd.push(_schemaType);
+      this.subpaths[arrayPath] = _schemaType;
     }
 
     for (const _schemaType of toAdd) {

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -754,4 +754,28 @@ describe('types.documentarray', function() {
 
     assert.equal(doc.myMap.get('foo').$path(), 'myMap.foo');
   });
+
+  it('bubbles up validation errors from doubly nested doc arrays (gh-14101)', async function() {
+    const optionsSchema = new mongoose.Schema({
+      val: {
+        type: Number,
+        required: true
+      }
+    });
+
+    const testSchema = new mongoose.Schema({
+      name: String,
+      options: {
+        type: [[optionsSchema]],
+        required: true
+      }
+    });
+
+    const Test = db.model('Test', testSchema);
+
+    await assert.rejects(
+      Test.create({ name: 'test', options: [[{ val: null }]] }),
+      /options.0.0.val: Path `val` is required./
+    );
+  });
 });


### PR DESCRIPTION
Fix #14101

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The underlying issue in #14101 is that we have two different schema types for `options` and `options.$`, even though they should be the same. Which leads to issues when validating a subdoc of `options.$`'s caster using `options` schematype. Specifically triggering [this `if` statement](https://github.com/Automattic/mongoose/blob/12c58921bb683acfa9c78a497a6f8e684ea5c368/lib/schema/documentArrayElement.js#L71-L73), which leads to issues with nested arrays because `scope` can be an array.

The fix is to avoid cloning, so `options` and `options.$` are largely interchangeable as far as casting and validation are concerned.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
