### PR TITLE
Improved timestamps option handling in bulkWrite

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -70,7 +70,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
         _addDiscriminatorToObject(schema, op['updateOne']['filter']);
 
         const doInitTimestamps = getTimestampsOpt(op['updateOne'], options);
-        
+
         if (model.schema.$timestamps != null && doInitTimestamps) {
           const createdAt = model.schema.$timestamps.createdAt;
           const updatedAt = model.schema.$timestamps.updatedAt;

--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -29,7 +29,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
       const model = decideModelByObject(originalModel, op['insertOne']['document']);
 
       const doc = new model(op['insertOne']['document']);
-      if (model.schema.options.timestamps && options.timestamps !== false) {
+      if (model.schema.options.timestamps && getTimestampsOpt(op['insertOne'], options)) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {
@@ -69,13 +69,15 @@ module.exports = function castBulkWrite(originalModel, op, options) {
 
         _addDiscriminatorToObject(schema, op['updateOne']['filter']);
 
-        if (model.schema.$timestamps != null && op['updateOne'].timestamps !== false) {
+        const doInitTimestamps = getTimestampsOpt(op['updateOne'], options);
+        
+        if (model.schema.$timestamps != null && doInitTimestamps) {
           const createdAt = model.schema.$timestamps.createdAt;
           const updatedAt = model.schema.$timestamps.updatedAt;
           applyTimestampsToUpdate(now, createdAt, updatedAt, update, {});
         }
 
-        if (op['updateOne'].timestamps !== false) {
+        if (doInitTimestamps) {
           applyTimestampsToChildren(now, update, model.schema);
         }
 
@@ -134,12 +136,14 @@ module.exports = function castBulkWrite(originalModel, op, options) {
           });
         }
 
-        if (model.schema.$timestamps != null && op['updateMany'].timestamps !== false) {
+        const doInitTimestamps = getTimestampsOpt(op['updateMany'], options);
+
+        if (model.schema.$timestamps != null && doInitTimestamps) {
           const createdAt = model.schema.$timestamps.createdAt;
           const updatedAt = model.schema.$timestamps.updatedAt;
           applyTimestampsToUpdate(now, createdAt, updatedAt, op['updateMany']['update'], {});
         }
-        if (op['updateMany'].timestamps !== false) {
+        if (doInitTimestamps) {
           applyTimestampsToChildren(now, op['updateMany']['update'], model.schema);
         }
 
@@ -184,7 +188,7 @@ module.exports = function castBulkWrite(originalModel, op, options) {
 
       // set `skipId`, otherwise we get "_id field cannot be changed"
       const doc = new model(op['replaceOne']['replacement'], strict, true);
-      if (model.schema.options.timestamps) {
+      if (model.schema.options.timestamps && getTimestampsOpt(op['replaceOne'], options)) {
         doc.initializeTimestamps();
       }
       if (options.session != null) {
@@ -272,4 +276,21 @@ function decideModelByObject(model, object) {
     model = getDiscriminatorByValue(model.discriminators, object[discriminatorKey]) || model;
   }
   return model;
+}
+
+
+/**
+ * gets timestamps option for a given operation. If the option is set within an individual operation, use it. Otherwise, use the global timestamps option configured in the `bulkWrite` options. Overall default is `true`.
+ * @api private
+ */
+
+function getTimestampsOpt(opCommand, options) {
+  const opLevelOpt = opCommand.timestamps;
+  const bulkLevelOpt = options.timestamps;
+  if (opLevelOpt != null) {
+    return opLevelOpt;
+  } else if (bulkLevelOpt != null) {
+    return bulkLevelOpt;
+  }
+  return true;
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3467,6 +3467,7 @@ function _setIsNew(doc, val) {
  *
  * @param {Array} ops
  * @param {Object} [ops.insertOne.document] The document to insert
+ * @param {Object} [ops.insertOne.timestamps=true] If false, do not apply [timestamps](https://mongoosejs.com/docs/guide.html#timestamps) to the operation
  * @param {Object} [ops.updateOne.filter] Update the first document that matches this filter
  * @param {Object} [ops.updateOne.update] An object containing [update operators](https://www.mongodb.com/docs/manual/reference/operator/update/)
  * @param {Boolean} [ops.updateOne.upsert=false] If true, insert a doc if none match
@@ -3484,8 +3485,10 @@ function _setIsNew(doc, val) {
  * @param {Object} [ops.replaceOne.filter] Replace the first document that matches this filter
  * @param {Object} [ops.replaceOne.replacement] The replacement document
  * @param {Boolean} [ops.replaceOne.upsert=false] If true, insert a doc if no documents match `filter`
+ * @param {Object} [ops.replaceOne.timestamps=true] If false, do not apply [timestamps](https://mongoosejs.com/docs/guide.html#timestamps) to the operation
  * @param {Object} [options]
  * @param {Boolean} [options.ordered=true] If true, execute writes in order and stop at the first error. If false, execute writes in parallel and continue until all writes have either succeeded or errored.
+ * @param {Boolean} [options.timestamps=true] If false, do not apply [timestamps](https://mongoosejs.com/docs/guide.html#timestamps) to any operations. Can be overridden at the operation-level.
  * @param {ClientSession} [options.session=null] The session associated with this bulk write. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
  * @param {String|number} [options.w=1] The [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/). See [`Query#w()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.w()) for more information.
  * @param {number} [options.wtimeout=null] The [write concern timeout](https://www.mongodb.com/docs/manual/reference/write-concern/#wtimeout).

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -28,6 +28,8 @@ declare module 'mongoose' {
     skipValidation?: boolean;
     throwOnValidationError?: boolean;
     strict?: boolean | 'throw';
+    /** When false, do not add timestamps to documents. Can be overridden at the operation level. */
+    timestamps?: boolean;
   }
 
   interface MongooseBulkSaveOptions extends mongodb.BulkWriteOptions {
@@ -179,7 +181,9 @@ declare module 'mongoose' {
   };
 
   export interface InsertOneModel<TSchema> {
-    document: mongodb.OptionalId<TSchema>
+    document: mongodb.OptionalId<TSchema>;
+    /** When false, do not add timestamps. When true, overrides the `timestamps` option set in the `bulkWrite` options. */
+    timestamps?: boolean;
   }
 
   export interface ReplaceOneModel<TSchema = AnyObject> {
@@ -193,6 +197,8 @@ declare module 'mongoose' {
     hint?: mongodb.Hint;
     /** When true, creates a new document if no document matches the query. */
     upsert?: boolean;
+    /** When false, do not add timestamps. When true, overrides the `timestamps` option set in the `bulkWrite` options. */
+    timestamps?: boolean;
   }
 
   export interface UpdateOneModel<TSchema = AnyObject> {
@@ -208,7 +214,7 @@ declare module 'mongoose' {
     hint?: mongodb.Hint;
     /** When true, creates a new document if no document matches the query. */
     upsert?: boolean;
-    /** When false, do not add timestamps. */
+    /** When false, do not add timestamps. When true, overrides the `timestamps` option set in the `bulkWrite` options. */
     timestamps?: boolean;
   }
 
@@ -225,7 +231,7 @@ declare module 'mongoose' {
     hint?: mongodb.Hint;
     /** When true, creates a new document if no document matches the query. */
     upsert?: boolean;
-    /** When false, do not add timestamps. */
+    /** When false, do not add timestamps. When true, overrides the `timestamps` option set in the `bulkWrite` options. */
     timestamps?: boolean;
   }
 


### PR DESCRIPTION
Fixes #14536

#### Summary
There's a fairly inconsistent experience with the `timestamps` option in `bulkWrite` right now:
- The only way to influence `insertOne` operations is by specifying `timestamps` in the the top-level `bulkWrite` options
- `updateOne` and `updateMany` have their `timestamps` option set purely at the operation level
- There's no way to set the `timestamps` option for `replaceOne` operations

Let's debate desired behavior here, but this PR introduces a hierarchy in order to (mostly) prevent breaking changes:
1. If `timestamps` is specified within a given operation (e.g., `op.updateOne.timestamps`), then use it
2. Next look at the `timestamps` setting in the top-level `bulkWrite` options and use it if it exists
3. Finally, default is `true`

#### Pros
-  Consistency!
- Doesn't represent a breaking change for many use-cases of officially-documented options, given `insertOne` is fully controlled by a different level than `updateOne` and `updateMany`. But it's not 100% non-breaking (see below)
- Gives users most flexibility. In my own experience, I'm generally either trying to set timestamps for all operations or none at all, which makes the top-level option useful. But if you do have a mix of commands where you want to set timestamps vs not, it's nice not having to split them into fully separate `bulkWrite` commands. I've run into this scenario myself, so I understand the benefit

#### Cons
- Complexity! Being able to specify the same option at multiple levels and keep track of what level overrides which other level is maybe too much.
- Technically this is a breaking change. If you send a `bulkWrite` with a mix of `insertOne` and `updateOne` commands, you currently control `insertOne` at the top level and `updateOne` at the operation level. Suppose you want to set timestamps for all `updateOne` commands but NOT for any `insertOne` commands. You would do that today by NOT specifying anything for `timestamps` in the `updateOne` commands and specifying `timestamps: false` in the top-level options. Moving forward, with this PR as written, the same `bulkWrite` will no longer set timestamps on anything.

#### Alternatives
1.  Make this truly non-breaking, and just add `insertOne.timestamps` and `replaceOne.timestamps` options. But we need to leave the top-level `timestamps` option in order to not break `insertOne` timestamp control for existing users. This will remain an inconsistent experience, as top-level will only control `insertOne` commands
2. Embrace the breakage while also keeping it simple by removing top-level `timestamps` altogether and just doing `timestamps` specification at the command level for all command types. Since it's a breaking change, delay landing this until 9.X
3. Make the argument that the top-level `timestamps` option for `bulkWrite` has never been officially documented, so we can remove it without it being a breaking change. Add `insertOne.timestamps` and `replaceOne.timestamps` options, and ship with 8.X. Honestly this is probably the optimal outcome from a simplicity/consistency/speed perspective...

#### Conclusion
After writing out everything above, I'm thinking my current solution as written is the worst of both worlds! Out of the alternatives listed above, I'm partial to alternative 3, but I don't know how others think about the argument that removing top-level `timestamps` is non-breaking.