### PR TITLE
perf(cursor): clear the stack every time if using populate with batchSize to avoid stack overflows with large docs

### DIFF
--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -557,17 +557,11 @@ function _onNext(error, doc) {
 
   if (this.ctx._batchDocs.length < this.ctx.options._populateBatchSize) {
     // If both `batchSize` and `_populateBatchSize` are huge, calling `next()` repeatedly may
-    // cause a stack overflow. So make sure we clear the stack regularly.
-    if (this.ctx._batchDocs.length > 0 && this.ctx._batchDocs.length % 1000 === 0) {
-      return immediate(() => this.ctx.cursor.next().then(
-        res => { _onNext.call(this, null, res); },
-        err => { _onNext.call(this, err); }
-      ));
-    }
-    this.ctx.cursor.next().then(
+    // cause a stack overflow. So make sure we clear the stack.
+    immediate(() => this.ctx.cursor.next().then(
       res => { _onNext.call(this, null, res); },
       err => { _onNext.call(this, err); }
-    );
+    ));
   } else {
     _populateBatch.call(this);
   }


### PR DESCRIPTION
Fix #10449

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I wasn't able to repro #10449 locally, but there shouldn't be any issues with clearing the stack on every call. Minor performance impact, but better parallelization and less risk of stack overflows.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
