### PR TITLE
fix(populate): backport security fix for $where in populate

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -207,6 +207,15 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
     if (hasMatchFunction) {
       match = match.call(doc, doc);
     }
+    if (Array.isArray(match)) {
+      for (const item of match) {
+        if (item != null && item.$where) {
+          throw new MongooseError('Cannot use $where filter with populate() match');
+        }
+      }
+    } else if (match != null && match.$where != null) {
+      throw new MongooseError('Cannot use $where filter with populate() match');
+    }
 
     if (Array.isArray(localField) && Array.isArray(foreignField) && localField.length === foreignField.length) {
       match = Object.assign({}, match);


### PR DESCRIPTION
Fix #15078

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Although 5.x is technically EOL, I think it is reasonable to make an exception and backport the security fix for CVE-2024-53900 to 5.x. It is not a difficult fix, and would help out developers that are still on 5.x.

After this though, we will mark Mongoose 5.x as deprecated in npm.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
