### PR TITLE
types(model): add missing `strict` property to `bulkWrite()` top level options

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -27,11 +27,12 @@ declare module 'mongoose' {
     skipValidation?: boolean;
     throwOnValidationError?: boolean;
     timestamps?: boolean;
+    strict?: boolean | 'throw';
   }
 
   interface MongooseBulkWritePerWriteOptions {
     timestamps?: boolean;
-    strict?: boolean;
+    strict?: boolean | 'throw';
     session?: ClientSession;
     skipValidation?: boolean;
   }


### PR DESCRIPTION
Fix #14234
Re: #8782
Re: #8778

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14234 points out that the `strict` option we added to `bulkWrite()` top level options in #8778 isn't reflected in `types`. This PR adds that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
