### PR TITLE
Receive resumeTokenChanged changeStream event also in 6.x

### DIFF
--- a/lib/cursor/ChangeStream.js
+++ b/lib/cursor/ChangeStream.js
@@ -75,7 +75,7 @@ class ChangeStream extends EventEmitter {
       this.closed = true;
     });
 
-    ['close', 'change', 'end', 'error'].forEach(ev => {
+    ['close', 'change', 'end', 'error', 'resumeTokenChanged'].forEach(ev => {
       this.driverChangeStream.on(ev, data => {
         // Sometimes Node driver still polls after close, so
         // avoid any uncaught exceptions due to closed change streams

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5406,6 +5406,20 @@ describe('Model', function() {
           assert.equal(changeData.operationType, 'insert');
           assert.equal(changeData.fullDocument.name, 'Child');
         });
+
+        it('bubbles up resumeTokenChanged events (gh-14349)', async function() {
+          const MyModel = db.model('Test', new Schema({ name: String }));
+
+          const resumeTokenChangedEvent = new Promise(resolve => {
+            changeStream = MyModel.watch();
+            listener = data => resolve(data);
+            changeStream.once('resumeTokenChanged', listener);
+          });
+
+          await MyModel.create({ name: 'test' });
+          const { _data } = await resumeTokenChangedEvent;
+          assert.ok(_data);
+        });
       });
 
       describe('sessions (gh-6362)', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
Hi. I've implemented receiving resumeTokenChanged logic on 6.x.
https://github.com/Automattic/mongoose/issues/14349

This code is picked from this PR https://github.com/Automattic/mongoose/pull/13736 and I've changed a bit for 6.x
**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
