### PR TITLE
handle initially null driver when instantiating Mongoose for Rollup support

### DIFF
--- a/lib/error/browserMissingSchema.js
+++ b/lib/error/browserMissingSchema.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 
 class MissingSchemaError extends MongooseError {

--- a/lib/error/divergentArray.js
+++ b/lib/error/divergentArray.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class DivergentArrayError extends MongooseError {
   /**

--- a/lib/error/eachAsyncMultiError.js
+++ b/lib/error/eachAsyncMultiError.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 
 /**

--- a/lib/error/invalidSchemaOption.js
+++ b/lib/error/invalidSchemaOption.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class InvalidSchemaOptionError extends MongooseError {
   /**

--- a/lib/error/missingSchema.js
+++ b/lib/error/missingSchema.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class MissingSchemaError extends MongooseError {
   /**

--- a/lib/error/notFound.js
+++ b/lib/error/notFound.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 const util = require('util');
 
 class DocumentNotFoundError extends MongooseError {

--- a/lib/error/objectExpected.js
+++ b/lib/error/objectExpected.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 
 class ObjectExpectedError extends MongooseError {

--- a/lib/error/objectParameter.js
+++ b/lib/error/objectParameter.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class ObjectParameterError extends MongooseError {
   /**

--- a/lib/error/overwriteModel.js
+++ b/lib/error/overwriteModel.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 
 class OverwriteModelError extends MongooseError {

--- a/lib/error/parallelSave.js
+++ b/lib/error/parallelSave.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class ParallelSaveError extends MongooseError {
   /**

--- a/lib/error/strict.js
+++ b/lib/error/strict.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 
 class StrictModeError extends MongooseError {

--- a/lib/error/strictPopulate.js
+++ b/lib/error/strictPopulate.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class StrictPopulateError extends MongooseError {
   /**

--- a/lib/error/validator.js
+++ b/lib/error/validator.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 
 class ValidatorError extends MongooseError {

--- a/lib/error/version.js
+++ b/lib/error/version.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const MongooseError = require('./');
+const MongooseError = require('./mongooseError');
 
 class VersionError extends MongooseError {
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,13 @@
  * Module dependencies.
  */
 
-require('./driver').set(require('./drivers/node-mongodb-native'));
+const mongodbDriver = require('./drivers/node-mongodb-native');
+
+require('./driver').set(mongodbDriver);
 
 const mongoose = require('./mongoose');
+
+mongoose.setDriver(mongodbDriver);
 
 mongoose.Mongoose.prototype.mongo = require('mongodb');
 

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -68,8 +68,8 @@ function Mongoose(options) {
     autoCreate: true,
     autoSearchIndex: false
   }, options);
-  const createInitialConnection = utils.getOption('createInitialConnection', this.options);
-  if (createInitialConnection == null || createInitialConnection) {
+  const createInitialConnection = utils.getOption('createInitialConnection', this.options) ?? true;
+  if (createInitialConnection && this.__driver != null) {
     const conn = this.createConnection(); // default connection
     conn.models = this.models;
   }
@@ -169,6 +169,9 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
   const oldDefaultConnection = _mongoose.connections[0];
   _mongoose.connections = [new Connection(_mongoose)];
   _mongoose.connections[0].models = _mongoose.models;
+  if (oldDefaultConnection == null) {
+    return _mongoose;
+  }
 
   // Update all models that pointed to the old default connection to
   // the new default connection, including collections


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

Fix #12335

**Summary**

`lib/index.js` and `lib/mongoose.js` contain the significant changes here. The issue is that, because of how Rollup hoists imports when you don't set `strictRequires: true`, the `setDriver()` call in `lib/mongoose.js` will always run _after_ the Mongoose singleton is initialized in `lib/index.js`. So the Mongoose constructor needs to handle null driver case, and `lib/mongoose.js` needs to call `setDriver()` to make sure the driver change propagates to the newly created Mongoose singleton.

In regular Node.js, that second `setDriver()` call is a no-op because `setDriver()` checks to see if new driver is `===` old driver.

On a related note, I also cleaned up some circular imports in `lib/error/*.js`. `lib/error/index.js` imports `lib/error/cast.js` and `lib/error/cast.js` imports `lib/error/index.js`. I was trying to see if cleaning up circular imports would help with Rollup support, but experimentation and further reading convinced me that it wasn't necessary for Rollup support. But still a nice to have since fixing the circular import is a bunch of one-liners.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
