### PR TITLE
feat(model): add insertOne() function to insert a single doc 

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2791,7 +2791,7 @@ Model.create = async function create(doc, options) {
  *     // Create a new character within a transaction.
  *     await Character.insertOne({ name: 'Jean-Luc Picard' }, { session });
  *
- * @param {Object|Document} docs Document to insert, as a POJO or Mongoose document
+ * @param {Object|Document} doc Document to insert, as a POJO or Mongoose document
  * @param {Object} [options] Options passed down to `save()`.
  * @return {Promise}
  * @api public

--- a/lib/model.js
+++ b/lib/model.js
@@ -2775,6 +2775,49 @@ Model.create = async function create(doc, options) {
 };
 
 /**
+ * Shortcut for saving one document to the database.
+ * `MyModel.insertOne(obj, options)` is almost equivalent to `new MyModel(obj).save(options)`.
+ * The difference is that `insertOne()` checks if `obj` is already a document, and checks for discriminators.
+ *
+ * This function triggers the following middleware.
+ *
+ * - `save()`
+ *
+ * #### Example:
+ *
+ *     // Insert one new `Character` document
+ *     await Character.insertOne({ name: 'Jean-Luc Picard' });
+ *
+ *     // Create a new character within a transaction.
+ *     await Character.insertOne({ name: 'Jean-Luc Picard' }, { session });
+ *
+ * @param {Object|Document} docs Document to insert, as a POJO or Mongoose document
+ * @param {Object} [options] Options passed down to `save()`.
+ * @return {Promise}
+ * @api public
+ */
+
+Model.insertOne = async function insertOne(doc, options) {
+  _checkContext(this, 'insertOne');
+
+  const discriminatorKey = this.schema.options.discriminatorKey;
+  const Model = this.discriminators && doc[discriminatorKey] != null ?
+    this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
+    this;
+  if (Model == null) {
+    throw new MongooseError(
+      `Discriminator "${doc[discriminatorKey]}" not found for model "${this.modelName}"`
+    );
+  }
+  let toSave = doc;
+  if (!(toSave instanceof Model)) {
+    toSave = new Model(toSave);
+  }
+
+  return await toSave.$save(options);
+};
+
+/**
  * _Requires a replica set running MongoDB >= 3.6.0._ Watches the
  * underlying collection for changes using
  * [MongoDB change streams](https://www.mongodb.com/docs/manual/changeStreams/).

--- a/lib/model.js
+++ b/lib/model.js
@@ -2786,14 +2786,15 @@ Model.create = async function create(doc, options) {
  * #### Example:
  *
  *     // Insert one new `Character` document
- *     await Character.insertOne({ name: 'Jean-Luc Picard' });
+ *     const character = await Character.insertOne({ name: 'Jean-Luc Picard' });
+ *     character.name; // 'Jean-Luc Picard'
  *
  *     // Create a new character within a transaction.
  *     await Character.insertOne({ name: 'Jean-Luc Picard' }, { session });
  *
  * @param {Object|Document} doc Document to insert, as a POJO or Mongoose document
  * @param {Object} [options] Options passed down to `save()`.
- * @return {Promise}
+ * @return {Promise<Document>} resolves to the saved document
  * @api public
  */
 
@@ -2809,12 +2810,11 @@ Model.insertOne = async function insertOne(doc, options) {
       `Discriminator "${doc[discriminatorKey]}" not found for model "${this.modelName}"`
     );
   }
-  let toSave = doc;
-  if (!(toSave instanceof Model)) {
-    toSave = new Model(toSave);
+  if (!(doc instanceof Model)) {
+    doc = new Model(doc);
   }
 
-  return await toSave.$save(options);
+  return await doc.$save(options);
 };
 
 /**

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8461,6 +8461,37 @@ describe('Model', function() {
       assert.deepStrictEqual(toDrop, []);
     });
   });
+
+  describe('insertOne() (gh-14843)', function() {
+    it('should insert a new document', async function() {
+      const userSchema = new Schema({
+        name: String
+      });
+      const User = db.model('User', userSchema);
+
+      const res = await User.insertOne({ name: 'John' });
+      assert.ok(res instanceof User);
+
+      const doc = await User.findOne({ _id: res._id });
+      assert.equal(doc.name, 'John');
+    });
+
+    it('should support validateBeforeSave: false option', async function() {
+      const userSchema = new Schema({
+        name: {
+          type: String,
+          required: true
+        }
+      });
+      const User = db.model('User', userSchema);
+
+      const res = await User.insertOne({}, { validateBeforeSave: false });
+      assert.ok(res instanceof User);
+
+      const doc = await User.findOne({ _id: res._id });
+      assert.equal(doc.name, undefined);
+    });
+  });
 });
 
 

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -988,3 +988,13 @@ async function gh14802() {
   const conn2 = mongoose.createConnection('mongodb://127.0.0.1:27017/mongoose_test');
   Model.useConnection(conn2);
 }
+
+async function gh14843() {
+  const schema = new mongoose.Schema({
+    name: String
+  });
+  const Model = model('Test', schema);
+
+  const doc = await Model.insertOne({ name: 'taco' });
+  expectType<ReturnType<(typeof Model)['hydrate']>>(doc);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -576,6 +576,11 @@ declare module 'mongoose' {
       Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>
     >;
 
+    /**
+     * Shortcut for saving one document to the database.
+     * `MyModel.insertOne(obj, options)` is almost equivalent to `new MyModel(obj).save(options)`.
+     * The difference is that `insertOne()` checks if `obj` is already a document, and checks for discriminators.
+     */
     insertOne<DocContents = AnyKeys<TRawDocType>>(doc: DocContents | TRawDocType, options?: SaveOptions): Promise<THydratedDocumentType>;
 
     /**

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -576,6 +576,8 @@ declare module 'mongoose' {
       Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>
     >;
 
+    insertOne<DocContents = AnyKeys<TRawDocType>>(doc: DocContents | TRawDocType, options?: SaveOptions): Promise<THydratedDocumentType>;
+
     /**
      * List all [Atlas search indexes](https://www.mongodb.com/docs/atlas/atlas-search/create-index/) on this model's collection.
      * This function only works when connected to MongoDB Atlas.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #14843 

`insertOne()` is similar to `create()`, but only supports creating a single document. `insertOne()` is useful for 2 reasons:

1. Consistency with the [MongoDB CRUD API](https://www.mongodb.com/resources/products/fundamentals/crud). Mongoose models currently support all of the MongoDB CRUD API methods _except_ `insertOne()`, which is a bit of a gotcha.
2. `create()` with `options` has proven to be confusing for users, because `create(doc, { session })` attempts to create 2 documents, the 2nd with a `session` property. I don't want to drop support for `create(doc1, doc2)` (spread args) because that would just create the opposite hard-to-diagnose issue where `doc2` gets treated as options. `insertOne()` offers a neat alternative for users who just want to create 1 doc within a transaction without `new`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
