### PR TITLE
perf(document): add fast path for applying non-nested virtuals to JSON

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4130,6 +4130,14 @@ function applyVirtuals(self, json, options, toObjectOptions) {
       }
       assignPath = path.substring(options.path.length + 1);
     }
+    if (assignPath.indexOf('.') === -1 && assignPath === path) {
+      v = clone(self.get(path, options ? { ...options, noDottedPath: true } : { noDottedPath: true }));
+      if (v === void 0) {
+        continue;
+      }
+      json[assignPath] = v;
+      continue;
+    }
     const parts = assignPath.split('.');
     v = clone(self.get(path), options);
     if (v === void 0) {


### PR DESCRIPTION
Re: #14394

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14394 points out that `toObject()` gets slow when there's a lot of virtuals. Part of that is we always take the "slow path" when applying virtuals by assuming the virtual is nested.

Consider the following script, 200 documents with 800 virtuals each. The below example uses replica set, but not strictly necessary for this example.

```javascript
'use strict';

const mongoose = require('mongoose');

void async function main() {
  await mongoose.connect('mongodb://127.0.0.1:27017,127.0.0.1:27018/mongoose_test');

  const ChildSchema = new mongoose.Schema({ name: String, parentId: 'ObjectId' });
  const ChildModel = mongoose.model('Child', ChildSchema);

  const ParentSchema = new mongoose.Schema({
    name: String
  });
  ParentSchema.virtual('child1', { ref: 'Child', localField: '_id', foreignField: 'parentId' });
  ParentSchema.virtual('child2', { ref: 'Child', localField: '_id', foreignField: 'parentId' });
  ParentSchema.virtual('child3', { ref: 'Child', localField: '_id', foreignField: 'parentId' });
  ParentSchema.virtual('child4', { ref: 'Child', localField: '_id', foreignField: 'parentId' });
  const ParentModel = mongoose.model('Parent', ParentSchema);
  /*await ParentModel.deleteMany({});
  await ChildModel.deleteMany({});

  const parents = [];
  for (let i = 0; i < 200; ++i) {
    const parent = await ParentModel.create({ name: 'test parent ' + i });
    const children = [];
    console.log(`${i} / 200`);
    for (let j = 0; j < 200; ++j) {
      children.push({ name: 'test child ' + i + '_' + j, parentId: parent._id });
    }
    await ChildModel.create(children);
    parents.push(parent);
  }

  await new Promise(resolve => setTimeout(resolve, 3000));*/

    const docs = await ParentModel.find().populate(['child1', 'child2', 'child3', 'child4']);
  console.log('Num docs', docs.length, docs[0]?.child1?.length);
  for (const doc of docs) {
    doc.name = 'test parent';
  }
  const start = Date.now();
  docs.forEach(doc => doc.toObject({ virtuals: true }));
  console.log('toObject ms:', Date.now() - start);

  console.log('Done');
  process.exit(0);
}();

```

Without this change:

```
$ node gh-14394.js 
Num docs 200 200
BulkSave and toObject ms: 2380
Done

```

With this change:

```
$ node gh-14394.js 
Num docs 200 200
BulkSave and toObject ms: 1215
Done

```

Nearly 2x faster. We can take a look and see if we can do better, but this PR seems like low hanging fruit.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
