### PR TITLE
[fix] Add back Typescript help for true Mongoose-specific `options` for updateOne, updateMany, etc. 

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -228,7 +228,7 @@ declare module 'mongoose' {
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.CountOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.CountOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       number,
       THydratedDocumentType,
@@ -266,7 +266,7 @@ declare module 'mongoose' {
      */
     deleteMany(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.DeleteOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -291,7 +291,7 @@ declare module 'mongoose' {
      */
     deleteOne(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.DeleteOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -743,14 +743,14 @@ declare module 'mongoose' {
     updateMany<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: (mongodb.UpdateOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean'>) | null
+      options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateMany'>;
 
     /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
     updateOne<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: (mongodb.UpdateOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean'>) | null
+      options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateOne'>;
 
     /** Creates a Query, applies the passed conditions, and returns the Query. */

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -39,7 +39,10 @@ declare module 'mongoose' {
 
   type MongooseBaseQueryOptions<DocType = unknown> = MongooseQueryOptions<DocType, MongooseBaseQueryOptionKeys>;
 
-  type MongooseUpdateQueryOptions<DocType = unknown> = MongooseQueryOptions<DocType,  MongooseBaseQueryOptionKeys | "timestamps">;
+  type MongooseUpdateQueryOptions<DocType = unknown> = MongooseQueryOptions<
+    DocType,
+    MongooseBaseQueryOptionKeys | "timestamps"
+  >;
 
   type ProjectionFields<DocType> = { [Key in keyof DocType]?: any } & Record<string, any>;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -17,24 +17,29 @@ declare module 'mongoose' {
    */
   type FilterQuery<T> = _FilterQuery<T>;
 
-  type MongooseQueryOptions<DocType = unknown> = Pick<
-    QueryOptions<DocType>,
-    'context' |
-    'lean' |
-    'multipleCastError' |
-    'overwriteDiscriminatorKey' |
-    'populate' |
-    'runValidators' |
-    'sanitizeProjection' |
-    'sanitizeFilter' |
-    'setDefaultsOnInsert' |
-    'strict' |
-    'strictQuery' |
-    'timestamps' |
-    'translateAliases'
-  > & {
+  type MongooseBaseQueryOptionKeys =
+    | "context"
+    | "multipleCastError"
+    | "overwriteDiscriminatorKey"
+    | "populate"
+    | "runValidators"
+    | "sanitizeProjection"
+    | "sanitizeFilter"
+    | "setDefaultsOnInsert"
+    | "strict"
+    | "strictQuery"
+    | "translateAliases";
+
+  type MongooseQueryOptions<
+    DocType = unknown,
+    Keys extends keyof QueryOptions<DocType> = MongooseBaseQueryOptionKeys | "timestamps" | "lean"
+  > = Pick<QueryOptions<DocType>, Keys> & {
     [other: string]: any;
   };
+
+  type MongooseBaseQueryOptions<DocType = unknown> = MongooseQueryOptions<DocType, MongooseBaseQueryOptionKeys>;
+
+  type MongooseUpdateQueryOptions<DocType = unknown> = MongooseQueryOptions<DocType,  MongooseBaseQueryOptionKeys | "timestamps">;
 
   type ProjectionFields<DocType> = { [Key in keyof DocType]?: any } & Record<string, any>;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -18,21 +18,21 @@ declare module 'mongoose' {
   type FilterQuery<T> = _FilterQuery<T>;
 
   type MongooseBaseQueryOptionKeys =
-    | "context"
-    | "multipleCastError"
-    | "overwriteDiscriminatorKey"
-    | "populate"
-    | "runValidators"
-    | "sanitizeProjection"
-    | "sanitizeFilter"
-    | "setDefaultsOnInsert"
-    | "strict"
-    | "strictQuery"
-    | "translateAliases";
+    | 'context'
+    | 'multipleCastError'
+    | 'overwriteDiscriminatorKey'
+    | 'populate'
+    | 'runValidators'
+    | 'sanitizeProjection'
+    | 'sanitizeFilter'
+    | 'setDefaultsOnInsert'
+    | 'strict'
+    | 'strictQuery'
+    | 'translateAliases';
 
   type MongooseQueryOptions<
     DocType = unknown,
-    Keys extends keyof QueryOptions<DocType> = MongooseBaseQueryOptionKeys | "timestamps" | "lean"
+    Keys extends keyof QueryOptions<DocType> = MongooseBaseQueryOptionKeys | 'timestamps' | 'lean'
   > = Pick<QueryOptions<DocType>, Keys> & {
     [other: string]: any;
   };
@@ -41,7 +41,7 @@ declare module 'mongoose' {
 
   type MongooseUpdateQueryOptions<DocType = unknown> = MongooseQueryOptions<
     DocType,
-    MongooseBaseQueryOptionKeys | "timestamps"
+    MongooseBaseQueryOptionKeys | 'timestamps'
   >;
 
   type ProjectionFields<DocType> = { [Key in keyof DocType]?: any } & Record<string, any>;


### PR DESCRIPTION
**Summary**
Addresses #14378. `MongooseQueryOptions` type was recently edited to include `& { [other: string]: any }` in order to support arbitrary options. This implementation broke Typescript support for all of the official Mongoose option properties, in the sense that there's no more auto-completion when you start typing something like "runValidators", and there's no in-line JSDoc displayed.

This is caused by the use of the `Omit` Typescript utility in the type for `options` in `updateOne`, `updateMany`, and a few others. Resolution is to redo the implementation with a build-up approach instead of using `Omit`.

**Examples**
See example and screenshots in #14378