### PR TITLE
Record<string, string> as valid query `select` argument

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -647,7 +647,7 @@ declare module 'mongoose' {
 
     /** Specifies which document fields to include or exclude (also known as the query "projection") */
     select<RawDocTypeOverride extends { [P in keyof RawDocType]?: any } = {}>(
-      arg: string | string[] | Record<string, number | boolean | object>
+      arg: string | string[] | Record<string, number | boolean | string | object>
     ): QueryWithHelpers<
       IfEquals<
         RawDocTypeOverride,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A `Record<string, string>` is a valid argument to `Query.select`, but Typescript currently rejects it since it doesn't overlap with `string | string[] | Record<string, number | boolean | object>`.

**Examples**

```ts
import mongoose from "mongoose";

export const selectTypeTest = async (): Promise<void> => {
  type Test = {
    _id: mongoose.Types.ObjectId;

    testProp: string;

    createdAt: number;
    updatedAt: number;
  };

  const schema = new mongoose.Schema<Test>(
    {
      testProp: { type: String },
      createdAt: { type: Number },
      updatedAt: { type: Number },
    },
    {
      timestamps: { currentTime: () => new Date().valueOf() },
    }
  );

  const M = mongoose.model<Test>("Test", schema);

  await M.create({ testProp: "hello" });

  const myDoc = await M.findOne({}).select({ _id: 0, renamed: "$testProp" }).lean().exec();

  /*
  myDoc successfully returns { renamed: "hello" }

  But we get the following Typescript error anyway:

  Argument of type '{ _id: number; renamed: string; }' is not assignable to parameter of type 'string | string[] | Record<string, number | boolean | object>'.
  Types of property 'renamed' are incompatible.
    Type 'string' is not assignable to type 'number | boolean | object | undefined'.
  */
};
```

