### PR TITLE
types(querycursor): correct cursor async iterator type with `populate()` support

### DIFF
--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -43,7 +43,7 @@ async function gh14374() {
   // This does not
   const cursor = ParentModel.find({}).populate<{ child: Child }>('child').cursor();
   for await (const doc of cursor) {
-    const _t: string = doc.child.name;
+    expectType<Child>(doc.child);
   }
 
 }

--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -20,3 +20,30 @@ Test.find().cursor().
     expectType<number>(i);
   }).
   then(() => console.log('Done!'));
+
+async function gh14374() {
+  // `Parent` represents the object as it is stored in MongoDB
+  interface Parent {
+    child?: Types.ObjectId
+    name?: string
+  }
+  const ParentModel = model<Parent>(
+    'Parent',
+    new Schema({
+        child: { type: Schema.Types.ObjectId, ref: 'Child' },
+        name: String
+    })
+  )
+
+  interface Child {
+    name: string
+  }
+  const childSchema: Schema = new Schema({ name: String });
+
+  // This does not
+  const cursor = ParentModel.find({}).populate<{ child: Child }>('child').cursor()
+  for await (const doc of cursor) {
+      const _t: string = doc.child.name;
+  }
+
+}

--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -30,10 +30,10 @@ async function gh14374() {
   const ParentModel = model<Parent>(
     'Parent',
     new Schema({
-        child: { type: Schema.Types.ObjectId, ref: 'Child' },
-        name: String
+      child: { type: Schema.Types.ObjectId, ref: 'Child' },
+      name: String
     })
-  )
+  );
 
   interface Child {
     name: string
@@ -41,9 +41,9 @@ async function gh14374() {
   const childSchema: Schema = new Schema({ name: String });
 
   // This does not
-  const cursor = ParentModel.find({}).populate<{ child: Child }>('child').cursor()
+  const cursor = ParentModel.find({}).populate<{ child: Child }>('child').cursor();
   for await (const doc of cursor) {
-      const _t: string = doc.child.name;
+    const _t: string = doc.child.name;
   }
 
 }

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -208,7 +208,7 @@ declare module 'mongoose' {
      * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
      * This is equivalent to calling `.cursor()` with no arguments.
      */
-    [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
+    [Symbol.asyncIterator](): AsyncIterableIterator<Unpacked<ResultType>>;
 
     /** Executes the query */
     exec(): Promise<ResultType>;
@@ -286,7 +286,7 @@ declare module 'mongoose' {
      * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html).
      * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
      */
-    cursor(options?: QueryOptions<DocType>): Cursor<DocType, QueryOptions<DocType>>;
+    cursor(options?: QueryOptions<DocType>): Cursor<Unpacked<ResultType>, QueryOptions<DocType>>;
 
     /**
      * Declare and/or execute this query as a `deleteMany()` operation. Works like


### PR DESCRIPTION
Fix #14374

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, using `for await` with a cursor doesn't quite work in TypeScript: you get `DocType[]` rather than `ResultType`. Similarly, that means `populate<Paths>()` doesn't work right with `cursor()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
