### PR TITLE
fix(model): filter applying static hooks by default if static name conflicts with mongoose middleware

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -44,3 +44,30 @@ const aggregateMiddlewareFunctions = [
 ];
 
 exports.aggregateMiddlewareFunctions = aggregateMiddlewareFunctions;
+
+/*!
+ * ignore
+ */
+
+const modelMiddlewareFunctions = [
+  'bulkWrite',
+  'createCollection',
+  'insertMany'
+];
+
+exports.modelMiddlewareFunctions = modelMiddlewareFunctions;
+
+/*!
+ * ignore
+ */
+
+const documentMiddlewareFunctions = [
+  'validate',
+  'save',
+  'remove',
+  'updateOne',
+  'deleteOne',
+  'init'
+];
+
+exports.documentMiddlewareFunctions = documentMiddlewareFunctions;

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -3,14 +3,14 @@
 const promiseOrCallback = require('../promiseOrCallback');
 const { queryMiddlewareFunctions, aggregateMiddlewareFunctions, modelMiddlewareFunctions, documentMiddlewareFunctions } = require('../../constants');
 
-const middlewareFunctions = [
-  ...[
+const middlewareFunctions = Array.from(
+  new Set([
     ...queryMiddlewareFunctions,
     ...aggregateMiddlewareFunctions,
     ...modelMiddlewareFunctions,
     ...documentMiddlewareFunctions
-  ].reduce((s, hook) => s.add(hook), new Set())
-];
+  ])  
+);
 
 module.exports = function applyStaticHooks(model, hooks, statics) {
   const kareemOptions = {

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -1,11 +1,15 @@
 'use strict';
 
 const promiseOrCallback = require('../promiseOrCallback');
-const { queryMiddlewareFunctions, aggregateMiddlewareFunctions } = require('../../constants');
+const { queryMiddlewareFunctions, aggregateMiddlewareFunctions, modelMiddlewareFunctions, documentMiddlewareFunctions } = require('../../constants');
 
 const middlewareFunctions = [
-  ...queryMiddlewareFunctions,
-  ...aggregateMiddlewareFunctions
+  ...[
+    ...queryMiddlewareFunctions,
+    ...aggregateMiddlewareFunctions,
+    ...modelMiddlewareFunctions,
+    ...documentMiddlewareFunctions
+  ].reduce((s, hook) => s.add(hook), new Set())
 ];
 
 module.exports = function applyStaticHooks(model, hooks, statics) {
@@ -14,8 +18,11 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
     numCallbackParams: 1
   };
 
+  model.$__insertMany = hooks.createWrapper('insertMany',
+    model.$__insertMany, model, kareemOptions);
+
   hooks = hooks.filter(hook => {
-    // If the custom static overwrites an existing query/aggregate middleware, don't apply
+    // If the custom static overwrites an existing middleware, don't apply
     // middleware to it by default. This avoids a potential backwards breaking
     // change with plugins like `mongoose-delete` that use statics to overwrite
     // built-in Mongoose functions.
@@ -24,9 +31,6 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
     }
     return hook.model !== false;
   });
-
-  model.$__insertMany = hooks.createWrapper('insertMany',
-    model.$__insertMany, model, kareemOptions);
 
   for (const key of Object.keys(statics)) {
     if (hooks.hasHooks(key)) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5920,7 +5920,7 @@ describe('Model', function() {
 
     const schema = new Schema({ name: String });
 
-    schema.statics.save = async function() {
+    schema.statics.save = function() {
       return 'foo';
     };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

Additional Fix for PR: https://github.com/Automattic/mongoose/pull/14904

**Summary**

Ensure that if a custom static method overwrites an existing mongoose middleware, the middleware is not applied by default, similar to how it works with query and aggregate middleware.

#### applyStaticHooks.js
```js
const middlewareFunctions = [
  ...[
    ...queryMiddlewareFunctions,
    ...aggregateMiddlewareFunctions,
    ...modelMiddlewareFunctions,
    ...documentMiddlewareFunctions
  ].reduce((s, hook) => s.add(hook), new Set())
];
```
I used a `Set()` to eliminate duplicates in the following three function names: updateOne, deleteOne, and validate.

1) Document middleware's **updateOne** and Query middleware's **updateOne**
2) Document middleware's **deleteOne** and Query middleware's **deleteOne**
3) Document middleware's **validate** and Query middleware's **validate**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

The following example demonstrates the newly implemented filtering applied to model and document middleware.

```js
schema.statics.save = function() {
  ...
};

schema.statics.insertMany = function() {
  ...
};
```

Suppose that the static method overwrites the built-in Mongoose `save` / `insertMany` function.

```js
schema.pre('save', function(next) {
    console.log(this);
    next();
});

schema.post('save', function() {
    console.log(this);
});

schema.pre('insertMany', function(next) {
    console.log(this);
    next();
});

schema.post('insertMany', function() {
    console.log(this);
});
```

In this case, also suppose that there are pre and post hooks for save, insertMany.

With this PR, when a custom static method overwrites an existing model or document middleware as described above, the middleware is no longer applied by default. As a result, the this context type in pre/post hooks is correctly set as intended.

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
