### PR TITLE
fix(document): handle setting nested path to spread doc with extra properties

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1162,7 +1162,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
   // Assume this is a Mongoose document that was copied into a POJO using
   // `Object.assign()` or `{...doc}`
-  val = handleSpreadDoc(val);
+  val = handleSpreadDoc(val, true);
 
   // if this doc is being constructed we should not trigger getters
   const priorVal = (() => {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12916,6 +12916,43 @@ describe('document', function() {
     doc.set({ nested: void 0 });
     assert.strictEqual(doc.toObject().nested, void 0);
   });
+
+  it('handles setting nested path to spread doc with extra properties (gh-14269)', async function() {
+    const addressSchema = new mongoose.Schema(
+      {
+        street: String,
+        city: String,
+        state: String,
+        zip: Number
+      },
+      { _id: false }
+    );
+    const personSchema = new mongoose.Schema({
+      name: String,
+      age: Number,
+      address: addressSchema
+    });
+
+    const personModel = db.model('Person', personSchema);
+    const person = new personModel({
+      name: 'John',
+      age: 42,
+      address: {
+        street: '123 Fake St',
+        city: 'Springfield',
+        state: 'IL',
+        zip: 12345
+      }
+    });
+
+    await person.save();
+
+    person.address = {
+      ...person.address,
+      zip: 54321
+    };
+    assert.equal(person.address.zip, 54321);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {


### PR DESCRIPTION
Fix #14269

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick improvement for handling spread docs in `$set()`. `true` means we retain existing properties, so `{ ...doc, foo: true }` will still have `foo: true`.

Worth noting that we don't currently have a good way of handling key order - I'm looking into that. But `{ foo: true, ...doc }` currently will still have `foo: true`, even if `doc` has `foo: false`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
