### PR TITLE
types(connection): fix return type of withSession()

### DIFF
--- a/test/types/connection.test.ts
+++ b/test/types/connection.test.ts
@@ -54,6 +54,11 @@ expectType<Promise<void>>(conn.transaction(async(res) => {
   return 'a';
 }, { readConcern: 'majority' }));
 
+expectType<Promise<string>>(conn.withSession(async(res) => {
+  expectType<mongodb.ClientSession>(res);
+  return 'a';
+}));
+
 expectError(conn.user = 'invalid');
 expectError(conn.pass = 'invalid');
 expectError(conn.host = 'invalid');

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -247,7 +247,7 @@ declare module 'mongoose' {
     /** Watches the entire underlying database for changes. Similar to [`Model.watch()`](/docs/api/model.html#model_Model-watch). */
     watch<ResultType extends mongodb.Document = any>(pipeline?: Array<any>, options?: mongodb.ChangeStreamOptions): mongodb.ChangeStream<ResultType>;
 
-    withSession<T = any>(executor: (session: ClientSession) => Promise<T>): T;
+    withSession<T = any>(executor: (session: ClientSession) => Promise<T>): Promise<T>;
   }
 
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

This fixes `Connection.withSession()`'s type definition, which currently doesn't seem to match the implementation [[here](https://github.com/Automattic/mongoose/blob/3ad5b4f932180609ed7e68926fd7ca4abc6228b1/lib/connection.js#L458)].

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

(a test is added instead)