### PR TITLE
fix(document): avoid passing validateModifiedOnly to subdocs so subdocs get fully validating if they're directly modified

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3053,7 +3053,6 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
       const doValidateOptions = {
         ...doValidateOptionsByPath[path],
         path: path,
-        validateModifiedOnly: shouldValidateModifiedOnly,
         validateAllPaths
       };
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -2570,7 +2570,7 @@ describe('document', function() {
           type: String,
           required: true
         },
-        testArray: [embedSchema],
+        testArray: [embedSchema]
       });
       const TestModel = db.model('Test', testSchema);
 


### PR DESCRIPTION
Fix #14677

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now we propagate `validateModifiedOnly` to subdocument `validate()`, which causes problems when a subdocument is directly modified. If you overwrite the full subdocument, we should validate the whole subdocument, not just the subdocs modified paths.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
