### PR TITLE
types: only apply BufferToBinary if type strictly equals Buffer | null | undefined

### DIFF
--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -206,3 +206,34 @@ async function gh13382() {
   const res = await Test.updateOne({}, { name: 'bar' }).lean();
   expectAssignable<{ matchedCount: number, modifiedCount: number }>(res);
 }
+
+async function gh15057() {
+  type Attachment =
+    | {
+        type: 'foo';
+        value?: undefined;
+      }
+    | {
+        type: 'string';
+        value?: string;
+      };
+
+  const TestSchema = new Schema<Attachment>({
+    type: { type: String, required: true },
+    value: { type: String }
+  });
+
+  const AttachmentModel = model<Attachment>('test', TestSchema);
+
+  const main = async() => {
+    const item = await AttachmentModel.findOne().lean();
+
+    if (!item) return;
+
+    doSomeThing(item);
+  };
+
+  const doSomeThing = (item: Attachment) => {
+    console.log(item);
+  };
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -715,13 +715,16 @@ declare module 'mongoose' {
   export type BufferToBinary<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends Buffer
       ? mongodb.Binary
-      : T[K] extends (Buffer | null | undefined)
-        ? mongodb.Binary | null | undefined
-        : T[K] extends Types.DocumentArray<infer ItemType>
+      : IfEquals<
+        T[K],
+        Buffer | null | undefined,
+        mongodb.Binary | null | undefined,
+        T[K] extends Types.DocumentArray<infer ItemType>
             ? Types.DocumentArray<BufferToBinary<ItemType>>
             : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
               ? HydratedSingleSubdocument<SubdocType>
-              : BufferToBinary<T[K]>;
+              : BufferToBinary<T[K]>
+      >;
   } : T;
 
   /**
@@ -730,13 +733,16 @@ declare module 'mongoose' {
   export type BufferToJSON<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends Buffer
       ? { type: 'buffer', data: number[] }
-      : T[K] extends (Buffer | null | undefined)
-        ? { type: 'buffer', data: number[] } | null | undefined
-        : T[K] extends Types.DocumentArray<infer ItemType>
+      : IfEquals<
+        T[K],
+        Buffer | null | undefined,
+        { type: 'buffer', data: number[] } | null | undefined,
+        T[K] extends Types.DocumentArray<infer ItemType>
             ? Types.DocumentArray<BufferToBinary<ItemType>>
             : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
               ? HydratedSingleSubdocument<SubdocType>
-              : BufferToBinary<T[K]>;
+              : BufferToBinary<T[K]>
+      >
   } : T;
 
   /**
@@ -745,13 +751,16 @@ declare module 'mongoose' {
   export type ObjectIdToString<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends mongodb.ObjectId
       ? string
-      : T[K] extends (mongodb.ObjectId | null | undefined)
-        ? string | null | undefined
-        : T[K] extends Types.DocumentArray<infer ItemType>
+      : IfEquals<
+        T[K],
+        mongodb.ObjectId | null | undefined,
+        string | null | undefined,
+        T[K] extends Types.DocumentArray<infer ItemType>
             ? Types.DocumentArray<ObjectIdToString<ItemType>>
             : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
               ? HydratedSingleSubdocument<ObjectIdToString<SubdocType>>
-              : ObjectIdToString<T[K]>;
+              : ObjectIdToString<T[K]>
+      >
   } : T;
 
   /**
@@ -760,13 +769,16 @@ declare module 'mongoose' {
   export type DateToString<T> = T extends TreatAsPrimitives ? T : T extends Record<string, any> ? {
     [K in keyof T]: T[K] extends NativeDate
       ? string
-      : T[K] extends (NativeDate | null | undefined)
-        ? string | null | undefined
-        : T[K] extends Types.DocumentArray<infer ItemType>
+      : IfEquals<
+        T[K],
+        NativeDate | null | undefined,
+        string | null | undefined,
+        T[K] extends Types.DocumentArray<infer ItemType>
             ? Types.DocumentArray<DateToString<ItemType>>
             : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
               ? HydratedSingleSubdocument<DateToString<SubdocType>>
-              : DateToString<T[K]>;
+              : DateToString<T[K]>
+      >
   } : T;
 
   /**


### PR DESCRIPTION
Fix #15057

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The issue in #15057 is  that BufferToBinary adds `Binary` to any type that `extends undefined` or `extends null`, which is not intentional. This PR now only applies the BufferToBinary transform if the type strictly equals Buffer | null | undefined. I also made a similar change to other transforms we use for calculating the JSON serialized type.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
