### PR TITLE
types(query): fix usage of "RawDocType" where "DocType" should be passed

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -374,7 +374,7 @@ declare module 'mongoose' {
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find'>;
     find(
       filter: FilterQuery<RawDocType>
-    ): QueryWithHelpers<Array<RawDocType>, DocType, THelpers, RawDocType, 'find'>;
+    ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find'>;
     find(): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find'>;
 
     /** Declares the query a findOne operation. When executed, returns the first found document. */
@@ -389,7 +389,7 @@ declare module 'mongoose' {
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne'>;
     findOne(
       filter?: FilterQuery<RawDocType>
-    ): QueryWithHelpers<DocType | null, RawDocType, THelpers, RawDocType, 'findOne'>;
+    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne'>;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
     findOneAndDelete(


### PR DESCRIPTION
**Summary**

This PR fixes `find` and `fineOne` overload returns where `DocType` should be used over `RawDocType`, at least to my understanding, this had already been done partially in fa0bc8d656cccd3081800026fa75d7b6990f51cd, but not for `findOne` so this could be forward-ported.

The generics for context (as of 7.7.0):
https://github.com/Automattic/mongoose/blob/061bb828c706512d79c79f5d42774316bf167357/types/query.d.ts#L191

Without this change using and expecting assignability would result in a error like in typegoose:

```txt
Type 'QueryHelperThis<typeof QueryMethodsClass, FindHelpers, DocumentType<QueryMethodsClass, FindHelpers>>' is not assignable to type 'QueryWithHelpers<DocumentType<QueryMethodsClass, FindHelpers> | null, DocumentType<QueryMethodsClass, FindHelpers>, FindHelpers, DocumentType<...>, "find">'.
  Type 'QueryHelperThis<typeof QueryMethodsClass, FindHelpers, DocumentType<QueryMethodsClass, FindHelpers>>' is not assignable to type 'Query<DocumentType<QueryMethodsClass, FindHelpers> | null, DocumentType<QueryMethodsClass, FindHelpers>, FindHelpers, DocumentType<...>, "find">'.
    The types returned by 'find(...)' are incompatible between these types.
      Type 'QueryWithHelpers<QueryMethodsClass[], DocumentType<QueryMethodsClass, FindHelpers>, FindHelpers, QueryMethodsClass, "find">' is not assignable to type 'QueryWithHelpers<DocumentType<QueryMethodsClass, FindHelpers>[], DocumentType<QueryMethodsClass, FindHelpers>, FindHelpers, DocumentType<...>, "find">'.
        Type 'QueryWithHelpers<QueryMethodsClass[], DocumentType<QueryMethodsClass, FindHelpers>, FindHelpers, QueryMethodsClass, "find">' is not assignable to type 'Query<DocumentType<QueryMethodsClass, FindHelpers>[], DocumentType<QueryMethodsClass, FindHelpers>, FindHelpers, DocumentType<...>, "find">'.
          The types returned by 'exec()' are incompatible between these types.
            Type 'Promise<QueryMethodsClass[]>' is not assignable to type 'Promise<DocumentType<QueryMethodsClass, FindHelpers>[]>'.
              Type 'QueryMethodsClass[]' is not assignable to type 'DocumentType<QueryMethodsClass, FindHelpers>[]'.
                Type 'QueryMethodsClass' is not assignable to type 'DocumentType<QueryMethodsClass, FindHelpers>'.
                  Type 'QueryMethodsClass' is missing the following properties from type 'Document<unknown, FindHelpers, QueryMethodsClass>': $assertPopulated, $clone, $getAllSubdocs, $ignore, and 47 more.ts(2322)
```

no change was necessary (to not result in a type error) before mongoose 7.6.6 and no change was necessary in mongoose 8.0.0 and up