### PR TITLE
Update migrating_to_6.md about mongoose.modelSchemas

### DIFF
--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -53,6 +53,7 @@ If you're still on Mongoose 4.x, please read the [Mongoose 4.x to 5.x migration 
 * [TypeScript changes](#typescript-changes)
 * [Removed `reconnectTries` and `reconnectInterval` options](#removed-reconnecttries-and-reconnectinterval-options)
 * [Lodash `.isEmpty()` returns false for ObjectIds](#lodash-object-id)
+* [mongoose.modelSchemas removed](#model-schemas)
 
 <h2 id="version-requirements"><a href="#version-requirements">Version Requirements</a></h2>
 
@@ -556,6 +557,17 @@ An ObjectId in mongoose is never empty, so if you're using `isEmpty()` you shoul
 if (!(val instanceof Types.ObjectId) && _.isEmpty(val)) {
   // Handle empty object here
 }
+```
+<h2 id="model-schemas"><a href="#model-schemas">Removed <code>mongoose.modelSchemas</code></a></h2>
+
+The `mongoose.modelSchemas` property was removed. This may have been used to delete a model schema.
+
+```javascript
+// before
+delete mongoose.modelSchemas.User;
+
+// with Mongoose 6.x
+delete mongoose.deleteModel('User');
 ```
 
 


### PR DESCRIPTION
It was removed by this commit that first appeared in the 6.x series:

6865fea216220a88d2e7128d3a8eb8228f29155e

My codebase only used this property for deleting models in a few places. Please peer-review the note
in case there are other uses of this property worth mentioning.
