### PR TITLE
feat: upgrade mongodb -> ~6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bson": "^6.7.0",
     "kareem": "2.6.3",
-    "mongodb": "6.9.0",
+    "mongodb": "~6.10.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",
     "ms": "2.1.3",


### PR DESCRIPTION
Fix #14877

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Most notably, this PR loosens our longstanding policy of pinning exact versions of the MongoDB Node driver: Mongoose 8.8 will now be compatible with MongoDB Node driver 6.10.x.

Re: issues like #14877, we may consider further loosening Mongoose's supported MongoDB Node driver semver range in the future, but `~6.10` should be a good first step.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
