### PR TITLE
types: make HydratedSingleSubdocument and HydratedArraySubdocument merge types instead of using &

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,8 +157,37 @@ declare module 'mongoose' {
         >
       >
   >;
-  export type HydratedSingleSubdocument<DocType, TOverrides = {}> = Types.Subdocument<unknown, Record<string, never>, DocType> & Require_id<DocType> & TOverrides;
-  export type HydratedArraySubdocument<DocType, TOverrides = {}> = Types.ArraySubdocument<unknown, Record<string, never>, DocType> & Require_id<DocType> & TOverrides;
+  export type HydratedSingleSubdocument<
+    DocType,
+    TOverrides = {}
+  > = IfAny<
+  DocType,
+  any,
+  TOverrides extends Record<string, never> ?
+    Types.Subdocument<unknown, Record<string, never>, DocType> & Require_id<DocType> :
+    IfAny<
+      TOverrides,
+      Types.Subdocument<unknown, Record<string, never>, DocType> & Require_id<DocType>,
+      Types.Subdocument<unknown, Record<string, never>, DocType> & MergeType<
+        Require_id<DocType>,
+        TOverrides
+      >
+    >
+  >;
+  export type HydratedArraySubdocument<DocType, TOverrides = {}> = IfAny<
+    DocType,
+    any,
+    TOverrides extends Record<string, never> ?
+      Types.ArraySubdocument<unknown, Record<string, never>, DocType> & Require_id<DocType> :
+      IfAny<
+        TOverrides,
+        Types.ArraySubdocument<unknown, Record<string, never>, DocType> & Require_id<DocType>,
+        Types.ArraySubdocument<unknown, Record<string, never>, DocType> & MergeType<
+          Require_id<DocType>,
+          TOverrides
+        >
+      >
+    >;
 
   export type HydratedDocumentFromSchema<TSchema extends Schema> = HydratedDocument<
   InferSchemaType<TSchema>,


### PR DESCRIPTION
Fix #14793

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

As #14793 points out, HydratedSingleSubdocument and HydratedArraySubdocument need to use `MergeTypes`, otherwise we end up with hard to diagnose compiler errors stemming back to having `RawType & HydratedType`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
