### PR TITLE
feat(connection): add listCollections() helper to connections

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -615,10 +615,6 @@ Connection.prototype.dropCollection = async function dropCollection(collection) 
  */
 
 Connection.prototype.listCollections = async function listCollections() {
-  if (arguments.length >= 2 && typeof arguments[1] === 'function') {
-    throw new MongooseError('Connection.prototype.dropCollection() no longer accepts a callback');
-  }
-
   if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
     await new Promise(resolve => {
       this._queue.push({ fn: resolve });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -606,6 +606,30 @@ Connection.prototype.dropCollection = async function dropCollection(collection) 
 };
 
 /**
+ * Helper for MongoDB Node driver's `listCollections()`.
+ * Returns an array of collection objects.
+ *
+ * @method listCollections
+ * @return {Promise<Collection[]>}
+ * @api public
+ */
+
+Connection.prototype.listCollections = async function listCollections() {
+  if (arguments.length >= 2 && typeof arguments[1] === 'function') {
+    throw new MongooseError('Connection.prototype.dropCollection() no longer accepts a callback');
+  }
+
+  if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
+    await new Promise(resolve => {
+      this._queue.push({ fn: resolve });
+    });
+  }
+
+  const cursor = this.db.listCollections();
+  return await cursor.toArray();
+};
+
+/**
  * Helper for `dropDatabase()`. Deletes the given database, including all
  * collections, documents, and indexes.
  *

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -195,6 +195,14 @@ describe('connections:', function() {
       const newCollectionsNames = collectionsAfterCreation.map(function(c) { return c.name; });
       assert.ok(newCollectionsNames.indexOf('gh5712') !== -1);
     });
+
+    it('listCollections()', async function() {
+      await conn.dropDatabase();
+      await conn.createCollection('test1176');
+
+      const collections = await conn.listCollections();
+      assert.deepStrictEqual(collections.map(coll => coll.name), ['test1176']);
+    });
   });
 
   it('should allow closing a closed connection', async function() {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -94,7 +94,7 @@ describe('connections:', function() {
       }));
       await Model.init();
 
-      const res = await conn.db.listCollections().toArray();
+      const res = await conn.listCollections();
       assert.ok(!res.map(c => c.name).includes('gh8814_Conn'));
       await conn.close();
     });
@@ -185,13 +185,13 @@ describe('connections:', function() {
         size: 1024
       });
 
-      const collections = await conn.db.listCollections().toArray();
+      const collections = await conn.listCollections();
 
       const names = collections.map(function(c) { return c.name; });
       assert.ok(names.indexOf('gh5712') !== -1);
       assert.ok(collections[names.indexOf('gh5712')].options.capped);
       await conn.createCollection('gh5712_0');
-      const collectionsAfterCreation = await conn.db.listCollections().toArray();
+      const collectionsAfterCreation = await conn.listCollections();
       const newCollectionsNames = collectionsAfterCreation.map(function(c) { return c.name; });
       assert.ok(newCollectionsNames.indexOf('gh5712') !== -1);
     });
@@ -199,9 +199,10 @@ describe('connections:', function() {
     it('listCollections()', async function() {
       await conn.dropDatabase();
       await conn.createCollection('test1176');
+      await conn.createCollection('test94112');
 
       const collections = await conn.listCollections();
-      assert.deepStrictEqual(collections.map(coll => coll.name), ['test1176']);
+      assert.deepStrictEqual(collections.map(coll => coll.name).sort(), ['test1176', 'test94112']);
     });
   });
 

--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -70,6 +70,10 @@ expectType<Connection>(conn.useDb('test', {}));
 expectType<Connection>(conn.useDb('test', { noListener: true }));
 expectType<Connection>(conn.useDb('test', { useCache: true }));
 
+expectType<Promise<string[]>>(
+  conn.listCollections().then(collections => collections.map(coll => coll.name))
+);
+
 export function autoTypedModelConnection() {
   const AutoTypedSchema = autoTypedSchema();
   const AutoTypedModel = connection.model('AutoTypeModelConnection', AutoTypedSchema);

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -125,7 +125,7 @@ declare module 'mongoose' {
      * Helper for MongoDB Node driver's `listCollections()`.
      * Returns an array of collection names.
      */
-    listCollections(collection: string): Promise<Pick<mongodb.CollectionInfo, 'name' | 'type'>[]>;
+    listCollections(): Promise<Pick<mongodb.CollectionInfo, 'name' | 'type'>[]>;
 
     /**
      * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -122,6 +122,12 @@ declare module 'mongoose' {
     readonly id: number;
 
     /**
+     * Helper for MongoDB Node driver's `listCollections()`.
+     * Returns an array of collection names.
+     */
+    listCollections(collection: string): Promise<Pick<mongodb.CollectionInfo, 'name' | 'type'>[]>;
+
+    /**
      * A [POJO](https://masteringjs.io/tutorials/fundamentals/pojo) containing
      * a map from model names to models. Contains all models that have been
      * added to this connection using [`Connection#model()`](/docs/api/connection.html#connection_Connection-model).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We have `dropCollection()` and `dropDatabase()` helpers on connections, but not `listCollections()`, so there's no way to list all connections in MongoDB without bypassing Mongoose. This PR adds a new `Connection.prototype.listCollections()` helper that wraps MongoDB's `listCollections()`, including handling the fact that `listCollections()` returns a cursor.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
