### PR TITLE
feat: add semver range for mongodb node driver and bson versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
             mongodb: 5.0.26
             node: 16
+            node-driver: latest
             coverage: true
         exclude:
           - os: ubuntu-22.04 # exclude because there are no 4.x mongodb builds for 2204

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         node: [16, 18, 20]
         os: [ubuntu-20.04, ubuntu-22.04]
         mongodb: [4.4.29, 5.0.26, 6.0.15, 7.0.12]
+        node-driver: [6.3.0, latest]
         include:
           - os: ubuntu-20.04 # customize on which matrix the coverage will be collected on
             mongodb: 5.0.26
@@ -52,7 +53,7 @@ jobs:
             mongodb: 4.4.29
           - os: ubuntu-22.04 # exclude because there are no 5.x mongodb builds for 2204
             mongodb: 5.0.26
-    name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongodb }} OS ${{ matrix.os }}
+    name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongodb }} OS ${{ matrix.os }} Node driver ${{ matrix.node-driver }}
     env:
       MONGOMS_VERSION: ${{ matrix.mongodb }}
       MONGOMS_PREFER_GLOBAL_PATH: 1
@@ -73,6 +74,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.mongodb }}
 
       - run: npm install
+      - run: npm install mongodb@${{ matrix.node-driver }}
       - name: NPM Test without Coverage
         run: npm test
         if: matrix.coverage != true

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bson": "^6.7.0",
+    "bson": "^6.2.0",
     "kareem": "2.6.3",
-    "mongodb": "6.9.0",
+    "mongodb": "^6.3.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",
     "ms": "2.1.3",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Instead of hard-coding an exact version of the mongodb node driver, add a semver range. This should help with issues like #14877, where users want to use an older version of the mongodb node driver without downgrading Mongoose.

I also modified GitHub workflows to run tests against both the lowest mongodb node driver version in the semver range, and the latest version.

This is a fairly substantial change, I'll think about this some more over the weekend. Mongoose has pinned exact versions since before I became involved with the project, because historically Mongoose was a bit too tightly coupled to the MongoDB Node driver and patch releases in the MongoDB Node driver would create breaking changes in Mongoose on occasion. However, it has been years since we've seen that happen, both due to increased stability in the MongoDB Node driver and due to Mongoose no longer reaching into internal connection state regularly.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
