### PR TITLE
types(models+query): infer return type from schema for 1-level deep nested paths

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -623,7 +623,11 @@ declare module 'mongoose' {
       field: DocKey,
       filter?: FilterQuery<TRawDocType>
     ): QueryWithHelpers<
-      Array<DocKey extends keyof TRawDocType ? Unpacked<TRawDocType[DocKey]> : ResultType>,
+      Array<
+        DocKey extends keyof WithLevel1NestedPaths<TRawDocType>
+          ? WithoutUndefined<Unpacked<WithLevel1NestedPaths<TRawDocType>[DocKey]>>
+          : ResultType
+      >,
       THydratedDocumentType,
       TQueryHelpers,
       TRawDocType,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -355,7 +355,18 @@ declare module 'mongoose' {
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
       filter?: FilterQuery<RawDocType>
-    ): QueryWithHelpers<Array<DocKey extends keyof DocType ? Unpacked<DocType[DocKey]> : ResultType>, DocType, THelpers, RawDocType, 'distinct', TInstanceMethods>;
+    ): QueryWithHelpers<
+      Array<
+        DocKey extends keyof WithLevel1NestedPaths<DocType>
+          ? WithoutUndefined<Unpacked<WithLevel1NestedPaths<DocType>[DocKey]>>
+          : ResultType
+      >,
+      DocType,
+      THelpers,
+      RawDocType,
+      'distinct',
+      TInstanceMethods
+    >;
 
     /** Specifies a `$elemMatch` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     elemMatch<K = string>(path: K, val: any): this;

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -2,6 +2,26 @@ declare module 'mongoose' {
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends (1 & IFTYPE) ? THENTYPE : ELSETYPE;
   type IfUnknown<IFTYPE, THENTYPE> = unknown extends IFTYPE ? THENTYPE : IFTYPE;
 
+  type WithLevel1NestedPaths<T, K extends keyof T = keyof T> = {
+    [P in K | NestedPaths<Required<T>, K>]: P extends K
+      ? T[P]
+      : P extends `${infer Key}.${infer Rest}`
+        ? Key extends keyof T
+          ? Rest extends keyof NonNullable<T[Key]>
+            ? NonNullable<T[Key]>[Rest]
+            : never
+          : never
+        : never;
+  };
+
+  type NestedPaths<T, K extends keyof T> = K extends string
+    ? T[K] extends Record<string, any> | null | undefined
+      ? `${K}.${keyof NonNullable<T[K]> & string}`
+      : never
+    : never;
+
+  type WithoutUndefined<T> = T extends undefined ? never : T;
+
   /**
     * @summary Removes keys from a type
     * @description It helps to exclude keys from a type


### PR DESCRIPTION
Fix #14615
Re: #13836
Re: #12064

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fixes #14615 by inferring the type of 1-level deep schema paths to help with query filters. Consider the following schema:

```
  const FooSchema = new Schema({
    one: { type: String }
  });

  const MyRecordSchema = new Schema({
    _id: { type: String },
    foo: { type: FooSchema }
  });
```

Currently, Mongoose can infer `await MyRecord.distinct('foo').exec()` return type because `foo` is a top-level path. But not `await MyRecord.distinct('foo.one').exec()` because `foo.one` is nested.

As per discussion in #12064, we don't want to infer arbitrarily deep nested paths: too risky because we don't want to run into the dreaded `Type instantiation is excessively deep and possibly infinite` error in an unforeseen case, and we don't want to cause performance issues.

However, #14615 encourages us to consider just the case of 1-level deep nested paths. If we cut off at 1 level, we don't need to worry about infinite recursion and risk of performance degradation is much lower.

This PR adds a reasonably simple `WithLevel1NestedPaths` helper which, given a type, also adds all the 1-level deep nested paths to the result type. That makes it easy to get the correct result type for `distinct()` with 1-level deep nested paths. This PR intentionally avoids arrays.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
