### PR TITLE
fix(update): set CastError path to full path if casting update fails

### DIFF
--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -212,7 +212,14 @@ SchemaBigInt.prototype.castForQuery = function($conditional, val, context) {
     return this.applySetters(null, val, context);
   }
 
-  return this.applySetters(val, context);
+  try {
+    return this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
+  }
 };
 
 /**

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -256,7 +256,14 @@ SchemaBoolean.prototype.castForQuery = function($conditional, val, context) {
     return this.applySetters(null, val, context);
   }
 
-  return this.applySetters(val, context);
+  try {
+    return this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
+  }
 };
 
 /**

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -279,7 +279,16 @@ SchemaBuffer.prototype.castForQuery = function($conditional, val, context) {
     }
     return handler.call(this, val);
   }
-  const casted = this.applySetters(val, context);
+
+  let casted;
+  try {
+    casted = this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
+  }
   return casted ? casted.toObject({ transform: false, virtuals: false }) : casted;
 };
 

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -407,7 +407,14 @@ SchemaDate.prototype.$conditionalHandlers = {
 
 SchemaDate.prototype.castForQuery = function($conditional, val, context) {
   if ($conditional == null) {
-    return this.applySetters(val, context);
+    try {
+      return this.applySetters(val, context);
+    } catch (err) {
+      if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+        err.path = this.$fullPath;
+      }
+      throw err;
+    }
   }
 
   const handler = this.$conditionalHandlers[$conditional];

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -429,7 +429,16 @@ SchemaNumber.prototype.castForQuery = function($conditional, val, context) {
     }
     return handler.call(this, val, context);
   }
-  val = this.applySetters(val, context);
+
+  try {
+    val = this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
+  }
+
   return val;
 };
 

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -688,7 +688,14 @@ SchemaString.prototype.castForQuery = function($conditional, val, context) {
     return val;
   }
 
-  return this.applySetters(val, context);
+  try {
+    return this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
+  }
 };
 
 /*!

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -344,8 +344,15 @@ SchemaUUID.prototype.castForQuery = function($conditional, val, context) {
     if (!handler)
       throw new Error('Can\'t use ' + $conditional + ' with UUID.');
     return handler.call(this, val, context);
-  } else {
-    return this.cast(val);
+  }
+
+  try {
+    return this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
   }
 };
 

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1630,7 +1630,14 @@ SchemaType.prototype.castForQuery = function($conditional, val, context) {
     return handler.call(this, val, context);
   }
 
-  return this.applySetters(val, context);
+  try {
+    return this.applySetters(val, context);
+  } catch (err) {
+    if (err instanceof CastError && err.path === this.path && this.$fullPath != null) {
+      err.path = this.$fullPath;
+    }
+    throw err;
+  }
 };
 
 /**

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -2200,4 +2200,34 @@ describe('model: findOneAndUpdate:', function() {
     );
     assert.equal(updated.defaultField, 'some non-default value');
   });
+
+  it('sets CastError path to full path (gh-14114)', async function() {
+    const testSchema = new mongoose.Schema({
+      id: mongoose.Schema.Types.ObjectId,
+      name: String,
+      accessories: [
+        {
+          isEnabled: Boolean,
+          additionals: [
+            {
+              k: String,
+              v: Number
+            }
+          ]
+        }
+      ]
+    });
+    const Test = db.model('Test', testSchema);
+    const err = await Test.findOneAndUpdate(
+      {},
+      {
+        $set: {
+          'accessories.0.additionals.0.k': ['test']
+        }
+      }
+    ).then(() => null, err => err);
+    assert.ok(err);
+    assert.equal(err.name, 'CastError');
+    assert.equal(err.path, 'accessories.0.additionals.0.k');
+  });
 });

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -25,7 +25,7 @@ describe('schema select option', function() {
   afterEach(() => require('./util').clearTestData(db));
   afterEach(() => require('./util').stopRemainingOps(db));
 
-  it('excluding paths through schematype', async function() {
+  it.only('excluding paths through schematype', async function() {
     const schema = new Schema({
       thin: Boolean,
       name: { type: String, select: false },

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -15,17 +15,19 @@ describe('schema select option', function() {
 
   before(function() {
     db = start();
+    mongoose.set('debug', true);
   });
 
   after(async function() {
     await db.close();
+    mongoose.set('debug', false);
   });
 
   beforeEach(() => db.deleteModel(/.*/));
   afterEach(() => require('./util').clearTestData(db));
   afterEach(() => require('./util').stopRemainingOps(db));
 
-  it.only('excluding paths through schematype', async function() {
+  it('excluding paths through schematype', async function() {
     const schema = new Schema({
       thin: Boolean,
       name: { type: String, select: false },

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -55,14 +55,14 @@ describe('schema select option', function() {
     assert.equal(findByIdDocAgain.isSelected('name'), false);
     assert.equal(findByIdDocAgain.isSelected('docs.name'), false);
     assert.strictEqual(undefined, findByIdDocAgain.name);
-    /*const findUpdateDoc = await Test.findOneAndUpdate({ _id: doc._id });
+    const findUpdateDoc = await Test.findOneAndUpdate({ _id: doc._id }, { name: 'the excluded' });
     assert.equal(findUpdateDoc.isSelected('name'), false);
     assert.equal(findUpdateDoc.isSelected('docs.name'), false);
     assert.strictEqual(undefined, findUpdateDoc.name);
     const findAndDeleteDoc = await Test.findOneAndDelete({ _id: doc._id });
     assert.equal(findAndDeleteDoc.isSelected('name'), false);
     assert.equal(findAndDeleteDoc.isSelected('docs.name'), false);
-    assert.strictEqual(undefined, findAndDeleteDoc.name);*/
+    assert.strictEqual(undefined, findAndDeleteDoc.name);
   });
 
   it('including paths through schematype', async function() {

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -55,14 +55,14 @@ describe('schema select option', function() {
     assert.equal(findByIdDocAgain.isSelected('name'), false);
     assert.equal(findByIdDocAgain.isSelected('docs.name'), false);
     assert.strictEqual(undefined, findByIdDocAgain.name);
-    const findUpdateDoc = await Test.findOneAndUpdate({ _id: doc._id });
+    /*const findUpdateDoc = await Test.findOneAndUpdate({ _id: doc._id });
     assert.equal(findUpdateDoc.isSelected('name'), false);
     assert.equal(findUpdateDoc.isSelected('docs.name'), false);
     assert.strictEqual(undefined, findUpdateDoc.name);
     const findAndDeleteDoc = await Test.findOneAndDelete({ _id: doc._id });
     assert.equal(findAndDeleteDoc.isSelected('name'), false);
     assert.equal(findAndDeleteDoc.isSelected('docs.name'), false);
-    assert.strictEqual(undefined, findAndDeleteDoc.name);
+    assert.strictEqual(undefined, findAndDeleteDoc.name);*/
   });
 
   it('including paths through schematype', async function() {


### PR DESCRIPTION
Fix #14114

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently, CastError only shows the path relative to parent, which is less than ideal in the case where casting update throws an error; in that case, Mongoose just throws the CastError, rather than wrapping the CastError in a `ValidationError` like how `save()` does. This PR makes CastError use `$fullPath` instead when casting updates

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
