### PR TITLE
fix: set flattenObjectIds to false when calling toObject() for internal purposes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -75,8 +75,7 @@ const subclassedSymbol = Symbol('mongoose#Model#subclassed');
 const { VERSION_INC, VERSION_WHERE, VERSION_ALL } = Document;
 
 const saveToObjectOptions = Object.assign({}, internalToObjectOptions, {
-  bson: true,
-  flattenObjectIds: false
+  bson: true
 });
 
 /**

--- a/lib/options.js
+++ b/lib/options.js
@@ -12,5 +12,6 @@ exports.internalToObjectOptions = {
   depopulate: true,
   flattenDecimals: false,
   useProjection: false,
-  versionKey: true
+  versionKey: true,
+  flattenObjectIds: false
 };

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13926,6 +13926,32 @@ describe('document', function() {
     cur.subdocs[0] = { test: 'updated' };
     await savedDoc.save();
   });
+
+  it('avoids flattening objectids on insertMany (gh-14935)', async function() {
+    const TestSchema = new Schema(
+      {
+        professionalId: {
+          type: Schema.Types.ObjectId
+        },
+        firstName: {
+          type: String
+        },
+        nested: {
+          test: String
+        }
+      },
+      {
+        toObject: { flattenObjectIds: true }
+      }
+    );
+    const Test = db.model('Test', TestSchema);
+
+    const professionalId = new mongoose.Types.ObjectId();
+    await Test.insertMany([{ professionalId, name: 'test' }]);
+
+    const doc = await Test.findOne({ professionalId }).lean().orFail();
+    assert.ok(doc.professionalId instanceof mongoose.Types.ObjectId);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13952,7 +13952,7 @@ describe('document', function() {
     const doc = await Test.findOne({ professionalId }).lean().orFail();
     assert.ok(doc.professionalId instanceof mongoose.Types.ObjectId);
   });
-    
+
   it('handles buffers stored as EJSON POJO (gh-14911)', async function() {
     const pdfSchema = new mongoose.Schema({
       pdfSettings: {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13947,7 +13947,7 @@ describe('document', function() {
     const Test = db.model('Test', TestSchema);
 
     const professionalId = new mongoose.Types.ObjectId();
-    await Test.insertMany([{ professionalId, name: 'test' }]);
+    await Test.insertMany([{ professionalId, firstName: 'test' }]);
 
     const doc = await Test.findOne({ professionalId }).lean().orFail();
     assert.ok(doc.professionalId instanceof mongoose.Types.ObjectId);

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13935,9 +13935,6 @@ describe('document', function() {
         },
         firstName: {
           type: String
-        },
-        nested: {
-          test: String
         }
       },
       {


### PR DESCRIPTION
Fix #14935

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`insertMany()` currently respects schema-level flattenObjectIds option settings, which means if schema sets `flattenObjectIds: true` then Mongoose will store ObjectIds as strings. 

This does not affect `save()` because `save()` was fixed in #13648, but that issue still affects `insertMany()`.

In general, `internalToObjectOptions` should always set `flattenObjectIds` to `true` because we rely on those options when trying to get the MongoDB server representation of an object for queries, `insertMany()`, etc.

We should also backport this fix to 6.x and 7.x.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
