### PR TITLE
BREAKING CHANGE: call virtual `ref` function with subdoc, not top-level doc

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -410,7 +410,15 @@ function _virtualPopulate(model, docs, options, _virtualRes) {
       justOne = options.justOne;
     }
 
-    modelNames = virtual._getModelNamesForPopulate(doc);
+    // Use the correct target doc/sub-doc for dynamic ref on nested schema. See gh-12363
+    if (_virtualRes.nestedSchemaPath && typeof virtual.options.ref === 'function') {
+      const subdocs = utils.getValue(_virtualRes.nestedSchemaPath, doc);
+      modelNames = Array.isArray(subdocs)
+        ? subdocs.flatMap(subdoc => virtual._getModelNamesForPopulate(subdoc))
+        : virtual._getModelNamesForPopulate(subdocs);
+    } else {
+      modelNames = virtual._getModelNamesForPopulate(doc);
+    }
     if (virtual.options.refPath) {
       justOne = !!virtual.options.justOne;
       data.isRefPath = true;

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -4280,10 +4280,11 @@ describe('model: populate:', function() {
         ]);
         await Parent.create([
           { b: { name: 'test1', referencedModel: 'Test1', aId: as[0]._id } },
-          { b: { name: 'test2', referencedModel: 'Test2', aId: as[1]._id } }
+          { b: { name: 'test2', referencedModel: 'Test2', aId: as[1]._id } },
+          { b: { name: 'test3', referencedModel: 'Test2', aId: '0'.repeat(24) } }
         ]);
         const parents = await Parent.find().populate('b.a').sort({ _id: 1 });
-        assert.deepStrictEqual(parents.map(p => p.b.a.name), ['a1', 'a2']);
+        assert.deepStrictEqual(parents.map(p => p.b.a?.name), ['a1', 'a2', undefined]);
       });
 
       it('with functions for match (gh-7397)', async function() {

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -4247,6 +4247,45 @@ describe('model: populate:', function() {
           catch(done);
       });
 
+      it('with functions for ref with subdoc virtual populate (gh-12440) (gh-12363)', async function() {
+        const ASchema = new Schema({
+          name: String
+        });
+
+        const BSchema = new Schema({
+          referencedModel: String,
+          aId: ObjectId
+        });
+
+        BSchema.virtual('a', {
+          ref: function() {
+            return this.referencedModel;
+          },
+          localField: 'aId',
+          foreignField: '_id',
+          justOne: true
+        });
+
+        const ParentSchema = new Schema({
+          b: BSchema
+        });
+
+        const A1 = db.model('Test1', ASchema);
+        const A2 = db.model('Test2', ASchema);
+        const Parent = db.model('Parent', ParentSchema);
+
+        const as = await Promise.all([
+          A1.create({ name: 'a1' }),
+          A2.create({ name: 'a2' })
+        ]);
+        await Parent.create([
+          { b: { name: 'test1', referencedModel: 'Test1', aId: as[0]._id } },
+          { b: { name: 'test2', referencedModel: 'Test2', aId: as[1]._id } }
+        ]);
+        const parents = await Parent.find().populate('b.a').sort({ _id: 1 });
+        assert.deepStrictEqual(parents.map(p => p.b.a.name), ['a1', 'a2']);
+      });
+
       it('with functions for match (gh-7397)', async function() {
         const ASchema = new Schema({
           name: String,
@@ -6642,8 +6681,8 @@ describe('model: populate:', function() {
       });
 
       clickedSchema.virtual('users_$', {
-        ref: function(doc) {
-          return doc.events[0].users[0].refKey;
+        ref: function(subdoc) {
+          return subdoc.users[0].refKey;
         },
         localField: 'users.ID',
         foreignField: 'employeeId'
@@ -6706,8 +6745,8 @@ describe('model: populate:', function() {
       });
 
       clickedSchema.virtual('users_$', {
-        ref: function(doc) {
-          const refKeys = doc.events[0].users.map(user => user.refKey);
+        ref: function(subdoc) {
+          const refKeys = subdoc.users.map(user => user.refKey);
           return refKeys;
         },
         localField: 'users.ID',


### PR DESCRIPTION
Fix #12363
Fix #12440

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The primary issue from #12363 and #12440 is that right now we call `ref()` functions on virtuals with the top-level document rather than the subdocument, even if the virtual is defined on the subdocument. For example, in Mongoose 8, with the following setup, `ref()` would see `this` as an instance of `ParentSchema`, not the `b` subdocument.

```javascript
        const ASchema = new Schema({
          name: String
        });

        const BSchema = new Schema({
          referencedModel: String,
          aId: ObjectId
        });

        BSchema.virtual('a', {
          ref: function() {
            return this.referencedModel;
          },
          localField: 'aId',
          foreignField: '_id',
          justOne: true
        });

        const ParentSchema = new Schema({
          b: BSchema
        });

        const A1 = db.model('Test1', ASchema);
        const A2 = db.model('Test2', ASchema);
        const Parent = db.model('Parent', ParentSchema);
```

With this PR, we will call `ref()` with the subdocument. This is more consistent with how things work in conventional populate: `ref()` would get called with the subdoc in virtual populate, see #8469 and [this test](https://github.com/Automattic/mongoose/blob/c71ba5e044ee1f84d1fa85a2c21a90fad2e90f72/test/model.populate.test.js#L9870-L9920).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

If you're using `ref()` as a function, it is easier to get the top-level document from the subdocument (using `subdoc.ownerDocument()`) than it is to get the correct subdocument from the top-level document. Plus, calling `ref()` with the subdocument helps make schemas easier to reuse.

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
