### PR TITLE
fix(model): handle `transactionAsyncLocalStorage` option with `insertMany()`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2838,6 +2838,11 @@ Model.$__insertMany = function(arr, options, callback) {
   const throwOnValidationError = typeof options.throwOnValidationError === 'boolean' ? options.throwOnValidationError : false;
   const lean = !!options.lean;
 
+  const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
+  if ((!options || !options.hasOwnProperty('session')) && asyncLocalStorage?.session != null) {
+    options = { ...options, session: asyncLocalStorage.session };
+  }
+
   if (!Array.isArray(arr)) {
     arr = [arr];
   }

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -388,6 +388,8 @@ describe('transactions', function() {
           }();
           assert.equal(doc.name, 'test_transactionAsyncLocalStorage');
 
+          await Test.insertMany([{ name: 'bar' }]);
+
           throw new Error('Oops!');
         }),
         /Oops!/
@@ -396,6 +398,9 @@ describe('transactions', function() {
       assert.ok(!exists);
 
       exists = await Test.exists({ name: 'foo' });
+      assert.ok(!exists);
+
+      exists = await Test.exists({ name: 'bar' });
       assert.ok(!exists);
     });
   });


### PR DESCRIPTION
Fix #14738

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like we missed a spot when implementing `transactionAsyncLocalStorage`, we're not adding `session` option to `insertMany()`. I reviewed and don't see any other places in `Model` where we aren't setting `session`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
