### PR TITLE
feat(model): add hideIndexes option to syncIndexes() and cleanIndexes()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1220,7 +1220,7 @@ Model.createCollection = async function createCollection(options) {
  *
  * @param {Object} [options] options to pass to `ensureIndexes()`
  * @param {Boolean} [options.background=null] if specified, overrides each index's `background` property
- * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping
+ * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping. Requires MongoDB server 4.4 or higher
  * @return {Promise}
  * @api public
  */
@@ -1443,7 +1443,7 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
  *
  * @param {Object} [options]
  * @param {Array<String>} [options.toDrop] if specified, contains a list of index names to drop
- * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping
+ * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping. Requires MongoDB server 4.4 or higher
  * @return {Promise<String>} list of dropped index names
  * @api public
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -1444,7 +1444,7 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
  * @param {Object} [options]
  * @param {Array<String>} [options.toDrop] if specified, contains a list of index names to drop
  * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping. Requires MongoDB server 4.4 or higher
- * @return {Promise<String>} list of dropped index names
+ * @return {Promise<String>} list of dropped or hidden index names
  * @api public
  */
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1220,6 +1220,7 @@ Model.createCollection = async function createCollection(options) {
  *
  * @param {Object} [options] options to pass to `ensureIndexes()`
  * @param {Boolean} [options.background=null] if specified, overrides each index's `background` property
+ * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping
  * @return {Promise}
  * @api public
  */
@@ -1440,8 +1441,10 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
  *
  * The returned promise resolves to a list of the dropped indexes' names as an array
  *
- * @param {Function} [callback] optional callback
- * @return {Promise|undefined} Returns `undefined` if callback is specified, returns a promise if no callback.
+ * @param {Object} [options]
+ * @param {Array<String>} [options.toDrop] if specified, contains a list of index names to drop
+ * @param {Boolean} [options.hideIndexes=false] set to `true` to hide indexes instead of dropping
+ * @return {Promise<String>} list of dropped index names
  * @api public
  */
 
@@ -1452,23 +1455,32 @@ Model.cleanIndexes = async function cleanIndexes(options) {
   }
   const model = this;
 
-  const collection = model.$__collection;
-
   if (Array.isArray(options && options.toDrop)) {
-    const res = await _dropIndexes(options.toDrop, collection);
+    const res = await _dropIndexes(options.toDrop, model, options);
     return res;
   }
 
   const res = await model.diffIndexes();
-  return await _dropIndexes(res.toDrop, collection);
+  return await _dropIndexes(res.toDrop, model, options);
 };
 
-async function _dropIndexes(toDrop, collection) {
+async function _dropIndexes(toDrop, model, options) {
   if (toDrop.length === 0) {
     return [];
   }
 
-  await Promise.all(toDrop.map(indexName => collection.dropIndex(indexName)));
+  const collection = model.$__collection;
+  if (options && options.hideIndexes) {
+    await Promise.all(toDrop.map(indexName => {
+      return model.db.db.command({
+        collMod: collection.collectionName,
+        index: { name: indexName, hidden: true }
+      });
+    }));
+  } else {
+    await Promise.all(toDrop.map(indexName => collection.dropIndex(indexName)));
+  }
+
   return toDrop;
 }
 

--- a/types/indexes.d.ts
+++ b/types/indexes.d.ts
@@ -57,7 +57,8 @@ declare module 'mongoose' {
   type IndexDefinition = Record<string, IndexDirection>;
 
   interface SyncIndexesOptions extends mongodb.CreateIndexesOptions {
-    continueOnError?: boolean
+    continueOnError?: boolean;
+    hideIndexes?: boolean;
   }
   type ConnectionSyncIndexesResult = Record<string, OneCollectionSyncIndexesResult>;
   type OneCollectionSyncIndexesResult = Array<string> & mongodb.MongoServerError;


### PR DESCRIPTION
Fix #14868

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Add an option to make `syncIndexes()` mark indexes as hidden (see [MongoDB hidden indexes docs](https://www.mongodb.com/docs/v5.1/core/index-hidden/)) as opposed to dropping them. Hidden indexes are useful because rebuilding an index can be expensive, so if you accidentally drop a index that you shouldn't it can take a while to recover. With hidden indexes, you can test whether removing this index will cause performance issues without actually dropping the index. `syncIndexes({ hideIndex: true })` will hide all non-schema indexes rather than dropping them.

Hidden index support was added in MongoDB 4.4 so we should make a quick note about version compatibility, since Mongoose 8 technically supports all the way back to MongoDB 3.6.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
