### PR TITLE
types: add UUID to RefType

### DIFF
--- a/docs/typescript/populate.md
+++ b/docs/typescript/populate.md
@@ -96,4 +96,4 @@ However, we recommend using the `.populate<{ child: Child }>` syntax from the fi
 Here's two reasons why:
 
 1. You still need to add an extra check to check if `child instanceof ObjectId`. Otherwise, the TypeScript compiler will fail with `Property name does not exist on type ObjectId`. So using `PopulatedDoc<>` means you need an extra check everywhere you use `doc.child`.
-2. In the `Parent` interface, `child` is a hydrated document, which makes it slow difficult for Mongoose to infer the type of `child` when you use `lean()` or `toObject()`.
+2. In the `Parent` interface, `child` is a hydrated document, which makes it difficult for Mongoose to infer the type of `child` when you use `lean()` or `toObject()`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -572,7 +572,8 @@ declare module 'mongoose' {
     | typeof Schema.Types.Number
     | typeof Schema.Types.String
     | typeof Schema.Types.Buffer
-    | typeof Schema.Types.ObjectId;
+    | typeof Schema.Types.ObjectId
+    | typeof Schema.Types.UUID;
 
 
   export type InferId<T> = T extends { _id?: any } ? T['_id'] : Types.ObjectId;


### PR DESCRIPTION
Fix #15101

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Mongoose does support using `ref` on UUID paths, so we should also support it in the RefType and PopulatedDoc<> helpers.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
