### PR TITLE
fix(query): shallow clone $or and $and array elements to avoid mutating query filter arguments

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2416,13 +2416,17 @@ Query.prototype.merge = function(source) {
   }
 
   opts.omit = {};
-  if (this._conditions && this._conditions.$and && source.$and) {
+  if (this._conditions && Array.isArray(source.$and)) {
     opts.omit['$and'] = true;
-    this._conditions.$and = this._conditions.$and.concat(source.$and);
+    this._conditions.$and = (this._conditions.$and || []).concat(
+      source.$and.map(el => utils.isPOJO(el) ? utils.merge({}, el) : el)
+    );
   }
-  if (this._conditions && this._conditions.$or && source.$or) {
+  if (this._conditions && Array.isArray(source.$or)) {
     opts.omit['$or'] = true;
-    this._conditions.$or = this._conditions.$or.concat(source.$or);
+    this._conditions.$or = (this._conditions.$or || []).concat(
+      source.$or.map(el => utils.isPOJO(el) ? utils.merge({}, el) : el)
+    );
   }
 
   // plain object

--- a/lib/query.js
+++ b/lib/query.js
@@ -2416,14 +2416,20 @@ Query.prototype.merge = function(source) {
   }
 
   opts.omit = {};
-  if (this._conditions && Array.isArray(source.$and)) {
+  if (Array.isArray(source.$and)) {
     opts.omit['$and'] = true;
+    if (!this._conditions) {
+      this._conditions = {};
+    }
     this._conditions.$and = (this._conditions.$and || []).concat(
       source.$and.map(el => utils.isPOJO(el) ? utils.merge({}, el) : el)
     );
   }
-  if (this._conditions && Array.isArray(source.$or)) {
+  if (Array.isArray(source.$or)) {
     opts.omit['$or'] = true;
+    if (!this._conditions) {
+      this._conditions = {};
+    }
     this._conditions.$or = (this._conditions.$or || []).concat(
       source.$or.map(el => utils.isPOJO(el) ? utils.merge({}, el) : el)
     );

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -294,6 +294,8 @@ exports.merge = function merge(to, from, options, path) {
       to[key] = from[key];
     }
   }
+
+  return to;
 };
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4214,4 +4214,19 @@ describe('Query', function() {
     assert.strictEqual(doc.account.owner, undefined);
     assert.strictEqual(doc.account.taxIds, undefined);
   });
+
+  it('avoids mutating $or, $and elements when casting (gh-14610)', async function() {
+    const personSchema = new mongoose.Schema({
+      name: String,
+      age: Number
+    });
+    const Person = db.model('Person', personSchema);
+
+    const filter = [{ name: 'Me', age: '20' }, { name: 'You', age: '50' }];
+    await Person.find({ $or: filter });
+    assert.deepStrictEqual(filter, [{ name: 'Me', age: '20' }, { name: 'You', age: '50' }]);
+
+    await Person.find({ $and: filter });
+    assert.deepStrictEqual(filter, [{ name: 'Me', age: '20' }, { name: 'You', age: '50' }]);
+  });
 });


### PR DESCRIPTION
Fix #14610

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Follow up on #14580, #14567: also shallow clone `$and` and `$or` conditions to make casting avoid mutating $or/$and elements in place. We already use `utils.merge()` to avoid mutating for top-level keys in query filter.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
