### PR TITLE
fix(schema): allow multiple self-referencing discriminator schemas using Schema.prototype.discriminator

### DIFF
--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -522,6 +522,7 @@ SchemaDocumentArray.prototype.clone = function() {
   }
   schematype.Constructor.discriminators = Object.assign({},
     this.Constructor.discriminators);
+  schematype._appliedDiscriminators = this._appliedDiscriminators;
   return schematype;
 };
 

--- a/lib/schema/subdocument.js
+++ b/lib/schema/subdocument.js
@@ -393,5 +393,6 @@ SchemaSubdocument.prototype.clone = function() {
     schematype.requiredValidator = this.requiredValidator;
   }
   schematype.caster.discriminators = Object.assign({}, this.caster.discriminators);
+  schematype._appliedDiscriminators = this._appliedDiscriminators;
   return schematype;
 };

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8004,6 +8004,36 @@ describe('Model', function() {
     assert.equal(doc.items[0].prop, 42);
   });
 
+  it('does not throw with multiple self-referencing discriminator schemas applied to schema (gh-15120)', async function() {
+    const baseSchema = new Schema({
+      type: { type: Number, required: true }
+    }, { discriminatorKey: 'type' });
+
+    const selfRefSchema = new Schema({
+      self: { type: [baseSchema] }
+    });
+
+    const anotherSelfRefSchema = new Schema({
+      self2: { type: [baseSchema] }
+    });
+
+    baseSchema.discriminator(5, selfRefSchema);
+    baseSchema.discriminator(6, anotherSelfRefSchema);
+    const Test = db.model('Test', baseSchema);
+
+    const doc = await Test.create({
+      type: 5,
+      self: {
+        type: 6,
+        self2: null
+      }
+    });
+    assert.strictEqual(doc.type, 5);
+    assert.equal(doc.self.length, 1);
+    assert.strictEqual(doc.self[0].type, 6);
+    assert.strictEqual(doc.self[0].self2, null);
+  });
+
   it('inserts versionKey even if schema has `toObject.versionKey` set to false (gh-14344)', async function() {
     const schema = new mongoose.Schema(
       { name: String },


### PR DESCRIPTION
Fix #15120

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15120 is caused by us reapplying embedded discriminators unnecessarily to cloned schematypes - when a schematype is `clone()`-ed, we also copy over the discriminator settings. So no need to reapply discriminators later. When cloning a schematype with discriminators, also copy the `_appliedDiscriminators` flag.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
