### PR TITLE
types: handle using BigInt global class in schema definitions

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1368,3 +1368,14 @@ function gh13424() {
   const doc = new TestModel({});
   expectType<Types.ObjectId | undefined>(doc.subDocArray[0]._id);
 }
+
+function gh14147() {
+  const affiliateSchema = new Schema({
+    balance: { type: BigInt, default: BigInt(0) }
+  });
+
+  const AffiliateModel = model('Affiliate', affiliateSchema);
+
+  const doc = new AffiliateModel();
+  expectType<bigint>(doc.balance);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -262,15 +262,16 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
                                     IfEquals<PathValueType, Schema.Types.Decimal128> extends true ? Types.Decimal128 :
                                       IfEquals<PathValueType, Types.Decimal128> extends true ? Types.Decimal128 :
                                         IfEquals<PathValueType, Schema.Types.BigInt> extends true ? bigint :
-                                          PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt ? bigint :
-                                            PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
-                                              IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
-                                                PathValueType extends MapConstructor | 'Map' ? Map<string, ResolvePathType<Options['of']>> :
-                                                  IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
-                                                    PathValueType extends ArrayConstructor ? any[] :
-                                                      PathValueType extends typeof Schema.Types.Mixed ? any:
-                                                        IfEquals<PathValueType, ObjectConstructor> extends true ? any:
-                                                          IfEquals<PathValueType, {}> extends true ? any:
-                                                            PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
-                                                              PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, { typeKey: TypeKey }> :
-                                                                unknown;
+                                          IfEquals<PathValueType, BigInt> extends true ? bigint :
+                                            PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt ? bigint :
+                                              PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
+                                                IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
+                                                  PathValueType extends MapConstructor | 'Map' ? Map<string, ResolvePathType<Options['of']>> :
+                                                    IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
+                                                      PathValueType extends ArrayConstructor ? any[] :
+                                                        PathValueType extends typeof Schema.Types.Mixed ? any:
+                                                          IfEquals<PathValueType, ObjectConstructor> extends true ? any:
+                                                            IfEquals<PathValueType, {}> extends true ? any:
+                                                              PathValueType extends typeof SchemaType ? PathValueType['prototype'] :
+                                                                PathValueType extends Record<string, any> ? ObtainDocumentType<PathValueType, any, { typeKey: TypeKey }> :
+                                                                  unknown;


### PR DESCRIPTION
Fix #14147

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix to make inferSchemaType handle `type: BigInt` in schema definitions


<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
