### PR TITLE
Fix ChangeStream.close to return a Promise<void> like the driver

### DIFF
--- a/lib/cursor/changeStream.js
+++ b/lib/cursor/changeStream.js
@@ -141,8 +141,9 @@ class ChangeStream extends EventEmitter {
   close() {
     this.closed = true;
     if (this.driverChangeStream) {
-      this.driverChangeStream.close();
+      return this.driverChangeStream.close();
     }
+    return Promise.resolve();
   }
 }
 


### PR DESCRIPTION
**Summary**

Client code that calls `stream.close().then(...)` fails with TypeError, since mongoose `close()` returns undefined.
