### PR TITLE
fix(document): allow setting nested path to `null`

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1153,6 +1153,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
           } else {
             throw new StrictModeError(key);
           }
+        } else if (pathtype === 'nested' && valForKey === null) {
+          this.$set(pathName, valForKey, constructing, options);
         }
       } else if (valForKey !== void 0) {
         this.$set(pathName, valForKey, constructing, options);

--- a/lib/document.js
+++ b/lib/document.js
@@ -1153,7 +1153,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
           } else {
             throw new StrictModeError(key);
           }
-        } else if (pathtype === 'nested' && valForKey === null) {
+        } else if (pathtype === 'nested' && valForKey == null) {
           this.$set(pathName, valForKey, constructing, options);
         }
       } else if (valForKey !== void 0) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12437,6 +12437,25 @@ describe('document', function() {
     const fromDb = await Test.findById(eventObj._id).lean().orFail();
     assert.strictEqual(fromDb.__stateBeforeSuspension.field3['.ippo'], 5);
   });
+
+  it('handles setting nested path to null (gh-14205)', function() {
+    const schema = new mongoose.Schema({
+      nested: {
+        key1: String,
+        key2: String
+      }
+    });
+
+    const Model = db.model('Test', schema);
+
+    const doc = new Model();
+    doc.init({
+      nested: { key1: 'foo', key2: 'bar' }
+    });
+
+    doc.set({ nested: null });
+    assert.strictEqual(doc.toObject().nested, null);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12456,6 +12456,25 @@ describe('document', function() {
     doc.set({ nested: null });
     assert.strictEqual(doc.toObject().nested, null);
   });
+
+  it('handles setting nested path to undefined (gh-14205)', function() {
+    const schema = new mongoose.Schema({
+      nested: {
+        key1: String,
+        key2: String
+      }
+    });
+
+    const Model = db.model('Test', schema);
+
+    const doc = new Model();
+    doc.init({
+      nested: { key1: 'foo', key2: 'bar' }
+    });
+
+    doc.set({ nested: void 0 });
+    assert.strictEqual(doc.toObject().nested, void 0);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #14205

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Still debugging the need for the `valForKey === null` check, but otherwise this works. Without the `=== null` check, the `with conflicted data in db` test in `model.test.js` fails; it looks like because we don't store validation errors on nested paths. Will take another look tomorrow.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
