### PR TITLE
fix(connection): avoid unhandled error on createConnection() if on('error') handler registered

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -830,6 +830,30 @@ Connection.prototype.openUri = async function openUri(uri, options) {
 };
 
 /*!
+ * Treat `on('error')` handlers as handling the initialConnection promise
+ * to avoid uncaught exceptions when using `on('error')`. See gh-14377.
+ */
+
+Connection.prototype.on = function on(event, callback) {
+  if (event === 'error' && this.$initialConnection) {
+    this.$initialConnection.catch(() => {});
+  }
+  return EventEmitter.prototype.on.call(this, event, callback);
+};
+
+/*!
+ * Treat `once('error')` handlers as handling the initialConnection promise
+ * to avoid uncaught exceptions when using `on('error')`. See gh-14377.
+ */
+
+Connection.prototype.once = function on(event, callback) {
+  if (event === 'error' && this.$initialConnection) {
+    this.$initialConnection.catch(() => {});
+  }
+  return EventEmitter.prototype.once.call(this, event, callback);
+};
+
+/*!
  * ignore
  */
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -916,6 +916,21 @@ describe('connections:', function() {
     assert.equal(err.name, 'MongooseServerSelectionError');
   });
 
+  it('avoids unhandled error on createConnection() if error handler registered (gh-14377)', async function() {
+    const opts = {
+      serverSelectionTimeoutMS: 100
+    };
+    const uri = 'mongodb://baddomain:27017/test';
+
+    const conn = mongoose.createConnection(uri, opts);
+    await new Promise(resolve => {
+      conn.on('error', err => {
+        assert.equal(err.name, 'MongoServerSelectionError');
+        resolve();
+      });
+    });
+  });
+
   it('`watch()` on a whole collection (gh-8425)', async function() {
     this.timeout(10000);
     if (!process.env.REPLICA_SET) {


### PR DESCRIPTION
Fix #14377

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`connection.on('error', fn)` should mean that `openUri()` errors shouldn't count as unhandled exceptions.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
