### PR TITLE
fix: allow adding discriminators using `Schema.prototype.discriminator()` to subdocuments after defining parent schema

### DIFF
--- a/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
+++ b/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = applyEmbeddedDiscriminators;
+
+function applyEmbeddedDiscriminators(schema, seen = new WeakSet()) {
+  if (seen.has(schema)) {
+    return;
+  }
+  seen.add(schema);
+  for (const path of Object.keys(schema.paths)) {
+    const schemaType = schema.paths[path];
+    if (!schemaType.schema) {
+      continue;
+    }
+    applyEmbeddedDiscriminators(schemaType.schema, seen);
+    if (!schemaType.schema._applyDiscriminators) {
+      continue;
+    }
+    for (const disc of schemaType.schema._applyDiscriminators.keys()) {
+      schemaType.discriminator(disc, schemaType.schema._applyDiscriminators.get(disc));
+    }
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ const sanitizeFilter = require('./helpers/query/sanitizeFilter');
 const isBsonType = require('./helpers/isBsonType');
 const MongooseError = require('./error/mongooseError');
 const SetOptionError = require('./error/setOptionError');
+const applyEmbeddedDiscriminators = require('./helpers/discriminator/applyEmbeddedDiscriminators');
 
 const defaultMongooseSymbol = Symbol.for('mongoose:default');
 
@@ -629,15 +630,7 @@ Mongoose.prototype._model = function(name, schema, collection, options) {
     }
   }
 
-  for (const path of Object.keys(schema.paths)) {
-    const schemaType = schema.paths[path];
-    if (!schemaType.schema || !schemaType.schema._applyDiscriminators) {
-      continue;
-    }
-    for (const disc of schemaType.schema._applyDiscriminators.keys()) {
-      schemaType.discriminator(disc, schemaType.schema._applyDiscriminators.get(disc));
-    }
-  }
+  applyEmbeddedDiscriminators(schema);
 
   return model;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -629,6 +629,16 @@ Mongoose.prototype._model = function(name, schema, collection, options) {
     }
   }
 
+  for (const path of Object.keys(schema.paths)) {
+    const schemaType = schema.paths[path];
+    if (!schemaType.schema || !schemaType.schema._applyDiscriminators) {
+      continue;
+    }
+    for (const disc of schemaType.schema._applyDiscriminators.keys()) {
+      schemaType.discriminator(disc, schemaType.schema._applyDiscriminators.get(disc));
+    }
+  }
+
   return model;
 };
 

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -55,11 +55,6 @@ function SubdocumentPath(schema, path, options) {
   this.$isSingleNested = true;
   this.base = schema.base;
   SchemaType.call(this, path, options, 'Embedded');
-  if (schema._applyDiscriminators != null && !options?._skipApplyDiscriminators) {
-    for (const disc of schema._applyDiscriminators.keys()) {
-      this.discriminator(disc, schema._applyDiscriminators.get(disc));
-    }
-  }
 }
 
 /*!

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -88,12 +88,6 @@ function DocumentArrayPath(key, schema, options, schemaOptions) {
 
   this.$embeddedSchemaType.caster = this.Constructor;
   this.$embeddedSchemaType.schema = this.schema;
-
-  if (schema._applyDiscriminators != null && !options?._skipApplyDiscriminators) {
-    for (const disc of schema._applyDiscriminators.keys()) {
-      this.discriminator(disc, schema._applyDiscriminators.get(disc));
-    }
-  }
 }
 
 /**
@@ -528,7 +522,7 @@ DocumentArrayPath.prototype.cast = function(value, doc, init, prev, options) {
 
 DocumentArrayPath.prototype.clone = function() {
   const options = Object.assign({}, this.options);
-  const schematype = new this.constructor(this.path, this.schema, { ...options, _skipApplyDiscriminators: true }, this.schemaOptions);
+  const schematype = new this.constructor(this.path, this.schema, options, this.schemaOptions);
   schematype.validators = this.validators.slice();
   if (this.requiredValidator !== undefined) {
     schematype.requiredValidator = this.requiredValidator;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12657,6 +12657,57 @@ describe('document', function() {
     );
   });
 
+  it('handles embedded discriminators defined using Schema.prototype.discriminator after defining schema (gh-14109) (gh-13898)', async function() {
+    const baseNestedDiscriminated = new Schema({
+      type: { type: Number, required: true }
+    }, { discriminatorKey: 'type' });
+
+    class BaseClass {
+      whoAmI() {
+        return 'I am baseNestedDiscriminated';
+      }
+    }
+    BaseClass.type = 1;
+
+    baseNestedDiscriminated.loadClass(BaseClass);
+
+    class NumberTyped extends BaseClass {
+      whoAmI() {
+        return 'I am NumberTyped';
+      }
+    }
+    NumberTyped.type = 3;
+
+    class StringTyped extends BaseClass {
+      whoAmI() {
+        return 'I am StringTyped';
+      }
+    }
+    StringTyped.type = 4;
+
+    const containsNestedSchema = new Schema({
+      nestedDiscriminatedTypes: { type: [baseNestedDiscriminated], required: true }
+    });
+
+    // After `containsNestedSchema`, in #13898 test these were before `containsNestedSchema`
+    baseNestedDiscriminated.discriminator(1, new Schema({}).loadClass(NumberTyped));
+    baseNestedDiscriminated.discriminator('3', new Schema({}).loadClass(StringTyped));
+
+    class ContainsNested {
+      whoAmI() {
+        return 'I am ContainsNested';
+      }
+    }
+    containsNestedSchema.loadClass(ContainsNested);
+
+    const Test = db.model('Test', containsNestedSchema);
+    const instance = await Test.create({ type: 1, nestedDiscriminatedTypes: [{ type: 1 }, { type: '3' }] });
+    assert.deepStrictEqual(
+      instance.nestedDiscriminatedTypes.map(i => i.whoAmI()),
+      ['I am NumberTyped', 'I am StringTyped']
+    );
+  });
+
   it('can use `collection` as schema name (gh-13956)', async function() {
     const schema = new mongoose.Schema({ name: String, collection: String });
     const Test = db.model('Test', schema);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12667,7 +12667,6 @@ describe('document', function() {
         return 'I am baseNestedDiscriminated';
       }
     }
-    BaseClass.type = 1;
 
     baseNestedDiscriminated.loadClass(BaseClass);
 
@@ -12676,14 +12675,12 @@ describe('document', function() {
         return 'I am NumberTyped';
       }
     }
-    NumberTyped.type = 3;
 
     class StringTyped extends BaseClass {
       whoAmI() {
         return 'I am StringTyped';
       }
     }
-    StringTyped.type = 4;
 
     const containsNestedSchema = new Schema({
       nestedDiscriminatedTypes: { type: [baseNestedDiscriminated], required: true }
@@ -12718,7 +12715,6 @@ describe('document', function() {
         return 'I am baseNestedDiscriminated';
       }
     }
-    BaseClass.type = 1;
 
     baseNestedDiscriminated.loadClass(BaseClass);
 
@@ -12727,14 +12723,12 @@ describe('document', function() {
         return 'I am NumberTyped';
       }
     }
-    NumberTyped.type = 3;
 
     class StringTyped extends BaseClass {
       whoAmI() {
         return 'I am StringTyped';
       }
     }
-    StringTyped.type = 4;
 
     const containsNestedSchema = new Schema({
       nestedDiscriminatedTypes: { type: [baseNestedDiscriminated], required: true }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12708,6 +12708,58 @@ describe('document', function() {
     );
   });
 
+  it('handles embedded discriminators on nested path defined using Schema.prototype.discriminator (gh-14109) (gh-13898)', async function() {
+    const baseNestedDiscriminated = new Schema({
+      type: { type: Number, required: true }
+    }, { discriminatorKey: 'type' });
+
+    class BaseClass {
+      whoAmI() {
+        return 'I am baseNestedDiscriminated';
+      }
+    }
+    BaseClass.type = 1;
+
+    baseNestedDiscriminated.loadClass(BaseClass);
+
+    class NumberTyped extends BaseClass {
+      whoAmI() {
+        return 'I am NumberTyped';
+      }
+    }
+    NumberTyped.type = 3;
+
+    class StringTyped extends BaseClass {
+      whoAmI() {
+        return 'I am StringTyped';
+      }
+    }
+    StringTyped.type = 4;
+
+    const containsNestedSchema = new Schema({
+      nestedDiscriminatedTypes: { type: [baseNestedDiscriminated], required: true }
+    });
+
+    baseNestedDiscriminated.discriminator(1, new Schema({}).loadClass(NumberTyped));
+    baseNestedDiscriminated.discriminator('3', new Schema({}).loadClass(StringTyped));
+
+    const l2Schema = new Schema({ l3: containsNestedSchema });
+    const l1Schema = new Schema({ l2: l2Schema });
+
+    const Test = db.model('Test', l1Schema);
+    const instance = await Test.create({
+      l2: {
+        l3: {
+          nestedDiscriminatedTypes: [{ type: 1 }, { type: '3' }]
+        }
+      }
+    });
+    assert.deepStrictEqual(
+      instance.l2.l3.nestedDiscriminatedTypes.map(i => i.whoAmI()),
+      ['I am NumberTyped', 'I am StringTyped']
+    );
+  });
+
   it('can use `collection` as schema name (gh-13956)', async function() {
     const schema = new mongoose.Schema({ name: String, collection: String });
     const Test = db.model('Test', schema);


### PR DESCRIPTION
Fix #14109

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

For #14109, re: #13898. Delay applying discriminators added using `Schema.prototype.discriminator()` on embedded schemas (document arrays and single nested paths) until you compile the top-level model. This allows adding discriminators to document arrays using `Schema.prototype.discriminator()` _after_ defining a document array with the schema, which is the primary issue in #14109.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
