### PR TITLE
refactor(connection): move listDatabases implementation to node-mongodb-native driver

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -398,11 +398,7 @@ Connection.prototype.createCollection = async function createCollection(collecti
     throw new MongooseError('Connection.prototype.createCollection() no longer accepts a callback');
   }
 
-  if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
-    await new Promise(resolve => {
-      this._queue.push({ fn: resolve });
-    });
-  }
+  await this._waitForConnect();
 
   return this.db.createCollection(collection, options);
 };
@@ -494,11 +490,7 @@ Connection.prototype.startSession = async function startSession(options) {
     throw new MongooseError('Connection.prototype.startSession() no longer accepts a callback');
   }
 
-  if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
-    await new Promise(resolve => {
-      this._queue.push({ fn: resolve });
-    });
-  }
+  await this._waitForConnect();
 
   const session = this.client.startSession(options);
   return session;
@@ -618,13 +610,24 @@ Connection.prototype.dropCollection = async function dropCollection(collection) 
     throw new MongooseError('Connection.prototype.dropCollection() no longer accepts a callback');
   }
 
+  await this._waitForConnect();
+
+  return this.db.dropCollection(collection);
+};
+
+/**
+ * Waits for connection to be established, so the connection has a `client`
+ *
+ * @return Promise
+ * @api private
+ */
+
+Connection.prototype._waitForConnect = async function _waitForConnect() {
   if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
     await new Promise(resolve => {
       this._queue.push({ fn: resolve });
     });
   }
-
-  return this.db.dropCollection(collection);
 };
 
 /**
@@ -637,11 +640,7 @@ Connection.prototype.dropCollection = async function dropCollection(collection) 
  */
 
 Connection.prototype.listCollections = async function listCollections() {
-  if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
-    await new Promise(resolve => {
-      this._queue.push({ fn: resolve });
-    });
-  }
+  await this._waitForConnect();
 
   const cursor = this.db.listCollections();
   return await cursor.toArray();
@@ -662,13 +661,8 @@ Connection.prototype.listCollections = async function listCollections() {
  */
 
 Connection.prototype.listDatabases = async function listDatabases() {
-  if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
-    await new Promise(resolve => {
-      this._queue.push({ fn: resolve });
-    });
-  }
-
-  return await this.db.admin().listDatabases();
+  // Implemented in `lib/drivers/node-mongodb-native/connection.js`
+  throw new MongooseError('listDatabases() not implemented by driver');
 };
 
 /**
@@ -691,11 +685,7 @@ Connection.prototype.dropDatabase = async function dropDatabase() {
     throw new MongooseError('Connection.prototype.dropDatabase() no longer accepts a callback');
   }
 
-  if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
-    await new Promise(resolve => {
-      this._queue.push({ fn: resolve });
-    });
-  }
+  await this._waitForConnect();
 
   // If `dropDatabase()` is called, this model's collection will not be
   // init-ed. It is sufficiently common to call `dropDatabase()` after

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -197,6 +197,19 @@ NativeConnection.prototype.doClose = async function doClose(force) {
   return this;
 };
 
+/**
+ * Implementation of `listDatabases()` for MongoDB driver
+ *
+ * @return Promise
+ * @api public
+ */
+
+NativeConnection.prototype.listDatabases = async function listDatabases() {
+  await this._waitForConnect();
+
+  return await this.db.admin().listDatabases();
+};
+
 /*!
  * ignore
  */

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1588,7 +1588,6 @@ describe('connections:', function() {
 
     const { databases } = await connection.listDatabases();
     assert.ok(connection.name);
-    console.log(databases);
     assert.ok(databases.map(database => database.name).includes(connection.name));
   });
   describe('createCollections()', function() {


### PR DESCRIPTION
Re: #14506
Re: #9048

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

As a general rule we should move any connection helper that isn't just transparently calling `this.db.functionName()` to node-mongodb-native driver. `listDatabases()` is close, but the extra `admin()` call makes it violate this rule.

Also refactored out the `this.readyState === STATES.connecting` check into a helper so we aren't copy/pasting that in every helper.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
