### PR TITLE
fix(query): make sanitizeFilter disable implicit $in

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -28,6 +28,7 @@ const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
  * @param {Object} [options] the query options
  * @param {Boolean|"throw"} [options.strict] Wheter to enable all strict options
  * @param {Boolean|"throw"} [options.strictQuery] Enable strict Queries
+ * @param {Boolean} [options.sanitizeFilter] avoid adding implict query selectors ($in)
  * @param {Boolean} [options.upsert]
  * @param {Query} [context] passed to setters
  * @api private
@@ -372,7 +373,7 @@ module.exports = function cast(schema, obj, options, context) {
 
           }
         }
-      } else if (Array.isArray(val) && ['Buffer', 'Array'].indexOf(schematype.instance) === -1) {
+      } else if (Array.isArray(val) && ['Buffer', 'Array'].indexOf(schematype.instance) === -1 && !options.sanitizeFilter) {
         const casted = [];
         const valuesArray = val;
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -4863,6 +4863,9 @@ Query.prototype.cast = function(model, obj) {
       opts.strictQuery = this.options.strictQuery;
     }
   }
+  if ('sanitizeFilter' in this._mongooseOptions) {
+    opts.sanitizeFilter = this._mongooseOptions.sanitizeFilter;
+  }
 
   try {
     return cast(model.schema, obj, opts, this);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3520,6 +3520,21 @@ describe('Query', function() {
     assert.ifError(q.error());
     assert.deepEqual(q._conditions, { username: 'val', pwd: { $gt: null } });
   });
+
+  it('sanitizeFilter disables implicit $in (gh-14657)', function() {
+    const schema = new mongoose.Schema({
+      name: {
+        type: String
+      }
+    });
+    const Test = db.model('Test', schema);
+
+    const q = Test.find({ name: ['foobar'] }).setOptions({ sanitizeFilter: true });
+    q._castConditions();
+    assert.ok(q.error());
+    assert.equal(q.error().name, 'CastError');
+  });
+
   it('should not error when $not is used with $size (gh-10716)', async function() {
     const barSchema = Schema({
       bar: String


### PR DESCRIPTION
Re: #14657

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

By default, Mongoose adds `$in` when you query a non-array field with an array value. So `Test.find({ name: ['foobar'] })` becomes `Test.find({ name: { $in: ['foobar'] } })` by default. #14657 pointed out that this behavior seems contradictory with `sanitizeFilter`, which is supposed to disallow any query selectors.  This PR makes `sanitizeFilter` disable the implicit `$in` behavior.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
