### PR TITLE
fix(connection): avoid MaxListenersExceededWarning on multiple useDb() calls by avoiding using event emitters

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -71,6 +71,9 @@ function Connection(base) {
   } else {
     this.id = base.nextConnectionId;
   }
+
+  // Internal queue of objects `{ fn, ctx, args }` that Mongoose calls when this connection is successfully
+  // opened. In `onOpen()`, Mongoose calls every entry in `_queue` and empties the queue.
   this._queue = [];
 }
 

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -10,7 +10,7 @@ const eachAsync = require('../helpers/cursor/eachAsync');
 const helpers = require('../queryHelpers');
 const kareem = require('kareem');
 const immediate = require('../helpers/immediate');
-const { once } = require('node:events');
+const { once } = require('events');
 const util = require('util');
 
 /**

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -96,7 +96,7 @@ NativeConnection.prototype.useDb = function(name, options) {
   if (this.db && this._readyState === STATES.connected) {
     wireup();
   } else {
-    this.once('connected', wireup);
+    this._queue.push({ fn: wireup });
   }
 
   function wireup() {


### PR DESCRIPTION
Fix #14859
Fix #14860

@Mouri-P can you please take a look at this one as well?

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

An alternative fix for #14859: I don't like using `setMaxListeners()` because that may hide memory leaks in user code, and there's no way to `setMaxListeners()` for just one event or one type of handler. Either way, connections have their own queueing mechanism with `_queue`, so we can just use that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

With this PR, no MaxListeners warning on the following script:

```js
const mongoose = require("mongoose");
const { Schema } = mongoose;
const iterations = 11;

const mongoConn = async () => {
  const dbs = ["admin", "config", "local", "temp"];
  const collections = {};

  for (let i = 0; i < iterations; i++) {
    const db = mongoose.connection.useDb(dbs[parseInt(Math.random() * 4)]);
    const collection = db.model(
      "collection" + i,
      new Schema({ data: Schema.Types.Mixed })
    );
    collections[db.name + i] = collection;
  }
  console.log("collections", collections);

  await mongoose
    .connect("mongodb://127.0.0.1:27017", {
      minPoolSize: 1,
      user: "",
      pass: "",
      readPreference: "primaryPreferred",
    })
    .then(() => console.log("Mongoose connection successful"))
    .catch((err) =>
      console.log(`Error while connecting Mongo, Error: ${err.message}`)
    );

  return {
    mongoose,
    collections,
  };
};

mongoConn();

```
