### PR TITLE
types: make `_id` required on Document type

### DIFF
--- a/test/types/docArray.test.ts
+++ b/test/types/docArray.test.ts
@@ -91,7 +91,7 @@ async function gh13424() {
   const TestModel = model('Test', testSchema);
 
   const doc = new TestModel();
-  expectType<Types.ObjectId | undefined>(doc.subDocArray[0]._id);
+  expectType<Types.ObjectId>(doc.subDocArray[0]._id);
 }
 
 async function gh14367() {

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1386,7 +1386,7 @@ function gh13424() {
   const TestModel = model('TestModel', new Schema(testSchema));
 
   const doc = new TestModel({});
-  expectType<Types.ObjectId | undefined>(doc.subDocArray[0]._id);
+  expectType<Types.ObjectId>(doc.subDocArray[0]._id);
 }
 
 function gh14147() {

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -22,7 +22,7 @@ declare module 'mongoose' {
     constructor(doc?: any);
 
     /** This documents _id. */
-    _id?: T;
+    _id: T;
 
     /** This documents __v. */
     __v?: any;


### PR DESCRIPTION
Fix #14660

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`_id: T` is more correct because `_id` should always exist on a hydrated document by default. And this doesn't break any tests other than ones that assert on the behavior from #14660. @hasezoey what do you think, does this work fine with Typegoose?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
