### PR TITLE
types(cursor): indicate that cursor.next() can return null

### DIFF
--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -21,6 +21,8 @@ Test.find().cursor().
   }).
   then(() => console.log('Done!'));
 
+Test.find().cursor().next().then((doc) => expectType<ITest | null>(doc));
+
 async function gh14374() {
   // `Parent` represents the object as it is stored in MongoDB
   interface Parent {

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -51,7 +51,7 @@ declare module 'mongoose' {
      * Get the next document from this cursor. Will return `null` when there are
      * no documents left.
      */
-    next(): Promise<DocType>;
+    next(): Promise<DocType | null>;
 
     options: Options;
   }


### PR DESCRIPTION
Fix #14787

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`await cursor.next()` will be `null` if there's no more docs

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
