### PR TITLE
types: correct `this` for `validate.validator` schematype option

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -18,7 +18,8 @@ import {
   SchemaType,
   Types,
   Query,
-  model
+  model,
+  ValidateOpts
 } from 'mongoose';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
@@ -1510,4 +1511,47 @@ function gh13772() {
   const TestModel = model('User', schema);
   const doc = new TestModel();
   expectAssignable<RawDocType>(doc.toObject());
+}
+
+function gh14696() {
+  interface User {
+    name: string;
+    isActive: boolean;
+    isActiveAsync: boolean;
+  }
+
+  const x: ValidateOpts<unknown, User> = {
+    validator(v: any) {
+      expectAssignable<User>(this);
+      return !v || this.name === 'super admin';
+    }
+  };
+
+  const userSchema = new Schema<User>({
+    name: {
+      type: String,
+      required: [true, 'Name on card is required']
+    },
+    isActive: {
+      type: Boolean,
+      default: false,
+      validate: {
+        validator(v: any) {
+          expectAssignable<User>(this);
+          return !v || this.name === 'super admin';
+        }
+      }
+    },
+    isActiveAsync: {
+      type: Boolean,
+      default: false,
+      validate: {
+        async validator(v: any) {
+          expectAssignable<User>(this);
+          return !v || this.name === 'super admin';
+        }
+      }
+    }
+  });
+
 }

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -60,7 +60,7 @@ declare module 'mongoose' {
     alias?: string | string[];
 
     /** Function or object describing how to validate this schematype. See [validation docs](https://mongoosejs.com/docs/validation.html). */
-    validate?: SchemaValidator<T> | AnyArray<SchemaValidator<T>>;
+    validate?: SchemaValidator<T, EnforcedDocType> | AnyArray<SchemaValidator<T, EnforcedDocType>>;
 
     /** Allows overriding casting logic for this individual path. If a string, the given string overwrites Mongoose's default cast error message. */
     cast?: string |

--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -1,6 +1,6 @@
 declare module 'mongoose' {
 
-  type SchemaValidator<T, EnforcedDocType> = ValidateOpts<T, EnforcedDocType>; // RegExp | [RegExp, string] | Function | [Function, string] | ValidateOpts<T, EnforcedDocType> | ValidateOpts<T, EnforcedDocType>[];
+  type SchemaValidator<T, EnforcedDocType> = RegExp | [RegExp, string] | Function | [Function, string] | ValidateOpts<T, EnforcedDocType> | ValidateOpts<T, EnforcedDocType>[];
 
   interface ValidatorProps {
     path: string;

--- a/types/validation.d.ts
+++ b/types/validation.d.ts
@@ -1,6 +1,6 @@
 declare module 'mongoose' {
 
-  type SchemaValidator<T> = RegExp | [RegExp, string] | Function | [Function, string] | ValidateOpts<T> | ValidateOpts<T>[];
+  type SchemaValidator<T, EnforcedDocType> = ValidateOpts<T, EnforcedDocType>; // RegExp | [RegExp, string] | Function | [Function, string] | ValidateOpts<T, EnforcedDocType> | ValidateOpts<T, EnforcedDocType>[];
 
   interface ValidatorProps {
     path: string;
@@ -13,23 +13,18 @@ declare module 'mongoose' {
     (props: ValidatorProps): string;
   }
 
-  interface ValidateFn<T> {
-    (value: T, props?: ValidatorProps & Record<string, any>): boolean;
-  }
+  type ValidateFn<T, EnforcedDocType> =
+    (this: EnforcedDocType, value: any, props?: ValidatorProps & Record<string, any>) => boolean;
 
-  interface LegacyAsyncValidateFn<T> {
-    (value: T, done: (result: boolean) => void): void;
-  }
+  type AsyncValidateFn<T, EnforcedDocType> =
+    (this: EnforcedDocType, value: any, props?: ValidatorProps & Record<string, any>) => Promise<boolean>;
 
-  interface AsyncValidateFn<T> {
-    (value: T, props?: ValidatorProps & Record<string, any>): Promise<boolean>;
-  }
-
-  interface ValidateOpts<T> {
+  interface ValidateOpts<T, EnforcedDocType> {
     msg?: string;
     message?: string | ValidatorMessageFn;
     type?: string;
-    validator: ValidateFn<T> | LegacyAsyncValidateFn<T> | AsyncValidateFn<T>;
+    validator: ValidateFn<T, EnforcedDocType>
+    | AsyncValidateFn<T, EnforcedDocType>;
     propsParameter?: boolean;
   }
 }


### PR DESCRIPTION
Fix #14696

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Ensure `this` has the correct type in `validate.validator` below.

```ts
    isActive: {
      type: Boolean,
      default: false,
      validate: {
        validator(v: any) {
          expectAssignable<User>(this);
          return !v || this.name === 'super admin';
        }
      }
    }
```

I made 2 changes to support this:

1) passing `EnforcedDocType` down to `ValidateFn` via `ValidateOpts` and `SchemaValidator` 
2) Removing `LegacyAsyncValidateFn`. For some reason, `LegacyAsyncValidateFn` breaks these tests, and I have no idea why. It has something to do with the `done` function. Either way, `LegacyAsyncValidateFn` is no longer necessary because we removed support for validators that receive a callback in [Mongoose 6](https://mongoosejs.com/docs/migrating_to_6.html#removed-validator-isasync), so I think it is safe to remove.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
