### PR TITLE
refactor: remove `utils.options` / `utils.object.shallowCopy`

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3690,8 +3690,7 @@ Document.prototype.$toObject = function(options, json) {
   const schemaOptions = this.$__schema && this.$__schema.options || {};
   // merge base default options with Schema's set default options if available.
   // `clone` is necessary here because `utils.options` directly modifies the second input.
-  defaultOptions = { ...defaultOptions, ...clone(baseOptions) };
-  defaultOptions = { ...defaultOptions, ...clone(schemaOptions[path] || {}) };
+  defaultOptions = { ...defaultOptions, ...baseOptions, ...schemaOptions[path] };
 
   // If options do not exist or is not an object, set it to empty object
   options = utils.isPOJO(options) ? { ...options } : {};

--- a/lib/document.js
+++ b/lib/document.js
@@ -3690,8 +3690,8 @@ Document.prototype.$toObject = function(options, json) {
   const schemaOptions = this.$__schema && this.$__schema.options || {};
   // merge base default options with Schema's set default options if available.
   // `clone` is necessary here because `utils.options` directly modifies the second input.
-  defaultOptions = utils.options(defaultOptions, clone(baseOptions));
-  defaultOptions = utils.options(defaultOptions, clone(schemaOptions[path] || {}));
+  defaultOptions = { ...defaultOptions, ...clone(baseOptions) };
+  defaultOptions = { ...defaultOptions, ...clone(schemaOptions[path] || {}) };
 
   // If options do not exist or is not an object, set it to empty object
   options = utils.isPOJO(options) ? { ...options } : {};
@@ -3753,7 +3753,7 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   // merge default options with input options.
-  options = utils.options(defaultOptions, options);
+  options = { ...defaultOptions, ...options };
   options._isNested = true;
   options.json = json;
   options.minimize = _minimize;

--- a/lib/model.js
+++ b/lib/model.js
@@ -4408,7 +4408,7 @@ function populate(model, docs, options, callback) {
         select = select.replace(excludeIdRegGlobal, ' ');
       } else {
         // preserve original select conditions by copying
-        select = utils.object.shallowCopy(select);
+        select = { ...select };
         delete select._id;
       }
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -560,7 +560,7 @@ Schema.prototype.defaultOptions = function(options) {
   const strict = 'strict' in baseOptions ? baseOptions.strict : true;
   const strictQuery = 'strictQuery' in baseOptions ? baseOptions.strictQuery : false;
   const id = 'id' in baseOptions ? baseOptions.id : true;
-  options = utils.options({
+  options = {
     strict,
     strictQuery,
     bufferCommands: true,
@@ -577,8 +577,9 @@ Schema.prototype.defaultOptions = function(options) {
     // the following are only applied at construction time
     _id: true,
     id: id,
-    typeKey: 'type'
-  }, clone(options));
+    typeKey: 'type',
+    ...clone(options)
+  };
 
   if (options.versionKey && typeof options.versionKey !== 'string') {
     throw new MongooseError('`versionKey` must be falsy or string, got `' + (typeof options.versionKey) + '`');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -578,7 +578,7 @@ Schema.prototype.defaultOptions = function(options) {
     _id: true,
     id: id,
     typeKey: 'type',
-    ...clone(options)
+    ...options
   };
 
   if (options.versionKey && typeof options.versionKey !== 'string') {

--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -7,7 +7,6 @@
 const CastError = require('../error/cast');
 const SchemaType = require('../schematype');
 const castBigInt = require('../cast/bigint');
-const utils = require('../utils');
 
 /**
  * BigInt SchemaType constructor.
@@ -177,12 +176,13 @@ SchemaBigInt.prototype.cast = function(value) {
  * ignore
  */
 
-SchemaBigInt.$conditionalHandlers = utils.options(SchemaType.prototype.$conditionalHandlers, {
+SchemaBigInt.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
   $lt: handleSingle,
   $lte: handleSingle
-});
+};
 
 /*!
  * ignore

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -7,7 +7,6 @@
 const CastError = require('../error/cast');
 const SchemaType = require('../schematype');
 const castBoolean = require('../cast/boolean');
-const utils = require('../utils');
 
 /**
  * Boolean SchemaType constructor.
@@ -235,8 +234,7 @@ SchemaBoolean.prototype.cast = function(value) {
   }
 };
 
-SchemaBoolean.$conditionalHandlers =
-    utils.options(SchemaType.prototype.$conditionalHandlers, {});
+SchemaBoolean.$conditionalHandlers = { ...SchemaType.prototype.$conditionalHandlers };
 
 /**
  * Casts contents for queries.

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -250,17 +250,17 @@ function handleSingle(val, context) {
   return this.castForQuery(null, val, context);
 }
 
-SchemaBuffer.prototype.$conditionalHandlers =
-    utils.options(SchemaType.prototype.$conditionalHandlers, {
-      $bitsAllClear: handleBitwiseOperator,
-      $bitsAnyClear: handleBitwiseOperator,
-      $bitsAllSet: handleBitwiseOperator,
-      $bitsAnySet: handleBitwiseOperator,
-      $gt: handleSingle,
-      $gte: handleSingle,
-      $lt: handleSingle,
-      $lte: handleSingle
-    });
+SchemaBuffer.prototype.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
+  $bitsAllClear: handleBitwiseOperator,
+  $bitsAnyClear: handleBitwiseOperator,
+  $bitsAllSet: handleBitwiseOperator,
+  $bitsAnySet: handleBitwiseOperator,
+  $gt: handleSingle,
+  $gte: handleSingle,
+  $lt: handleSingle,
+  $lte: handleSingle
+};
 
 /**
  * Casts contents for queries.

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -388,13 +388,13 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-SchemaDate.prototype.$conditionalHandlers =
-    utils.options(SchemaType.prototype.$conditionalHandlers, {
-      $gt: handleSingle,
-      $gte: handleSingle,
-      $lt: handleSingle,
-      $lte: handleSingle
-    });
+SchemaDate.prototype.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
+  $gt: handleSingle,
+  $gte: handleSingle,
+  $lt: handleSingle,
+  $lte: handleSingle
+};
 
 
 /**

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -7,7 +7,6 @@
 const SchemaType = require('../schematype');
 const CastError = SchemaType.CastError;
 const castDecimal128 = require('../cast/decimal128');
-const utils = require('../utils');
 const isBsonType = require('../helpers/isBsonType');
 
 /**
@@ -214,13 +213,13 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-Decimal128.prototype.$conditionalHandlers =
-    utils.options(SchemaType.prototype.$conditionalHandlers, {
-      $gt: handleSingle,
-      $gte: handleSingle,
-      $lt: handleSingle,
-      $lte: handleSingle
-    });
+Decimal128.prototype.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
+  $gt: handleSingle,
+  $gte: handleSingle,
+  $lt: handleSingle,
+  $lte: handleSingle
+};
 
 /*!
  * Module exports.

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -399,18 +399,18 @@ function handleArray(val) {
   });
 }
 
-SchemaNumber.prototype.$conditionalHandlers =
-    utils.options(SchemaType.prototype.$conditionalHandlers, {
-      $bitsAllClear: handleBitwiseOperator,
-      $bitsAnyClear: handleBitwiseOperator,
-      $bitsAllSet: handleBitwiseOperator,
-      $bitsAnySet: handleBitwiseOperator,
-      $gt: handleSingle,
-      $gte: handleSingle,
-      $lt: handleSingle,
-      $lte: handleSingle,
-      $mod: handleArray
-    });
+SchemaNumber.prototype.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
+  $bitsAllClear: handleBitwiseOperator,
+  $bitsAnyClear: handleBitwiseOperator,
+  $bitsAllSet: handleBitwiseOperator,
+  $bitsAnySet: handleBitwiseOperator,
+  $gt: handleSingle,
+  $gte: handleSingle,
+  $lt: handleSingle,
+  $lte: handleSingle,
+  $mod: handleArray
+};
 
 /**
  * Casts contents for queries.

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -259,13 +259,13 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-ObjectId.prototype.$conditionalHandlers =
-    utils.options(SchemaType.prototype.$conditionalHandlers, {
-      $gt: handleSingle,
-      $gte: handleSingle,
-      $lt: handleSingle,
-      $lte: handleSingle
-    });
+ObjectId.prototype.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
+  $gt: handleSingle,
+  $gte: handleSingle,
+  $lt: handleSingle,
+  $lte: handleSingle
+};
 
 /*!
  * ignore

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -641,7 +641,8 @@ function handleSingleNoSetters(val) {
   return this.cast(val, this);
 }
 
-const $conditionalHandlers = utils.options(SchemaType.prototype.$conditionalHandlers, {
+const $conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
   $all: handleArray,
   $gt: handleSingle,
   $gte: handleSingle,
@@ -656,7 +657,7 @@ const $conditionalHandlers = utils.options(SchemaType.prototype.$conditionalHand
     return handleSingleNoSetters.call(this, val);
   },
   $not: handleSingle
-});
+};
 
 Object.defineProperty(SchemaString.prototype, '$conditionalHandlers', {
   configurable: false,

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -313,8 +313,8 @@ function handleArray(val) {
   });
 }
 
-SchemaUUID.prototype.$conditionalHandlers =
-utils.options(SchemaType.prototype.$conditionalHandlers, {
+SchemaUUID.prototype.$conditionalHandlers = {
+  ...SchemaType.prototype.$conditionalHandlers,
   $bitsAllClear: handleBitwiseOperator,
   $bitsAnyClear: handleBitwiseOperator,
   $bitsAllSet: handleBitwiseOperator,
@@ -327,7 +327,7 @@ utils.options(SchemaType.prototype.$conditionalHandlers, {
   $lte: handleSingle,
   $ne: handleSingle,
   $nin: handleArray
-});
+};
 
 /**
  * Casts contents for queries.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -227,33 +227,6 @@ exports.omit = function omit(obj, keys) {
   return ret;
 };
 
-
-/**
- * Shallow copies defaults into options.
- *
- * @param {Object} defaults
- * @param {Object} [options]
- * @return {Object} the merged object
- * @api private
- */
-
-exports.options = function(defaults, options) {
-  const keys = Object.keys(defaults);
-  let i = keys.length;
-  let k;
-
-  options = options || {};
-
-  while (i--) {
-    k = keys[i];
-    if (!(k in options)) {
-      options[k] = defaults[k];
-    }
-  }
-
-  return options;
-};
-
 /**
  * Merges `from` into `to` without overwriting existing properties.
  *
@@ -686,12 +659,6 @@ exports.object.vals = function vals(o) {
 
   return ret;
 };
-
-/**
- * @see exports.options
- */
-
-exports.object.shallowCopy = exports.options;
 
 const hop = Object.prototype.hasOwnProperty;
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -121,29 +121,6 @@ describe('utils', function() {
     });
   });
 
-  it('utils.options', function() {
-    const o = { a: 1, b: 2, c: 3, 0: 'zero1' };
-    const defaults = { b: 10, d: 20, 0: 'zero2' };
-    const result = utils.options(defaults, o);
-    assert.equal(result.a, 1);
-    assert.equal(result.b, 2);
-    assert.equal(result.c, 3);
-    assert.equal(result.d, 20);
-    assert.deepEqual(o.d, result.d);
-    assert.equal(result['0'], 'zero1');
-
-    const result2 = utils.options(defaults);
-    assert.equal(result2.b, 10);
-    assert.equal(result2.d, 20);
-    assert.equal(result2['0'], 'zero2');
-
-    // same properties/vals
-    assert.deepEqual(defaults, result2);
-
-    // same object
-    assert.notEqual(defaults, result2);
-  });
-
   it('deepEquals on ObjectIds', function() {
     const s = (new ObjectId()).toString();
 


### PR DESCRIPTION
**Summary**

This PR removes function `utils.options` (`lib/utils.js`) which shallow-copies objects, which is now solved with JS-native spread-operator.

i got this idea because of #14155.

my only concern would be the removal of `clone`'s that was done previously (with 6820605d5082f94bba5a5b7ccae2dfe8c5d0a0c8), no tests fail and the comments mentioned it was because `utils.options` directly assigned to the second parameter.

as for performance, i have not measured, but i would assume it is about the same, if not better thanks to the removal of `clone`s