### PR TITLE
feat(model+query): support `options` parameter for distinct()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2115,17 +2115,21 @@ Model.countDocuments = function countDocuments(conditions, options) {
  *
  * @param {String} field
  * @param {Object} [conditions] optional
+ * @param {Object} [options] optional
  * @return {Query}
  * @api public
  */
 
-Model.distinct = function distinct(field, conditions) {
+Model.distinct = function distinct(field, conditions, options) {
   _checkContext(this, 'distinct');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
+  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
     throw new MongooseError('Model.distinct() no longer accepts a callback');
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
+  if (options != null) {
+    mq.setOptions(options);
+  }
 
   return mq.distinct(field, conditions);
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -2870,21 +2870,24 @@ Query.prototype.__distinct = async function __distinct() {
  *
  * #### Example:
  *
+ *     distinct(field, conditions, options)
  *     distinct(field, conditions)
  *     distinct(field)
  *     distinct()
  *
  * @param {String} [field]
  * @param {Object|Query} [filter]
+ * @param {Object} [options]
  * @return {Query} this
  * @see distinct https://www.mongodb.com/docs/manual/reference/method/db.collection.distinct/
  * @api public
  */
 
-Query.prototype.distinct = function(field, conditions) {
+Query.prototype.distinct = function(field, conditions, options) {
   if (typeof field === 'function' ||
       typeof conditions === 'function' ||
-      typeof arguments[2] === 'function') {
+      typeof options === 'function' ||
+      typeof arguments[3] === 'function') {
     throw new MongooseError('Query.prototype.distinct() no longer accepts a callback');
   }
 
@@ -2901,6 +2904,10 @@ Query.prototype.distinct = function(field, conditions) {
 
   if (field != null) {
     this._distinct = field;
+  }
+
+  if (typeof options === 'object' && options != null) {
+    this.setOptions(options);
   }
 
   return this;

--- a/lib/query.js
+++ b/lib/query.js
@@ -2773,7 +2773,7 @@ Query.prototype.estimatedDocumentCount = function(options) {
   this.op = 'estimatedDocumentCount';
   this._validateOp();
 
-  if (typeof options === 'object' && options != null) {
+  if (options != null) {
     this.setOptions(options);
   }
 
@@ -2832,7 +2832,7 @@ Query.prototype.countDocuments = function(conditions, options) {
     this.merge(conditions);
   }
 
-  if (typeof options === 'object' && options != null) {
+  if (options != null) {
     this.setOptions(options);
   }
 
@@ -2906,7 +2906,7 @@ Query.prototype.distinct = function(field, conditions, options) {
     this._distinct = field;
   }
 
-  if (typeof options === 'object' && options != null) {
+  if (options != null) {
     this.setOptions(options);
   }
 

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -341,7 +341,6 @@ describe('transactions', function() {
   it('distinct (gh-8006)', async function() {
     const Character = db.model('gh8006_Character', new Schema({ name: String, rank: String }, { versionKey: false }));
 
-
     const session = await db.startSession();
 
     session.startTransaction();

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1088,6 +1088,16 @@ describe('Query', function() {
 
       assert.equal(q.op, 'distinct');
     });
+
+    it('using options parameter for distinct', function() {
+      const q = new Query({});
+      const options = { collation: { locale: 'en', strength: 2 } };
+
+      q.distinct('blah', {}, options);
+
+      assert.equal(q.op, 'distinct');
+      assert.deepEqual(q.options.collation, options.collation);
+    });
   });
 
   describe('findOne', function() {

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -109,6 +109,7 @@ Test.find({ name: { $gte: 'Test' } }, null, { collation: { locale: 'en-us' } }).
 Test.findOne().orFail(new Error('bar')).then((doc: ITest | null) => console.log('Found! ' + doc));
 
 Test.distinct('name').exec().then((res: Array<any>) => console.log(res[0]));
+Test.distinct('name', {}, { collation: { locale: 'en', strength: 2 } }).exec().then((res: Array<any>) => console.log(res[0]));
 
 Test.findOneAndUpdate({ name: 'test' }, { name: 'test2' }).exec().then((res: ITest | null) => console.log(res));
 Test.findOneAndUpdate({ name: 'test' }, { name: 'test2' }).then((res: ITest | null) => console.log(res));

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -621,7 +621,8 @@ declare module 'mongoose' {
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
-      filter?: FilterQuery<TRawDocType>
+      filter?: FilterQuery<TRawDocType>,
+      options?: QueryOptions<TRawDocType>
     ): QueryWithHelpers<
       Array<
         DocKey extends keyof WithLevel1NestedPaths<TRawDocType>

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -354,7 +354,8 @@ declare module 'mongoose' {
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
-      filter?: FilterQuery<RawDocType>
+      filter?: FilterQuery<RawDocType>,
+      options?: QueryOptions<DocType>
     ): QueryWithHelpers<
       Array<
         DocKey extends keyof WithLevel1NestedPaths<DocType>


### PR DESCRIPTION
Fix #8006

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Make it easier to use `distinct()` with transactions, so you don't need to chain `setOptions()`. `distinct()` looks to be the only query function where you can't pass in `options`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
