### PR TITLE
types(schema): add missing `omit()` method

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1379,3 +1379,15 @@ function gh14147() {
   const doc = new AffiliateModel();
   expectType<bigint>(doc.balance);
 }
+
+function gh14235() {
+  interface IUser {
+    name: string;
+    age: number;
+  }
+
+  const userSchema = new Schema<IUser>({ name: String, age: Number });
+
+  userSchema.omit<Omit<IUser, 'age'>>(['age']);
+}
+

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -302,6 +302,9 @@ declare module 'mongoose' {
     /** The original object passed to the schema constructor */
     obj: SchemaDefinition<SchemaDefinitionType<EnforcedDocType>, EnforcedDocType>;
 
+    /** Returns a new schema that has the `paths` from the original schema, minus the omitted ones. */
+    omit<T = this>(paths: string[], options?: SchemaOptions): T;
+
     /** Gets/sets schema paths. */
     path<ResultType extends SchemaType = SchemaType<any, THydratedDocumentType>>(path: string): ResultType;
     path<pathGeneric extends keyof EnforcedDocType>(path: pathGeneric): SchemaType<EnforcedDocType[pathGeneric]>;


### PR DESCRIPTION
**Summary**

Adding the missing `omit()` method to the `Schema` class type definition

**Examples**

