### PR TITLE
Allow defining index on base model that applies to all discriminators

### DIFF
--- a/lib/helpers/indexes/getRelatedIndexes.js
+++ b/lib/helpers/indexes/getRelatedIndexes.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const hasDollarKeys = require('../query/hasDollarKeys');
+
 function getRelatedSchemaIndexes(model, schemaIndexes) {
   return getRelatedIndexes({
     baseModelName: model.baseModelName,
@@ -48,7 +50,7 @@ function getRelatedIndexes({
     const partialFilterExpression = getPartialFilterExpression(index, indexesType);
     return !partialFilterExpression
       || !partialFilterExpression[discriminatorKey]
-      || partialFilterExpression[discriminatorKey]['$exists'];
+      || (hasDollarKeys(partialFilterExpression[discriminatorKey]) && !('$eq' in partialFilterExpression[discriminatorKey]));
   });
 }
 

--- a/lib/helpers/indexes/getRelatedIndexes.js
+++ b/lib/helpers/indexes/getRelatedIndexes.js
@@ -46,7 +46,9 @@ function getRelatedIndexes({
 
   return indexes.filter(index => {
     const partialFilterExpression = getPartialFilterExpression(index, indexesType);
-    return !partialFilterExpression || !partialFilterExpression[discriminatorKey];
+    return !partialFilterExpression
+      || !partialFilterExpression[discriminatorKey]
+      || partialFilterExpression[discriminatorKey]['$exists'];
   });
 }
 

--- a/test/helpers/indexes.getRelatedIndexes.test.js
+++ b/test/helpers/indexes.getRelatedIndexes.test.js
@@ -92,6 +92,46 @@ describe('getRelatedIndexes', () => {
         ]
       );
     });
+    it('with base model that has discriminator, it includes discriminator indexes that only checks for existence', () => {
+      // Arrange
+      const eventSchema = new Schema(
+        { actorId: { type: Schema.Types.ObjectId } },
+        { autoIndex: false }
+      );
+      eventSchema.index({ actorId: 1 },
+        { unique: true,
+          partialFilterExpression: {
+            __t: { $exists: true }
+          }
+        });
+
+      const Event = db.model('Event', eventSchema);
+
+      const clickEventSchema = new Schema(
+        {
+          clickedAt: Date,
+          productCategory: String
+        },
+        { autoIndex: false }
+      );
+      Event.discriminator('ClickEvent', clickEventSchema);
+
+      // Act
+      const filteredSchemaIndexes = getRelatedSchemaIndexes(Event, Event.schema.indexes());
+
+      // Assert
+      assert.deepStrictEqual(
+        filteredSchemaIndexes,
+        [
+          [{ actorId: 1 },
+            { background: true,
+              unique: true,
+              partialFilterExpression: { __t: { $exists: true } }
+            }
+          ]
+        ]
+      );
+    });
     it('with discriminator model, it only gets discriminator indexes', () => {
       // Arrange
       const eventSchema = new Schema(


### PR DESCRIPTION
**Summary**

We would like to define an index on a base model, with a partial filter so that it only applies to discriminators. It's not a discriminator index (as described in #11424), because it's not specific to any one child. 

We were surprised that these indexes were being silently ignored during syncing, and wondered if you are open to changing the behavior. Alternatively, please let me know if this key is just not necessary in the filter. I'm new to both Mongoose and MongoDB. Thanks!

**Examples**

I've added a test, where you can see that getRelatedIndexes no longer skips indexes on base models with the discriminator key, if it's just checking existence:

```
__t: { $exists: true }
```
