### PR TITLE
docs(migration-guide-6x): document that strictQuery default will flip-back

### DIFF
--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -144,9 +144,16 @@ if (existingUser) {
 <h2 id="strictquery-is-removed-and-replaced-by-strict"><a href="#strictquery-is-removed-and-replaced-by-strict"><code>strictQuery</code> is now equal to <code>strict</code> by default</a></h2>
 
 ~Mongoose no longer supports a `strictQuery` option. You must now use `strict`.~
-As of Mongoose 6.0.10, we brought back the `strictQuery` option.
-However, `strictQuery` is tied to `strict` by default.
-This means that, by default, Mongoose will filter out query filter properties that are not in the schema.
+As of Mongoose 6.0.10, we brought back the `strictQuery` option. In Mongoose 6, `strictQuery` is set to `strict` by default. This means that, by default, Mongoose will filter out query filter properties that are not in the schema.
+
+However, this behavior was a source of confusion in some cases, so in Mongoose 7, this default changes back to `false`. So if you want to retain the default behavior of Mongoose 5 as well as Mongoose 7 and later, you can also disable `strictQuery` globally to override:
+
+```javascript
+mongoose.set('strictQuery', false);
+```
+In a test suite, it may be useful to set `strictQuery` to `throw`, which will throw exceptions any time a query references schema that doesn't exist, which could help identify a bug in your tests or code.
+
+Here's an example of the effect of `strictQuery`:
 
 ```javascript
 const userSchema = new Schema({ name: String });

--- a/docs/migrating_to_6.md
+++ b/docs/migrating_to_6.md
@@ -544,7 +544,7 @@ The MongoDB node driver will always attempt to retry any operation for up to `se
 So, it will never run out of retries or try to reconnect to MongoDB.
 
 
-<h2 id="lodash-object-id"><a href="#lodash-object-id">Lodash <code>.isEmpty()</code> returns true for ObjectIds</h2>
+<h2 id="lodash-object-id"><a href="#lodash-object-id">Lodash <code>.isEmpty()</code> returns true for ObjectIds</a></h2>
 
 Lodash's `isEmpty()` function returns true for primitives and primitive wrappers.
 `ObjectId()` is an object wrapper that is treated as a primitive by Mongoose.


### PR DESCRIPTION
I spent many hours migrating a large code base from 5.x to 6.x. By a large margin, more hours were lost as a result of the change to `strictQuery: true`. Parts of my queries had been discarded and it wasn't clear why.

Although I had read the migration guide multiple times, perhaps I glossed over this section believing that since I wasn't using the strictQuery option before, this change didn't apply to me.

To limit my scope of work, I always wasn't reading ahead to the changes in 7.x, where the default flipped back to what it was in 5.x.

So only at the very end during peer-review did someone point out that we should set `strictQuery:false`-- the default in both 5.x and >=7.x. Then I re-read that section of the migration guide and all my problems with parts of queries being discarded made sense.

So I recommend adding a note about this to the "Migrating to 6.x" guide because I think it could save some other people some headache, if they set `strictQuery:false` when upgrading from 5.x to 6.x.

This PR also fixes a closing tag issue in the same document.

---

Related to this, I would also suggest that there be extra logging when `strictQuery:true`. At least at the debug level if not `info` or `warn`, include some logging like:

`foo:'zoo' was discarded from query because strictQuery:true`

Considering that could be a separate issue. Really, after living with the effects of having `strictQuery:true`, I think it's dangerous and unintuitive option to silently modify queries, and would prefer that referencing missing schema throw (like `strictQuery:'throw'` or work anyway, like `strictQuery:'false'`).
