### PR TITLE
fix(document): avoid massive perf degradation when saving new doc with 10 level deep subdocs

### DIFF
--- a/benchmarks/createDeepNestedDocArray.js
+++ b/benchmarks/createDeepNestedDocArray.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const mongoose = require('../');
+
+run().catch(err => {
+  console.error(err);
+  process.exit(-1);
+});
+
+async function run() {
+  await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_benchmark');
+
+  const levels = 12;
+
+  let schema = new mongoose.Schema({ test: { type: String, required: true } });
+  let doc = { test: 'gh-14897' };
+  for (let i = 0; i < levels; ++i) {
+    schema = new mongoose.Schema({ level: Number, subdocs: [schema] });
+    doc = { level: (levels - i), subdocs: [{ ...doc }, { ...doc }] };
+  }
+  const Test = mongoose.model('Test', schema);
+
+  if (!process.env.MONGOOSE_BENCHMARK_SKIP_SETUP) {
+    await Test.deleteMany({});
+  }
+
+  const insertStart = Date.now();
+  await Test.create(doc);
+  const insertEnd = Date.now();
+
+  const results = {
+    'create() time ms': +(insertEnd - insertStart).toFixed(2)
+  };
+
+  console.log(JSON.stringify(results, null, '  '));
+  process.exit(0);
+}

--- a/lib/document.js
+++ b/lib/document.js
@@ -3484,44 +3484,9 @@ Document.prototype.$__reset = function reset() {
   // Skip for subdocuments
   const subdocs = !this.$isSubdocument ? this.$getAllSubdocs() : null;
   if (subdocs && subdocs.length > 0) {
-    const resetArrays = new Set();
     for (const subdoc of subdocs) {
-      const fullPathWithIndexes = subdoc.$__fullPathWithIndexes();
       subdoc.$__reset();
-      if (this.isModified(fullPathWithIndexes) || isParentInit(fullPathWithIndexes)) {
-        if (subdoc.$isDocumentArrayElement) {
-          resetArrays.add(subdoc.parentArray());
-        } else {
-          const parent = subdoc.$parent();
-          if (parent === this) {
-            this.$__.activePaths.clearPath(subdoc.$basePath);
-          } else if (parent != null && parent.$isSubdocument) {
-            // If map path underneath subdocument, may end up with a case where
-            // map path is modified but parent still needs to be reset. See gh-10295
-            parent.$__reset();
-          }
-        }
-      }
     }
-
-    for (const array of resetArrays) {
-      this.$__.activePaths.clearPath(array.$path());
-      array[arrayAtomicsBackupSymbol] = array[arrayAtomicsSymbol];
-      array[arrayAtomicsSymbol] = {};
-    }
-  }
-
-  function isParentInit(path) {
-    path = path.indexOf('.') === -1 ? [path] : path.split('.');
-    let cur = '';
-    for (let i = 0; i < path.length; ++i) {
-      cur += (cur.length ? '.' : '') + path[i];
-      if (_this.$__.activePaths[cur] === 'init') {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   // clear atomics

--- a/lib/document.js
+++ b/lib/document.js
@@ -2689,7 +2689,7 @@ function _evaluateRequiredFunctions(doc) {
  * ignore
  */
 
-function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
+function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate) {
   const doValidateOptions = {};
 
   _evaluateRequiredFunctions(doc);
@@ -2709,37 +2709,40 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
   Object.keys(doc.$__.activePaths.getStatePaths('default')).forEach(addToPaths);
   function addToPaths(p) { paths.add(p); }
 
-  const subdocs = doc.$getAllSubdocs();
-  const modifiedPaths = doc.modifiedPaths();
-  for (const subdoc of subdocs) {
-    if (subdoc.$basePath) {
-      const fullPathToSubdoc = subdoc.$isSingleNested ? subdoc.$__pathRelativeToParent() : subdoc.$__fullPathWithIndexes();
+  if (!isNestedValidate) {
+    // If we're validating a subdocument, all this logic will run anyway on the top-level document, so skip for subdocuments
+    const subdocs = doc.$getAllSubdocs();
+    const modifiedPaths = doc.modifiedPaths();
+    for (const subdoc of subdocs) {
+      if (subdoc.$basePath) {
+        const fullPathToSubdoc = subdoc.$isSingleNested ? subdoc.$__pathRelativeToParent() : subdoc.$__fullPathWithIndexes();
 
-      // Remove child paths for now, because we'll be validating the whole
-      // subdoc.
-      // The following is a faster take on looping through every path in `paths`
-      // and checking if the path starts with `fullPathToSubdoc` re: gh-13191
-      for (const modifiedPath of subdoc.modifiedPaths()) {
-        paths.delete(fullPathToSubdoc + '.' + modifiedPath);
-      }
-
-      if (doc.$isModified(fullPathToSubdoc, null, modifiedPaths) &&
-            // Avoid using isDirectModified() here because that does additional checks on whether the parent path
-            // is direct modified, which can cause performance issues re: gh-14897
-            !doc.$__.activePaths.getStatePaths('modify').hasOwnProperty(fullPathToSubdoc) &&
-            !doc.$isDefault(fullPathToSubdoc)) {
-        paths.add(fullPathToSubdoc);
-
-        if (doc.$__.pathsToScopes == null) {
-          doc.$__.pathsToScopes = {};
+        // Remove child paths for now, because we'll be validating the whole
+        // subdoc.
+        // The following is a faster take on looping through every path in `paths`
+        // and checking if the path starts with `fullPathToSubdoc` re: gh-13191
+        for (const modifiedPath of subdoc.modifiedPaths()) {
+          paths.delete(fullPathToSubdoc + '.' + modifiedPath);
         }
-        doc.$__.pathsToScopes[fullPathToSubdoc] = subdoc.$isDocumentArrayElement ?
-          subdoc.__parentArray :
-          subdoc.$parent();
 
-        doValidateOptions[fullPathToSubdoc] = { skipSchemaValidators: true };
-        if (subdoc.$isDocumentArrayElement && subdoc.__index != null) {
-          doValidateOptions[fullPathToSubdoc].index = subdoc.__index;
+        if (doc.$isModified(fullPathToSubdoc, null, modifiedPaths) &&
+              // Avoid using isDirectModified() here because that does additional checks on whether the parent path
+              // is direct modified, which can cause performance issues re: gh-14897
+              !doc.$__.activePaths.getStatePaths('modify').hasOwnProperty(fullPathToSubdoc) &&
+              !doc.$isDefault(fullPathToSubdoc)) {
+          paths.add(fullPathToSubdoc);
+
+          if (doc.$__.pathsToScopes == null) {
+            doc.$__.pathsToScopes = {};
+          }
+          doc.$__.pathsToScopes[fullPathToSubdoc] = subdoc.$isDocumentArrayElement ?
+            subdoc.__parentArray :
+            subdoc.$parent();
+
+          doValidateOptions[fullPathToSubdoc] = { skipSchemaValidators: true };
+          if (subdoc.$isDocumentArrayElement && subdoc.__index != null) {
+            doValidateOptions[fullPathToSubdoc].index = subdoc.__index;
+          }
         }
       }
     }
@@ -2974,7 +2977,7 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
     paths = [...paths];
     doValidateOptionsByPath = {};
   } else {
-    const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip);
+    const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip, options && options._nestedValidate);
     paths = shouldValidateModifiedOnly ?
       pathDetails[0].filter((path) => this.$isModified(path)) :
       pathDetails[0];
@@ -3061,7 +3064,8 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
       const doValidateOptions = {
         ...doValidateOptionsByPath[path],
         path: path,
-        validateAllPaths
+        validateAllPaths,
+        _nestedValidate: true
       };
 
       schemaType.doValidate(val, function(err) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -2724,7 +2724,9 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip) {
       }
 
       if (doc.$isModified(fullPathToSubdoc, null, modifiedPaths) &&
-            !doc.isDirectModified(fullPathToSubdoc) &&
+            // Avoid using isDirectModified() here because that does additional checks on whether the parent path
+            // is direct modified, which can cause performance issues re: gh-14897
+            !doc.$__.activePaths.getStatePaths('modify').hasOwnProperty(fullPathToSubdoc) &&
             !doc.$isDefault(fullPathToSubdoc)) {
         paths.add(fullPathToSubdoc);
 


### PR DESCRIPTION
Fix #14897

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Saving a new doc with many very deep subdocs is extremely expensive: the test case in this PR fails after 35 seconds on my local without the change I made to `lib/document.js`. Saving a new doc 10 levels deep is still more expensive than I'd like, this test now takes maybe 300ms, I'll investigate why this is so slow and add a benchmark.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
