### PR TITLE
feat(document): add `validateAllPaths` option to `validate()` and `validateSync()`

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2756,47 +2756,7 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
 
   // gh-661: if a whole array is modified, make sure to run validation on all
   // the children as well
-  for (const path of paths) {
-    const _pathType = doc.$__schema.path(path);
-    if (!_pathType) {
-      continue;
-    }
-
-    if (!_pathType.$isMongooseArray ||
-        // To avoid potential performance issues, skip doc arrays whose children
-        // are not required. `getPositionalPathType()` may be slow, so avoid
-        // it unless we have a case of #6364
-        (!Array.isArray(_pathType) &&
-          _pathType.$isMongooseDocumentArray &&
-          !(_pathType && _pathType.schemaOptions && _pathType.schemaOptions.required))) {
-      continue;
-    }
-
-    // gh-11380: optimization. If the array isn't a document array and there's no validators
-    // on the array type, there's no need to run validation on the individual array elements.
-    if (_pathType.$isMongooseArray &&
-        !_pathType.$isMongooseDocumentArray && // Skip document arrays...
-        !_pathType.$embeddedSchemaType.$isMongooseArray && // and arrays of arrays
-        _pathType.$embeddedSchemaType.validators.length === 0) {
-      continue;
-    }
-
-    const val = doc.$__getValue(path);
-    _pushNestedArrayPaths(val, paths, path);
-  }
-
-  function _pushNestedArrayPaths(val, paths, path) {
-    if (val != null) {
-      const numElements = val.length;
-      for (let j = 0; j < numElements; ++j) {
-        if (Array.isArray(val[j])) {
-          _pushNestedArrayPaths(val[j], paths, path + '.' + j);
-        } else {
-          paths.add(path + '.' + j);
-        }
-      }
-    }
-  }
+  _addArrayPathsToValidate(doc, paths);
 
   const flattenOptions = { skipArrays: true };
   for (const pathToCheck of paths) {
@@ -2841,12 +2801,55 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
   return [paths, doValidateOptions];
 }
 
+function _addArrayPathsToValidate(doc, paths) {
+  for (const path of paths) {
+    const _pathType = doc.$__schema.path(path);
+    if (!_pathType) {
+      continue;
+    }
+
+    if (!_pathType.$isMongooseArray ||
+        // To avoid potential performance issues, skip doc arrays whose children
+        // are not required. `getPositionalPathType()` may be slow, so avoid
+        // it unless we have a case of #6364
+        (!Array.isArray(_pathType) &&
+          _pathType.$isMongooseDocumentArray &&
+          !(_pathType && _pathType.schemaOptions && _pathType.schemaOptions.required))) {
+      continue;
+    }
+
+    // gh-11380: optimization. If the array isn't a document array and there's no validators
+    // on the array type, there's no need to run validation on the individual array elements.
+    if (_pathType.$isMongooseArray &&
+        !_pathType.$isMongooseDocumentArray && // Skip document arrays...
+        !_pathType.$embeddedSchemaType.$isMongooseArray && // and arrays of arrays
+        _pathType.$embeddedSchemaType.validators.length === 0) {
+      continue;
+    }
+
+    const val = doc.$__getValue(path);
+    _pushNestedArrayPaths(val, paths, path);
+  }
+}
+
+function _pushNestedArrayPaths(val, paths, path) {
+  if (val != null) {
+    const numElements = val.length;
+    for (let j = 0; j < numElements; ++j) {
+      if (Array.isArray(val[j])) {
+        _pushNestedArrayPaths(val[j], paths, path + '.' + j);
+      } else {
+        paths.add(path + '.' + j);
+      }
+    }
+  }
+}
+
 /*!
  * ignore
  */
 
 Document.prototype.$__validate = function(pathsToValidate, options, callback) {
-
   if (this.$__.saveOptions && this.$__.saveOptions.pathsToSave && !pathsToValidate) {
     pathsToValidate = [...this.$__.saveOptions.pathsToSave];
   } else if (typeof pathsToValidate === 'function') {
@@ -2869,6 +2872,19 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
     shouldValidateModifiedOnly = !!options.validateModifiedOnly;
   } else {
     shouldValidateModifiedOnly = this.$__schema.options.validateModifiedOnly;
+  }
+
+  const validateAllPaths = options && options.validateAllPaths;
+  if (validateAllPaths) {
+    if (pathsToSkip) {
+      throw new TypeError('Cannot set both `validateAllPaths` and `pathsToSkip`');
+    }
+    if (pathsToValidate) {
+      throw new TypeError('Cannot set both `validateAllPaths` and `pathsToValidate`');
+    }
+    if (hasValidateModifiedOnlyOption && shouldValidateModifiedOnly) {
+      throw new TypeError('Cannot set both `validateAllPaths` and `validateModifiedOnly`');
+    }
   }
 
   const _this = this;
@@ -2908,11 +2924,33 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
   };
 
   // only validate required fields when necessary
-  const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
-  const paths = shouldValidateModifiedOnly ?
-    pathDetails[0].filter((path) => this.$isModified(path)) :
-    pathDetails[0];
-  const doValidateOptionsByPath = pathDetails[1];
+  let paths;
+  let doValidateOptionsByPath;
+  if (validateAllPaths) {
+    paths = new Set(Object.keys(this.$__schema.paths));
+    // gh-661: if a whole array is modified, make sure to run validation on all
+    // the children as well
+    for (const path of paths) {
+      const schemaType = this.$__schema.path(path);
+      if (!schemaType || !schemaType.$isMongooseArray) {
+        continue;
+      }
+      const val = this.$__getValue(path);
+      if (!val) {
+        continue;
+      }
+      _pushNestedArrayPaths(val, paths, path);
+    }
+    paths = [...paths];
+    doValidateOptionsByPath = {};
+  } else {
+    const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
+    paths = shouldValidateModifiedOnly ?
+      pathDetails[0].filter((path) => this.$isModified(path)) :
+      pathDetails[0];
+    doValidateOptionsByPath = pathDetails[1];
+  }
+
   if (typeof pathsToValidate === 'string') {
     pathsToValidate = pathsToValidate.split(' ');
   }
@@ -2993,7 +3031,8 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
       const doValidateOptions = {
         ...doValidateOptionsByPath[path],
         path: path,
-        validateModifiedOnly: shouldValidateModifiedOnly
+        validateModifiedOnly: shouldValidateModifiedOnly,
+        validateAllPaths
       };
 
       schemaType.doValidate(val, function(err) {
@@ -3111,6 +3150,16 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
 
   let pathsToSkip = options && options.pathsToSkip;
 
+  const validateAllPaths = options && options.validateAllPaths;
+  if (validateAllPaths) {
+    if (pathsToSkip) {
+      throw new TypeError('Cannot set both `validateAllPaths` and `pathsToSkip`');
+    }
+    if (pathsToValidate) {
+      throw new TypeError('Cannot set both `validateAllPaths` and `pathsToValidate`');
+    }
+  }
+
   if (typeof pathsToValidate === 'string') {
     const isOnePathOnly = pathsToValidate.indexOf(' ') === -1;
     pathsToValidate = isOnePathOnly ? [pathsToValidate] : pathsToValidate.split(' ');
@@ -3119,11 +3168,32 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
   }
 
   // only validate required fields when necessary
-  const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
-  const paths = shouldValidateModifiedOnly ?
-    pathDetails[0].filter((path) => this.$isModified(path)) :
-    pathDetails[0];
-  const skipSchemaValidators = pathDetails[1];
+  let paths;
+  let skipSchemaValidators;
+  if (validateAllPaths) {
+    paths = new Set(Object.keys(this.$__schema.paths));
+    // gh-661: if a whole array is modified, make sure to run validation on all
+    // the children as well
+    for (const path of paths) {
+      const schemaType = this.$__schema.path(path);
+      if (!schemaType || !schemaType.$isMongooseArray) {
+        continue;
+      }
+      const val = this.$__getValue(path);
+      if (!val) {
+        continue;
+      }
+      _pushNestedArrayPaths(val, paths, path);
+    }
+    paths = [...paths];
+    skipSchemaValidators = {};
+  } else {
+    const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
+    paths = shouldValidateModifiedOnly ?
+      pathDetails[0].filter((path) => this.$isModified(path)) :
+      pathDetails[0];
+    skipSchemaValidators = pathDetails[1];
+  }
 
   const validating = {};
 
@@ -3148,7 +3218,8 @@ Document.prototype.validateSync = function(pathsToValidate, options) {
     const err = p.doValidateSync(val, _this, {
       skipSchemaValidators: skipSchemaValidators[path],
       path: path,
-      validateModifiedOnly: shouldValidateModifiedOnly
+      validateModifiedOnly: shouldValidateModifiedOnly,
+      validateAllPaths
     });
     if (err) {
       const isSubdoc = p.$isSingleNested ||

--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -279,7 +279,7 @@ SchemaDocumentArray.prototype.doValidate = function(array, fn, scope, options) {
         continue;
       }
 
-      doc.$__validate(callback);
+      doc.$__validate(null, options, callback);
     }
   }
 };
@@ -330,7 +330,7 @@ SchemaDocumentArray.prototype.doValidateSync = function(array, scope, options) {
       continue;
     }
 
-    const subdocValidateError = doc.validateSync();
+    const subdocValidateError = doc.validateSync(options);
 
     if (subdocValidateError && resultError == null) {
       resultError = subdocValidateError;


### PR DESCRIPTION


Fix #14414

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Setting `validateAllPaths` makes Mongoose run validation on all paths in the schema, regardless of change tracking. This is useful because sometimes change tracking makes Mongoose skip running validators that users expect to run, so handy to have a mechanism to run all validators if the end user prefers that approach.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
