### PR TITLE
types: added toJSON:flattenObjectIds effect

### DIFF
--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -256,10 +256,17 @@ declare module 'mongoose' {
     set(value: string | Record<string, any>): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
-    toJSON(options?: ToObjectOptions & { flattenMaps?: true }): FlattenMaps<Require_id<DocType>>;
+    toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Require_id<DocType>>;
+    toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Require_id<DocType>>;
+    toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Require_id<DocType>>>;
     toJSON(options: ToObjectOptions & { flattenMaps: false }): Require_id<DocType>;
-    toJSON<T = Require_id<DocType>>(options?: ToObjectOptions & { flattenMaps?: true }): FlattenMaps<T>;
+    toJSON(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<Require_id<DocType>>;
+
+    toJSON<T = Require_id<DocType>>(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<T>;
+    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<T>;
+    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<T>>;
     toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenMaps: false }): T;
+    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<T>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
     toObject(options?: ToObjectOptions): Require_id<DocType>;


### PR DESCRIPTION

**Summary**

- There is type support for `flattenMaps`, but there wasn't any for `flattenObjectIds`, and I wanted to add type support for that. I hope there are no errors; if there are, please provide this support. Thank you.

**Examples**

![Ekran Resmi 2024-10-28 18 20 04](https://github.com/user-attachments/assets/8f917be8-efab-4cef-a803-2bca03b03a92)
