### PR TITLE
perf(model): make `insertMany()` `lean` option skip hydrating Mongoose docs

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3430,6 +3430,13 @@ Model.$__insertMany = function(arr, options, callback) {
   const results = ordered ? null : new Array(arr.length);
   const toExecute = arr.map((doc, index) =>
     callback => {
+      // If option `lean` is set to true bypass validation and hydration
+      if (lean) {
+        // we have to execute callback at the nextTick to be compatible
+        // with parallelLimit, as `results` variable has TDZ issue if we
+        // execute the callback synchronously
+        return immediate(() => callback(null, doc));
+      }
       if (!(doc instanceof _this)) {
         try {
           doc = new _this(doc);
@@ -3439,13 +3446,6 @@ Model.$__insertMany = function(arr, options, callback) {
       }
       if (options.session != null) {
         doc.$session(options.session);
-      }
-      // If option `lean` is set to true bypass validation
-      if (lean) {
-        // we have to execute callback at the nextTick to be compatible
-        // with parallelLimit, as `results` variable has TDZ issue if we
-        // execute the callback synchronously
-        return immediate(() => callback(null, doc));
       }
       doc.$validate({ __noPromise: true }, function(error) {
         if (error) {
@@ -3510,7 +3510,7 @@ Model.$__insertMany = function(arr, options, callback) {
       callback(null, []);
       return;
     }
-    const docObjects = docAttributes.map(function(doc) {
+    const docObjects = lean ? docAttributes : docAttributes.map(function(doc) {
       if (doc.$__schema.options.versionKey) {
         doc[doc.$__schema.options.versionKey] = 0;
       }
@@ -3572,6 +3572,9 @@ Model.$__insertMany = function(arr, options, callback) {
             return !isErrored;
           }).
           map(function setIsNewForInsertedDoc(doc) {
+            if (lean) {
+              return doc;
+            }
             doc.$__reset();
             _setIsNew(doc, false);
             return doc;
@@ -3588,9 +3591,11 @@ Model.$__insertMany = function(arr, options, callback) {
         return;
       }
 
-      for (const attribute of docAttributes) {
-        attribute.$__reset();
-        _setIsNew(attribute, false);
+      if (!lean) {
+        for (const attribute of docAttributes) {
+          attribute.$__reset();
+          _setIsNew(attribute, false);
+        }
       }
 
       if (rawResult) {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1542,7 +1542,12 @@ describe('connections:', function() {
     it('should not throw an error when attempting to mutate unmutable options object gh-13335', async function() {
       const m = new mongoose.Mongoose();
       const opts = Object.preventExtensions({});
-      const conn = await m.connect('mongodb://127.0.0.1:27017/db?retryWrites=true&w=majority&readPreference=primaryPreferred', opts);
+
+      const uri = start.uri.lastIndexOf('?') === -1 ?
+        start.uri + '?retryWrites=true&w=majority&readPreference=primaryPreferred' :
+        start.uri.slice(0, start.uri.lastIndexOf('?')) + '?retryWrites=true&w=majority&readPreference=primaryPreferred';
+      
+      const conn = await m.connect(uri, opts);
       assert.ok(conn);
     });
   });

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1546,7 +1546,7 @@ describe('connections:', function() {
       const uri = start.uri.lastIndexOf('?') === -1 ?
         start.uri + '?retryWrites=true&w=majority&readPreference=primaryPreferred' :
         start.uri.slice(0, start.uri.lastIndexOf('?')) + '?retryWrites=true&w=majority&readPreference=primaryPreferred';
-      
+
       const conn = await m.connect(uri, opts);
       assert.ok(conn);
     });

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1542,7 +1542,7 @@ describe('connections:', function() {
     it('should not throw an error when attempting to mutate unmutable options object gh-13335', async function() {
       const m = new mongoose.Mongoose();
       const opts = Object.preventExtensions({});
-      const conn = await m.connect('mongodb://127.0.0.1:27017/db?retryWrites=true&w=majority&readPreference=secondaryPreferred', opts);
+      const conn = await m.connect('mongodb://127.0.0.1:27017/db?retryWrites=true&w=majority&readPreference=primaryPreferred', opts);
       assert.ok(conn);
     });
   });


### PR DESCRIPTION
Fix #14372

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Initial implementation of `lean` for `insertMany` in #8507 made `lean` just skip validation, not hydrating docs, which makes `insertMany` with `lean` still significantly slower. I'm inclined to change it so that `insertMany` with `lean` also skips hydrating Mongoose docs, because the name `lean` implies that we skip all hydration and other Mongoose-specific stuff similar to [query lean](https://mongoosejs.com/docs/tutorials/lean.html).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
