### PR TITLE
docs(mongoose): remove out-of-date callback-based example for `mongoose.connect()`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -330,7 +330,7 @@ Mongoose.prototype.get = Mongoose.prototype.set;
  *
  *     // initialize now, connect later
  *     db = mongoose.createConnection();
- *     db.openUri('127.0.0.1', 'database', port, [opts]);
+ *     await db.openUri('mongodb://127.0.0.1:27017/database');
  *
  * @param {String} uri mongodb URI to connect to
  * @param {Object} [options] passed down to the [MongoDB driver's `connect()` function](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html), except for 4 mongoose-specific options explained below.
@@ -378,11 +378,10 @@ Mongoose.prototype.createConnection = function(uri, options) {
  *     // with options
  *     mongoose.connect(uri, options);
  *
- *     // optional callback that gets fired when initial connection completed
+ *     // Using `await` throws "MongooseServerSelectionError: Server selection timed out after 30000 ms"
+ *     // if Mongoose can't connect.
  *     const uri = 'mongodb://nonexistent.domain:27000';
- *     mongoose.connect(uri, function(error) {
- *       // if error is truthy, the initial connection failed.
- *     })
+ *     await mongoose.connect(uri);
  *
  * @param {String} uri mongodb URI to connect to
  * @param {Object} [options] passed down to the [MongoDB driver's `connect()` function](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html), except for 4 mongoose-specific options explained below.


### PR DESCRIPTION
Fix #14810

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fixed an out-of-date example and improved it to make better use of `await`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
