### PR TITLE
fix(model): avoid throwing unnecessary error if `updateOne()` returns `null` in `save()`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -387,7 +387,11 @@ Model.prototype.$__handleSave = function(options, callback) {
 
     this[modelCollectionSymbol].updateOne(where, update, saveOptions).then(
       ret => {
-        ret.$where = where;
+        if (ret == null) {
+          ret = { $where: where };
+        } else {
+          ret.$where = where;
+        }
         callback(null, ret);
       },
       err => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Although `updateOne()` should never return a nullish value under normal circumstances, we can be more defensive in this code

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
