### PR TITLE
fix(document): call required functions on subdocuments underneath nested paths with correct context

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2770,15 +2770,6 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
     }
   }
 
-  for (const path of paths) {
-    // Single nested paths (paths embedded under single nested subdocs) will
-    // be validated on their own when we call `validate()` on the subdoc itself.
-    // Re: gh-8468
-    if (doc.$__schema.singleNestedPaths.hasOwnProperty(path)) {
-      paths.delete(path);
-      continue;
-    }
-  }
 
   if (Array.isArray(pathsToValidate)) {
     paths = _handlePathsToValidate(paths, pathsToValidate);
@@ -2800,7 +2791,10 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
         _v = _v.toObject({ transform: false });
       }
       const flat = flatten(_v, pathToCheck, flattenOptions, doc.$__schema);
-      Object.keys(flat).forEach(addToPaths);
+      // Single nested paths (paths embedded under single nested subdocs) will
+      // be validated on their own when we call `validate()` on the subdoc itself.
+      // Re: gh-8468
+      Object.keys(flat).filter(path => !doc.$__schema.singleNestedPaths.hasOwnProperty(path)).forEach(addToPaths);
     }
   }
 


### PR DESCRIPTION
Fix #14788

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When we add all paths underneath a nested path to list of paths to validate, we actually need to avoid adding paths underneath single nested subdocuments. That's because validating a single nested subdoc triggers validation on all paths underneath that subdoc.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
