### PR TITLE
Added typescript support for arbitrary fields for the options parameter of Model functions which are of type MongooseQueryOptions

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -32,7 +32,9 @@ declare module 'mongoose' {
     'strictQuery' |
     'timestamps' |
     'translateAliases'
-  >;
+  > & {
+    [other: string]: any;
+  };
 
   type ProjectionFields<DocType> = { [Key in keyof DocType]?: any } & Record<string, any>;
 


### PR DESCRIPTION
Fixes - #14341 

**Summary**

Fixed the issue of unable to add arbitrary fields in the `options` object for Model functions whose `options` parameter had the type of `MongooseQueryOptions`, such as `deleteMany`, `deleteOne`, `replaceOne`, `updateMany`, `updateOne`, etc.
