### PR TITLE
fix(document): apply virtuals to subdocuments if parent schema has `virtuals: true` for backwards compatibility

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3801,7 +3801,7 @@ Document.prototype.$__handleReject = function handleReject(err) {
 };
 
 /**
- * Internal helper for toObject() and toJSON() that doesn't manipulate options
+ * Internal common logic for toObject() and toJSON()
  *
  * @return {Object}
  * @api private
@@ -3834,13 +3834,16 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   const depopulate = options._calledWithOptions.depopulate
-    ?? options._parentOptions?.depopulate
     ?? defaultOptions?.depopulate
+    ?? options.depopulate
     ?? false;
   // _isNested will only be true if this is not the top level document, we
   // should never depopulate the top-level document
   if (depopulate && options._isNested && this.$__.wasPopulated) {
     return clone(this.$__.wasPopulated.value || this._doc._id, options);
+  }
+  if (depopulate) {
+    options.depopulate = true;
   }
 
   // merge default options with input options.
@@ -3855,7 +3858,9 @@ Document.prototype.$toObject = function(options, json) {
   options.json = json;
   options.minimize = _minimize;
 
-  options._parentOptions = options;
+  const parentOptions = options._parentOptions;
+  // Parent options should only bubble down for subdocuments, not populated docs
+  options._parentOptions = this.$isSubdocument ? options : null;
 
   options._skipSingleNestedGetters = false;
   // remember the root transform function
@@ -3886,6 +3891,7 @@ Document.prototype.$toObject = function(options, json) {
 
   const virtuals = options._calledWithOptions.virtuals
     ?? defaultOptions.virtuals
+    ?? parentOptions?.virtuals
     ?? undefined;
 
   if (virtuals || (getters && virtuals !== false)) {


### PR DESCRIPTION
Fix #14771
Re: #14394
Re: #14623

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fixing #14771, which is a bug that was likely introduced by #14623. The issue is that older versions of Mongoose make parent `virtuals` option apply to subdocs presuming that the subdocs don't explicitly set `virtuals`.

```javascript
const userLabSchema = new mongoose.Schema({
  capacityLevel: Number
});

userLabSchema.virtual('capacityLevelCeil').get(function() {
  return Math.ceil(this.capacityLevel);
});

const labPlotSchema = new mongoose.Schema({
  plotId: Number,
  lab: userLabSchema
});

const userSchema = new mongoose.Schema({
  username: String,
  labPlots: [labPlotSchema]
}, { toObject: { virtuals: true } });

const User = mongoose.model('User', userSchema);

const doc = new User({
  username: 'test',
  labPlots: [{
    plotId: 1,
    lab: { capacityLevel: 3.14 }
  }]
});
// In Mongoose 8.4.0, virtual is applied because top-level schema has `toObject: { virtuals: true }`
// In Mongoose 8.5.2, virtual is not applied because `userLabSchema` does not have `toObject: { virtuals: true }`
console.log(doc.toObject().labPlots[0].lab.capacityLevelCeil);
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
