### PR TITLE
fix(query): cast $pull using embedded discriminator schema when discriminator key is set in filter

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -202,6 +202,12 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
     // an update.
     if (op === '$pull') {
       schematype = schema._getSchema(prefix + key);
+      if (schematype == null) {
+        const _res = getEmbeddedDiscriminatorPath(schema, obj, filter, prefix + key, options);
+        if (_res.schematype != null) {
+          schematype = _res.schematype;
+        }
+      }
       if (schematype != null && schematype.schema != null) {
         obj[key] = cast(schematype.schema, obj[key], options, context);
         hasKeys = true;


### PR DESCRIPTION
Fix #14675

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

For other update operators, we correctly handle casting embedded discriminator paths when we can infer the embedded discriminator type from the filter. But looks like not for `$pull`. This PR fixes that.

We should really clean up the duplicated `_getSchema()` followed by `getEmbeddedDiscriminatorPath()` calls. Looks like the only reason why we need to call `_getSchema()` is because of `$fullPath`, but we need to investigate some more to figure that out.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
