### PR TITLE
fix(discriminator): handle reusing schema with embedded discriminators defined using Schema.prototype.discriminator

### DIFF
--- a/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
+++ b/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
@@ -16,8 +16,15 @@ function applyEmbeddedDiscriminators(schema, seen = new WeakSet()) {
     if (!schemaType.schema._applyDiscriminators) {
       continue;
     }
-    for (const disc of schemaType.schema._applyDiscriminators.keys()) {
-      schemaType.discriminator(disc, schemaType.schema._applyDiscriminators.get(disc));
+    if (schemaType._appliedDiscriminators) {
+      continue;
     }
+    for (const disc of schemaType.schema._applyDiscriminators.keys()) {
+      schemaType.discriminator(
+        disc,
+        schemaType.schema._applyDiscriminators.get(disc)
+      );
+    }
+    schemaType._appliedDiscriminators = true;
   }
 }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12775,7 +12775,7 @@ describe('document', function() {
 
     const containerSchema = new Schema({ items: [discriminated] });
     const containerModel = db.model('Test', containerSchema);
-    const containerModel2 = db.model('Test1', containerSchema); // Error: Discriminator with name "1" already exists
+    const containerModel2 = db.model('Test1', containerSchema);
     const doc1 = new containerModel({ items: [{ type: 1, prop1: 'foo' }, { type: 3, prop2: 'bar' }] });
     const doc2 = new containerModel2({ items: [{ type: 1, prop1: 'baz' }, { type: 3, prop2: 'qux' }] });
     await doc1.save();


### PR DESCRIPTION
Fix #14162

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14162 points out that if you reuse a schema that has embedded discriminators defined using `Schema.prototype.discriminator()`, you'll get an OverwriteModelError because Mongoose already applied discriminators to the schema type. This PR makes it so that applying discriminators to the same SchemaType twice is a no-op.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
