### PR TITLE
types(cursor): correct `asyncIterator` and `asyncDispose` for TypeScript with lib: 'esnext'

### DIFF
--- a/types/cursor.d.ts
+++ b/types/cursor.d.ts
@@ -11,8 +11,10 @@ declare module 'mongoose' {
     signal?: AbortSignal;
   }
 
-  class Cursor<DocType = any, Options = never> extends stream.Readable {
-    [Symbol.asyncIterator](): AsyncIterableIterator<DocType>;
+  class Cursor<DocType = any, Options = never, NextResultType = DocType | null> extends stream.Readable {
+    [Symbol.asyncIterator](): Cursor<IteratorResult<DocType>, Options, IteratorResult<DocType>>;
+
+    [Symbol.asyncDispose](): Promise<void>;
 
     /**
      * Adds a [cursor flag](https://mongodb.github.io/node-mongodb-native/4.9/classes/FindCursor.html#addCursorFlag).
@@ -58,7 +60,7 @@ declare module 'mongoose' {
      * Get the next document from this cursor. Will return `null` when there are
      * no documents left.
      */
-    next(): Promise<DocType | null>;
+    next(): Promise<NextResultType>;
 
     options: Options;
   }


### PR DESCRIPTION
Fix #14976

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Add `Symbol.asyncDispose()` to querycursors and correct the return type of `Symbol.asyncIterator` to indicate that it returns a cursor with different return type. I had to add a new generic `NextResultType` to work around the issue where `next()` always returns `DocType | null`.

No need for any runtime changes AFAIK because [Node.js streams already support AsyncDispose](https://nodejs.org/api/stream.html#readablesymbolasyncdispose)

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
