### PR TITLE
feat: add forceRepopulate option for populate() to allow avoiding repopulating already populated docs

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -54,6 +54,13 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     doc = docs[i];
     let justOne = null;
 
+    if (doc.$__ != null && doc.populated(options.path)) {
+      const forceRepopulate = options.forceRepopulate != null ? options.forceRepopulate : doc.constructor.base.options.forceRepopulate;
+      if (forceRepopulate === false) {
+        continue;
+      }
+    }
+
     const docSchema = doc != null && doc.$__ != null ? doc.$__schema : modelSchema;
     schema = getSchemaTypes(model, docSchema, doc, options.path);
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -4199,6 +4199,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
  * - options: optional query options like sort, limit, etc
  * - justOne: optional boolean, if true Mongoose will always set `path` to a document, or `null` if no document was found. If false, Mongoose will always set `path` to an array, which will be empty if no documents are found. Inferred from schema by default.
  * - strictPopulate: optional boolean, set to `false` to allow populating paths that aren't in the schema.
+ * - forceRepopulate: optional boolean, defaults to `true`. Set to `false` to prevent Mongoose from repopulating paths that are already populated
  *
  * #### Example:
  *
@@ -4235,6 +4236,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
  * @param {Boolean} [options.strictPopulate=true] Set to false to allow populating paths that aren't defined in the given model's schema.
  * @param {Object} [options.options=null] Additional options like `limit` and `lean`.
  * @param {Function} [options.transform=null] Function that Mongoose will call on every populated document that allows you to transform the populated document.
+ * @param {Boolean} [options.forceRepopulate=true] Set to `false` to prevent Mongoose from repopulating paths that are already populated
  * @param {Function} [callback(err,doc)] Optional callback, executed upon completion. Receives `err` and the `doc(s)`.
  * @return {Promise}
  * @api public

--- a/lib/validOptions.js
+++ b/lib/validOptions.js
@@ -17,6 +17,7 @@ const VALID_OPTIONS = Object.freeze([
   'cloneSchemas',
   'createInitialConnection',
   'debug',
+  'forceRepopulate',
   'id',
   'timestamps.createdAt.immutable',
   'maxTimeMS',

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11280,7 +11280,7 @@ describe('model: populate:', function() {
     assert.strictEqual(doc.node[0]._id, '65c7953e-c6e9-4c2f-8328-fe2de7df560d');
   });
 
-  it('avoids repopulating if forceRepopulate disabled (gh-14979)', async function() {
+  it('avoids repopulating if forceRepopulate is disabled (gh-14979)', async function() {
     const ChildSchema = new Schema({ name: String });
     const ParentSchema = new Schema({
       children: [{ type: Schema.Types.ObjectId, ref: 'Child' }],

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -37,6 +37,8 @@ declare module 'mongoose' {
     localField?: string;
     /** Overwrite the schema-level foreign field to populate on if this is a populated virtual. */
     foreignField?: string;
+    /** Set to `false` to prevent Mongoose from repopulating paths that are already populated */
+    forceRepopulate?: boolean;
   }
 
   interface PopulateOption {


### PR DESCRIPTION
Fix #14979

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

It is a little strange that `doc.populate('child')` will populate 'child' even if 'child' is already populated. This PR adds an option to disable that behavior, either for an individual populate call using `doc.populate({ path: 'child', forceRepopulate: false })` or globally with `mongoose.set('forceRepopulate', false)`.

We should consider making `forceRepopulate` default to false for Mongoose 9.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
