### PR TITLE
fix(model): skip applying static hooks by default if static name conflicts with aggregate middleware

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -34,3 +34,13 @@ const queryMiddlewareFunctions = queryOperations.concat([
 ]);
 
 exports.queryMiddlewareFunctions = queryMiddlewareFunctions;
+
+/*!
+ * ignore
+ */
+
+const aggregateMiddlewareFunctions = [
+  'aggregate'
+];
+
+exports.aggregateMiddlewareFunctions = aggregateMiddlewareFunctions;

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -15,7 +15,7 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
   };
 
   hooks = hooks.filter(hook => {
-    // If the custom static overwrites an existing middleware, don't apply
+    // If the custom static overwrites an existing query/aggregate middleware, don't apply
     // middleware to it by default. This avoids a potential backwards breaking
     // change with plugins like `mongoose-delete` that use statics to overwrite
     // built-in Mongoose functions.

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -1,7 +1,12 @@
 'use strict';
 
-const middlewareFunctions = require('../../constants').queryMiddlewareFunctions;
 const promiseOrCallback = require('../promiseOrCallback');
+const { queryMiddlewareFunctions, aggregateMiddlewareFunctions } = require('../../constants');
+
+const middlewareFunctions = [
+  ...queryMiddlewareFunctions,
+  ...aggregateMiddlewareFunctions
+];
 
 module.exports = function applyStaticHooks(model, hooks, statics) {
   const kareemOptions = {
@@ -10,7 +15,7 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
   };
 
   hooks = hooks.filter(hook => {
-    // If the custom static overwrites an existing query middleware, don't apply
+    // If the custom static overwrites an existing middleware, don't apply
     // middleware to it by default. This avoids a potential backwards breaking
     // change with plugins like `mongoose-delete` that use statics to overwrite
     // built-in Mongoose functions.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

Fix https://github.com/Automattic/mongoose/issues/14903

**Summary**

Make it so that if the custom static overwrites an existing aggregate middleware, don't apply middleware to it by default. This should be achieved by filtering custom static-named aggregates in `applyStaticHooks.js`. 

Furthermore, aside from this PR, I believe we should extend this filtering not only to query and aggregation middleware but also to other [Mongoose middlewares](https://mongoosejs.com/docs/middleware.html), including Document and Model middleware. Does that make sense? If so, I would like to create another PR for this work.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

```
schema.statics.aggregate = function(pipeline) {
    let match = { $match: { deleted: { '$ne': false } } };

    if (pipeline.length && pipeline[0].$match) {
        pipeline[0].$match.deleted = { '$ne': false };
    } else {
        pipeline.unshift(match);
    }

    const query = Model.aggregate.apply(this, [pipeline]);
    return query;
};
```

Assume that the static method overwrites the built-in Mongoose aggregate function.

```
schema.pre('aggregate', function(next) {
    console.log(this);
    next();
});

schema.post('aggregate', function() {
    console.log(this);
});
```

In this situation, also assume that there are pre and post hooks for aggregate.

With this PR, when a custom static method overwrites an existing aggregate middleware as described above, the middleware is not applied by default. As a result, the `this` context type in pre/post hooks is correctly set to Aggregate, as intended.

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
