### PR TITLE
fix(document): make `$clone` avoid converting subdocs into POJOs

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4735,7 +4735,7 @@ Document.prototype.$clone = function() {
   const clonedDoc = new Model();
   clonedDoc.$isNew = this.$isNew;
   if (this._doc) {
-    clonedDoc._doc = clone(this._doc);
+    clonedDoc._doc = clone(this._doc, { retainDocuments: true });
   }
   if (this.$__) {
     const Cache = this.$__.constructor;

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -41,6 +41,17 @@ function clone(obj, options, isArrayChild) {
     if (options && options._skipSingleNestedGetters && obj.$isSingleNested) {
       options = Object.assign({}, options, { getters: false });
     }
+    if (options != null && options.retainDocuments != null && obj.$__ != null) {
+      const clonedDoc = obj.$clone();
+      if (obj.__index != null) {
+        clonedDoc.__index = obj.__index;
+      }
+      if (obj.__parentArray != null) {
+        clonedDoc.__parentArray = obj.__parentArray;
+      }
+      clonedDoc.$__parent = obj.$__parent;
+      return clonedDoc;
+    }
     const isSingleNested = obj.$isSingleNested;
 
     if (isPOJO(obj) && obj.$__ != null && obj._doc != null) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12070,6 +12070,27 @@ describe('document', function() {
     assert.strictEqual(clonedDoc.$session(), session);
   });
 
+  it('$clone() with single nested and doc array (gh-14353) (gh-11849)', async function() {
+    const schema = new mongoose.Schema({
+      subdocArray: [{
+        name: String
+      }],
+      subdoc: new mongoose.Schema({ name: String })
+    });
+    const Test = db.model('Test', schema);
+
+    const item = await Test.create({ subdocArray: [{ name: 'test 1' }], subdoc: { name: 'test 2' } });
+
+    const doc = await Test.findById(item._id);
+    const clonedDoc = doc.$clone();
+
+    assert.ok(clonedDoc.subdocArray[0].$__);
+    assert.ok(clonedDoc.subdoc.$__);
+
+    assert.deepEqual(doc.subdocArray[0], clonedDoc.subdocArray[0]);
+    assert.deepEqual(doc.subdoc, clonedDoc.subdoc);
+  });
+
   it('can create document with document array and top-level key named `schema` (gh-12480)', async function() {
     const AuthorSchema = new Schema({
       fullName: { type: 'String', required: true }


### PR DESCRIPTION
Re: #14353

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix for [this issue from #14353](https://github.com/Automattic/mongoose/issues/14353#issuecomment-1944564724), there are a couple of unrelated issues reported in #14353. This particular issue is that document `$clone` method converts subdocs into POJOs, which is definitely incorrect.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
