### PR TITLE
fix(model): make `Model.recompileSchema()` also re-apply discriminators

### DIFF
--- a/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
+++ b/lib/helpers/discriminator/applyEmbeddedDiscriminators.js
@@ -2,7 +2,7 @@
 
 module.exports = applyEmbeddedDiscriminators;
 
-function applyEmbeddedDiscriminators(schema, seen = new WeakSet()) {
+function applyEmbeddedDiscriminators(schema, seen = new WeakSet(), overwriteExisting = false) {
   if (seen.has(schema)) {
     return;
   }
@@ -16,13 +16,17 @@ function applyEmbeddedDiscriminators(schema, seen = new WeakSet()) {
     if (!schemaType.schema._applyDiscriminators) {
       continue;
     }
-    if (schemaType._appliedDiscriminators) {
+    if (schemaType._appliedDiscriminators && !overwriteExisting) {
       continue;
     }
     for (const discriminatorKey of schemaType.schema._applyDiscriminators.keys()) {
       const discriminatorSchema = schemaType.schema._applyDiscriminators.get(discriminatorKey);
       applyEmbeddedDiscriminators(discriminatorSchema, seen);
-      schemaType.discriminator(discriminatorKey, discriminatorSchema);
+      schemaType.discriminator(
+        discriminatorKey,
+        discriminatorSchema,
+        overwriteExisting ? { overwriteExisting: true } : null
+      );
     }
     schemaType._appliedDiscriminators = true;
   }

--- a/lib/helpers/model/discriminator.js
+++ b/lib/helpers/model/discriminator.js
@@ -21,7 +21,7 @@ const CUSTOMIZABLE_DISCRIMINATOR_OPTIONS = {
  * ignore
  */
 
-module.exports = function discriminator(model, name, schema, tiedValue, applyPlugins, mergeHooks) {
+module.exports = function discriminator(model, name, schema, tiedValue, applyPlugins, mergeHooks, overwriteExisting) {
   if (!(schema && schema.instanceOfSchema)) {
     throw new Error('You must pass a valid discriminator Schema');
   }
@@ -205,7 +205,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
 
   model.schema.discriminators[name] = schema;
 
-  if (model.discriminators[name] && !schema.options.overwriteModels) {
+  if (model.discriminators[name] && !schema.options.overwriteModels && !overwriteExisting) {
     throw new Error('Discriminator with name "' + name + '" already exists');
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -23,6 +23,7 @@ const VersionError = require('./error/version');
 const ParallelSaveError = require('./error/parallelSave');
 const applyDefaultsHelper = require('./helpers/document/applyDefaults');
 const applyDefaultsToPOJO = require('./helpers/model/applyDefaultsToPOJO');
+const applyEmbeddedDiscriminators = require('./helpers/discriminator/applyEmbeddedDiscriminators');
 const applyHooks = require('./helpers/model/applyHooks');
 const applyMethods = require('./helpers/model/applyMethods');
 const applyProjection = require('./helpers/projection/applyProjection');
@@ -5001,6 +5002,15 @@ Model.__subclass = function subclass(conn, schema, collection) {
 
 Model.recompileSchema = function recompileSchema() {
   this.prototype.$__setSchema(this.schema);
+
+  if (this.schema._applyDiscriminators != null) {
+    for (const disc of this.schema._applyDiscriminators.keys()) {
+      this.discriminator(disc, this.schema._applyDiscriminators.get(disc));
+    }
+  }
+
+  const overwriteExisting = true;
+  applyEmbeddedDiscriminators(this.schema, new WeakSet(), overwriteExisting);
 };
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -5009,8 +5009,7 @@ Model.recompileSchema = function recompileSchema() {
     }
   }
 
-  const overwriteExisting = true;
-  applyEmbeddedDiscriminators(this.schema, new WeakSet(), overwriteExisting);
+  applyEmbeddedDiscriminators(this.schema, new WeakSet(), true);
 };
 
 /**

--- a/lib/schema/subdocument.js
+++ b/lib/schema/subdocument.js
@@ -325,7 +325,7 @@ SchemaSubdocument.prototype.discriminator = function(name, schema, options) {
     schema = schema.clone();
   }
 
-  schema = discriminator(this.caster, name, schema, value);
+  schema = discriminator(this.caster, name, schema, value, null, null, options.overwriteExisting);
 
   this.caster.discriminators[name] = _createConstructor(schema, this.caster);
 

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -878,7 +878,7 @@ SchemaType.prototype.validateAll = function(validators) {
  *
  *     schema.path('name').validate({
  *       validator: function() { throw new Error('Oops!'); },
- *       // `errors['name']` will be "Oops!"
+ *       // `errors['name'].message` will be "Oops!"
  *       message: function(props) { return props.reason.message; }
  *     });
  *

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7432,7 +7432,7 @@ describe('Model', function() {
 
     // Define discriminated class before model is compiled
     class Deco1 extends Decorator { whoAmI() { return 'I am Test1'; }}
-    const deco1Schema = new Schema({}).loadClass(Deco1);
+    const deco1Schema = new Schema({});
     deco1Schema.loadClass(Deco1);
     decoratorSchema.discriminator('Test1', deco1Schema);
 
@@ -7440,20 +7440,23 @@ describe('Model', function() {
     const shopSchema = new Schema({
       item: { type: decoratorSchema, required: true }
     });
-
-    class Shop {}
-    shopSchema.loadClass(Shop);
     const shopModel = db.model('Test', shopSchema);
 
     // Define another discriminated class after the model is compiled
     class Deco2 extends Decorator { whoAmI() { return 'I am Test2'; }}
-    const deco2Schema = new Schema({}).loadClass(Deco2);
+    const deco2Schema = new Schema({});
     deco2Schema.loadClass(Deco2);
     decoratorSchema.discriminator('Test2', deco2Schema);
 
+    let instance = new shopModel({ item: { type: 'Test1' } });
+    assert.equal(instance.item.whoAmI(), 'I am Test1');
+
+    instance = new shopModel({ item: { type: 'Test2' } });
+    assert.equal(instance.item.whoAmI(), 'I am BaseDeco');
+
     shopModel.recompileSchema();
 
-    let instance = new shopModel({ item: { type: 'Test1' } });
+    instance = new shopModel({ item: { type: 'Test1' } });
     assert.equal(instance.item.whoAmI(), 'I am Test1');
 
     instance = new shopModel({ item: { type: 'Test2' } });


### PR DESCRIPTION
Fix #14444

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Right now `recompileSchema()` applies most schema changes, but not additional `Schema.prototype.discriminator()` or `SchemaType.prototype.discriminator()` calls. This PR makes `recompileSchema()` go through and reapply every discriminator that was added to the schema.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
