### PR TITLE
docs(findoneandupdate): improve example that shows findOneAndUpdate() returning doc before updates were applied

### DIFF
--- a/docs/tutorials/findoneandupdate.md
+++ b/docs/tutorials/findoneandupdate.md
@@ -19,6 +19,8 @@ function findOneAndUpdate(filter, update, options) {}
 ```
 
 By default, `findOneAndUpdate()` returns the document as it was **before** `update` was applied.
+In the following example, `doc` initially only has `name` and `_id` properties.
+`findOneAndUpdate()` adds an `age` property, but the result of `findOneAndUpdate()` does **not** have an `age` property.
 
 ```acquit
 [require:Tutorial.*findOneAndUpdate.*basic case]

--- a/test/docs/findoneandupdate.test.js
+++ b/test/docs/findoneandupdate.test.js
@@ -40,16 +40,18 @@ describe('Tutorial: findOneAndUpdate()', function() {
       age: Number
     }));
 
-    await Character.create({ name: 'Jean-Luc Picard' });
+    const _id = new mongoose.Types.ObjectId('0'.repeat(24));
+    let doc = await Character.create({ _id, name: 'Jean-Luc Picard' });
+    doc; // { name: 'Jean-Luc Picard', _id: ObjectId('000000000000000000000000') }
 
     const filter = { name: 'Jean-Luc Picard' };
     const update = { age: 59 };
 
-    // `doc` is the document _before_ `update` was applied
-    let doc = await Character.findOneAndUpdate(filter, update);
-    doc.name; // 'Jean-Luc Picard'
-    doc.age; // undefined
+    // The result of `findOneAndUpdate()` is the document _before_ `update` was applied
+    doc = await Character.findOneAndUpdate(filter, update);
+    doc; // { name: 'Jean-Luc Picard', _id: ObjectId('000000000000000000000000') }
     // acquit:ignore:start
+    assert.equal(doc._id.toHexString(), _id.toHexString());
     assert.equal(doc.name, 'Jean-Luc Picard');
     assert.equal(doc.age, undefined);
     // acquit:ignore:end


### PR DESCRIPTION
Fix #14670

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Add a little more clarification on the "returns document as it was before updates were applied" section to be a bit more explicit.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
