### PR TITLE
Remove default connection if setting createInitialConnection to false after Mongoose instance created

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -436,6 +436,11 @@ Mongoose.prototype.connect = async function connect(uri, options) {
   }
 
   const _mongoose = this instanceof Mongoose ? this : mongoose;
+  if (_mongoose.connection == null) {
+    const conn = this.createConnection(); // default connection
+    conn[defaultConnectionSymbol] = true;
+    conn.models = this.models;
+  }
   const conn = _mongoose.connection;
 
   return conn.openUri(uri, options).then(() => _mongoose);

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -33,6 +33,7 @@ const SetOptionError = require('./error/setOptionError');
 const applyEmbeddedDiscriminators = require('./helpers/discriminator/applyEmbeddedDiscriminators');
 
 const defaultMongooseSymbol = Symbol.for('mongoose:default');
+const defaultConnectionSymbol = Symbol('mongoose:defaultConnection');
 
 require('./helpers/printJestWarning');
 
@@ -73,6 +74,7 @@ function Mongoose(options) {
   const createInitialConnection = utils.getOption('createInitialConnection', this.options) ?? true;
   if (createInitialConnection && this.__driver != null) {
     const conn = this.createConnection(); // default connection
+    conn[defaultConnectionSymbol] = true;
     conn.models = this.models;
   }
 
@@ -291,6 +293,16 @@ Mongoose.prototype.set = function(key, value) {
         _mongoose.transactionAsyncLocalStorage = new AsyncLocalStorage();
       } else if (!optionValue && _mongoose.transactionAsyncLocalStorage) {
         delete _mongoose.transactionAsyncLocalStorage;
+      }
+    } else if (optionKey === 'createInitialConnection') {
+      if (optionValue && !_mongoose.connection) {
+        const conn = this.createConnection(); // default connection
+        conn[defaultConnectionSymbol] = true;
+        conn.models = this.models;
+      } else if (optionValue === false && _mongoose.connection && _mongoose.connection[defaultConnectionSymbol]) {
+        if (_mongoose.connection.readyState === STATES.disconnected && Object.keys(_mongoose.connection.models).length === 0) {
+          _mongoose.connections.shift();
+        }
       }
     }
   }

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -73,9 +73,7 @@ function Mongoose(options) {
   }, options);
   const createInitialConnection = utils.getOption('createInitialConnection', this.options) ?? true;
   if (createInitialConnection && this.__driver != null) {
-    const conn = this.createConnection(); // default connection
-    conn[defaultConnectionSymbol] = true;
-    conn.models = this.models;
+    _createDefaultConnection(this);
   }
 
   if (this.options.pluralization) {
@@ -296,9 +294,7 @@ Mongoose.prototype.set = function(key, value) {
       }
     } else if (optionKey === 'createInitialConnection') {
       if (optionValue && !_mongoose.connection) {
-        const conn = this.createConnection(); // default connection
-        conn[defaultConnectionSymbol] = true;
-        conn.models = this.models;
+        _createDefaultConnection(_mongoose);
       } else if (optionValue === false && _mongoose.connection && _mongoose.connection[defaultConnectionSymbol]) {
         if (_mongoose.connection.readyState === STATES.disconnected && Object.keys(_mongoose.connection.models).length === 0) {
           _mongoose.connections.shift();
@@ -437,9 +433,7 @@ Mongoose.prototype.connect = async function connect(uri, options) {
 
   const _mongoose = this instanceof Mongoose ? this : mongoose;
   if (_mongoose.connection == null) {
-    const conn = this.createConnection(); // default connection
-    conn[defaultConnectionSymbol] = true;
-    conn.models = this.models;
+    _createDefaultConnection(_mongoose);
   }
   const conn = _mongoose.connection;
 
@@ -1331,6 +1325,20 @@ Mongoose.prototype.overwriteMiddlewareResult = Kareem.overwriteResult;
  */
 
 Mongoose.prototype.omitUndefined = require('./helpers/omitUndefined');
+
+/*!
+ * Create a new default connection (`mongoose.connection`) for a Mongoose instance.
+ * No-op if there is already a default connection.
+ */
+
+function _createDefaultConnection(mongoose) {
+  if (mongoose.connection) {
+    return;
+  }
+  const conn = mongoose.createConnection(); // default connection
+  conn[defaultConnectionSymbol] = true;
+  conn.models = mongoose.models;
+}
 
 /**
  * The exports object is an instance of Mongoose.

--- a/lib/validOptions.js
+++ b/lib/validOptions.js
@@ -15,6 +15,7 @@ const VALID_OPTIONS = Object.freeze([
   'bufferCommands',
   'bufferTimeoutMS',
   'cloneSchemas',
+  'createInitialConnection',
   'debug',
   'id',
   'timestamps.createdAt.immutable',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1189,5 +1189,14 @@ describe('mongoose module:', function() {
 
     const conn = m.createConnection();
     assert.equal(conn, m.connection);
+
+    const m2 = new mongoose.Mongoose();
+    assert.ok(m2.connection);
+    m2.set('createInitialConnection', false);
+    assert.strictEqual(m2.connection, undefined);
+
+    await m2.connect(start.uri);
+    assert.ok(m2.connection);
+    await m2.disconnect();
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1180,4 +1180,14 @@ describe('mongoose module:', function() {
       }
     });
   });
+
+  it('setting createInitialConnection after creation deletes existing connection (gh-8302)', async function() {
+    const m = new mongoose.Mongoose();
+    assert.ok(m.connection);
+    m.set('createInitialConnection', false);
+    assert.strictEqual(m.connection, undefined);
+
+    const conn = m.createConnection();
+    assert.equal(conn, m.connection);
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1192,7 +1192,7 @@ describe('mongoose module:', function() {
       await m.disconnect();
     });
 
-    it('should delete existing connection when setting createInitialConnection to false (part 1)', function() {
+    it('should delete existing connection when setting createInitialConnection to false', function() {
       assert.ok(m.connection);
       m.set('createInitialConnection', false);
       assert.strictEqual(m.connection, undefined);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1181,22 +1181,51 @@ describe('mongoose module:', function() {
     });
   });
 
-  it('setting createInitialConnection after creation deletes existing connection (gh-8302)', async function() {
-    const m = new mongoose.Mongoose();
-    assert.ok(m.connection);
-    m.set('createInitialConnection', false);
-    assert.strictEqual(m.connection, undefined);
+  describe('createInitialConnection (gh-8302)', function() {
+    let m;
 
-    const conn = m.createConnection();
-    assert.equal(conn, m.connection);
+    beforeEach(function() {
+      m = new mongoose.Mongoose();
+    });
 
-    const m2 = new mongoose.Mongoose();
-    assert.ok(m2.connection);
-    m2.set('createInitialConnection', false);
-    assert.strictEqual(m2.connection, undefined);
+    afterEach(async function() {
+      await m.disconnect();
+    });
 
-    await m2.connect(start.uri);
-    assert.ok(m2.connection);
-    await m2.disconnect();
+    it('should delete existing connection when setting createInitialConnection to false (part 1)', function() {
+      assert.ok(m.connection);
+      m.set('createInitialConnection', false);
+      assert.strictEqual(m.connection, undefined);
+    });
+
+    it('should create connection when createConnection is called', function() {
+      m.set('createInitialConnection', false);
+      const conn = m.createConnection();
+      assert.equal(conn, m.connection);
+    });
+
+    it('should create a new connection automatically when connect() is called if no existing default connection', async function() {
+      assert.ok(m.connection);
+      m.set('createInitialConnection', false);
+      assert.strictEqual(m.connection, undefined);
+
+      await m.connect(start.uri);
+      assert.ok(m.connection);
+    });
+
+    it('should not delete default connection if it has models', async function() {
+      assert.ok(m.connection);
+      m.model('Test', new m.Schema({ name: String }));
+      m.set('createInitialConnection', false);
+      assert.ok(m.connection);
+    });
+
+    it('should not delete default connection if it is connected', async function() {
+      assert.ok(m.connection);
+      await m.connect(start.uri);
+      m.set('createInitialConnection', false);
+      assert.ok(m.connection);
+      assert.equal(m.connection.readyState, 1);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now there's always a default `mongoose.connection`. We added a `createInitialConnection` option that prevents new `Mongoose` instances from creating a default connection, but that doesn't apply to existing `Mongoose` instances, including the default one. So there's no way to really "delete" the default connection in the API.

With this PR, `mongoose.set('createInitialConnection', false)` will also remove the default connection, presuming it isn't connected and there are no models already on it.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
