### PR TITLE
Add TypeScript interface for the new PipelineStage - Vector Search - solving issue #14428

### DIFF
--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -525,7 +525,7 @@ const vectorSearchStages: PipelineStage[] = [
     $vectorSearch: {
       index: 'title_vector_index',
       path: 'embedding',
-      queryVector: [0.522,0.123,0.487],
+      queryVector: [0.522, 0.123, 0.487],
       limit: 5,
       numCandidates: 100
     }

--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -532,8 +532,8 @@ const vectorSearchStages: PipelineStage[] = [
   },
   {
     $project: {
-    title: 1,
-    score: { $meta: 'searchScore' }
+      title: 1,
+      score: { $meta: 'searchScore' }
     }
   }
 ];

--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -523,11 +523,11 @@ function gh12269() {
 const vectorSearchStages: PipelineStage[] = [
   {
     $vectorSearch: {
-    index: 'title_vector_index',
-    path: 'embedding',
-    queryVector: [0.522,0.123,0.487],
-    limit: 5,
-    numCandidates: 100
+      index: 'title_vector_index',
+      path: 'embedding',
+      queryVector: [0.522,0.123,0.487],
+      limit: 5,
+      numCandidates: 100
     }
   },
   {

--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -520,3 +520,20 @@ function gh12269() {
     }
   };
 }
+const vectorSearchStages: PipelineStage[] = [
+  {
+    $vectorSearch: {
+    index: 'title_vector_index',
+    path: 'embedding',
+    queryVector: [0.522,0.123,0.487],
+    limit: 5,
+    numCandidates: 100
+    }
+  },
+  {
+    $project: {
+    title: 1,
+    score: { $meta: 'searchScore' }
+    }
+  }
+];

--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -36,7 +36,8 @@ declare module 'mongoose' {
     | PipelineStage.SortByCount
     | PipelineStage.UnionWith
     | PipelineStage.Unset
-    | PipelineStage.Unwind;
+    | PipelineStage.Unwind
+    | PipelineStage.VectorSearch;
 
   export namespace PipelineStage {
     export interface AddFields {
@@ -308,5 +309,17 @@ declare module 'mongoose' {
       /** [`$unwind` reference](https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/) */
       $unwind: string | { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean }
     }
+    export interface VectorSearch {
+      /** [`$vectorSearch` reference](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/) */
+      $vectorSearch: {
+        index: string,
+        path: string,
+        queryVector: number[],
+        numCandidates: number,
+        limit: number,
+        filter?: Expression,
+      }
+    }
+
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
With MongoDB releasing the new vector search index & pipeline stage, Mongoose is missing this PiplineStage, which creates a compilation error in TypeScript. The proposal is to add support for this new PipelineStage - VecrorSearch

The motivation is to maintain & support the typesafe aggregation pipeline in Mongoose.

This PR is aiming to solve [this issue](https://github.com/Automattic/mongoose/issues/14428)

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
```
const mongoose = require("mongoose");
const contentsSchema = new mongoose.Schema({
  embedding: {
    type: [Number],
  },
  title: String,
});
export const Contents = mongoose.model(
  "Contents",
  contentsSchema,
  "contents",
);

 const result = await Contents.aggregate([
    {
      $vectorSearch: {
        index: "title_vector_index",
        path: "embedding",
        filter: {someField: "value",}
        queryVector:[0.3455,......,0.123],
        numCandidates: 200,
        limit: 10,
      },
    },
  ]);
```
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
