### PR TITLE
fix(model): throw MongooseBulkSaveIncompleteError if bulkSave() didn't completely succeed

### DIFF
--- a/lib/error/bulkSaveIncompleteError.js
+++ b/lib/error/bulkSaveIncompleteError.js
@@ -1,0 +1,44 @@
+/*!
+ * Module dependencies.
+ */
+
+'use strict';
+
+const MongooseError = require('./mongooseError');
+
+
+/**
+ * If the underwriting `bulkWrite()` for `bulkSave()` succeeded, but wasn't able to update or
+ * insert all documents, we throw this error.
+ *
+ * @api private
+ */
+
+class MongooseBulkSaveIncompleteError extends MongooseError {
+  constructor(modelName, documents, bulkWriteResult) {
+    const matchedCount = bulkWriteResult?.matchedCount ?? 0;
+    const insertedCount = bulkWriteResult?.insertedCount ?? 0;
+    let preview = documents.map(doc => doc._id).join(', ');
+    if (preview.length > 100) {
+      preview = preview.slice(0, 100) + '...';
+    }
+
+    const numDocumentsNotUpdated = documents.length - matchedCount - insertedCount;
+    super(`${modelName}.bulkSave() was not able to update ${numDocumentsNotUpdated} of the given documents due to incorrect version or optimistic concurrency, document ids: ${preview}`);
+
+    this.modelName = modelName;
+    this.documents = documents;
+    this.bulkWriteResult = bulkWriteResult;
+    this.numDocumentsNotUpdated = numDocumentsNotUpdated;
+  }
+}
+
+Object.defineProperty(MongooseBulkSaveIncompleteError.prototype, 'name', {
+  value: 'MongooseBulkSaveIncompleteError'
+});
+
+/*!
+ * exports
+ */
+
+module.exports = MongooseBulkSaveIncompleteError;

--- a/lib/model.js
+++ b/lib/model.js
@@ -64,6 +64,7 @@ const STATES = require('./connectionState');
 const util = require('util');
 const utils = require('./utils');
 const minimize = require('./helpers/minimize');
+const MongooseBulkSaveIncompleteError = require('./error/bulkSaveIncompleteError');
 
 const modelCollectionSymbol = Symbol('mongoose#Model#collection');
 const modelDbSymbol = Symbol('mongoose#Model#db');
@@ -3418,11 +3419,10 @@ Model.bulkSave = async function bulkSave(documents, options) {
 
   const matchedCount = bulkWriteResult?.matchedCount ?? 0;
   const insertedCount = bulkWriteResult?.insertedCount ?? 0;
-  if (writeOperations.length > 0 && matchedCount + insertedCount === 0 && !bulkWriteError) {
-    throw new DocumentNotFoundError(
-      writeOperations.filter(op => op.updateOne).map(op => op.updateOne.filter),
+  if (writeOperations.length > 0 && matchedCount + insertedCount < writeOperations.length && !bulkWriteError) {
+    throw new MongooseBulkSaveIncompleteError(
       this.modelName,
-      writeOperations.length,
+      documents,
       bulkWriteResult
     );
   }


### PR DESCRIPTION
Fix #14763

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Make it so that `bulkSave()` throws an error if not all documents were successfully updated due to version errors or optimistic concurrency. I thought more about #14763 and this seems like the way to go: if not all documents were updated, we don't know which documents we can run post save hooks on, or which documents to update `$isNew` on.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
