### PR TITLE
types(model): allow passing strict type checking override to create()

### DIFF
--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -40,6 +40,15 @@ Test.create([{ name: 'test' }], { validateBeforeSave: true }).then(docs => {
   expectType<string>(docs[0].name);
 });
 
+Test.create({}).then(doc => {
+  expectType<string>(doc.name);
+});
+
+Test.create([{}]).then(docs => {
+  expectType<string>(docs[0].name);
+});
+
+expectError(Test.create<ITest>({}));
 
 Test.insertMany({ name: 'test' }, {}, (err, docs) => {
   expectType<CallbackError>(err);

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -50,6 +50,9 @@ Test.create([{}]).then(docs => {
 
 expectError(Test.create<ITest>({}));
 
+Test.create<ITest>({ name: 'test' });
+Test.create<ITest>({ _id: new Types.ObjectId('0'.repeat(24)), name: 'test' });
+
 Test.insertMany({ name: 'test' }, {}, (err, docs) => {
   expectType<CallbackError>(err);
   expectType<Types.ObjectId>(docs[0]._id);

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -192,12 +192,12 @@ declare module 'mongoose' {
     countDocuments(callback?: Callback<number>): QueryWithHelpers<number, HydratedDocument<T, TMethodsAndOverrides, TVirtuals>, TQueryHelpers, T>;
 
     /** Creates a new document or documents */
-    create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, options?: SaveOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(docs: Array<T | DocContents>, callback: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): void;
-    create<DocContents = AnyKeys<T>>(doc: DocContents | T): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
-    create<DocContents = AnyKeys<T>>(...docs: Array<T | DocContents>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
-    create<DocContents = AnyKeys<T>>(doc: T | DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
+    create<DocContents = AnyKeys<T>>(docs: Array<DocContents>, options?: SaveOptions): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create<DocContents = AnyKeys<T>>(docs: Array<DocContents>, options?: SaveOptions, callback?: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create<DocContents = AnyKeys<T>>(docs: Array<DocContents>, callback: Callback<Array<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>>): void;
+    create<DocContents = AnyKeys<T>>(doc: DocContents): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>;
+    create<DocContents = AnyKeys<T>>(...docs: Array<DocContents>): Promise<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>[]>;
+    create<DocContents = AnyKeys<T>>(doc: DocContents, callback: Callback<HydratedDocument<T, TMethodsAndOverrides, TVirtuals>>): void;
 
     /**
      * Create the collection for this model. By default, if no indexes are specified,


### PR DESCRIPTION
Fix #14548

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now the generic param to `create()` makes `create()`'s type checking slightly looser. This was introduced in https://github.com/Automattic/mongoose/commit/e75d4b6b530868cd14233d3a2ae0a6628e536bc2 (#11563) but doesn't look to be strictly necessary. With this PR, `create()` generic param can be used to make `create()` type checking strict.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
