### PR TITLE
types: improve the typing of FilterQuery<T> type to prevent it from only getting typed to any

### DIFF
--- a/scripts/tsc-diagnostics-check.js
+++ b/scripts/tsc-diagnostics-check.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 
 const stdin = fs.readFileSync(0).toString('utf8');
-const maxInstantiations = isNaN(process.argv[2]) ? 120000 : parseInt(process.argv[2], 10);
+const maxInstantiations = isNaN(process.argv[2]) ? 130000 : parseInt(process.argv[2], 10);
 
 console.log(stdin);
 


### PR DESCRIPTION
Re: #14398
Fix #14397

@FaizBShah WDYT?

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14398 but with a couple of changes:

1. Avoided changing `FilterQuery<RawDocType>` back to `FilterQuery<DocType>` for everything but `getFilter()` and `getQuery()`. For some reason, tests fail without that
2. Fixes for the #11964 test. The fact that we had to change that test was concerning, but after diving down the rabbit hole I'm convinced the #11964 test is just incorrect and will never work unless `FilterQuery` types to `any`. [Here's a couple of TypeScript playground examples demonstrating the issue](https://www.typescriptlang.org/play?#code/PTAEGUAsHsHcGdQBdIEMkBpQFMBu2A7UASwDNQBPaAV1FQBN7QADAMlAG8T6AuUeJACdiBAOagAvsywpsoQdnjUANkhHikFAA5z60RQQDkSUAWwBjRfFTDlFAFAhQafHSLNivfkPXNQWwWgdQU17TR1QABVQAF5Obj4zfEFJUHYuTz4BYTFJAG57c2gCAVAADz5ouIyvQ1JoaEN8+0cwKDhEFHQWTNM8bEE-AWJlZRwypEJ6RA8vbN9C5VR4RAAlbC1oeGIkaEEKAB5o7AmpxBqsn1yJAD5Oe1BQUhF6AApe+bEASnvHx6KSiZSABGSqxeKeZqPCT2GEA0oUPjrTbbXb7A4cXpJAa3cFmWCgZFbHZ7Q6YrzYwS3V5fPJAA), which is that with `class Repository<T>`, there's no way to type `T` so that `T` excludes `{ id: never }`, and `WithId<{ id: never }>` still types to `{id: never}`. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
