### PR TITLE
fix(schema): throw error if duplicate index definition using `unique` in schema path and subsequent `.index()` call

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2134,6 +2134,12 @@ Schema.prototype.index = function(fields, options) {
     }
   }
 
+  for (const existingIndex of this.indexes()) {
+    if (util.isDeepStrictEqual(existingIndex[0], fields)) {
+      throw new MongooseError(`Schema already has an index on ${JSON.stringify(fields)}`);
+    }
+  }
+
   this._indexes.push([fields, options]);
   return this;
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3278,4 +3278,21 @@ describe('schema', function() {
     assert.ok(subdoc instanceof mongoose.Document);
     assert.equal(subdoc.getAnswer(), 42);
   });
+  it('throws "already has an index" error if duplicate index definition (gh-15056)', function() {
+    const ObjectKeySchema = new mongoose.Schema({
+      key: {
+        type: String,
+        required: true,
+        unique: true,
+      },
+      type: {
+        type: String,
+        required: false,
+      },
+    });
+
+    assert.throws(() => {
+      ObjectKeySchema.index({ key: 1 });
+    }, /MongooseError.*already has an index/);
+  });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3283,12 +3283,12 @@ describe('schema', function() {
       key: {
         type: String,
         required: true,
-        unique: true,
+        unique: true
       },
       type: {
         type: String,
-        required: false,
-      },
+        required: false
+      }
     });
 
     assert.throws(() => {


### PR DESCRIPTION
Fix #15056

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Defining an index using `unique` in schema path and later calling `schema.index()` causes 2 indexes to be added, which is likely a user error.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
