### PR TITLE
avoid double-calling query transform() with findOne()

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2498,12 +2498,12 @@ Query.prototype._findOne = async function _findOne() {
   // don't pass in the conditions because we already merged them in
   const doc = await this.mongooseCollection.findOne(this._conditions, options);
   return new Promise((resolve, reject) => {
-    this._completeOne(doc, null, _wrapThunkCallback(this, (err, res) => {
+    this._completeOne(doc, null, (err, res) => {
       if (err) {
         return reject(err);
       }
       resolve(res);
-    }));
+    });
   });
 };
 
@@ -3303,12 +3303,12 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   const doc = !options.includeResultMetadata ? res : res.value;
 
   return new Promise((resolve, reject) => {
-    this._completeOne(doc, res, _wrapThunkCallback(this, (err, res) => {
+    this._completeOne(doc, res, (err, res) => {
       if (err) {
         return reject(err);
       }
       resolve(res);
-    }));
+    });
   });
 };
 
@@ -3399,12 +3399,12 @@ Query.prototype._findOneAndDelete = async function _findOneAndDelete() {
   const doc = !includeResultMetadata ? res : res.value;
 
   return new Promise((resolve, reject) => {
-    this._completeOne(doc, res, _wrapThunkCallback(this, (err, res) => {
+    this._completeOne(doc, res, (err, res) => {
       if (err) {
         return reject(err);
       }
       resolve(res);
-    }));
+    });
   });
 };
 
@@ -3553,12 +3553,12 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
 
   const doc = !includeResultMetadata ? res : res.value;
   return new Promise((resolve, reject) => {
-    this._completeOne(doc, res, _wrapThunkCallback(this, (err, res) => {
+    this._completeOne(doc, res, (err, res) => {
       if (err) {
         return reject(err);
       }
       resolve(res);
-    }));
+    });
   });
 };
 
@@ -4380,28 +4380,6 @@ function _executePreHooks(query, op) {
       resolve();
     });
   });
-}
-
-/*!
- * ignore
- */
-
-function _wrapThunkCallback(query, cb) {
-  return function(error, res) {
-    if (error != null) {
-      return cb(error);
-    }
-
-    for (const fn of query._transforms) {
-      try {
-        res = fn(res);
-      } catch (error) {
-        return cb(error);
-      }
-    }
-
-    return cb(null, res);
-  };
 }
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2328,18 +2328,20 @@ describe('Query', function() {
     });
   });
 
-  it('map (gh-7142)', async function() {
+  it('transform (gh-14236) (gh-7142)', async function() {
     const Model = db.model('Test', new Schema({ name: String }));
 
-
+    let called = 0;
     await Model.create({ name: 'test' });
     const now = new Date();
     const res = await Model.findOne().transform(res => {
       res.loadedAt = now;
+      ++called;
       return res;
     });
 
     assert.equal(res.loadedAt, now);
+    assert.strictEqual(called, 1);
   });
 
   describe('orFail (gh-6841)', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

It looks like with `findOne()`, `findOneAndDelete()`, and `findOneAndUpdate()` Mongoose double calls query `transform()` functions. This PR removes the obsolete `_wrapThunkCallback()` function that causes this issue.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
