### PR TITLE
fix(populate): handle ref() functions that return a model instance

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -494,7 +494,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
 
   let k = modelNames.length;
   while (k--) {
-    const modelName = modelNames[k];
+    let modelName = modelNames[k];
     if (modelName == null) {
       continue;
     }
@@ -504,6 +504,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
       Model = options.model;
     } else if (modelName[modelSymbol]) {
       Model = modelName;
+      modelName = Model.modelName;
     } else {
       try {
         Model = _getModelFromConn(connection, modelName);


### PR DESCRIPTION
Fix #14249

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14249 turns out to be an easy fix: it looks like we don't correctly handle `ref()` functions that return a model instance. `available[modelName]` then indexes based on the source code of the `model` constructor :disappointed: . This PR fixes that. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
