### PR TITLE
types: allow arbitrary keys in query filters again

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -216,7 +216,7 @@ function find() {
   Project.find({ name: 'Hello' });
 
   // just callback; this is no longer supported on .find()
-  expectError(Project.find((error: CallbackError, result: IProject[]) => console.log(error, result)));
+  Project.find((error: CallbackError, result: IProject[]) => console.log(error, result));
 
   // filter + projection
   Project.find({}, undefined);
@@ -976,30 +976,4 @@ function testWithLevel1NestedPaths() {
     foo?: { one?: string | null | undefined } | null | undefined,
     'foo.one': string | null | undefined
   }>({} as Test2);
-}
-
-function gh14764TestFilterQueryRestrictions() {
-  const TestModel = model<{ validKey: number }>('Test', new Schema({}));
-  // A key not in the schema should be invalid
-  expectError(TestModel.find({ invalidKey: 0 }));
-  // A key not in the schema should be invalid for simple root operators
-  expectError(TestModel.find({ $and: [{ invalidKey: 0 }] }));
-
-  // Any "nested" keys should be valid
-  TestModel.find({ 'validKey.subkey': 0 });
-
-  // And deeply "nested" keys should be valid
-  TestModel.find({ 'validKey.deep.nested.key': 0 });
-  TestModel.find({ validKey: { deep: { nested: { key: 0 } } } });
-
-  // Any Query should be accepted as the root argument (due to merge support)
-  TestModel.find(TestModel.find());
-  // A Query should not be a valid type for a FilterQuery within an op like $and
-  expectError(TestModel.find({ $and: [TestModel.find()] }));
-
-  const id = new Types.ObjectId();
-  // Any ObjectId should be accepted as the root argument
-  TestModel.find(id);
-  // A ObjectId should not be a valid type for a FilterQuery within an op like $and
-  expectError(TestModel.find({ $and: [id] }));
 }

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -12,7 +12,7 @@ declare module 'mongoose' {
    */
   type RootFilterQuery<T> = FilterQuery<T> | Query<any, any> | Types.ObjectId;
 
-  type FilterQuery<T> ={
+  type FilterQuery<T> = {
     [P in keyof T]?: Condition<T[P]>;
   } & RootQuerySelector<T> & { _id?: Condition<string>; };
 
@@ -117,10 +117,8 @@ declare module 'mongoose' {
     /** @see https://www.mongodb.com/docs/manual/reference/operator/query/comment/#op._S_comment */
     $comment?: string;
     $expr?: Record<string, any>;
-    // we could not find a proper TypeScript generic to support nested queries e.g. 'user.friends.name'
-    // this will mark all unrecognized properties as any (including nested queries) only if
-    // they include a "." (to avoid generically allowing any unexpected keys)
-    [nestedSelector: `${string}.${string}`]: any;
+    // this will mark all unrecognized properties as any (including nested queries)
+    [key: string]: any;
   };
 
   interface QueryTimestampsConfig {


### PR DESCRIPTION
Revert #14764
Fix #14863
Fix #14862

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14764 introduced issues for quite a few devs, see #14863. We should revert for now, and consider adding #14764 in 9.0.

cc @alex-statsig 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
