### PR TITLE
CI: add Node 22

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 16
+          node-version: 22
 
       - run: npm install
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20
+          node-version: 22
 
       - run: npm install
 
@@ -54,7 +54,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20
+          node-version: 22
 
       - run: npm install
       - name: Setup MongoDB

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 18
+          node-version: 22
 
       - run: npm install
 
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20]
+        node: [16, 18, 20, 22]
         os: [ubuntu-20.04, ubuntu-22.04]
         mongodb: [4.4.29, 5.0.26, 6.0.15, 7.0.12, 8.0.0]
         include:
@@ -98,7 +98,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 16
+          node-version: 22
       - name: Load MongoDB binary cache
         id: cache-mongodb-binaries
         uses: actions/cache@v4
@@ -126,7 +126,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 16
+          node-version: 22
       - run: npm install
       - name: Test
         run: npm run test-rs

--- a/.github/workflows/tidelift-alignment.yml
+++ b/.github/workflows/tidelift-alignment.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 16
+          node-version: 22
       - name: Alignment
         uses: tidelift/alignment-action@8d7700fe795fc01179c1f9fa05b72a089873027d # main
         env:

--- a/.github/workflows/tsd.yml
+++ b/.github/workflows/tsd.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 18
+          node-version: 22
 
       - run: npm install
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 16
+          node-version: 22
 
       - run: npm install
 


### PR DESCRIPTION
**Summary**

Node 22 is the current Node.js version and LTS version. It was missing from CI test matrix.

I've already been running Mongoose on Node 22 for a while without issues, but it should be included in the official CI too. Therefore:

- Add 22 to test matrix, in addition to existing ones.
- Replace older single-version actions with 22. Some were run in Node 16, which is end-of-life. Some in 18, which will be end-of-life in six months. If an action is only run in one version, might as well be the latest.

For successful CI run, see the [PR in this fork](https://github.com/stscoundrel/mongoose/pull/1)

