### PR TITLE
Refine query selector to highlight unexpected query keys

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -215,9 +215,8 @@ function find() {
   Project.find({});
   Project.find({ name: 'Hello' });
 
-  // just callback
-  // @ts-expect-error: Callback to find is longer supported
-  Project.find((error: CallbackError, result: IProject[]) => console.log(error, result));
+  // just callback; this is no longer supported on .find()
+  expectError(Project.find((error: CallbackError, result: IProject[]) => console.log(error, result)));
 
   // filter + projection
   Project.find({}, undefined);

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -981,10 +981,10 @@ function testWithLevel1NestedPaths() {
 
 function gh14764TestFilterQueryRestrictions() {
   const TestModel = model<{ validKey: number }>('Test', new Schema({}));
-  // @ts-expect-error: A key not in the schema should be invalid
-  TestModel.find({ invalidKey: 0 });
-  // @ts-expect-error: A key not in the schema should be invalid for simple root operators
-  TestModel.find({ $and: [{ invalidKey: 0 }] });
+  // A key not in the schema should be invalid
+  expectError(TestModel.find({ invalidKey: 0 }));
+  // A key not in the schema should be invalid for simple root operators
+  expectError(TestModel.find({ $and: [{ invalidKey: 0 }] }));
 
   // Any "nested" keys should be valid
   TestModel.find({ 'validKey.subkey': 0 });
@@ -995,12 +995,12 @@ function gh14764TestFilterQueryRestrictions() {
 
   // Any Query should be accepted as the root argument (due to merge support)
   TestModel.find(TestModel.find());
-  // @ts-expect-error: A Query should not be a valid type for a FilterQuery within an op like $and
-  TestModel.find({ $and: [TestModel.find()] });
+  // A Query should not be a valid type for a FilterQuery within an op like $and
+  expectError(TestModel.find({ $and: [TestModel.find()] }));
 
   const id = new Types.ObjectId();
   // Any ObjectId should be accepted as the root argument
   TestModel.find(id);
-  // @ts-expect-error: A ObjectId should not be a valid type for a FilterQuery within an op like $and
-  TestModel.find({ $and: [id] });
+  // A ObjectId should not be a valid type for a FilterQuery within an op like $and
+  expectError(TestModel.find({ $and: [id] }));
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -216,6 +216,7 @@ function find() {
   Project.find({ name: 'Hello' });
 
   // just callback
+  // @ts-expect-error: Callback to find is longer supported
   Project.find((error: CallbackError, result: IProject[]) => console.log(error, result));
 
   // filter + projection
@@ -976,4 +977,30 @@ function testWithLevel1NestedPaths() {
     foo?: { one?: string | null | undefined } | null | undefined,
     'foo.one': string | null | undefined
   }>({} as Test2);
+}
+
+function gh14764TestFilterQueryRestrictions() {
+  const TestModel = model<{ validKey: number }>('Test', new Schema({}));
+  // @ts-expect-error: A key not in the schema should be invalid
+  TestModel.find({ invalidKey: 0 });
+  // @ts-expect-error: A key not in the schema should be invalid for simple root operators
+  TestModel.find({ $and: [{ invalidKey: 0 }] });
+
+  // Any "nested" keys should be valid
+  TestModel.find({ 'validKey.subkey': 0 });
+
+  // And deeply "nested" keys should be valid
+  TestModel.find({ 'validKey.deep.nested.key': 0 });
+  TestModel.find({ validKey: { deep: { nested: { key: 0 } } } });
+
+  // Any Query should be accepted as the root argument (due to merge support)
+  TestModel.find(TestModel.find());
+  // @ts-expect-error: A Query should not be a valid type for a FilterQuery within an op like $and
+  TestModel.find({ $and: [TestModel.find()] });
+
+  const id = new Types.ObjectId();
+  // Any ObjectId should be accepted as the root argument
+  TestModel.find(id);
+  // @ts-expect-error: A ObjectId should not be a valid type for a FilterQuery within an op like $and
+  TestModel.find({ $and: [id] });
 }

--- a/test/types/queryhelpers.test.ts
+++ b/test/types/queryhelpers.test.ts
@@ -8,7 +8,7 @@ interface Project {
 type ProjectModelType = Model<Project, ProjectQueryHelpers>;
 // Query helpers should return `Query<any, Document<DocType>> & ProjectQueryHelpers`
 // to enable chaining.
-type ProjectModelQuery = Query<any, HydratedDocument<Project>, ProjectQueryHelpers> & ProjectQueryHelpers;
+type ProjectModelQuery = Query<any, HydratedDocument<Project>, ProjectQueryHelpers, any> & ProjectQueryHelpers;
 interface ProjectQueryHelpers {
   byName(this: ProjectModelQuery, name: string): ProjectModelQuery;
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -188,7 +188,7 @@ declare module 'mongoose' {
 
   export interface ReplaceOneModel<TSchema = AnyObject> {
     /** The filter to limit the replaced document. */
-    filter: FilterQuery<TSchema>;
+    filter: RootFilterQuery<TSchema>;
     /** The document with which to replace the matched document. */
     replacement: mongodb.WithoutId<TSchema>;
     /** Specifies a collation. */
@@ -203,7 +203,7 @@ declare module 'mongoose' {
 
   export interface UpdateOneModel<TSchema = AnyObject> {
     /** The filter to limit the updated documents. */
-    filter: FilterQuery<TSchema>;
+    filter: RootFilterQuery<TSchema>;
     /** A document or pipeline containing update operators. */
     update: UpdateQuery<TSchema>;
     /** A set of filters specifying to which array elements an update should apply. */
@@ -220,7 +220,7 @@ declare module 'mongoose' {
 
   export interface UpdateManyModel<TSchema = AnyObject> {
     /** The filter to limit the updated documents. */
-    filter: FilterQuery<TSchema>;
+    filter: RootFilterQuery<TSchema>;
     /** A document or pipeline containing update operators. */
     update: UpdateQuery<TSchema>;
     /** A set of filters specifying to which array elements an update should apply. */
@@ -237,7 +237,7 @@ declare module 'mongoose' {
 
   export interface DeleteOneModel<TSchema = AnyObject> {
     /** The filter to limit the deleted documents. */
-    filter: FilterQuery<TSchema>;
+    filter: RootFilterQuery<TSchema>;
     /** Specifies a collation. */
     collation?: mongodb.CollationOptions;
     /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -246,7 +246,7 @@ declare module 'mongoose' {
 
   export interface DeleteManyModel<TSchema = AnyObject> {
     /** The filter to limit the deleted documents. */
-    filter: FilterQuery<TSchema>;
+    filter: RootFilterQuery<TSchema>;
     /** Specifies a collation. */
     collation?: mongodb.CollationOptions;
     /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -318,7 +318,7 @@ declare module 'mongoose' {
 
     /** Creates a `countDocuments` query: counts the number of documents that match `filter`. */
     countDocuments(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       options?: (mongodb.CountOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       number,
@@ -357,7 +357,7 @@ declare module 'mongoose' {
      * regardless of the `single` option.
      */
     deleteMany(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
@@ -368,7 +368,7 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     deleteMany(
-      filter: FilterQuery<TRawDocType>
+      filter: RootFilterQuery<TRawDocType>
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -384,7 +384,7 @@ declare module 'mongoose' {
      * `single` option.
      */
     deleteOne(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
@@ -395,7 +395,7 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     deleteOne(
-      filter: FilterQuery<TRawDocType>
+      filter: RootFilterQuery<TRawDocType>
     ): QueryWithHelpers<
       mongodb.DeleteResult,
       THydratedDocumentType,
@@ -446,7 +446,7 @@ declare module 'mongoose' {
 
     /** Finds one document. */
     findOne<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
@@ -458,16 +458,16 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     findOne<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods>;
     findOne<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods>;
     findOne<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>
+      filter?: RootFilterQuery<TRawDocType>
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods>;
 
     /**
@@ -621,7 +621,7 @@ declare module 'mongoose' {
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
-      filter?: FilterQuery<TRawDocType>
+      filter?: RootFilterQuery<TRawDocType>
     ): QueryWithHelpers<
       Array<
         DocKey extends keyof WithLevel1NestedPaths<TRawDocType>
@@ -650,7 +650,7 @@ declare module 'mongoose' {
      * the given `filter`, and `null` otherwise.
      */
     exists(
-      filter: FilterQuery<TRawDocType>
+      filter: RootFilterQuery<TRawDocType>
     ): QueryWithHelpers<
       { _id: InferId<TRawDocType> } | null,
       THydratedDocumentType,
@@ -662,7 +662,7 @@ declare module 'mongoose' {
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
@@ -674,16 +674,16 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     find<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> | null | undefined
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods>;
     find<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods>;
     find<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>
+      filter: RootFilterQuery<TRawDocType>
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods>;
     find<ResultDoc = THydratedDocumentType>(
     ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods>;
@@ -711,7 +711,7 @@ declare module 'mongoose' {
 
     /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
     ): QueryWithHelpers<
@@ -756,7 +756,7 @@ declare module 'mongoose' {
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
       GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndDelete'> | null,
@@ -767,17 +767,17 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete', TInstanceMethods>;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType> | null,
+      filter?: RootFilterQuery<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete', TInstanceMethods>;
 
     /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
@@ -789,24 +789,24 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace', TInstanceMethods>;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace', TInstanceMethods>;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       replacement?: TRawDocType | AnyObject,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace', TInstanceMethods>;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
     ): QueryWithHelpers<
@@ -818,7 +818,7 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
@@ -830,24 +830,24 @@ declare module 'mongoose' {
       TInstanceMethods
     >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods>;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: FilterQuery<TRawDocType>,
+      filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods>;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType>,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods>;
 
     /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
     replaceOne<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       replacement?: TRawDocType | AnyObject,
       options?: (mongodb.ReplaceOptions & MongooseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'replaceOne', TInstanceMethods>;
@@ -860,14 +860,14 @@ declare module 'mongoose' {
 
     /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
     updateMany<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
       options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateMany', TInstanceMethods>;
 
     /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
     updateOne<ResultDoc = THydratedDocumentType>(
-      filter?: FilterQuery<TRawDocType>,
+      filter?: RootFilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
       options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateOne', TInstanceMethods>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -621,7 +621,7 @@ declare module 'mongoose' {
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
-      filter?: RootFilterQuery<TRawDocType>
+      filter?: RootFilterQuery<TRawDocType>,
       options?: QueryOptions<TRawDocType>
     ): QueryWithHelpers<
       Array<

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -115,8 +115,9 @@ declare module 'mongoose' {
     /** @see https://www.mongodb.com/docs/manual/reference/operator/query/comment/#op._S_comment */
     $comment?: string;
     // we could not find a proper TypeScript generic to support nested queries e.g. 'user.friends.name'
-    // this will mark all unrecognized properties as any (including nested queries)
-    [key: string]: any;
+    // this will mark all unrecognized properties as any (including nested queries) only if
+    // they include a "." (to avoid generically allowing any unexpected keys)
+    [nestedSelector: `${string}.${string}`]: any;
   };
 
   interface QueryTimestampsConfig {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -10,9 +10,11 @@ declare module 'mongoose' {
    * { age: { $gte: 30 } }
    * ```
    */
-  type FilterQuery<T> = {
+  type RootFilterQuery<T> = FilterQuery<T> | Query<any, any> | Types.ObjectId;
+
+  type FilterQuery<T> ={
     [P in keyof T]?: Condition<T[P]>;
-  } & RootQuerySelector<T>;
+  } & RootQuerySelector<T> & { _id?: Condition<string>; };
 
   type MongooseBaseQueryOptionKeys =
     | 'context'
@@ -304,7 +306,7 @@ declare module 'mongoose' {
 
     /** Specifies this query as a `countDocuments` query. */
     countDocuments(
-      criteria?: FilterQuery<RawDocType>,
+      criteria?: RootFilterQuery<RawDocType>,
       options?: QueryOptions<DocType>
     ): QueryWithHelpers<number, DocType, THelpers, RawDocType, 'countDocuments', TInstanceMethods>;
 
@@ -320,10 +322,10 @@ declare module 'mongoose' {
      * collection, regardless of the value of `single`.
      */
     deleteMany(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       options?: QueryOptions<DocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteMany', TInstanceMethods>;
-    deleteMany(filter: FilterQuery<RawDocType>): QueryWithHelpers<
+    deleteMany(filter: RootFilterQuery<RawDocType>): QueryWithHelpers<
       any,
       DocType,
       THelpers,
@@ -339,10 +341,10 @@ declare module 'mongoose' {
      * option.
      */
     deleteOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       options?: QueryOptions<DocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne', TInstanceMethods>;
-    deleteOne(filter: FilterQuery<RawDocType>): QueryWithHelpers<
+    deleteOne(filter: RootFilterQuery<RawDocType>): QueryWithHelpers<
       any,
       DocType,
       THelpers,
@@ -355,7 +357,7 @@ declare module 'mongoose' {
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
-      filter?: FilterQuery<RawDocType>
+      filter?: RootFilterQuery<RawDocType>
     ): QueryWithHelpers<
       Array<
         DocKey extends keyof WithLevel1NestedPaths<DocType>
@@ -407,52 +409,52 @@ declare module 'mongoose' {
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find(
-      filter: FilterQuery<RawDocType>,
+      filter: RootFilterQuery<RawDocType>,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TInstanceMethods>;
     find(
-      filter: FilterQuery<RawDocType>,
+      filter: RootFilterQuery<RawDocType>,
       projection?: ProjectionType<RawDocType> | null
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TInstanceMethods>;
     find(
-      filter: FilterQuery<RawDocType>
+      filter: RootFilterQuery<RawDocType>
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TInstanceMethods>;
     find(): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TInstanceMethods>;
 
     /** Declares the query a findOne operation. When executed, returns the first found document. */
     findOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TInstanceMethods>;
     findOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       projection?: ProjectionType<RawDocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TInstanceMethods>;
     findOne(
-      filter?: FilterQuery<RawDocType>
+      filter?: RootFilterQuery<RawDocType>
     ): QueryWithHelpers<DocType | null, RawDocType, THelpers, RawDocType, 'findOne', TInstanceMethods>;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
     findOneAndDelete(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete'>;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
     findOneAndUpdate(
-      filter: FilterQuery<RawDocType>,
+      filter: RootFilterQuery<RawDocType>,
       update: UpdateQuery<RawDocType>,
       options: QueryOptions<DocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndUpdate', TInstanceMethods>;
     findOneAndUpdate(
-      filter: FilterQuery<RawDocType>,
+      filter: RootFilterQuery<RawDocType>,
       update: UpdateQuery<RawDocType>,
       options: QueryOptions<DocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate', TInstanceMethods>;
     findOneAndUpdate(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       update?: UpdateQuery<RawDocType>,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TInstanceMethods>;
@@ -593,7 +595,7 @@ declare module 'mongoose' {
     maxTimeMS(ms: number): this;
 
     /** Merges another Query or conditions object into this one. */
-    merge(source: Query<any, any> | FilterQuery<RawDocType>): this;
+    merge(source: RootFilterQuery<RawDocType>): this;
 
     /** Specifies a `$mod` condition, filters documents for documents whose `path` property is a number that is equal to `remainder` modulo `divisor`. */
     mod<K = string>(path: K, val: number): this;
@@ -712,7 +714,7 @@ declare module 'mongoose' {
      * not accept any [atomic](https://www.mongodb.com/docs/manual/tutorial/model-data-for-atomic-operations/#pattern) operators (`$set`, etc.)
      */
     replaceOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       replacement?: DocType | AnyObject,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'replaceOne', TInstanceMethods>;
@@ -820,7 +822,7 @@ declare module 'mongoose' {
      * the `multi` option.
      */
     updateMany(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       update?: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateMany', TInstanceMethods>;
@@ -830,7 +832,7 @@ declare module 'mongoose' {
      * `update()`, except it does not support the `multi` or `overwrite` options.
      */
     updateOne(
-      filter?: FilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       update?: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateOne', TInstanceMethods>;


### PR DESCRIPTION
**Summary**

Previously, there was a catch-all case in RootQuerySelector which would accept any key with type "any". This still allows nice IDE typehints, but can lead to bugs where the incorrect key is used for a filter with no warning that the key is clearly wrong.

With this PR, only keys that contain a "." are unsafely typed as any, which should reduce the blast radius of the hacky types dramatically.


**Examples**
Previously, the following would be a valid type:
```ts
const testDoc: FilterQuery<{ testKey: string }> = {
  invalidKey: 'test',
};
```
Now, the above case gives a type error for "invalidKey".

Note that a case such as this will still be accepted (since its hard to properly type any nested queries):
```ts
const testDoc: FilterQuery<{ testKey: string }> = {
  "invalidKey.test": 'test',
};
```