### PR TITLE
types: improve goto definition for inferred schema definitions

### DIFF
--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -146,9 +146,10 @@ type RequiredPathKeys<T, TypeKey extends string = DefaultTypeKey> = {
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  * @returns a record contains required paths with the corresponding type.
  */
-type RequiredPaths<T, TypeKey extends string = DefaultTypeKey> = {
-  [K in RequiredPathKeys<T, TypeKey>]: T[K];
-};
+type RequiredPaths<T, TypeKey extends string = DefaultTypeKey> = Pick<
+  { -readonly [K in keyof T]: T[K] },
+  RequiredPathKeys<T, TypeKey>
+>;
 
 /**
  * @summary A Utility to obtain schema's optional path keys.
@@ -166,9 +167,10 @@ type OptionalPathKeys<T, TypeKey extends string = DefaultTypeKey> = {
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  * @returns a record contains optional paths with the corresponding type.
  */
-type OptionalPaths<T, TypeKey extends string = DefaultTypeKey> = {
-  [K in OptionalPathKeys<T, TypeKey>]?: T[K];
-};
+type OptionalPaths<T, TypeKey extends string = DefaultTypeKey> = Pick<
+  { -readonly [K in keyof T]?: T[K] },
+  OptionalPathKeys<T, TypeKey>
+>;
 
 /**
  * @summary Allows users to optionally choose their own type for a schema field for stronger typing.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Improve Go to Definition for inferred schema definitions

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

In [schema.test.ts](https://github.com/Automattic/mongoose/blob/c187fd84d197e2f29759a157c798538661d36079/test/types/schema.test.ts#L471), add a type alias such as

```ts
  type InferredSchemaDecimal2 = InferredTestSchemaType['decimal2'];
```

Without this change, using "Go to Definition" does not work, and the typescript language service reports "No definition found". With this change, "Go to Definition" navigates directly to the definition in the schema.

[Screencast](https://github.com/user-attachments/assets/9d59082d-b592-48a7-9021-264ac46a2331)

I don't think there's a way to test for this with `tsd`, you just need to know the pattern to make it work nicely.