### PR TITLE
types: make Buffers into mongodb.Binary in lean result type to match runtime behavior

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -20,8 +20,10 @@ import {
   Types,
   Query,
   model,
-  ValidateOpts
+  ValidateOpts,
+  BufferToBinary
 } from 'mongoose';
+import { Binary } from 'mongodb';
 import { IsPathRequired } from '../../types/inferschematype';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
@@ -917,7 +919,7 @@ async function gh12593() {
   expectType<Buffer | undefined | null>(doc2.x);
 
   const doc3 = await Test.findOne({}).orFail().lean();
-  expectType<Buffer | undefined | null>(doc3.x);
+  expectType<Binary | undefined | null>(doc3.x);
 
   const arrSchema = new Schema({ arr: [{ type: Schema.Types.UUID }] });
 
@@ -1662,4 +1664,15 @@ async function gh14950() {
 
   expectType<string>(doc.location!.type);
   expectType<number[]>(doc.location!.coordinates);
+}
+
+async function gh14902() {
+  const def = {
+    image: { type: Buffer }
+  } as const;
+  const exampleSchema = new Schema(def);
+  const Test = model('Test', exampleSchema);
+
+  const doc = await Test.findOne().lean().orFail();
+  expectType<Binary | null | undefined>(doc.image);
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1667,12 +1667,17 @@ async function gh14950() {
 }
 
 async function gh14902() {
-  const def = {
-    image: { type: Buffer }
-  } as const;
-  const exampleSchema = new Schema(def);
+  const exampleSchema = new Schema({
+    image: { type: Buffer },
+    subdoc: {
+      type: new Schema({
+        testBuf: Buffer
+      })
+    }
+  });
   const Test = model('Test', exampleSchema);
 
   const doc = await Test.findOne().lean().orFail();
   expectType<Binary | null | undefined>(doc.image);
+  expectType<Binary | null | undefined>(doc.subdoc!.testBuf);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -706,12 +706,16 @@ declare module 'mongoose' {
     [K in keyof T]: FlattenProperty<T[K]>;
   };
 
-  export type BufferToBinary<T> = T extends object ? {
+  export type BufferToBinary<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends Buffer
       ? mongodb.Binary
       : T[K] extends (Buffer | null | undefined)
         ? mongodb.Binary | null | undefined
-        : T[K];
+        : T[K] extends Types.DocumentArray<infer ItemType>
+            ? Types.DocumentArray<BufferToBinary<ItemType>>
+            : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
+              ? HydratedSingleSubdocument<SubdocType>
+              : BufferToBinary<T[K]>;
   } : T;
 
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -706,6 +706,14 @@ declare module 'mongoose' {
     [K in keyof T]: FlattenProperty<T[K]>;
   };
 
+  export type BufferToBinary<T> = T extends object ? {
+    [K in keyof T]: T[K] extends Buffer
+      ? mongodb.Binary
+      : T[K] extends (Buffer | null | undefined)
+        ? mongodb.Binary | null | undefined
+        : T[K];
+  } : T;
+
   /**
    * Separate type is needed for properties of union type (for example, Types.DocumentArray | undefined) to apply conditional check to each member of it
    * https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
@@ -716,7 +724,7 @@ declare module 'mongoose' {
         ? Types.DocumentArray<FlattenMaps<ItemType>> : FlattenMaps<T>;
 
   export type actualPrimitives = string | boolean | number | bigint | symbol | null | undefined;
-  export type TreatAsPrimitives = actualPrimitives | NativeDate | RegExp | symbol | Error | BigInt | Types.ObjectId | Buffer | Function;
+  export type TreatAsPrimitives = actualPrimitives | NativeDate | RegExp | symbol | Error | BigInt | Types.ObjectId | Buffer | Function | mongodb.Binary;
 
   export type SchemaDefinitionType<T> = T extends Document ? Omit<T, Exclude<keyof Document, '_id' | 'id' | '__v'>> : T;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -211,7 +211,7 @@ declare module 'mongoose' {
   type QueryOpThatReturnsDocument = 'find' | 'findOne' | 'findOneAndUpdate' | 'findOneAndReplace' | 'findOneAndDelete';
 
   type GetLeanResultType<RawDocType, ResultType, QueryOp> = QueryOp extends QueryOpThatReturnsDocument
-    ? (ResultType extends any[] ? Require_id<FlattenMaps<BufferToBinary<RawDocType>>>[] : Require_id<FlattenMaps<BufferToBinary<RawDocType>>>)
+    ? (ResultType extends any[] ? Require_id<BufferToBinary<FlattenMaps<RawDocType>>>[] : Require_id<BufferToBinary<FlattenMaps<RawDocType>>>)
     : ResultType;
 
   type MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, TQueryHelpers, TInstanceMethods = Record<string, never>> = QueryOp extends QueryOpThatReturnsDocument

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -211,7 +211,7 @@ declare module 'mongoose' {
   type QueryOpThatReturnsDocument = 'find' | 'findOne' | 'findOneAndUpdate' | 'findOneAndReplace' | 'findOneAndDelete';
 
   type GetLeanResultType<RawDocType, ResultType, QueryOp> = QueryOp extends QueryOpThatReturnsDocument
-    ? (ResultType extends any[] ? Require_id<FlattenMaps<RawDocType>>[] : Require_id<FlattenMaps<RawDocType>>)
+    ? (ResultType extends any[] ? Require_id<FlattenMaps<BufferToBinary<RawDocType>>>[] : Require_id<FlattenMaps<BufferToBinary<RawDocType>>>)
     : ResultType;
 
   type MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, TQueryHelpers, TInstanceMethods = Record<string, never>> = QueryOp extends QueryOpThatReturnsDocument


### PR DESCRIPTION
Fix #14902

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#14902 points out correctly that `lean()` returns buffers as instances of `mongodb.Binary` at runtime, but our types say buffers are of type `Buffer`. This PR changes Mongoose's TypeScript types to match the runtime behavior.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
