### PR TITLE
fix: ensure buildBulkWriteOperations target shard if shardKey is set

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3956,6 +3956,17 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
 
       _applyCustomWhere(document, where);
 
+      // If shard key is set, add shard keys to _filter_ condition to right shard is targeted 
+      const shardKey = this.schema.options.shardKey;
+      if (shardKey) {
+        const paths = Object.keys(shardKey);
+        const len = paths.length;
+
+        for (let i = 0; i < len; ++i) {
+          where[paths[i]] = shardKey[paths[i]];
+        }
+      }
+
       // Set the discriminator key, so bulk write casting knows which
       // schema to use re: gh-13907
       if (document[discriminatorKey] != null && !(discriminatorKey in where)) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6331,14 +6331,14 @@ describe('Model', function() {
 
       const userSchema = new Schema({
         name: { type: String }
-      });
+      }, { shardKey: { a: 1 } });
 
       const User = db.model('User', userSchema);
 
       const users = [
-        new User({ name: 'Hafez1_gh-9673-1' }),
-        new User({ name: 'Hafez2_gh-9673-1' }),
-        new User({ name: 'I am the third name' })
+        new User({ name: 'Hafez1_gh-9673-1', a: 1 }),
+        new User({ name: 'Hafez2_gh-9673-1', a: 2 }),
+        new User({ name: 'I am the third name', a: 3 })
       ];
 
       await users[2].save();
@@ -6349,7 +6349,7 @@ describe('Model', function() {
       const desiredWriteOperations = [
         { insertOne: { document: users[0] } },
         { insertOne: { document: users[1] } },
-        { updateOne: { filter: { _id: users[2]._id }, update: { $set: { name: 'I am the updated third name' } } } }
+        { updateOne: { filter: { _id: users[2]._id, a: 1 }, update: { $set: { name: 'I am the updated third name' } } } }
       ];
 
       assert.deepEqual(


### PR DESCRIPTION
Fixes #14622
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When having a sharded collection and having set _shardKey_ on  the schema,  using buildBulkWriteOperations does not take the _shardKey_ into account. 

The documention for _shardKey_ states (https://mongoosejs.com/docs/guide.html#shardKey):
> Each sharded collection is given a shard key which must be present in all insert/update operations

This PR enabled support for the _shardKey_ option when using the _buildBulkWriteOperations_ method. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

Given this schema 
```js
const measurementSchema = new Schema({
  temperature: { type: Number },
  sensorId: { type: String },
}, { shardKey: { sensorId: 1 } });

const Measurement = db.model('Measurement',measurementSchema )
```
and assuming an saved document _m_, this _bulkSave_ action will correctly include _sensorId_ in the bulkWrite command:

```js 

m.temperature = 21.1

await Measurement.bulkWrite([m])
/* This will generate 

bulkWrite([
  {
    updateOne: {
      filter: {
        _id: ...,
        sensorId: 1
      },
      {
        update: {
          $set: {
            temperature: 21.1
          }
        }
      }
    },
  },
])

*/
```






<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
