### PR TITLE
fix(cursor): close underlying query cursor when calling destroy()

### DIFF
--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -218,7 +218,7 @@ AggregationCursor.prototype._destroy = function _destroy(_err, callback) {
   waitForCursor
     .then(() => this.cursor.close())
     .then(() => {
-      this._closed = false;
+      this._closed = true;
       callback();
     })
     .catch(error => {

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -197,6 +197,37 @@ AggregationCursor.prototype.close = async function close() {
 };
 
 /**
+ * Marks this cursor as destroyed. Will stop streaming and subsequent calls to
+ * `next()` will error.
+ *
+ * @return {this}
+ * @api private
+ * @method _destroy
+ */
+
+AggregationCursor.prototype._destroy = function _destroy(_err, callback) {
+  let waitForCursor = null;
+  if (!this.cursor) {
+    waitForCursor = new Promise((resolve) => {
+      this.once('cursor', resolve);
+    });
+  } else {
+    waitForCursor = Promise.resolve();
+  }
+
+  waitForCursor
+    .then(() => this.cursor.close())
+    .then(() => {
+      this._closed = false;
+      callback();
+    })
+    .catch(error => {
+      callback(error);
+    });
+  return this;
+};
+
+/**
  * Get the next document from this cursor. Will return `null` when there are
  * no documents left.
  *

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -239,6 +239,27 @@ QueryCursor.prototype.close = async function close() {
 };
 
 /**
+ * Marks this cursor as destroyed. Will stop streaming and subsequent calls to
+ * `next()` will error.
+ *
+ * @return {this}
+ * @api private
+ * @method _destroy
+ */
+
+QueryCursor.prototype._destroy = function _destroy(_err, callback) {
+  this.cursor.close()
+    .then(() => {
+      this._closed = false;
+      callback();
+    })
+    .catch(error => {
+      callback(error);
+    });
+  return this;
+};
+
+/**
  * Rewind this cursor to its uninitialized state. Any options that are present on the cursor will
  * remain in effect. Iterating this cursor will cause new queries to be sent to the server, even
  * if the resultant data has already been retrieved by this cursor.

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -262,7 +262,7 @@ QueryCursor.prototype._destroy = function _destroy(_err, callback) {
       this.cursor.close();
     })
     .then(() => {
-      this._closed = false;
+      this._closed = true;
       callback();
     })
     .catch(error => {

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -248,7 +248,19 @@ QueryCursor.prototype.close = async function close() {
  */
 
 QueryCursor.prototype._destroy = function _destroy(_err, callback) {
-  this.cursor.close()
+  let waitForCursor = null;
+  if (!this.cursor) {
+    waitForCursor = new Promise((resolve) => {
+      this.once('cursor', resolve);
+    });
+  } else {
+    waitForCursor = Promise.resolve();
+  }
+
+  waitForCursor
+    .then(() => {
+      this.cursor.close();
+    })
     .then(() => {
       this._closed = false;
       callback();

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -936,6 +936,19 @@ describe('QueryCursor', function() {
     assert.ok(stream.destroyed);
     assert.ok(stream.cursor.closed);
   });
+
+  it('handles destroy() before cursor is created (gh-14966)', async function() {
+    db.deleteModel(/Test/);
+    const TestModel = db.model('Test', mongoose.Schema({ name: String }));
+
+    const stream = await TestModel.find().cursor();
+    assert.ok(!stream.cursor);
+    stream.destroy();
+
+    await once(stream, 'cursor');
+    assert.ok(stream.destroyed);
+    assert.ok(stream.cursor.closed);
+  });
 });
 
 async function delay(ms) {

--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -27,6 +27,12 @@ declare module 'mongoose' {
     close(): Promise<void>;
 
     /**
+     * Destroy this cursor, closing the underlying cursor. Will stop streaming
+     * and subsequent calls to `next()` will error.
+     */
+    destroy(): this;
+
+    /**
      * Rewind this cursor to its uninitialized state. Any options that are present on the cursor will
      * remain in effect. Iterating this cursor will cause new queries to be sent to the server, even
      * if the resultant data has already been retrieved by this cursor.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Implemented using `_destroy()` like recommended in Node docs here: https://nodejs.org/api/stream.html#writable_destroyerr-callback because that's the preferred way to handle async cleanup in destroy(), because destroy() itself needs to be sync.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
