### PR TITLE
type(inferrawdoctype): infer Date types as JS dates rather than Mongoose SchemaType Date

### DIFF
--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -1,0 +1,25 @@
+import { InferRawDocType } from 'mongoose';
+import { expectType, expectError } from 'tsd';
+
+function gh14839() {
+  const schemaDefinition = {
+    email: {
+      type: String,
+      trim: true,
+      required: true,
+      unique: true,
+      lowercase: true
+    },
+    password: {
+      type: String,
+      required: true
+    },
+    dateOfBirth: {
+      type: Date,
+      required: true
+    }
+  };
+
+  type UserType = InferRawDocType< typeof schemaDefinition>;
+  expectType<{ email: string, password: string, dateOfBirth: Date }>({} as UserType);
+}

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -91,8 +91,8 @@ declare module 'mongoose' {
             IfEquals<PathValueType, String> extends true ? PathEnumOrString<Options['enum']> :
               PathValueType extends NumberSchemaDefinition ? Options['enum'] extends ReadonlyArray<any> ? Options['enum'][number] : number :
                 IfEquals<PathValueType, Schema.Types.Number> extends true ? number :
-                  PathValueType extends DateSchemaDefinition ? Date :
-                    IfEquals<PathValueType, Schema.Types.Date> extends true ? Date :
+                  PathValueType extends DateSchemaDefinition ? NativeDate :
+                    IfEquals<PathValueType, Schema.Types.Date> extends true ? NativeDate :
                       PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
                         PathValueType extends BooleanSchemaDefinition ? boolean :
                           IfEquals<PathValueType, Schema.Types.Boolean> extends true ? boolean :

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -281,8 +281,8 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
               IfEquals<PathValueType, String> extends true ? PathEnumOrString<Options['enum']> :
                 PathValueType extends NumberSchemaDefinition ? Options['enum'] extends ReadonlyArray<any> ? Options['enum'][number] : number :
                   IfEquals<PathValueType, Schema.Types.Number> extends true ? number :
-                    PathValueType extends DateSchemaDefinition ? Date :
-                      IfEquals<PathValueType, Schema.Types.Date> extends true ? Date :
+                    PathValueType extends DateSchemaDefinition ? NativeDate :
+                      IfEquals<PathValueType, Schema.Types.Date> extends true ? NativeDate :
                         PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer :
                           PathValueType extends BooleanSchemaDefinition ? boolean :
                             IfEquals<PathValueType, Schema.Types.Boolean> extends true ? boolean :


### PR DESCRIPTION
Fix #14839

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

For some reason, it looks like `inferRawDocType<>` is inferring dates as Mongoose Date SchemaType rather than JavaScript dates. If I change to `NativeDate`, that works as expected. I made the same change in InferRawDocType, which doesn't look to be affected by this issue, but should fix that just in case TypeScript decides to change its mind.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
