### PR TITLE
Fix aggregate cursor als

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -95,7 +95,7 @@ Aggregate.prototype.options;
  */
 
 Aggregate.prototype._optionsForExec = function() {
-  const options = clone(this.options || {});
+  const options = this.options || {};
 
   const asyncLocalStorage = this.model()?.db?.base.transactionAsyncLocalStorage?.getStore();
   if (!options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
@@ -932,6 +932,7 @@ Aggregate.prototype.option = function(value) {
  */
 
 Aggregate.prototype.cursor = function(options) {
+  this._optionsForExec();
   this.options.cursor = options || {};
   return new AggregationCursor(this); // return this;
 };
@@ -1040,7 +1041,7 @@ Aggregate.prototype.exec = async function exec() {
   applyGlobalMaxTimeMS(this.options, model.db.options, model.base.options);
   applyGlobalDiskUse(this.options, model.db.options, model.base.options);
 
-  const options = this._optionsForExec()
+  this._optionsForExec();
 
   if (this.options && this.options.cursor) {
     return new AggregationCursor(this);
@@ -1065,6 +1066,8 @@ Aggregate.prototype.exec = async function exec() {
   if (!this._pipeline.length) {
     throw new MongooseError('Aggregate has empty pipeline');
   }
+
+  const options = clone(this.options || {});
 
   let result;
   try {

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -88,6 +88,24 @@ function Aggregate(pipeline, model) {
 Aggregate.prototype.options;
 
 /**
+ * Returns default options for this aggregate.
+ *
+ * @param {Model} model
+ * @api private
+ */
+
+Aggregate.prototype._optionsForExec = function() {
+  const options = clone(this.options || {});
+
+  const asyncLocalStorage = this.model()?.db?.base.transactionAsyncLocalStorage?.getStore();
+  if (!options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
+    options.session = asyncLocalStorage.session;
+  }
+
+  return options;
+};
+
+/**
  * Get/set the model that this aggregation will execute on.
  *
  * #### Example:
@@ -1022,10 +1040,7 @@ Aggregate.prototype.exec = async function exec() {
   applyGlobalMaxTimeMS(this.options, model.db.options, model.base.options);
   applyGlobalDiskUse(this.options, model.db.options, model.base.options);
 
-  const asyncLocalStorage = this.model()?.db?.base.transactionAsyncLocalStorage?.getStore();
-  if (!this.options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
-    this.options.session = asyncLocalStorage.session;
-  }
+  const options = this._optionsForExec()
 
   if (this.options && this.options.cursor) {
     return new AggregationCursor(this);
@@ -1051,7 +1066,6 @@ Aggregate.prototype.exec = async function exec() {
     throw new MongooseError('Aggregate has empty pipeline');
   }
 
-  const options = clone(this.options || {});
   let result;
   try {
     const cursor = await collection.aggregate(this._pipeline, options);

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -44,6 +44,7 @@ function AggregationCursor(agg) {
   const model = agg._model;
   delete agg.options.cursor.useMongooseAggCursor;
   this._mongooseOptions = {};
+  this.options = {};
 
   _init(model, this, agg);
 }
@@ -57,21 +58,25 @@ util.inherits(AggregationCursor, Readable);
 function _init(model, c, agg) {
   if (!model.collection.buffer) {
     model.hooks.execPre('aggregate', agg, function() {
+      Object.assign(c.options, agg._optionsForExec());
+
       if (typeof agg.options?.cursor?.transform === 'function') {
         c._transforms.push(agg.options.cursor.transform);
       }
 
-      c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
+      c.cursor = model.collection.aggregate(agg._pipeline, c.options || {});
       c.emit('cursor', c.cursor);
     });
   } else {
     model.collection.emitter.once('queue', function() {
       model.hooks.execPre('aggregate', agg, function() {
+        Object.assign(c.options, agg._optionsForExec());
+
         if (typeof agg.options?.cursor?.transform === 'function') {
           c._transforms.push(agg.options.cursor.transform);
         }
 
-        c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
+        c.cursor = model.collection.aggregate(agg._pipeline, c.options || {});
         c.emit('cursor', c.cursor);
       });
     });

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -44,7 +44,6 @@ function AggregationCursor(agg) {
   const model = agg._model;
   delete agg.options.cursor.useMongooseAggCursor;
   this._mongooseOptions = {};
-  this.options = {};
 
   _init(model, this, agg);
 }
@@ -58,25 +57,21 @@ util.inherits(AggregationCursor, Readable);
 function _init(model, c, agg) {
   if (!model.collection.buffer) {
     model.hooks.execPre('aggregate', agg, function() {
-      Object.assign(c.options, agg._optionsForExec());
-
       if (typeof agg.options?.cursor?.transform === 'function') {
         c._transforms.push(agg.options.cursor.transform);
       }
 
-      c.cursor = model.collection.aggregate(agg._pipeline, c.options || {});
+      c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
       c.emit('cursor', c.cursor);
     });
   } else {
     model.collection.emitter.once('queue', function() {
       model.hooks.execPre('aggregate', agg, function() {
-        Object.assign(c.options, agg._optionsForExec());
-
         if (typeof agg.options?.cursor?.transform === 'function') {
           c._transforms.push(agg.options.cursor.transform);
         }
 
-        c.cursor = model.collection.aggregate(agg._pipeline, c.options || {});
+        c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
         c.emit('cursor', c.cursor);
       });
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
Aggregate cursors didn't automatically add session if it was present in AsyncLocalStorage. Also the options weren't the same for exec and cursor so I added a function to make them the same just like in QueryCursor.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```js
const mongoose = require("mongoose");
mongoose.set("transactionAsyncLocalStorage", true);

mongoose.connect("mongodb://127.0.0.1:27017/cursortest");

const test = async () => {
  await mongoose.connection.transaction(async (session) => {
    const TestModel = mongoose.model(
      "Test",
      new mongoose.Schema({ name: String })
    );

    mongoose.set("debug", true);
    await TestModel.aggregate([{ $match: {} }]);
    const cursor1 = TestModel.aggregate([{ $match: {} }]).cursor();
    const cursor2 = TestModel.aggregate([{ $match: {} }])
      .session(session)
      .cursor();

    await cursor1.next();
    await cursor2.next();
    mongoose.set("debug", false);

    /*
        From the debug logs:
            Mongoose: TestModel.aggregate([ { '$match': {} } ], { session: ClientSession("bb843cfeb01d4ec3ad0373d2b7d3db20") })
            Mongoose: TestModel.aggregate([ { '$match': {} } ], { cursor: {}, session: ClientSession("bb843cfeb01d4ec3ad0373d2b7d3db20")})
            Mongoose: TestModel.aggregate([ { '$match': {} } ], { session: ClientSession("bb843cfeb01d4ec3ad0373d2b7d3db20"), cursor: {}})

        Before the fix the first cursor didn't have a session but aggregate and second cursor had a session.
    */
  });
};

test()
  .then(() => console.log("Finished"))
  .catch((error) => console.error(error))
  .finally(() => process.exit(0));
```
