### PR TITLE
fix(collection): correctly handle buffer timeouts with `find()`

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -138,10 +138,23 @@ function iter(i) {
       let _args = args;
       let promise = null;
       let timeout = null;
-      if (syncCollectionMethods[i]) {
-        this.addQueue(() => {
-          lastArg.call(this, null, this[i].apply(this, _args.slice(0, _args.length - 1)));
-        }, []);
+      if (syncCollectionMethods[i] && typeof lastArg === 'function') {
+        this.addQueue(i, _args);
+        callback = lastArg;
+      } else if (syncCollectionMethods[i]) {
+        promise = new this.Promise((resolve, reject) => {
+          callback = function collectionOperationCallback(err, res) {
+            if (timeout != null) {
+              clearTimeout(timeout);
+            }
+            if (err != null) {
+              return reject(err);
+            }
+            resolve(res);
+          };
+          _args = args.concat([callback]);
+          this.addQueue(i, _args);
+        });
       } else if (typeof lastArg === 'function') {
         callback = function collectionOperationCallback() {
           if (timeout != null) {

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -68,6 +68,19 @@ describe('collections:', function() {
     });
   });
 
+  it('returns a promise if buffering and callback with find() (gh-14184)', function(done) {
+    db = mongoose.createConnection();
+    const collection = db.collection('gh14184');
+    collection.opts.bufferTimeoutMS = 100;
+
+    collection.find({ foo: 'bar' }, {}, (err, docs) => {
+      assert.ok(err);
+      assert.ok(err.message.includes('buffering timed out after 100ms'));
+      assert.equal(docs, undefined);
+      done();
+    });
+  });
+
   it('methods should that throw (unimplemented)', function() {
     const collection = new Collection('test', mongoose.connection);
     let thrown = false;


### PR DESCRIPTION
Fix #14184

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14184 points out that buffer timeouts with `find()` silently time out in 6.x. This PR makes it so that the [`removeQueue()` call in the buffer timeout callback](https://github.com/Automattic/mongoose/blob/4b6d208ead94152643f95d2503b235e2c264ef64/lib/drivers/node-mongodb-native/collection.js#L171) can actually find the `find()` call. `removeQueue()` searches by name and args, and the `this.addQueue(() => {})` pushes an anonymous function onto the queue.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
