### PR TITLE
fix(model): allow passing validateBeforeSave option to bulkSave() to skip validation

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3436,6 +3436,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
  * @param {String|number} [options.w=1] The [write concern](https://www.mongodb.com/docs/manual/reference/write-concern/). See [`Query#w()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.w()) for more information.
  * @param {number} [options.wtimeout=null] The [write concern timeout](https://www.mongodb.com/docs/manual/reference/write-concern/#wtimeout).
  * @param {Boolean} [options.j=true] If false, disable [journal acknowledgement](https://www.mongodb.com/docs/manual/reference/write-concern/#j-option)
+ * @param {Boolean} [options.validateBeforeSave=true] set to `false` to skip Mongoose validation on all documents
  * @return {BulkWriteResult} the return value from `bulkWrite()`
  */
 Model.bulkSave = async function bulkSave(documents, options) {
@@ -3455,15 +3456,13 @@ Model.bulkSave = async function bulkSave(documents, options) {
     }
   }
 
-  await Promise.all(documents.map(buildPreSavePromise));
+  await Promise.all(documents.map(doc => buildPreSavePromise(doc, options)));
 
   const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options.timestamps });
-
-  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, options).then(
+  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, { skipValidation: true, ...options }).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })
   );
-
   // If not a MongoBulkWriteError, treat this as all documents failed to save.
   if (bulkWriteError != null && !(bulkWriteError instanceof MongoBulkWriteError)) {
     throw bulkWriteError;
@@ -3491,7 +3490,6 @@ Model.bulkSave = async function bulkSave(documents, options) {
       successfulDocuments.push(document);
     }
   }
-
   await Promise.all(successfulDocuments.map(document => handleSuccessfulWrite(document)));
 
   if (bulkWriteError && bulkWriteError.writeErrors && bulkWriteError.writeErrors.length) {
@@ -3501,9 +3499,9 @@ Model.bulkSave = async function bulkSave(documents, options) {
   return bulkWriteResult;
 };
 
-function buildPreSavePromise(document) {
+function buildPreSavePromise(document, options) {
   return new Promise((resolve, reject) => {
-    document.schema.s.hooks.execPre('save', document, (err) => {
+    document.schema.s.hooks.execPre('save', document, [options], (err) => {
       if (err) {
         reject(err);
         return;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -625,12 +625,12 @@ describe('document', function() {
     assert.equal(doc.val, 'test2');
   });
 
-  it('allows you to skip validation on save (gh-2981)', function() {
+  it('allows you to skip validation on save (gh-2981)', async function() {
     const schema = new Schema({ name: { type: String, required: true } });
     const MyModel = db.model('Test', schema);
 
     const doc = new MyModel();
-    return doc.save({ validateBeforeSave: false });
+    await doc.save({ validateBeforeSave: false });
   });
 
   it('doesnt use custom toObject options on save', async function() {
@@ -12750,6 +12750,16 @@ describe('document', function() {
     updatedPerson = await Person.findById(person._id);
 
     assert.equal(updatedPerson?._age, 61);
+  });
+
+  it('bulkSave() allows skipping validation with validateBeforeSave (gh-15156)', async() => {
+    const schema = new Schema({ name: { type: String, required: true } });
+    const MyModel = db.model('Test', schema);
+
+    const doc = new MyModel();
+    await MyModel.bulkSave([doc], { validateBeforeSave: false });
+
+    assert.ok(await MyModel.exists({ _id: doc._id }));
   });
 
   it('handles default embedded discriminator values (gh-13835)', async function() {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -35,6 +35,7 @@ declare module 'mongoose' {
   interface MongooseBulkSaveOptions extends mongodb.BulkWriteOptions {
     timestamps?: boolean;
     session?: ClientSession;
+    validateBeforeSave?: boolean;
   }
 
   /**


### PR DESCRIPTION
Fix #15156

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Support `validateBeforeSave` option for `bulkSave()`, equivalent to the same option for `save()`. Also fixed an issue where `bulkSave()` currently validates document twice when inserting new doc.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
