### PR TITLE
Fix missing `Aggregate` re-exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports.modelNames = mongoose.modelNames;
 module.exports.plugin = mongoose.plugin;
 module.exports.connections = mongoose.connections;
 module.exports.version = mongoose.version;
+module.exports.Aggregate = mongoose.Aggregate;
 module.exports.Mongoose = mongoose.Mongoose;
 module.exports.Schema = mongoose.Schema;
 module.exports.SchemaType = mongoose.SchemaType;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

While using Sentry (with OpenTelemetry as the underlying system) to instrument Mongoose in my project, I encountered the following error:
```
2024-09-12 11:26:31.183 TypeError: Cannot read properties of undefined (reading ‘prototype’)
2024-09-12 11:26:31.183     at MongooseInstrumentation.patch (/usr/src/app/node_modules/.pnpm/@opentelemetry+instrumentation-mongoose@0.42.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation-mongoose/build/src/mongoose.js:94:44)
2024-09-12 11:26:31.183     at MongooseInstrumentation._onRequire (/usr/src/app/node_modules/.pnpm/@opentelemetry+instrumentation@0.53.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/platform/node/instrumentation.js:164:39)
2024-09-12 11:26:31.183     at hookFn (/usr/src/app/node_modules/.pnpm/@opentelemetry+instrumentation@0.53.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/platform/node/instrumentation.js:222:29)
2024-09-12 11:26:31.183     at callHookFn (/usr/src/app/node_modules/.pnpm/import-in-the-middle@1.11.0/node_modules/import-in-the-middle/index.js:29:22)
2024-09-12 11:26:31.183     at Hook._iitmHook (/usr/src/app/node_modules/.pnpm/import-in-the-middle@1.11.0/node_modules/import-in-the-middle/index.js:150:11)
2024-09-12 11:26:31.183     at /usr/src/app/node_modules/.pnpm/import-in-the-middle@1.11.0/node_modules/import-in-the-middle/lib/register.js:28:31
2024-09-12 11:26:31.183     at Array.forEach (<anonymous>)
2024-09-12 11:26:31.183     at register (/usr/src/app/node_modules/.pnpm/import-in-the-middle@1.11.0/node_modules/import-in-the-middle/lib/register.js:28:15)
2024-09-12 11:26:31.183     at file:///usr/src/app/node_modules/.pnpm/mongoose@8.3.4_@aws-sdk+credential-providers@3.649.0_socks@2.8.3/node_modules/mongoose/index.js?iitm=true:381:1
2024-09-12 11:26:31.183     at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
```

Upon investigation, I found that the issue is caused by a missing re-export of `Aggregate` in Mongoose’s ESM exports.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

I was able to temporarily resolve the issue by adding the following command to my project’s Dockerfile:
```
# Hack to fix otel mongoose instruementation issue
RUN echo "module.exports.Aggregate = mongoose.Aggregate;" >> /usr/src/app/node_modules/.pnpm/mongoose@8.3.4_@aws-sdk+credential-providers@3.650.0_socks@2.8.3/node_modules/mongoose/index.js
```

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
