### PR TITLE
Added the signal option to eachAsync typings

### DIFF
--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -8,6 +8,7 @@ declare module 'mongoose' {
     parallel?: number;
     batchSize?: number;
     continueOnError?: boolean;
+    signal?: AbortSignal;
   }
 
   class Cursor<DocType = any, Options = never> extends stream.Readable {


### PR DESCRIPTION
Hi, this is a very small contribution to add the `signal` option to `eachAsync` typing. Thanks!