### PR TITLE
types: avoid inferring Boolean, Buffer, ObjectId as Date in schema definitions under certain circumstances

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -493,7 +493,7 @@ declare module 'mongoose' {
   export type NumberSchemaDefinition = typeof Number | 'number' | 'Number' | typeof Schema.Types.Number;
   export type StringSchemaDefinition = typeof String | 'string' | 'String' | typeof Schema.Types.String;
   export type BooleanSchemaDefinition = typeof Boolean | 'boolean' | 'Boolean' | typeof Schema.Types.Boolean;
-  export type DateSchemaDefinition = typeof NativeDate | 'date' | 'Date' | typeof Schema.Types.Date;
+  export type DateSchemaDefinition = DateConstructor | 'date' | 'Date' | typeof Schema.Types.Date;
   export type ObjectIdSchemaDefinition = 'ObjectId' | 'ObjectID' | typeof Schema.Types.ObjectId;
 
   export type SchemaDefinitionWithBuiltInClass<T> = T extends number


### PR DESCRIPTION
Fix #14630

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14630 pointed out that, under certain circumstances that I'm unable to quantify exactly, `Boolean`, `mongoose.Schema.Types.ObjectId`, and several other schema types get inferred as dates. This doesn't happen in tsd, or if Mongoose is symlinked into node_modules, so we can't write tests for this issue with our current testing setup.

I tracked the issue down to somehow `typeof NativeDate` catching `Boolean` and other data class types. This PR appears to fix the issue, and doesn't break any existing code that we're currently aware of.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
