### PR TITLE
fix(model): make `bulkWrite()` and `insertMany()` throw if `throwOnValidationError` set and all ops invalid

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3233,6 +3233,14 @@ Model.$__insertMany = function(arr, options, callback) {
 
     // Quickly escape while there aren't any valid docAttributes
     if (docAttributes.length === 0) {
+      if (throwOnValidationError) {
+        return callback(new MongooseBulkWriteError(
+          validationErrors,
+          results,
+          null,
+          'insertMany'
+        ));
+      }
       if (rawResult) {
         const res = {
           acknowledged: true,
@@ -3588,6 +3596,14 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
     validOps = validOps.sort().map(index => ops[index]);
 
     if (validOps.length === 0) {
+      if (options.throwOnValidationError && validationErrors.length) {
+        throw new MongooseBulkWriteError(
+          validationErrors,
+          results,
+          res,
+          'bulkWrite'
+        );
+      }
       return getDefaultBulkwriteResult();
     }
 


### PR DESCRIPTION
Fix #14572

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now we have a `throwOnValidationError` that means `bulkWrite()` and `insertMany()` will throw if any operations fail validation... except if all operations fail validation. This PR makes it so that we still throw a `MongooseBulkWriteError` if all operations fail validation.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
