### PR TITLE
Vkarpov15/gh 14954

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -938,6 +938,15 @@ Mongoose.prototype.Mongoose = Mongoose;
 Mongoose.prototype.Schema = Schema;
 
 /**
+ * Identical to `Schema` at runtime. Exists purely to work around some TypeScript compatibility issues.
+ *
+ * @method AutoInferredSchema
+ * @api public
+ */
+
+Mongoose.prototype.AutoInferredSchema = Schema;
+
+/**
  * The Mongoose [SchemaType](https://mongoosejs.com/docs/api/schematype.html#SchemaType()) constructor
  *
  * @method SchemaType

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -19,6 +19,39 @@ function gh14839() {
       required: true
     },
     subdoc: new AutoInferredSchema({
+      name: { type: String, required: true }
+    }),
+    docArr: [new AutoInferredSchema({ test: { type: String, required: true } })]
+  };
+
+  type UserType = InferRawDocType<typeof schemaDefinition>;
+  expectType<{
+    email: string,
+    password: string,
+    dateOfBirth: Date,
+    subdoc?: { name: string } | null,
+    docArr: { test: string }[]
+  }>({} as UserType);
+}
+
+function gh14954() {
+  const schemaDefinition = {
+    email: {
+      type: String,
+      trim: true,
+      required: true,
+      unique: true,
+      lowercase: true
+    },
+    password: {
+      type: String,
+      required: true
+    },
+    dateOfBirth: {
+      type: Date,
+      required: true
+    },
+    subdoc: new AutoInferredSchema({
       name: { type: String, required: true },
       l2: new AutoInferredSchema({
         myProp: { type: Number, required: true }

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -1,4 +1,4 @@
-import { InferRawDocType } from 'mongoose';
+import { InferRawDocType, Schema, AutoInferredSchema } from 'mongoose';
 import { expectType, expectError } from 'tsd';
 
 function gh14839() {
@@ -17,9 +17,22 @@ function gh14839() {
     dateOfBirth: {
       type: Date,
       required: true
-    }
+    },
+    subdoc: new AutoInferredSchema({
+      name: { type: String, required: true },
+      l2: new AutoInferredSchema({
+        myProp: { type: Number, required: true }
+      })
+    }),
+    docArr: [new AutoInferredSchema({ test: { type: String, required: true } })]
   };
 
-  type UserType = InferRawDocType< typeof schemaDefinition>;
-  expectType<{ email: string, password: string, dateOfBirth: Date }>({} as UserType);
+  type UserType = InferRawDocType<typeof schemaDefinition>;
+  expectType<{
+    email: string,
+    password: string,
+    dateOfBirth: Date,
+    subdoc?: { name: string, l2?: { myProp: number } | null } | null,
+    docArr: { test: string }[]
+  }>({} as UserType);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -252,6 +252,29 @@ declare module 'mongoose' {
     TVirtuals,
     TStaticMethods> = (schema: Schema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods>, opts?: any) => void;
 
+  export class AutoInferredSchema<
+    SchemaDef = unknown,
+    RawDocType = any,
+    TModelType = Model<RawDocType, any, any, any>,
+    TInstanceMethods = {},
+    TQueryHelpers = {},
+    TVirtuals = {},
+    TStaticMethods = {},
+    TSchemaOptions = DefaultSchemaOptions,
+    DocType extends ApplySchemaOptions<
+      ObtainDocumentType<DocType, RawDocType, ResolveSchemaOptions<TSchemaOptions>>,
+      ResolveSchemaOptions<TSchemaOptions>
+    > = ApplySchemaOptions<
+      ObtainDocumentType<any, RawDocType, ResolveSchemaOptions<TSchemaOptions>>,
+      ResolveSchemaOptions<TSchemaOptions>
+    >,
+    THydratedDocumentType = HydratedDocument<FlatRecord<DocType>, TVirtuals & TInstanceMethods>
+  > extends Schema<RawDocType, TModelType, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods, TSchemaOptions, DocType, THydratedDocumentType> {
+    constructor(definition?: SchemaDef, options?: SchemaOptions<FlatRecord<DocType>, TInstanceMethods, TQueryHelpers, TStaticMethods, TVirtuals, THydratedDocumentType> | ResolveSchemaOptions<TSchemaOptions>);
+
+    _schemaDefinition: SchemaDef;
+  }
+
   export class Schema<
     RawDocType = any,
     TModelType = Model<RawDocType, any, any, any>,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14954 points out an unfortunate issue: with our current automatic schema inference, there's no good way for `InferRawDocType` to handle nested schemas. The core issue there is that we don't have access to the SchemaDefinition type in TypeScript generics. `class Schema<DocType>` has the constructor schema definition param typed as `SchemaDefinition<SchemaDefinitionType<RawDocType>, RawDocType> | DocType`, and that type isn't something that we can use to infer the raw doc type.

This PR adds a separate `AutoInferredSchema` class that takes the schema definition as the first generic param. There's a separate class for backwards compatibility, to avoid breaking code like `new Schema<UserType>`.

In the long term, I think AutoInferredSchema is a step in the right direction, because we want the exact schema definition so we can infer both the correct raw document type and the correct hydrated document type, rather than trying to infer the raw document type and hydrated document type from the "both but not quite" behavior of `InferSchemaType<>`.

One big outstanding question: changing `RawDocType = any` to `RawDocType = InferRawDocType<SchemaDef>` in the `AutoInferredSchema` generics causes the test for #14954 test to fail with the following error, which makes it seem like 2-level deep subdoc schemas are treated as POJOs somewhere. While tests pass with the current setup, this error makes me feel like I'm missing something, so I'll take a step back and come back to this issue later.

```
  ✖  70:5  Argument of type { email: string; docArr: { test: string; }[]; password: string; dateOfBirth: NativeDate; subdoc?: { childSchemas: DocumentArray<{ model?: unknown; schema?: { [x: string]: unknown; } | null | undefined; }>; ... 49 more ...; eventNames?: {} | ... 1 more ... | undefined; } | null | undefined; } is not assignable to parameter of type { email: string; password: string; dateOfBirth: Date; subdoc?: { name: string; l2?: { myProp: number; } | null | undefined; } | null | undefined; docArr: { test: string; }[]; }.
  Types of property subdoc are incompatible.
    Type { childSchemas: DocumentArray<{ model?: unknown; schema?: { [x: string]: unknown; } | null | undefined; }>; index?: {} | null | undefined; set?: {} | null | undefined; once?: {} | null | undefined; ... 46 more ...; eventNames?: {} | ... 1 more ... | undefined; } | null | undefined is not assignable to type { name: string; l2?: { myProp: number; } | null | undefined; } | null | undefined.
      Property name is missing in type { childSchemas: DocumentArray<{ model?: unknown; schema?: { [x: string]: unknown; } | null | undefined; }>; index?: {} | null | undefined; set?: {} | null | undefined; once?: {} | null | undefined; ... 46 more ...; eventNames?: {} | ... 1 more ... | undefined; } but required in type { name: string; l2?: { myProp: number; } | null | undefined; }.  

  1 error

```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
