### PR TITLE
fix(document): fire pre validate hooks on 5 level deep single nested subdoc when modifying after save()

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1716,6 +1716,9 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
         } else {
           obj._doc[parts[i]] = val;
         }
+        if (shouldModify) {
+          obj.markModified(parts[i]);
+        }
       } else {
         obj[parts[i]] = val;
       }
@@ -2698,6 +2701,7 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
             !doc.isDirectModified(fullPathToSubdoc) &&
             !doc.$isDefault(fullPathToSubdoc)) {
         paths.add(fullPathToSubdoc);
+
         if (doc.$__.pathsToScopes == null) {
           doc.$__.pathsToScopes = {};
         }

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -113,7 +113,7 @@ Subdocument.prototype.$__fullPath = function(path) {
 
 /**
  * Given a path relative to this document, return the path relative
- * to the top-level document.
+ * to the parent document.
  * @param {String} p
  * @returns {String}
  * @method $__pathRelativeToParent


### PR DESCRIPTION
Fix #14591

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Tricky issue: if you `save()` a doc, then `set()` a more than 3 level nested single nested path using dot notation, pre('validate') hooks don't fire because the subdoc paths aren't marked as modified beyond the 1st level.

This PR provides a reasonable fix for this particular case, but I will look more closely at how our change tracking handles subdocs as a followup to this work.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
