### PR TITLE
fix(populate): allow deselecting discriminator key when populating

### DIFF
--- a/lib/helpers/projection/isExclusive.js
+++ b/lib/helpers/projection/isExclusive.js
@@ -12,13 +12,12 @@ module.exports = function isExclusive(projection) {
   }
 
   const keys = Object.keys(projection);
-  let ki = keys.length;
   let exclude = null;
 
-  if (ki === 1 && keys[0] === '_id') {
+  if (keys.length === 1 && keys[0] === '_id') {
     exclude = !projection._id;
   } else {
-    while (ki--) {
+    for (let ki = 0; ki < keys.length; ++ki) {
       // Does this projection explicitly define inclusion/exclusion?
       // Explicitly avoid `$meta` and `$slice`
       const key = keys[ki];

--- a/lib/model.js
+++ b/lib/model.js
@@ -4408,7 +4408,7 @@ function populate(model, docs, options, callback) {
         select = select.replace(excludeIdRegGlobal, ' ');
       } else {
         // preserve original select conditions by copying
-        select = utils.object.shallowCopy(select);
+        select = { ...select };
         delete select._id;
       }
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -4932,16 +4932,14 @@ Query.prototype._castFields = function _castFields(fields) {
       elemMatchKeys,
       keys,
       key,
-      out,
-      i;
+      out;
 
   if (fields) {
     keys = Object.keys(fields);
     elemMatchKeys = [];
-    i = keys.length;
 
     // collect $elemMatch args
-    while (i--) {
+    for (let i = 0; i < keys.length; ++i) {
       key = keys[i];
       if (fields[key].$elemMatch) {
         selected || (selected = {});
@@ -4960,8 +4958,7 @@ Query.prototype._castFields = function _castFields(fields) {
     }
 
     // apply the casted field args
-    i = elemMatchKeys.length;
-    while (i--) {
+    for (let i = 0; i < elemMatchKeys.length; ++i) {
       key = elemMatchKeys[i];
       fields[key] = out[key];
     }

--- a/lib/queryhelpers.js
+++ b/lib/queryhelpers.js
@@ -180,9 +180,10 @@ exports.applyPaths = function applyPaths(fields, schema) {
       if (!isDefiningProjection(field)) {
         continue;
       }
-      // `_id: 1, name: 0` is a mixed inclusive/exclusive projection in
-      // MongoDB 4.0 and earlier, but not in later versions.
       if (keys[keyIndex] === '_id' && keys.length > 1) {
+        continue;
+      }
+      if (keys[keyIndex] === schema.options.discriminatorKey && keys.length > 1 && field != null && !field) {
         continue;
       }
       exclude = !field;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -687,12 +687,6 @@ exports.object.vals = function vals(o) {
   return ret;
 };
 
-/**
- * @see exports.options
- */
-
-exports.object.shallowCopy = exports.options;
-
 const hop = Object.prototype.hasOwnProperty;
 
 /**


### PR DESCRIPTION
Fix #3230
Re: #13760
Re: #13679

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, populating with `__t: 0` in projection throws a "Cannot do inclusion on field prop in exclusion projection", whereas deselecting projection works fine outside of `populate()`. The issue looks to be an ordering issue: Mongoose isn't correctly handling `__t: 0` as the first property in the `select` object, and with `populate()` Mongoose was reversing key order, so `{ name: 1, __t: 0 }` was ending up as `{ __t: 0, name: 1 }` because of `utils.object.shallowCopy`.

Both issues are fixed: Mongoose now handles `__t: 0` as first property in select object (`utils.object.shallowCopy()` was removed, no longer necessary with spread operator), and `populate()` with `{ __t: 0 }` now works as expected :+1:

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
