### PR TITLE
fix(document): make sure depopulate does not convert hydrated arrays to vanilla arrays

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4774,7 +4774,23 @@ Document.prototype.depopulate = function(path) {
         continue;
       }
       delete populated[key];
-      utils.setValue(key, populatedIds, this._doc);
+      if (Array.isArray(populatedIds)) {
+        const arr = utils.getValue(key, this._doc);
+        if (arr.isMongooseArray) {
+          const rawArray = arr.__array;
+          for (let i = 0; i < rawArray.length; ++i) {
+            const subdoc = rawArray[i];
+            if (subdoc == null) {
+              continue;
+            }
+            rawArray[i] = subdoc instanceof Document ? subdoc._doc._id : subdoc._id;
+          }
+        } else {
+          utils.setValue(key, populatedIds, this._doc);
+        }
+      } else {
+        utils.setValue(key, populatedIds, this._doc);
+      }
     }
     return this;
   }
@@ -4787,7 +4803,23 @@ Document.prototype.depopulate = function(path) {
       delete this.$$populatedVirtuals[singlePath];
       delete this._doc[singlePath];
     } else if (populatedIds) {
-      utils.setValue(singlePath, populatedIds, this._doc);
+      if (Array.isArray(populatedIds)) {
+        const arr = utils.getValue(singlePath, this._doc);
+        if (arr.isMongooseArray) {
+          const rawArray = arr.__array;
+          for (let i = 0; i < rawArray.length; ++i) {
+            const subdoc = rawArray[i];
+            if (subdoc == null) {
+              continue;
+            }
+            rawArray[i] = subdoc instanceof Document ? subdoc._doc._id : subdoc._id;
+          }
+        } else {
+          utils.setValue(singlePath, populatedIds, this._doc);
+        }
+      } else {
+        utils.setValue(singlePath, populatedIds, this._doc);
+      }
     }
   }
   return this;

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -721,6 +721,7 @@ const methods = {
     }
 
     this._registerAtomic('$push', atomic);
+
     return ret;
   },
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -10805,7 +10805,10 @@ describe('document', function() {
     assert.ok(!band.populated('members'));
     assert.ok(!band.populated('lead'));
     assert.ok(!band.populated('embeddedMembers.member'));
+    assert.ok(band.members.isMongooseArray);
+    assert.ok(band.embeddedMembers.isMongooseArray);
     assert.ok(!band.embeddedMembers[0].member.name);
+    // assert.ok(!band.embeddedMembers[0].$populated('member'));
   });
 
   it('should allow dashes in the path name (gh-10677)', async function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

One issue that popped up while I was working on #1635 is that `depopulate()` converts Mongoose arrays to vanilla JavaScript arrays. So `band.depopulate('members'); band.members.addToSet(id);` will error out because `band.members` is no longer a Mongoose array.

The approach I came up with is to use `getValue()`: if `getValue()` returns a Mongoose array, then we just modify the array in-place to avoid triggering setters. If not a Mongoose array, then we have a case where mpath is returning an array of values underneath a document array, like in the #10592 test case `doc.depopulate('docArr.members')`, so we fall back to `setValue()`. 

I left `assert.ok(!band.embeddedMembers[0].$populated('member'));` commented out because that assertion fails, but I want to look at it some more when we come back to #1635.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
