### PR TITLE
docs(migrating_to_7): add id setter to Mongoose 7 migration guide

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -16,6 +16,7 @@ If you're still on Mongoose 5.x, please read the [Mongoose 5.x to 6.x migration 
 * [Dropped callback support](#dropped-callback-support)
 * [Removed `update()`](#removed-update)
 * [ObjectId requires `new`](#objectid-requires-new)
+* [`id` setter](#id-setter)
 * [Discriminator schemas use base schema options by default](#discriminator-schemas-use-base-schema-options-by-default)
 * [Removed `castForQueryWrapper()`, updated `castForQuery()` signature](#removed-castforquerywrapper)
 * [Copy schema options in `Schema.prototype.add()`](#copy-schema-options-in-schema-prototype-add)
@@ -195,6 +196,31 @@ In Mongoose 7, `ObjectId` is now a [JavaScript class](https://masteringjs.io/tut
 // Works in Mongoose 6 and Mongoose 7
 const oid = new mongoose.Types.ObjectId('0'.repeat(24));
 ```
+
+<h2 id="id-setter"><a href="#id-setter"><code>id</code> Setter</a></h2>
+
+Starting in Mongoose 7.4, Mongoose's built-in `id` virtual (which stores the document's `_id` as a string) has a setter which allows modifying the document's `_id` property via `id`.
+
+```javascript
+const doc = await TestModel.findOne();
+
+doc.id = '000000000000000000000000';
+doc._id; // ObjectId('000000000000000000000000')
+```
+
+This can cause surprising behavior if you create a `new TestModel(obj)` where `obj` contains both an `id` and an `_id`, or if you use `doc.set()`
+
+```javascript
+// Because `id` is after `_id`, the `id` will overwrite the `_id`
+const doc = new TestModel({
+  _id: '000000000000000000000000',
+  id: '111111111111111111111111'
+});
+
+doc._id; // ObjectId('111111111111111111111111')
+```
+
+[The `id` setter was later removed in Mongoose 8](/docs/migrating_to_8.html#removed-id-setter) due to compatibility issues.
 
 <h2 id="discriminator-schemas-use-base-schema-options-by-default"><a href="#discriminator-schemas-use-base-schema-options-by-default">Discriminator schemas use base schema options by default</a></h2>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #13762, specifically [this comment](https://github.com/Automattic/mongoose/issues/13762#issuecomment-2108700170). The `id` setter has caused enough confusion that we should mention it in the migration guide.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
