### PR TITLE
feat(connection): support Connection.prototype.aggregate() for db-level aggregations

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1058,6 +1058,7 @@ Aggregate.prototype.exec = async function exec() {
   applyGlobalMaxTimeMS(this.options, model.db.options, model.base.options);
   applyGlobalDiskUse(this.options, model.db.options, model.base.options);
 
+  this._optionsForExec();
 
   if (this.options && this.options.cursor) {
     return new AggregationCursor(this);

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -13,6 +13,7 @@ const getConstructorName = require('./helpers/getConstructorName');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
+const Connection = require('./connection');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -46,13 +47,17 @@ const validRedactStringValues = new Set(['$$DESCEND', '$$PRUNE', '$$KEEP']);
  * @see MongoDB https://www.mongodb.com/docs/manual/applications/aggregation/
  * @see driver https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#aggregate
  * @param {Array} [pipeline] aggregation pipeline as an array of objects
- * @param {Model} [model] the model to use with this aggregate.
+ * @param {Model|Connection} [modelOrConn] the model or connection to use with this aggregate.
  * @api public
  */
 
-function Aggregate(pipeline, model) {
+function Aggregate(pipeline, modelOrConn) {
   this._pipeline = [];
-  this._model = model;
+  if (modelOrConn instanceof Connection) {
+    this._connection = modelOrConn;
+  } else {
+    this._model = modelOrConn;
+  }
   this.options = {};
 
   if (arguments.length === 1 && Array.isArray(pipeline)) {
@@ -1029,19 +1034,30 @@ Aggregate.prototype.pipeline = function() {
  */
 
 Aggregate.prototype.exec = async function exec() {
-  if (!this._model) {
+  if (!this._model && !this._connection) {
     throw new Error('Aggregate not bound to any Model');
   }
   if (typeof arguments[0] === 'function') {
     throw new MongooseError('Aggregate.prototype.exec() no longer accepts a callback');
   }
+
+  if (this._connection) {
+    if (!this._pipeline.length) {
+      throw new MongooseError('Aggregate has empty pipeline');
+    }
+
+    this._optionsForExec();
+
+    const cursor = await this._connection.client.db().aggregate(this._pipeline, this.options);
+    return await cursor.toArray();
+  }
+
   const model = this._model;
   const collection = this._model.collection;
 
   applyGlobalMaxTimeMS(this.options, model.db.options, model.base.options);
   applyGlobalDiskUse(this.options, model.db.options, model.base.options);
 
-  this._optionsForExec();
 
   if (this.options && this.options.cursor) {
     return new AggregationCursor(this);

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -13,7 +13,7 @@ const getConstructorName = require('./helpers/getConstructorName');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
-const Connection = require('./connection');
+const { populateModelSymbol } = require('./helpers/symbols');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -53,10 +53,10 @@ const validRedactStringValues = new Set(['$$DESCEND', '$$PRUNE', '$$KEEP']);
 
 function Aggregate(pipeline, modelOrConn) {
   this._pipeline = [];
-  if (modelOrConn instanceof Connection) {
-    this._connection = modelOrConn;
-  } else {
+  if (modelOrConn == null || modelOrConn[populateModelSymbol]) {
     this._model = modelOrConn;
+  } else {
+    this._connection = modelOrConn;
   }
   this.options = {};
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -13,7 +13,7 @@ const getConstructorName = require('./helpers/getConstructorName');
 const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
-const { populateModelSymbol } = require('./helpers/symbols');
+const { modelSymbol } = require('./helpers/symbols');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -53,7 +53,7 @@ const validRedactStringValues = new Set(['$$DESCEND', '$$PRUNE', '$$KEEP']);
 
 function Aggregate(pipeline, modelOrConn) {
   this._pipeline = [];
-  if (modelOrConn == null || modelOrConn[populateModelSymbol]) {
+  if (modelOrConn == null || modelOrConn[modelSymbol]) {
     this._model = modelOrConn;
   } else {
     this._connection = modelOrConn;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1743,6 +1743,18 @@ Connection.prototype.syncIndexes = async function syncIndexes(options = {}) {
  */
 
 /**
+ * Runs a [db-level aggregate()](https://www.mongodb.com/docs/manual/reference/method/db.aggregate/) on this connection's underlying `db`
+ *
+ * @method aggregate
+ * @memberOf Connection
+ * @param {Array} pipeline
+ * @param {Object} [options]
+ * @param {Boolean} [options.cursor=false] If true, make the Aggregate resolve to a Mongoose AggregationCursor rather than an array
+ * @return {Aggregate} Aggregation wrapper
+ * @api public
+ */
+
+/**
  * Removes the database connection with the given name created with with `useDb()`.
  *
  * Throws an error if the database connection was not found.

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -41,11 +41,17 @@ function AggregationCursor(agg) {
   this.cursor = null;
   this.agg = agg;
   this._transforms = [];
+  const connection = agg._connection;
   const model = agg._model;
   delete agg.options.cursor.useMongooseAggCursor;
   this._mongooseOptions = {};
 
-  _init(model, this, agg);
+  if (connection) {
+    this.cursor = connection.db.aggregate(agg._pipeline, agg.options || {});
+    setImmediate(() => this.emit('cursor', this.cursor));
+  } else {
+    _init(model, this, agg);
+  }
 }
 
 util.inherits(AggregationCursor, Readable);

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -142,9 +142,7 @@ NativeConnection.prototype.useDb = function(name, options) {
  */
 
 NativeConnection.prototype.aggregate = function aggregate(pipeline, options) {
-  Aggregate = Aggregate || require('../../aggregate');
-
-  return new Aggregate(null, this).append(pipeline).option(options ?? {});
+  return new this.base.Aggregate(null, this).append(pipeline).option(options ?? {});
 };
 
 /**

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const Aggregate = require('../../aggregate');
 const MongooseConnection = require('../../connection');
 const MongooseError = require('../../error/index');
 const STATES = require('../../connectionState');
@@ -130,6 +131,17 @@ NativeConnection.prototype.useDb = function(name, options) {
   }
 
   return newConn;
+};
+
+/**
+ * Runs a [db-level aggregate()](https://www.mongodb.com/docs/manual/reference/method/db.aggregate/) on this connection's underlying `db`
+ *
+ * @param {Array} pipeline
+ * @param {Object} [options]
+ */
+
+NativeConnection.prototype.aggregate = function aggregate(pipeline, options) {
+  return new Aggregate(null, this).append(pipeline).option(options ?? {});
 };
 
 /**

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -13,8 +13,6 @@ const processConnectionOptions = require('../../helpers/processConnectionOptions
 const setTimeout = require('../../helpers/timers').setTimeout;
 const utils = require('../../utils');
 
-let Aggregate;
-
 /**
  * A [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) connection implementation.
  *

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const Aggregate = require('../../aggregate');
 const MongooseConnection = require('../../connection');
 const MongooseError = require('../../error/index');
 const STATES = require('../../connectionState');
@@ -13,6 +12,8 @@ const pkg = require('../../../package.json');
 const processConnectionOptions = require('../../helpers/processConnectionOptions');
 const setTimeout = require('../../helpers/timers').setTimeout;
 const utils = require('../../utils');
+
+let Aggregate;
 
 /**
  * A [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) connection implementation.
@@ -141,6 +142,8 @@ NativeConnection.prototype.useDb = function(name, options) {
  */
 
 NativeConnection.prototype.aggregate = function aggregate(pipeline, options) {
+  Aggregate = Aggregate || require('../../aggregate');
+
   return new Aggregate(null, this).append(pipeline).option(options ?? {});
 };
 

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -59,6 +59,8 @@ declare module 'mongoose' {
   }
 
   class Connection extends events.EventEmitter implements SessionStarter {
+    aggregate<ResultType = unknown>(pipeline?: PipelineStage[] | null, options?: AggregateOptions): Aggregate<Array<ResultType>>;
+
     /** Returns a promise that resolves when this connection successfully connects to MongoDB */
     asPromise(): Promise<this>;
 


### PR DESCRIPTION
Fix #15118

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

MongoDB 7 and up supports `aggregate()` on databases. The `$documents` stage only works on db.aggregate(), more info on db.aggregate() here: https://www.mongodb.com/docs/manual/reference/method/db.aggregate/.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
