### PR TITLE
fix(error): remove model property from CastError to avoid printing all model properties to console

### DIFF
--- a/lib/error/cast.js
+++ b/lib/error/cast.js
@@ -75,7 +75,6 @@ class CastError extends MongooseError {
    * ignore
    */
   setModel(model) {
-    this.model = model;
     this.message = formatMessage(model, this.kind, this.value, this.path,
       this.messageFormat, this.valueType);
   }


### PR DESCRIPTION
Fix #14529

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The following script currently prints > 10k lines of output:

```
'use strict';

const mongoose = require('mongoose');

mongoose.connect('mongodb://127.0.0.1:27017/mongoose_test2');

const TestModel = mongoose.model('Test', mongoose.Schema({ 
  num: { type: Number }
}));

TestModel.findOne({ num: 'foo' }).exec();

```

Because `CastError` contains the full model, and Node.js' `inspect()` seems to ignore custom inspect handlers for error instances. So the above script prints out `TestModel` and all its subprops, including connections and connection strings in plaintext. This is a bit of a nasty surprise as we saw in #14529.

I did a bunch of digging to try to find some way to get Node's error formatting to avoid printing `model`, the only approach that seems to work is making `model` a getter and storing the actual mapping of error -> model in a WeakMap. However that seems a bit excessive.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
