### PR TITLE
Fix problem when deleting an entry on a populated Map

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -119,7 +119,7 @@ class MongooseMap extends Map {
           v.$__.wasPopulated = { value: v._id };
           return v;
         });
-      } else {
+      } else if (value) { // Fix when using delete method because the value is undefined
         if (value.$__ == null) {
           value = new populated.options[populateModelSymbol](value);
         }

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -119,7 +119,7 @@ class MongooseMap extends Map {
           v.$__.wasPopulated = { value: v._id };
           return v;
         });
-      } else if (value) { // Fix when using delete method because the value is undefined
+      } else if (value != null) {
         if (value.$__ == null) {
           value = new populated.options[populateModelSymbol](value);
         }


### PR DESCRIPTION
**Summary**

I had a bug when deleting an entry from a populated Map.

**Examples**

```js
import mongoose, { Schema } from 'mongoose';
import connectToDatabase from '@/server/libs/database/mongoose';

await connectToDatabase();

const playerSchema = new mongoose.Schema({
  name: String,
});

const PlayerModel = mongoose.model('PlayerTest', playerSchema);

const characterSchema = new mongoose.Schema({
  name: String,
  items: [{
    type: Schema.Types.ObjectId,
    ref: 'ItemTest',
  }],
});

const CharacterModel = mongoose.model('CharacterTest', characterSchema);

const itemSchema = new mongoose.Schema({
  name: String,
});

const ItemModel = mongoose.model('ItemTest', itemSchema);

const gameSchema = new mongoose.Schema({
  characters: {
    type: Map,
    of: {
      type: Schema.Types.ObjectId,
      ref: 'CharacterTest',
    },
    required: true,
  },
});

const GameModel = mongoose.model('GameTest', gameSchema);

const playerTest = await PlayerModel.create({ name: 'Player 1' });
const itemTest = await ItemModel.create({ name: 'Item 1' });
const characterTest = await CharacterModel.create({
  name: 'Character 1',
  items: [itemTest],
});

const gameTest = await GameModel.create({
  characters: {
    [playerTest.id]: characterTest,
  },
});

await gameTest.populate('characters');

console.log(gameTest.characters);

try {
  gameTest.characters.delete(playerTest.id); // <-- This will throw an error
  console.log('Deleted character from game');
} catch (err) {
  console.error(err); // TypeError: Cannot read properties of undefined (reading '$__')
}
```
