### PR TITLE
fix(document): avoid using childSchemas.path for compatibility with pre-Mongoose-8.8 schemas

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3703,8 +3703,10 @@ Document.prototype.$getAllSubdocs = function(options) {
   const subDocs = [];
   function getSubdocs(doc) {
     const newSubdocs = [];
-    for (const { path } of doc.$__schema.childSchemas) {
-      const val = doc.$__getValue(path);
+
+    for (const { model } of doc.$__schema.childSchemas) {
+      // Avoid using `childSchemas.path` to avoid compatibility versions with pre-8.8 versions of Mongoose
+      const val = doc.$__getValue(model.path);
       if (val == null) {
         continue;
       }
@@ -3726,6 +3728,7 @@ Document.prototype.$getAllSubdocs = function(options) {
         }
       }
     }
+
     for (const subdoc of newSubdocs) {
       getSubdocs(subdoc);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -631,6 +631,9 @@ exports.getValue = function(path, obj, map) {
 const mapGetterOptions = Object.freeze({ getters: false });
 
 function getValueLookup(obj, part) {
+  if (part === '$*' && obj instanceof Map) {
+    return obj;
+  }
   let _from = obj?._doc || obj;
   if (_from != null && _from.isMongooseArrayProxy) {
     _from = _from.__array;


### PR DESCRIPTION
Fix #15071

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15071 is a tricky situation where the user has a shared connection package that uses Mongoose 8.8, and a client npm package which defines schemas using Mongoose 8.5 but then defines models using the Mongoose 8.8 connection. And we added a new `childSchemas.path` property in 8.8.3 with #15029 that Mongoose 8.8.3 expects, but schemas from Mongoose 8.5 do not have.

The "right" solution is to tell the user to ensure a consistent version of Mongoose, because we cannot realistically test that schemas from every version of Mongoose work with models from every other version of Mongoose. However, in the interest of not breaking code that previously worked, we can use this PR's more backwards-compatible approach.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
