### PR TITLE
types: consistently infer array of objects in schema as a DocumentArray

### DIFF
--- a/test/types/docArray.test.ts
+++ b/test/types/docArray.test.ts
@@ -93,3 +93,37 @@ async function gh13424() {
   const doc = new TestModel();
   expectType<Types.ObjectId | undefined>(doc.subDocArray[0]._id);
 }
+
+async function gh14367() {
+  const UserSchema = new Schema(
+    {
+      reminders: {
+        type: [
+          {
+            type: { type: Schema.Types.String },
+            date: { type: Schema.Types.Date },
+            toggle: { type: Schema.Types.Boolean },
+            notified: { type: Schema.Types.Boolean }
+          }
+        ],
+        default: [
+          { type: 'vote', date: new Date(), toggle: false, notified: false },
+          { type: 'daily', date: new Date(), toggle: false, notified: false },
+          { type: 'drop', date: new Date(), toggle: false, notified: false },
+          { type: 'claim', date: new Date(), toggle: false, notified: false },
+          { type: 'work', date: new Date(), toggle: false, notified: false }
+        ]
+      },
+      avatar: {
+        type: Schema.Types.String
+      }
+    },
+    { timestamps: true }
+  );
+
+  type IUser = InferSchemaType<typeof UserSchema>;
+  expectType<string | null | undefined>({} as IUser['reminders'][0]['type']);
+  expectType<Date | null | undefined>({} as IUser['reminders'][0]['date']);
+  expectType<boolean | null | undefined>({} as IUser['reminders'][0]['toggle']);
+  expectType<string | null | undefined>({} as IUser['avatar']);
+}

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1059,10 +1059,10 @@ function gh12882() {
   });
   type tArrType = InferSchemaType<typeof arrType>;
   expectType<{
-    fooArray: {
+    fooArray: Types.DocumentArray<{
       type: string;
       foo: number;
-    }[]
+    }>
   }>({} as tArrType);
   // Readonly array of strings
   const rArrString = new Schema({
@@ -1110,10 +1110,10 @@ function gh12882() {
   });
   type rTArrType = InferSchemaType<typeof rArrType>;
   expectType<{
-    fooArray: {
+    fooArray: Types.DocumentArray<{
       type: string;
       foo: number;
-    }[]
+    }>
   }>({} as rTArrType);
 }
 

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -229,7 +229,7 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
               ObtainDocumentPathType<Item, TypeKey>[] :
               // If the type key isn't callable, then this is an array of objects, in which case
               // we need to call ObtainDocumentType to correctly infer its type.
-              ObtainDocumentType<Item, any, { typeKey: TypeKey }>[] :
+              Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>> :
             IsSchemaTypeFromBuiltinClass<Item> extends true ?
               ObtainDocumentPathType<Item, TypeKey>[] :
               IsItRecordAndNotAny<Item> extends true ?


### PR DESCRIPTION
Fix #14367

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The root cause of #14367 looks to be a minor inconsistency in type inference: on L232 we had `ObtainDocumentType<Item, any, { typeKey: TypeKey }>[]`, and on L238 we have `Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>>`. If these 2 are consistent, the code from #14367 compiles. Not 100% sure why, but we have tests proving this does the right thing.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
