### PR TITLE
docs: update findOneAndUpdate tutorial to use includeResultMetadata

### DIFF
--- a/docs/tutorials/findoneandupdate.md
+++ b/docs/tutorials/findoneandupdate.md
@@ -6,7 +6,7 @@ However, there are some cases where you need to use [`findOneAndUpdate()`](https
 * [Getting Started](#getting-started)
 * [Atomic Updates](#atomic-updates)
 * [Upsert](#upsert)
-* [The `rawResult` Option](#raw-result)
+* [The `includeResultMetadata` Option](#includeresultmetadata)
 
 ## Getting Started
 
@@ -51,17 +51,17 @@ Using the `upsert` option, you can use `findOneAndUpdate()` as a find-and-[upser
 [require:Tutorial.*findOneAndUpdate.*upsert]
 ```
 
-<h2 id="raw-result">The `rawResult` Option</h2>
+<h2 id="includeresultmetadata">The `includeResultMetadata` Option<h2 id="rawresult"></h2></h2>
 
 Mongoose transforms the result of `findOneAndUpdate()` by default: it
 returns the updated document. That makes it difficult to check whether
 a document was upserted or not. In order to get the updated document
 and check whether MongoDB upserted a new document in the same operation,
-you can set the `rawResult` flag to make Mongoose return the raw result
+you can set the `includeResultMetadata` flag to make Mongoose return the raw result
 from MongoDB.
 
 ```acquit
-[require:Tutorial.*findOneAndUpdate.*rawResult$]
+[require:Tutorial.*findOneAndUpdate.*includeResultMetadata$]
 ```
 
 Here's what the `res` object from the above example looks like:

--- a/docs/tutorials/findoneandupdate.md
+++ b/docs/tutorials/findoneandupdate.md
@@ -51,7 +51,7 @@ Using the `upsert` option, you can use `findOneAndUpdate()` as a find-and-[upser
 [require:Tutorial.*findOneAndUpdate.*upsert]
 ```
 
-<h2 id="includeresultmetadata">The `includeResultMetadata` Option<h2 id="rawresult"></h2></h2>
+<h2 id="includeresultmetadata">The <code>includeResultMetadata</code> Option<h2 id="rawresult"></h2></h2>
 
 Mongoose transforms the result of `findOneAndUpdate()` by default: it
 returns the updated document. That makes it difficult to check whether

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1334,7 +1334,6 @@ describe('model: findOneAndUpdate:', function() {
       const opts = {
         new: true,
         upsert: false,
-        passRawResult: false,
         overwrite: false,
         runValidators: true
       };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`findOneAndUpdate` docs still use `rawResult`, and it looks like we had a broken reference to an old test name as well. This PR fixes that.

Fix #14207

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
