### PR TITLE
fix(model+query): support overwriteDiscriminatorKey for bulkWrite updateOne and updateMany, allow inferring discriminator key from update

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -104,7 +104,8 @@ module.exports = function castBulkWrite(originalModel, op, options) {
         op['updateOne']['update'] = castUpdate(model.schema, update, {
           strict: strict,
           upsert: op['updateOne'].upsert,
-          arrayFilters: op['updateOne'].arrayFilters
+          arrayFilters: op['updateOne'].arrayFilters,
+          overwriteDiscriminatorKey: op['updateOne'].overwriteDiscriminatorKey
         }, model, op['updateOne']['filter']);
       } catch (error) {
         return callback(error, null);
@@ -164,7 +165,8 @@ module.exports = function castBulkWrite(originalModel, op, options) {
         op['updateMany']['update'] = castUpdate(model.schema, op['updateMany']['update'], {
           strict: strict,
           upsert: op['updateMany'].upsert,
-          arrayFilters: op['updateMany'].arrayFilters
+          arrayFilters: op['updateMany'].arrayFilters,
+          overwriteDiscriminatorKey: op['updateMany'].overwriteDiscriminatorKey
         }, model, op['updateMany']['filter']);
       } catch (error) {
         return callback(error, null);

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -8,6 +8,7 @@ const ValidationError = require('../../error/validation');
 const castNumber = require('../../cast/number');
 const cast = require('../../cast');
 const getConstructorName = require('../getConstructorName');
+const getDiscriminatorByValue = require('../discriminator/getDiscriminatorByValue');
 const getEmbeddedDiscriminatorPath = require('./getEmbeddedDiscriminatorPath');
 const handleImmutable = require('./handleImmutable');
 const moveImmutableProperties = require('../update/moveImmutableProperties');
@@ -60,6 +61,27 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
       }
     }
     return obj;
+  }
+
+  if (schema != null &&
+      filter != null &&
+      utils.hasUserDefinedProperty(filter, schema.options.discriminatorKey) &&
+      typeof filter[schema.options.discriminatorKey] !== 'object' &&
+      schema.discriminators != null) {
+    const discriminatorValue = filter[schema.options.discriminatorKey];
+    const byValue = getDiscriminatorByValue(context.model.discriminators, discriminatorValue);
+    schema = schema.discriminators[discriminatorValue] ||
+      (byValue && byValue.schema) ||
+      schema;
+  } else if (schema != null &&
+      options.overwriteDiscriminatorKey &&
+      utils.hasUserDefinedProperty(obj, schema.options.discriminatorKey) &&
+      schema.discriminators != null) {
+    const discriminatorValue = obj[schema.options.discriminatorKey];
+    const byValue = getDiscriminatorByValue(context.model.discriminators, discriminatorValue);
+    schema = schema.discriminators[discriminatorValue] ||
+      (byValue && byValue.schema) ||
+      schema;
   }
 
   if (options.upsert) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4700,18 +4700,6 @@ Query.prototype._castUpdate = function _castUpdate(obj) {
     upsert = this.options.upsert;
   }
 
-  const filter = this._conditions;
-  if (schema != null &&
-      utils.hasUserDefinedProperty(filter, schema.options.discriminatorKey) &&
-      typeof filter[schema.options.discriminatorKey] !== 'object' &&
-      schema.discriminators != null) {
-    const discriminatorValue = filter[schema.options.discriminatorKey];
-    const byValue = getDiscriminatorByValue(this.model.discriminators, discriminatorValue);
-    schema = schema.discriminators[discriminatorValue] ||
-      (byValue && byValue.schema) ||
-      schema;
-  }
-
   return castUpdate(schema, obj, {
     strict: this._mongooseOptions.strict,
     upsert: upsert,


### PR DESCRIPTION
Fix #15040

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15040 points out there's no way to set `overwriteDiscriminatorKey` for `bulkWrite()`. Also had a good suggestion for inferring the discriminator key from the update if `overwriteDiscriminatorKey` is set, I added that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
