### PR TITLE
7.x: deps(mongodb-memory-server): upgrade to 9.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mkdirp": "^3.0.1",
     "mocha": "10.2.0",
     "moment": "2.x",
-    "mongodb-memory-server": "9.2.0",
+    "mongodb-memory-server": "9.5.0",
     "ncp": "^2.0.0",
     "nyc": "15.1.0",
     "pug": "3.0.2",


### PR DESCRIPTION
**Summary**

This PR updates 7.x `mongodb-memory-server` to `9.5.0` as it has some fixes regarding ubuntu 2404 and rhel 8 handling (backported from 10.x)
