### PR TITLE
fix(model): handle document array paths set to non-array values in Model.castObject()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -69,6 +69,7 @@ const util = require('util');
 const utils = require('./utils');
 const minimize = require('./helpers/minimize');
 const MongooseBulkSaveIncompleteError = require('./error/bulkSaveIncompleteError');
+const ObjectExpectedError = require('./error/objectExpected');
 
 const modelCollectionSymbol = Symbol('mongoose#Model#collection');
 const modelDbSymbol = Symbol('mongoose#Model#db');
@@ -3687,6 +3688,19 @@ Model.castObject = function castObject(obj, options) {
     }
 
     if (schemaType.$isMongooseDocumentArray) {
+      const castNonArraysOption = schemaType.options.castNonArrays != null ? schemaType.options.castNonArrays : schemaType.constructor.options.castNonArrays;
+      if (!Array.isArray(val)) {
+        if (!castNonArraysOption) {
+          if (!options.ignoreCastErrors) {
+            error = error || new ValidationError();
+            error.addError(path, new ObjectExpectedError(path, val));
+          }
+        } else {
+          cur[pieces[pieces.length - 1]] = [
+            Model.castObject.call(schemaType.caster, val)
+          ];
+        }
+      }
       continue;
     }
     if (schemaType.$isSingleNested || schemaType.$isMongooseDocumentArrayElement) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3688,7 +3688,7 @@ Model.castObject = function castObject(obj, options) {
     }
 
     if (schemaType.$isMongooseDocumentArray) {
-      const castNonArraysOption = schemaType.options.castNonArrays != null ? schemaType.options.castNonArrays : schemaType.constructor.options.castNonArrays;
+      const castNonArraysOption = schemaType.options?.castNonArrays ??schemaType.constructor.options.castNonArrays;
       if (!Array.isArray(val)) {
         if (!castNonArraysOption) {
           if (!options.ignoreCastErrors) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7777,6 +7777,24 @@ describe('Model', function() {
         TestModel.castObject(square).shape[0],
         { kind: 'Square', propertyPaths: [{ property: '42' }] }
       );
+
+      const square2 = { shape: [{ kind: 'Square', propertyPaths: {} }] };
+      assert.deepStrictEqual(
+        TestModel.castObject(square2).shape[0],
+        { kind: 'Square', propertyPaths: [{}] }
+      );
+    });
+    it('handles castNonArrays when document array is set to non-array value (gh-15075)', function() {
+      const sampleSchema = new mongoose.Schema({
+        sampleArray: {
+          type: [new mongoose.Schema({ name: String })],
+          castNonArrays: false
+        }
+      });
+      const Test = db.model('Test', sampleSchema);
+
+      const obj = { sampleArray: { name: 'Taco' } };
+      assert.throws(() => Test.castObject(obj), /Tried to set nested object field `sampleArray` to primitive value/);
     });
   });
 


### PR DESCRIPTION
Fix #15075

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15075 pointed out that `Model.castObject()` silently ignores document arrays that are set to primitive non-null values. This PR fixes that, including accounting for `castNonArrays` schema object.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
