### PR TITLE
types(document): add generic param to depopulate() to allow updating properties

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -359,3 +359,51 @@ function gh13738() {
   expectType<Date>(person.get('dob'));
   expectType<{ theme: string; alerts: { sms: boolean } }>(person.get('settings'));
 }
+
+async function gh14876() {
+  type CarObjectInterface = {
+    make: string;
+    model: string;
+    year: number;
+    owner: Types.ObjectId;
+  };
+  const carSchema = new Schema<CarObjectInterface>({
+    make: { type: String, required: true },
+    model: { type: String, required: true },
+    year: { type: Number, required: true },
+    owner: { type: Schema.Types.ObjectId, ref: 'User' }
+  });
+
+  type UserObjectInterface = {
+    name: string;
+    age: number;
+  };
+  const userSchema = new Schema<UserObjectInterface>({
+    name: String,
+    age: Number
+  });
+
+  const Car = model<CarObjectInterface>('Car', carSchema);
+  const User = model<UserObjectInterface>('User', userSchema);
+
+  const user = await User.create({ name: 'John', age: 25 });
+  const car = await Car.create({
+    make: 'Toyota',
+    model: 'Camry',
+    year: 2020,
+    owner: user._id
+  });
+
+  const populatedCar = await Car.findById(car._id)
+    .populate<{ owner: UserObjectInterface }>('owner')
+    .exec();
+
+  if (!populatedCar) return;
+
+  console.log(populatedCar.owner.name); // outputs John
+
+  const depopulatedCar = populatedCar.depopulate<{ owner: Types.ObjectId }>('owner');
+
+  expectType<UserObjectInterface>(populatedCar.owner);
+  expectType<Types.ObjectId>(depopulatedCar.owner);
+}

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -138,7 +138,7 @@ declare module 'mongoose' {
      * Takes a populated field and returns it to its unpopulated state. If called with
      * no arguments, then all populated fields are returned to their unpopulated state.
      */
-    depopulate(path?: string | string[]): this;
+    depopulate<Paths = {}>(path?: string | string[]): MergeType<this, Paths>;
 
     /**
      * Returns the list of paths that have been directly modified. A direct


### PR DESCRIPTION
Fix #14876

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now `doc.depopulate()` just returns `this`, which may be incorrect if paths are depopulated. This PR adds generic parameter, similar to how `doc.populate<{ user: UserType }>('user')` returns document with `user` property updated, `doc.depopulate<{ user: ObjectId }>('user')` also updates the `user` property type.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
