### PR TITLE
types: avoid BufferToBinary<> wiping lean types when passed to generic functions

### DIFF
--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -323,3 +323,29 @@ async function gh15122() {
     testFn(parentDoc);
   }
 }
+
+async function gh15158() {
+  type FooBar = {
+    value: string;
+  };
+
+  const createSomeModelAndDoSomething = async <T extends FooBar>() => {
+    const TestSchema = new Schema<T>({
+      value: { type: String }
+    });
+
+    const FooBarModel = model<T>('test', TestSchema);
+
+    const item = await FooBarModel.findOne().lean();
+
+    if (!item) return;
+
+    doSomeThing(item);
+  };
+
+  const doSomeThing = <T extends FooBar>(item: T) => {
+    console.log(item);
+  };
+
+  createSomeModelAndDoSomething();
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -710,6 +710,14 @@ declare module 'mongoose' {
     [K in keyof T]: FlattenProperty<T[K]>;
   };
 
+  export type BufferToBinaryProperty<T> = T extends Buffer
+    ? mongodb.Binary
+    : T extends Types.DocumentArray<infer ItemType>
+      ? Types.DocumentArray<BufferToBinary<ItemType>>
+      : T extends Types.Subdocument<unknown, unknown, infer SubdocType>
+        ? HydratedSingleSubdocument<BufferToBinary<SubdocType>>
+        : BufferToBinary<T>;
+
   /**
    * Converts any Buffer properties into mongodb.Binary instances, which is what `lean()` returns
    */
@@ -719,15 +727,11 @@ declare module 'mongoose' {
       ? T
       : T extends TreatAsPrimitives
         ? T
-        : T extends Record<string, any> ? {
-          [K in keyof T]: T[K] extends Buffer
-            ? mongodb.Binary
-            : T[K] extends Types.DocumentArray<infer ItemType>
-              ? Types.DocumentArray<BufferToBinary<ItemType>>
-              : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
-                ? HydratedSingleSubdocument<BufferToBinary<SubdocType>>
-                : BufferToBinary<T[K]>;
-      } : T;
+        : T extends Record<string, any>
+          ? {
+              [K in keyof T]: BufferToBinaryProperty<T[K]>
+            }
+          : T;
 
   /**
    * Converts any Buffer properties into { type: 'buffer', data: [1, 2, 3] } format for JSON serialization

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -223,7 +223,7 @@ declare module 'mongoose' {
   type QueryOpThatReturnsDocument = 'find' | 'findOne' | 'findOneAndUpdate' | 'findOneAndReplace' | 'findOneAndDelete';
 
   type GetLeanResultType<RawDocType, ResultType, QueryOp> = QueryOp extends QueryOpThatReturnsDocument
-    ? (ResultType extends any[] ? Default__v<Require_id<BufferToBinary<FlattenMaps<RawDocType>>>>[] : Default__v<Require_id<BufferToBinary<FlattenMaps<RawDocType>>>>)
+    ? (ResultType extends any[] ? Default__v<Require_id<FlattenMaps<BufferToBinary<RawDocType>>>>[] : Default__v<Require_id<FlattenMaps<BufferToBinary<RawDocType>>>>)
     : ResultType;
 
   type MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, TQueryHelpers, TDocOverrides = Record<string, never>> = QueryOp extends QueryOpThatReturnsDocument


### PR DESCRIPTION
Fix #15158

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I am not entirely certain why this fix works, mostly done by trial and error. Likely https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types.

This PR is more reason why I would like to get rid of the various `BufferToBinary` etc. helper types in favor of calculating various types in the schema: raw doc type, hydrated doc type, and JSON serialized doc type.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
