### PR TITLE
fix(connection): avoid returning `readyState = connected` if connection state is stale

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -103,6 +103,15 @@ Object.setPrototypeOf(Connection.prototype, EventEmitter.prototype);
 
 Object.defineProperty(Connection.prototype, 'readyState', {
   get: function() {
+    // If connection thinks it is connected, but we haven't received a heartbeat in 2 heartbeat intervals,
+    // that likely means the connection is stale (potentially due to frozen AWS Lambda container)
+    if (
+      this._readyState === STATES.connected &&
+      this._lastHeartbeatAt != null &&
+      typeof this.client?.topology?.s?.description?.heartbeatFrequencyMS === 'number' &&
+      Date.now() - this._lastHeartbeatAt >= this.client.topology.s.description.heartbeatFrequencyMS * 2) {
+      return STATES.disconnected;
+    }
     return this._readyState;
   },
   set: function(val) {

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -23,6 +23,11 @@ const utils = require('../../utils');
 function NativeConnection() {
   MongooseConnection.apply(this, arguments);
   this._listening = false;
+  // Tracks the last time (as unix timestamp) the connection received a
+  // serverHeartbeatSucceeded or serverHeartbeatFailed event from the underlying MongoClient.
+  // If we haven't received one in a while (like due to a frozen AWS Lambda container) then
+  // `readyState` is likely stale.
+  this._lastHeartbeatAt = null;
 }
 
 /**
@@ -106,6 +111,7 @@ NativeConnection.prototype.useDb = function(name, options) {
       _opts.noListener = options.noListener;
     }
     newConn.db = _this.client.db(name, _opts);
+    newConn._lastHeartbeatAt = _this._lastHeartbeatAt;
     newConn.onOpen();
   }
 
@@ -409,6 +415,12 @@ function _setClient(conn, client, options, dbName) {
       }
     });
   }
+  client.on('serverHeartbeatSucceeded', () => {
+    conn._lastHeartbeatAt = Date.now();
+  });
+  client.on('serverHeartbeatFailed', () => {
+    conn._lastHeartbeatAt = Date.now();
+  });
 
   if (options.monitorCommands) {
     client.on('commandStarted', (data) => conn.emit('commandStarted', data));
@@ -417,6 +429,9 @@ function _setClient(conn, client, options, dbName) {
   }
 
   conn.onOpen();
+  if (client.topology?.s?.state === 'connected') {
+    conn._lastHeartbeatAt = Date.now();
+  }
 
   for (const i in conn.collections) {
     if (utils.object.hasOwnProperty(conn.collections, i)) {

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -418,9 +418,6 @@ function _setClient(conn, client, options, dbName) {
   client.on('serverHeartbeatSucceeded', () => {
     conn._lastHeartbeatAt = Date.now();
   });
-  client.on('serverHeartbeatFailed', () => {
-    conn._lastHeartbeatAt = Date.now();
-  });
 
   if (options.monitorCommands) {
     client.on('commandStarted', (data) => conn.emit('commandStarted', data));


### PR DESCRIPTION
Fix #14727

cc @alexbevi 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The problem here is that `readyState` can return `connected` immediately after an AWS Lambda container thaws after some time. `readyState` only looks at the last heartbeat, but not how long ago the last heartbeat occurred - with this PR, if the last heartbeat is stale (more than 2 heartbeat intervals) then we assume we're disconnected.

This PR still needs significant testing, but I wanted to put it out for review to solicit early feedback.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
