### PR TITLE
fix(populate): handle deselecting `_id` with array of fields in `populate()`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4298,6 +4298,8 @@ function populate(model, docs, options, callback) {
       // _id back off before returning the result.
       if (typeof select === 'string') {
         select = select.replace(excludeIdRegGlobal, ' ');
+      } else if (Array.isArray(select)) {
+        select = select.filter(field => field !== '-_id');
       } else {
         // preserve original select conditions by copying
         select = { ...select };

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -2197,7 +2197,7 @@ describe('model: populate:', function() {
     });
 
     describe('in a subdocument', function() {
-      it('works', async function() {
+      it('works (gh-14231)', async function() {
         const docs = await U.find({ name: 'u1' }).populate('comments', { _id: 0 });
 
         let doc = docs[0];
@@ -2229,6 +2229,15 @@ describe('model: populate:', function() {
           assert.equal(typeof d._doc.__v, 'number');
         });
 
+        doc = await U.findOne({ name: 'u1' }).populate('comments', ['-_id']);
+        assert.equal(doc.comments.length, 2);
+        doc.comments.forEach(function(d) {
+          assert.equal(d._id, undefined);
+          assert.equal(Object.keys(d._doc).indexOf('_id'), -1);
+          assert.ok(d.title.length);
+          assert.ok(d.body.length);
+          assert.equal(typeof d._doc.__v, 'number');
+        });
       });
 
       it('with lean', async function() {


### PR DESCRIPTION
Fix #14231

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We handle deselecting `_id` in `populate()` using the following syntax: `await U.findOne({ name: 'u1' }).populate('comments', '-_id');` but putting `-_id` in an array `await U.findOne({ name: 'u1' }).populate('comments', ['-_id']);` leads to a malformed result document where `comments` is `[ { '0': '-_id' } ]` due to how we shallow copy select conditions before removing `_id`. So we need an additional case to avoid using `{ ... }` to shallow copy an array.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
