### PR TITLE
types: make SchemaType static `setters` property accessible in TypeScript

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1634,3 +1634,7 @@ function gh14825() {
   type SchemaType = InferSchemaType<typeof schema>;
   expectAssignable<User>({} as SchemaType);
 }
+
+function gh14879() {
+  Schema.Types.String.setters.push((val?: unknown) => typeof val === 'string' ? val.trim() : val);
+}

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -216,6 +216,9 @@ declare module 'mongoose' {
     /** Attaches a getter for all instances of this schema type. */
     static get(getter: (value: any) => any): void;
 
+    /** Array containing default setters for all instances of this SchemaType */
+    static setters: Function[];
+
     /** The class that Mongoose uses internally to instantiate this SchemaType's `options` property. */
     OptionsConstructor: SchemaTypeOptions<T>;
 

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -217,7 +217,7 @@ declare module 'mongoose' {
     static get(getter: (value: any) => any): void;
 
     /** Array containing default setters for all instances of this SchemaType */
-    static setters: Function[];
+    static setters: ((val?: unknown, priorVal?: unknown, doc?: Document<unknown>, options?: Record<string, any> | null) => unknown)[];
 
     /** The class that Mongoose uses internally to instantiate this SchemaType's `options` property. */
     OptionsConstructor: SchemaTypeOptions<T>;


### PR DESCRIPTION
Fix #14879

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

There are places in the docs where we recommend pushing default setters to schematypes like `mongoose.Schema.String.setters.push(fn)`, but TypeScript types currently don't support that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
