### PR TITLE
fix: handle buffers stored in MongoDB as EJSON representation with { $binary }

### DIFF
--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -219,6 +219,14 @@ SchemaBuffer.prototype.cast = function(value, doc, init) {
     return ret;
   }
 
+  if (utils.isPOJO(value) && (value.$binary instanceof Binary || typeof value.$binary === 'string')) {
+    const buf = this.cast(Buffer.from(value.$binary, 'base64'));
+    if (value.$type != null) {
+      buf._subtype = value.$type;
+      return buf;
+    }
+  }
+
   throw new CastError('Buffer', value, this.path, null, this);
 };
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13926,6 +13926,35 @@ describe('document', function() {
     cur.subdocs[0] = { test: 'updated' };
     await savedDoc.save();
   });
+
+  it('handles buffers stored as EJSON POJO (gh-14911)', async function() {
+    const pdfSchema = new mongoose.Schema({
+      pdfSettings: {
+        type: {
+          _id: false,
+          fileContent: { type: Buffer, required: true },
+          filePreview: { type: Buffer, required: true },
+          fileName: { type: String, required: true }
+        }
+      }
+    });
+    const PdfModel = db.model('Test', pdfSchema);
+
+    const _id = new mongoose.Types.ObjectId();
+    const buf = { $binary: Buffer.from('hello', 'utf8').toString('base64'), $type: '00' };
+    await PdfModel.collection.insertOne({
+      _id,
+      pdfSettings: {
+        fileContent: buf,
+        filePreview: buf,
+        fileName: 'sample.pdf'
+      }
+    });
+
+    const reloaded = await PdfModel.findById(_id);
+    assert.ok(Buffer.isBuffer(reloaded.pdfSettings.fileContent));
+    assert.strictEqual(reloaded.pdfSettings.fileContent.toString('utf8'), 'hello');
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {


### PR DESCRIPTION
Fix #14911

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14911 is caused by some edge case that caused buffers to be saved in MongoDB as `{ $binary: 'base64str' }` EJSON representation. In older versions of Mongoose, Mongoose buffers correctly handled that format, so I'm adding explicit support for that format with tests for compatibility.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
