### PR TITLE
types(model+query): use stricter typings for updateX(), replaceOne(),deleteX() Model functions

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -222,7 +222,7 @@ declare module 'mongoose' {
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.CountOptions & MongooseSpecificQueryOptions) | null
+      options?: (mongodb.CountOptions & Omit<MongooseSpecificQueryOptions, 'lean' | 'timestamps'>) | null
     ): QueryWithHelpers<
       number,
       THydratedDocumentType,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -222,7 +222,7 @@ declare module 'mongoose' {
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
       filter?: FilterQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType>
+      options?: (mongodb.CountOptions & MongooseSpecificQueryOptions) | null
     ): QueryWithHelpers<
       number,
       THydratedDocumentType,
@@ -254,7 +254,7 @@ declare module 'mongoose' {
      */
     deleteMany(
       filter?: FilterQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType>
+      options?: (mongodb.DeleteOptions & Omit<MongooseSpecificQueryOptions, 'lean' | 'timestamps'>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -279,7 +279,7 @@ declare module 'mongoose' {
      */
     deleteOne(
       filter?: FilterQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType>
+      options?: (mongodb.DeleteOptions & Omit<MongooseSpecificQueryOptions, 'lean' | 'timestamps'>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -689,7 +689,7 @@ declare module 'mongoose' {
     replaceOne<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       replacement?: TRawDocType | AnyObject,
-      options?: QueryOptions<TRawDocType> | null
+      options?: (mongodb.ReplaceOptions & MongooseSpecificQueryOptions) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'replaceOne'>;
 
     /** Schema the model uses. */
@@ -699,14 +699,14 @@ declare module 'mongoose' {
     updateMany<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<TRawDocType> | null
+      options?: (mongodb.UpdateOptions & Omit<MongooseSpecificQueryOptions, 'lean'>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateMany'>;
 
     /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
     updateOne<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<TRawDocType> | null
+      options?: (mongodb.UpdateOptions & Omit<MongooseSpecificQueryOptions, 'lean'>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateOne'>;
 
     /** Creates a Query, applies the passed conditions, and returns the Query. */

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -95,33 +95,70 @@ declare module 'mongoose' {
     updatedAt?: boolean;
   }
 
+  interface MongooseSpecificQueryOptions {
+    /**
+     * If truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document.
+     */
+    lean?: boolean | Record<string, any>;
+
+    multipleCastError?: boolean;
+
+    overwriteDiscriminatorKey?: boolean;
+    runValidators?: boolean;
+    /**
+     * Set to `true` to automatically sanitize potentially unsafe query filters by stripping out query selectors that
+     * aren't explicitly allowed using `mongoose.trusted()`.
+     */
+    sanitizeFilter?: boolean;
+    setDefaultsOnInsert?: boolean;
+    /** overwrites the schema's strict mode option */
+    strict?: boolean | string;
+
+    /**
+     * equal to `strict` by default, may be `false`, `true`, or `'throw'`. Sets the default
+     * [strictQuery](https://mongoosejs.com/docs/guide.html#strictQuery) mode for schemas.
+     */
+    strictQuery?: boolean | 'throw';
+    /**
+     * If set to `false` and schema-level timestamps are enabled,
+     * skip timestamps for this update. Note that this allows you to overwrite
+     * timestamps. Does nothing if schema-level timestamps are not set.
+     */
+    timestamps?: boolean | QueryTimestampsConfig;
+
+    /**
+     * If `true`, convert any aliases in filter, projection, update, and distinct
+     * to their database property names. Defaults to false.
+     */
+    translateAliases?: boolean;
+
+    [other: string]: any;
+  }
+
   interface QueryOptions<DocType = unknown> extends
     PopulateOption,
-    SessionOption {
+    SessionOption,
+    MongooseSpecificQueryOptions {
     arrayFilters?: { [key: string]: any }[];
     batchSize?: number;
+    bypassDocumentValidation?: boolean;
     collation?: mongodb.CollationOptions;
     comment?: any;
     context?: string;
     explain?: mongodb.ExplainVerbosityLike;
     fields?: any | string;
     hint?: mongodb.Hint;
-    /**
-     * If truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document.
-     */
-    lean?: boolean | Record<string, any>;
+
+    let?: Record<string, any>;
     limit?: number;
     maxTimeMS?: number;
     multi?: boolean;
-    multipleCastError?: boolean;
     /**
      * By default, `findOneAndUpdate()` returns the document as it was **before**
      * `update` was applied. If you set `new: true`, `findOneAndUpdate()` will
      * instead give you the object after `update` was applied.
      */
     new?: boolean;
-
-    overwriteDiscriminatorKey?: boolean;
     projection?: ProjectionType<DocType>;
     /**
      * if true, returns the full ModifyResult rather than just the document
@@ -136,40 +173,11 @@ declare module 'mongoose' {
      * Another alias for the `new` option. `returnOriginal` is deprecated so this should be used.
      */
     returnDocument?: 'before' | 'after';
-    /**
-     * Set to true to enable `update validators`
-     * (https://mongoosejs.com/docs/validation.html#update-validators). Defaults to false.
-     */
-    runValidators?: boolean;
-    /* Set to `true` to automatically sanitize potentially unsafe user-generated query projections */
-    sanitizeProjection?: boolean;
-    /**
-     * Set to `true` to automatically sanitize potentially unsafe query filters by stripping out query selectors that
-     * aren't explicitly allowed using `mongoose.trusted()`.
-     */
-    sanitizeFilter?: boolean;
-    setDefaultsOnInsert?: boolean;
     skip?: number;
     sort?: any;
-    /** overwrites the schema's strict mode option */
-    strict?: boolean | string;
-    /**
-     * equal to `strict` by default, may be `false`, `true`, or `'throw'`. Sets the default
-     * [strictQuery](https://mongoosejs.com/docs/guide.html#strictQuery) mode for schemas.
-     */
-    strictQuery?: boolean | 'throw';
+
     tailable?: number;
-    /**
-     * If set to `false` and schema-level timestamps are enabled,
-     * skip timestamps for this update. Note that this allows you to overwrite
-     * timestamps. Does nothing if schema-level timestamps are not set.
-     */
-    timestamps?: boolean | QueryTimestampsConfig;
-    /**
-     * If `true`, convert any aliases in filter, projection, update, and distinct
-     * to their database property names. Defaults to false.
-     */
-    translateAliases?: boolean;
+
     upsert?: boolean;
     useBigInt64?: boolean;
     writeConcern?: mongodb.WriteConcern;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -104,6 +104,10 @@ declare module 'mongoose' {
     multipleCastError?: boolean;
 
     overwriteDiscriminatorKey?: boolean;
+    /**
+     * Set to true to enable `update validators`
+     * (https://mongoosejs.com/docs/validation.html#update-validators). Defaults to false.
+     */
     runValidators?: boolean;
     /**
      * Set to `true` to automatically sanitize potentially unsafe query filters by stripping out query selectors that

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -110,6 +110,8 @@ declare module 'mongoose' {
      * aren't explicitly allowed using `mongoose.trusted()`.
      */
     sanitizeFilter?: boolean;
+    /* Set to `true` to automatically sanitize potentially unsafe user-generated query projections */
+    sanitizeProjection?: boolean;
     setDefaultsOnInsert?: boolean;
     /** overwrites the schema's strict mode option */
     strict?: boolean | string;


### PR DESCRIPTION
Fix #14204

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

While Mongoose's current options typings are technically correct because of chaining, using stricter types in the Model functions that return a query lines up better with how developers use it. Plus with `[other: string]: any`, devs can still use other options.

I only made these changes for `deleteX()`, `replaceOne()`, and `updateX()` because Mongoose's `QueryOptions` has a `projection` property that doesn't line up exactly with the MongoDB Node driver's: the MongoDB Node driver's `projection` type is just `Record<string, any>`, doesn't take into account schema definitions.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
