### PR TITLE
perf(document): avoid cloning options using spread operator for perf reasons

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3830,14 +3830,18 @@ Document.prototype.$toObject = function(options, json) {
   // `clone()` will recursively call `$toObject()` on embedded docs, so we
   // need the original options the user passed in, plus `_isNested` and
   // `_parentOptions` for checking whether we need to depopulate.
-  const cloneOptions = Object.assign({}, options, {
+  const cloneOptions = {
     _isNested: true,
     json: json,
     minimize: _minimize,
     flattenMaps: flattenMaps,
     flattenObjectIds: flattenObjectIds,
-    _seen: (options && options._seen) || new Map()
-  });
+    _seen: (options && options._seen) || new Map(),
+    _calledWithOptions: options._calledWithOptions,
+    virtuals: options.virtuals,
+    getters: options.getters,
+    depopulate: options.depopulate
+  };
 
   const depopulate = options.depopulate ||
     (options._parentOptions && options._parentOptions.depopulate || false);

--- a/lib/document.js
+++ b/lib/document.js
@@ -3855,7 +3855,11 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   // merge default options with input options.
-  options = { ...defaultOptions, ...options };
+  for (const key of Object.keys(defaultOptions)) {
+    if (options[key] == null) {
+      options[key] = defaultOptions[key];
+    }
+  }
   options._isNested = true;
   options.json = json;
   options.minimize = _minimize;

--- a/lib/document.js
+++ b/lib/document.js
@@ -3839,13 +3839,6 @@ Document.prototype.$toObject = function(options, json) {
     _seen: (options && options._seen) || new Map()
   });
 
-  if (utils.hasUserDefinedProperty(options, 'getters')) {
-    cloneOptions.getters = options.getters;
-  }
-  if (utils.hasUserDefinedProperty(options, 'virtuals')) {
-    cloneOptions.virtuals = options.virtuals;
-  }
-
   const depopulate = options.depopulate ||
     (options._parentOptions && options._parentOptions.depopulate || false);
   // _isNested will only be true if this is not the top level document, we

--- a/lib/document.js
+++ b/lib/document.js
@@ -3780,7 +3780,7 @@ Document.prototype.$__handleReject = function handleReject(err) {
  */
 
 Document.prototype.$toObject = function(options, json) {
-  let defaultOptions = {
+  const defaultOptions = {
     transform: true,
     flattenDecimals: true
   };
@@ -3793,7 +3793,7 @@ Document.prototype.$toObject = function(options, json) {
   const schemaOptions = this.$__schema && this.$__schema.options || {};
   // merge base default options with Schema's set default options if available.
   // `clone` is necessary here because `utils.options` directly modifies the second input.
-  defaultOptions = { ...defaultOptions, ...baseOptions, ...schemaOptions[path] };
+  Object.assign(defaultOptions, baseOptions, schemaOptions[path]);
 
   // If options do not exist or is not an object, set it to empty object
   options = utils.isPOJO(options) ? { ...options } : {};
@@ -3865,19 +3865,17 @@ Document.prototype.$toObject = function(options, json) {
   options.minimize = _minimize;
 
   cloneOptions._parentOptions = options;
+
   cloneOptions._skipSingleNestedGetters = false;
-
-  const gettersOptions = Object.assign({}, cloneOptions);
-  gettersOptions._skipSingleNestedGetters = true;
-
   // remember the root transform function
   // to save it from being overwritten by sub-transform functions
   const originalTransform = options.transform;
 
   let ret = clone(this._doc, cloneOptions) || {};
 
+  cloneOptions._skipSingleNestedGetters = true;
   if (options.getters) {
-    applyGetters(this, ret, gettersOptions);
+    applyGetters(this, ret, cloneOptions);
 
     if (options.minimize) {
       ret = minimize(ret) || {};
@@ -3885,7 +3883,7 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   if (options.virtuals || (options.getters && options.virtuals !== false)) {
-    applyVirtuals(this, ret, gettersOptions, options);
+    applyVirtuals(this, ret, cloneOptions, options);
   }
 
   if (options.versionKey === false && this.$__schema.options.versionKey) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -722,32 +722,27 @@ describe('document', function() {
         lastName: String,
         password: String
       });
-
       userSchema.virtual('fullName').get(function() {
         return this.firstName + ' ' + this.lastName;
       });
-
       userSchema.set('toObject', { virtuals: false });
 
       const postSchema = new Schema({
         owner: { type: Schema.Types.ObjectId, ref: 'User' },
         content: String
       });
-
       postSchema.virtual('capContent').get(function() {
         return this.content.toUpperCase();
       });
-
       postSchema.set('toObject', { virtuals: true });
+      
       const User = db.model('User', userSchema);
       const Post = db.model('BlogPost', postSchema);
 
       const user = new User({ firstName: 'Joe', lastName: 'Smith', password: 'password' });
-
       const savedUser = await user.save();
 
       const post = await Post.create({ owner: savedUser._id, content: 'lorem ipsum' });
-
       const newPost = await Post.findById(post._id).populate('owner').exec();
 
       const obj = newPost.toObject();

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -735,7 +735,7 @@ describe('document', function() {
         return this.content.toUpperCase();
       });
       postSchema.set('toObject', { virtuals: true });
-      
+
       const User = db.model('User', userSchema);
       const Post = db.model('BlogPost', postSchema);
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -2976,33 +2976,27 @@ describe('model: populate:', function() {
           return ret;
         }
       });
-
       const Team = db.model('Test', teamSchema);
 
       const userSchema = new Schema({
         username: String
       });
-
       userSchema.set('toJSON', {
         transform: function(doc, ret) {
           return ret;
         }
       });
-
       const User = db.model('User', userSchema);
 
       const user = new User({ username: 'Test' });
-
       await user.save();
 
       const team = new Team({ members: [{ user: user }] });
-
       await team.save();
-
       await team.populate('members.user');
 
+      assert.equal(calls, 0);
       team.toJSON();
-
       assert.equal(calls, 1);
     });
 


### PR DESCRIPTION
Re: #14394

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

3x perf improvement on benchmark with this one weird trick. Without this PR:

```
$ node gh-14394.js 
Num docs 200 200
toObject ms: 1141
{
  _id: new ObjectId('66365214acdcbc00eacbd721'),
  name: 'test child 0_0',
  parentId: new ObjectId('66365214acdcbc00eacbd71f'),
  __v: 0
}
Done

```

With this PR:

```
$ node gh-14394.js 
Num docs 200 200
toObject ms: 492
{
  _id: new ObjectId('66365214acdcbc00eacbd721'),
  name: 'test child 0_0',
  parentId: new ObjectId('66365214acdcbc00eacbd71f'),
  __v: 0
}
Done
```

Not sure why this is so much faster, but still works and makes `$toObject()` that much faster :man_shrugging: 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
