### PR TITLE
fix: cast using overwritten embedded discriminator key when set

### DIFF
--- a/lib/helpers/query/getEmbeddedDiscriminatorPath.js
+++ b/lib/helpers/query/getEmbeddedDiscriminatorPath.js
@@ -28,7 +28,8 @@ module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, p
   const updatedPathsByFilter = updatedPathsByArrayFilter(update);
 
   for (let i = 0; i < parts.length; ++i) {
-    const subpath = cleanPositionalOperators(parts.slice(0, i + 1).join('.'));
+    const originalSubpath = parts.slice(0, i + 1).join('.');
+    const subpath = cleanPositionalOperators(originalSubpath);
     schematype = schema.path(subpath);
     if (schematype == null) {
       continue;
@@ -54,6 +55,11 @@ module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, p
       if (schematype.$isMongooseDocumentArrayElement &&
           get(filter[wrapperPath], '$elemMatch.' + key) != null) {
         discriminatorKey = filter[wrapperPath].$elemMatch[key];
+      }
+
+      const discriminatorKeyUpdatePath = originalSubpath + '.' + key;
+      if (discriminatorKeyUpdatePath in update) {
+        discriminatorKey = update[discriminatorKeyUpdatePath];
       }
 
       if (discriminatorValuePath in update) {

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3091,6 +3091,7 @@ describe('model: updateOne: ', function() {
     assert.equal(doc.login.keys.length, 1);
     assert.equal(doc.login.keys[0].id, 'test2');
   });
+
   it('casts using overwritten discriminator key schema (gh-15051)', async function() {
     const embedDiscriminatorSchema = new mongoose.Schema({
       field1: String

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3091,6 +3091,57 @@ describe('model: updateOne: ', function() {
     assert.equal(doc.login.keys.length, 1);
     assert.equal(doc.login.keys[0].id, 'test2');
   });
+  it('casts using overwritten discriminator key schema (gh-15051)', async function() {
+    const embedDiscriminatorSchema = new mongoose.Schema({
+      field1: String
+    });
+    const embedDiscriminatorSchema2 = new mongoose.Schema({
+      field2: String
+    });
+    const embedSchema = new mongoose.Schema({
+      field: String,
+      key: String
+    }, { discriminatorKey: 'key' });
+    embedSchema.discriminator('Type1', embedDiscriminatorSchema);
+    embedSchema.discriminator('Type2', embedDiscriminatorSchema2);
+
+    const testSchema = new mongoose.Schema({
+      testArray: [embedSchema]
+    });
+
+    const TestModel = db.model('Test', testSchema);
+    const test = new TestModel({
+      testArray: [{
+        key: 'Type1',
+        field: 'field',
+        field1: 'field1'
+      }]
+    });
+    await test.save();
+
+    const field2update = 'field2 update';
+    await TestModel.updateOne(
+      { _id: test._id },
+      {
+        $set: {
+          'testArray.$[element].key': 'Type2',
+          'testArray.$[element].field2': field2update
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            'element._id': test.testArray[0]._id
+          }
+        ],
+        overwriteDiscriminatorKey: true
+      }
+    );
+
+    const r2 = await TestModel.findById(test._id);
+    assert.equal(r2.testArray[0].key, 'Type2');
+    assert.equal(r2.testArray[0].field2, field2update);
+  });
 });
 
 async function delay(ms) {


### PR DESCRIPTION
Fix #15051

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If user updates the embedded discriminator key via array filter, use the overwritten discriminator key when casting the update.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
