### PR TITLE
types(query+populate): apply populate overrides to doc `toObject()` result

### DIFF
--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -373,3 +373,49 @@ async function gh13070() {
   const doc2 = await Child.populate<{ child: IChild }>(doc, 'child');
   const name: string = doc2.child.name;
 }
+
+function gh14441() {
+  interface Parent {
+    child?: Types.ObjectId;
+    name?: string;
+  }
+  const ParentModel = model<Parent>(
+    'Parent',
+    new Schema({
+      child: { type: Schema.Types.ObjectId, ref: 'Child' },
+      name: String
+    })
+  );
+
+  interface Child {
+    name: string;
+  }
+  const childSchema: Schema = new Schema({ name: String });
+  model<Child>('Child', childSchema);
+
+  ParentModel.findOne({})
+    .populate<{ child: Child }>('child')
+    .orFail()
+    .then(doc => {
+      expectType<string>(doc.child.name);
+      const docObject = doc.toObject();
+      expectType<string>(docObject.child.name);
+    });
+
+  ParentModel.findOne({})
+    .populate<{ child: Child }>('child')
+    .lean()
+    .orFail()
+    .then(doc => {
+      expectType<string>(doc.child.name);
+    });
+
+  ParentModel.find({})
+    .populate<{ child: Child }>('child')
+    .orFail()
+    .then(docs => {
+      expectType<string>(docs[0]!.child.name);
+      const docObject = docs[0]!.toObject();
+      expectType<string>(docObject.child.name);
+    });
+}

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -612,3 +612,27 @@ function gh14473() {
     const query2: FilterQuery<D> = { deletedAt: { $lt: new Date() } };
   };
 }
+
+async function gh14525() {
+  type BeAnObject = Record<string, any>;
+
+  interface SomeDoc {
+    something: string;
+    func(this: TestDoc): string;
+  }
+
+  interface PluginExtras {
+    pfunc(): number;
+  }
+
+  type TestDoc = Document<unknown, BeAnObject, SomeDoc> & PluginExtras;
+
+  type ModelType = Model<SomeDoc, BeAnObject, PluginExtras, BeAnObject>;
+
+  const doc = await ({} as ModelType).findOne({}).populate('test').orFail().exec();
+
+  doc.func();
+
+  let doc2 = await ({} as ModelType).create({});
+  doc2 = await ({} as ModelType).findOne({}).populate('test').orFail().exec();
+}

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -205,6 +205,18 @@ declare module 'mongoose' {
     ? (ResultType extends any[] ? Require_id<FlattenMaps<RawDocType>>[] : Require_id<FlattenMaps<RawDocType>>)
     : ResultType;
 
+  type MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, TQueryHelpers> = QueryOp extends QueryOpThatReturnsDocument
+    ? ResultType extends null
+      ? ResultType
+      : ResultType extends (infer U)[]
+        ? U extends Document
+          ? HydratedDocument<MergeType<RawDocType, Paths>, Record<string, never>, TQueryHelpers>[]
+          : (MergeType<U, Paths>)[]
+        : ResultType extends Document
+          ? HydratedDocument<MergeType<RawDocType, Paths>, Record<string, never>, TQueryHelpers>
+          : MergeType<ResultType, Paths>
+    : MergeType<ResultType, Paths>;
+
   class Query<ResultType, DocType, THelpers = {}, RawDocType = DocType, QueryOp = 'find'> implements SessionOperation {
     _mongooseOptions: MongooseQueryOptions<DocType>;
 
@@ -608,7 +620,7 @@ declare module 'mongoose' {
       model?: string | Model<any, THelpers>,
       match?: any
     ): QueryWithHelpers<
-      UnpackedIntersection<ResultType, Paths>,
+      MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, THelpers>,
       DocType,
       THelpers,
       UnpackedIntersection<RawDocType, Paths>,
@@ -617,7 +629,7 @@ declare module 'mongoose' {
     populate<Paths = {}>(
       options: PopulateOptions | (PopulateOptions | string)[]
     ): QueryWithHelpers<
-      UnpackedIntersection<ResultType, Paths>,
+      MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, THelpers>,
       DocType,
       THelpers,
       UnpackedIntersection<RawDocType, Paths>,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -614,7 +614,28 @@ declare module 'mongoose' {
     polygon(...coordinatePairs: number[][]): this;
 
     /** Specifies paths which should be populated with other documents. */
-    populate<Paths = {}>(
+    populate(
+      path: string | string[],
+      select?: string | any,
+      model?: string | Model<any, THelpers>,
+      match?: any
+    ): QueryWithHelpers<
+      ResultType,
+      DocType,
+      THelpers,
+      RawDocType,
+      QueryOp
+    >;
+    populate(
+      options: PopulateOptions | (PopulateOptions | string)[]
+    ): QueryWithHelpers<
+      ResultType,
+      DocType,
+      THelpers,
+      RawDocType,
+      QueryOp
+    >;
+    populate<Paths>(
       path: string | string[],
       select?: string | any,
       model?: string | Model<any, THelpers>,
@@ -626,7 +647,7 @@ declare module 'mongoose' {
       UnpackedIntersection<RawDocType, Paths>,
       QueryOp
     >;
-    populate<Paths = {}>(
+    populate<Paths>(
       options: PopulateOptions | (PopulateOptions | string)[]
     ): QueryWithHelpers<
       MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, THelpers>,


### PR DESCRIPTION
Fix #14441

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When you pass a generic to `populate()`, like `populate<{ child: Child }>('child')`, to override the result type, calling `toObject()` loses the `{ child: Child }` type override by default.

Future work: if passing `depopulate: true` to `toObject()`, that removes the populated paths.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
