### PR TITLE
fix: added fix to populate a nested document field inside an array parent when using path string

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1929,7 +1929,7 @@ Document.prototype.get = function(path, type, options) {
     obj = adhoc.cast(obj);
   }
 
-  if (schema != null && options.getters !== false) {
+  if (schema != null && schema !== 'nested' && options.getters !== false) {
     obj = schema.applyGetters(obj, this);
   } else if (this.$__schema.nested[path] && options.virtuals) {
     // Might need to apply virtuals if this is a nested path

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -934,4 +934,118 @@ describe('document.populate', function() {
     assert.ok(foundBook.populated('authorId'));
     assert.ok(foundBook.authorId.populated('websiteId'));
   });
+
+  it('works when populating a nested document inside an array parent (gh-14435)', async function() {
+    const CodeSchema = new Schema({
+      code: String
+    });
+
+    const UserSchema = new Schema({
+      username: String,
+      extras: [
+        new Schema({
+          config: new Schema({
+            paymentConfiguration: {
+              paymentMethods: [
+                {
+                  type: Schema.Types.ObjectId,
+                  ref: 'Code'
+                }
+              ]
+            }
+          })
+        })
+      ]
+    });
+
+    const Code = db.model('Code', CodeSchema);
+    const CodeUser = db.model('CodeUser', UserSchema);
+
+    const code = await new Code({
+      code: 'test code'
+    }).save();
+
+    await new CodeUser({
+      username: 'TestUser',
+      extras: [
+        {
+          config: {
+            paymentConfiguration: {
+              paymentMethods: [code._id]
+            }
+          }
+        }
+      ]
+    }).save();
+
+    const codeUser = await CodeUser.findOne({ username: 'TestUser' }).populate(
+      'extras.config.paymentConfiguration.paymentMethods'
+    );
+
+    assert.ok(codeUser.username);
+    assert.strictEqual(codeUser.username, 'TestUser');
+    assert.ok(codeUser.extras);
+    assert.strictEqual(codeUser.extras.length, 1);
+    assert.ok(codeUser.extras[0]);
+    assert.ok(codeUser.extras[0].config);
+    assert.ok(codeUser.extras[0].config.paymentConfiguration);
+    assert.ok(codeUser.extras[0].config.paymentConfiguration.paymentMethods);
+    assert.strictEqual(codeUser.extras[0].config.paymentConfiguration.paymentMethods.length, 1);
+    assert.deepStrictEqual(codeUser.extras[0].config.paymentConfiguration.paymentMethods[0]._id, code._id);
+    assert.strictEqual(codeUser.extras[0].config.paymentConfiguration.paymentMethods[0].code, 'test code');
+  });
+
+  it('works when populating a nested document not inside an array parent (gh-14435)', async function() {
+    const CodeSchema = new Schema({
+      code: String
+    });
+
+    const UserSchema = new Schema({
+      username: String,
+      extras: new Schema({
+        config: new Schema({
+          paymentConfiguration: {
+            paymentMethods: [
+              {
+                type: Schema.Types.ObjectId,
+                ref: 'Code'
+              }
+            ]
+          }
+        })
+      })
+    });
+
+    const Code = db.model('Code', CodeSchema);
+    const CodeUser = db.model('CodeUser', UserSchema);
+
+    const code = await new Code({
+      code: 'test code'
+    }).save();
+
+    await new CodeUser({
+      username: 'TestUser',
+      extras: {
+        config: {
+          paymentConfiguration: {
+            paymentMethods: [code._id]
+          }
+        }
+      }
+    }).save();
+
+    const codeUser = await CodeUser.findOne({ username: 'TestUser' }).populate(
+      'extras.config.paymentConfiguration.paymentMethods'
+    );
+
+    assert.ok(codeUser.username);
+    assert.strictEqual(codeUser.username, 'TestUser');
+    assert.ok(codeUser.extras);
+    assert.ok(codeUser.extras.config);
+    assert.ok(codeUser.extras.config.paymentConfiguration);
+    assert.ok(codeUser.extras.config.paymentConfiguration.paymentMethods);
+    assert.strictEqual(codeUser.extras.config.paymentConfiguration.paymentMethods.length, 1);
+    assert.deepStrictEqual(codeUser.extras.config.paymentConfiguration.paymentMethods[0]._id, code._id);
+    assert.strictEqual(codeUser.extras.config.paymentConfiguration.paymentMethods[0].code, 'test code');
+  });
 });


### PR DESCRIPTION
Fixes #14435 

**Summary**
Added the fix to handle population of fields inside a nested document schema, when the schema of the document is `'nested'`. In some cases, as in the issue attached, where the nested document was inside a parent which is an array, the schema of the field might turn out to be `'nested'` in the `document.get()` function and thus the population was failing and throwing an error, even though intuitively the path made sense. Now, since `'nested'` is a string, therefore it won't have the `.applyGetters()` function which is present in other schemas, and thus it threw error. Therefore excluded the `'nested'` schema from calling that function and preventing failing of the population logic. The result populated data is still correct as by the time this function is called, the population of data for a nested document is already done

**Examples**
Have added subsequent tests.
