### PR TITLE
Add Atlas search index helpers to Models and Schemas

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -558,6 +558,7 @@ Valid options:
 * [collectionOptions](#collectionOptions)
 * [methods](#methods)
 * [query](#query-helpers)
+* [autoSearchIndex](#autoSearchIndex)
 
 <h2 id="autoIndex"><a href="#autoIndex">option: autoIndex</a></h2>
 
@@ -1452,6 +1453,25 @@ const Test = mongoose.model('Test', schema);
 // Equivalent to `createCollection({ capped: true, max: 1000 })`
 await Test.createCollection();
 ```
+
+<h2 id="autoSearchIndex">
+  <a href="#autoSearchIndex">
+    option: autoSearchIndex
+  </a>
+</h2>
+
+Similar to [`autoIndex`](#autoIndex), except for automatically creates any [Atlas search indexes](https://www.mongodb.com/docs/atlas/atlas-search/create-index/) defined in your schema.
+Unlike `autoIndex`, this option defaults to false.
+
+```javascript
+const schema = new Schema({ name: String }, { autoSearchIndex: true });
+schema.searchIndex({
+  name: 'my-index',
+  definition: { mappings: { dynamic: true } }
+});
+// Will automatically attempt to create the `my-index` search index.
+const Test = mongoose.model('Test', schema);
+``
 
 <h2 id="es6-classes"><a href="#es6-classes">With ES6 Classes</a></h2>
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -983,7 +983,8 @@ Connection.prototype.onClose = function(force) {
 Connection.prototype.collection = function(name, options) {
   const defaultOptions = {
     autoIndex: this.config.autoIndex != null ? this.config.autoIndex : this.base.options.autoIndex,
-    autoCreate: this.config.autoCreate != null ? this.config.autoCreate : this.base.options.autoCreate
+    autoCreate: this.config.autoCreate != null ? this.config.autoCreate : this.base.options.autoCreate,
+    autoSearchIndex: this.config.autoSearchIndex != null ? this.config.autoSearchIndex : this.base.options.autoSearchIndex
   };
   options = Object.assign({}, defaultOptions, options ? clone(options) : {});
   options.$wasForceClosed = this.$wasForceClosed;

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -246,6 +246,11 @@ NativeConnection.prototype.createClient = async function createClient(uri, optio
       delete options.sanitizeFilter;
     }
 
+    if ('autoSearchIndex' in options) {
+      this.config.autoSearchIndex = options.autoSearchIndex;
+      delete options.autoSearchIndex;
+    }
+
     // Backwards compat
     if (options.user || options.pass) {
       options.auth = options.auth || {};

--- a/lib/model.js
+++ b/lib/model.js
@@ -1585,7 +1585,6 @@ Model.updateSearchIndex = async function updateSearchIndex(name, definition) {
  *     await Customer.dropSearchIndex('test');
  *
  * @param {String} name
- * @param {Object} definition
  * @return {Promise}
  * @api public
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -1507,6 +1507,29 @@ Model.syncIndexes = async function syncIndexes(options) {
 };
 
 /**
+ * Create an [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
+ * This function only works when connected to MongoDB Atlas.
+ *
+ * #### Example:
+ *
+ *     const schema = new Schema({ name: { type: String, unique: true } });
+ *     const Customer = mongoose.model('Customer', schema);
+ *     await Customer.createSearchIndex({ name: 'test', definition: { mappings: { dynamic: true } } })
+ *
+ * @param {Object} description index options, including `name` and `definition`
+ * @param {String} description.name
+ * @param {Object} description.definition
+ * @return {Promise}
+ * @api public
+ */
+
+Model.createSearchIndex = async function createSearchIndex(description) {
+  _checkContext(this, 'createSearchIndex');
+
+  return await this.$__collection.createSearchIndex(description);
+};
+
+/**
  * Does a dry-run of `Model.syncIndexes()`, returning the indexes that `syncIndexes()` would drop and create if you were to run `syncIndexes()`.
  *
  * #### Example:

--- a/lib/model.js
+++ b/lib/model.js
@@ -1530,6 +1530,50 @@ Model.createSearchIndex = async function createSearchIndex(description) {
 };
 
 /**
+ * Update an existing [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
+ * This function only works when connected to MongoDB Atlas.
+ *
+ * #### Example:
+ *
+ *     const schema = new Schema({ name: { type: String, unique: true } });
+ *     const Customer = mongoose.model('Customer', schema);
+ *     await Customer.updateSearchIndex('test', { mappings: { dynamic: true } });
+ *
+ * @param {String} name
+ * @param {Object} definition
+ * @return {Promise}
+ * @api public
+ */
+
+Model.updateSearchIndex = async function updateSearchIndex(name, definition) {
+  _checkContext(this, 'updateSearchIndex');
+
+  return await this.$__collection.updateSearchIndex(name, definition);
+};
+
+/**
+ * Delete an existing [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/) by name.
+ * This function only works when connected to MongoDB Atlas.
+ *
+ * #### Example:
+ *
+ *     const schema = new Schema({ name: { type: String, unique: true } });
+ *     const Customer = mongoose.model('Customer', schema);
+ *     await Customer.dropSearchIndex('test');
+ *
+ * @param {String} name
+ * @param {Object} definition
+ * @return {Promise}
+ * @api public
+ */
+
+Model.dropSearchIndex = async function dropSearchIndex(name) {
+  _checkContext(this, 'dropSearchIndex');
+
+  return await this.$__collection.dropSearchIndex(name);
+};
+
+/**
  * Does a dry-run of `Model.syncIndexes()`, returning the indexes that `syncIndexes()` would drop and create if you were to run `syncIndexes()`.
  *
  * #### Example:

--- a/lib/model.js
+++ b/lib/model.js
@@ -1273,10 +1273,14 @@ for (const i in EventEmitter.prototype) {
 }
 
 /**
- * This function is responsible for building [indexes](https://www.mongodb.com/docs/manual/indexes/),
- * unless [`autoIndex`](https://mongoosejs.com/docs/guide.html#autoIndex) is turned off.
+ * This function is responsible for initializing the underlying connection in MongoDB based on schema options.
+ * This function performs the following operations:
  *
- * Mongoose calls this function automatically when a model is created using
+ * - `createCollection()` unless [`autoCreate`](https://mongoosejs.com/docs/guide.html#autoCreate) option is turned off
+ * - `ensureIndexes()` unless [`autoIndex`](https://mongoosejs.com/docs/guide.html#autoIndex) option is turned off
+ * - `createSearchIndex()` on all schema search indexes if `autoSearchIndex` is enabled.
+ *
+ * Mongoose calls this function automatically when a model is a created using
  * [`mongoose.model()`](https://mongoosejs.com/docs/api/mongoose.html#Mongoose.prototype.model()) or
  * [`connection.model()`](https://mongoosejs.com/docs/api/connection.html#Connection.prototype.model()), so you
  * don't need to call `init()` to trigger index builds.
@@ -1324,6 +1328,23 @@ Model.init = function init() {
     }
     return await this.ensureIndexes({ _automatic: true });
   };
+  const _createSearchIndexes = async() => {
+    const autoSearchIndex = utils.getOption(
+      'autoSearchIndex',
+      this.schema.options,
+      conn.config,
+      conn.base.options
+    );
+    if (!autoSearchIndex) {
+      return;
+    }
+
+    const results = [];
+    for (const searchIndex of this.schema._searchIndexes) {
+      results.push(await this.createSearchIndex(searchIndex));
+    }
+    return results;
+  };
   const _createCollection = async() => {
     if ((conn.readyState === STATES.connecting || conn.readyState === STATES.disconnected) && conn._shouldBufferCommands()) {
       await new Promise(resolve => {
@@ -1342,7 +1363,9 @@ Model.init = function init() {
     return await this.createCollection();
   };
 
-  this.$init = _createCollection().then(() => _ensureIndexes());
+  this.$init = _createCollection().
+    then(() => _ensureIndexes()).
+    then(() => _createSearchIndexes());
 
   const _catch = this.$init.catch;
   const _this = this;
@@ -1514,7 +1537,7 @@ Model.syncIndexes = async function syncIndexes(options) {
  *
  *     const schema = new Schema({ name: { type: String, unique: true } });
  *     const Customer = mongoose.model('Customer', schema);
- *     await Customer.createSearchIndex({ name: 'test', definition: { mappings: { dynamic: true } } })
+ *     await Customer.createSearchIndex({ name: 'test', definition: { mappings: { dynamic: true } } });
  *
  * @param {Object} description index options, including `name` and `definition`
  * @param {String} description.name

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -65,7 +65,8 @@ function Mongoose(options) {
   this.options = Object.assign({
     pluralization: true,
     autoIndex: true,
-    autoCreate: true
+    autoCreate: true,
+    autoSearchIndex: false
   }, options);
   const createInitialConnection = utils.getOption('createInitialConnection', this.options);
   if (createInitialConnection == null || createInitialConnection) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -116,6 +116,7 @@ function Schema(obj, options) {
   this.inherits = {};
   this.callQueue = [];
   this._indexes = [];
+  this._searchIndexes = [];
   this.methods = (options && options.methods) || {};
   this.methodOptions = {};
   this.statics = (options && options.statics) || {};
@@ -411,6 +412,7 @@ Schema.prototype._clone = function _clone(Constructor) {
   s.query = clone(this.query);
   s.plugins = Array.prototype.slice.call(this.plugins);
   s._indexes = clone(this._indexes);
+  s._searchIndexes = clone(this._searchIndexes);
   s.s.hooks = this.s.hooks.clone();
 
   s.tree = clone(this.tree);
@@ -904,6 +906,25 @@ Schema.prototype.removeIndex = function removeIndex(index) {
 
 Schema.prototype.clearIndexes = function clearIndexes() {
   this._indexes.length = 0;
+
+  return this;
+};
+
+/**
+ * Add an [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/) that Mongoose will create using `Model.createSearchIndex()`.
+ * This function only works when connected to MongoDB Atlas.
+ *
+ * #### Example:
+ *
+ *     const ToySchema = new Schema({ name: String, color: String, price: Number });
+ *     ToySchema.searchIndex({ name: 'test', definition: { mappings: { dynamic: true } } });
+ *
+ * @return {Schema} the Schema instance
+ * @api public
+ */
+
+Schema.prototype.searchIndex = function searchIndex(description) {
+  this._searchIndexes.push(description);
 
   return this;
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -919,6 +919,9 @@ Schema.prototype.clearIndexes = function clearIndexes() {
  *     const ToySchema = new Schema({ name: String, color: String, price: Number });
  *     ToySchema.searchIndex({ name: 'test', definition: { mappings: { dynamic: true } } });
  *
+ * @param {Object} description index options, including `name` and `definition`
+ * @param {String} description.name
+ * @param {Object} description.definition
  * @return {Schema} the Schema instance
  * @api public
  */

--- a/lib/validOptions.js
+++ b/lib/validOptions.js
@@ -11,6 +11,7 @@ const VALID_OPTIONS = Object.freeze([
   'applyPluginsToDiscriminators',
   'autoCreate',
   'autoIndex',
+  'autoSearchIndex',
   'bufferCommands',
   'bufferTimeoutMS',
   'cloneSchemas',

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -48,7 +48,7 @@ declare module 'mongoose' {
     pass?: string;
     /** Set to false to disable automatic index creation for all models associated with this connection. */
     autoIndex?: boolean;
-    /** Set to `true` to make Mongoose automatically call `createCollection()` on every model created on this connection. */
+    /** Set to `false` to disable Mongoose automatically calling `createCollection()` on every model created on this connection. */
     autoCreate?: boolean;
   }
 

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -271,7 +271,7 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
                                         IfEquals<PathValueType, Types.Decimal128> extends true ? Types.Decimal128 :
                                           IfEquals<PathValueType, Schema.Types.BigInt> extends true ? bigint :
                                             IfEquals<PathValueType, BigInt> extends true ? bigint :
-                                            PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt ? bigint :
+                                              PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt ? bigint :
                                                 PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
                                                   IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
                                                     PathValueType extends MapConstructor | 'Map' ? Map<string, ResolvePathType<Options['of']>> :

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -245,6 +245,8 @@ declare module 'mongoose' {
      */
     createCollection<T extends mongodb.Document>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
 
+    createSearchIndex(description: mongodb.SearchIndexDescription): Promise<string>;
+
     /** Connection the model uses. */
     db: Connection;
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -245,6 +245,10 @@ declare module 'mongoose' {
      */
     createCollection<T extends mongodb.Document>(options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>): Promise<mongodb.Collection<T>>;
 
+    /**
+     * Create an [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
+     * This function only works when connected to MongoDB Atlas.
+     */
     createSearchIndex(description: mongodb.SearchIndexDescription): Promise<string>;
 
     /** Connection the model uses. */
@@ -300,6 +304,10 @@ declare module 'mongoose' {
       'deleteOne'
     >;
 
+    /**
+     * Delete an existing [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/) by name.
+     * This function only works when connected to MongoDB Atlas.
+     */
     dropSearchIndex(name: string): Promise<void>;
 
     /**
@@ -477,6 +485,10 @@ declare module 'mongoose' {
       doc: any, options: PopulateOptions | Array<PopulateOptions> | string
     ): Promise<MergeType<THydratedDocumentType, Paths>>;
 
+    /**
+     * Update an existing [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
+     * This function only works when connected to MongoDB Atlas.
+     */
     updateSearchIndex(name: string, definition: AnyObject): Promise<void>;
 
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -300,6 +300,8 @@ declare module 'mongoose' {
       'deleteOne'
     >;
 
+    dropSearchIndex(name: string): Promise<void>;
+
     /**
      * Event emitter that reports any errors that occurred. Useful for global error
      * handling.
@@ -474,6 +476,8 @@ declare module 'mongoose' {
     populate<Paths>(
       doc: any, options: PopulateOptions | Array<PopulateOptions> | string
     ): Promise<MergeType<THydratedDocumentType, Paths>>;
+
+    updateSearchIndex(name: string, definition: AnyObject): Promise<void>;
 
     /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
     validate(): Promise<void>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

cc @alexbevi 

Atlas search indexes are special indexes for Atlas text search. There's distinct functionality to create Atlas search indexes in the MongoDB Node driver, so I added the following functionality:

1. Model helpers: `Model.createSearchIndex()`, `Model.updateSearchIndex()`, `Model.dropSearchIndex()` to wrap the MongoDB Node driver's `Collection.prototype.createSearchIndex()`, etc. functions
2. Schema helper to define search indexes `Schema.prototype.searchIndex()`
3. An `autoSearchIndex` option analogous to `autoIndex` that opts in to automatically creating search indexes. Unlike `autoIndex`, `autoSearchIndex` is false by default.

Here's an example of this code in action:

```
mongoose.set('autoSearchIndex', true);

const schema = new mongoose.Schema({ name: String }, { });
schema.searchIndex({
  name: 'my-index',
  definition: { mappings: { dynamic: true } }
});
// Will automatically attempt to create the `my-index` search index.
const Test = mongoose.model('Test', schema); 
```

No tests right now because search indexes are only supported in MongoDB Atlas, and our CI tests don't run in Atlas. [The MongoDB Node driver has a "manual" test suite](https://github.com/mongodb/node-mongodb-native/blob/8504d915e5aae8f9bdf5f3dc14119cfe4e7066fe/test/manual/search-index-management.prose.test.ts#L94) that tests search indexes, something we should consider.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
