### PR TITLE
fix(update): cast array of strings underneath doc array with array filters

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2584,6 +2584,10 @@ Schema.prototype._getSchema = function(path) {
           // If there is no foundschema.schema we are dealing with
           // a path like array.$
           if (p !== parts.length) {
+            if (p + 1 === parts.length && foundschema.$embeddedSchemaType && (parts[p] === '$' || isArrayFilter(parts[p]))) {
+              return foundschema.$embeddedSchemaType;
+            }
+
             if (foundschema.schema) {
               let ret;
               if (parts[p] === '$' || isArrayFilter(parts[p])) {


### PR DESCRIPTION
Fix #14595

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`Schema.prototype._getSchema()` doesn't quite handle the case where you have `docArr.$.primitiveArr.$`, that last `$` gets dropped off because `primitiveArr.schema == null`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
