### PR TITLE
fix: cast error when there is an elemMatch in the and clause

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -637,7 +637,7 @@ handle.$or = createLogicalQueryOperatorHandler('$or');
 handle.$and = createLogicalQueryOperatorHandler('$and');
 handle.$nor = createLogicalQueryOperatorHandler('$nor');
 
-function createLogicalQueryOperatorHandler(op, context) {
+function createLogicalQueryOperatorHandler(op) {
   return function logicalQueryOperatorHandler(val, context) {
     if (!Array.isArray(val)) {
       throw new TypeError('conditional ' + op + ' requires an array');

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -637,15 +637,15 @@ handle.$or = createLogicalQueryOperatorHandler('$or');
 handle.$and = createLogicalQueryOperatorHandler('$and');
 handle.$nor = createLogicalQueryOperatorHandler('$nor');
 
-function createLogicalQueryOperatorHandler(op) {
-  return function logicalQueryOperatorHandler(val) {
+function createLogicalQueryOperatorHandler(op, context) {
+  return function logicalQueryOperatorHandler(val, context) {
     if (!Array.isArray(val)) {
       throw new TypeError('conditional ' + op + ' requires an array');
     }
 
     const ret = [];
     for (const obj of val) {
-      ret.push(cast(this.casterConstructor.schema, obj, null, this && this.$$context));
+      ret.push(cast(this.casterConstructor.schema ?? context.schema, obj, null, this && this.$$context));
     }
 
     return ret;


### PR DESCRIPTION
**Summary**
- after this PR is merged
	- https://github.com/Automattic/mongoose/pull/13938
- Error in cast because options.discriminatorKey is obtained before checking if the schema is null
	- here:
		- https://github.com/Automattic/mongoose/pull/13938/files#diff-5078cdf8af89c694947cdcb5e60fcd3e29dda608e62642ecf5fc3eeb97e43ce1R71
- Changed to refer to context.schema as well as this PR
	- https://github.com/Automattic/mongoose/commit/266804b995ae715cd4746d0e5b687e7fb96441fc

**Examples**
query:
```
{
  users: {
    $elemMatch: {
      $and: [
        { name: "test" },
        $or: [
          { is_deleted: true },
          { is_deleted: null } 
        ]
      ]
    }
  }
}
```
