### PR TITLE
fix(document): allow calling `push()` with different `$position` arguments

### DIFF
--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -2,7 +2,6 @@
 
 const Document = require('../../../document');
 const ArraySubdocument = require('../../ArraySubdocument');
-const MongooseError = require('../../../error/mongooseError');
 const cleanModifiedSubpaths = require('../../../helpers/document/cleanModifiedSubpaths');
 const internalToObjectOptions = require('../../../options').internalToObjectOptions;
 const mpath = require('mpath');
@@ -684,22 +683,21 @@ const methods = {
 
       if ((atomics.$push && atomics.$push.$each && atomics.$push.$each.length || 0) !== 0 &&
           atomics.$push.$position != atomic.$position) {
-        throw new MongooseError('Cannot call `Array#push()` multiple times ' +
-          'with different `$position`');
-      }
+        if (atomic.$position != null) {
+          [].splice.apply(arr, [atomic.$position, 0].concat(values));
+          ret = arr.length;
+        } else {
+          ret = [].push.apply(arr, values);
+        }
 
-      if (atomic.$position != null) {
+        this._registerAtomic('$set', this);
+      } else if (atomic.$position != null) {
         [].splice.apply(arr, [atomic.$position, 0].concat(values));
         ret = this.length;
       } else {
         ret = [].push.apply(arr, values);
       }
     } else {
-      if ((atomics.$push && atomics.$push.$each && atomics.$push.$each.length || 0) !== 0 &&
-          atomics.$push.$position != null) {
-        throw new MongooseError('Cannot call `Array#push()` multiple times ' +
-          'with different `$position`');
-      }
       atomic = values;
       ret = [].push.apply(arr, values);
     }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -8208,7 +8208,7 @@ describe('document', function() {
     assert.deepEqual(Object.keys(err.errors), ['age']);
   });
 
-  it('array push with $position (gh-4322)', async function() {
+  it('array push with $position (gh-14244) (gh-4322)', async function() {
     const schema = Schema({
       nums: [Number]
     });

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -8232,12 +8232,13 @@ describe('document', function() {
       $each: [0],
       $position: 0
     });
-    assert.throws(() => {
-      doc.nums.push({ $each: [5] });
-    }, /Cannot call.*multiple times/);
-    assert.throws(() => {
-      doc.nums.push(5);
-    }, /Cannot call.*multiple times/);
+    assert.deepStrictEqual(doc.nums.$__getAtomics(), [['$push', { $each: [0], $position: 0 }]]);
+
+    doc.nums.push({ $each: [5] });
+    assert.deepStrictEqual(doc.nums.$__getAtomics(), [['$set', [0, 1, 2, 3, 4, 5]]]);
+
+    doc.nums.push({ $each: [0.5], $position: 1 });
+    assert.deepStrictEqual(doc.nums.$__getAtomics(), [['$set', [0, 0.5, 1, 2, 3, 4, 5]]]);
   });
 
   it('setting a path to a single nested document should update the single nested doc parent (gh-8400)', function() {


### PR DESCRIPTION
Fix #14244
Re: #4322

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When we originally implemented `push()` with `$position` in #4322, we made it so that calling `push()` with different `$position` arguments would throw a sync error. This decision is not completely unreasonable because the MongoDB server doesn't support `$push` with different `$position` arguments. However, this decision is inconsistent with the rest of the array API: as a general rule, Mongoose arrays revert to just making the operation a `$set` on the entire array when Mongoose can't represent the user's desired update using atomic operators. With this PR, we will convert from atomic update to `$set` on the whole array if the user calls `push()` with multiple different `$position` arguments. 

With this change, a modified version of the repro script from #14244 prints the following:

```
Mongoose: events.insertOne({ name: 'event object', arr: [ 'x', 'y', 'z' ], _id: new ObjectId("65a1512d0debc605ade502af"), __v: 0}, {})
true
[ 'x', 'y', 'z', '8' ]
[ 'x', 'y', 'z', '8' ]
[ 'x', 'y', 'b', 'z', '8' ]
[ 'x', 'c', 'y', 'b', 'z', '8' ]
Mongoose: events.updateOne({ _id: new ObjectId("65a1512d0debc605ade502af"), __v: 0 }, { '$set': { arr: [ 'x', 'c', 'y', 'b', 'z', '8' ] }, '$inc': { __v: 1 }}, {})

```

Modified version as follows:

```js
const mongoose = require('mongoose');

mongoose.set('debug', true);
const util = require('util')
console.log(mongoose.version)
let Schema = mongoose.Schema
var eventSchema = new Schema({
  name: { type: String },
  arr: { type: Array, patch: true },
})

var Event = mongoose.model('Event', eventSchema)
async function run() {
  await mongoose.connect('mongodb://localhost:27017');
  let eventObj = new Event({ name: 'event object', arr: ['x', 'y', 'z'] })
  eventObj.save(function (err, eventObj) {
    console.log(util.types.isProxy(eventObj['arr']))
    eventObj['arr'].push('8')
    console.log(eventObj['arr'])
    eventObj['arr'].push({
      $each: ['a'],
      $position: 3
    })
    console.log(eventObj['arr'])
    eventObj['arr'].push({
      $each: ['b'],
      $position: 2
    })
    console.log(eventObj['arr'])
    eventObj['arr'].push({
      $each: ['c'],
      $position: 1
    })
    console.log(eventObj['arr']);

    eventObj.save();
  })
}
run();

```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
