### PR TITLE
Add empty string check for collection name passed

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,6 +53,12 @@ exports.toCollectionName = function(name, pluralize) {
     return name;
   }
   if (typeof pluralize === 'function') {
+    if (typeof name !== 'string') {
+      throw new TypeError('Collection name must be a string');
+    }
+    if (name.length === 0) {
+      throw new TypeError('Collection name cannot be empty');
+    }
     return pluralize(name);
   }
   return name;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -324,4 +324,31 @@ describe('utils', function() {
       assert.deepEqual(pojoError.metadata, { hello: 'world' });
     });
   });
+
+  describe('toCollectionName', function() {
+    it('returns the same name for system.profile', function() {
+      assert.equal(utils.toCollectionName('system.profile'), 'system.profile');
+    });
+
+    it('returns the same name for system.indexes', function() {
+      assert.equal(utils.toCollectionName('system.indexes'), 'system.indexes');
+    });
+
+    it('throws an error when name is not a string', function() {
+      assert.throws(() => {
+        utils.toCollectionName(123, () => {});
+      }, /Collection name must be a string/);
+    });
+
+    it('throws an error when name is an empty string', function() {
+      assert.throws(() => {
+        utils.toCollectionName('', () => {});
+      }, /Collection name cannot be empty/);
+    });
+
+    it('uses the pluralize function when provided', function() {
+      const pluralize = (name) => name + 's';
+      assert.equal(utils.toCollectionName('test', pluralize), 'tests');
+    });
+  });
 });


### PR DESCRIPTION
@vkarpov15, I was unable to add reviewers directly and would appreciate your feedback on this PR. Please let me know if there are any additional steps I should follow or if you have any suggestions.

Feel free to reach out if you have any questions or need further information.

**Summary**

The motivation for me to make this pull request is that while we were working on our serverless project we used Mongoose but we got an error that said Cannot read properties of undefined (reading 'toLowerCase') we were not able to fix as on our local we could run and it worked fine so we scratched a lot of our head thinking we didn't use toString function anywhere where is the issue code, so we put consoles and then check on deployment logs and realized the issue was that the secret manager was not properly configured so let say we have process.env.COLLECTION_NAME will be undefined, so the problem was not handled and threw an error from the module where it tried to convert undefined to lowercase using the javascript method but it took a good amount of effort and time to fix it so I thought of understanding the flow and got to know the utils.js file has method that runs a function on collection name, that is toCollectionName so I put a string and empty string check here so meaningful message are thrown and error is immediately caught saving from a lot of frustration, effort and saving time, also I ran the test case to confirm nothing breaks but found some lines were not covered in the test so added some test cases to cover them as well.


**Examples**

The demonstration is passing values other than string will give Collection name must be a string error message and if it is a string but empty then it will say Collection name cannot be empty.

To test after making a successful mongoose connection: 
`const User = mongoose.model('', userSchema);
or 
const User = mongoose.model(undefined, userSchema);
`

Earlier it used to throw a toLowerCase error but now with the above-referenced message will be thrown

Please do let me know if you have any queries regarding, suggestions, feedback, or enhancement to make.