### PR TITLE
fix(connection): fix MaxListenersExceededWarning issue

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -93,6 +93,13 @@ NativeConnection.prototype.useDb = function(name, options) {
 
   newConn.client = _this.client;
 
+  // Allow unlimited listeners
+  // If we do not have a db or the state is not connected, and the number of
+  // `this.once('connected', wireup)` event listeners exceeded nodejs default
+  // of 10, `MaxListenersExceededWarning` is thrown. So, set unlimited listeners
+
+  this.setMaxListeners(0);
+
   if (this.db && this._readyState === STATES.connected) {
     wireup();
   } else {


### PR DESCRIPTION
this fixes the MaxListenersExceededWarning warning thrown when more than 10 useDb calls are made before connection

Re: #14859 

**Summary**

This solves the issue [#14859 ](https://github.com/Automattic/mongoose/issues/14859)

**Examples**
Output on running the script attached on the issue

Before this fix
```
➜  rough_work node --trace-warnings code/mongo.js
collections {
  temp0: Model { collection0 },
  config1: Model { collection1 },
  temp2: Model { collection2 },
  local3: Model { collection3 },
  local4: Model { collection4 },
  temp5: Model { collection5 },
  temp6: Model { collection6 },
  local7: Model { collection7 },
  temp8: Model { collection8 },
  config9: Model { collection9 },
  temp10: Model { collection10 }
}
(node:56423) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 connected listeners added to [NativeConnection]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:591:17)
    at NativeConnection.addListener (node:events:609:10)
    at NativeConnection.on (/Users/mouri/Code/rough_work/node_modules/mongoose/lib/connection.js:863:36)
    at NativeConnection.once (node:events:653:8)
    at NativeConnection.on [as once] (/Users/mouri/Code/rough_work/node_modules/mongoose/lib/connection.js:875:38)
    at NativeConnection.useDb (/Users/mouri/Code/rough_work/node_modules/mongoose/lib/drivers/node-mongodb-native/connection.js:100:10)
    at mongoConn (/Users/mouri/Code/rough_work/code/mongo.js:10:36)
    at Object.<anonymous> (/Users/mouri/Code/rough_work/code/mongo.js:37:1)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
Mongoose connection successful
```

After this fix
```
➜  rough_work node --trace-warnings code/mongo.js
collections {
  config0: Model { collection0 },
  admin1: Model { collection1 },
  local2: Model { collection2 },
  config3: Model { collection3 },
  admin4: Model { collection4 },
  admin5: Model { collection5 },
  temp6: Model { collection6 },
  config7: Model { collection7 },
  local8: Model { collection8 },
  local9: Model { collection9 },
  temp10: Model { collection10 }
}
Mongoose connection successful

```