### PR TITLE
fix: handle casting primitive array with $elemMatch in bulkWrite()

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -607,24 +607,7 @@ function cast$elemMatch(val, context) {
     }
   }
 
-  // Is this an embedded discriminator and is the discriminator key set?
-  // If so, use the discriminator schema. See gh-7449
-  const discriminatorKey = this &&
-    this.casterConstructor &&
-    this.casterConstructor.schema &&
-    this.casterConstructor.schema.options &&
-    this.casterConstructor.schema.options.discriminatorKey;
-  const discriminators = this &&
-  this.casterConstructor &&
-  this.casterConstructor.schema &&
-  this.casterConstructor.schema.discriminators || {};
-  if (discriminatorKey != null &&
-      val[discriminatorKey] != null &&
-      discriminators[val[discriminatorKey]] != null) {
-    return cast(discriminators[val[discriminatorKey]], val, null, this && this.$$context);
-  }
-  const schema = this.casterConstructor.schema ?? context.schema;
-  return cast(schema, val, null, this && this.$$context);
+  return val;
 }
 
 const handle = SchemaArray.prototype.$conditionalHandlers = {};

--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -11,9 +11,11 @@ const SchemaArray = require('./array');
 const SchemaDocumentArrayOptions =
   require('../options/schemaDocumentArrayOptions');
 const SchemaType = require('../schemaType');
+const cast = require('../cast');
 const discriminator = require('../helpers/model/discriminator');
 const handleIdOption = require('../helpers/schema/handleIdOption');
 const handleSpreadDoc = require('../helpers/document/handleSpreadDoc');
+const isOperator = require('../helpers/query/isOperator');
 const utils = require('../utils');
 const getConstructor = require('../helpers/discriminator/getConstructor');
 const InvalidSchemaOptionError = require('../error/invalidSchemaOption');
@@ -114,6 +116,7 @@ SchemaDocumentArray.options = { castNonArrays: true };
 SchemaDocumentArray.prototype = Object.create(SchemaArray.prototype);
 SchemaDocumentArray.prototype.constructor = SchemaDocumentArray;
 SchemaDocumentArray.prototype.OptionsConstructor = SchemaDocumentArrayOptions;
+SchemaDocumentArray.prototype.$conditionalHandlers = { ...SchemaArray.prototype.$conditionalHandlers };
 
 /*!
  * ignore
@@ -608,6 +611,44 @@ SchemaDocumentArray.setters = [];
  */
 
 SchemaDocumentArray.get = SchemaType.get;
+
+/*!
+ * Handle casting $elemMatch operators
+ */
+
+SchemaDocumentArray.prototype.$conditionalHandlers.$elemMatch = cast$elemMatch;
+
+function cast$elemMatch(val, context) {
+  const keys = Object.keys(val);
+  const numKeys = keys.length;
+  for (let i = 0; i < numKeys; ++i) {
+    const key = keys[i];
+    const value = val[key];
+    if (isOperator(key) && value != null) {
+      val[key] = this.castForQuery(key, value, context);
+    }
+  }
+
+  // Is this an embedded discriminator and is the discriminator key set?
+  // If so, use the discriminator schema. See gh-7449
+  const discriminatorKey = this &&
+    this.casterConstructor &&
+    this.casterConstructor.schema &&
+    this.casterConstructor.schema.options &&
+    this.casterConstructor.schema.options.discriminatorKey;
+  const discriminators = this &&
+  this.casterConstructor &&
+  this.casterConstructor.schema &&
+  this.casterConstructor.schema.discriminators || {};
+  if (discriminatorKey != null &&
+      val[discriminatorKey] != null &&
+      discriminators[val[discriminatorKey]] != null) {
+    return cast(discriminators[val[discriminatorKey]], val, null, this && this.$$context);
+  }
+
+  const schema = this.casterConstructor.schema ?? context.schema;
+  return cast(schema, val, null, this && this.$$context);
+}
 
 /*!
  * Module exports.

--- a/test/model.query.casting.test.js
+++ b/test/model.query.casting.test.js
@@ -453,7 +453,10 @@ describe('model query casting', function() {
       const id = post._id.toString();
 
       await post.save();
-      const doc = await BlogPostB.findOne({ _id: id, comments: { $not: { $elemMatch: { _id: commentId.toString() } } } });
+      const doc = await BlogPostB.findOne({
+        _id: id,
+        comments: { $not: { $elemMatch: { _id: commentId.toString() } } }
+      });
       assert.equal(doc, null);
     });
 


### PR DESCRIPTION
Fix #14678

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now, casting `$elemMatch` on a primitive array in `bulkWrite()` throws an error. That's because we have some logic for casting `$elemMatch` in the primitive array schematype that really belongs in the document array schematype, but in the past we've just thrown all conditional handling logic for arrays onto the primitive array schematype.

With this PR, we now have separate `$conditionalHandlers` for document array schematype vs primitive array schematype. And the offending logic that caused #14678 is only on the documentarray schematype.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
