### PR TITLE
Added Null check in case schema.options['type'][0] is undefined

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1388,6 +1388,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
     if (schema.options &&
         Array.isArray(schema.options[typeKey]) &&
         schema.options[typeKey].length &&
+        schema.options[typeKey][0] &&
         schema.options[typeKey][0].ref &&
         _isManuallyPopulatedArray(val, schema.options[typeKey][0].ref)) {
       popOpts = { [populateModelSymbol]: val[0].constructor };


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In the process of creating a new document, I encountered a TypeError. Upon investigating the error stack, it revealed that the issue was related to an undefined property 'ref' during the execution of model.$set in the Mongoose library.

Upon further examination, I noticed that there was a missing null check for schema.options[typeKey][0], where typeKey is a crucial part of the schema. In my case, schema.options[typeKey][0] was undefined, leading to a subsequent error when trying to access the 'ref' property. To address this issue, I have proposed a pull request to the Mongoose repository that includes the necessary null check for schema.options[typeKey][0]. This modification ensures a smoother handling of cases where the referenced type is absent.
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

