### PR TITLE
fix(connection): remove heartbeat check in load balanced mode

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -106,15 +106,6 @@ Object.setPrototypeOf(Connection.prototype, EventEmitter.prototype);
 
 Object.defineProperty(Connection.prototype, 'readyState', {
   get: function() {
-    // If connection thinks it is connected, but we haven't received a heartbeat in 2 heartbeat intervals,
-    // that likely means the connection is stale (potentially due to frozen AWS Lambda container)
-    if (
-      this._readyState === STATES.connected &&
-      this._lastHeartbeatAt != null &&
-      typeof this.client?.topology?.s?.description?.heartbeatFrequencyMS === 'number' &&
-      Date.now() - this._lastHeartbeatAt >= this.client.topology.s.description.heartbeatFrequencyMS * 2) {
-      return STATES.disconnected;
-    }
     return this._readyState;
   },
   set: function(val) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -106,6 +106,18 @@ Object.setPrototypeOf(Connection.prototype, EventEmitter.prototype);
 
 Object.defineProperty(Connection.prototype, 'readyState', {
   get: function() {
+    // If connection thinks it is connected, but we haven't received a heartbeat in 2 heartbeat intervals,
+    // that likely means the connection is stale (potentially due to frozen AWS Lambda container)
+    if (
+      this._readyState === STATES.connected &&
+      this._lastHeartbeatAt != null &&
+      // LoadBalanced topology (behind haproxy, including Atlas serverless instances) don't use heartbeats,
+      // so we can't use this check in that case.
+      this.client?.topology?.s?.description?.type !== 'LoadBalanced' &&
+      typeof this.client?.topology?.s?.description?.heartbeatFrequencyMS === 'number' &&
+      Date.now() - this._lastHeartbeatAt >= this.client.topology.s.description.heartbeatFrequencyMS * 2) {
+      return STATES.disconnected;
+    }
     return this._readyState;
   },
   set: function(val) {

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -426,9 +426,6 @@ function _setClient(conn, client, options, dbName) {
   }
 
   conn.onOpen();
-  if (client.topology?.s?.state === 'connected') {
-    conn._lastHeartbeatAt = Date.now();
-  }
 
   for (const i in conn.collections) {
     if (utils.object.hasOwnProperty(conn.collections, i)) {


### PR DESCRIPTION
cc @alexbevi 

Fix #15042
Revert #14812

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We've gotten a few bug reports that indicate connectivity issues with Mongoose 8.7, including #14971 etc. Most notably, we've confirmed that #15042 is caused by the heartbeat check we added in #14812: we should not use that heartbeat check if the topology is `LoadBalanced` because the MongoDB Node driver doesn't send heartbeats in that case, so for LoadBalanced topology Mongoose currently loses connectivity after 20 seconds. Given this and all the issues we've gotten specifically referencing connectivity issues in Mongoose 8.7.0, I think it is prudent to remove this check for now.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
