### PR TITLE
fix(query): handle casting $switch in $expr

### DIFF
--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -93,8 +93,12 @@ function _castExpression(val, schema, strictQuery) {
   } else if (val.$ifNull != null) {
     val.$ifNull.map(v => _castExpression(v, schema, strictQuery));
   } else if (val.$switch != null) {
-    val.$switch.branches = val.$switch.branches.map(v => _castExpression(v, schema, strictQuery));
-    val.$switch.default = _castExpression(val.$switch.default, schema, strictQuery);
+    if (Array.isArray(val.$switch.branches)) {
+      val.$switch.branches = val.$switch.branches.map(v => _castExpression(v, schema, strictQuery));
+    }
+    if ('default' in val.$switch) {
+      val.$switch.default = _castExpression(val.$switch.default, schema, strictQuery);
+    }
   }
 
   const keys = Object.keys(val);

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -93,8 +93,8 @@ function _castExpression(val, schema, strictQuery) {
   } else if (val.$ifNull != null) {
     val.$ifNull.map(v => _castExpression(v, schema, strictQuery));
   } else if (val.$switch != null) {
-    val.branches.map(v => _castExpression(v, schema, strictQuery));
-    val.default = _castExpression(val.default, schema, strictQuery);
+    val.$switch.branches = val.$switch.branches.map(v => _castExpression(v, schema, strictQuery));
+    val.$switch.default = _castExpression(val.$switch.default, schema, strictQuery);
   }
 
   const keys = Object.keys(val);

--- a/test/helpers/query.cast$expr.test.js
+++ b/test/helpers/query.cast$expr.test.js
@@ -118,4 +118,33 @@ describe('castexpr', function() {
     res = cast$expr({ $eq: [{ $round: ['$value'] }, 2] }, testSchema);
     assert.deepStrictEqual(res, { $eq: [{ $round: ['$value'] }, 2] });
   });
+
+  it('casts $switch (gh-14751)', function() {
+    const testSchema = new Schema({
+      name: String,
+      scores: [Number]
+    });
+    const res = cast$expr({
+      $eq: [
+        {
+          $switch: {
+            branches: [{ case: { $eq: ['$$NOW', '$$NOW'] }, then: true }],
+            default: false
+          }
+        },
+        true
+      ]
+    }, testSchema);
+    assert.deepStrictEqual(res, {
+      $eq: [
+        {
+          $switch: {
+            branches: [{ case: { $eq: ['$$NOW', '$$NOW'] }, then: true }],
+            default: false
+          }
+        },
+        true
+      ]
+    });
+  });
 });


### PR DESCRIPTION
Fix #14751

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Incorrect handling for `$switch` in `cast$expr()`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
