### PR TITLE
fix: support schema type inference based on schema options timestamps as well

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1575,3 +1575,32 @@ function gh14748() {
   const subdoc3 = schema.path<Schema.Types.Subdocument<{ name: string }>>('singleNested').cast({ name: 'bar' });
   expectAssignable<{ name: string }>(subdoc3);
 }
+
+function gh13215() {
+  const schemaDefinition = {
+    userName: { type: String, required: true }
+  } as const;
+  const schemaOptions = {
+    typeKey: 'type',
+    timestamps: {
+      createdAt: 'date',
+      updatedAt: false
+    }
+  } as const;
+
+  type RawDocType = InferRawDocType<
+    typeof schemaDefinition,
+    typeof schemaOptions
+  >;
+  type User = {
+    userName: string;
+  } & {
+    date: Date;
+  };
+
+  expectType<User>({} as RawDocType);
+
+  const schema = new Schema(schemaDefinition, schemaOptions);
+  type SchemaType = InferSchemaType<typeof schema>;
+  expectType<User>({} as SchemaType);
+}

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -10,12 +10,12 @@ declare module 'mongoose' {
   export type InferRawDocType<
     DocDefinition,
     TSchemaOptions extends Record<any, any> = DefaultSchemaOptions
-  > = {
+  > = ApplySchemaOptions<{
     [
     K in keyof (RequiredPaths<DocDefinition, TSchemaOptions['typeKey']> &
     OptionalPaths<DocDefinition, TSchemaOptions['typeKey']>)
     ]: ObtainRawDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>;
-  };
+  }, TSchemaOptions>;
 
   /**
    * @summary Obtains schema Path type.


### PR DESCRIPTION
support schema type inference based on schema options timestamps as well

Fix #13215

**Summary**
Currently, `InferSchemaType` and `InferRawDocType` does not infer type based on timestamps fields provided in the schema options, which can lead to some difficulties while developing process (you'll have to add fields into your schema types manually to avoid the issue or extend returned typescript type).
