### PR TITLE
docs(connections): add example of registering connection event handlers

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -276,7 +276,7 @@ connection may emit.
 
 When you're connecting to a single MongoDB server (a ["standalone"](https://www.mongodb.com/docs/cloud-manager/tutorial/deploy-standalone/)), Mongoose will emit `disconnected` if it gets
 disconnected from the standalone server, and `connected` if it successfully connects to the standalone. In a
-[replica set](https://www.mongodb.com/docs/manual/replication/), Mongoose will emit 'disconnected' if it loses connectivity to the replica set primary, and 'connected' if it manages to reconnect to the replica set primary.
+[replica set](https://www.mongodb.com/docs/manual/replication/), Mongoose will emit `disconnected` if it loses connectivity to the replica set primary, and `connected` if it manages to reconnect to the replica set primary.
 
 If you are using `mongoose.connect()`, you can use the following to listen to the above events:
 


### PR DESCRIPTION
Fix #13879

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Added a code sample of how to register connection event handlers to Connection Events section. Also removed the `fullsetup` and `all` events, because those are no longer emitted. Mongoose used to bubble those up from the MongoDB Node.js driver, but those were removed a long time ago.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
