### PR TITLE
types(validation): support function for validator `message` property,  and add support for accessing validator `reason`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1407,3 +1407,20 @@ function gh14235() {
   userSchema.omit<Omit<IUser, 'age'>>(['age']);
 }
 
+function gh14496() {
+  const schema = new Schema({
+    name: {
+      type: String
+    }
+  });
+  schema.path('name').validate({
+    validator: () => {
+      throw new Error('Oops!');
+    },
+    // `errors['name']` will be "Oops!"
+    message: (props) => {
+      expectType<Error | undefined>(props.reason);
+      return 'test';
+    }
+  });
+}

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -193,9 +193,10 @@ declare module 'mongoose' {
   }
 
   interface Validator<DocType = any> {
-    message?: string;
+    message?: string | ((props: ValidatorProps) => string);
     type?: string;
     validator?: ValidatorFunction<DocType>;
+    reason?: Error;
   }
 
   type ValidatorFunction<DocType = any> = (this: DocType, value: any, validatorProperties?: Validator) => any;

--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -6,6 +6,7 @@ declare module 'mongoose' {
     path: string;
     fullPath: string;
     value: any;
+    reason?: Error;
   }
 
   interface ValidatorMessageFn {


### PR DESCRIPTION
Fix #14496

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The [SchemaType.prototyp.validate API docs](https://mongoosejs.com/docs/api/schematype.html#SchemaType.prototype.validate()) include an example of returning the original error message that the validator threw instead of Mongoose's automatic message formatting:

```javascript
schema.path('name').validate({
  validator: function() { throw new Error('Oops!'); },
  // `errors['name']` will be "Oops!"
  message: function(props) { return props.reason.message; }
});
```

The TypeScript types disallow this currently.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
