### PR TITLE
Improve fix cast empty query

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -65,7 +65,7 @@ module.exports = function cast(schema, obj, options, context) {
       if (!Array.isArray(val)) {
         throw new CastError('Array', val, path);
       }
-      for (let k = val.length - 1; k >= 0; k--) {
+      for (let k = 0; k < val.length; ++k) {
         if (val[k] == null || typeof val[k] !== 'object') {
           throw new CastError('Object', val[k], path + '.' + k);
         }

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -69,12 +69,15 @@ module.exports = function cast(schema, obj, options, context) {
         if (val[k] == null || typeof val[k] !== 'object') {
           throw new CastError('Object', val[k], path + '.' + k);
         }
+
+        const beforeCastKeysLength = Object.keys(val[k]).length;
         val[k] = cast(schema, val[k], options, context);
-        if (Object.keys(val[k]).length === 0) {
+        if (Object.keys(val[k]).length === 0 && beforeCastKeysLength !== 0) {
           val.splice(k, 1);
         }
       }
 
+      // delete empty: {$or: []} -> {}
       if (val.length === 0) {
         delete obj[path];
       }

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -65,11 +65,18 @@ module.exports = function cast(schema, obj, options, context) {
       if (!Array.isArray(val)) {
         throw new CastError('Array', val, path);
       }
-      for (let k = 0; k < val.length; ++k) {
+      for (let k = val.length - 1; k >= 0; k--) {
         if (val[k] == null || typeof val[k] !== 'object') {
           throw new CastError('Object', val[k], path + '.' + k);
         }
         val[k] = cast(schema, val[k], options, context);
+        if (Object.keys(val[k]).length === 0) {
+          val.splice(k, 1);
+        }
+      }
+
+      if (val.length === 0) {
+        delete obj[path];
       }
     } else if (path === '$where') {
       type = typeof val;

--- a/test/docs/cast.test.js
+++ b/test/docs/cast.test.js
@@ -101,40 +101,58 @@ describe('Cast Tutorial', function() {
     await query.exec();
   });
 
-  it('strictQuery true', async function() {
-    mongoose.deleteModel('Character');
-    const schema = new mongoose.Schema({ name: String, age: Number }, {
-      strictQuery: true
+  describe('strictQuery', function() {
+    it('strictQuery true - simple object', async function() {
+      mongoose.deleteModel('Character');
+      const schema = new mongoose.Schema({ name: String, age: Number }, {
+        strictQuery: true
+      });
+      Character = mongoose.model('Character', schema);
+
+      const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
+
+      await query.exec();
+      query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
+      // acquit:ignore:start
+      assert.deepEqual(query.getFilter(), {});
+      // acquit:ignore:end
     });
-    Character = mongoose.model('Character', schema);
 
-    const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
+    it('strictQuery true - conditions', async function() {
+      mongoose.deleteModel('Character');
+      const schema = new mongoose.Schema({ name: String, age: Number }, {
+        strictQuery: true
+      });
+      Character = mongoose.model('Character', schema);
 
-    await query.exec();
-    query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
-    // acquit:ignore:start
-    assert.deepEqual(query.getFilter(), {});
-    // acquit:ignore:end
-  });
+      const query = Character.findOne({ $or: [{ notInSchema: { $lt: 'not a number' } }], $and: [{ name: 'abc' }, { age: { $gt: 18 } }, { notInSchema: { $lt: 'not a number' } }] });
 
-  it('strictQuery throw', async function() {
-    mongoose.deleteModel('Character');
-    const schema = new mongoose.Schema({ name: String, age: Number }, {
-      strictQuery: 'throw'
+      await query.exec();
+      query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
+      // acquit:ignore:start
+      assert.deepEqual(query.getFilter(), { $and: [{ name: 'abc' }, { age: { $gt: 18 } }] });
+      // acquit:ignore:end
     });
-    Character = mongoose.model('Character', schema);
 
-    const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
+    it('strictQuery throw', async function() {
+      mongoose.deleteModel('Character');
+      const schema = new mongoose.Schema({ name: String, age: Number }, {
+        strictQuery: 'throw'
+      });
+      Character = mongoose.model('Character', schema);
 
-    const err = await query.exec().then(() => null, err => err);
-    err.name; // 'StrictModeError'
-    // Path "notInSchema" is not in schema and strictQuery is 'throw'.
-    err.message;
-    // acquit:ignore:start
-    assert.equal(err.name, 'StrictModeError');
-    assert.equal(err.message, 'Path "notInSchema" is not in schema and ' +
-      'strictQuery is \'throw\'.');
-    // acquit:ignore:end
+      const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
+
+      const err = await query.exec().then(() => null, err => err);
+      err.name; // 'StrictModeError'
+      // Path "notInSchema" is not in schema and strictQuery is 'throw'.
+      err.message;
+      // acquit:ignore:start
+      assert.equal(err.name, 'StrictModeError');
+      assert.equal(err.message, 'Path "notInSchema" is not in schema and ' +
+        'strictQuery is \'throw\'.');
+      // acquit:ignore:end
+    });
   });
 
   it('implicit in', async function() {

--- a/test/docs/cast.test.js
+++ b/test/docs/cast.test.js
@@ -125,12 +125,16 @@ describe('Cast Tutorial', function() {
       });
       Character = mongoose.model('Character', schema);
 
-      const query = Character.findOne({ $or: [{ notInSchema: { $lt: 'not a number' } }], $and: [{ name: 'abc' }, { age: { $gt: 18 } }, { notInSchema: { $lt: 'not a number' } }] });
+      const query = Character.findOne({
+        $or: [{ notInSchema: { $lt: 'not a number' } }],
+        $and: [{ name: 'abc' }, { age: { $gt: 18 } }, { notInSchema: { $lt: 'not a number' } }],
+        $nor: [{}] // should be kept
+      });
 
       await query.exec();
       query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
       // acquit:ignore:start
-      assert.deepEqual(query.getFilter(), { $and: [{ name: 'abc' }, { age: { $gt: 18 } }] });
+      assert.deepEqual(query.getFilter(), { $and: [{ name: 'abc' }, { age: { $gt: 18 } }], $nor: [{}] });
       // acquit:ignore:end
     });
 

--- a/test/docs/cast.test.js
+++ b/test/docs/cast.test.js
@@ -101,62 +101,60 @@ describe('Cast Tutorial', function() {
     await query.exec();
   });
 
-  describe('strictQuery', function() {
-    it('strictQuery true - simple object', async function() {
-      mongoose.deleteModel('Character');
-      const schema = new mongoose.Schema({ name: String, age: Number }, {
-        strictQuery: true
-      });
-      Character = mongoose.model('Character', schema);
+  it('strictQuery true', async function() {
+    mongoose.deleteModel('Character');
+    const schema = new mongoose.Schema({ name: String, age: Number }, {
+      strictQuery: true
+    });
+    Character = mongoose.model('Character', schema);
 
-      const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
+    const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
 
-      await query.exec();
-      query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
-      // acquit:ignore:start
-      assert.deepEqual(query.getFilter(), {});
-      // acquit:ignore:end
+    await query.exec();
+    query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
+    // acquit:ignore:start
+    assert.deepEqual(query.getFilter(), {});
+    // acquit:ignore:end
+  });
+
+  it('strictQuery throw', async function() {
+    mongoose.deleteModel('Character');
+    const schema = new mongoose.Schema({ name: String, age: Number }, {
+      strictQuery: 'throw'
+    });
+    Character = mongoose.model('Character', schema);
+
+    const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
+
+    const err = await query.exec().then(() => null, err => err);
+    err.name; // 'StrictModeError'
+    // Path "notInSchema" is not in schema and strictQuery is 'throw'.
+    err.message;
+    // acquit:ignore:start
+    assert.equal(err.name, 'StrictModeError');
+    assert.equal(err.message, 'Path "notInSchema" is not in schema and ' +
+      'strictQuery is \'throw\'.');
+    // acquit:ignore:end
+  });
+  
+  it('strictQuery removes casted empty objects', async function() {
+    mongoose.deleteModel('Character');
+    const schema = new mongoose.Schema({ name: String, age: Number }, {
+      strictQuery: true
+    });
+    Character = mongoose.model('Character', schema);
+
+    const query = Character.findOne({
+      $or: [{ notInSchema: { $lt: 'not a number' } }],
+      $and: [{ name: 'abc' }, { age: { $gt: 18 } }, { notInSchema: { $lt: 'not a number' } }],
+      $nor: [{}] // should be kept
     });
 
-    it('strictQuery true - conditions', async function() {
-      mongoose.deleteModel('Character');
-      const schema = new mongoose.Schema({ name: String, age: Number }, {
-        strictQuery: true
-      });
-      Character = mongoose.model('Character', schema);
-
-      const query = Character.findOne({
-        $or: [{ notInSchema: { $lt: 'not a number' } }],
-        $and: [{ name: 'abc' }, { age: { $gt: 18 } }, { notInSchema: { $lt: 'not a number' } }],
-        $nor: [{}] // should be kept
-      });
-
-      await query.exec();
-      query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
-      // acquit:ignore:start
-      assert.deepEqual(query.getFilter(), { $and: [{ name: 'abc' }, { age: { $gt: 18 } }], $nor: [{}] });
-      // acquit:ignore:end
-    });
-
-    it('strictQuery throw', async function() {
-      mongoose.deleteModel('Character');
-      const schema = new mongoose.Schema({ name: String, age: Number }, {
-        strictQuery: 'throw'
-      });
-      Character = mongoose.model('Character', schema);
-
-      const query = Character.findOne({ notInSchema: { $lt: 'not a number' } });
-
-      const err = await query.exec().then(() => null, err => err);
-      err.name; // 'StrictModeError'
-      // Path "notInSchema" is not in schema and strictQuery is 'throw'.
-      err.message;
-      // acquit:ignore:start
-      assert.equal(err.name, 'StrictModeError');
-      assert.equal(err.message, 'Path "notInSchema" is not in schema and ' +
-        'strictQuery is \'throw\'.');
-      // acquit:ignore:end
-    });
+    await query.exec();
+    query.getFilter(); // Empty object `{}`, Mongoose removes `notInSchema`
+    // acquit:ignore:start
+    assert.deepEqual(query.getFilter(), { $and: [{ name: 'abc' }, { age: { $gt: 18 } }], $nor: [{}] });
+    // acquit:ignore:end
   });
 
   it('implicit in', async function() {


### PR DESCRIPTION
due to update on [6.10.1](https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md#6101--2023-03-03) was reverted #12898 because of #13086
I believe that my commit has actually fixed a bug where `{}` was unintentionally created through the strict process, which was not the developer's intention. I am updating this pull request to address the issue I just mentioned.
Now, only allows empty condition when the developer directly provides it. Additionally, if an empty condition appears due to the casting process, it will be removed.