### PR TITLE
Pass options to `clone` instead of `get` in applyVirtuals.

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4128,7 +4128,7 @@ function applyVirtuals(self, json, options, toObjectOptions) {
       assignPath = path.substring(options.path.length + 1);
     }
     if (assignPath.indexOf('.') === -1 && assignPath === path) {
-      v = clone(self.get(path, options ? { ...options, noDottedPath: true } : { noDottedPath: true }));
+      v = clone(self.get(path, { noDottedPath: true }), options);
       if (v === void 0) {
         continue;
       }


### PR DESCRIPTION
**Summary**

A bug introduced in v8.3.3 by #14543 caused `toJSON` to not be executed for virtual sub documents. The issue is caused by the `options` being incorrectly passed into the `get` function instead of the `clone` function.

**Examples**

I don't have an easy examples sorry, but I think the fix should be fairly evident. The intentions of #14543 was to pass `noDottedPath: true` to the `get` function but it mistakenly included the clone options which should have been passed to `clone` instead, as on line 4139 below it.
