### PR TITLE
feat(connection): bubble up monitorCommands events to Mongoose connection if `monitorCommands` option set

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -410,6 +410,12 @@ function _setClient(conn, client, options, dbName) {
     });
   }
 
+  if (options.monitorCommands) {
+    client.on('commandStarted', (data) => conn.emit('commandStarted', data));
+    client.on('commandFailed', (data) => conn.emit('commandFailed', data));
+    client.on('commandSucceeded', (data) => conn.emit('commandSucceeded', data));
+  }
+
   conn.onOpen();
 
   for (const i in conn.collections) {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -210,7 +210,7 @@ describe('connections:', function() {
     let conn;
 
     before(async function() {
-      conn = mongoose.createConnection(start.uri2);
+      conn = mongoose.createConnection(start.uri2, { monitorCommands: true });
       await conn.asPromise();
       await conn.collection('test').deleteMany({});
       return conn;
@@ -253,6 +253,28 @@ describe('connections:', function() {
       assert.equal(events[1].collectionName, 'test');
       assert.equal(events[1].method, 'findOne');
       assert.deepStrictEqual(events[1].result, { _id: 17, answer: 42 });
+    });
+
+    it('commandStarted, commandFailed, commandSucceeded (gh-14611)', async function() {
+      let events = [];
+      conn.on('commandStarted', event => events.push(event));
+      conn.on('commandFailed', event => events.push(event));
+      conn.on('commandSucceeded', event => events.push(event));
+
+      await conn.collection('test').insertOne({ _id: 14611, answer: 42 });
+      assert.equal(events.length, 2);
+      assert.equal(events[0].constructor.name, 'CommandStartedEvent');
+      assert.equal(events[0].commandName, 'insert');
+      assert.equal(events[1].constructor.name, 'CommandSucceededEvent');
+      assert.equal(events[1].requestId, events[0].requestId);
+
+      events = [];
+      await conn.createCollection('tests', { capped: 1024 }).catch(() => {});
+      assert.equal(events.length, 2);
+      assert.equal(events[0].constructor.name, 'CommandStartedEvent');
+      assert.equal(events[0].commandName, 'create');
+      assert.equal(events[1].constructor.name, 'CommandFailedEvent');
+      assert.equal(events[1].requestId, events[0].requestId);
     });
   });
 


### PR DESCRIPTION
Fix #14611

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

MongoDB driver introduced a handy set of `commandStarted`, `commandFailed`, `commandSucceeded` events that are great for monitoring performance. With this PR, we'll bubble those events up to the Mongoose connection if the `monitorCommands` option is set.

We shouldn't need to add `monitorCommands` to Mongoose's `ConnectOptions` because `monitorCommands` is already an option in MongoDB driver's connection options: https://github.com/mongodb/node-mongodb-native/blob/8fb43f86b22f98e488a3a98c0b562ca240ffdaa1/src/cmap/connection.ts#L118

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
