### PR TITLE
style(map): document key name constraints

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -69,7 +69,7 @@ class MongooseMap extends Map {
    * ObjectIds as keys.
    *
    * Keys also cannot:
-   * - be named after special properties (like `prototype`, `constructor` and `__proto__`)
+   * - be named after special properties `prototype`, `constructor`, and `__proto__`
    * - start with a dollar sign (`$`)
    * - contain any dots (`.`)
    *

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -68,10 +68,17 @@ class MongooseMap extends Map {
    * and change tracking. Note that Mongoose maps _only_ support strings and
    * ObjectIds as keys.
    *
+   * Keys also cannot:
+   * - be named after special properties (like `prototype`, `constructor` and `__proto__`)
+   * - start with a dollar sign (`$`)
+   * - contain any dots (`.`)
+   *
    * #### Example:
    *
    *     doc.myMap.set('test', 42); // works
    *     doc.myMap.set({ obj: 42 }, 42); // Throws "Mongoose maps only support string keys"
+   *     doc.myMap.set(10, 42); // Throws "Mongoose maps only support string keys"
+   *     doc.myMap.set("$test", 42); // Throws "Mongoose maps do not support keys that start with "$", got "$test""
    *
    * @api public
    * @method set


### PR DESCRIPTION
**Summary**

Updates SchemaType `Map.set`'s documentation to note which extra constraints are on the key names.