### PR TITLE
perf(clone): avoid further unnecessary checks if cloning a primitive value

### DIFF
--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -17,7 +17,7 @@ const trustedSymbol = require('./query/trusted').trustedSymbol;
  *
  * If options.minimize is true, creates a minimal data object. Empty objects and undefined values will not be cloned. This makes the data payload sent to MongoDB as small as possible.
  *
- * Functions are never cloned.
+ * Functions and primitives are never cloned.
  *
  * @param {Object} obj the object to clone
  * @param {Object} options
@@ -28,6 +28,9 @@ const trustedSymbol = require('./query/trusted').trustedSymbol;
 
 function clone(obj, options, isArrayChild) {
   if (obj == null) {
+    return obj;
+  }
+  if (typeof obj === 'number' || typeof obj === 'string' || typeof obj === 'boolean' || typeof obj === 'bigint') {
     return obj;
   }
 
@@ -148,13 +151,12 @@ function cloneObject(obj, options, isArrayChild) {
     ret[trustedSymbol] = obj[trustedSymbol];
   }
 
-  let i = 0;
-  let key = '';
   const keys = Object.keys(obj);
   const len = keys.length;
 
-  for (i = 0; i < len; ++i) {
-    if (specialProperties.has(key = keys[i])) {
+  for (let i = 0; i < len; ++i) {
+    const key = keys[i];
+    if (specialProperties.has(key)) {
       continue;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looking more closely at #14394, we actually call `clone()` on primitive values a **lot** in Mongoose. `cloneObject()`, for instance, calls `clone()` on every key.

This PR is looking like another maybe 10% speedup on `recursiveToObject` benchmark, 308ms average vs 345ms average.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
