### PR TITLE
fix(model): skip createCollection() in syncIndexes() if autoCreate: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+8.9.3 / 2024-12-30
+==================
+ * fix(schema): make duplicate index error a warning for now to prevent blocking upgrading #15135 #15112 #15109
+ * fix(model): handle document array paths set to non-array values in Model.castObject() #15124 #15075
+ * fix(document): avoid using childSchemas.path for compatibility with pre-Mongoose-8.8 schemas #15131 #15071
+ * fix(model): avoid throwing unnecessary error if updateOne() returns null in save() #15126
+ * perf(cursor): clear the stack every time if using populate with batchSize to avoid stack overflows with large docs #15136 #10449
+ * types: make BufferToBinary avoid Document instances #15123 #15122
+ * types(model+query): avoid stripping out virtuals when calling populate with paths generic #15132 #15111
+ * types(schema): add missing removeIndex #15134
+ * types: add cleanIndexes() to IndexManager interface #15127
+ * docs: move search endpoint to netlify #15119
+
 8.9.2 / 2024-12-19
 ==================
  * fix(schema): avoid throwing duplicate index error if index spec keys have different order or index has a custom name #15112 #15109

--- a/lib/model.js
+++ b/lib/model.js
@@ -1246,19 +1246,21 @@ Model.syncIndexes = async function syncIndexes(options) {
     throw new MongooseError('Model.syncIndexes() no longer accepts a callback');
   }
 
-  const model = this;
+  const autoCreate = options?.autoCreate ?? this.schema.options?.autoCreate ?? this.db.config.autoCreate ?? true;
 
-  try {
-    await model.createCollection();
-  } catch (err) {
-    if (err != null && (err.name !== 'MongoServerError' || err.code !== 48)) {
-      throw err;
+  if (autoCreate) {
+    try {
+      await this.createCollection();
+    } catch (err) {
+      if (err != null && (err.name !== 'MongoServerError' || err.code !== 48)) {
+        throw err;
+      }
     }
   }
 
-  const diffIndexesResult = await model.diffIndexes();
-  const dropped = await model.cleanIndexes({ ...options, toDrop: diffIndexesResult.toDrop });
-  await model.createIndexes({ ...options, toCreate: diffIndexesResult.toCreate });
+  const diffIndexesResult = await this.diffIndexes();
+  const dropped = await this.cleanIndexes({ ...options, toDrop: diffIndexesResult.toDrop });
+  await this.createIndexes({ ...options, toCreate: diffIndexesResult.toCreate });
 
   return dropped;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose",
   "description": "Mongoose MongoDB ODM",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",
   "keywords": [
     "mongodb",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`autoCreate` is supposed to skip implicit `createCollection()` calls, but `syncIndexes()` still sends a `createCollection()` even if `autoCreate` is disabled.

The potential issue with automatic `createCollection()` is calling `createCollection()` unnecessarily on every server restart (presuming the user calls `syncIndexes()` on every server restart) is wasteful and may cause slight performance degradation. 

Will put this in 8.10 in the interest of being cautious.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
