### PR TITLE
fix(schema): make duplicate index error a warning for now to prevent blocking upgrading

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2148,7 +2148,7 @@ Schema.prototype.index = function(fields, options) {
 
   for (const existingIndex of this.indexes()) {
     if (options.name == null && existingIndex[1].name == null && isIndexSpecEqual(existingIndex[0], fields)) {
-      throw new MongooseError(`Schema already has an index on ${JSON.stringify(fields)}`);
+      utils.warn(`Duplicate schema index on ${JSON.stringify(fields)} found. This is often due to declaring an index using both "index: true" and "schema.index()". Please remove the duplicate index definition.`);
     }
   }
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3315,6 +3315,7 @@ describe('schema', function() {
       ObjectKeySchema.index({ type: 1, key: 1 });
       ObjectKeySchema.index({ key: 1, type: -1 });
       ObjectKeySchema.index({ key: 1, type: 1 }, { unique: true, name: 'special index' });
+      assert.equal(utils.warn.getCalls().length, 2);
     } finally {
       sinon.restore();
     }


### PR DESCRIPTION
Fix #15109
Re: #15112

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The new duplicate index error has caused some headache for a lot of users, so in the interest of not blocking anyone from upgrading, I changed the error to a warning. That way there is an indication that duplicate indexes are a problem, and it should be only slightly more difficult to trace down the duplicate index because Node.js warnings can get stack traces with the `--trace-warnings` command line flag.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
