### PR TITLE
fix(ChangeStream): avoid suppressing errors in closed change stream

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -60,12 +60,6 @@ class ChangeStream extends EventEmitter {
 
         driverChangeStreamEvents.forEach(ev => {
           this.driverChangeStream.on(ev, data => {
-            // Sometimes Node driver still polls after close, so
-            // avoid any uncaught exceptions due to closed change streams
-            // See tests for gh-7022
-            if (ev === 'error' && this.closed) {
-              return;
-            }
             if (data != null && data.fullDocument != null && this.options && this.options.hydrate) {
               data.fullDocument = this.options.model.hydrate(data.fullDocument);
             }
@@ -83,12 +77,6 @@ class ChangeStream extends EventEmitter {
 
     driverChangeStreamEvents.forEach(ev => {
       this.driverChangeStream.on(ev, data => {
-        // Sometimes Node driver still polls after close, so
-        // avoid any uncaught exceptions due to closed change streams
-        // See tests for gh-7022
-        if (ev === 'error' && this.closed) {
-          return;
-        }
         if (data != null && data.fullDocument != null && this.options && this.options.hydrate) {
           data.fullDocument = this.options.model.hydrate(data.fullDocument);
         }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3546,6 +3546,7 @@ describe('Model', function() {
           assert.equal(changeData.operationType, 'insert');
           assert.equal(changeData.fullDocument.name, 'Ned Stark');
 
+          await changeStream.close();
           await db.close();
         });
 


### PR DESCRIPTION
Fix #14177

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

It looks like the potential bug we mentioned in #12890 was actually correct behavior; MongoDB change streams can emit 'error' events after 'close'. The original reason for this change was to avoid a flakey test, so I think we should just remove the `if (ev === 'error' && this.closed)` check.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
