### PR TITLE
types(query): add back `context` and `setDefaultsOnInsert` as Mongoose-specific query options

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -553,11 +553,13 @@ function mongooseQueryOptions() {
     { name: 'bar' },
     { name: 'baz' },
     {
+      context: 'query',
       multipleCastError: true,
       overwriteDiscriminatorKey: true,
       runValidators: true,
       sanitizeProjection: true,
       sanitizeFilter: true,
+      setDefaultsOnInsert: true,
       strict: true,
       strictQuery: 'throw',
       timestamps: false,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -19,6 +19,7 @@ declare module 'mongoose' {
 
   type MongooseQueryOptions<DocType = unknown> = Pick<
     QueryOptions<DocType>,
+    'context' |
     'lean' |
     'multipleCastError' |
     'overwriteDiscriminatorKey' |
@@ -26,6 +27,7 @@ declare module 'mongoose' {
     'runValidators' |
     'sanitizeProjection' |
     'sanitizeFilter' |
+    'setDefaultsOnInsert' |
     'strict' |
     'strictQuery' |
     'timestamps' |


### PR DESCRIPTION
Fix #14282

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Missed a couple of options in #14278

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
