### PR TITLE
fix(map): clean modified subpaths when overwriting values in map of subdocs

### DIFF
--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -9,6 +9,7 @@ const handleSpreadDoc = require('../helpers/document/handleSpreadDoc');
 const util = require('util');
 const specialProperties = require('../helpers/specialProperties');
 const isBsonType = require('../helpers/isBsonType');
+const cleanModifiedSubpaths = require('../helpers/document/cleanModifiedSubpaths');
 
 const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
@@ -157,7 +158,13 @@ class MongooseMap extends Map {
     super.set(key, value);
 
     if (parent != null && parent.$__ != null && !deepEqual(value, priorVal)) {
-      parent.markModified(fullPath.call(this));
+      const path = fullPath.call(this);
+      parent.markModified(path);
+      // If overwriting the full document array or subdoc, make sure to clean up any paths that were modified
+      // before re: #15108
+      if (this.$__schemaType.$isMongooseDocumentArray || this.$__schemaType.$isSingleNested) {
+        cleanModifiedSubpaths(parent, path);
+      }
     }
 
     // Delay calculating full path unless absolutely necessary, because string


### PR DESCRIPTION
Fix #15108

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15108 is due to Mongoose change tracking not cleaning up modified paths underneath maps of subdocs when overwriting the entire subdoc. So `doc.map.delete('subdoc')` will still leave any subpaths of `map.subdoc` modified. This PR cleans up those paths.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
