### PR TITLE
types(schema): add missing search index types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -275,6 +275,13 @@ declare module 'mongoose' {
     index(fields: IndexDefinition, options?: IndexOptions): this;
 
     /**
+     * Define a search index for this schema.
+     *
+     * @remarks Search indexes are only supported when used against a 7.0+ Mongo Atlas cluster.
+     */
+    searchIndex(description: mongodb.SearchIndexDescription): Promise<string>;
+
+    /**
      * Returns a list of indexes that this schema declares, via `schema.index()`
      * or by `index: true` in a path's options.
      */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -279,7 +279,7 @@ declare module 'mongoose' {
      *
      * @remarks Search indexes are only supported when used against a 7.0+ Mongo Atlas cluster.
      */
-    searchIndex(description: mongodb.SearchIndexDescription): Promise<string>;
+    searchIndex(description: mongodb.SearchIndexDescription): this;
 
     /**
      * Returns a list of indexes that this schema declares, via `schema.index()`

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -25,6 +25,11 @@ declare module 'mongoose' {
      */
     autoIndex?: boolean;
     /**
+     * Similar to autoIndex, except for automatically creates any Atlas search indexes defined in your
+     * schema. Unlike autoIndex, this option defaults to false.
+     */
+    autoSearchIndex?: boolean;
+    /**
      * If set to `true`, Mongoose will call Model.createCollection() to create the underlying collection
      * in MongoDB if autoCreate is set to true. Calling createCollection() sets the collection's default
      * collation based on the collation option and establishes the collection as a capped collection if


### PR DESCRIPTION
**Summary**

Support for MongoDB Atlas search indexes was added in [#14251](https://github.com/Automattic/mongoose/pull/14251) but the types for `Schema.searchIndex` and the `autoSearchIndex` option were missed.

Add these types so that the typescript definitions match the capabilities of the JavaScript version of `mongoose`.

**Examples**

Not applicable. Just adding type definitions for existing functionality.
