### PR TITLE
types(schema): correctly infer Array<Schema.Types.*>

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1424,3 +1424,21 @@ function gh14496() {
     }
   });
 }
+
+function gh14367() {
+  const UserSchema = new Schema({
+    counts: [Schema.Types.Number],
+    roles: [Schema.Types.String],
+    dates: [Schema.Types.Date],
+    flags: [Schema.Types.Boolean]
+  });
+
+  type IUser = InferSchemaType<typeof UserSchema>;
+
+  const x: IUser = {
+    counts: [12],
+    roles: ['test'],
+    dates: [new Date('2016-06-01')],
+    flags: [true]
+  };
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -198,15 +198,27 @@ type IsSchemaTypeFromBuiltinClass<T> = T extends (typeof String)
             ? true
             : T extends (typeof Schema.Types.Decimal128)
               ? true
-              : T extends Types.ObjectId
+              : T extends (typeof Schema.Types.String)
                 ? true
-                : T extends Types.Decimal128
+                : T extends (typeof Schema.Types.Number)
                   ? true
-                  : T extends Buffer
+                  : T extends (typeof Schema.Types.Date)
                     ? true
-                    : T extends (typeof Schema.Types.Mixed)
+                    : T extends (typeof Schema.Types.Boolean)
                       ? true
-                      : IfEquals<T, Schema.Types.ObjectId, true, false>;
+                      : T extends (typeof Schema.Types.Buffer)
+                        ? true
+                        : T extends Types.ObjectId
+                          ? true
+                          : T extends Types.Decimal128
+                            ? true
+                            : T extends Buffer
+                              ? true
+                              : T extends NativeDate
+                                ? true
+                                : T extends (typeof Schema.Types.Mixed)
+                                  ? true
+                                  : IfEquals<T, Schema.Types.ObjectId, true, false>;
 
 /**
  * @summary Resolve path type by returning the corresponding type.


### PR DESCRIPTION
Re: #14367

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Part of the issue in [this comment](https://github.com/Automattic/mongoose/issues/14367#issuecomment-2002045122) is that we don't infer correct type in TypeScript when user uses `path: [Schema.Types.String]` to define an array of strings.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
