### PR TITLE
fix(document): ensure `transform` function passed to `toObject()` opt…

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3831,16 +3831,14 @@ Document.prototype.$toObject = function(options, json) {
   // need the original options the user passed in, plus `_isNested` and
   // `_parentOptions` for checking whether we need to depopulate.
   const cloneOptions = {
+    ...options,
     _isNested: true,
     json: json,
     minimize: _minimize,
     flattenMaps: flattenMaps,
     flattenObjectIds: flattenObjectIds,
     _seen: (options && options._seen) || new Map(),
-    _calledWithOptions: options._calledWithOptions,
-    virtuals: options.virtuals,
-    getters: options.getters,
-    depopulate: options.depopulate
+    _calledWithOptions: options._calledWithOptions
   };
 
   const depopulate = options.depopulate ||


### PR DESCRIPTION
Fix #14589
Re: #14565
Re: #14394 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

It looks like the last changes from #14565 had the unintended consequence of not passing `transform` functions down to subdocuments. This PR fixes that, and adds a test to protect against regressions.

Will likely need to do some further work on #14394 since this PR undoes a small perf gain from #14565

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
