### PR TITLE
feat(connection): add support for Connection.prototype.bulkWrite() with MongoDB server 8.0

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -8,6 +8,7 @@ const ChangeStream = require('./cursor/changeStream');
 const EventEmitter = require('events').EventEmitter;
 const Schema = require('./schema');
 const STATES = require('./connectionState');
+const MongooseBulkWriteError = require('./error/bulkWriteError');
 const MongooseError = require('./error/index');
 const ServerSelectionError = require('./error/serverSelection');
 const SyncIndexesError = require('./error/syncIndexes');
@@ -15,9 +16,13 @@ const applyPlugins = require('./helpers/schema/applyPlugins');
 const clone = require('./helpers/clone');
 const driver = require('./driver');
 const get = require('./helpers/get');
+const getDefaultBulkwriteResult = require('./helpers/getDefaultBulkwriteResult');
 const immediate = require('./helpers/immediate');
 const utils = require('./utils');
 const CreateCollectionsError = require('./error/createCollectionsError');
+const castBulkWrite = require('./helpers/model/castBulkWrite');
+const { modelSymbol } = require('./helpers/symbols');
+const isPromise = require('./helpers/isPromise');
 
 const arrayAtomicsSymbol = require('./helpers/symbols').arrayAtomicsSymbol;
 const sessionNewDocuments = require('./helpers/symbols').sessionNewDocuments;
@@ -414,6 +419,178 @@ Connection.prototype.createCollection = async function createCollection(collecti
   await this._waitForConnect();
 
   return this.db.createCollection(collection, options);
+};
+
+/**
+ * _Requires MongoDB Server 8.0 or greater_. Executes bulk write operations across multiple models in a single operation.
+ * You must specify the `model` for each operation: Mongoose will use `model` for casting and validation, as well as
+ * determining which collection to apply the operation to.
+ *
+ * #### Example:
+ *     const Test = mongoose.model('Test', new Schema({ name: String }));
+ *
+ *     await db.bulkWrite([
+ *       { model: Test, name: 'insertOne', document: { name: 'test1' } }, // Can specify model as a Model class...
+ *       { model: 'Test', name: 'insertOne', document: { name: 'test2' } } // or as a model name
+ *     ], { ordered: false });
+ *
+ * @method bulkWrite
+ * @param {Array} ops
+ * @param {Object} [options]
+ * @param {Boolean} [options.ordered] If false, perform unordered operations. If true, perform ordered operations.
+ * @param {Session} [options.session] The session to use for the operation.
+ * @return {Promise}
+ * @see MongoDB https://www.mongodb.com/docs/manual/reference/command/bulkWrite/#mongodb-dbcommand-dbcmd.bulkWrite
+ * @api public
+ */
+
+
+Connection.prototype.bulkWrite = async function bulkWrite(ops, options) {
+  await this._waitForConnect();
+  options = options || {};
+
+  const ordered = options.ordered == null ? true : options.ordered;
+  const asyncLocalStorage = this.base.transactionAsyncLocalStorage?.getStore();
+  if ((!options || !options.hasOwnProperty('session')) && asyncLocalStorage?.session != null) {
+    options = { ...options, session: asyncLocalStorage.session };
+  }
+
+  const now = this.base.now();
+
+  let res = null;
+  if (ordered) {
+    const opsToSend = [];
+    for (const op of ops) {
+      if (typeof op.model !== 'string' && !op.model?.[modelSymbol]) {
+        throw new MongooseError('Must specify model in Connection.prototype.bulkWrite() operations');
+      }
+      const Model = op.model[modelSymbol] ? op.model : this.model(op.model);
+
+      if (op.name == null) {
+        throw new MongooseError('Must specify operation name in Connection.prototype.bulkWrite()');
+      }
+      if (!castBulkWrite.cast.hasOwnProperty(op.name)) {
+        throw new MongooseError(`Unrecognized bulkWrite() operation name ${op.name}`);
+      }
+
+      await castBulkWrite.cast[op.name](Model, op, options, now);
+      opsToSend.push({ ...op, namespace: Model.namespace() });
+    }
+
+    res = await this.client.bulkWrite(opsToSend, options);
+  } else {
+    const validOps = [];
+    const validOpIndexes = [];
+    let validationErrors = [];
+    const asyncValidations = [];
+    const results = [];
+    for (let i = 0; i < ops.length; ++i) {
+      const op = ops[i];
+      if (typeof op.model !== 'string' && !op.model?.[modelSymbol]) {
+        const error = new MongooseError('Must specify model in Connection.prototype.bulkWrite() operations');
+        validationErrors.push({ index: i, error: error });
+        results[i] = error;
+        continue;
+      }
+      let Model;
+      try {
+        Model = op.model[modelSymbol] ? op.model : this.model(op.model);
+      } catch (error) {
+        validationErrors.push({ index: i, error: error });
+        continue;
+      }
+      if (op.name == null) {
+        const error = new MongooseError('Must specify operation name in Connection.prototype.bulkWrite()');
+        validationErrors.push({ index: i, error: error });
+        results[i] = error;
+        continue;
+      }
+      if (!castBulkWrite.cast.hasOwnProperty(op.name)) {
+        const error = new MongooseError(`Unrecognized bulkWrite() operation name ${op.name}`);
+        validationErrors.push({ index: i, error: error });
+        results[i] = error;
+        continue;
+      }
+
+      let maybePromise = null;
+      try {
+        maybePromise = castBulkWrite.cast[op.name](Model, op, options, now);
+      } catch (error) {
+        validationErrors.push({ index: i, error: error });
+        results[i] = error;
+        continue;
+      }
+      if (isPromise(maybePromise)) {
+        asyncValidations.push(
+          maybePromise.then(
+            () => {
+              validOps.push({ ...op, namespace: Model.namespace() });
+              validOpIndexes.push(i);
+            },
+            error => {
+              validationErrors.push({ index: i, error: error });
+              results[i] = error;
+            }
+          )
+        );
+      } else {
+        validOps.push({ ...op, namespace: Model.namespace() });
+        validOpIndexes.push(i);
+      }
+    }
+
+    if (asyncValidations.length > 0) {
+      await Promise.all(asyncValidations);
+    }
+
+    validationErrors = validationErrors.
+      sort((v1, v2) => v1.index - v2.index).
+      map(v => v.error);
+
+    if (validOps.length === 0) {
+      if (options.throwOnValidationError && validationErrors.length) {
+        throw new MongooseBulkWriteError(
+          validationErrors,
+          results,
+          res,
+          'bulkWrite'
+        );
+      }
+      return getDefaultBulkwriteResult();
+    }
+
+    let error;
+    [res, error] = await this.client.bulkWrite(validOps, options).
+      then(res => ([res, null])).
+      catch(err => ([null, err]));
+
+    if (error) {
+      if (validationErrors.length > 0) {
+        error.mongoose = error.mongoose || {};
+        error.mongoose.validationErrors = validationErrors;
+      }
+    }
+
+    for (let i = 0; i < validOpIndexes.length; ++i) {
+      results[validOpIndexes[i]] = null;
+    }
+    if (validationErrors.length > 0) {
+      if (options.throwOnValidationError) {
+        throw new MongooseBulkWriteError(
+          validationErrors,
+          results,
+          res,
+          'bulkWrite'
+        );
+      } else {
+        res.mongoose = res.mongoose || {};
+        res.mongoose.validationErrors = validationErrors;
+        res.mongoose.results = results;
+      }
+    }
+  }
+
+  return res;
 };
 
 /**

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -437,7 +437,6 @@ function _setClient(conn, client, options, dbName) {
   }
 }
 
-
 /*!
  * Module exports.
  */

--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -23,232 +23,47 @@ const setDefaultsOnInsert = require('../setDefaultsOnInsert');
 module.exports = function castBulkWrite(originalModel, op, options) {
   const now = originalModel.base.now();
 
-  const globalSetDefaultsOnInsert = originalModel.base.options.setDefaultsOnInsert;
   if (op['insertOne']) {
-    return (callback) => {
-      const model = decideModelByObject(originalModel, op['insertOne']['document']);
-
-      const doc = new model(op['insertOne']['document']);
-      if (model.schema.options.timestamps && getTimestampsOpt(op['insertOne'], options)) {
-        doc.initializeTimestamps();
-      }
-      if (options.session != null) {
-        doc.$session(options.session);
-      }
-      const versionKey = model?.schema?.options?.versionKey;
-      if (versionKey && doc[versionKey] == null) {
-        doc[versionKey] = 0;
-      }
-      op['insertOne']['document'] = doc;
-
-      if (options.skipValidation || op['insertOne'].skipValidation) {
-        callback(null);
-        return;
-      }
-
-      op['insertOne']['document'].$validate().then(
-        () => { callback(null); },
-        err => { callback(err, null); }
-      );
-    };
+    return callback => module.exports.castInsertOne(originalModel, op['insertOne'], options).then(() => callback(null), err => callback(err));
   } else if (op['updateOne']) {
     return (callback) => {
       try {
-        if (!op['updateOne']['filter']) {
-          throw new Error('Must provide a filter object.');
-        }
-        if (!op['updateOne']['update']) {
-          throw new Error('Must provide an update object.');
-        }
-
-        const model = decideModelByObject(originalModel, op['updateOne']['filter']);
-        const schema = model.schema;
-        const strict = options.strict != null ? options.strict : model.schema.options.strict;
-
-        const update = clone(op['updateOne']['update']);
-
-        _addDiscriminatorToObject(schema, op['updateOne']['filter']);
-
-        const doInitTimestamps = getTimestampsOpt(op['updateOne'], options);
-
-        if (model.schema.$timestamps != null && doInitTimestamps) {
-          const createdAt = model.schema.$timestamps.createdAt;
-          const updatedAt = model.schema.$timestamps.updatedAt;
-          applyTimestampsToUpdate(now, createdAt, updatedAt, update, {});
-        }
-
-        if (doInitTimestamps) {
-          applyTimestampsToChildren(now, update, model.schema);
-        }
-
-        const shouldSetDefaultsOnInsert = op['updateOne'].setDefaultsOnInsert == null ?
-          globalSetDefaultsOnInsert :
-          op['updateOne'].setDefaultsOnInsert;
-        if (shouldSetDefaultsOnInsert !== false) {
-          setDefaultsOnInsert(op['updateOne']['filter'], model.schema, update, {
-            setDefaultsOnInsert: true,
-            upsert: op['updateOne'].upsert
-          });
-        }
-
-        decorateUpdateWithVersionKey(
-          update,
-          op['updateOne'],
-          model.schema.options.versionKey
-        );
-
-        op['updateOne']['filter'] = cast(model.schema, op['updateOne']['filter'], {
-          strict: strict,
-          upsert: op['updateOne'].upsert
-        });
-        op['updateOne']['update'] = castUpdate(model.schema, update, {
-          strict: strict,
-          upsert: op['updateOne'].upsert,
-          arrayFilters: op['updateOne'].arrayFilters
-        }, model, op['updateOne']['filter']);
-      } catch (error) {
-        return callback(error, null);
+        module.exports.castUpdateOne(originalModel, op['updateOne'], options, now);
+        callback(null);
+      } catch (err) {
+        callback(err);
       }
-
-      callback(null);
     };
   } else if (op['updateMany']) {
     return (callback) => {
       try {
-        if (!op['updateMany']['filter']) {
-          throw new Error('Must provide a filter object.');
-        }
-        if (!op['updateMany']['update']) {
-          throw new Error('Must provide an update object.');
-        }
-
-        const model = decideModelByObject(originalModel, op['updateMany']['filter']);
-        const schema = model.schema;
-        const strict = options.strict != null ? options.strict : model.schema.options.strict;
-
-        const shouldSetDefaultsOnInsert = op['updateMany'].setDefaultsOnInsert == null ?
-          globalSetDefaultsOnInsert :
-          op['updateMany'].setDefaultsOnInsert;
-
-        if (shouldSetDefaultsOnInsert !== false) {
-          setDefaultsOnInsert(op['updateMany']['filter'], model.schema, op['updateMany']['update'], {
-            setDefaultsOnInsert: true,
-            upsert: op['updateMany'].upsert
-          });
-        }
-
-        const doInitTimestamps = getTimestampsOpt(op['updateMany'], options);
-
-        if (model.schema.$timestamps != null && doInitTimestamps) {
-          const createdAt = model.schema.$timestamps.createdAt;
-          const updatedAt = model.schema.$timestamps.updatedAt;
-          applyTimestampsToUpdate(now, createdAt, updatedAt, op['updateMany']['update'], {});
-        }
-        if (doInitTimestamps) {
-          applyTimestampsToChildren(now, op['updateMany']['update'], model.schema);
-        }
-
-        _addDiscriminatorToObject(schema, op['updateMany']['filter']);
-
-        decorateUpdateWithVersionKey(
-          op['updateMany']['update'],
-          op['updateMany'],
-          model.schema.options.versionKey
-        );
-
-        op['updateMany']['filter'] = cast(model.schema, op['updateMany']['filter'], {
-          strict: strict,
-          upsert: op['updateMany'].upsert
-        });
-
-        op['updateMany']['update'] = castUpdate(model.schema, op['updateMany']['update'], {
-          strict: strict,
-          upsert: op['updateMany'].upsert,
-          arrayFilters: op['updateMany'].arrayFilters
-        }, model, op['updateMany']['filter']);
-      } catch (error) {
-        return callback(error, null);
+        module.exports.castUpdateMany(originalModel, op['updateMany'], options, now);
+        callback(null);
+      } catch (err) {
+        callback(err);
       }
-
-      callback(null);
     };
   } else if (op['replaceOne']) {
     return (callback) => {
-      const model = decideModelByObject(originalModel, op['replaceOne']['filter']);
-      const schema = model.schema;
-      const strict = options.strict != null ? options.strict : model.schema.options.strict;
-
-      _addDiscriminatorToObject(schema, op['replaceOne']['filter']);
-      try {
-        op['replaceOne']['filter'] = cast(model.schema, op['replaceOne']['filter'], {
-          strict: strict,
-          upsert: op['replaceOne'].upsert
-        });
-      } catch (error) {
-        return callback(error, null);
-      }
-
-      // set `skipId`, otherwise we get "_id field cannot be changed"
-      const doc = new model(op['replaceOne']['replacement'], strict, true);
-      if (model.schema.options.timestamps && getTimestampsOpt(op['replaceOne'], options)) {
-        doc.initializeTimestamps();
-      }
-      if (options.session != null) {
-        doc.$session(options.session);
-      }
-      const versionKey = model?.schema?.options?.versionKey;
-      if (versionKey && doc[versionKey] == null) {
-        doc[versionKey] = 0;
-      }
-      op['replaceOne']['replacement'] = doc;
-
-      if (options.skipValidation || op['replaceOne'].skipValidation) {
-        op['replaceOne']['replacement'] = op['replaceOne']['replacement'].toBSON();
-        callback(null);
-        return;
-      }
-
-      op['replaceOne']['replacement'].$validate().then(
-        () => {
-          op['replaceOne']['replacement'] = op['replaceOne']['replacement'].toBSON();
-          callback(null);
-        },
-        error => {
-          callback(error, null);
-        }
-      );
+      module.exports.castReplaceOne(originalModel, op['replaceOne'], options).then(() => callback(null), err => callback(err));
     };
   } else if (op['deleteOne']) {
     return (callback) => {
-      const model = decideModelByObject(originalModel, op['deleteOne']['filter']);
-      const schema = model.schema;
-
-      _addDiscriminatorToObject(schema, op['deleteOne']['filter']);
-
       try {
-        op['deleteOne']['filter'] = cast(model.schema,
-          op['deleteOne']['filter']);
-      } catch (error) {
-        return callback(error, null);
+        module.exports.castDeleteOne(originalModel, op['deleteOne']);
+        callback(null);
+      } catch (err) {
+        callback(err);
       }
-
-      callback(null);
     };
   } else if (op['deleteMany']) {
     return (callback) => {
-      const model = decideModelByObject(originalModel, op['deleteMany']['filter']);
-      const schema = model.schema;
-
-      _addDiscriminatorToObject(schema, op['deleteMany']['filter']);
-
       try {
-        op['deleteMany']['filter'] = cast(model.schema,
-          op['deleteMany']['filter']);
-      } catch (error) {
-        return callback(error, null);
+        module.exports.castDeleteMany(originalModel, op['deleteMany']);
+        callback(null);
+      } catch (err) {
+        callback(err);
       }
-
-      callback(null);
     };
   } else {
     return (callback) => {
@@ -256,6 +71,204 @@ module.exports = function castBulkWrite(originalModel, op, options) {
       callback(error, null);
     };
   }
+};
+
+module.exports.castInsertOne = async function castInsertOne(originalModel, insertOne, options) {
+  const model = decideModelByObject(originalModel, insertOne['document']);
+
+  const doc = new model(insertOne['document']);
+  if (model.schema.options.timestamps && getTimestampsOpt(insertOne, options)) {
+    doc.initializeTimestamps();
+  }
+  if (options.session != null) {
+    doc.$session(options.session);
+  }
+  const versionKey = model?.schema?.options?.versionKey;
+  if (versionKey && doc[versionKey] == null) {
+    doc[versionKey] = 0;
+  }
+  insertOne['document'] = doc;
+
+  if (options.skipValidation || insertOne.skipValidation) {
+    return insertOne;
+  }
+
+  await insertOne['document'].$validate();
+  return insertOne;
+};
+
+module.exports.castUpdateOne = function castUpdateOne(originalModel, updateOne, options, now) {
+  if (!updateOne['filter']) {
+    throw new Error('Must provide a filter object.');
+  }
+  if (!updateOne['update']) {
+    throw new Error('Must provide an update object.');
+  }
+
+  const model = decideModelByObject(originalModel, updateOne['filter']);
+  const schema = model.schema;
+  const strict = options.strict != null ? options.strict : model.schema.options.strict;
+
+  const update = clone(updateOne['update']);
+
+  _addDiscriminatorToObject(schema, updateOne['filter']);
+
+  const doInitTimestamps = getTimestampsOpt(updateOne, options);
+
+  if (model.schema.$timestamps != null && doInitTimestamps) {
+    const createdAt = model.schema.$timestamps.createdAt;
+    const updatedAt = model.schema.$timestamps.updatedAt;
+    applyTimestampsToUpdate(now, createdAt, updatedAt, update, {});
+  }
+
+  if (doInitTimestamps) {
+    applyTimestampsToChildren(now, update, model.schema);
+  }
+
+  const globalSetDefaultsOnInsert = originalModel.base.options.setDefaultsOnInsert;
+  const shouldSetDefaultsOnInsert = updateOne.setDefaultsOnInsert == null ?
+    globalSetDefaultsOnInsert :
+    updateOne.setDefaultsOnInsert;
+  if (shouldSetDefaultsOnInsert !== false) {
+    setDefaultsOnInsert(updateOne['filter'], model.schema, update, {
+      setDefaultsOnInsert: true,
+      upsert: updateOne.upsert
+    });
+  }
+
+  decorateUpdateWithVersionKey(
+    update,
+    updateOne,
+    model.schema.options.versionKey
+  );
+
+  updateOne['filter'] = cast(model.schema, updateOne['filter'], {
+    strict: strict,
+    upsert: updateOne.upsert
+  });
+  updateOne['update'] = castUpdate(model.schema, update, {
+    strict: strict,
+    upsert: updateOne.upsert,
+    arrayFilters: updateOne.arrayFilters
+  }, model, updateOne['filter']);
+
+  return updateOne;
+};
+
+module.exports.castUpdateMany = function castUpdateMany(originalModel, updateMany, options, now) {
+  if (!updateMany['filter']) {
+    throw new Error('Must provide a filter object.');
+  }
+  if (!updateMany['update']) {
+    throw new Error('Must provide an update object.');
+  }
+
+  const model = decideModelByObject(originalModel, updateMany['filter']);
+  const schema = model.schema;
+  const strict = options.strict != null ? options.strict : model.schema.options.strict;
+
+  const globalSetDefaultsOnInsert = originalModel.base.options.setDefaultsOnInsert;
+  const shouldSetDefaultsOnInsert = updateMany.setDefaultsOnInsert == null ?
+    globalSetDefaultsOnInsert :
+    updateMany.setDefaultsOnInsert;
+
+  if (shouldSetDefaultsOnInsert !== false) {
+    setDefaultsOnInsert(updateMany['filter'], model.schema, updateMany['update'], {
+      setDefaultsOnInsert: true,
+      upsert: updateMany.upsert
+    });
+  }
+
+  const doInitTimestamps = getTimestampsOpt(updateMany, options);
+
+  if (model.schema.$timestamps != null && doInitTimestamps) {
+    const createdAt = model.schema.$timestamps.createdAt;
+    const updatedAt = model.schema.$timestamps.updatedAt;
+    applyTimestampsToUpdate(now, createdAt, updatedAt, updateMany['update'], {});
+  }
+  if (doInitTimestamps) {
+    applyTimestampsToChildren(now, updateMany['update'], model.schema);
+  }
+
+  _addDiscriminatorToObject(schema, updateMany['filter']);
+
+  decorateUpdateWithVersionKey(
+    updateMany['update'],
+    updateMany,
+    model.schema.options.versionKey
+  );
+
+  updateMany['filter'] = cast(model.schema, updateMany['filter'], {
+    strict: strict,
+    upsert: updateMany.upsert
+  });
+
+  updateMany['update'] = castUpdate(model.schema, updateMany['update'], {
+    strict: strict,
+    upsert: updateMany.upsert,
+    arrayFilters: updateMany.arrayFilters
+  }, model, updateMany['filter']);
+};
+
+module.exports.castReplaceOne = async function castReplaceOne(originalModel, replaceOne, options) {
+  const model = decideModelByObject(originalModel, replaceOne['filter']);
+  const schema = model.schema;
+  const strict = options.strict != null ? options.strict : model.schema.options.strict;
+
+  _addDiscriminatorToObject(schema, replaceOne['filter']);
+  replaceOne['filter'] = cast(model.schema, replaceOne['filter'], {
+    strict: strict,
+    upsert: replaceOne.upsert
+  });
+
+  // set `skipId`, otherwise we get "_id field cannot be changed"
+  const doc = new model(replaceOne['replacement'], strict, true);
+  if (model.schema.options.timestamps && getTimestampsOpt(replaceOne, options)) {
+    doc.initializeTimestamps();
+  }
+  if (options.session != null) {
+    doc.$session(options.session);
+  }
+  const versionKey = model?.schema?.options?.versionKey;
+  if (versionKey && doc[versionKey] == null) {
+    doc[versionKey] = 0;
+  }
+  replaceOne['replacement'] = doc;
+
+  if (options.skipValidation || replaceOne.skipValidation) {
+    replaceOne['replacement'] = replaceOne['replacement'].toBSON();
+    return;
+  }
+
+  await replaceOne['replacement'].$validate();
+  replaceOne['replacement'] = replaceOne['replacement'].toBSON();
+};
+
+module.exports.castDeleteOne = function castDeleteOne(originalModel, deleteOne) {
+  const model = decideModelByObject(originalModel, deleteOne['filter']);
+  const schema = model.schema;
+
+  _addDiscriminatorToObject(schema, deleteOne['filter']);
+
+  deleteOne['filter'] = cast(model.schema, deleteOne['filter']);
+};
+
+module.exports.castDeleteMany = function castDeleteMany(originalModel, deleteMany) {
+  const model = decideModelByObject(originalModel, deleteMany['filter']);
+  const schema = model.schema;
+
+  _addDiscriminatorToObject(schema, deleteMany['filter']);
+
+  deleteMany['filter'] = cast(model.schema, deleteMany['filter']);
+};
+
+module.exports.cast = {
+  insertOne: module.exports.castInsertOne,
+  updateOne: module.exports.castUpdateOne,
+  updateMany: module.exports.castUpdateMany,
+  replaceOne: module.exports.castReplaceOne,
+  deleteOne: module.exports.castDeleteOne,
+  deleteMany: module.exports.castDeleteMany
 };
 
 function _addDiscriminatorToObject(schema, obj) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4934,6 +4934,23 @@ Model.inspect = function() {
   return `Model { ${this.modelName} }`;
 };
 
+/**
+ * Return the MongoDB namespace for this model as a string. The namespace is the database name, followed by '.', followed by the collection name.
+ *
+ * #### Example:
+ *
+ *     const conn = mongoose.createConnection('mongodb://127.0.0.1:27017/mydb');
+ *     const TestModel = conn.model('Test', mongoose.Schema({ name: String }));
+ *
+ *     TestModel.namespace(); // 'mydb.tests'
+ *
+ * @api public
+ */
+
+Model.namespace = function namespace() {
+  return this.db.name + '.' + this.collection.collectionName;
+};
+
 if (util.inspect.custom) {
   // Avoid Node deprecation warning DEP0079
   Model[util.inspect.custom] = Model.inspect;


### PR DESCRIPTION
Fix #15028

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

MongoDB server 8.0 supports `bulkWrite()` on multiple collections with a single command. This PR adds support for that as Connection.prototype.bulkWrite()

MongoDB Node driver expects a `namespace` parameter on each bulk write operation to determine which collection the bulk write operation applies to. With Mongoose, we instead use a `model` parameter, which can be either a model class or a model name. We also cast and validate each bulk write operation.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
