### PR TITLE
fix: strict check "ok" on validate function

### DIFF
--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1356,7 +1356,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     if (err) {
       return;
     }
-    if (ok === undefined || (ok && ok !== 0)) {
+    if (ok === undefined || ok || ok === 0) {
       if (--count <= 0) {
         immediate(function() {
           fn(null);

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1356,7 +1356,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     if (err) {
       return;
     }
-    if (ok === undefined || ok !== false) {
+    if (ok === undefined || (ok && ok !== '')) {
       if (--count <= 0) {
         immediate(function() {
           fn(null);

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1356,7 +1356,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     if (err) {
       return;
     }
-    if (ok === undefined || (ok && ok !== '')) {
+    if (ok === undefined || (ok && ok !== 0)) {
       if (--count <= 0) {
         immediate(function() {
           fn(null);

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1356,7 +1356,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     if (err) {
       return;
     }
-    if (ok === undefined || ok) {
+    if (ok === undefined || ok !== false) {
       if (--count <= 0) {
         immediate(function() {
           fn(null);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The problem is that when val is a string and its length is 0 - 0 will be a "falsey" value and the function will error. We should strictly check if the validate function explictly made "ok" false to prevent this behavior, since empty string should be allowed even if the required property is true. 

**Examples**


SCHEMA DEF && CODE (was initially failing on contextResponse being an empty string - when I expect it to fail when its undefined):

```
const messageSchema = new Schema({
	chat_id: {
        type: Schema.Types.ObjectId, 
        ref: 'Chat',
        required: true
	},

	role: {
		type: String,
		required: true
	},

	content: {
		type: String,
		required: true
	},

       embeds :{
                type: [Object],
                required: true
 
       },

    contextResponse: {
        type: String,
        required: true
    }
    

}, {timestamps: true});

  await models.Message.create({
        chat_id: '65bcedc1a78c24f230b4be7d',
        role: 'user',
        content: 'message',
        embeds: [],
        contextResponse: ''
    })
```
    