### PR TITLE
types: use globalThis instead of global for NativeDate

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@
 /// <reference path="./virtuals.d.ts" />
 /// <reference path="./augmentations.d.ts" />
 
-declare class NativeDate extends global.Date { }
+declare class NativeDate extends globalThis.Date { }
 
 declare module 'mongoose' {
   import Kareem = require('kareem');


### PR DESCRIPTION
Fix: #14988 

**Summary**

The global is defined in the @types/node package, which is not in the dependencies. Without the package, NativeDate would be interpreted as any by typescript, and resolves the types in the Schema incorrectly.

**Examples**
```
import { Schema, Types } from "mongoose";

interface IUser {
  organization: Types.ObjectId;
}

const userSchema = new Schema<IUser>({
  // typescript error: Type 'typeof ObjectId' is not assignable to type 'DateSchemaDefinition | typeof Mixed | undefined'.
  organization: { type: Schema.Types.ObjectId, ref: "Organization" },
});
```
