### PR TITLE
fix: save execution stack in query as string

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4433,10 +4433,10 @@ Query.prototype.exec = async function exec(op) {
       str = str.slice(0, 60) + '...';
     }
     const err = new MongooseError('Query was already executed: ' + str);
-    err.originalStack = this._executionStack.stack;
+    err.originalStack = this._executionStack;
     throw err;
   } else {
-    this._executionStack = new Error();
+    this._executionStack = new Error().stack;
   }
 
   let skipWrappedFunction = null;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

While debugging some unexpected memory usage in a production cluster, we noticed that mongoose's `Query` object was constructing a new `Error` instance in order to be able to preserve the original stack when throwing an error after attempting to execute the query more than once. This is problematic in that until the stack is converted to a string, the error retains references to every object in the call site info. This PR changes the execution stack object to the actual stack string to avoid this problem. Since this variable appears intended to not be part of the public API it seems reasonable to change.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**
<img width="1496" alt="Screenshot 2024-11-13 at 22 25 56 copy" src="https://github.com/user-attachments/assets/91f20651-7d33-42d9-b2b3-0e10ec60708d">
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
