### PR TITLE
fix(populate): call setter on virtual populated path with populated doc instead of undefined

### DIFF
--- a/lib/helpers/populate/setPopulatedVirtualValue.js
+++ b/lib/helpers/populate/setPopulatedVirtualValue.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = function setPopulatedVirtualValue(populatedVirtuals, name, v, options) {
+  if (options.justOne || options.count) {
+    populatedVirtuals[name] = Array.isArray(v) ?
+      v[0] :
+      v;
+
+    if (typeof populatedVirtuals[name] !== 'object') {
+      populatedVirtuals[name] = options.count ? v : null;
+    }
+  } else {
+    populatedVirtuals[name] = Array.isArray(v) ?
+      v :
+      v == null ? [] : [v];
+
+    populatedVirtuals[name] = populatedVirtuals[name].filter(function(doc) {
+      return doc && typeof doc === 'object';
+    });
+  }
+
+  return populatedVirtuals[name];
+};

--- a/lib/helpers/populate/setPopulatedVirtualValue.js
+++ b/lib/helpers/populate/setPopulatedVirtualValue.js
@@ -1,5 +1,15 @@
 'use strict';
 
+/**
+ * Set a populated virtual value on a document's `$$populatedVirtuals` value
+ *
+ * @param {*} populatedVirtuals A document's `$$populatedVirtuals`
+ * @param {*} name The virtual name
+ * @param {*} v The result of the populate query
+ * @param {*} options The populate options. This function handles `justOne` and `count` options.
+ * @returns {Array<Document>|Document|Object|Array<Object>} the populated virtual value that was set
+ */
+
 module.exports = function setPopulatedVirtualValue(populatedVirtuals, name, v, options) {
   if (options.justOne || options.count) {
     populatedVirtuals[name] = Array.isArray(v) ?

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -20,6 +20,7 @@ const handleReadPreferenceAliases = require('./helpers/query/handleReadPreferenc
 const idGetter = require('./helpers/schema/idGetter');
 const merge = require('./helpers/schema/merge');
 const mpath = require('mpath');
+const setPopulatedVirtualValue = require('./helpers/populate/setPopulatedVirtualValue');
 const setupTimestamps = require('./helpers/timestamps/setupTimestamps');
 const utils = require('./utils');
 const validateRef = require('./helpers/populate/validateRef');
@@ -2293,25 +2294,12 @@ Schema.prototype.virtual = function(name, options) {
           this.$$populatedVirtuals = {};
         }
 
-        if (options.justOne || options.count) {
-          this.$$populatedVirtuals[name] = Array.isArray(v) ?
-            v[0] :
-            v;
-
-          if (typeof this.$$populatedVirtuals[name] !== 'object') {
-            this.$$populatedVirtuals[name] = options.count ? v : null;
-          }
-        } else {
-          this.$$populatedVirtuals[name] = Array.isArray(v) ?
-            v :
-            v == null ? [] : [v];
-
-          this.$$populatedVirtuals[name] = this.$$populatedVirtuals[name].filter(function(doc) {
-            return doc && typeof doc === 'object';
-          });
-        }
-
-        return this.$$populatedVirtuals[name];
+        return setPopulatedVirtualValue(
+          this.$$populatedVirtuals,
+          name,
+          v,
+          options
+        );
       });
 
     if (typeof options.get === 'function') {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2288,28 +2288,30 @@ Schema.prototype.virtual = function(name, options) {
     virtual.options = options;
 
     virtual.
-      set(function(_v) {
+      set(function(v) {
         if (!this.$$populatedVirtuals) {
           this.$$populatedVirtuals = {};
         }
 
         if (options.justOne || options.count) {
-          this.$$populatedVirtuals[name] = Array.isArray(_v) ?
-            _v[0] :
-            _v;
+          this.$$populatedVirtuals[name] = Array.isArray(v) ?
+            v[0] :
+            v;
 
           if (typeof this.$$populatedVirtuals[name] !== 'object') {
-            this.$$populatedVirtuals[name] = options.count ? _v : null;
+            this.$$populatedVirtuals[name] = options.count ? v : null;
           }
         } else {
-          this.$$populatedVirtuals[name] = Array.isArray(_v) ?
-            _v :
-            _v == null ? [] : [_v];
+          this.$$populatedVirtuals[name] = Array.isArray(v) ?
+            v :
+            v == null ? [] : [v];
 
           this.$$populatedVirtuals[name] = this.$$populatedVirtuals[name].filter(function(doc) {
             return doc && typeof doc === 'object';
           });
         }
+
+        return this.$$populatedVirtuals[name];
       });
 
     if (typeof options.get === 'function') {


### PR DESCRIPTION
Fix #14285

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like the virtual populate setter doesn't correctly return the populated doc, this PR fixes that. Also did a quick bit of refactor to make it so that we have less populate logic in `lib/schema.js`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
