### PR TITLE
feat(mongoose): allow drivers to set global plugins

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -171,6 +171,14 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
   }
   _mongoose.__driver = driver;
 
+  if (Array.isArray(driver.plugins)) {
+    for (const plugin of driver.plugins) {
+      if (typeof plugin === 'function') {
+        _mongoose.plugin(plugin);
+      }
+    }
+  }
+
   const Connection = driver.Connection;
   const oldDefaultConnection = _mongoose.connections[0];
   _mongoose.connections = [new Connection(_mongoose)];

--- a/test/driver.test.js
+++ b/test/driver.test.js
@@ -34,10 +34,12 @@ describe('driver', function() {
     }
     const driver = {
       Collection,
-      Connection
+      Connection,
+      plugins: [foo]
     };
 
     m.setDriver(driver);
+    assert.deepStrictEqual(m.plugins.slice(mongoose.plugins.length), [[foo, undefined]]);
 
     await m.connect();
 
@@ -45,6 +47,8 @@ describe('driver', function() {
 
     const res = await Test.findOne();
     assert.deepEqual(res.toObject(), { answer: 42 });
+
+    function foo() {}
   });
 
   it('multiple drivers (gh-12638)', async function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

One thing that's unfortunately missing from the driver API is the ability to set global plugins. Drivers can always do `mongoose.plugin(myPlugin)`, but the problem is that assumes you only have one Mongoose instance. If a user were to do `const mongoose = new Mongoose(); mongoose.setDriver(myDriver);`, then there's no way for that driver to apply plugins to the new Mongoose instance.

With this PR, drivers can export a `plugins` array that `setDriver()` will look for, and apply plugins to the Mongoose instance.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
