### PR TITLE
fix(cast): cast $comment to string in query filters

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -8,6 +8,7 @@ const CastError = require('./error/cast');
 const StrictModeError = require('./error/strict');
 const Types = require('./schema/index');
 const cast$expr = require('./helpers/query/cast$expr');
+const castString = require('./cast/string');
 const castTextSearch = require('./schema/operators/text');
 const get = require('./helpers/get');
 const getConstructorName = require('./helpers/getConstructorName');
@@ -89,6 +90,9 @@ module.exports = function cast(schema, obj, options, context) {
       val = cast(schema, val, options, context);
     } else if (path === '$text') {
       val = castTextSearch(val, path);
+    } else if (path === '$comment' && !schema.paths.hasOwnProperty('$comment')) {
+      val = castString(val, path);
+      obj[path] = val;
     } else {
       if (!schema) {
         // no casting for Mixed types

--- a/lib/schema/operators/text.js
+++ b/lib/schema/operators/text.js
@@ -15,7 +15,7 @@ const castString = require('../../cast/string');
  * @api private
  */
 
-module.exports = function(val, path) {
+module.exports = function castTextSearch(val, path) {
   if (val == null || typeof val !== 'object') {
     throw new CastError('$text', val, path);
   }

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -160,6 +160,33 @@ describe('cast: ', function() {
     });
   });
 
+  it('casts $comment (gh-14576)', function() {
+    const schema = new Schema({ name: String });
+
+    let res = cast(schema, {
+      $comment: 'test'
+    });
+    assert.deepStrictEqual(res, { $comment: 'test' });
+
+    res = cast(schema, {
+      $comment: 42
+    });
+    assert.deepStrictEqual(res, { $comment: '42' });
+
+    assert.throws(
+      () => cast(schema, {
+        $comment: { name: 'taco' }
+      }),
+      /\$comment/
+    );
+
+    const schema2 = new Schema({ $comment: Number });
+    res = cast(schema2, {
+      $comment: 42
+    });
+    assert.deepStrictEqual(res, { $comment: 42 });
+  });
+
   it('avoids setting stripped out nested schema values to undefined (gh-11291)', function() {
     const nested = new Schema({}, {
       id: false,


### PR DESCRIPTION
Fix #14576

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Cast `$comment` to string, unless there's a schema path called `$comment`. See [MongoDB docs](https://www.mongodb.com/docs/manual/reference/operator/query/comment/) for more info on $comment.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
