### PR TITLE
docs(change-streams): fix markdown syntax highlighting for script output example

### DIFF
--- a/docs/change-streams.md
+++ b/docs/change-streams.md
@@ -21,7 +21,7 @@ await Person.create({ name: 'Axl Rose' });
 
 The above script will print output that looks like:
 
-```no-highlight
+```javascript
 {
   _id: {
     _data: '8262408DAC000000012B022C0100296E5A10042890851837DB4792BE6B235E8B85489F46645F6964006462408DAC6F5C42FF5EE087A20004'


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
I was reading the documentation on [Change Streams](https://mongoosejs.com/docs/change-streams.html) and found the output example of the script to be uncomfortable to read. So, I fixed the syntax to improve its appearance.
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

**AS-IS**
![image](https://github.com/user-attachments/assets/78308f81-bdda-4cc1-a72f-5922c639fd49)

**TO-BE**
![image](https://github.com/user-attachments/assets/ec0aa04b-0866-433a-b39a-cc3eb80955a8)

