### PR TITLE
fix(schema): deduplicate idGetter so creating multiple models with same schema doesn't result in multiple id getters

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1916,6 +1916,7 @@ Schema.prototype.plugin = function(fn, opts) {
       'got "' + (typeof fn) + '"');
   }
 
+
   if (opts && opts.deduplicate) {
     for (const plugin of this.plugins) {
       if (plugin.fn === fn) {
@@ -2720,7 +2721,7 @@ function isArrayFilter(piece) {
  */
 
 Schema.prototype._preCompile = function _preCompile() {
-  idGetter(this);
+  this.plugin(idGetter, { deduplicate: true });
 };
 
 /*!

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3172,6 +3172,13 @@ describe('schema', function() {
     const res = await Test.findOne({ _id: { $eq: doc._id, $type: 'objectId' } });
     assert.equal(res.name, 'Test Testerson');
   });
+  it('deduplicates idGetter (gh-14457)', function() {
+    const schema = new Schema({ name: String });
+    schema._preCompile();
+    assert.equal(schema.virtual('id').getters.length, 1);
+    schema._preCompile();
+    assert.equal(schema.virtual('id').getters.length, 1);
+  });
 
   it('handles recursive definitions in discriminators (gh-13978)', function() {
     const base = new Schema({


### PR DESCRIPTION
Fix #14457
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Need to be careful to avoid adding multiple id getters when reusing the same schema multiple times

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
