### PR TITLE
fix(model): support `session: null` option for `save()` to opt out of automatic `session` option with `transactionAsyncLocalStorage`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -290,9 +290,9 @@ Model.prototype.$__handleSave = function(options, callback) {
 
   const session = this.$session();
   const asyncLocalStorage = this[modelDbSymbol].base.transactionAsyncLocalStorage?.getStore();
-  if (!saveOptions.hasOwnProperty('session') && session != null) {
+  if (!options.hasOwnProperty('session') && session != null) {
     saveOptions.session = session;
-  } else if (asyncLocalStorage?.session != null) {
+  } else if (!options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
     saveOptions.session = asyncLocalStorage.session;
   }
   if (this.$isNew) {

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -370,7 +370,7 @@ describe('transactions', function() {
       await Test.createCollection();
       await Test.deleteMany({});
 
-      const doc = new Test({ name: 'test_transactionAsyncLocalStorage' });
+      let doc = new Test({ name: 'test_transactionAsyncLocalStorage' });
       await assert.rejects(
         () => m.connection.transaction(async() => {
           await doc.save();
@@ -397,6 +397,17 @@ describe('transactions', function() {
 
       exists = await Test.exists({ name: 'foo' });
       assert.ok(!exists);
+
+      doc = new Test({ name: 'test_transactionAsyncLocalStorage' });
+      await assert.rejects(
+        () => m.connection.transaction(async() => {
+          await doc.save({ session: null });
+          throw new Error('Oops!');
+        }),
+        /Oops!/
+      );
+      exists = await Test.exists({ _id: doc._id });
+      assert.ok(exists);
     });
   });
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13746,7 +13746,7 @@ describe('document', function() {
   });
 });
 
-describe('Check if instance function that is supplied in schema option is availabe', function() {
+describe('Check if instance function that is supplied in schema option is available', function() {
   it('should give an instance function back rather than undefined', function ModelJS() {
     const testSchema = new mongoose.Schema({}, { methods: { instanceFn() { return 'Returned from DocumentInstanceFn'; } } });
     const TestModel = mongoose.model('TestModel', testSchema);


### PR DESCRIPTION
Fix #14736

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`doc.save({ session: null })` should override default `session` option from `transactionAsyncLocalStorage`. That's how `await TestModel.find().setOptions({ session: null })` and others work, it looks like `save()` is the only one affected

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
