### PR TITLE
Correct shardkey access in buildBulkWriteOps

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3631,7 +3631,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
         const len = paths.length;
 
         for (let i = 0; i < len; ++i) {
-          where[paths[i]] = shardKey[paths[i]];
+          where[paths[i]] = document[paths[i]];
         }
       }
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6365,9 +6365,9 @@ describe('Model', function() {
   describe('buildBulkWriteOperations() (gh-9673)', () => {
     it('builds write operations', async() => {
 
-
       const userSchema = new Schema({
-        name: { type: String }
+        name: { type: String },
+        a: { type: Number }
       }, { shardKey: { a: 1 } });
 
       const User = db.model('User', userSchema);
@@ -6386,7 +6386,7 @@ describe('Model', function() {
       const desiredWriteOperations = [
         { insertOne: { document: users[0] } },
         { insertOne: { document: users[1] } },
-        { updateOne: { filter: { _id: users[2]._id, a: 1 }, update: { $set: { name: 'I am the updated third name' } } } }
+        { updateOne: { filter: { _id: users[2]._id, a: 3 }, update: { $set: { name: 'I am the updated third name' } } } }
       ];
 
       assert.deepEqual(


### PR DESCRIPTION
fixes #14753 

**Summary**

buildBulkWriteOperations adds the shard key to the filter condition, but it sets it to the schema's value, not the document's value. 

This PR also updates a problematic test, which passed because the update value it uses was the same schema's shard key value.

Also, not sure about the backport policy, but we might need to get this ported to the minor version. It was broken in 8.4.1