### PR TITLE
fix: apply embedded discriminators to subdoc schemas before compiling top level model so middleware applies correctly

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -661,6 +661,8 @@ Mongoose.prototype._model = function(name, schema, collection, options) {
       utils.toCollectionName(name, _mongoose.pluralize());
   }
 
+  applyEmbeddedDiscriminators(schema);
+
   const connection = options.connection || _mongoose.connection;
   model = _mongoose.Model.compile(model || name, schema, collection, connection, _mongoose);
   // Errors handled internally, so safe to ignore error
@@ -677,8 +679,6 @@ Mongoose.prototype._model = function(name, schema, collection, options) {
       model.discriminator(disc, discriminatorSchema, options);
     }
   }
-
-  applyEmbeddedDiscriminators(schema);
 
   return model;
 };


### PR DESCRIPTION
Fix #14961

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary** 

We found in #14961 that subdocument discriminators created using `Schema.prototype.discriminator()` don't get 'validate' hooks applied correctly. That's because are calling `applyEmbeddedDiscriminators()` _after_ `Model.compile()`. And Mongoose generally assumes that all middleware is registered before model compilation. This PR moves `applyEmbeddedDiscriminators()` up.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
