### PR TITLE
fix(model): make diffIndexes() avoid trying to drop default timeseries collection index

### DIFF
--- a/lib/helpers/indexes/isTimeseriesIndex.js
+++ b/lib/helpers/indexes/isTimeseriesIndex.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Returns `true` if the given index matches the schema's `timestamps` options
+ */
+
+module.exports = function isTimeseriesIndex(dbIndex, schemaOptions) {
+  if (schemaOptions.timeseries == null) {
+    return false;
+  }
+  const { timeField, metaField } = schemaOptions.timeseries;
+  if (typeof timeField !== 'string' || typeof metaField !== 'string') {
+    return false;
+  }
+  return Object.keys(dbIndex.key).length === 2 && dbIndex.key[timeField] === 1 && dbIndex.key[metaField] === 1;
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -51,6 +51,7 @@ const immediate = require('./helpers/immediate');
 const internalToObjectOptions = require('./options').internalToObjectOptions;
 const isDefaultIdIndex = require('./helpers/indexes/isDefaultIdIndex');
 const isIndexEqual = require('./helpers/indexes/isIndexEqual');
+const isTimeseriesIndex = require('./helpers/indexes/isTimeseriesIndex');
 const {
   getRelatedDBIndexes,
   getRelatedSchemaIndexes
@@ -1418,6 +1419,10 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
     if (isDefaultIdIndex(dbIndex)) {
       continue;
     }
+    // Timeseries collections have a default index on { timeField: 1, metaField: 1 }.
+    if (isTimeseriesIndex(dbIndex, schema.options)) {
+      continue;
+    }
 
     for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
       const options = decorateDiscriminatorIndexOptions(schema, clone(schemaIndexOptions));
@@ -1429,9 +1434,11 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
       }
     }
 
-    if (!found) {
-      toDrop.push(dbIndex.name);
+    if (found) {
+      continue;
     }
+
+    toDrop.push(dbIndex.name);
   }
 
   return toDrop;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8150,6 +8150,12 @@ describe('Model', function() {
 
   describe('diffIndexes()', function() {
     it('avoids trying to drop timeseries collections (gh-14984)', async function() {
+      const version = await start.mongodVersion();
+      if (version[0] < 5) {
+        this.skip();
+        return;
+      }
+
       const schema = new mongoose.Schema(
         {
           time: {


### PR DESCRIPTION
Fix #14984

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Starting in MongoDB 6.3, MongoDB server creates a default index on timeseries collections, see [docs here](https://www.mongodb.com/docs/manual/core/timeseries/timeseries-index/#compound-indexes). We shouldn't try to drop that index if the schema has `timeseries` option.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
