### PR TITLE
fix: allow setting document array default to `null`

### DIFF
--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -69,7 +69,7 @@ function SchemaDocumentArray(key, schema, options, schemaOptions) {
 
   const fn = this.defaultValue;
 
-  if (!('defaultValue' in this) || fn !== void 0) {
+  if (!('defaultValue' in this) || fn != null) {
     this.default(function() {
       let arr = fn.call(this);
       if (arr != null && !Array.isArray(arr)) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -3203,16 +3203,22 @@ describe('document', function() {
         names: {
           type: [String],
           default: null
+        },
+        tags: {
+          type: [{ tag: String }],
+          default: null
         }
       });
 
       const Model = db.model('Test', schema);
       const m = new Model();
       assert.strictEqual(m.names, null);
+      assert.strictEqual(m.tags, null);
       await m.save();
 
       const doc = await Model.collection.findOne({ _id: m._id });
       assert.strictEqual(doc.names, null);
+      assert.strictEqual(doc.tags, null);
     });
 
     it('validation works when setting array index (gh-3816)', async function() {


### PR DESCRIPTION
Fix #6691
Re: #14717

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like #14717 missed a spot, we still need a change to support `default: null` for document arrays

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
