### PR TITLE
fix: missing typescript details on options params of updateMany, updateOne, etc.

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -291,7 +291,7 @@ declare module 'mongoose' {
      */
     deleteOne(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.DeleteOptions & ExcludeKeys<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -228,7 +228,7 @@ declare module 'mongoose' {
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.CountOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.CountOptions & ExcludeKeys<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
     ): QueryWithHelpers<
       number,
       THydratedDocumentType,
@@ -266,7 +266,7 @@ declare module 'mongoose' {
      */
     deleteMany(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.DeleteOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.DeleteOptions & ExcludeKeys<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -291,7 +291,7 @@ declare module 'mongoose' {
      */
     deleteOne(
       filter?: FilterQuery<TRawDocType>,
-      options?: (mongodb.DeleteOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
+      options?: (mongodb.DeleteOptions & ExcludeKeys<MongooseQueryOptions<TRawDocType>, 'lean' | 'timestamps'>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -743,14 +743,14 @@ declare module 'mongoose' {
     updateMany<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: (mongodb.UpdateOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean'>) | null
+      options?: (mongodb.UpdateOptions & ExcludeKeys<MongooseQueryOptions<TRawDocType>, 'lean'>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateMany'>;
 
     /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
     updateOne<ResultDoc = THydratedDocumentType>(
       filter?: FilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: (mongodb.UpdateOptions & Omit<MongooseQueryOptions<TRawDocType>, 'lean'>) | null
+      options?: (mongodb.UpdateOptions & ExcludeKeys<MongooseQueryOptions<TRawDocType>, 'lean'>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateOne'>;
 
     /** Creates a Query, applies the passed conditions, and returns the Query. */

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -2,6 +2,17 @@ declare module 'mongoose' {
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends (1 & IFTYPE) ? THENTYPE : ELSETYPE;
   type IfUnknown<IFTYPE, THENTYPE> = unknown extends IFTYPE ? THENTYPE : IFTYPE;
 
+  /**
+    * @summary Removes keys from a type
+    * @description It helps to exclude keys from a type
+    * @param {T} T A generic type to be checked.
+    * @param {K} K Keys from T that are to be excluded from the generic type
+    * @returns T with the keys in K excluded
+    */
+  type ExcludeKeys<T, K extends keyof T> = {
+    [P in keyof T as P extends K ? never : P]: T[P];
+  };
+
   type Unpacked<T> = T extends (infer U)[] ?
     U :
     T extends ReadonlyArray<infer U> ? U : T;


### PR DESCRIPTION
Fixes #14378

**Summary**
Fixes the missing typescript details from the `options` parameter of functions like `updateMany()`, `updateOne()`, etc. The issue happened because the `Omit` in `Omit<MongooseQueryOptions<TRawDocType>, 'lean'>` was making the type of the keys vague because `MongooseQueryOptions` contains `[other: string]: any`. To fix this, introdduced a new TS Util function called `ExcludeKeys` which fixes this logic without weakening the type

**Examples**
The property `timestamps` and other such params are now visible
![Screenshot 2024-02-26 190616](https://github.com/Automattic/mongoose/assets/54135532/8ec6c89f-56bf-4216-944c-5df4e631432f)

Its still supporting arbitrary options like `fallback` without any type issues
![Screenshot 2024-02-26 190710](https://github.com/Automattic/mongoose/assets/54135532/e0ae75a8-9985-4f51-855e-0fcf006aad3e)

