### PR TITLE
Avoid leaving subdoc defaults on top-level doc when setting subdocument to same value

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1691,6 +1691,13 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
         }
       });
     }
+  } else if (schema && schema.instance === 'Embedded') {
+    const defaultPaths = Object.keys(this.$__.activePaths.states['default'] ?? {});
+    for (const defaultPath of defaultPaths) {
+      if (defaultPath.startsWith(path + '.')) {
+        this.$__.activePaths.clearPath(defaultPath);
+      }
+    }
   }
 
   let obj = this._doc;

--- a/lib/document.js
+++ b/lib/document.js
@@ -155,7 +155,9 @@ function Document(obj, fields, skipId, options) {
     // By default, defaults get applied **before** setting initial values
     // Re: gh-6155
     if (defaults) {
-      applyDefaults(this, fields, exclude, hasIncludedChildren, true, null);
+      applyDefaults(this, fields, exclude, hasIncludedChildren, true, null, {
+        skipParentChangeTracking: true
+      });
     }
   }
   if (obj) {
@@ -1690,13 +1692,6 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
           doc.$isNew = false;
         }
       });
-    }
-  } else if (schema && schema.instance === 'Embedded') {
-    const defaultPaths = Object.keys(this.$__.activePaths.states['default'] ?? {});
-    for (const defaultPath of defaultPaths) {
-      if (defaultPath.startsWith(path + '.')) {
-        this.$__.activePaths.clearPath(defaultPath);
-      }
     }
   }
 

--- a/lib/helpers/document/applyDefaults.js
+++ b/lib/helpers/document/applyDefaults.js
@@ -2,9 +2,10 @@
 
 const isNestedProjection = require('../projection/isNestedProjection');
 
-module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildren, isBeforeSetters, pathsToSkip) {
+module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildren, isBeforeSetters, pathsToSkip, options) {
   const paths = Object.keys(doc.$__schema.paths);
   const plen = paths.length;
+  const skipParentChangeTracking = options && options.skipParentChangeTracking;
 
   for (let i = 0; i < plen; ++i) {
     let def;
@@ -80,7 +81,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
 
             if (typeof def !== 'undefined') {
               doc_[piece] = def;
-              applyChangeTracking(doc, p);
+              applyChangeTracking(doc, p, skipParentChangeTracking);
             }
           } else if (included) {
             // selected field
@@ -93,7 +94,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
 
             if (typeof def !== 'undefined') {
               doc_[piece] = def;
-              applyChangeTracking(doc, p);
+              applyChangeTracking(doc, p, skipParentChangeTracking);
             }
           }
         } else {
@@ -106,7 +107,7 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
 
           if (typeof def !== 'undefined') {
             doc_[piece] = def;
-            applyChangeTracking(doc, p);
+            applyChangeTracking(doc, p, skipParentChangeTracking);
           }
         }
       } else {
@@ -120,9 +121,9 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
  * ignore
  */
 
-function applyChangeTracking(doc, fullPath) {
+function applyChangeTracking(doc, fullPath, skipParentChangeTracking) {
   doc.$__.activePaths.default(fullPath);
-  if (doc.$isSubdocument && doc.$isSingleNested && doc.$parent() != null) {
+  if (!skipParentChangeTracking && doc.$isSubdocument && doc.$isSingleNested && doc.$parent() != null) {
     doc.$parent().$__.activePaths.default(doc.$__pathRelativeToParent(fullPath));
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The cause of #14722 is that, when creating a new subdocument, Mongoose first applies defaults to the subdocument, and those defaults bubble up to the top-level document. Which leaves any default paths in `default` state on the top-level document, even if we're setting the subdocument to the exact same value.

This PR makes it so that we skip parent change tracking on defaults when creating a completely new subdocument - the idea is, if we're creating a new subdocument, we'll be setting the subdocument to the top-level document, so we will track the change as "set the subdocument" rather than "set the subdocument, and also set this default on the subdocument."

There's also some followup work I want to do related to #4145: #4145 succeeds because we leave document array underneath a nested path in `default` state, even though we modify the document array.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
