### PR TITLE
fix(model): throw error if calling `create()` with multiple docs in a transaction unless `ordered: true`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2619,6 +2619,10 @@ Model.create = async function create(doc, options) {
 
   delete options.aggregateErrors; // dont pass on the option to "$save"
 
+  if (options.session && !options.ordered && args.length > 1) {
+    throw new MongooseError('Cannot call `create()` with a session and multiple documents unless `ordered: true` is set');
+  }
+
   if (options.ordered) {
     for (let i = 0; i < args.length; i++) {
       try {

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -344,7 +344,10 @@ describe('transactions', function() {
     const session = await db.startSession();
 
     session.startTransaction();
-    await Character.create([{ name: 'Will Riker', rank: 'Commander' }, { name: 'Jean-Luc Picard', rank: 'Captain' }], { session });
+    await Character.create([
+      { name: 'Will Riker', rank: 'Commander' },
+      { name: 'Jean-Luc Picard', rank: 'Captain' }
+    ], { session, ordered: true });
 
     let names = await Character.distinct('name', {}, { session });
     assert.deepStrictEqual(names.sort(), ['Jean-Luc Picard', 'Will Riker']);
@@ -670,6 +673,7 @@ describe('transactions', function() {
     });
 
     // Create models
+    db.deleteModel(/Test/);
     const Booking = db.model('Test', BookingSchema);
 
     // Define a sample payload

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -686,7 +686,7 @@ describe('transactions', function() {
       ]
     };
 
-    const session = await mongoose.startSession();
+    const session = await db.startSession();
     session.startTransaction();
 
     const bookingData = payload.data.map((obj) => ({

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -660,4 +660,44 @@ describe('transactions', function() {
     const { name } = await Test.findById(_id);
     assert.strictEqual(name, 'bar');
   });
+
+  it('throws error if using `create()` with multiple docs in a transaction (gh-15091)', async function() {
+    const BookingSchema = new Schema({
+      user: mongoose.Types.ObjectId,
+      slot: mongoose.Types.ObjectId,
+      bookingFor: String,
+      moreInfo: String
+    });
+
+    // Create models
+    const Booking = db.model('Test', BookingSchema);
+
+    // Define a sample payload
+    const user = { userId: new mongoose.Types.ObjectId() };
+    const payload = {
+      slotId: new mongoose.Types.ObjectId(),
+      data: [
+        { bookingFor: 'Person A', moreInfo: 'Some info' },
+        { bookingFor: 'Person B', moreInfo: 'Other info' }
+      ]
+    };
+
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    const bookingData = payload.data.map((obj) => ({
+      user: user.userId,
+      slot: payload.slotId,
+      bookingFor: obj.bookingFor,
+      moreInfo: obj.moreInfo
+    }));
+
+    await assert.rejects(
+      Booking.create(bookingData, { session }),
+      /Cannot call `create\(\)` with a session and multiple documents unless `ordered: true` is set/
+    );
+
+    const bookings = await Booking.create(bookingData, { session, ordered: true });
+    assert.equal(bookings.length, 2);
+  });
 });

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -696,12 +696,15 @@ describe('transactions', function() {
       moreInfo: obj.moreInfo
     }));
 
+    const bookings = await Booking.create(bookingData, { session, ordered: true });
+    assert.equal(bookings.length, 2);
+
     await assert.rejects(
       Booking.create(bookingData, { session }),
       /Cannot call `create\(\)` with a session and multiple documents unless `ordered: true` is set/
     );
 
-    const bookings = await Booking.create(bookingData, { session, ordered: true });
-    assert.equal(bookings.length, 2);
+    await session.abortTransaction();
+    await session.endSession();
   });
 });


### PR DESCRIPTION
Fix #15091

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

MongoDB does not allow multiple operations on a single transaction in parallel. Since Mongoose `create()` uses `save()` under the hood, Mongoose cannot reliably `create()` multiple docs in a transaction unless `ordered: true` is set.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
