### PR TITLE
Upgrade `mongodb-memory-server` to 10.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,17 +41,17 @@ jobs:
       matrix:
         node: [16, 18, 20]
         os: [ubuntu-20.04, ubuntu-22.04]
-        mongodb: [4.4.28, 5.0.25, 6.0.14, 7.0.7]
+        mongodb: [4.4.29, 5.0.26, 6.0.15, 7.0.12]
         include:
           - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
-            mongodb: 5.0.25
+            mongodb: 5.0.26
             node: 16
             coverage: true
         exclude:
           - os: ubuntu-22.04 # exclude because there are no 4.x mongodb builds for 2204
-            mongodb: 4.4.28
+            mongodb: 4.4.29
           - os: ubuntu-22.04 # exclude because there are no 5.x mongodb builds for 2204
-            mongodb: 5.0.25
+            mongodb: 5.0.26
     name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongodb }} OS ${{ matrix.os }}
     env:
       MONGOMS_VERSION: ${{ matrix.mongodb }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Deno tests
     env:
-      MONGOMS_VERSION: 6.0.14
+      MONGOMS_VERSION: 6.0.15
       MONGOMS_PREFER_GLOBAL_PATH: 1
       FORCE_COLOR: true
     steps:

--- a/.github/workflows/tsd.yml
+++ b/.github/workflows/tsd.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 14
+          node-version: 16
 
       - run: npm install
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^3.0.1",
     "mocha": "10.6.0",
     "moment": "2.30.1",
-    "mongodb-memory-server": "9.4.0",
+    "mongodb-memory-server": "10.0.0",
     "ncp": "^2.0.0",
     "nyc": "15.1.0",
     "pug": "3.0.3",


### PR DESCRIPTION
**Summary**

This PR updates the dev-dependency `mongodb-memory-server` to major version 10.
Additionally also updates all mongodb server versions to their latest patch again.

~~This PR is a DRAFT for now as version 10.0.0 is not yet released and this PR currently makes use of `-beta` releases~~