### PR TITLE
types: avoid automatically inferring lean result type when assigning to explicitly typed variable

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -10,7 +10,7 @@ import {
   DefaultSchemaOptions
 } from 'mongoose';
 import { DeleteResult } from 'mongodb';
-import { expectAssignable, expectError, expectType } from 'tsd';
+import { expectAssignable, expectError, expectNotAssignable, expectType } from 'tsd';
 import { autoTypedModel } from './models.test';
 import { autoTypedModelConnection } from './connection.test';
 import { AutoTypedSchemaType } from './schema.test';
@@ -42,7 +42,8 @@ void async function main() {
 
   expectType<DeleteResult>(await doc.deleteOne());
   expectType<TestDocument | null>(await doc.deleteOne().findOne());
-  expectType<{ _id: Types.ObjectId, name?: string } | null>(await doc.deleteOne().findOne().lean());
+  expectAssignable<{ _id: Types.ObjectId, name?: string } | null>(await doc.deleteOne().findOne().lean());
+  expectNotAssignable<TestDocument | null>(await doc.deleteOne().findOne().lean());
 }();
 
 

--- a/test/types/plugin.test.ts
+++ b/test/types/plugin.test.ts
@@ -49,7 +49,7 @@ interface TestStaticMethods {
   findSomething(this: TestModel): Promise<TestDocument>;
 }
 type TestDocument = HydratedDocument<Test, TestVirtuals & TestInstanceMethods>;
-type TestQuery = Query<any, TestDocument, TestQueryHelpers> & TestQueryHelpers;
+type TestQuery = Query<any, TestDocument, TestQueryHelpers, Test> & TestQueryHelpers;
 interface TestQueryHelpers {
   whereSomething(this: TestQuery): this
 }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -38,11 +38,11 @@ const schema: Schema<ITest, Model<ITest, QueryHelpers>, {}, QueryHelpers> = new 
   endDate: Date
 });
 
-schema.query._byName = function(name: string): QueryWithHelpers<any, ITest, QueryHelpers> {
+schema.query._byName = function(name: string): QueryWithHelpers<ITest[], ITest, QueryHelpers> {
   return this.find({ name });
 };
 
-schema.query.byName = function(name: string): QueryWithHelpers<any, ITest, QueryHelpers> {
+schema.query.byName = function(name: string): QueryWithHelpers<ITest[], ITest, QueryHelpers> {
   expectError(this.notAQueryHelper());
   return this._byName(name);
 };

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -224,7 +224,7 @@ declare module 'mongoose' {
           : MergeType<ResultType, Paths>
     : MergeType<ResultType, Paths>;
 
-  class Query<ResultType, DocType, THelpers = {}, RawDocType = DocType, QueryOp = 'find', TInstanceMethods = Record<string, never>> implements SessionOperation {
+  class Query<ResultType, DocType, THelpers = {}, RawDocType = unknown, QueryOp = 'find', TInstanceMethods = Record<string, never>> implements SessionOperation {
     _mongooseOptions: MongooseQueryOptions<DocType>;
 
     /**
@@ -548,9 +548,19 @@ declare module 'mongoose' {
     j(val: boolean | null): this;
 
     /** Sets the lean option. */
-    lean<
-      LeanResultType = GetLeanResultType<RawDocType, ResultType, QueryOp>
-    >(
+    lean(
+      val?: boolean | any
+    ): QueryWithHelpers<
+      ResultType extends null
+        ? GetLeanResultType<RawDocType, ResultType, QueryOp> | null
+        : GetLeanResultType<RawDocType, ResultType, QueryOp>,
+      DocType,
+      THelpers,
+      RawDocType,
+      QueryOp,
+      TInstanceMethods
+      >;
+    lean<LeanResultType>(
       val?: boolean | any
     ): QueryWithHelpers<
       ResultType extends null


### PR DESCRIPTION
Fix #14697

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

With the way that `lean()` is currently implemented, the following code unexpectedly compiles

```ts
export interface IUser {
  name: string;
  createdAt: Date;
  updatedAt: Date;
}
export interface IUserVirtuals {
  id: string;
}
type UserModelType = Model<IUser, {}, {}, IUserVirtuals>;
export type UserInstance = InstanceType<UserModelType>;


let user: UserInstance | null = null;
// Compiles even though `lean()` but `user` is hydrated doc
user = await UserModel.findOne().lean();
```

That's because TypeScript automatically infers the generic param to `lean()` if `user` has an explicit type.

In order to support this, I needed to change the default value of `RawDocType` param to `Query<>` to `unknown`. When `RawDocType` was set to `DocType` by default, that would break when `DocType` was set to be a hydrated document.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
