### PR TITLE
fix: include virtuals in document array `toString()` output if `toObject.virtuals` set

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4287,7 +4287,8 @@ Document.prototype.inspect = function(options) {
     opts = options;
     opts.minimize = false;
   }
-  const ret = this.toObject(opts);
+
+  const ret = arguments.length > 0 ? this.toObject(opts) : this.toObject();
 
   if (ret == null) {
     // If `toObject()` returns null, `this` is still an object, so if `inspect()`

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2144,6 +2144,18 @@ Schema.prototype.set = function(key, value, tags) {
   if (key === 'strictQuery') {
     _propagateOptionsToImplicitlyCreatedSchemas(this, { strictQuery: value });
   }
+  if (key === 'toObject') {
+    value = { ...value };
+    // Avoid propagating transform to implicitly created schemas re: gh-3279
+    delete value.transform;
+    _propagateOptionsToImplicitlyCreatedSchemas(this, { toObject: value });
+  }
+  if (key === 'toJSON') {
+    value = { ...value };
+    // Avoid propagating transform to implicitly created schemas re: gh-3279
+    delete value.transform;
+    _propagateOptionsToImplicitlyCreatedSchemas(this, { toJSON: value });
+  }
 
   return this;
 };

--- a/lib/types/documentArray/methods/index.js
+++ b/lib/types/documentArray/methods/index.js
@@ -13,6 +13,8 @@ const arrayPathSymbol = require('../../../helpers/symbols').arrayPathSymbol;
 const arraySchemaSymbol = require('../../../helpers/symbols').arraySchemaSymbol;
 const documentArrayParent = require('../../../helpers/symbols').documentArrayParent;
 
+const _baseToString = Array.prototype.toString;
+
 const methods = {
   /*!
    * ignore
@@ -20,6 +22,15 @@ const methods = {
 
   toBSON() {
     return this.toObject(internalToObjectOptions);
+  },
+
+  toString() {
+    return _baseToString.call(this.__array.map(subdoc => {
+      if (subdoc != null && subdoc.$__ != null) {
+        return subdoc.toString();
+      }
+      return subdoc;
+    }));
   },
 
   /*!

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -400,11 +400,7 @@ Subdocument.prototype.populate = function() {
  */
 
 Subdocument.prototype.inspect = function() {
-  return this.toObject({
-    transform: false,
-    virtuals: false,
-    flattenDecimals: false
-  });
+  return this.toObject();
 };
 
 if (util.inspect.custom) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12953,6 +12953,25 @@ describe('document', function() {
     };
     assert.equal(person.address.zip, 54321);
   });
+
+  it('includes virtuals in doc array toString() output if virtuals enabled on toObject (gh-14315)', function() {
+    const schema = new Schema({
+      docArr: [{ childId: mongoose.ObjectId }]
+    });
+    schema.virtual('docArr.child', { ref: 'Child', localField: 'docArr.childId', foreignField: '_id' });
+    schema.set('toObject', { virtuals: true });
+    schema.set('toJSON', { virtuals: true });
+    const Test = db.model('Test', schema);
+    const Child = db.model('Child', new Schema({
+      name: String
+    }));
+
+    const child = new Child({ name: 'test child' });
+    const doc = new Test({ docArr: [{ childId: child._id }] });
+    doc.docArr[0].child = child;
+    assert.ok(doc.docArr.toString().includes('child'), doc.docArr.toString());
+    assert.ok(doc.docArr.toString().includes('test child'), doc.docArr.toString());
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is availabe', function() {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -675,17 +675,6 @@ declare module 'mongoose' {
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
-    ): QueryWithHelpers<
-      ModifyResult<TRawDocType>,
-      ResultDoc,
-      TQueryHelpers,
-      TRawDocType,
-      'findOneAndUpdate'
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
       GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
@@ -694,6 +683,11 @@ declare module 'mongoose' {
       TRawDocType,
       'findOneAndUpdate'
     >;
+    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
+      filter: FilterQuery<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
+    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate'>;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -675,9 +675,9 @@ declare module 'mongoose' {
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: true }
+      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
     ): QueryWithHelpers<
-      GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
+      ModifyResult<TRawDocType>,
       ResultDoc,
       TQueryHelpers,
       TRawDocType,
@@ -686,8 +686,14 @@ declare module 'mongoose' {
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate'>;
+      options: QueryOptions<TRawDocType> & { lean: true }
+    ): QueryWithHelpers<
+      GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate'
+    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: FilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,


### PR DESCRIPTION
Fix #14315

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now document arrays' `toString()` function never includes virtuals in output, even if `toObject.virtuals` is set. This PR makes it so that we 1) bubble `toObject` and `toJSON`, minus `transform`, to implicitly created schemas, 2) don't hard-code `virtuals: false` when calling `inspect()` on subdocuments.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
