### PR TITLE
fix(QueryCursor): eachAsync parameter of AggregationCursor and QueryCursor

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -87,6 +87,7 @@ They always return promises.
 * `Aggregate.prototype.exec`
 * `Aggregate.prototype.explain`
 * `AggregationCursor.prototype.close`
+* `AggregationCursor.prototype.eachAsync`
 * `Connection.prototype.startSession`
 * `Connection.prototype.dropCollection`
 * `Connection.prototype.createCollection`
@@ -138,6 +139,7 @@ They always return promises.
 * `Query.prototype.exec`
 * `QueryCursor.prototype.close`
 * `QueryCursor.prototype.next`
+* `QueryCursor.prototype.eachAsync`
 
 If you are using the above functions with callbacks, we recommend switching to async/await, or promises if async functions don't work for you.
 If you need help refactoring a legacy codebase, [this tool from Mastering JS callbacks to async await](https://masteringjs.io/tutorials/tools/callback-to-async-await) using ChatGPT.

--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -87,6 +87,7 @@ They always return promises.
 * `Aggregate.prototype.exec`
 * `Aggregate.prototype.explain`
 * `AggregationCursor.prototype.close`
+* `AggregationCursor.prototype.next`
 * `AggregationCursor.prototype.eachAsync`
 * `Connection.prototype.startSession`
 * `Connection.prototype.dropCollection`

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -219,21 +219,19 @@ AggregationCursor.prototype.next = async function next() {
  * @param {Function} fn
  * @param {Object} [options]
  * @param {Number} [options.parallel] the number of promises to execute in parallel. Defaults to 1.
- * @param {Function} [callback] executed when all docs have been processed
  * @return {Promise}
  * @api public
  * @method eachAsync
  */
 
-AggregationCursor.prototype.eachAsync = function(fn, opts, callback) {
+AggregationCursor.prototype.eachAsync = function(fn, opts) {
   const _this = this;
   if (typeof opts === 'function') {
-    callback = opts;
     opts = {};
   }
   opts = opts || {};
 
-  return eachAsync(function(cb) { return _next(_this, cb); }, fn, opts, callback);
+  return eachAsync(function(cb) { return _next(_this, cb); }, fn, opts);
 };
 
 /**

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -227,6 +227,9 @@ AggregationCursor.prototype.next = async function next() {
  */
 
 AggregationCursor.prototype.eachAsync = function(fn, opts) {
+  if (typeof arguments[2] === 'function') {
+    throw new MongooseError('AggregationCursor.prototype.eachAsync() no longer accepts a callback');
+  }
   const _this = this;
   if (typeof opts === 'function') {
     opts = {};

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -219,6 +219,8 @@ AggregationCursor.prototype.next = async function next() {
  * @param {Function} fn
  * @param {Object} [options]
  * @param {Number} [options.parallel] the number of promises to execute in parallel. Defaults to 1.
+ * @param {Number} [options.batchSize=null] if set, Mongoose will call `fn` with an array of at most `batchSize` documents, instead of a single document
+ * @param {Boolean} [options.continueOnError=false] if true, `eachAsync()` iterates through all docs even if `fn` throws an error. If false, `eachAsync()` throws an error immediately if the given function `fn()` throws an error.
  * @return {Promise}
  * @api public
  * @method eachAsync

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -243,7 +243,7 @@ QueryCursor.prototype.rewind = function() {
  */
 
 QueryCursor.prototype.next = async function next() {
-  if (arguments[0] === 'function') {
+  if (typeof arguments[0] === 'function') {
     throw new MongooseError('QueryCursor.prototype.next() no longer accepts a callback');
   }
   return new Promise((resolve, reject) => {

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -283,6 +283,9 @@ QueryCursor.prototype.next = async function next() {
  */
 
 QueryCursor.prototype.eachAsync = function(fn, opts) {
+  if (typeof arguments[2] === 'function') {
+    throw new MongooseError('QueryCursor.prototype.eachAsync() no longer accepts a callback');
+  }
   if (typeof opts === 'function') {
     opts = {};
   }

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -277,20 +277,18 @@ QueryCursor.prototype.next = async function next() {
  * @param {Number} [options.parallel] the number of promises to execute in parallel. Defaults to 1.
  * @param {Number} [options.batchSize] if set, will call `fn()` with arrays of documents with length at most `batchSize`
  * @param {Boolean} [options.continueOnError=false] if true, `eachAsync()` iterates through all docs even if `fn` throws an error. If false, `eachAsync()` throws an error immediately if the given function `fn()` throws an error.
- * @param {Function} [callback] executed when all docs have been processed
  * @return {Promise}
  * @api public
  * @method eachAsync
  */
 
-QueryCursor.prototype.eachAsync = function(fn, opts, callback) {
+QueryCursor.prototype.eachAsync = function(fn, opts) {
   if (typeof opts === 'function') {
-    callback = opts;
     opts = {};
   }
   opts = opts || {};
 
-  return eachAsync((cb) => _next(this, cb), fn, opts, callback);
+  return eachAsync((cb) => _next(this, cb), fn, opts);
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Currently, [documentation](https://mongoosejs.com/docs/api/querycursor.html#QueryCursor.prototype.eachAsync()) for QueryCursor.prototype.eachAsync write that it takes a callback as a parameter.

However, with the update to version 7, eachAsync no longer supports callbacks. - [Show commits](https://github.com/Automattic/mongoose/commit/b911bef9e41ed622ec3961b03d130edc5c2e4c09#diff-b9b6c3043d3ed32b9229dc3abc6d06af6f84d23106dc129cdefe46db4f89de54)
So, I fix parameters of eachAsync and the migrating guide to 7.

it has two more changes.
1. Add `AggregationCursor.prototype.next`, which was missing the guide.
2. fix conditional statements conditional in `QueryCursor.prototype.next`