### PR TITLE
Add `null` to `select` override return type for `findOne`

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -701,9 +701,10 @@ declare module 'mongoose' {
           ResultType extends HydratedDocument<any>[] ?
             HydratedDocument<RawDocTypeOverride>[] :
             RawDocTypeOverride[] :
-          ResultType extends HydratedDocument<any> ?
-            HydratedDocument<RawDocTypeOverride> :
-            RawDocTypeOverride
+              | (ResultType extends HydratedDocument<any>
+                ? HydratedDocument<RawDocTypeOverride>
+                : RawDocTypeOverride)
+              | (null extends ResultType ? null : never)
       >,
       DocType,
       THelpers,


### PR DESCRIPTION
**Summary**

Normally, a `findOne` or `findById` returns `DocType | null`. When using `Query.prototype.select`, we can provide a `RawDocTypeOverride` in order to define the true return type of the projected document. Currently, this makes `findOne` and `find` queries return `RawDocTypeOverride` directly, but in order to be consistent, it should return `RawDocTypeOverride | null`.

This is consistent with how you don't currently have to specify the array version for `find`; that method automatically returns the array version of `RawDocTypeOverride`. Therefore, `select` on `findOne` should return the nullable version of `RawDocTypeOverride` automatically.

**Examples**

```ts
import mongoose from "mongoose";

export const selectReturnType = async (): Promise<void> => {
  type Test = {
    _id: mongoose.Types.ObjectId;

    prop: string;
    another: string;

    createdAt: number;
    updatedAt: number;
  };

  const schema = new mongoose.Schema<Test>({
    prop: { type: String },
    another: {type: String },
    createdAt: { type: Number },
    updatedAt: { type: Number },
  });

  type TestDocument = mongoose.HydratedDocument<Test>;
  type TestModel = mongoose.Model<Test, {}, {}, {}, TestDocument>;

  type SlimTest = Pick<Test, "_id" | "prop">;
  type SlimTestDocument = mongoose.HydratedDocument<SlimTest>;

  const M = mongoose.model<Test, TestModel>("Test", schema);

  const myDocs = await M.find({}).exec();
  const myDoc = await M.findOne({}).exec();

  const myProjections = await M.find({}).select<SlimTest>({ prop: 1 }).exec();
  const myProjection = await M.findOne({}).select<SlimTest>({ prop: 1 }).exec();

  /*
  CURRENTLY:
    myDocs is of type TestDocument[]
    myDoc is of type TestDocument | null
    myProjections is of type SlimTestDocument[]
    myProjection is of type SlimTestDocument - THIS IS INCONSISTENT WITH THE NULLABLE RETURN TYPE OF myDoc (two lines above)

  WITH THIS CHANGE:
    [unchanged] myDocs is still of type TestDocument[]
    [unchanged] myDoc is still of type TestDocument | null
    [unchanged] myProjections is still of type SlimTestDocument[]
    [CHANGED] myProjection is now of type SlimTestDocument | null
  */
};
```