### PR TITLE
types: make findOneAndDelete() without options return result doc, not ModifyResult

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -853,3 +853,12 @@ async function gh14003() {
   await TestModel.validate({ name: 'foo' }, ['name']);
   await TestModel.validate({ name: 'foo' }, { pathsToSkip: ['name'] });
 }
+
+async function gh14114() {
+  const schema = new mongoose.Schema({ name: String });
+  const Test = mongoose.model('Test', schema);
+
+  expectType<ReturnType<(typeof Test)['hydrate']> | null>(
+    await Test.findOneAndDelete({ name: 'foo' })
+  );
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -608,11 +608,11 @@ declare module 'mongoose' {
       'findOneAndDelete'
     >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType> & { includeResultMetadata: true }
+      filter: FilterQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete'>;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: FilterQuery<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete'>;
 


### PR DESCRIPTION
Fix #14130

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14130 points out that, right now, calling `Model.findOneAndDelete(filter)` will return `Query<ModifyResult<THydratedDocType>>` rather than `Query<THydratedDocType>` because of the `?:` in the `& { includeResultMetadata: true }` type definition.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
