### PR TITLE
docs(model): remove callback example for `ensureIndexes()`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1671,9 +1671,7 @@ Model.listIndexes = async function listIndexes() {
  *
  * #### Example:
  *
- *     Event.ensureIndexes(function (err) {
- *       if (err) return handleError(err);
- *     });
+ *     await Event.ensureIndexes();
  *
  * After completion, an `index` event is emitted on this `Model` passing an error if one occurred.
  *
@@ -1684,7 +1682,7 @@ Model.listIndexes = async function listIndexes() {
  *
  *     Event.on('index', function (err) {
  *       if (err) console.error(err); // error occurred during index creation
- *     })
+ *     });
  *
  * _NOTE: It is not recommended that you run this in production. Index creation may impact database performance depending on your load. Use with caution._
  *


### PR DESCRIPTION
Fix #14238

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fixed an out of date example that still uses callbacks; we dropped support for callbacks in Mongoose 7.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
