### PR TITLE
add missing Type for applyDefaults

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -185,7 +185,7 @@ declare module 'mongoose' {
 
     /* Apply defaults to the given document or POJO. */
     applyDefaults(obj: AnyObject|TRawDocType): TRawDocType;
-    
+
     /**
      * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,
      * `deleteOne`, and/or `deleteMany` operations to the MongoDB server in one

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -183,6 +183,9 @@ declare module 'mongoose' {
     /* Cast the given POJO to the model's schema */
     castObject(obj: AnyObject, options?: { ignoreCastErrors?: boolean }): TRawDocType;
 
+    /* Apply defaults to the given document or POJO. */
+    applyDefaults(obj: AnyObject|TRawDocType): TRawDocType;
+    
     /**
      * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,
      * `deleteOne`, and/or `deleteMany` operations to the MongoDB server in one

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -184,7 +184,8 @@ declare module 'mongoose' {
     castObject(obj: AnyObject, options?: { ignoreCastErrors?: boolean }): TRawDocType;
 
     /* Apply defaults to the given document or POJO. */
-    applyDefaults(obj: AnyObject|TRawDocType): TRawDocType;
+    applyDefaults(obj: AnyObject): AnyObject;
+    applyDefaults(obj: TRawDocType): TRawDocType;
 
     /**
      * Sends multiple `insertOne`, `updateOne`, `updateMany`, `replaceOne`,


### PR DESCRIPTION

**Summary**
The Typescript types definition file is missing a definition for `applyDefaults()` in `Model` Interface.

**Examples**

Error was
```
TS2339: Property 'applyDefaults' does not exist on type 'Model<Item, {}, {}, {}, any>'.
```
