### PR TITLE
Avoid corrupting $set-ed arrays when transaction error occurs

### DIFF
--- a/lib/plugins/trackTransaction.js
+++ b/lib/plugins/trackTransaction.js
@@ -85,7 +85,12 @@ function mergeAtomics(destination, source) {
     destination.$addToSet = (destination.$addToSet || []).concat(source.$addToSet);
   }
   if (source.$set != null) {
-    destination.$set = Object.assign(destination.$set || {}, source.$set);
+    if (Array.isArray(destination.$set || []) && Array.isArray(source.$set || [])) {
+      destination.$set = (destination.$set || []).concat(source.$set);
+    } else {
+      destination.$set = Object.assign(destination.$set || {}, source.$set);
+    }
+
   }
 
   return destination;

--- a/lib/plugins/trackTransaction.js
+++ b/lib/plugins/trackTransaction.js
@@ -85,12 +85,7 @@ function mergeAtomics(destination, source) {
     destination.$addToSet = (destination.$addToSet || []).concat(source.$addToSet);
   }
   if (source.$set != null) {
-    if (Array.isArray(destination.$set || []) && Array.isArray(source.$set || [])) {
-      destination.$set = (destination.$set || []).concat(source.$set);
-    } else {
-      destination.$set = Object.assign(destination.$set || {}, source.$set);
-    }
-
+    destination.$set = Array.isArray(source.$set) ? [...source.$set] : Object.assign({}, source.$set);
   }
 
   return destination;

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -433,7 +433,6 @@ describe('transactions', function() {
     await db.transaction(async(session) => {
       await doc.save({ session });
 
-      // This is the important bit. Uncomment this to trigger a transaction retry.
       if (attempt === 0) {
         attempt += 1;
         throw new mongoose.mongo.MongoServerError({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When we `$set` an array, it looks like Mongoose converts the array to an object. This PR makes sure we handle array atomics correctly when we reset the document after a transient transaction error.

Fix #14340

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
