### PR TITLE
Avoid depopulating populated subdocs underneath document arrays when copying to another document

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1087,7 +1087,11 @@ Document.prototype.$set = function $set(path, val, type, options) {
       if (path.$__isNested) {
         path = path.toObject();
       } else {
-        path = path._doc;
+        // This ternary is to support gh-7898 (copying virtuals if same schema)
+        // while not breaking gh-10819, which for some reason breaks if we use toObject()
+        path = path.$__schema === this.$__schema
+          ? applyVirtuals(path, { ...path._doc })
+          : path._doc;
       }
     }
     if (path == null) {
@@ -4012,11 +4016,11 @@ function applyVirtuals(self, json, options, toObjectOptions) {
     ? toObjectOptions.aliases
     : true;
 
+  options = options || {};
   let virtualsToApply = null;
   if (Array.isArray(options.virtuals)) {
     virtualsToApply = new Set(options.virtuals);
-  }
-  else if (options.virtuals && options.virtuals.pathsToSkip) {
+  } else if (options.virtuals && options.virtuals.pathsToSkip) {
     virtualsToApply = new Set(paths);
     for (let i = 0; i < options.virtuals.pathsToSkip.length; i++) {
       if (virtualsToApply.has(options.virtuals.pathsToSkip[i])) {
@@ -4029,7 +4033,6 @@ function applyVirtuals(self, json, options, toObjectOptions) {
     return json;
   }
 
-  options = options || {};
   for (i = 0; i < numPaths; ++i) {
     path = paths[i];
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -5124,7 +5124,7 @@ function _assign(model, vals, mod, assignmentOpts) {
       }
       // flag each as result of population
       if (!lean) {
-        val.$__.wasPopulated = val.$__.wasPopulated || true;
+        val.$__.wasPopulated = val.$__.wasPopulated || { value: _val };
       }
     }
   }

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -443,19 +443,9 @@ DocumentArrayPath.prototype.cast = function(value, doc, init, prev, options) {
 
     const Constructor = getConstructor(this.casterConstructor, rawArray[i]);
 
-    // Check if the document has a different schema (re gh-3701)
-    if (rawArray[i].$__ != null && !(rawArray[i] instanceof Constructor)) {
-      const spreadDoc = handleSpreadDoc(rawArray[i], true);
-      if (rawArray[i] !== spreadDoc) {
-        rawArray[i] = spreadDoc;
-      } else {
-        rawArray[i] = rawArray[i].toObject({
-          transform: false,
-          // Special case: if different model, but same schema, apply virtuals
-          // re: gh-7898
-          virtuals: rawArray[i].schema === Constructor.schema
-        });
-      }
+    const spreadDoc = handleSpreadDoc(rawArray[i], true);
+    if (rawArray[i] !== spreadDoc) {
+      rawArray[i] = spreadDoc;
     }
 
     if (rawArray[i] instanceof Subdocument) {

--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -1505,7 +1505,7 @@ SchemaType.prototype._castRef = function _castRef(value, doc, init) {
   }
 
   if (value.$__ != null) {
-    value.$__.wasPopulated = value.$__.wasPopulated || true;
+    value.$__.wasPopulated = value.$__.wasPopulated || { value: value._id };
     return value;
   }
 
@@ -1531,7 +1531,7 @@ SchemaType.prototype._castRef = function _castRef(value, doc, init) {
     !doc.$__.populated[path].options.options ||
     !doc.$__.populated[path].options.options.lean) {
     ret = new pop.options[populateModelSymbol](value);
-    ret.$__.wasPopulated = true;
+    ret.$__.wasPopulated = { value: ret._id };
   }
 
   return ret;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14418 is a tricky issue, there's a couple of causes:

1. [This `toObject()` call](https://github.com/Automattic/mongoose/blob/d516f50f2073f69c62cabd6bf0e765e08abb0208/lib/schema/documentArray.js#L456) swallows up the fact that you're setting the doc array element to a document that potentially includes populated values
2. [This check fails](https://github.com/Automattic/mongoose/blob/d516f50f2073f69c62cabd6bf0e765e08abb0208/lib/document.js#L1381) because `$__.wasPopulated` was `true` rather than an object with `value`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
