### PR TITLE
fix: fixing schema type based on timestamps schema options value

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1604,3 +1604,30 @@ function gh13215() {
   type SchemaType = InferSchemaType<typeof schema>;
   expectType<User>({} as SchemaType);
 }
+
+function gh14825() {
+  const schemaDefinition = {
+    userName: { type: String, required: true }
+  } as const;
+  const schemaOptions = {
+    typeKey: 'type' as const,
+    timestamps: {
+      createdAt: 'date',
+      updatedAt: false
+    }
+  };
+
+  type RawDocType = InferRawDocType<
+    typeof schemaDefinition,
+    typeof schemaOptions
+  >;
+  type User = {
+    userName: string;
+  };
+
+  expectAssignable<User>({} as RawDocType);
+
+  const schema = new Schema(schemaDefinition, schemaOptions);
+  type SchemaType = InferSchemaType<typeof schema>;
+  expectAssignable<User>({} as SchemaType);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -87,8 +87,8 @@ declare module 'mongoose' {
             'createdAt' | 'updatedAt'
           > as TimestampOptions[K] extends true
             ? K
-            : TimestampOptions[K] extends string
-              ? TimestampOptions[K]
+            : TimestampOptions[K] extends `${infer TimestampValue}`
+              ? TimestampValue
               : never]: NativeDate;
         } & T
         : T


### PR DESCRIPTION
ignoring timestamps schema options field if createdAt, updatedAt fields are string, non-literal fields in TS.

Fix #14825 

Summary
Currently, `InferSchemaType` and `InferRawDocType` incorrectly infer schema type based on timestamps schema options fields when the fields have a string type instead of string literal type. In order to avoid the incorrect users behavior mongoose will ignore the timestamp fields