### PR TITLE
feat(model): add `recompileSchema()` function to models to allow applying schema changes after compiling

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4862,6 +4862,34 @@ Model.__subclass = function subclass(conn, schema, collection) {
 };
 
 /**
+ * Apply changes made to this model's schema after this model was compiled.
+ * By default, adding virtuals and other properties to a schema after the model is compiled does nothing.
+ * Call this function to apply virtuals and properties that were added later.
+ *
+ * #### Example:
+ *     const schema = new mongoose.Schema({ field: String });
+ *     const TestModel = mongoose.model('Test', schema);
+ *     TestModel.schema.virtual('myVirtual').get(function() {
+ *       return this.field + ' from myVirtual';
+ *     });
+ *     const doc = new TestModel({ field: 'Hello' });
+ *     doc.myVirtual; // undefined
+ *
+ *     TestModel.recompileSchema();
+ *     doc.myVirtual; // 'Hello from myVirtual'
+ *
+ * @return {Model}
+ * @api public
+ * @memberOf Model
+ * @static
+ * @method recompileSchema
+ */
+
+Model.recompileSchema = function recompileSchema() {
+  this.prototype.$__setSchema(this.schema);
+};
+
+/**
  * Helper for console.log. Given a model named 'MyModel', returns the string
  * `'Model { MyModel }'`.
  *

--- a/lib/model.js
+++ b/lib/model.js
@@ -4878,7 +4878,7 @@ Model.__subclass = function subclass(conn, schema, collection) {
  *     TestModel.recompileSchema();
  *     doc.myVirtual; // 'Hello from myVirtual'
  *
- * @return {Model}
+ * @return {undefined}
  * @api public
  * @memberOf Model
  * @static

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7302,6 +7302,19 @@ describe('Model', function() {
       /First argument to `Model` constructor must be an object/
     );
   });
+
+  it('supports recompiling model with new schema additions (gh-14296)', function() {
+    const schema = new mongoose.Schema({ field: String });
+    const TestModel = db.model('Test', schema);
+    TestModel.schema.virtual('myVirtual').get(function() {
+      return this.field + ' from myVirtual';
+    });
+    const doc = new TestModel({ field: 'Hello' });
+    assert.strictEqual(doc.myVirtual, undefined);
+
+    TestModel.recompileSchema();
+    assert.equal(doc.myVirtual, 'Hello from myVirtual');
+  });
 });
 
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -711,6 +711,8 @@ declare module 'mongoose' {
       options?: (mongodb.ReplaceOptions & MongooseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'replaceOne'>;
 
+    recompileSchema(): void;
+
     /** Schema the model uses. */
     schema: Schema<TRawDocType>;
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -711,6 +711,7 @@ declare module 'mongoose' {
       options?: (mongodb.ReplaceOptions & MongooseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'replaceOne'>;
 
+    /** Apply changes made to this model's schema after this model was compiled. */
     recompileSchema(): void;
 
     /** Schema the model uses. */


### PR DESCRIPTION
Fix #14296

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Making changes to schemas after compiling a model is a common feature request. We can support that by adding an extra model function `recompileSchema()` that applies schema changes after model compilation.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
