### PR TITLE
fix(cursor): make aggregation cursor support `transform` option to match query cursor

### DIFF
--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -57,12 +57,20 @@ util.inherits(AggregationCursor, Readable);
 function _init(model, c, agg) {
   if (!model.collection.buffer) {
     model.hooks.execPre('aggregate', agg, function() {
+      if (typeof agg.options?.cursor?.transform === 'function') {
+        c._transforms.push(agg.options.cursor.transform);
+      }
+
       c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
       c.emit('cursor', c.cursor);
     });
   } else {
     model.collection.emitter.once('queue', function() {
       model.hooks.execPre('aggregate', agg, function() {
+        if (typeof agg.options?.cursor?.transform === 'function') {
+          c._transforms.push(agg.options.cursor.transform);
+        }
+
         c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
         c.emit('cursor', c.cursor);
       });


### PR DESCRIPTION
Fix #14331

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Aggregation cursor doesn't support `transform` option currently, which is inconsistent with query cursor API. This PR makes it so that calling `Model.aggregate(pipeline).cursor({ transform })` adds a transform to the aggregation cursor's `_transforms`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
