### PR TITLE
types: correct schema type inference when using nested typeKey like `type: { type: String }`

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1645,3 +1645,21 @@ function gh8389() {
 function gh14879() {
   Schema.Types.String.setters.push((val?: unknown) => typeof val === 'string' ? val.trim() : val);
 }
+
+async function gh14950() {
+  const SightingSchema = new Schema(
+    {
+      _id: { type: Schema.Types.ObjectId, required: true },
+      location: {
+        type: { type: String, required: true },
+        coordinates: [{ type: Number }]
+      }
+    }
+  );
+
+  const TestModel = model('Test', SightingSchema);
+  const doc = await TestModel.findOne().orFail();
+
+  expectType<string>(doc.location!.type);
+  expectType<number[]>(doc.location!.coordinates);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -183,8 +183,16 @@ type TypeHint<T> = T extends { __typehint: infer U } ? U: never;
  * @param {TypeKey} TypeKey A generic refers to document definition.
  */
 type ObtainDocumentPathType<PathValueType, TypeKey extends string = DefaultTypeKey> = ResolvePathType<
-PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? PathValueType[TypeKey] : PathValueType,
-PathValueType extends PathWithTypePropertyBaseType<TypeKey> ? Omit<PathValueType, TypeKey> : {},
+  PathValueType extends PathWithTypePropertyBaseType<TypeKey>
+    ? PathValueType[TypeKey] extends PathWithTypePropertyBaseType<TypeKey>
+      ? PathValueType
+      : PathValueType[TypeKey]
+    : PathValueType,
+  PathValueType extends PathWithTypePropertyBaseType<TypeKey>
+    ? PathValueType[TypeKey] extends PathWithTypePropertyBaseType<TypeKey>
+      ? {}
+      : Omit<PathValueType, TypeKey>
+    : {},
 TypeKey,
 TypeHint<PathValueType>
 >;


### PR DESCRIPTION
Fix #14950

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14950 points out that it is tricky to handle GeoJSON with TypeScript schema definitions because `inferschematype` doesn't handle `type: { type: String }` correctly.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
