### PR TITLE
types: pass DocType down to subdocuments so `HydratedSingleSubdocument` and `HydratedArraySubdocument` `toObject()` returns correct type

### DIFF
--- a/test/types/subdocuments.test.ts
+++ b/test/types/subdocuments.test.ts
@@ -143,9 +143,6 @@ function gh14601() {
     f3: [{ field1: 'test' }]
   });
 
-  const obj = item.toObject();
-
-  const obj2 = item.f2.toObject();
-
-  expectAssignable<{ _id: Types.ObjectId, field1: string }>(obj2);
+  const f2obj = item.f2.toObject();
+  expectAssignable<{ _id: Types.ObjectId, field1: string }>(f2obj);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,8 +157,8 @@ declare module 'mongoose' {
         >
       >
   >;
-  export type HydratedSingleSubdocument<DocType, TOverrides = {}> = Types.Subdocument<unknown> & Require_id<DocType> & TOverrides;
-  export type HydratedArraySubdocument<DocType, TOverrides = {}> = Types.ArraySubdocument<unknown> & Require_id<DocType> & TOverrides;
+  export type HydratedSingleSubdocument<DocType, TOverrides = {}> = Types.Subdocument<unknown, Record<string, never>, DocType> & Require_id<DocType> & TOverrides;
+  export type HydratedArraySubdocument<DocType, TOverrides = {}> = Types.ArraySubdocument<unknown, Record<string, never>, DocType> & Require_id<DocType> & TOverrides;
 
   export type HydratedDocumentFromSchema<TSchema extends Schema> = HydratedDocument<
   InferSchemaType<TSchema>,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -96,7 +96,7 @@ declare module 'mongoose' {
       $parent(): Document;
     }
 
-    class ArraySubdocument<IdType = any> extends Subdocument<IdType> {
+    class ArraySubdocument<IdType = any, TQueryHelpers = unknown, DocType = unknown> extends Subdocument<IdType, TQueryHelpers, DocType> {
       /** Returns this sub-documents parent array. */
       parentArray(): Types.DocumentArray<unknown>;
     }


### PR DESCRIPTION
Fix #14601

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now `toObject()` on subdocs will return `any` if you use `HydratedArraySubdocument` or `HydratedSingleSubdocument`.

I made this PR against master, but when merged I will also cherry-pick to 7.x.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
