### PR TITLE
fix(document): make update minimization unset property rather than setting to null

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -375,7 +375,9 @@ Model.prototype.$__handleSave = function(options, callback) {
           }
           minimize(updateOp[key]);
           if (Object.keys(updateOp[key]).length === 0) {
-            updateOp[key] = null;
+            delete updateOp[key];
+            update.$unset = update.$unset || {};
+            update.$unset[key] = 1;
           }
         }
       }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13060,8 +13060,8 @@ describe('document', function() {
     x.metadata = {};
     await x.save();
 
-    const { metadata } = await Model.findById(m._id).orFail();
-    assert.strictEqual(metadata, null);
+    const { metadata } = await Model.findById(m._id).lean().orFail();
+    assert.strictEqual(metadata, undefined);
   });
 
   it('saves when setting subdocument to empty object (gh-14420) (gh-13782)', async function() {
@@ -13085,7 +13085,7 @@ describe('document', function() {
     await doc.save();
 
     const savedDoc = await MainModel.findById(doc.id).orFail();
-    assert.strictEqual(savedDoc.sub, null);
+    assert.strictEqual(savedDoc.sub, undefined);
   });
 
   it('validate supports validateAllPaths', async function() {
@@ -13204,6 +13204,37 @@ describe('document', function() {
       err.errors['docArr.0.subprop'].message.includes('Validator failed for path `subprop` with value ``'),
       err.errors['docArr.0.subprop'].message
     );
+  });
+
+  it('minimize unsets property rather than setting to null (gh-14445)', async function() {
+    const SubSchema = new mongoose.Schema({
+      name: { type: String }
+    }, { _id: false });
+
+    const MainSchema = new mongoose.Schema({
+      name: String,
+      sub: {
+        type: SubSchema,
+        default: {}
+      }
+    });
+
+    const Test = db.model('Test', MainSchema);
+    const doc = new Test({ name: 'foo' });
+    await doc.save();
+
+    const savedDocFirst = await Test.findById(doc.id).orFail();
+    assert.deepStrictEqual(savedDocFirst.toObject({ minimize: false }).sub, {});
+
+    savedDocFirst.name = 'bar';
+    await savedDocFirst.save();
+
+    const lean = await Test.findById(doc.id).lean().orFail();
+    assert.strictEqual(lean.sub, undefined);
+
+    const savedDocSecond = await Test.findById(doc.id).orFail();
+    assert.deepStrictEqual(savedDocSecond.toObject({ minimize: false }).sub, {});
+
   });
 });
 


### PR DESCRIPTION
Fix #14445

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now the Mongoose 8 functionality that minimizes empty documents when updating sets empty subdocuments to `null`, which is problematic because defaults don't kick in on null values. With this PR, we'll instead $unset empty subdocuments.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
