### PR TITLE
fix: make getters convert uuid to string when calling toObject() and toJSON()

### DIFF
--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -54,7 +54,7 @@ function binaryToString(uuidBin) {
   // i(hasezoey) dont quite know why, but "uuidBin" may sometimes also be the already processed string
   let hex;
   if (typeof uuidBin !== 'string' && uuidBin != null) {
-    hex = uuidBin != null && uuidBin.toString('hex');
+    hex = uuidBin.toString('hex');
     const uuidStr = hex.substring(0, 8) + '-' + hex.substring(8, 8 + 4) + '-' + hex.substring(12, 12 + 4) + '-' + hex.substring(16, 16 + 4) + '-' + hex.substring(20, 20 + 12);
     return uuidStr;
   }

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -80,9 +80,7 @@ function SchemaUUID(key, options) {
     if (Buffer.isBuffer(value)) {
       return binaryToString(value);
     } else if (value instanceof Binary) {
-      if (value instanceof Binary) {
-        return binaryToString(value.buffer);
-      }
+      return binaryToString(value.buffer);
     } else if (utils.isPOJO(value) && value.type === 'Buffer' && Array.isArray(value.data)) {
       // Cloned buffers look like `{ type: 'Buffer', data: [5, 224, ...] }`
       return binaryToString(Buffer.from(value.data));

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -27,19 +27,6 @@ function hex2buffer(hex) {
 }
 
 /**
- * Helper function to convert the buffer input to a string
- * @param {Buffer} buf The buffer to convert to a hex-string
- * @returns {String} The buffer as a hex-string
- * @api private
- */
-
-function binary2hex(buf) {
-  // use buffer built-in function to convert from buffer to hex-string
-  const hex = buf != null && buf.toString('hex');
-  return hex;
-}
-
-/**
  * Convert a String to Binary
  * @param {String} uuidStr The value to process
  * @returns {MongooseBuffer} The binary to store
@@ -67,7 +54,7 @@ function binaryToString(uuidBin) {
   // i(hasezoey) dont quite know why, but "uuidBin" may sometimes also be the already processed string
   let hex;
   if (typeof uuidBin !== 'string' && uuidBin != null) {
-    hex = binary2hex(uuidBin);
+    hex = uuidBin != null && uuidBin.toString('hex');
     const uuidStr = hex.substring(0, 8) + '-' + hex.substring(8, 8 + 4) + '-' + hex.substring(12, 12 + 4) + '-' + hex.substring(16, 16 + 4) + '-' + hex.substring(20, 20 + 12);
     return uuidStr;
   }
@@ -90,7 +77,17 @@ function SchemaUUID(key, options) {
     if (value != null && value.$__ != null) {
       return value;
     }
-    return binaryToString(value);
+    if (Buffer.isBuffer(value)) {
+      return binaryToString(value);
+    } else if (value instanceof Binary) {
+    if (value instanceof Binary) {
+      return binaryToString(value.buffer);
+    }
+    } else if (utils.isPOJO(value) && value.type === 'Buffer' && Array.isArray(value.data)) {
+      // Cloned buffers look like `{ type: 'Buffer', data: [5, 224, ...] }`
+      return binaryToString(Buffer.from(value.data));
+    }
+    return value;
   });
 }
 

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -80,9 +80,9 @@ function SchemaUUID(key, options) {
     if (Buffer.isBuffer(value)) {
       return binaryToString(value);
     } else if (value instanceof Binary) {
-    if (value instanceof Binary) {
-      return binaryToString(value.buffer);
-    }
+      if (value instanceof Binary) {
+        return binaryToString(value.buffer);
+      }
     } else if (utils.isPOJO(value) && value.type === 'Buffer' && Array.isArray(value.data)) {
       // Cloned buffers look like `{ type: 'Buffer', data: [5, 224, ...] }`
       return binaryToString(Buffer.from(value.data));


### PR DESCRIPTION
Fix #14869

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

As #14869 pointed out, calling `toObject()` on a document with uuids with `getters: true` ends up with `"[object -Obje-ct]--"` strings :cry: This PR should fix that

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
