### PR TITLE
fix(document): avoid treating nested projection as inclusive when applying defaults

### DIFF
--- a/lib/helpers/document/applyDefaults.js
+++ b/lib/helpers/document/applyDefaults.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const isNestedProjection = require('../projection/isNestedProjection');
+
 module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildren, isBeforeSetters, pathsToSkip) {
   const paths = Object.keys(doc.$__schema.paths);
   const plen = paths.length;
@@ -32,7 +34,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
         }
       } else if (exclude === false && fields && !included) {
         const hasSubpaths = type.$isSingleNested || type.$isMongooseDocumentArray;
-        if (curPath in fields || (j === len - 1 && hasSubpaths && hasIncludedChildren != null && hasIncludedChildren[curPath])) {
+        if ((curPath in fields && !isNestedProjection(fields[curPath])) || (j === len - 1 && hasSubpaths && hasIncludedChildren != null && hasIncludedChildren[curPath])) {
           included = true;
         } else if (hasIncludedChildren != null && !hasIncludedChildren[curPath]) {
           break;

--- a/lib/helpers/projection/hasIncludedChildren.js
+++ b/lib/helpers/projection/hasIncludedChildren.js
@@ -21,6 +21,7 @@ module.exports = function hasIncludedChildren(fields) {
   const keys = Object.keys(fields);
 
   for (const key of keys) {
+
     if (key.indexOf('.') === -1) {
       hasIncludedChildren[key] = 1;
       continue;

--- a/lib/helpers/projection/isNestedProjection.js
+++ b/lib/helpers/projection/isNestedProjection.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function isNestedProjection(val) {
+  if (val == null || typeof val !== 'object') {
+    return false;
+  }
+  return val.$slice == null && val.$elemMatch == null && val.$meta == null && val.$ == null;
+};

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4385,6 +4385,11 @@ describe('Query', function() {
   });
 
   it('does not apply sibling path defaults if using nested projection (gh-14115)', async function() {
+    const version = await start.mongodVersion();
+    if (version[0] < 5) {
+      return this.skip();
+    }
+
     const userSchema = new mongoose.Schema({
       name: String,
       account: {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4383,4 +4383,33 @@ describe('Query', function() {
       await Error.find().sort('-');
     }, { message: 'Invalid field "" passed to sort()' });
   });
+
+  it('does not apply sibling path defaults if using nested projection (gh-14115)', async function() {
+    const userSchema = new mongoose.Schema({
+      name: String,
+      account: {
+        amount: Number,
+        owner: { type: String, default: () => 'OWNER' },
+        taxIds: [Number]
+      }
+    });
+    const User = db.model('User', userSchema);
+
+    const { _id } = await User.create({
+      name: 'test',
+      account: {
+        amount: 25,
+        owner: 'test',
+        taxIds: [42]
+      }
+    });
+
+    const doc = await User
+      .findOne({ _id }, { name: 1, account: { amount: 1 } })
+      .orFail();
+    assert.strictEqual(doc.name, 'test');
+    assert.strictEqual(doc.account.amount, 25);
+    assert.strictEqual(doc.account.owner, undefined);
+    assert.strictEqual(doc.account.taxIds, undefined);
+  });
 });


### PR DESCRIPTION
Fix #14115

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now nested projections, like `{ prop: { subprop: 1 } }`, throw off the logic that checks for projections when applying defaults. So `{ prop: { subprop: 1 } }` will still apply defaults on all properties underneath `prop` that have defaults _other than_ `subprop`.

With this PR, we won't treat `{ prop: { subprop: 1 } }` as `{ prop: 1}` for applying defaults, which is what our `applyDefaults()` function does now.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
