### PR TITLE
fix(document): handle embedded recursive discriminators on nested path defined using Schema.prototype.discriminator

### DIFF
--- a/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
+++ b/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
@@ -19,11 +19,10 @@ function applyEmbeddedDiscriminators(schema, seen = new WeakSet()) {
     if (schemaType._appliedDiscriminators) {
       continue;
     }
-    for (const disc of schemaType.schema._applyDiscriminators.keys()) {
-      schemaType.discriminator(
-        disc,
-        schemaType.schema._applyDiscriminators.get(disc)
-      );
+    for (const discriminatorKey of schemaType.schema._applyDiscriminators.keys()) {
+      const discriminatorSchema = schemaType.schema._applyDiscriminators.get(discriminatorKey);
+      applyEmbeddedDiscriminators(discriminatorSchema, seen);
+      schemaType.discriminator(discriminatorKey, discriminatorSchema);
     }
     schemaType._appliedDiscriminators = true;
   }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12787,6 +12787,54 @@ describe('document', function() {
     await doc2.save();
   });
 
+  it('handles embedded recursive discriminators on nested path defined using Schema.prototype.discriminator (gh-14245)', async function() {
+    const baseSchema = new Schema({
+      type: { type: Number, required: true }
+    }, { discriminatorKey: 'type' });
+
+    class Base {
+      whoAmI() { return 'I am Base'; }
+    }
+
+    baseSchema.loadClass(Base);
+
+    class NumberTyped extends Base {
+      whoAmI() { return 'I am NumberTyped'; }
+    }
+
+    class StringTyped extends Base {
+      whoAmI() { return 'I am StringTyped'; }
+    }
+
+    const selfRefSchema = new Schema({
+      self: { type: [baseSchema], required: true }
+    });
+
+    class SelfReferenceTyped extends Base {
+      whoAmI() { return 'I am SelfReferenceTyped'; }
+    }
+
+    selfRefSchema.loadClass(SelfReferenceTyped);
+    baseSchema.discriminator(5, selfRefSchema);
+
+    const numberTypedSchema = new Schema({}).loadClass(NumberTyped);
+    const stringTypedSchema = new Schema({}).loadClass(StringTyped);
+    baseSchema.discriminator(1, numberTypedSchema);
+    baseSchema.discriminator(3, stringTypedSchema);
+    const containerSchema = new Schema({ items: [baseSchema] });
+    const containerModel = db.model('Test', containerSchema);
+
+    const instance = await containerModel.create({
+      items: [{ type: 5, self: [{ type: 1 }, { type: 3 }] }]
+    });
+
+    assert.equal(instance.items[0].whoAmI(), 'I am SelfReferenceTyped');
+    assert.deepStrictEqual(instance.items[0].self.map(item => item.whoAmI()), [
+      'I am NumberTyped',
+      'I am StringTyped'
+    ]);
+  });
+
   it('can use `collection` as schema name (gh-13956)', async function() {
     const schema = new mongoose.Schema({ name: String, collection: String });
     const Test = db.model('Test', schema);


### PR DESCRIPTION
Fix #14245

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14245 points out that we don't correctly call `applyEmbeddedDiscriminators()` on the discriminator schema, which leads to missing discriminators on self-referential discriminator schemas. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
