### PR TITLE
docs: fix a wrong example in v6 migration guide

### DIFF
--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -314,7 +314,7 @@ Schema paths declared with `type: { name: String }` become single nested subdocs
 
 ```javascript
 // In Mongoose 6, the below makes `foo` into a subdocument with a `name` property.
-// In Mongoose 5, the below would make `foo` a `Mixed` type, _unless_ you set `typePojoToMixed: true`.
+// In Mongoose 5, the below would make `foo` a `Mixed` type, _unless_ you set `typePojoToMixed: false`.
 const schema = new Schema({
   foo: { type: { name: String } }
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

fixes a wrong example with `typePojoToMixed` behavior in mongoose 5

**Examples**

