### PR TITLE
fix(projection): avoid setting projection to unknown exclusive/inclusive if elemMatch on a Date, ObjectId, etc.

### DIFF
--- a/lib/helpers/projection/isExclusive.js
+++ b/lib/helpers/projection/isExclusive.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isDefiningProjection = require('./isDefiningProjection');
+const isPOJO = require('../isPOJO');
 
 /*!
  * ignore
@@ -22,10 +23,12 @@ module.exports = function isExclusive(projection) {
       // Explicitly avoid `$meta` and `$slice`
       const key = keys[ki];
       if (key !== '_id' && isDefiningProjection(projection[key])) {
-        exclude = (projection[key] != null && typeof projection[key] === 'object') ?
-          isExclusive(projection[key]) :
+        exclude = isPOJO(projection[key]) ?
+          (isExclusive(projection[key]) ?? exclude) :
           !projection[key];
-        break;
+        if (exclude != null) {
+          break;
+        }
       }
     }
   }

--- a/lib/helpers/projection/isInclusive.js
+++ b/lib/helpers/projection/isInclusive.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isDefiningProjection = require('./isDefiningProjection');
+const isPOJO = require('../isPOJO');
 
 /*!
  * ignore
@@ -26,7 +27,7 @@ module.exports = function isInclusive(projection) {
     // If field is truthy (1, true, etc.) and not an object, then this
     // projection must be inclusive. If object, assume its $meta, $slice, etc.
     if (isDefiningProjection(projection[prop]) && !!projection[prop]) {
-      if (projection[prop] != null && typeof projection[prop] === 'object') {
+      if (isPOJO(projection[prop])) {
         return isInclusive(projection[prop]);
       } else {
         return !!projection[prop];

--- a/test/helpers/projection.isExclusive.test.js
+++ b/test/helpers/projection.isExclusive.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
+const isExclusive = require('../../lib/helpers/projection/isExclusive');
+
+describe('isExclusive', function() {
+  it('handles $elemMatch (gh-14893)', function() {
+    assert.strictEqual(isExclusive({ field: { $elemMatch: { test: new Date('2024-06-01') } }, otherProp: 1 }), false);
+  });
+});

--- a/test/helpers/projection.isInclusive.test.js
+++ b/test/helpers/projection.isInclusive.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const assert = require('assert');
+
+require('../common'); // required for side-effect setup (so that the default driver is set-up)
+const isInclusive = require('../../lib/helpers/projection/isInclusive');
+
+describe('isInclusive', function() {
+  it('handles $elemMatch (gh-14893)', function() {
+    assert.strictEqual(isInclusive({ field: { $elemMatch: { test: new Date('2024-06-01') } }, otherProp: 1 }), true);
+  });
+});


### PR DESCRIPTION
Fix #14893

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

https://github.com/Automattic/mongoose/commit/2b197b21dff7fb53333a623426d564442f78552e#diff-af7545780ae0b49c587fcbe08b131ce99659ccac5786983702610b6c7a3b8a24 made it so that `isExclusive()` would return `null` if the projection had a `$elemMatch` where the first property was an ObjectId, Date, Buffer, or other value object.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
