### PR TITLE
fix(document): avoid unnecessary clone() in `applyGetters()` that was triggering additional getters

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3856,7 +3856,6 @@ Document.prototype.$toObject = function(options, json) {
   // Parent options should only bubble down for subdocuments, not populated docs
   options._parentOptions = this.$isSubdocument ? options : null;
 
-  options._skipSingleNestedGetters = false;
   // remember the root transform function
   // to save it from being overwritten by sub-transform functions
   // const originalTransform = options.transform;
@@ -3870,13 +3869,13 @@ Document.prototype.$toObject = function(options, json) {
     ret = clone(this._doc, options) || {};
   }
 
-  options._skipSingleNestedGetters = true;
   const getters = options._calledWithOptions.getters
     ?? options.getters
     ?? defaultOptions.getters
     ?? false;
+
   if (getters) {
-    applyGetters(this, ret, options);
+    applyGetters(this, ret);
 
     if (options.minimize) {
       ret = minimize(ret) || {};
@@ -4187,12 +4186,11 @@ function applyVirtuals(self, json, options, toObjectOptions) {
  *
  * @param {Document} self
  * @param {Object} json
- * @param {Object} [options]
  * @return {Object} `json`
  * @api private
  */
 
-function applyGetters(self, json, options) {
+function applyGetters(self, json) {
   const schema = self.$__schema;
   const paths = Object.keys(schema.paths);
   let i = paths.length;
@@ -4228,8 +4226,10 @@ function applyGetters(self, json, options) {
       if (branch != null && typeof branch !== 'object') {
         break;
       } else if (ii === last) {
-        const val = self.$get(path);
-        branch[part] = clone(val, options);
+        branch[part] = schema.paths[path].applyGetters(
+          branch[part],
+          self
+        );
         if (Array.isArray(branch[part]) && schema.paths[path].$embeddedSchemaType) {
           for (let i = 0; i < branch[part].length; ++i) {
             branch[part][i] = schema.paths[path].$embeddedSchemaType.applyGetters(

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -40,11 +40,6 @@ function clone(obj, options, isArrayChild) {
 
   if (isMongooseObject(obj)) {
     if (options) {
-      // Single nested subdocs should apply getters later in `applyGetters()`
-      // when calling `toObject()`. See gh-7442, gh-8295
-      if (options._skipSingleNestedGetters && obj.$isSingleNested) {
-        options._calledWithOptions = Object.assign({}, options._calledWithOptions || {}, { getters: false });
-      }
       if (options.retainDocuments && obj.$__ != null) {
         const clonedDoc = obj.$clone();
         if (obj.__index != null) {


### PR DESCRIPTION
Fix #14840
Fix #14835
Re: #14724

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We finally managed to fix the root cause of #7442 etc.: `applyGetters()` was re-triggering getters on single nested subdocs by using `get()` to get the value, even though that isn't necessary because `applyGetters()` is only called on already cloned values. This PR fixes that, and means we can get rid of the `_skipSingleNestedGetters` option as well

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
