### PR TITLE
docs: remove link to Mongoose 5.x docs from dropdown

### DIFF
--- a/scripts/website.js
+++ b/scripts/website.js
@@ -311,8 +311,7 @@ const versionObj = (() => {
     latestVersion: getLatestVersion(),
     pastVersions: [
       getLatestVersionOf(7),
-      getLatestVersionOf(6),
-      getLatestVersionOf(5),
+      getLatestVersionOf(6)
     ]
   };
   const versionedDeploy = !!process.env.DOCS_DEPLOY ? !(base.currentVersion.listed === base.latestVersion.listed) : false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Mongoose 5 has been EOL for a while, so it may be time to remove the link to the Mongoose 5 docs from our home page. This doesn't delete the existing 5.x docs (which is fine, we still have the 3.8.x docs on mongoosejs.com too) but it does make them a bit harder to find.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
