### PR TITLE
fix(schema): avoid applying default write concern to operations that are in a transaction

### DIFF
--- a/lib/helpers/schema/applyWriteConcern.js
+++ b/lib/helpers/schema/applyWriteConcern.js
@@ -6,6 +6,12 @@ module.exports = function applyWriteConcern(schema, options) {
   if (options.writeConcern != null) {
     return;
   }
+  // Don't apply default write concern to operations in transactions,
+  // because setting write concern on an operation in a transaction is an error
+  // See: https://www.mongodb.com/docs/manual/reference/write-concern/
+  if (options && options.session && options.session.transaction) {
+    return;
+  }
   const writeConcern = get(schema, 'options.writeConcern', {});
   if (Object.keys(writeConcern).length != 0) {
     options.writeConcern = {};


### PR DESCRIPTION
Fix #11382

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

You aren't supposed to set write concern on operations in a transaction, rather set writeConcern on the transaction as a whole:

![image](https://github.com/Automattic/mongoose/assets/1620265/9c99f9f6-32de-47a2-89b2-f05616aa392c)

This PR makes it so that Mongoose doesn't apply schema-level write concern to operations that are within a transaction

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
