### PR TITLE
types: add JSONSerialized helper that can convert HydratedDocument to JSON output type

### DIFF
--- a/test/types/check-types-filename.js
+++ b/test/types/check-types-filename.js
@@ -18,7 +18,7 @@ const checkFolder = (folder) => {
         }
         continue;
       } else {
-        console.error('File ' + entry + ' is not having a valid file-extension.\n');
+        console.error('File ' + entry + ' does not have a valid extension, must be .d.ts or .gitignore.\n');
         process.exit(1);
       }
     }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1687,12 +1687,13 @@ async function gh14451() {
   const exampleSchema = new Schema({
     myId: { type: 'ObjectId' },
     myRequiredId: { type: 'ObjectId', required: true },
+    myBuf: { type: Buffer, required: true },
     subdoc: {
       type: new Schema({
         subdocProp: Date
       })
-    }
-    // docArr: [{ nums: [Number], times: [Date] }]
+    },
+    docArr: [{ nums: [Number], times: [{ type: Date }] }]
   });
 
   const Test = model('Test', exampleSchema);
@@ -1701,9 +1702,10 @@ async function gh14451() {
   expectType<{
     myId?: string | undefined | null,
     myRequiredId: string,
+    myBuf: { type: 'buffer', data: number[] },
     subdoc?: {
       subdocProp?: string | undefined | null
     } | null,
-    // docArr: { nums: number[], times: string[] }[]
+    docArr: { nums: number[], times: string[] }[]
   }>({} as TestJSON);
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -10,6 +10,7 @@ import {
   InferRawDocType,
   InferSchemaType,
   InsertManyOptions,
+  JSONSerialized,
   ObtainDocumentType,
   ObtainSchemaGeneric,
   ResolveSchemaOptions,
@@ -1680,4 +1681,29 @@ async function gh14902() {
   const doc = await Test.findOne().lean().orFail();
   expectType<Binary | null | undefined>(doc.image);
   expectType<Binary | null | undefined>(doc.subdoc!.testBuf);
+}
+
+async function gh14451() {
+  const exampleSchema = new Schema({
+    myId: { type: 'ObjectId' },
+    myRequiredId: { type: 'ObjectId', required: true },
+    subdoc: {
+      type: new Schema({
+        subdocProp: Date
+      })
+    }
+    // docArr: [{ nums: [Number], times: [Date] }]
+  });
+
+  const Test = model('Test', exampleSchema);
+
+  type TestJSON = JSONSerialized<InferSchemaType<typeof exampleSchema>>;
+  expectType<{
+    myId?: string | undefined | null,
+    myRequiredId: string,
+    subdoc?: {
+      subdocProp?: string | undefined | null
+    } | null,
+    // docArr: { nums: number[], times: string[] }[]
+  }>({} as TestJSON);
 }

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1693,7 +1693,11 @@ async function gh14451() {
         subdocProp: Date
       })
     },
-    docArr: [{ nums: [Number], times: [{ type: Date }] }]
+    docArr: [{ nums: [Number], times: [{ type: Date }] }],
+    myMap: {
+      type: Map,
+      of: String
+    }
   });
 
   const Test = model('Test', exampleSchema);
@@ -1706,6 +1710,7 @@ async function gh14451() {
     subdoc?: {
       subdocProp?: string | undefined | null
     } | null,
-    docArr: { nums: number[], times: string[] }[]
+    docArr: { nums: number[], times: string[] }[],
+    myMap?: Record<string, string> | null | undefined
   }>({} as TestJSON);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -706,6 +706,9 @@ declare module 'mongoose' {
     [K in keyof T]: FlattenProperty<T[K]>;
   };
 
+  /**
+   * Converts any Buffer properties into mongodb.Binary instances, which is what `lean()` returns
+   */
   export type BufferToBinary<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends Buffer
       ? mongodb.Binary
@@ -718,6 +721,9 @@ declare module 'mongoose' {
               : BufferToBinary<T[K]>;
   } : T;
 
+  /**
+   * Converts any Buffer properties into { type: 'buffer', data: [1, 2, 3] } format for JSON serialization
+   */
   export type BufferToJSON<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends Buffer
       ? { type: 'buffer', data: number[] }
@@ -730,6 +736,9 @@ declare module 'mongoose' {
               : BufferToBinary<T[K]>;
   } : T;
 
+  /**
+   * Converts any ObjectId properties into strings for JSON serialization
+   */
   export type ObjectIdToString<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends mongodb.ObjectId
       ? string
@@ -742,6 +751,9 @@ declare module 'mongoose' {
               : ObjectIdToString<T[K]>;
   } : T;
 
+  /**
+   * Converts any Date properties into strings for JSON serialization
+   */
   export type DateToString<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends NativeDate
       ? string
@@ -754,6 +766,9 @@ declare module 'mongoose' {
               : DateToString<T[K]>;
   } : T;
 
+  /**
+   * Converts any Mongoose subdocuments (single nested or doc arrays) into POJO equivalents
+   */
   export type SubdocsToPOJOs<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends NativeDate
       ? string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -718,6 +718,50 @@ declare module 'mongoose' {
               : BufferToBinary<T[K]>;
   } : T;
 
+  export type ObjectIdToString<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
+    [K in keyof T]: T[K] extends mongodb.ObjectId
+      ? string
+      : T[K] extends (mongodb.ObjectId | null | undefined)
+        ? string | null | undefined
+        : T[K] extends Types.DocumentArray<infer ItemType>
+            ? Types.DocumentArray<ObjectIdToString<ItemType>>
+            : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
+              ? HydratedSingleSubdocument<ObjectIdToString<SubdocType>>
+              : ObjectIdToString<T[K]>;
+  } : T;
+
+  export type DateToString<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
+    [K in keyof T]: T[K] extends NativeDate
+      ? string
+      : T[K] extends (NativeDate | null | undefined)
+        ? string | null | undefined
+        : T[K] extends Types.DocumentArray<infer ItemType>
+            ? Types.DocumentArray<DateToString<ItemType>>
+            : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
+              ? HydratedSingleSubdocument<DateToString<SubdocType>>
+              : DateToString<T[K]>;
+  } : T;
+
+  export type SubdocsToPOJOs<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
+    [K in keyof T]: T[K] extends NativeDate
+      ? string
+      : T[K] extends (NativeDate | null | undefined)
+        ? string | null | undefined
+        : T[K] extends Types.DocumentArray<infer ItemType>
+            ? ItemType
+            : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
+              ? SubdocType
+              : SubdocsToPOJOs<T[K]>;
+  } : T;
+
+  export type JSONSerialized<T> = SubdocsToPOJOs<
+    FlattenMaps<
+      ObjectIdToString<
+        DateToString<T>
+      >
+    >
+  >;
+
   /**
    * Separate type is needed for properties of union type (for example, Types.DocumentArray | undefined) to apply conditional check to each member of it
    * https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types


### PR DESCRIPTION
Fix #14451

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now it is hard to get the type of the JSON serialized document from a Mongoose document and schema. This PR adds a JSONSerialized<T> type helper which transforms Mongoose subdocs into POJOs, ObjectIds into strings, Dates into strings, and Maps into POJOs. That should cover most cases.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
