### PR TITLE
fix: avoid minimizing single nested subdocs if they are required

### DIFF
--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -54,7 +54,7 @@ function clone(obj, options, isArrayChild) {
       ret = obj.toObject(options);
     }
 
-    if (options && options.minimize && isSingleNested && Object.keys(ret).length === 0) {
+    if (options && options.minimize && !obj.constructor.$__required && isSingleNested && Object.keys(ret).length === 0) {
       return undefined;
     }
 

--- a/lib/schema/SubdocumentPath.js
+++ b/lib/schema/SubdocumentPath.js
@@ -48,7 +48,7 @@ function SubdocumentPath(schema, path, options) {
 
   schema = handleIdOption(schema, options);
 
-  this.caster = _createConstructor(schema);
+  this.caster = _createConstructor(schema, null, options);
   this.caster.path = path;
   this.caster.prototype.$basePath = path;
   this.schema = schema;
@@ -69,7 +69,7 @@ SubdocumentPath.prototype.OptionsConstructor = SchemaSubdocumentOptions;
  * ignore
  */
 
-function _createConstructor(schema, baseClass) {
+function _createConstructor(schema, baseClass, options) {
   // lazy load
   Subdocument || (Subdocument = require('../types/subdocument'));
 
@@ -89,6 +89,7 @@ function _createConstructor(schema, baseClass) {
   _embedded.prototype = Object.create(proto);
   _embedded.prototype.$__setSchema(schema);
   _embedded.prototype.constructor = _embedded;
+  _embedded.$__required = options?.required;
   _embedded.base = schema.base;
   _embedded.schema = schema;
   _embedded.$isSingleNested = true;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -793,6 +793,17 @@ describe('document', function() {
       assert.strictEqual(myModel.toObject().foo, void 0);
     });
 
+    it('does not minimize single nested subdocs if they are required (gh-14058) (gh-11247)', async function() {
+      const nestedSchema = Schema({ bar: String }, { _id: false });
+      const schema = Schema({ foo: { type: nestedSchema, required: true } });
+
+      const MyModel = db.model('Test', schema);
+
+      const myModel = await MyModel.create({ foo: {} });
+
+      assert.deepStrictEqual(myModel.toObject().foo, {});
+    });
+
     it('should propogate toObject to implicitly created schemas (gh-13599) (gh-13325)', async function() {
       const transformCalls = [];
       const userSchema = Schema({


### PR DESCRIPTION
Fix #14058

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14058 pointed out an unfortunate issue with the fix for #11247: `required` subdocuments without defaults end up getting minimized out, which leads to errors on subsequent saves by default unless you use the `validateBeforeSave: false` option for `save()`. This behavior is very unintuitive. With this PR, we'll skip minimizing subdocuments that have `required` set to a truthy value, including functions. So still works as expected if not `required`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
