### PR TITLE
docs: add schema type widening advice

### DIFF
--- a/docs/typescript/schemas.md
+++ b/docs/typescript/schemas.md
@@ -32,6 +32,8 @@ There are a few caveats for using automatic type inference:
 2. You need to define your schema in the `new Schema()` call. Don't assign your schema definition to a temporary variable. Doing something like `const schemaDefinition = { name: String }; const schema = new Schema(schemaDefinition);` will not work.
 3. Mongoose adds `createdAt` and `updatedAt` to your schema if you specify the `timestamps` option in your schema, *except* if you also specify `methods`, `virtuals`, or `statics`. There is a [known issue](https://github.com/Automattic/mongoose/issues/12807) with type inference with timestamps and methods/virtuals/statics options. If you use methods, virtuals, and statics, you're responsible for adding `createdAt` and `updatedAt` to your schema definition.
 
+If you must define your schema separately, use [as const](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) (`const schemaDefinition = { ... } as const;`) to prevent *type widening*. TypeScript will automatically widen types like `required: false` to `required: boolean`, which will cause Mongoose to assume the field is required. Using `as const` forces TypeScript to retain these types.
+
 If you need to explicitly get the raw document type (the value returned from `doc.toObject()`, `await Model.findOne().lean()`, etc.) from your schema definition, you can use Mongoose's `inferRawDocType` helper as follows:
 
 ```ts


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

### Summary

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

While using Mongoose with TypeScript, @ShunnShine and I discovered the dangers of defining the schema in a separate variable when we realized all of our fields with `required: false` were being treated as `required: true`.

We eventually figured out how to fix the type definitions by using `as const`.

We looked at the [Schemas in TypeScript](https://mongoosejs.com/docs/typescript/schemas.html) documentation and saw a warning about assigning a schema to a temporary variable (fair enough), but did not see any information about using `as const`, even though it is used in the example code right below - without explanation.

This PR adds a little section about type widening and `as const` to help users understand why this was done.