### PR TITLE
Fix return types for findByIdAndDelete overrides

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -534,7 +534,7 @@ function gh14190() {
   );
   expectAssignable<
     ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
-  >(res);
+      >(res);
 
   const res2 = await UserModel.find().findByIdAndDelete(
     '0'.repeat(24),
@@ -542,5 +542,5 @@ function gh14190() {
   );
   expectAssignable<
     ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
-  >(res2);
+      >(res2);
 }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -520,3 +520,11 @@ function gh13630() {
   const x: UpdateQueryKnownOnly<User> = { $set: { name: 'John' } };
   expectAssignable<UpdateQuery<User>>(x);
 }
+
+function gh14190() {
+  const userSchema = new Schema({ name: String, age: Number });
+  const UserModel = model('User', userSchema);
+
+  const doc = await UserModel.findByIdAndDelete('0'.repeat(24));
+  expectType<ReturnType<(typeof UserModel)['hydrate']> | null>(doc);
+}

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -17,7 +17,7 @@ import {
   ProjectionFields,
   QueryOptions
 } from 'mongoose';
-import { ObjectId } from 'mongodb';
+import { ModifyResult, ObjectId } from 'mongodb';
 import { expectAssignable, expectError, expectNotAssignable, expectType } from 'tsd';
 import { autoTypedModel } from './models.test';
 import { AutoTypedSchemaType } from './schema.test';
@@ -527,4 +527,20 @@ function gh14190() {
 
   const doc = await UserModel.findByIdAndDelete('0'.repeat(24));
   expectType<ReturnType<(typeof UserModel)['hydrate']> | null>(doc);
+
+  const res = await UserModel.findByIdAndDelete(
+    '0'.repeat(24),
+    { includeResultMetadata: true }
+  );
+  expectAssignable<
+    ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
+  >(res);
+
+  const res2 = await UserModel.find().findByIdAndDelete(
+    '0'.repeat(24),
+    { includeResultMetadata: true }
+  );
+  expectAssignable<
+    ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
+  >(res2);
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -564,8 +564,8 @@ declare module 'mongoose' {
       'findOneAndDelete'
     >;
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
-      id?: mongodb.ObjectId | any,
-      options?: QueryOptions<TRawDocType> & { includeResultMetadata: true }
+      id: mongodb.ObjectId | any,
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete'>;
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
       id?: mongodb.ObjectId | any,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -416,6 +416,10 @@ declare module 'mongoose' {
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
     findByIdAndDelete(
+      id: mongodb.ObjectId | any,
+      options: QueryOptions<DocType> & { includeResultMetadata: true }
+    ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndDelete'>;
+    findByIdAndDelete(
       id?: mongodb.ObjectId | any,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete'>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #14190; findByIdAndDelete() is currently returning `ModifyResult` even if options isn't set

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
