### PR TITLE
fix(model): throw error if `bulkSave()` did not insert or update any documents

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3364,10 +3364,17 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
 };
 
 /**
- *  takes an array of documents, gets the changes and inserts/updates documents in the database
- *  according to whether or not the document is new, or whether it has changes or not.
+ * Takes an array of documents, gets the changes and inserts/updates documents in the database
+ * according to whether or not the document is new, or whether it has changes or not.
  *
  * `bulkSave` uses `bulkWrite` under the hood, so it's mostly useful when dealing with many documents (10K+)
+ *
+ * `bulkSave()` throws errors under the following conditions:
+ *
+ * - `bulkWrite()` fails (for example, due to being unable to connect to MongoDB or due to duplicate key error)
+ * - `bulkWrite()` did not insert or update any documents
+ *
+ * Note that `bulkSave()` will **not** throw an error if only some of the `save()` calls succeeded.
  *
  * @param {Array<Document>} documents
  * @param {Object} [options] options passed to the underlying `bulkWrite()`
@@ -3376,7 +3383,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
  * @param {String|number} [options.w=1] The [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/). See [`Query#w()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.w()) for more information.
  * @param {number} [options.wtimeout=null] The [write concern timeout](https://www.mongodb.com/docs/manual/reference/write-concern/#wtimeout).
  * @param {Boolean} [options.j=true] If false, disable [journal acknowledgement](https://www.mongodb.com/docs/manual/reference/write-concern/#j-option)
- *
+ * @return {BulkWriteResult} the return value from `bulkWrite()`
  */
 Model.bulkSave = async function bulkSave(documents, options) {
   options = options || {};
@@ -3404,18 +3411,31 @@ Model.bulkSave = async function bulkSave(documents, options) {
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })
   );
 
-  await Promise.all(
-    documents.map(async(document) => {
-      const documentError = bulkWriteError && bulkWriteError.writeErrors.find(writeError => {
-        const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
-        return writeErrorDocumentId.toString() === document._doc._id.toString();
-      });
+  const matchedCount = bulkWriteResult?.matchedCount ?? 0;
+  const insertedCount = bulkWriteResult?.insertedCount ?? 0;
+  if (writeOperations.length > 0 && matchedCount + insertedCount === 0 && !bulkWriteError) {
+    throw new DocumentNotFoundError(
+      writeOperations.filter(op => op.updateOne).map(op => op.updateOne.filter),
+      this.modelName,
+      writeOperations.length,
+      bulkWriteResult
+    );
+  }
 
-      if (documentError == null) {
-        await handleSuccessfulWrite(document);
-      }
-    })
-  );
+  const successfulDocuments = [];
+  for (let i = 0; i < documents.length; i++) {
+    const document = documents[i];
+    const documentError = bulkWriteError && bulkWriteError.writeErrors.find(writeError => {
+      const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
+      return writeErrorDocumentId.toString() === document._doc._id.toString();
+    });
+
+    if (documentError == null) {
+      successfulDocuments.push(document);
+    }
+  }
+
+  await Promise.all(successfulDocuments.map(document => handleSuccessfulWrite(document)));
 
   if (bulkWriteError && bulkWriteError.writeErrors && bulkWriteError.writeErrors.length) {
     throw bulkWriteError;


### PR DESCRIPTION
Re: #14763

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

First step for fixing #14763 (option 1), throwing an error if `bulkSave()` did not update or insert any documents successfully. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
