### PR TITLE
fix(mongoose): make setDriver() update mongoose.model() connections and collections

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4893,8 +4893,14 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   return model;
 };
 
-/*!
- * ignore
+/**
+ * Update this model to use the new connection, including updating all internal
+ * references and creating a new `COllection` instance using the new connection.
+ * Not for external use, only used by `setDriver()` to ensure that you can still
+ * call `setDriver()` after creating a model using `mongoose.model()`.
+ *
+ * @param {Connection} newConnection the new connection to use
+ * @api private
  */
 
 Model.$__updateConnection = function $__updateConnection(newConnection) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4893,6 +4893,28 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   return model;
 };
 
+/*!
+ * ignore
+ */
+
+Model.$__updateConnection = function $__updateConnection(newConnection) {
+  this.db = newConnection;
+  this.prototype.db = newConnection;
+  this.prototype[modelDbSymbol] = newConnection;
+
+  const collection = newConnection.collection(
+    this.collection.collectionName,
+    this.collection.opts
+  );
+
+  this.prototype.collection = collection;
+  this.prototype.$collection = collection;
+  this.prototype[modelCollectionSymbol] = collection;
+
+  this.collection = collection;
+  this.$__collection = collection;
+};
+
 /**
  * Register custom query methods for this model
  *

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -166,8 +166,18 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
   _mongoose.__driver = driver;
 
   const Connection = driver.Connection;
+  const oldDefaultConnection = _mongoose.connections[0];
   _mongoose.connections = [new Connection(_mongoose)];
   _mongoose.connections[0].models = _mongoose.models;
+
+  // Update all models that pointed to the old default connection to
+  // the new default connection, including collections
+  for (const model of Object.values(_mongoose.models)) {
+    if (model.connection !== oldDefaultConnection) {
+      continue;
+    }
+    model.$__updateConnection(_mongoose.connections[0]);
+  }
 
   return _mongoose;
 };

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -173,7 +173,7 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
   // Update all models that pointed to the old default connection to
   // the new default connection, including collections
   for (const model of Object.values(_mongoose.models)) {
-    if (model.connection !== oldDefaultConnection) {
+    if (model.db !== oldDefaultConnection) {
       continue;
     }
     model.$__updateConnection(_mongoose.connections[0]);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Right now calling `setDriver()` after `mongoose.model()` leaves models in an inconsistent state where they point to the old default connection and collections derived from the old default connection.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
