### PR TITLE
fix(model): avoid unhandled error if `createIndex()` throws a sync error

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1653,7 +1653,24 @@ function _ensureIndexes(model, options, callback) {
       }
     }
 
-    model.collection.createIndex(indexFields, indexOptions).then(
+    // Just in case `createIndex()` throws a sync error
+    let promise = null;
+    try {
+      promise = model.collection.createIndex(indexFields, indexOptions);
+    } catch (err) {
+      if (!indexError) {
+        indexError = err;
+      }
+      if (!model.$caught) {
+        model.emit('error', err);
+      }
+
+      indexSingleDone(err, indexFields, indexOptions);
+      create();
+      return;
+    }
+
+    promise.then(
       name => {
         indexSingleDone(null, indexFields, indexOptions, name);
         create();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If `collection.createIndex()` happens to throw a sync error (as opposed to returning a promise that rejects), we end up with an unhandled error. Long term, I think what we should do is refactor to use async/await, but this fix should be enough for now.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
