### PR TITLE
fix(populate): avoid match function filtering out `null` values in populate result

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -101,8 +101,8 @@ module.exports = function assignVals(o) {
       valueToSet = numDocs(rawIds[i]);
     } else if (Array.isArray(o.match)) {
       valueToSet = Array.isArray(rawIds[i]) ?
-        rawIds[i].filter(sift(o.match[i])) :
-        [rawIds[i]].filter(sift(o.match[i]))[0];
+        rawIds[i].filter(v => v == null || sift(o.match[i])(v)) :
+        [rawIds[i]].filter(v => v == null || sift(o.match[i])(v))[0];
     } else {
       valueToSet = rawIds[i];
     }

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -10968,4 +10968,57 @@ describe('model: populate:', function() {
     assert.equal(res.children[0].subdoc.name, 'A');
     assert.equal(res.children[1].subdoc.name, 'B');
   });
+
+  it('avoids filtering out `null` values when applying match function (gh-14494)', async function() {
+    const gradeSchema = new mongoose.Schema({
+      studentId: mongoose.Types.ObjectId,
+      classId: mongoose.Types.ObjectId,
+      grade: String
+    });
+
+    const Grade = db.model('Test', gradeSchema);
+
+    const studentSchema = new mongoose.Schema({
+      name: String
+    });
+
+    studentSchema.virtual('grade', {
+      ref: Grade,
+      localField: '_id',
+      foreignField: 'studentId',
+      match: (doc) => ({
+        classId: doc._id
+      }),
+      justOne: true
+    });
+
+    const classSchema = new mongoose.Schema({
+      name: String,
+      students: [studentSchema]
+    });
+
+    const Class = db.model('Test2', classSchema);
+
+    const newClass = await Class.create({
+      name: 'History',
+      students: [{ name: 'Henry' }, { name: 'Robert' }]
+    });
+
+    const studentRobert = newClass.students.find(
+      ({ name }) => name === 'Robert'
+    );
+
+    await Grade.create({
+      studentId: studentRobert._id,
+      classId: newClass._id,
+      grade: 'B'
+    });
+
+    const latestClass = await Class.findOne({ name: 'History' }).populate('students.grade');
+
+    assert.equal(latestClass.students[0].name, 'Henry');
+    assert.equal(latestClass.students[0].grade, null);
+    assert.equal(latestClass.students[1].name, 'Robert');
+    assert.equal(latestClass.students[1].grade.grade, 'B');
+  });
 });


### PR DESCRIPTION
Fix #14494

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If there's a `match` function, `sift` will always filter out `null` results, so we may populate docs in incorrect order.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
