### PR TITLE
fix(document): recursively clear modified subpaths when setting deeply nested subdoc to null

### DIFF
--- a/lib/helpers/document/cleanModifiedSubpaths.js
+++ b/lib/helpers/document/cleanModifiedSubpaths.js
@@ -25,11 +25,21 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
       ++deleted;
 
       if (doc.$isSubdocument) {
-        const owner = doc.ownerDocument();
-        const fullPath = doc.$__fullPath(modifiedPath);
-        owner.$__.activePaths.clearPath(fullPath);
+        cleanParent(doc, modifiedPath);
       }
     }
   }
   return deleted;
 };
+
+function cleanParent(doc, path, seen = new Set()) {
+  if (seen.has(doc)) {
+    throw new Error('Infinite subdocument loop: subdoc with _id ' + doc._id + ' is a parent of itself');
+  }
+  const parent = doc.$parent();
+  const newPath = doc.$__pathRelativeToParent(void 0, false) + '.' + path;
+  parent.$__.activePaths.clearPath(newPath);
+  if (parent.$isSubdocument) {
+    cleanParent(parent, newPath, seen);
+  }
+}


### PR DESCRIPTION
Fix #14952

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now `cleanModifiedSubpaths()` cleans the modified paths from the affected subdoc and the top-level doc, but not any intermediate subdocs, which can cause false validation errors like in #14952.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
