### PR TITLE
perf: avoid unnecesary get() call and use faster approach for converting to string

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4066,7 +4066,8 @@ Document.prototype.toObject = function(options) {
 
 function applyVirtuals(self, json, options, toObjectOptions) {
   const schema = self.$__schema;
-  const paths = Object.keys(schema.virtuals);
+  const virtuals = schema.virtuals;
+  const paths = Object.keys(virtuals);
   let i = paths.length;
   const numPaths = i;
   let path;
@@ -4117,7 +4118,7 @@ function applyVirtuals(self, json, options, toObjectOptions) {
       assignPath = path.substring(options.path.length + 1);
     }
     if (assignPath.indexOf('.') === -1 && assignPath === path) {
-      v = self.get(path, null, { noDottedPath: true });
+      v = virtuals[path].applyGetters(void 0, self);
       v = clone(v, options);
       if (v === void 0) {
         continue;

--- a/lib/helpers/schema/idGetter.js
+++ b/lib/helpers/schema/idGetter.js
@@ -27,7 +27,7 @@ module.exports = function addIdGetter(schema) {
 
 function idGetter() {
   if (this._id != null) {
-    return String(this._id);
+    return this._id.toString();
   }
 
   return null;

--- a/test/document.unit.test.js
+++ b/test/document.unit.test.js
@@ -37,12 +37,11 @@ describe('toObject()', function() {
 
   beforeEach(function() {
     Stub = function() {
-      const schema = this.$__schema = {
+      this.$__schema = {
         options: { toObject: { minimize: false, virtuals: true } },
-        virtuals: { virtual: 'test' }
+        virtuals: { virtual: { applyGetters: () => 'test' } }
       };
       this._doc = { empty: {} };
-      this.get = function(path) { return schema.virtuals[path]; };
       this.$__ = {};
     };
     Stub.prototype = Object.create(mongoose.Document.prototype);


### PR DESCRIPTION
Re: #14394

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Turns out `.toString()` is significantly faster than `String()` for converting values to strings:

![image](https://github.com/Automattic/mongoose/assets/1620265/01c7cbc2-f09d-4915-ae48-d949a460663f)

This PR gives us maybe 12% speedup on `recursiveToObject` benchmark with no breaking changes :sunglasses: 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
