### PR TITLE
Adding missing pluralizations, fixing pluralization: virus -> viruses

### DIFF
--- a/lib/helpers/pluralize.js
+++ b/lib/helpers/pluralize.js
@@ -8,13 +8,13 @@ module.exports = pluralize;
 
 exports.pluralization = [
   [/human$/gi, 'humans'],
-  [/(m)an$/gi, '$1en'],
+  [/(m|wom)an$/gi, '$1en'],
   [/(pe)rson$/gi, '$1ople'],
   [/(child)$/gi, '$1ren'],
   [/^(ox)$/gi, '$1en'],
   [/(ax|test)is$/gi, '$1es'],
-  [/(octop|vir)us$/gi, '$1i'],
-  [/(alias|status)$/gi, '$1es'],
+  [/(octop|cact|foc|fung|nucle)us$/gi, '$1i'],
+  [/(alias|status|virus)$/gi, '$1es'],
   [/(bu)s$/gi, '$1ses'],
   [/(buffal|tomat|potat)o$/gi, '$1oes'],
   [/([ti])um$/gi, '$1a'],


### PR DESCRIPTION
**Summary**
Adds pluralization for woman, cactus, focus, fungus, nucleus, and fixes the pluralization of virus from `viri` to [`viruses`](https://simple.wiktionary.org/wiki/viruses)

**Examples**
woman -> women
virus -> viruses
cactus -> cacti
focus -> foci
fungus -> fungi
nucleus -> nuclei