### PR TITLE
feat: add `transactionAsyncLocalStorage` option to opt in to automatically setting `session` on all transactions

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -102,7 +102,7 @@ const doc = new Test({ name: 'test' });
 await connection.transaction(async() => {
   await doc.save(); // Notice no session here
   throw new Error('Oops');
-});
+}).catch(() => {});
 
 // false, `save()` was rolled back
 await Test.exists({ _id: doc._id });

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1022,6 +1022,11 @@ Aggregate.prototype.exec = async function exec() {
   applyGlobalMaxTimeMS(this.options, model.db.options, model.base.options);
   applyGlobalDiskUse(this.options, model.db.options, model.base.options);
 
+  const asyncLocalStorage = this.model?.db?.base.transactionAsyncLocalStorage?.getStore();
+  if (!this.options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
+    this.options.session = asyncLocalStorage.session;
+  }
+
   if (this.options && this.options.cursor) {
     return new AggregationCursor(this);
   }

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1022,7 +1022,7 @@ Aggregate.prototype.exec = async function exec() {
   applyGlobalMaxTimeMS(this.options, model.db.options, model.base.options);
   applyGlobalDiskUse(this.options, model.db.options, model.base.options);
 
-  const asyncLocalStorage = this.model?.db?.base.transactionAsyncLocalStorage?.getStore();
+  const asyncLocalStorage = this.model()?.db?.base.transactionAsyncLocalStorage?.getStore();
   if (!this.options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
     this.options.session = asyncLocalStorage.session;
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -539,7 +539,7 @@ Connection.prototype.startSession = async function startSession(options) {
 Connection.prototype.transaction = function transaction(fn, options) {
   return this.startSession().then(session => {
     session[sessionNewDocuments] = new Map();
-    return session.withTransaction(() => _wrapUserTransaction(fn, session), options).
+    return session.withTransaction(() => _wrapUserTransaction(fn, session, this.base), options).
       then(res => {
         delete session[sessionNewDocuments];
         return res;
@@ -558,9 +558,16 @@ Connection.prototype.transaction = function transaction(fn, options) {
  * Reset document state in between transaction retries re: gh-13698
  */
 
-async function _wrapUserTransaction(fn, session) {
+async function _wrapUserTransaction(fn, session, mongoose) {
   try {
-    const res = await fn(session);
+    const res = mongoose.transactionAsyncLocalStorage == null
+      ? await fn(session)
+      : await new Promise(resolve => {
+        mongoose.transactionAsyncLocalStorage.run(
+          { session },
+          () => resolve(fn(session))
+        );
+      });
     return res;
   } catch (err) {
     _resetSessionDocuments(session);

--- a/lib/model.js
+++ b/lib/model.js
@@ -296,8 +296,11 @@ Model.prototype.$__handleSave = function(options, callback) {
   }
 
   const session = this.$session();
+  const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
   if (!saveOptions.hasOwnProperty('session') && session != null) {
     saveOptions.session = session;
+  } else if (asyncLocalStorage?.session != null) {
+    saveOptions.session = asyncLocalStorage.session;
   }
   if (this.$isNew) {
     // send entire doc
@@ -3533,6 +3536,10 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   }
 
   const validations = ops.map(op => castBulkWrite(this, op, options));
+  const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
+  if (!options.hasOwnProperty('session') && asyncLocalStorage.session != null) {
+    options = { ...options, session: asyncLocalStorage.session };
+  }
 
   let res = null;
   if (ordered) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -296,7 +296,7 @@ Model.prototype.$__handleSave = function(options, callback) {
   }
 
   const session = this.$session();
-  const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
+  const asyncLocalStorage = this[modelDbSymbol].base.transactionAsyncLocalStorage?.getStore();
   if (!saveOptions.hasOwnProperty('session') && session != null) {
     saveOptions.session = session;
   } else if (asyncLocalStorage?.session != null) {
@@ -3537,7 +3537,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
 
   const validations = ops.map(op => castBulkWrite(this, op, options));
   const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
-  if (!options.hasOwnProperty('session') && asyncLocalStorage.session != null) {
+  if ((!options || !options.hasOwnProperty('session')) && asyncLocalStorage?.session != null) {
     options = { ...options, session: asyncLocalStorage.session };
   }
 

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -38,6 +38,8 @@ require('./helpers/printJestWarning');
 
 const objectIdHexRegexp = /^[0-9A-Fa-f]{24}$/;
 
+const { AsyncLocalStorage } = require('node:async_hooks');
+
 /**
  * Mongoose constructor.
  *
@@ -100,6 +102,10 @@ function Mongoose(options) {
     }
   }
   this.Schema.prototype.base = this;
+
+  if (options?.transactionAsyncLocalStorage) {
+    this.transactionAsyncLocalStorage = new AsyncLocalStorage();
+  }
 
   Object.defineProperty(this, 'plugins', {
     configurable: false,
@@ -267,7 +273,7 @@ Mongoose.prototype.set = function(key, value) {
 
     if (optionKey === 'objectIdGetter') {
       if (optionValue) {
-        Object.defineProperty(mongoose.Types.ObjectId.prototype, '_id', {
+        Object.defineProperty(_mongoose.Types.ObjectId.prototype, '_id', {
           enumerable: false,
           configurable: true,
           get: function() {
@@ -275,7 +281,13 @@ Mongoose.prototype.set = function(key, value) {
           }
         });
       } else {
-        delete mongoose.Types.ObjectId.prototype._id;
+        delete _mongoose.Types.ObjectId.prototype._id;
+      }
+    } else if (optionKey === 'transactionAsyncLocalStorage') {
+      if (optionValue && !_mongoose.transactionAsyncLocalStorage) {
+        _mongoose.transactionAsyncLocalStorage = new AsyncLocalStorage();
+      } else if (!optionValue && _mongoose.transactionAsyncLocalStorage) {
+        delete _mongoose.transactionAsyncLocalStorage;
       }
     }
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -1947,7 +1947,7 @@ Query.prototype._optionsForExec = function(model) {
   // Apply schema-level `writeConcern` option
   applyWriteConcern(model.schema, options);
 
-  const asyncLocalStorage = this.model.db.base.transactionAsyncLocalStorage?.getStore();
+  const asyncLocalStorage = this.model?.db?.base.transactionAsyncLocalStorage?.getStore();
   if (!this.options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
     options.session = asyncLocalStorage.session;
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -1947,6 +1947,11 @@ Query.prototype._optionsForExec = function(model) {
   // Apply schema-level `writeConcern` option
   applyWriteConcern(model.schema, options);
 
+  const asyncLocalStorage = this.model.db.base.transactionAsyncLocalStorage?.getStore();
+  if (!this.options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
+    options.session = asyncLocalStorage.session;
+  }
+
   const readPreference = model &&
   model.schema &&
   model.schema.options &&

--- a/lib/validOptions.js
+++ b/lib/validOptions.js
@@ -32,6 +32,7 @@ const VALID_OPTIONS = Object.freeze([
   'strictQuery',
   'toJSON',
   'toObject',
+  'transactionAsyncLocalStorage',
   'translateAliases'
 ]);
 

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -370,7 +370,7 @@ describe('transactions', function() {
       await Test.createCollection();
       await Test.deleteMany({});
 
-      const doc = new Test({ name: 'test' });
+      const doc = new Test({ name: 'test_transactionAsyncLocalStorage' });
       await assert.rejects(
         () => m.connection.transaction(async() => {
           await doc.save();
@@ -383,10 +383,10 @@ describe('transactions', function() {
           docs = await Test.find({ _id: doc._id });
           assert.equal(docs.length, 1);
 
-          docs = await Promise.all([async() => {
+          docs = await async function test() {
             return await Test.findOne({ _id: doc._id });
-          }]).then(res => res[0]);
-          assert.equal(docs.length, 1);
+          }();
+          assert.equal(doc.name, 'test_transactionAsyncLocalStorage');
 
           throw new Error('Oops!');
         }),

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -380,7 +380,12 @@ describe('transactions', function() {
           let docs = await Test.aggregate([{ $match: { _id: doc._id } }]);
           assert.equal(docs.length, 1);
 
-          const docs = await Test.find({ _id: doc._id });
+          docs = await Test.find({ _id: doc._id });
+          assert.equal(docs.length, 1);
+
+          docs = await Promise.all([async() => {
+            return await Test.findOne({ _id: doc._id });
+          }]).then(res => res[0]);
           assert.equal(docs.length, 1);
 
           throw new Error('Oops!');

--- a/test/model.findByIdAndUpdate.test.js
+++ b/test/model.findByIdAndUpdate.test.js
@@ -53,9 +53,6 @@ describe('model: findByIdAndUpdate:', function() {
       'shape.side': 4,
       'shape.color': 'white'
     }, { new: true });
-    console.log('doc');
-    console.log(doc);
-    console.log('doc');
 
     assert.equal(doc.shape.kind, 'gh8378_Square');
     assert.equal(doc.shape.name, 'after');

--- a/types/mongooseoptions.d.ts
+++ b/types/mongooseoptions.d.ts
@@ -204,6 +204,13 @@ declare module 'mongoose' {
     toObject?: ToObjectOptions;
 
     /**
+     * Set to true to make Mongoose use Node.js' built-in AsyncLocalStorage (Node >= 16.0.0)
+     * to set `session` option on all operations within a `connection.transaction(fn)` call
+     * by default. Defaults to false.
+     */
+    transactionAsyncLocalStorage?: boolean;
+
+    /**
      * If `true`, convert any aliases in filter, projection, update, and distinct
      * to their database property names. Defaults to false.
      */


### PR DESCRIPTION
Fix #13889

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Having to pass `session` option to every operation in a transaction is cumbersome and error prone. Node 16+ has a stable AsyncLocalStorage class as part of the async_hooks API; we can use AsyncLocalStorage to set `session` option by default on all operations in a function as long as the user uses `Connection.prototype.transaction()` wrapper. See `docs/transactions.md` changes for an example.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
