### PR TITLE
types(models): fix incorrect bulk write options

### DIFF
--- a/test/types/middleware.test.ts
+++ b/test/types/middleware.test.ts
@@ -1,6 +1,6 @@
-import { Schema, model, Model, Document, SaveOptions, Query, Aggregate, HydratedDocument, PreSaveMiddlewareFunction, ModifyResult } from 'mongoose';
+import { Schema, model, Model, Document, SaveOptions, Query, Aggregate, HydratedDocument, PreSaveMiddlewareFunction, ModifyResult, AnyBulkWriteOperation } from 'mongoose';
 import { expectError, expectType, expectNotType, expectAssignable } from 'tsd';
-import { AnyBulkWriteOperation, CreateCollectionOptions } from 'mongodb';
+import { CreateCollectionOptions } from 'mongodb';
 
 const preMiddlewareFn: PreSaveMiddlewareFunction<Document> = function(next, opts) {
   this.$markValid('name');

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -824,7 +824,7 @@ async function gh14072() {
   );
 
   const M = mongoose.model<Test>('Test', schema);
-  const bulkWriteArray = [
+  await M.bulkWrite([
     {
       insertOne: {
         document: { num: 3 }
@@ -844,9 +844,7 @@ async function gh14072() {
         timestamps: false
       }
     }
-  ];
-
-  await M.bulkWrite(bulkWriteArray);
+  ]);
 }
 
 async function gh14003() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -431,7 +431,7 @@ declare module 'mongoose' {
       fn: (
         this: T,
         next: (err?: CallbackError) => void,
-        ops: Array<mongodb.AnyBulkWriteOperation<any> & MongooseBulkWritePerWriteOptions>,
+        ops: Array<AnyBulkWriteOperation<any>>,
         options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions
       ) => void | Promise<void>
     ): this;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -23,13 +23,21 @@ declare module 'mongoose' {
     ): U;
   }
 
-  interface MongooseBulkWriteOptions {
+  interface MongooseBulkWriteOptions extends mongodb.BulkWriteOptions {
+    session?: ClientSession;
     skipValidation?: boolean;
     throwOnValidationError?: boolean;
-    timestamps?: boolean;
     strict?: boolean | 'throw';
   }
 
+  interface MongooseBulkSaveOptions extends mongodb.BulkWriteOptions {
+    timestamps?: boolean;
+    session?: ClientSession;
+  }
+
+  /**
+   * @deprecated use AnyBulkWriteOperation instead
+   */
   interface MongooseBulkWritePerWriteOptions {
     timestamps?: boolean;
     strict?: boolean | 'throw';
@@ -200,6 +208,8 @@ declare module 'mongoose' {
     hint?: mongodb.Hint;
     /** When true, creates a new document if no document matches the query. */
     upsert?: boolean;
+    /** When false, do not add timestamps. */
+    timestamps?: boolean;
   }
 
   export interface UpdateManyModel<TSchema = AnyObject> {
@@ -215,6 +225,8 @@ declare module 'mongoose' {
     hint?: mongodb.Hint;
     /** When true, creates a new document if no document matches the query. */
     upsert?: boolean;
+    /** When false, do not add timestamps. */
+    timestamps?: boolean;
   }
 
   export interface DeleteOneModel<TSchema = AnyObject> {
@@ -281,11 +293,11 @@ declare module 'mongoose' {
      */
     bulkWrite<DocContents = TRawDocType>(
       writes: Array<AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
-      options: mongodb.BulkWriteOptions & MongooseBulkWriteOptions & { ordered: false }
+      options: MongooseBulkWriteOptions & { ordered: false }
     ): Promise<mongodb.BulkWriteResult & { mongoose?: { validationErrors: Error[] } }>;
     bulkWrite<DocContents = TRawDocType>(
       writes: Array<AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
-      options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions
+      options?: MongooseBulkWriteOptions
     ): Promise<mongodb.BulkWriteResult>;
 
     /**
@@ -293,7 +305,7 @@ declare module 'mongoose' {
      * sending multiple `save()` calls because with `bulkSave()` there is only one
      * network round trip to the MongoDB server.
      */
-    bulkSave(documents: Array<Document>, options?: mongodb.BulkWriteOptions & { timestamps?: boolean }): Promise<mongodb.BulkWriteResult>;
+    bulkSave(documents: Array<Document>, options?: MongooseBulkSaveOptions): Promise<mongodb.BulkWriteResult>;
 
     /** Collection the model uses. */
     collection: Collection;


### PR DESCRIPTION
**Summary**
The `bulkWrite` options are incorrectly typed. `timestamp` does not exists as an option on `updateOne`/`updateMany` (there was a test but it didn't work, I fixed this as well). And the type incorrectly showed a timestamp as options to `bulkWrite`, which doesn't work. 

Also extended the mongodb `BulkWriteOptions` making it easier to use the `MongooseBulkWriteOption` without the need to also always extend mongodb.

**Examples**

See fixed test