### PR TITLE
types(schema): re-export the defintion for `SearchIndexDescription`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -279,7 +279,7 @@ declare module 'mongoose' {
      *
      * @remarks Search indexes are only supported when used against a 7.0+ Mongo Atlas cluster.
      */
-    searchIndex(description: mongodb.SearchIndexDescription): this;
+    searchIndex(description: SearchIndexDescription): this;
 
     /**
      * Returns a list of indexes that this schema declares, via `schema.index()`

--- a/types/indexes.d.ts
+++ b/types/indexes.d.ts
@@ -86,4 +86,6 @@ declare module 'mongoose' {
     expires?: number | string;
     weights?: Record<string, number>;
   }
+
+  type SearchIndexDescription = mongodb.SearchIndexDescription;
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -327,7 +327,7 @@ declare module 'mongoose' {
      * Create an [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
      * This function only works when connected to MongoDB Atlas.
      */
-    createSearchIndex(description: mongodb.SearchIndexDescription): Promise<string>;
+    createSearchIndex(description: SearchIndexDescription): Promise<string>;
 
     /** Connection the model uses. */
     db: Connection;


### PR DESCRIPTION
**Summary**

I'm trying to add support for creating search indices to `typegoose` here: https://github.com/typegoose/typegoose/pull/921

Since `typegoose` doesn't depend on or import `mongodb` I've had to create a copy of the `SearchIndexDescription` type from `mongodb` that is going to become out of date if the type in `mongodb` changes. I thought it'd be better if `mongoose` could re-export the type so that `typegoose`, `mongoose`, and `mongodb` can all be in sync.

**Examples**

N/A