### PR TITLE
fix(populate): handle array of ids with parent refPath

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -478,9 +478,10 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
     return;
   }
 
-  let k = modelNames.length;
+  const flatModelNames = utils.array.flatten(modelNames);
+  let k = flatModelNames.length;
   while (k--) {
-    let modelName = modelNames[k];
+    let modelName = flatModelNames[k];
     if (modelName == null) {
       continue;
     }
@@ -503,11 +504,10 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
     }
 
     let ids = ret;
-    const flat = Array.isArray(ret) ? utils.array.flatten(ret) : [];
 
     const modelNamesForRefPath = data.modelNamesInOrder ? data.modelNamesInOrder : modelNames;
-    if (data.isRefPath && Array.isArray(ret) && flat.length === modelNamesForRefPath.length) {
-      ids = flat.filter((val, i) => modelNamesForRefPath[i] === modelName);
+    if (data.isRefPath && Array.isArray(ret) && ret.length === modelNamesForRefPath.length) {
+      ids = matchIdsToRefPaths(ret, modelNamesForRefPath, modelName);
     }
 
     const perDocumentLimit = options.perDocumentLimit == null ?
@@ -567,6 +567,20 @@ function _getModelFromConn(conn, modelName) {
   }
 
   return conn.model(modelName);
+}
+
+function matchIdsToRefPaths(ids, refPaths, refPathToFind) {
+  if (!Array.isArray(refPaths)) {
+    return refPaths === refPathToFind
+      ? Array.isArray(ids)
+        ? utils.array.flatten(ids)
+        : [ids]
+      : [];
+  }
+  if (Array.isArray(ids) && Array.isArray(refPaths)) {
+    return ids.flatMap((id, index) => matchIdsToRefPaths(id, refPaths[index], refPathToFind));
+  }
+  return [];
 }
 
 /*!

--- a/lib/helpers/populate/modelNamesFromRefPath.js
+++ b/lib/helpers/populate/modelNamesFromRefPath.js
@@ -62,7 +62,5 @@ module.exports = function modelNamesFromRefPath(refPath, doc, populatedPath, mod
     modelNames = Array.isArray(refValue) ? refValue : [refValue];
   }
 
-  modelNames = utils.array.flatten(modelNames);
-
   return modelNames;
 };


### PR DESCRIPTION
Re: #10983

Also related to #6870, that issue addresses a slightly different case where the `refPath` is within the same doc array as the id.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

There was a bug in our fix for #10983 where we mishandle `refPath` in an array of ObjectIds where the `refPath` refers to a parent of the array.

```javascript
      const Parent = db.model(
        'Parent',
        new mongoose.Schema({
          docArray: [
            {
              type: {
                type: String,
                enum: ['Child', 'OtherModel']
              },
              ids: [
                {
                  type: mongoose.Schema.ObjectId,
                  refPath: 'docArray.type' // <-- note that `docArray.type` is not within the `ids` array
                }
              ]
            }
          ]
        })
      );
```

In `getModelsMapForPopulate()`, we end up with a case where we have a flat array of all ids and a flat array of all model names, but no way to match the two. In `flat.filter((val, i) => modelNamesForRefPath[i] === modelName);` we then end up accidentally filtering out incorrect ids.

Without flattening, we end up with the following list of model names:

```
[
  undefined, 'Child',
  'Child',   undefined,
  'Child',   undefined,
  'Child'
]
```

and the following ids:

```
[
  [],
  [
    new ObjectId('6671a008596112f0729c2045'),
    new ObjectId('667195f3596112f0728abe24'),
    new ObjectId('6671bd39596112f072cda69c'),
    new ObjectId('6672c351596112f072868565')
  ],
  [ new ObjectId('66734edd596112f0727304a2') ],
  [],
  [ new ObjectId('66726eff596112f072f8e834') ],
  [],
  [ new ObjectId('667267ff596112f072ed56b1') ]
]
```

We just need to correctly filter which ids belong to the `child` model by recursively going through the model names and ids.
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
