### PR TITLE
fix(model): avoid throwing TypeError if bulkSave()'s bulkWrite() fails with a non-BulkWriteError

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -10,6 +10,7 @@ const Document = require('./document');
 const DocumentNotFoundError = require('./error/notFound');
 const EventEmitter = require('events').EventEmitter;
 const Kareem = require('kareem');
+const { MongoBulkWriteError } = require('mongodb');
 const MongooseBulkWriteError = require('./error/bulkWriteError');
 const MongooseError = require('./error/index');
 const ObjectParameterError = require('./error/objectParameter');
@@ -3417,6 +3418,11 @@ Model.bulkSave = async function bulkSave(documents, options) {
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })
   );
 
+  // If not a MongoBulkWriteError, treat this as all documents failed to save.
+  if (bulkWriteError != null && !(bulkWriteError instanceof MongoBulkWriteError)) {
+    throw bulkWriteError;
+  }
+
   const matchedCount = bulkWriteResult?.matchedCount ?? 0;
   const insertedCount = bulkWriteResult?.insertedCount ?? 0;
   if (writeOperations.length > 0 && matchedCount + insertedCount < writeOperations.length && !bulkWriteError) {
@@ -3430,13 +3436,7 @@ Model.bulkSave = async function bulkSave(documents, options) {
   const successfulDocuments = [];
   for (let i = 0; i < documents.length; i++) {
     const document = documents[i];
-    const hasWriteErrors = bulkWriteError && Array.isArray(bulkWriteError.writeErrors);
-    // If there is an error, but the error doesn't have a list of `writeErrors`, then treat the error as
-    // indicating that all documents failed. This might happen because of a MongooseServerSelectionError.
-    if (!hasWriteErrors) {
-      continue;
-    }
-    const documentError = bulkWriteError.writeErrors.find(writeError => {
+    const documentError = bulkWriteError && bulkWriteError.writeErrors.find(writeError => {
       const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
       return writeErrorDocumentId.toString() === document._doc._id.toString();
     });

--- a/lib/model.js
+++ b/lib/model.js
@@ -3430,7 +3430,13 @@ Model.bulkSave = async function bulkSave(documents, options) {
   const successfulDocuments = [];
   for (let i = 0; i < documents.length; i++) {
     const document = documents[i];
-    const documentError = bulkWriteError && bulkWriteError.writeErrors.find(writeError => {
+    const hasWriteErrors = bulkWriteError && Array.isArray(bulkWriteError.writeErrors);
+    // If there is an error, but the error doesn't have a list of `writeErrors`, then treat the error as
+    // indicating that all documents failed. This might happen because of a MongooseServerSelectionError.
+    if (!hasWriteErrors) {
+      continue;
+    }
+    const documentError = bulkWriteError.writeErrors.find(writeError => {
       const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
       return writeErrorDocumentId.toString() === document._doc._id.toString();
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If `bulkWrite()` throws any error that doesn't have a `writeErrors` property, `bulkSave()` fails with `TypeError: Cannot read properties of undefined (reading 'find')`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
