### PR TITLE
fix(model): improve update minimizing to only minimize top-level properties in the update

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -351,12 +351,22 @@ Model.prototype.$__handleSave = function(options, callback) {
 
     const update = delta[1];
     if (this.$__schema.options.minimize) {
-      minimize(update);
-      // minimize might leave us with an empty object, which would
-      // lead to MongoDB throwing a "Update document requires atomic operators" error
-      if (Object.keys(update).length === 0) {
-        handleEmptyUpdate.call(this);
-        return;
+      for (const updateOp of Object.values(update)) {
+        if (updateOp == null) {
+          continue;
+        }
+        for (const key of Object.keys(updateOp)) {
+          if (updateOp[key] == null || typeof updateOp[key] !== 'object') {
+            continue;
+          }
+          if (!utils.isPOJO(updateOp[key])) {
+            continue;
+          }
+          minimize(updateOp[key]);
+          if (Object.keys(updateOp[key]).length === 0) {
+            updateOp[key] = null;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Fix #14420
Re: #13782

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The issue in #14420 is that the update to `save()` is `{ $set: { sub: {} } }`, which gets minimized away by #13782. With this PR, we'll only minimize top-level properties of update operators in the `save()` update. So in the #14420 case, we'll just minimize `sub` to `null`, but leave the rest of the update. I think this is the most consistent way to handle #14420 without undoing the changes we made in #13782.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
