### PR TITLE
types: make toObject() and toJSON() not generic by default to avoid type widening

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -22,6 +22,7 @@ import {
   model,
   ValidateOpts
 } from 'mongoose';
+import { IsPathRequired } from '../../types/inferschematype';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
 
@@ -1502,16 +1503,18 @@ function gh13772() {
   const schemaDefinition = {
     name: String,
     docArr: [{ name: String }]
-  };
+  } as const;
   const schema = new Schema(schemaDefinition);
-  type RawDocType = InferRawDocType<typeof schemaDefinition>;
-  expectAssignable<
-    { name?: string | null, docArr?: Array<{ name?: string | null }> }
-  >({} as RawDocType);
 
   const TestModel = model('User', schema);
+  type RawDocType = InferRawDocType<typeof schemaDefinition>;
+  expectAssignable<
+    { name?: string | null, docArr?: Array<{ name?: string | null }> | null }
+  >({} as RawDocType);
+
   const doc = new TestModel();
   expectAssignable<RawDocType>(doc.toObject());
+  expectAssignable<RawDocType>(doc.toJSON());
 }
 
 function gh14696() {

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -259,11 +259,14 @@ declare module 'mongoose' {
     set(value: string | Record<string, any>): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
+    toJSON(options?: ToObjectOptions & { flattenMaps?: true }): FlattenMaps<Require_id<DocType>>;
+    toJSON(options: ToObjectOptions & { flattenMaps: false }): Require_id<DocType>;
     toJSON<T = Require_id<DocType>>(options?: ToObjectOptions & { flattenMaps?: true }): FlattenMaps<T>;
     toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenMaps: false }): T;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
-    toObject<T = Require_id<DocType>>(options?: ToObjectOptions): Require_id<T>;
+    toObject(options?: ToObjectOptions): Require_id<DocType>;
+    toObject<T>(options?: ToObjectOptions): Require_id<T>;
 
     /** Clears the modified state on the specified path. */
     unmarkModified<T extends keyof DocType>(path: T): void;

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -1,4 +1,5 @@
 import {
+  IsPathRequired,
   IsSchemaTypeFromBuiltinClass,
   RequiredPaths,
   OptionalPaths,
@@ -14,7 +15,9 @@ declare module 'mongoose' {
     [
     K in keyof (RequiredPaths<DocDefinition, TSchemaOptions['typeKey']> &
     OptionalPaths<DocDefinition, TSchemaOptions['typeKey']>)
-    ]: ObtainRawDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>;
+    ]: IsPathRequired<DocDefinition[K], TSchemaOptions['typeKey']> extends true
+      ? ObtainRawDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>
+      : ObtainRawDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']> | null;
   }, TSchemaOptions>;
 
   /**


### PR DESCRIPTION
Fix #12883

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Making document methods generic by default makes TypeScript do some strange type widening where it automatically infers the generic parameter if the variable being assigned has an explicit type. This PR makes `toJSON()` and `toObject()` not generic by default.

In the interest of caution, I'm targeting merging this in v8.6 because it may cause some issues for users that rely on the broken behavior.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
