### PR TITLE
types(document): make document _id type default to unknown instead of any

### DIFF
--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -195,7 +195,7 @@ SchemaDocumentArray.prototype.discriminator = function(name, schema, options) {
     schema = schema.clone();
   }
 
-  schema = discriminator(this.casterConstructor, name, schema, tiedValue);
+  schema = discriminator(this.casterConstructor, name, schema, tiedValue, null, null, options?.overwriteExisting);
 
   const EmbeddedDocument = _createConstructor(schema, null, this.casterConstructor);
   EmbeddedDocument.baseCasterConstructor = this.casterConstructor;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7463,6 +7463,23 @@ describe('Model', function() {
     assert.equal(instance.item.whoAmI(), 'I am Test2');
   });
 
+  it('overwrites existing discriminators when calling recompileSchema (gh-14527) (gh-14444)', async function() {
+    const shopItemSchema = new mongoose.Schema({}, { discriminatorKey: 'type' });
+    const shopSchema = new mongoose.Schema({
+      items: { type: [shopItemSchema], required: true }
+    });
+
+    const shopItemSubType = new mongoose.Schema({ prop: Number });
+    shopItemSchema.discriminator(2, shopItemSubType);
+    const shopModel = db.model('shop', shopSchema);
+
+    shopModel.recompileSchema();
+    const doc = new shopModel({
+      items: [{ type: 2, prop: 42 }]
+    });
+    assert.equal(doc.items[0].prop, 42);
+  });
+
   it('inserts versionKey even if schema has `toObject.versionKey` set to false (gh-14344)', async function() {
     const schema = new mongoose.Schema(
       { name: String },

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -16,7 +16,7 @@ declare module 'mongoose' {
    * *  TQueryHelpers - Object with any helpers that should be mixed into the Query type
    * *  DocType - the type of the actual Document created
    */
-  class Document<T = any, TQueryHelpers = any, DocType = any> {
+  class Document<T = unknown, TQueryHelpers = any, DocType = any> {
     constructor(doc?: any);
 
     /** This documents _id. */

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -83,7 +83,7 @@ declare module 'mongoose' {
     class ObjectId extends mongodb.ObjectId {
     }
 
-    class Subdocument<IdType = any, TQueryHelpers = any, DocType = any> extends Document<IdType, TQueryHelpers, DocType> {
+    class Subdocument<IdType = unknown, TQueryHelpers = any, DocType = any> extends Document<IdType, TQueryHelpers, DocType> {
       $isSingleNested: true;
 
       /** Returns the top level document of this sub-document. */


### PR DESCRIPTION
Fix #14520

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

 I don't see any reason why `IdType` can't default to `unknown`, tests pass and `unknown` seems more correct. @hasezoey can you please check if this causes any problems for typegoose?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
