### PR TITLE
feat: allow setting array default value to `null`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -314,7 +314,7 @@ const Kitten = connection.model('Kitten', kittySchema);
 
 <a class="anchor" href="#array-defaults">**Q**</a>. How can I change mongoose's default behavior of initializing an array path to an empty array so that I can require real data on document creation?
 
-**A**. You can set the default of the array to a function that returns `undefined`.
+**A**. You can set the default of the array to `undefined`.
 
 ```javascript
 const CollectionSchema = new Schema({
@@ -329,13 +329,13 @@ const CollectionSchema = new Schema({
 
 <a class="anchor" href="#initialize-array-path-null">**Q**</a>. How can I initialize an array path to `null`?
 
-**A**. You can set the default of the array to a function that returns `null`.
+**A**. You can set the default of the array to [`null`](https://masteringjs.io/tutorials/fundamentals/null).
 
 ```javascript
 const CollectionSchema = new Schema({
   field1: {
     type: [String],
-    default: () => { return null; }
+    default: null
   }
 });
 ```

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -111,7 +111,7 @@ function SchemaArray(key, cast, options, schemaOptions) {
     fn = typeof defaultArr === 'function';
   }
 
-  if (!('defaultValue' in this) || this.defaultValue !== void 0) {
+  if (!('defaultValue' in this) || this.defaultValue != null) {
     const defaultFn = function() {
       // Leave it up to `cast()` to convert the array
       return fn

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -3198,6 +3198,23 @@ describe('document', function() {
       assert.ok(!('names' in doc));
     });
 
+    it('can set array default to null (gh-14717)', async function() {
+      const schema = new Schema({
+        names: {
+          type: [String],
+          default: null
+        }
+      });
+
+      const Model = db.model('Test', schema);
+      const m = new Model();
+      assert.strictEqual(m.names, null);
+      await m.save();
+
+      const doc = await Model.collection.findOne({ _id: m._id });
+      assert.strictEqual(doc.names, null);
+    });
+
     it('validation works when setting array index (gh-3816)', async function() {
       const mySchema = new mongoose.Schema({
         items: [


### PR DESCRIPTION
Fix #6691

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I took another look at #6691 and I can't see any reason for us continuing to disallow `default: null` on array paths. We already allow `default: undefined` and `default: () => null`, the latter of which is practically identical. Silently ignoring `default: null` for arrays feels more like a bug than anything, and changing it doesn't break any tests. 8.5 release is a good opportunity to make this change.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
