### PR TITLE
Update version support documentation for mongoose 5 & 6

### DIFF
--- a/docs/version-support.md
+++ b/docs/version-support.md
@@ -18,4 +18,4 @@ Mongoose 6.x will no longer receive any updates, security or otherwise, after th
 
 ## Mongoose 5
 
-Mongoose 5.x (released January 17, 2018) is since March 1, 2024 End-of-Life (EOL), it will no longer receive any updates, security or otherwise.
+Mongoose 5.x (released January 17, 2018) is End-of-Life (EOL) since March 1, 2024. Mongoose 5.x will no longer receive any updates, security or otherwise.

--- a/docs/version-support.md
+++ b/docs/version-support.md
@@ -22,10 +22,4 @@ Mongoose 6.x will no longer receive any updates, security or otherwise, after th
 
 ## Mongoose 5
 
-Mongoose 5.x (released January 17, 2018) is currently only receiving security fixes and requested bug fixes.
-Please open a [bug report on GitHub](https://github.com/Automattic/mongoose/issues/new?assignees=&labels=&template=bug.yml) to request backporting a fix to Mongoose 5.
-We will **not** backport any new features from Mongoose 6 or Mongoose 7 into Mongoose 5.
-This includes support for newer versions of MongoDB: we do not intend to add support for MongoDB 5 or higher to Mongoose 5.x.
-
-Mongoose 5.x end of life (EOL) is March 1, 2024.
-Mongoose 5.x will no longer receive any updates, security or otherwise, after that date.
+Mongoose 5.x (released January 17, 2018) is since March 1, 2024 End-of-Life (EOL), it will no longer receive any updates, security or otherwise.

--- a/docs/version-support.md
+++ b/docs/version-support.md
@@ -13,10 +13,6 @@ We ship all new bug fixes and features to 7.x.
 Mongoose 6.x (released August 24, 2021) is currently only receiving security fixes and requested bug fixes as of August 24, 2023.
 Please open a [bug report on GitHub](https://github.com/Automattic/mongoose/issues/new?assignees=&labels=&template=bug.yml) to request backporting a fix to Mongoose 6.
 
-We are **not** actively backporting any new features from Mongoose 7 into Mongoose 6.
-Until August 24, 2023, we will backport requested features into Mongoose 6; please open a [feature request on GitHub](https://github.com/Automattic/mongoose/issues/new?assignees=&labels=enhancement%2Cnew+feature&template=feature.yml) to request backporting a feature into Mongoose 6.
-After August 24, 2023, we will not backport any new features into Mongoose 6.
-
 Mongoose 6.x end of life (EOL) is January 1, 2025.
 Mongoose 6.x will no longer receive any updates, security or otherwise, after that date.
 


### PR DESCRIPTION
**Summary**

This PR updates `version-support` to:
- indicate `Mongoose 5` is completely EOL, no requestion backporting of anything
- indicate `Mongoose 6` does not accept requesting backporting of features anymore