### PR TITLE
perf(document+schema): small optimizations to make `init()` faster

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -741,7 +741,7 @@ function init(self, obj, doc, opts, prefix) {
     if (i === '__proto__' || i === 'constructor') {
       return;
     }
-    path = prefix + i;
+    path = prefix ? prefix + i : i;
     schemaType = docSchema.path(path);
 
     // Should still work if not a model-level discriminator, but should not be
@@ -751,7 +751,8 @@ function init(self, obj, doc, opts, prefix) {
       return;
     }
 
-    if (!schemaType && utils.isPOJO(obj[i])) {
+    const value = obj[i];
+    if (!schemaType && utils.isPOJO(value)) {
       // assume nested object
       if (!doc[i]) {
         doc[i] = {};
@@ -759,30 +760,30 @@ function init(self, obj, doc, opts, prefix) {
           self[i] = doc[i];
         }
       }
-      init(self, obj[i], doc[i], opts, path + '.');
+      init(self, value, doc[i], opts, path + '.');
     } else if (!schemaType) {
-      doc[i] = obj[i];
+      doc[i] = value;
       if (!strict && !prefix) {
-        self[i] = obj[i];
+        self[i] = value;
       }
     } else {
       // Retain order when overwriting defaults
-      if (doc.hasOwnProperty(i) && obj[i] !== void 0) {
+      if (doc.hasOwnProperty(i) && value !== void 0) {
         delete doc[i];
       }
-      if (obj[i] === null) {
+      if (value === null) {
         doc[i] = schemaType._castNullish(null);
-      } else if (obj[i] !== undefined) {
-        const wasPopulated = obj[i].$__ == null ? null : obj[i].$__.wasPopulated;
+      } else if (value !== undefined) {
+        const wasPopulated = value.$__ == null ? null : value.$__.wasPopulated;
 
         if (schemaType && !wasPopulated) {
           try {
             if (opts && opts.setters) {
               // Call applySetters with `init = false` because otherwise setters are a noop
               const overrideInit = false;
-              doc[i] = schemaType.applySetters(obj[i], self, overrideInit);
+              doc[i] = schemaType.applySetters(value, self, overrideInit);
             } else {
-              doc[i] = schemaType.cast(obj[i], self, true);
+              doc[i] = schemaType.cast(value, self, true);
             }
           } catch (e) {
             self.invalidate(e.path, new ValidatorError({
@@ -794,7 +795,7 @@ function init(self, obj, doc, opts, prefix) {
             }));
           }
         } else {
-          doc[i] = obj[i];
+          doc[i] = value;
         }
       }
       // mark as hydrated

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -955,6 +955,9 @@ reserved.collection = 1;
 
 Schema.prototype.path = function(path, obj) {
   if (obj === undefined) {
+    if (this.paths[path] != null) {
+      return this.paths[path];
+    }
     // Convert to '.$' to check subpaths re: gh-6405
     const cleanPath = _pathToPositionalSyntax(path);
     let schematype = _getPath(this, path, cleanPath);


### PR DESCRIPTION
Re: #14113

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Without this change:

```
$ node gh-14113.js 
6.12.6
mongoose spendTime: 24358 average: 48.716
$ node gh-14113.js 
6.12.6
mongoose spendTime: 24956 average: 49.912
$ node gh-14113.js 
6.12.6
mongoose spendTime: 25182 average: 50.364

```

With this change:

```
$ node gh-14113.js 
6.12.6
mongoose spendTime: 24003 average: 48.006
$ node gh-14113.js 
6.12.6
mongoose spendTime: 24222 average: 48.444
$ node gh-14113.js 
6.12.6
mongoose spendTime: 24247 average: 48.494
```

Seems like a small difference, but if you remove `init` entirely the average goes down to about 47.5, so this is actually a fairly significant speedup of `init()`. I'm assuming that the rest of the relatively small performance degradation in Mongoose 5 and 6 is due to bson slowdowns discussed in #13456.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
