### PR TITLE
fix populate called with lean (gh-14794)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4459,7 +4459,7 @@ function _assign(model, vals, mod, assignmentOpts) {
         }
       } else {
         if (_val instanceof Document) {
-          _val = _val._doc._id;
+          _val = _val._id;
         }
         key = String(_val);
         if (rawDocs[key]) {
@@ -4468,7 +4468,7 @@ function _assign(model, vals, mod, assignmentOpts) {
             rawOrder[key].push(i);
           } else if (isVirtual ||
             rawDocs[key].constructor !== val.constructor ||
-            String(rawDocs[key]._doc._id) !== String(val._doc._id)) {
+            String(rawDocs[key]._id) !== String(val._id)) {
             // May need to store multiple docs with the same id if there's multiple models
             // if we have discriminators or a ref function. But avoid converting to an array
             // if we have multiple queries on the same model because of `perDocumentLimit` re: gh-9906

--- a/lib/model.js
+++ b/lib/model.js
@@ -4459,7 +4459,7 @@ function _assign(model, vals, mod, assignmentOpts) {
         }
       } else {
         if (_val instanceof Document) {
-          _val = _val._id;
+          _val = _val._doc._id;
         }
         key = String(_val);
         if (rawDocs[key]) {
@@ -4468,7 +4468,7 @@ function _assign(model, vals, mod, assignmentOpts) {
             rawOrder[key].push(i);
           } else if (isVirtual ||
             rawDocs[key].constructor !== val.constructor ||
-            String(rawDocs[key]._id) !== String(val._id)) {
+            (rawDocs[key] instanceof Document ? String(rawDocs[key]._doc._id) : String(rawDocs[key]._id)) !== (val instanceof Document ? String(val._doc._id) : String(val._id))) {
             // May need to store multiple docs with the same id if there's multiple models
             // if we have discriminators or a ref function. But avoid converting to an array
             // if we have multiple queries on the same model because of `perDocumentLimit` re: gh-9906


### PR DESCRIPTION
**Summary**

in #14794 due to being called with `lean()` there's no `_doc` object so that throws an error

another issue here is documents with duplicate foreignField so the `rawDocs[key]` already exists and its value is being overwritten.

this change shouldn't affect (gh-14759) and its test case still runs successfully.

another solution would be to check for `rawDocs[key]._id`  and `val._doc` first using the following statement instead
```js
(rawDocs[key]._doc && String(rawDocs[key]._doc._id)) !== (val._doc && String(val._doc._id))) 