### PR TITLE
feat(query): make sanitizeProjection prevent projecting in paths deselected in the schema

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1143,6 +1143,59 @@ Query.prototype.select = function select() {
 };
 
 /**
+ * Sets this query's `sanitizeProjection` option. If set, `sanitizeProjection` does
+ * two things:
+ *
+ * 1. Enforces that projection values are numbers, not strings.
+ * 2. Prevents using `+` syntax to override properties that are deselected by default.
+ *
+ * With `sanitizeProjection()`, you can pass potentially untrusted user data to `.select()`.
+ *
+ * #### Example
+ *
+ *     const userSchema = new Schema({
+ *       name: String,
+ *       password: { type: String, select: false }
+ *     });
+ *     const UserModel = mongoose.model('User', userSchema);
+ *     const { _id } = await UserModel.create({ name: 'John', password: 'secret' })
+ *
+ *     // The MongoDB server has special handling for string values that start with '$'
+ *     // in projections, which can lead to unexpected leaking of sensitive data.
+ *     let doc = await UserModel.findOne().select({ name: '$password' });
+ *     doc.name; // 'secret'
+ *     doc.password; // undefined
+ *
+ *     // With `sanitizeProjection`, Mongoose forces all projection values to be numbers
+ *     doc = await UserModel.findOne().sanitizeProjection(true).select({ name: '$password' });
+ *     doc.name; // 'John'
+ *     doc.password; // undefined
+ *
+ *     // By default, Mongoose supports projecting in `password` using `+password`
+ *     doc = await UserModel.findOne().select('+password');
+ *     doc.password; // 'secret'
+ *
+ *     // With `sanitizeProjection`, Mongoose prevents projecting in `password` and other
+ *     // fields that have `select: false` in the schema.
+ *     doc = await UserModel.findOne().sanitizeProjection(true).select('+password');
+ *     doc.password; // undefined
+ *
+ * @method sanitizeProjection
+ * @memberOf Query
+ * @instance
+ * @param {Boolean} value
+ * @return {Query} this
+ * @see sanitizeProjection https://thecodebarbarian.com/whats-new-in-mongoose-5-13-sanitizeprojection.html
+ * @api public
+ */
+
+Query.prototype.sanitizeProjection = function sanitizeProjection(value) {
+  this._mongooseOptions.sanitizeProjection = value;
+
+  return this;
+};
+
+/**
  * Determines the MongoDB nodes from which to read.
  *
  * #### Preferences:

--- a/lib/query.js
+++ b/lib/query.js
@@ -4866,7 +4866,17 @@ Query.prototype._applyPaths = function applyPaths() {
     return;
   }
   this._fields = this._fields || {};
-  helpers.applyPaths(this._fields, this.model.schema);
+
+  let sanitizeProjection = undefined;
+  if (this.model != null && utils.hasUserDefinedProperty(this.model.db.options, 'sanitizeProjection')) {
+    sanitizeProjection = this.model.db.options.sanitizeProjection;
+  } else if (this.model != null && utils.hasUserDefinedProperty(this.model.base.options, 'sanitizeProjection')) {
+    sanitizeProjection = this.model.base.options.sanitizeProjection;
+  } else {
+    sanitizeProjection = this._mongooseOptions.sanitizeProjection;
+  }
+
+  helpers.applyPaths(this._fields, this.model.schema, sanitizeProjection);
 
   let _selectPopulatedPaths = true;
 

--- a/lib/queryHelpers.js
+++ b/lib/queryHelpers.js
@@ -145,7 +145,7 @@ exports.createModelAndInit = function createModelAndInit(model, doc, fields, use
  * ignore
  */
 
-exports.applyPaths = function applyPaths(fields, schema) {
+exports.applyPaths = function applyPaths(fields, schema, sanitizeProjection) {
   // determine if query is selecting or excluding fields
   let exclude;
   let keys;
@@ -321,6 +321,10 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
     // User overwriting default exclusion
     if (type.selected === false && fields[path]) {
+      if (sanitizeProjection) {
+        fields[path] = 0;
+      }
+
       return;
     }
 
@@ -345,8 +349,10 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
       // if there are other fields being included, add this one
       // if no other included fields, leave this out (implied inclusion)
-      if (exclude === false && keys.length > 1 && !~keys.indexOf(path)) {
+      if (exclude === false && keys.length > 1 && !~keys.indexOf(path) && !sanitizeProjection) {
         fields[path] = 1;
+      } else if (exclude == null && sanitizeProjection && type.selected === false) {
+        fields[path] = 0;
       }
 
       return;

--- a/test/schema.select.test.js
+++ b/test/schema.select.test.js
@@ -346,6 +346,19 @@ describe('schema select option', function() {
       assert.equal(d.id, doc.id);
     });
 
+    it('works if only one plus path and only one deselected field', async function() {
+      const MySchema = Schema({
+        name: String,
+        email: String,
+        password: { type: String, select: false }
+      });
+      const Test = db.model('Test', MySchema);
+      const { _id } = await Test.create({ name: 'test', password: 'secret' });
+
+      const doc = await Test.findById(_id).select('+password');
+      assert.strictEqual(doc.password, 'secret');
+    });
+
     it('works with query.slice (gh-1370)', async function() {
       const M = db.model('Test', new Schema({ many: { type: [String], select: false } }));
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -716,6 +716,11 @@ declare module 'mongoose' {
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'replaceOne', TInstanceMethods>;
 
+    /**
+     * Sets this query's `sanitizeProjection` option. With `sanitizeProjection()`, you can pass potentially untrusted user data to `.select()`.
+     */
+    sanitizeProjection(value: boolean): this;
+
     /** Specifies which document fields to include or exclude (also known as the query "projection") */
     select<RawDocTypeOverride extends { [P in keyof RawDocType]?: any } = {}>(
       arg: string | string[] | Record<string, number | boolean | string | object>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

[sanitizeProjection option](https://thecodebarbarian.com/whats-new-in-mongoose-5-13-sanitizeprojection.html) currently exists to prevent cases like `select({ name: '$password' })`, which would cause the `name` property to contain the value of the `password` property in newer versions of MongoDB.

While that is helpful, `sanitizeProjection` can do a bit more to prevent inclusion of sensitive data when the projection is potentially untrusted. With this PR, if `sanitizeProjection` is enabled, there is no way to project in a field that's deselected with `select: false` in the schema definition. If `password` has `{ type: String, select: false }` and `sanitizeProjection` is set, then `select('+password')`, `select('password')`, etc. will be ignored.

@hasezoey what do you think about this PR, is this a reasonable feature and do you think it's reasonable to ship in 8.5?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
