### PR TITLE
types: add __v to lean() result type and ModifyResult

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -371,7 +371,7 @@ async function gh12959() {
 
   const doc = await Model.findById('id').orFail();
   expectType<Types.ObjectId>(doc._id);
-  expectType<number | undefined>(doc.__v);
+  expectType<number>(doc.__v);
 
   expectError(doc.subdocArray[0].__v);
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -623,9 +623,9 @@ async function gh13151() {
 
   const TestModel = model<ITest>('Test', TestSchema);
   const test = await TestModel.findOne().lean();
-  expectType<ITest & { _id: Types.ObjectId } | null>(test);
+  expectType<ITest & { _id: Types.ObjectId } & { __v: number } | null>(test);
   if (!test) return;
-  expectType<ITest & { _id: Types.ObjectId }>(test);
+  expectType<ITest & { _id: Types.ObjectId } & { __v: number }>(test);
 }
 
 function gh13206() {
@@ -661,7 +661,7 @@ async function gh13705() {
   const schema = new Schema({ name: String });
   const TestModel = model('Test', schema);
 
-  type ExpectedLeanDoc = (mongoose.FlattenMaps<{ name?: string | null }> & { _id: mongoose.Types.ObjectId });
+  type ExpectedLeanDoc = (mongoose.FlattenMaps<{ name?: string | null }> & { _id: mongoose.Types.ObjectId } & { __v: number });
 
   const findByIdRes = await TestModel.findById('0'.repeat(24), undefined, { lean: true });
   expectType<ExpectedLeanDoc | null>(findByIdRes);

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -248,7 +248,6 @@ async function _11532() {
 
   if (!leanResult) return;
   expectType<string>(leanResult.child.name);
-  expectError(leanResult?.__v);
 }
 
 async function gh11710() {

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1714,3 +1714,13 @@ async function gh14451() {
     myMap?: Record<string, string> | null | undefined
   }>({} as TestJSON);
 }
+
+async function gh12959() {
+  const schema = new Schema({ name: String });
+  const TestModel = model('Test', schema);
+
+  const doc = await TestModel.findOne().orFail();
+  expectType<number>(doc.__v);
+  const leanDoc = await TestModel.findOne().lean().orFail();
+  expectType<number>(leanDoc.__v);
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -140,7 +140,7 @@ declare module 'mongoose' {
 
   export type Default__v<T> = T extends { __v?: infer U }
     ? T
-    : T & { __v?: number };
+    : T & { __v: number };
 
   /** Helper type for getting the hydrated document type from the raw document type. The hydrated document type is what `new MyModel()` returns. */
   export type HydratedDocument<

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -126,7 +126,7 @@ declare module 'mongoose' {
   }
 
   interface ModifyResult<T> {
-    value: Require_id<T> | null;
+    value: Default__v<Require_id<T>> | null;
     /** see https://www.mongodb.com/docs/manual/reference/command/findAndModify/#lasterrorobject */
     lastErrorObject?: {
       updatedExisting?: boolean;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -217,7 +217,7 @@ declare module 'mongoose' {
   type QueryOpThatReturnsDocument = 'find' | 'findOne' | 'findOneAndUpdate' | 'findOneAndReplace' | 'findOneAndDelete';
 
   type GetLeanResultType<RawDocType, ResultType, QueryOp> = QueryOp extends QueryOpThatReturnsDocument
-    ? (ResultType extends any[] ? Require_id<BufferToBinary<FlattenMaps<RawDocType>>>[] : Require_id<BufferToBinary<FlattenMaps<RawDocType>>>)
+    ? (ResultType extends any[] ? Default__v<Require_id<BufferToBinary<FlattenMaps<RawDocType>>>>[] : Default__v<Require_id<BufferToBinary<FlattenMaps<RawDocType>>>>)
     : ResultType;
 
   type MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, TQueryHelpers, TInstanceMethods = Record<string, never>> = QueryOp extends QueryOpThatReturnsDocument


### PR DESCRIPTION
Re: #12959

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Technically `__v` always exists on hydrated documents, unless `versionKey` option is set to `false` in the schema. Admittedly most developers don't use `__v` directly, but #12959 pointed it out.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
