### PR TITLE
types(model): add no-generic override for `insertMany()` with options

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -853,3 +853,19 @@ async function gh14003() {
   await TestModel.validate({ name: 'foo' }, ['name']);
   await TestModel.validate({ name: 'foo' }, { pathsToSkip: ['name'] });
 }
+
+async function gh13999() {
+  class RepositoryBase<T> {
+    protected model: mongoose.Model<T>;
+
+    constructor(schemaModel: mongoose.Model<T>) {
+      this.model = schemaModel;
+    }
+
+    async insertMany(elems: T[]): Promise<T[]> {
+      elems = await this.model.insertMany(elems, { session: null });
+      return elems;
+    }
+  }
+
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -395,6 +395,10 @@ declare module 'mongoose' {
       docs: Array<TRawDocType>,
       options: InsertManyOptions & { rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<THydratedDocumentType>>>;
+    insertMany(
+      doc: Array<TRawDocType>,
+      options: InsertManyOptions
+    ): Promise<Array<THydratedDocumentType>>;
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>,
       options: InsertManyOptions & { lean: true; }


### PR DESCRIPTION
Fix #13999

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix to expand the fix for #13957 to also support passing plain `InsertManyOptions` without `lean`, `rawResult`, or `ordered`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
