### PR TITLE
fix(document): handle virtuals that are stored as objects but getter returns string with toJSON

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4113,7 +4113,12 @@ function applyGetters(self, json, options) {
     for (let ii = 0; ii < plen; ++ii) {
       part = parts[ii];
       v = cur[part];
-      if (ii === last) {
+      // If we've reached a non-object part of the branch, continuing would
+      // cause "Cannot create property 'foo' on string 'bar'" error.
+      // Necessary for mongoose-intl plugin re: gh-14446
+      if (branch != null && typeof branch !== 'object') {
+        break;
+      } else if (ii === last) {
         const val = self.$get(path);
         branch[part] = clone(val, options);
       } else if (v == null) {


### PR DESCRIPTION
Fix #14446

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14446 points out that we continue to loop through and try to create properties when getting nested paths underneath a virtual even if the virtual returned a non-object. Since this will always throw an error, we should just avoid that and assume this is just the virtual returning a non-object by design.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
