### PR TITLE
types(document): make sure `toObject()` and `toJSON()` apply versionKey __v

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -456,6 +456,6 @@ async function gh15077() {
 
     const createdFoo = await fooModel.create(newFoo);
 
-    foundFoo = createdFoo.toObject(); // this errors on 8.8.3
+    foundFoo = createdFoo.toObject();
   }
 }

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -423,3 +423,39 @@ async function gh14876() {
   expectType<UserObjectInterface>(populatedCar.owner);
   expectType<Types.ObjectId>(depopulatedCar.owner);
 }
+
+async function gh15077() {
+  type Foo = {
+    state: 'on' | 'off';
+  };
+
+  const fooSchema = new Schema<Foo>(
+    {
+      state: {
+        type: String,
+        enum: ['on', 'off']
+      }
+    },
+    { timestamps: true }
+  );
+
+  const fooModel = model('foo', fooSchema);
+
+  let foundFoo = await fooModel
+    .findOne({
+      state: 'on'
+    })
+    .lean()
+    .exec();
+
+  if (!foundFoo) {
+    const newFoo = {
+      state: 'on'
+      // extra props but irrelevant
+    };
+
+    const createdFoo = await fooModel.create(newFoo);
+
+    foundFoo = createdFoo.toObject(); // this errors on 8.8.3
+  }
+}

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -256,21 +256,21 @@ declare module 'mongoose' {
     set(value: string | Record<string, any>): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
-    toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Require_id<DocType>>;
-    toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Require_id<DocType>>;
-    toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Require_id<DocType>>>;
-    toJSON(options: ToObjectOptions & { flattenMaps: false }): Require_id<DocType>;
-    toJSON(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<Require_id<DocType>>;
+    toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Default__v<Require_id<DocType>>>;
+    toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Default__v<Require_id<DocType>>>;
+    toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType>>>>;
+    toJSON(options: ToObjectOptions & { flattenMaps: false }): Default__v<Require_id<DocType>>;
+    toJSON(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType>>>;
 
-    toJSON<T = Require_id<DocType>>(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<T>;
-    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<T>;
-    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<T>>;
-    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenMaps: false }): T;
-    toJSON<T = Require_id<DocType>>(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<T>;
+    toJSON<T = Default__v<Require_id<DocType>>>(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<T>;
+    toJSON<T = Default__v<Require_id<DocType>>>(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<T>;
+    toJSON<T = Default__v<Require_id<DocType>>>(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<T>>;
+    toJSON<T = Default__v<Require_id<DocType>>>(options: ToObjectOptions & { flattenMaps: false }): T;
+    toJSON<T = Default__v<Require_id<DocType>>>(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<T>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
-    toObject(options?: ToObjectOptions): Require_id<DocType>;
-    toObject<T>(options?: ToObjectOptions): Require_id<T>;
+    toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>>;
+    toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>>;
 
     /** Clears the modified state on the specified path. */
     unmarkModified<T extends keyof DocType>(path: T): void;


### PR DESCRIPTION
Fix #15077

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15077 points out that `lean()` and `toObject()` should return compatible types, but currently do not due to __v

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
