### PR TITLE
fix: fixed the typing of FilterQuery<T> type to prevent it from only getting typed to any

### DIFF
--- a/scripts/tsc-diagnostics-check.js
+++ b/scripts/tsc-diagnostics-check.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 
 const stdin = fs.readFileSync(0).toString('utf8');
-const maxInstantiations = isNaN(process.argv[2]) ? 120000 : parseInt(process.argv[2], 10);
+const maxInstantiations = isNaN(process.argv[2]) ? 130000 : parseInt(process.argv[2], 10);
 
 console.log(stdin);
 

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -84,6 +84,8 @@ Test.find({ parent: { $in: ['0'.repeat(24)] } });
 Test.find({ name: { $in: ['Test'] } }).exec().then((res: Array<ITest>) => console.log(res));
 Test.find({ tags: 'test' }).exec();
 Test.find({ tags: { $in: ['test'] } }).exec();
+Test.find({ tags: /test/ }).exec();
+Test.find({ tags: { $in: [/test/] } }).exec();
 
 // Implicit `$in`
 Test.find({ name: ['Test1', 'Test2'] }).exec();

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -324,8 +324,8 @@ function gh11964() {
   let idCondition: Condition<WithId<TestUser>['id']>;
   let filter: FilterQuery<WithId<TestUser>>;
 
-  expectType<typeof idCondition>(id);
-  expectType<typeof filter>({ id });
+  expectAssignable<typeof idCondition>(id);
+  expectAssignable<typeof filter>({ id });
 }
 
 function gh12091() {

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -88,6 +88,9 @@ Test.find({ tags: { $in: ['test'] } }).exec();
 // Implicit `$in`
 Test.find({ name: ['Test1', 'Test2'] }).exec();
 
+// Implicit `$in` for regex string
+Test.find({ name: [/Test1/, /Test2/] });
+
 Test.find({ name: 'test' }, (err: Error | null, docs: ITest[]) => {
   console.log(!!err, docs[0].age);
 });
@@ -311,16 +314,18 @@ function gh11964() {
 
   type WithId<T extends object> = T & { id: string };
 
-  class Repository<T extends object> {
-    /* ... */
+  type TestUser = {
+    name: string;
+    age: number;
+  };
 
-    find(id: string) {
-      const idCondition: Condition<WithId<T>>['id'] = id; // error :(
-      const filter: FilterQuery<WithId<T>> = { id }; // error :(
+  const id: string = 'Test Id';
 
-      /* ... */
-    }
-  }
+  let idCondition: Condition<WithId<TestUser>['id']>;
+  let filter: FilterQuery<WithId<TestUser>>;
+
+  expectType<typeof idCondition>(id);
+  expectType<typeof filter>({ id });
 }
 
 function gh12091() {

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -316,6 +316,19 @@ function gh11964() {
 
   type WithId<T extends object> = T & { id: string };
 
+  class Repository<T extends object> {
+    find(id: string) {
+      const idCondition: Condition<ReturnType<(arg: WithId<T>) => typeof arg.id>> = id;
+      const filter: FilterQuery<WithId<T>> = { id } as FilterQuery<WithId<T>>;
+    }
+  }
+}
+
+function gh14397() {
+  type Condition<T> = ApplyBasicQueryCasting<T> | QuerySelector<ApplyBasicQueryCasting<T>>; // redefined here because it's not exported by mongoose
+
+  type WithId<T extends object> = T & { id: string };
+
   type TestUser = {
     name: string;
     age: number;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -16,7 +16,7 @@ declare module 'mongoose' {
           ? BufferQueryTypeCasting
           : T;
 
-  export type ApplyBasicQueryCasting<T> = T | T[] | (T extends (infer U)[] ? U : never);
+  export type ApplyBasicQueryCasting<T> = T | T[] | (T extends (infer U)[] ? QueryTypeCasting<U> : never);
   type Condition<T> = ApplyBasicQueryCasting<QueryTypeCasting<T>> | QuerySelector<ApplyBasicQueryCasting<QueryTypeCasting<T>>>;
 
   type _FilterQuery<T> = {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -3,12 +3,18 @@ declare module 'mongoose' {
 
   type StringQueryTypeCasting = string | RegExp;
   type ObjectIdQueryTypeCasting = Types.ObjectId | string;
+  type UUIDQueryTypeCasting = Types.UUID | string;
+  type BufferQueryTypeCasting = Buffer | any;
 
   type QueryTypeCasting<T> = T extends string
     ? StringQueryTypeCasting
     : T extends Types.ObjectId
       ? ObjectIdQueryTypeCasting
-      : T;
+      : T extends Types.UUID
+        ? UUIDQueryTypeCasting
+        : T extends Buffer
+          ? BufferQueryTypeCasting
+          : T;
 
   export type ApplyBasicQueryCasting<T> = T | T[] | (T extends (infer U)[] ? U : never);
   type Condition<T> = ApplyBasicQueryCasting<QueryTypeCasting<T>> | QuerySelector<ApplyBasicQueryCasting<QueryTypeCasting<T>>>;
@@ -246,7 +252,7 @@ declare module 'mongoose' {
     allowDiskUse(value: boolean): this;
 
     /** Specifies arguments for an `$and` condition. */
-    and(array: FilterQuery<RawDocType>[]): this;
+    and(array: FilterQuery<DocType>[]): this;
 
     /** Specifies the batchSize option. */
     batchSize(val: number): this;
@@ -295,7 +301,7 @@ declare module 'mongoose' {
 
     /** Specifies this query as a `countDocuments` query. */
     countDocuments(
-      criteria?: FilterQuery<RawDocType>,
+      criteria?: FilterQuery<DocType>,
       options?: QueryOptions<DocType>
     ): QueryWithHelpers<number, DocType, THelpers, RawDocType, 'countDocuments'>;
 
@@ -311,10 +317,10 @@ declare module 'mongoose' {
      * collection, regardless of the value of `single`.
      */
     deleteMany(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       options?: QueryOptions<DocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteMany'>;
-    deleteMany(filter: FilterQuery<RawDocType>): QueryWithHelpers<
+    deleteMany(filter: FilterQuery<DocType>): QueryWithHelpers<
       any,
       DocType,
       THelpers,
@@ -329,10 +335,10 @@ declare module 'mongoose' {
      * option.
      */
     deleteOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       options?: QueryOptions<DocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne'>;
-    deleteOne(filter: FilterQuery<RawDocType>): QueryWithHelpers<
+    deleteOne(filter: FilterQuery<DocType>): QueryWithHelpers<
       any,
       DocType,
       THelpers,
@@ -344,7 +350,7 @@ declare module 'mongoose' {
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
-      filter?: FilterQuery<RawDocType>
+      filter?: FilterQuery<DocType>
     ): QueryWithHelpers<Array<DocKey extends keyof DocType ? Unpacked<DocType[DocKey]> : ResultType>, DocType, THelpers, RawDocType, 'distinct'>;
 
     /** Specifies a `$elemMatch` query condition. When called with one argument, the most recent path passed to `where()` is used. */
@@ -384,52 +390,52 @@ declare module 'mongoose' {
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find(
-      filter: FilterQuery<RawDocType>,
+      filter: FilterQuery<DocType>,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find'>;
     find(
-      filter: FilterQuery<RawDocType>,
+      filter: FilterQuery<DocType>,
       projection?: ProjectionType<RawDocType> | null
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find'>;
     find(
-      filter: FilterQuery<RawDocType>
+      filter: FilterQuery<DocType>
     ): QueryWithHelpers<Array<RawDocType>, DocType, THelpers, RawDocType, 'find'>;
     find(): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find'>;
 
     /** Declares the query a findOne operation. When executed, returns the first found document. */
     findOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne'>;
     findOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       projection?: ProjectionType<RawDocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne'>;
     findOne(
-      filter?: FilterQuery<RawDocType>
+      filter?: FilterQuery<DocType>
     ): QueryWithHelpers<DocType | null, RawDocType, THelpers, RawDocType, 'findOne'>;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
     findOneAndDelete(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete'>;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
     findOneAndUpdate(
-      filter: FilterQuery<RawDocType>,
+      filter: FilterQuery<DocType>,
       update: UpdateQuery<RawDocType>,
       options: QueryOptions<DocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndUpdate'>;
     findOneAndUpdate(
-      filter: FilterQuery<RawDocType>,
+      filter: FilterQuery<DocType>,
       update: UpdateQuery<RawDocType>,
       options: QueryOptions<DocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate'>;
     findOneAndUpdate(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       update?: UpdateQuery<RawDocType>,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate'>;
@@ -490,7 +496,7 @@ declare module 'mongoose' {
     get(path: string): any;
 
     /** Returns the current query filter (also known as conditions) as a POJO. */
-    getFilter(): FilterQuery<RawDocType>;
+    getFilter(): FilterQuery<DocType>;
 
     /** Gets query options. */
     getOptions(): QueryOptions<DocType>;
@@ -499,7 +505,7 @@ declare module 'mongoose' {
     getPopulatedPaths(): Array<string>;
 
     /** Returns the current query filter. Equivalent to `getFilter()`. */
-    getQuery(): FilterQuery<RawDocType>;
+    getQuery(): FilterQuery<DocType>;
 
     /** Returns the current update operations as a JSON object. */
     getUpdate(): UpdateQuery<DocType> | UpdateWithAggregationPipeline | null;
@@ -569,7 +575,7 @@ declare module 'mongoose' {
     maxTimeMS(ms: number): this;
 
     /** Merges another Query or conditions object into this one. */
-    merge(source: Query<any, any> | FilterQuery<RawDocType>): this;
+    merge(source: Query<any, any> | FilterQuery<DocType>): this;
 
     /** Specifies a `$mod` condition, filters documents for documents whose `path` property is a number that is equal to `remainder` modulo `divisor`. */
     mod<K = string>(path: K, val: number): this;
@@ -597,10 +603,10 @@ declare module 'mongoose' {
     nin(val: Array<any>): this;
 
     /** Specifies arguments for an `$nor` condition. */
-    nor(array: Array<FilterQuery<RawDocType>>): this;
+    nor(array: Array<FilterQuery<DocType>>): this;
 
     /** Specifies arguments for an `$or` condition. */
-    or(array: Array<FilterQuery<RawDocType>>): this;
+    or(array: Array<FilterQuery<DocType>>): this;
 
     /**
      * Make this query throw an error if no documents match the given `filter`.
@@ -657,7 +663,7 @@ declare module 'mongoose' {
      * not accept any [atomic](https://www.mongodb.com/docs/manual/tutorial/model-data-for-atomic-operations/#pattern) operators (`$set`, etc.)
      */
     replaceOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       replacement?: DocType | AnyObject,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'replaceOne'>;
@@ -716,7 +722,7 @@ declare module 'mongoose' {
     setOptions(options: QueryOptions<DocType>, overwrite?: boolean): this;
 
     /** Sets the query conditions to the provided JSON object. */
-    setQuery(val: FilterQuery<RawDocType> | null): void;
+    setQuery(val: FilterQuery<DocType> | null): void;
 
     setUpdate(update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline): void;
 
@@ -756,7 +762,7 @@ declare module 'mongoose' {
      * the `multi` option.
      */
     updateMany(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       update?: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateMany'>;
@@ -766,7 +772,7 @@ declare module 'mongoose' {
      * `update()`, except it does not support the `multi` or `overwrite` options.
      */
     updateOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: FilterQuery<DocType>,
       update?: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateOne'>;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -1,8 +1,17 @@
 declare module 'mongoose' {
   import mongodb = require('mongodb');
 
-  export type ApplyBasicQueryCasting<T> = T | T[] | (T extends (infer U)[] ? U : any) | any;
-  type Condition<T> = ApplyBasicQueryCasting<T> | QuerySelector<ApplyBasicQueryCasting<T>>;
+  type StringQueryTypeCasting = string | RegExp;
+  type ObjectIdQueryTypeCasting = Types.ObjectId | string;
+
+  type QueryTypeCasting<T> = T extends string
+    ? StringQueryTypeCasting
+    : T extends Types.ObjectId
+      ? ObjectIdQueryTypeCasting
+      : T;
+
+  export type ApplyBasicQueryCasting<T> = T | T[] | (T extends (infer U)[] ? U : never);
+  type Condition<T> = ApplyBasicQueryCasting<QueryTypeCasting<T>> | QuerySelector<ApplyBasicQueryCasting<QueryTypeCasting<T>>>;
 
   type _FilterQuery<T> = {
     [P in keyof T]?: Condition<T[P]>;


### PR DESCRIPTION
Fixes #14397 

**Summary**
Fixed the typing to of `FilterQuery<T>` by preventing it from getting type-casted to `any` always. Strengthened the type by removing `any` and still keeping the ability to add generic fields. Fixed the typescript issue of `$regex`, `$eq` not showing the hint messages.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
![Screenshot 2024-03-01 233516](https://github.com/Automattic/mongoose/assets/54135532/ee451038-16ae-4071-94d4-9e861fd63fa7)
