### PR TITLE
Make `hydrate()` recursively hydrate virtual populate docs if `hydratedPopulatedDocs` is set

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -410,26 +410,12 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
       justOne = options.justOne;
     }
 
+    modelNames = virtual._getModelNamesForPopulate(doc);
     if (virtual.options.refPath) {
-      modelNames =
-        modelNamesFromRefPath(virtual.options.refPath, doc, options.path);
       justOne = !!virtual.options.justOne;
       data.isRefPath = true;
     } else if (virtual.options.ref) {
-      let normalizedRef;
-      if (typeof virtual.options.ref === 'function' && !virtual.options.ref[modelSymbol]) {
-        normalizedRef = virtual.options.ref.call(doc, doc);
-      } else {
-        normalizedRef = virtual.options.ref;
-      }
       justOne = !!virtual.options.justOne;
-      // When referencing nested arrays, the ref should be an Array
-      // of modelNames.
-      if (Array.isArray(normalizedRef)) {
-        modelNames = normalizedRef;
-      } else {
-        modelNames = [normalizedRef];
-      }
     }
 
     data.isVirtual = true;

--- a/lib/model.js
+++ b/lib/model.js
@@ -3959,7 +3959,8 @@ Model.hydrate = function(obj, projection, options) {
     obj = applyProjection(obj, projection);
   }
   const document = require('./queryHelpers').createModel(this, obj, projection);
-  document.$init(obj, options);
+  options = options || {};
+  document.$init(obj, { ...options, hydrate: true });
   return document;
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3959,8 +3959,7 @@ Model.hydrate = function(obj, projection, options) {
     obj = applyProjection(obj, projection);
   }
   const document = require('./queryHelpers').createModel(this, obj, projection);
-  options = options || {};
-  document.$init(obj, { ...options, hydrate: true });
+  document.$init(obj, options);
   return document;
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2317,7 +2317,7 @@ Schema.prototype.virtual = function(name, options) {
             _v == null ? [] : [_v];
         }
 
-        if (opts?.hydrate && !options.count) {
+        if (opts?.hydratedPopulatedDocs && !options.count) {
           const modelNames = virtual._getModelNamesForPopulate(this);
           const populatedVal = this.$$populatedVirtuals[name];
           if (!Array.isArray(populatedVal) && !populatedVal.$__ && modelNames?.length === 1) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2297,7 +2297,10 @@ Schema.prototype.virtual = function(name, options) {
       throw new Error('Reference virtuals require `foreignField` option');
     }
 
-    this.pre('init', function virtualPreInit(obj) {
+    const virtual = this.virtual(name);
+    virtual.options = options;
+
+    this.pre('init', function virtualPreInit(obj, opts) {
       if (mpath.has(name, obj)) {
         const _v = mpath.get(name, obj);
         if (!this.$$populatedVirtuals) {
@@ -2314,12 +2317,25 @@ Schema.prototype.virtual = function(name, options) {
             _v == null ? [] : [_v];
         }
 
+        if (opts?.hydrate && !options.count) {
+          const modelNames = virtual._getModelNamesForPopulate(this);
+          const populatedVal = this.$$populatedVirtuals[name];
+          if (!Array.isArray(populatedVal) && !populatedVal.$__ && modelNames?.length === 1) {
+            const PopulateModel = this.db.model(modelNames[0]);
+            this.$$populatedVirtuals[name] = PopulateModel.hydrate(populatedVal);
+          } else if (Array.isArray(populatedVal) && modelNames?.length === 1) {
+            const PopulateModel = this.db.model(modelNames[0]);
+            for (let i = 0; i < populatedVal.length; ++i) {
+              if (!populatedVal[i].$__) {
+                populatedVal[i] = PopulateModel.hydrate(populatedVal[i]);
+              }
+            }
+          }
+        }
+
         mpath.unset(name, obj);
       }
     });
-
-    const virtual = this.virtual(name);
-    virtual.options = options;
 
     virtual.
       set(function(v) {

--- a/lib/virtualType.js
+++ b/lib/virtualType.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const modelNamesFromRefPath = require('./helpers/populate/modelNamesFromRefPath');
 const utils = require('./utils');
+
+const modelSymbol = require('./helpers/symbols').modelSymbol;
 
 /**
  * VirtualType constructor
@@ -166,6 +169,32 @@ VirtualType.prototype.applySetters = function(value, doc) {
     v = setter.call(doc, v, this, doc);
   }
   return v;
+};
+
+/**
+ * Get the names of models used to populate this model given a doc
+ *
+ * @param {Document} doc
+ * @return {Array<string> | null}
+ * @api private
+ */
+
+VirtualType.prototype._getModelNamesForPopulate = function _getModelNamesForPopulate(doc) {
+  if (this.options.refPath) {
+    return modelNamesFromRefPath(this.options.refPath, doc, this.path);
+  }
+
+  let normalizedRef = null;
+  if (typeof this.options.ref === 'function' && !this.options.ref[modelSymbol]) {
+    normalizedRef = this.options.ref.call(doc, doc);
+  } else {
+    normalizedRef = this.options.ref;
+  }
+  if (normalizedRef != null && !Array.isArray(normalizedRef)) {
+    return [normalizedRef];
+  }
+
+  return normalizedRef;
 };
 
 /*!

--- a/test/model.hydrate.test.js
+++ b/test/model.hydrate.test.js
@@ -117,5 +117,59 @@ describe('model', function() {
       const C = Company.hydrate(company, null, { hydratedPopulatedDocs: true });
       assert.equal(C.users[0].name, 'Val');
     });
+    it('should hydrate documents in virtual populate (gh-14503)', async function() {
+      const StorySchema = new Schema({
+        userId: {
+          type: Schema.Types.ObjectId,
+          ref: 'User'
+        },
+        title: {
+          type: String
+        }
+      }, { timestamps: true });
+
+      const UserSchema = new Schema({
+        name: String
+      }, { timestamps: true });
+
+      UserSchema.virtual('stories', {
+        ref: 'Story',
+        localField: '_id',
+        foreignField: 'userId'
+      });
+      UserSchema.virtual('storiesCount', {
+        ref: 'Story',
+        localField: '_id',
+        foreignField: 'userId',
+        count: true
+      });
+
+      const User = db.model('User', UserSchema);
+      const Story = db.model('Story', StorySchema);
+
+      const user = await User.create({ name: 'Alex' });
+      const story1 = await Story.create({ title: 'Ticket 1', userId: user._id });
+      const story2 = await Story.create({ title: 'Ticket 2', userId: user._id });
+
+      const populated = await User.findOne({ name: 'Alex' }).populate(['stories', 'storiesCount']).lean();
+      const hydrated = User.hydrate(
+        JSON.parse(JSON.stringify(populated))
+      );
+
+      assert.equal(hydrated.stories[0]._id.toString(), story1._id.toString());
+      assert(typeof hydrated.stories[0]._id == 'object', typeof hydrated.stories[0]._id);
+      assert(hydrated.stories[0]._id instanceof mongoose.Types.ObjectId);
+      assert(typeof hydrated.stories[0].createdAt == 'object');
+      assert(hydrated.stories[0].createdAt instanceof Date);
+
+      assert.equal(hydrated.stories[1]._id.toString(), story2._id.toString());
+      assert(typeof hydrated.stories[1]._id == 'object');
+
+      assert(hydrated.stories[1]._id instanceof mongoose.Types.ObjectId);
+      assert(typeof hydrated.stories[1].createdAt == 'object');
+      assert(hydrated.stories[1].createdAt instanceof Date);
+
+      assert.strictEqual(hydrated.storiesCount, 2);
+    });
   });
 });

--- a/test/model.hydrate.test.js
+++ b/test/model.hydrate.test.js
@@ -153,7 +153,9 @@ describe('model', function() {
 
       const populated = await User.findOne({ name: 'Alex' }).populate(['stories', 'storiesCount']).lean();
       const hydrated = User.hydrate(
-        JSON.parse(JSON.stringify(populated))
+        JSON.parse(JSON.stringify(populated)),
+        null,
+        { hydratedPopulatedDocs: true }
       );
 
       assert.equal(hydrated.stories[0]._id.toString(), story1._id.toString());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In #14503, the issue is that `hydrate()` sets the populated docs in the populated virtual, but doesn't hydrate them. The docs are still lean. This PR makes `hydrate()` hydrate those populated docs if `hydratedPopulatedDocs` is set.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
