### PR TITLE
types(query): add missing `runValidators` back to MongooseQueryOptions

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -544,3 +544,29 @@ function gh14190() {
     ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
       >(res2);
 }
+
+function mongooseQueryOptions() {
+  const userSchema = new Schema({ name: String, age: Number });
+  const UserModel = model('User', userSchema);
+
+  UserModel.updateOne(
+    { name: 'bar' },
+    { name: 'baz' },
+    {
+      multipleCastError: true,
+      overwriteDiscriminatorKey: true,
+      runValidators: true,
+      sanitizeProjection: true,
+      sanitizeFilter: true,
+      strict: true,
+      strictQuery: 'throw',
+      timestamps: false,
+      translateAliases: false
+    }
+  );
+
+  UserModel.findOne({}, null, {
+    lean: true,
+    populate: 'test'
+  });
+}

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -17,13 +17,19 @@ declare module 'mongoose' {
    */
   type FilterQuery<T> = _FilterQuery<T>;
 
-  type MongooseQueryOptions<DocType = unknown> = Pick<QueryOptions<DocType>, 'populate' |
-  'lean' |
-  'strict' |
-  'sanitizeProjection' |
-  'sanitizeFilter' |
-  'timestamps' |
-  'translateAliases'
+  type MongooseQueryOptions<DocType = unknown> = Pick<
+    QueryOptions<DocType>,
+    'lean' |
+    'multipleCastError' |
+    'overwriteDiscriminatorKey' |
+    'populate' |
+    'runValidators' |
+    'sanitizeProjection' |
+    'sanitizeFilter' |
+    'strict' |
+    'strictQuery' |
+    'timestamps' |
+    'translateAliases'
   >;
 
   type ProjectionFields<DocType> = { [Key in keyof DocType]?: any } & Record<string, any>;


### PR DESCRIPTION
Fix #14275

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

8.1 accidentally removed a few Mongoose-specific query options, including `runValidators`. This PR adds those options back, and adds test to protect against future regression.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
