### PR TITLE
fix(schema): support setting discriminator options in Schema.prototype.discriminator()

### DIFF
--- a/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
+++ b/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
@@ -20,9 +20,12 @@ function applyEmbeddedDiscriminators(schema, seen = new WeakSet()) {
       continue;
     }
     for (const discriminatorKey of schemaType.schema._applyDiscriminators.keys()) {
-      const discriminatorSchema = schemaType.schema._applyDiscriminators.get(discriminatorKey);
+      const {
+        schema: discriminatorSchema,
+        options
+      } = schemaType.schema._applyDiscriminators.get(discriminatorKey);
       applyEmbeddedDiscriminators(discriminatorSchema, seen);
-      schemaType.discriminator(discriminatorKey, discriminatorSchema);
+      schemaType.discriminator(discriminatorKey, discriminatorSchema, options);
     }
     schemaType._appliedDiscriminators = true;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -628,7 +628,11 @@ Mongoose.prototype._model = function(name, schema, collection, options) {
 
   if (schema._applyDiscriminators != null) {
     for (const disc of schema._applyDiscriminators.keys()) {
-      model.discriminator(disc, schema._applyDiscriminators.get(disc));
+      const {
+        schema: discriminatorSchema,
+        options
+      } = schema._applyDiscriminators.get(disc);
+      model.discriminator(disc, discriminatorSchema, options);
     }
   }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -624,12 +624,18 @@ Schema.prototype.defaultOptions = function(options) {
  *
  * @param {String} name the name of the discriminator
  * @param {Schema} schema the discriminated Schema
+ * @param {Object} [options] discriminator options
+ * @param {String} [options.value] the string stored in the `discriminatorKey` property. If not specified, Mongoose uses the `name` parameter.
+ * @param {Boolean} [options.clone=true] By default, `discriminator()` clones the given `schema`. Set to `false` to skip cloning.
+ * @param {Boolean} [options.overwriteModels=false] by default, Mongoose does not allow you to define a discriminator with the same name as another discriminator. Set this to allow overwriting discriminators with the same name.
+ * @param {Boolean} [options.mergeHooks=true] By default, Mongoose merges the base schema's hooks with the discriminator schema's hooks. Set this option to `false` to make Mongoose use the discriminator schema's hooks instead.
+ * @param {Boolean} [options.mergePlugins=true] By default, Mongoose merges the base schema's plugins with the discriminator schema's plugins. Set this option to `false` to make Mongoose use the discriminator schema's plugins instead.
  * @return {Schema} the Schema instance
  * @api public
  */
-Schema.prototype.discriminator = function(name, schema) {
+Schema.prototype.discriminator = function(name, schema, options) {
   this._applyDiscriminators = this._applyDiscriminators || new Map();
-  this._applyDiscriminators.set(name, schema);
+  this._applyDiscriminators.set(name, { schema, options });
 
   return this;
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -72,6 +72,7 @@ describe('schema', function() {
         },
         b: { $type: String }
       }, { typeKey: '$type' });
+      db.deleteModel(/Test/);
       NestedModel = db.model('Test', NestedSchema);
     });
 
@@ -3201,5 +3202,23 @@ describe('schema', function() {
     const baseModel = db.model('gh14055', base);
     const doc = new baseModel({ type: 1, self: [{ type: 1 }] });
     assert.equal(doc.self[0].type, 1);
+  });
+
+  it('handles discriminator options with Schema.prototype.discriminator (gh-14448)', async function() {
+    const eventSchema = new mongoose.Schema({
+      name: String
+    }, { discriminatorKey: 'kind' });
+    const clickedEventSchema = new mongoose.Schema({ element: String });
+    eventSchema.discriminator(
+      'Test2',
+      clickedEventSchema,
+      { value: 'click' }
+    );
+    const Event = db.model('Test', eventSchema);
+    const ClickedModel = db.model('Test2');
+
+    const doc = await Event.create({ kind: 'click', element: '#hero' });
+    assert.equal(doc.element, '#hero');
+    assert.ok(doc instanceof ClickedModel);
   });
 });


### PR DESCRIPTION
Fix #14448

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix to allow calling `Schema.prototype.discriminator()` with discriminator options, right now no way to set a custom discriminator value with `Schema.prototype.discriminator()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
