### PR TITLE
Updating id type to be string instead of any

### DIFF
--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -170,7 +170,7 @@ declare module 'mongoose' {
     getChanges(): UpdateQuery<this>;
 
     /** The string version of this documents _id. */
-    id?: any;
+    id?: string;
 
     /** Signal that we desire an increment of this documents version. */
     increment(): this;


### PR DESCRIPTION
I am chanigng the type of the document id property to be a string.