### PR TITLE
fix(cursor): throw error in ChangeStream constructor if `changeStreamThunk()` throws a sync error

### DIFF
--- a/lib/cursor/changeStream.js
+++ b/lib/cursor/changeStream.js
@@ -5,6 +5,7 @@
  */
 
 const EventEmitter = require('events').EventEmitter;
+const MongooseError = require('../error/mongooseError');
 
 /*!
  * ignore
@@ -25,6 +26,7 @@ class ChangeStream extends EventEmitter {
     this.bindedEvents = false;
     this.pipeline = pipeline;
     this.options = options;
+    this.errored = false;
 
     if (options && options.hydrate && !options.model) {
       throw new Error(
@@ -39,6 +41,7 @@ class ChangeStream extends EventEmitter {
       try {
         changeStreamThunk((err, driverChangeStream) => {
           if (err != null) {
+            this.errored = true;
             this.emit('error', err);
             return reject(err);
           }
@@ -49,6 +52,7 @@ class ChangeStream extends EventEmitter {
         });
       } catch (err) {
         syncError = err;
+        this.errored = true;
         this.emit('error', err);
         reject(err);
       }
@@ -107,10 +111,16 @@ class ChangeStream extends EventEmitter {
   }
 
   hasNext(cb) {
+    if (this.errored) {
+      throw new MongooseError('Cannot call hasNext() on errored ChangeStream');
+    }
     return this.driverChangeStream.hasNext(cb);
   }
 
   next(cb) {
+    if (this.errored) {
+      throw new MongooseError('Cannot call next() on errored ChangeStream');
+    }
     if (this.options && this.options.hydrate) {
       if (cb != null) {
         const originalCb = cb;
@@ -141,16 +151,25 @@ class ChangeStream extends EventEmitter {
   }
 
   addListener(event, handler) {
+    if (this.errored) {
+      throw new MongooseError('Cannot call addListener() on errored ChangeStream');
+    }
     this._bindEvents();
     return super.addListener(event, handler);
   }
 
   on(event, handler) {
+    if (this.errored) {
+      throw new MongooseError('Cannot call on() on errored ChangeStream');
+    }
     this._bindEvents();
     return super.on(event, handler);
   }
 
   once(event, handler) {
+    if (this.errored) {
+      throw new MongooseError('Cannot call once() on errored ChangeStream');
+    }
     this._bindEvents();
     return super.once(event, handler);
   }

--- a/lib/cursor/changeStream.js
+++ b/lib/cursor/changeStream.js
@@ -33,19 +33,34 @@ class ChangeStream extends EventEmitter {
       );
     }
 
+    let syncError = null;
     this.$driverChangeStreamPromise = new Promise((resolve, reject) => {
       // This wrapper is necessary because of buffering.
-      changeStreamThunk((err, driverChangeStream) => {
-        if (err != null) {
-          this.emit('error', err);
-          return reject(err);
-        }
+      try {
+        changeStreamThunk((err, driverChangeStream) => {
+          if (err != null) {
+            this.emit('error', err);
+            return reject(err);
+          }
 
-        this.driverChangeStream = driverChangeStream;
-        this.emit('ready');
-        resolve();
-      });
+          this.driverChangeStream = driverChangeStream;
+          this.emit('ready');
+          resolve();
+        });
+      } catch (err) {
+        syncError = err;
+        this.emit('error', err);
+        reject(err);
+      }
     });
+
+    // Because a ChangeStream is an event emitter, there's no way to register an 'error' handler
+    // that catches errors which occur in the constructor, unless we force sync errors into async
+    // errors with setImmediate(). For cleaner stack trace, we just immediately throw any synchronous
+    // errors that occurred with changeStreamThunk().
+    if (syncError != null) {
+      throw syncError;
+    }
   }
 
   _bindEvents() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

An unintended consequence of #14813 using promises rather than event emitters is that sync errors in `changeStreamThunk()` aren't possible to handle. `Model.watch().on('error')` doesn't work because the constructor throws an error before the `on('error')` call happens.

This PR makes `ChangeStream()` constructor throw an error if `changeStreamThunk()` throws a synchronous error. The code is a little clunky, but at least avoids silently ignoring sync errors in `changeStreamThunk()`. This code is hard to test because `changeStreamThunk()` doesn't throw in Mongoose in general. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
