### PR TITLE
fix(projection): handle projections on arrays in `Model.hydrate()` projection option

### DIFF
--- a/lib/helpers/projection/applyProjection.js
+++ b/lib/helpers/projection/applyProjection.js
@@ -35,6 +35,9 @@ function applyExclusiveProjection(doc, projection, hasIncludedChildren, projecti
   if (doc == null || typeof doc !== 'object') {
     return doc;
   }
+  if (Array.isArray(doc)) {
+    return doc.map(el => applyExclusiveProjection(el, projection, hasIncludedChildren, projectionLimb, prefix));
+  }
   const ret = { ...doc };
   projectionLimb = prefix ? (projectionLimb || {}) : projection;
 
@@ -56,6 +59,9 @@ function applyExclusiveProjection(doc, projection, hasIncludedChildren, projecti
 function applyInclusiveProjection(doc, projection, hasIncludedChildren, projectionLimb, prefix) {
   if (doc == null || typeof doc !== 'object') {
     return doc;
+  }
+  if (Array.isArray(doc)) {
+    return doc.map(el => applyInclusiveProjection(el, projection, hasIncludedChildren, projectionLimb, prefix));
   }
   const ret = { ...doc };
   projectionLimb = prefix ? (projectionLimb || {}) : projection;

--- a/test/helpers/projection.applyProjection.test.js
+++ b/test/helpers/projection.applyProjection.test.js
@@ -21,4 +21,15 @@ describe('applyProjection', function() {
     assert.deepEqual(applyProjection(obj, { 'nested.str2': 0 }), { str: 'test', nested: { num3: 42 } });
     assert.deepEqual(applyProjection(obj, { nested: { num3: 0 } }), { str: 'test', nested: { str2: 'test2' } });
   });
+
+  it('handles projections underneath arrays (gh-14680)', function() {
+    const obj = {
+      _id: 12,
+      testField: 'foo',
+      testArray: [{ _id: 42, field1: 'bar' }]
+    };
+
+    assert.deepEqual(applyProjection(obj, { 'testArray.field1': 1 }), { testArray: [{ field1: 'bar' }] });
+    assert.deepEqual(applyProjection(obj, { 'testArray.field1': 0, _id: 0 }), { testField: 'foo', testArray: [{ _id: 42 }] });
+  });
 });


### PR DESCRIPTION
Fix #14680

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Our `applyProjection()` helper doesn't currently handle projections underneath arrays. This PR should fix that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
