### PR TITLE
Call transform object with single id instead of array when populating a justOne path under an array

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -80,6 +80,8 @@ module.exports = function assignVals(o) {
       return valueFilter(val[0], options, populateOptions, _allIds);
     } else if (o.justOne === false && !Array.isArray(val)) {
       return valueFilter([val], options, populateOptions, _allIds);
+    } else if (o.justOne === true && !Array.isArray(val) && Array.isArray(_allIds)) {
+      return valueFilter(val, options, populateOptions, val == null ? val : _allIds[o.rawOrder[val._id]]);
     }
     return valueFilter(val, options, populateOptions, _allIds);
   }

--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -39,8 +39,10 @@ module.exports = function assignVals(o) {
   const options = o.options;
   const count = o.count && o.isVirtual;
   let i;
+  let setValueIndex = 0;
 
   function setValue(val) {
+    ++setValueIndex;
     if (count) {
       return val;
     }
@@ -81,12 +83,13 @@ module.exports = function assignVals(o) {
     } else if (o.justOne === false && !Array.isArray(val)) {
       return valueFilter([val], options, populateOptions, _allIds);
     } else if (o.justOne === true && !Array.isArray(val) && Array.isArray(_allIds)) {
-      return valueFilter(val, options, populateOptions, val == null ? val : _allIds[o.rawOrder[val._id]]);
+      return valueFilter(val, options, populateOptions, val == null ? val : _allIds[setValueIndex - 1]);
     }
     return valueFilter(val, options, populateOptions, _allIds);
   }
 
   for (i = 0; i < docs.length; ++i) {
+    setValueIndex = 0;
     const _path = o.path.endsWith('.$*') ? o.path.slice(0, -3) : o.path;
     const existingVal = mpath.get(_path, docs[i], lookupLocalFields);
     if (existingVal == null && !getVirtual(o.originalModel.schema, _path)) {

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -10811,6 +10811,9 @@ describe('model: populate:', function() {
     for (let i = 0; i < brands.length; i++) {
       test.items.push({ name: `${i}`, brand: brands[i]._id });
     }
+
+    const id4 = new mongoose.Types.ObjectId();
+    test.items.push({ name: '4', brand: id4 });
     await test.save();
 
     const ids = [];
@@ -10825,10 +10828,10 @@ describe('model: populate:', function() {
           }
         }
       ]);
-    assert.equal(ids.length, 3);
+    assert.equal(ids.length, 4);
     assert.deepStrictEqual(
-      ids.map(id => id.toHexString()),
-      [id1.toString(), id2.toString(), id3.toString()]
+      ids.map(id => id?.toHexString()),
+      [id1.toString(), id2.toString(), id3.toString(), id4.toString()]
     );
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #14073 

A bit of a weird fix, but it works. The idea is that, if you call populate on `items.brand`, where `items` is a doc array and `brand` is an ObjectId ref, the `transform` option will get an array of ids as 2nd arg, not a single id. To work around this, we need to track what position in the array is being assigned, and get the original id by that index.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
