### PR TITLE
fix(types/query): bring "getFilter" and "getQuery" in-line with "find" and other types

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -493,7 +493,7 @@ declare module 'mongoose' {
     get(path: string): any;
 
     /** Returns the current query filter (also known as conditions) as a POJO. */
-    getFilter(): FilterQuery<DocType>;
+    getFilter(): FilterQuery<RawDocType>;
 
     /** Gets query options. */
     getOptions(): QueryOptions<DocType>;
@@ -502,7 +502,7 @@ declare module 'mongoose' {
     getPopulatedPaths(): Array<string>;
 
     /** Returns the current query filter. Equivalent to `getFilter()`. */
-    getQuery(): FilterQuery<DocType>;
+    getQuery(): FilterQuery<RawDocType>;
 
     /** Returns the current update operations as a JSON object. */
     getUpdate(): UpdateQuery<DocType> | UpdateWithAggregationPipeline | null;

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -234,7 +234,7 @@ declare module 'mongoose' {
     query?: IfEquals<
     QueryHelpers,
     {},
-    Record<any, <T extends QueryWithHelpers<unknown, THydratedDocumentType>>(this: T, ...args: any) => T>,
+    Record<any, <T extends QueryWithHelpers<unknown, THydratedDocumentType, QueryHelpers, DocType>>(this: T, ...args: any) => T>,
     QueryHelpers
     >
 


### PR DESCRIPTION
**Summary**

This PR changes `Query.getFilter` and `Query.getQuery` to use `RawDocType` again, as this is the same argument as in `.find`'s `filter` parameter.
In addition also pass-through the `QueryHelpers` and `DocType` in `SchemaOptions`'s `query`'s object (otherwise there is a test failure).

This change from e3f320515297240f6bca4ec6be7b14c442a97a46 somehow made it so that `PopulatedDoc<Document, RefType>` could not be narrowed down to the used `RefType` anymore, and i dont know why, but this change fixed it again for typegoose.