### PR TITLE
types: make BufferToBinary avoid Document instances

### DIFF
--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -308,8 +308,7 @@ async function gh15122() {
         ref: 'Child',
         required: true
       }
-    },
-    { optimisticConcurrency: true }
+    }
   );
 
   parentSchema.virtual('fullName').get(function() {

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Types, InferSchemaType, FlattenMaps } from 'mongoose';
+import { Schema, model, Types, InferSchemaType, FlattenMaps, HydratedDocument, Model, Document, PopulatedDoc } from 'mongoose';
 import { expectAssignable, expectError, expectType } from 'tsd';
 
 function gh10345() {
@@ -236,4 +236,91 @@ async function gh15057() {
   const doSomeThing = (item: Attachment) => {
     console.log(item);
   };
+}
+
+async function gh15122() {
+  interface IChild {
+    _id: Types.ObjectId;
+    name: string;
+  }
+
+  type ChildDocumentOverrides = {};
+
+  interface IChildVirtuals {
+    id: string;
+  }
+
+  type ChildInstance = HydratedDocument<
+    IChild,
+    ChildDocumentOverrides & IChildVirtuals
+  >;
+
+  type ChildModelType = Model<
+    IChild,
+    {},
+    ChildDocumentOverrides,
+    IChildVirtuals,
+    ChildInstance
+  >;
+
+
+  interface IParent {
+    _id: Types.ObjectId;
+    name: string;
+    surname: string;
+    child: PopulatedDoc<Document<Types.ObjectId> & IChild>;
+  }
+
+  type ParentDocumentOverrides = {};
+
+  interface IParentVirtuals {
+    id: string;
+    fullName: string;
+  }
+
+  type ParentInstance = HydratedDocument<
+    IParent,
+    ParentDocumentOverrides & IParentVirtuals
+  >;
+
+  type ParentModelType = Model<
+    IParent,
+    {},
+    ParentDocumentOverrides,
+    IParentVirtuals,
+    ParentInstance
+  >;
+
+  const parentSchema = new Schema<IParent, ParentModelType>(
+    {
+      name: {
+        type: String,
+        required: true,
+        trim: true
+      },
+      surname: {
+        type: String,
+        required: true,
+        trim: true
+      },
+      child: {
+        type: 'ObjectId',
+        ref: 'Child',
+        required: true
+      }
+    },
+    { optimisticConcurrency: true }
+  );
+
+  parentSchema.virtual('fullName').get(function() {
+    return `${this.name} ${this.surname}`;
+  });
+
+  const Parent = model<IParent, ParentModelType>('Parent', parentSchema);
+
+  const testFn = (parent: IParent) => {};
+  const parentDoc = await Parent.findOne().lean();
+  if (parentDoc) {
+    testFn(parentDoc);
+  }
 }


### PR DESCRIPTION
Fix #15122

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The problem in #15122 is that BufferToBinary is drilling into Document instances, and when a user does `Document & IChild` we can't reliably infer the raw document type, so we need to skip that case.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
