### PR TITLE
Set ESLint ECMAScript version to `2022`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,7 +104,7 @@ module.exports = {
     // 'markdown'
   ],
   parserOptions: {
-    ecmaVersion: 2020
+    ecmaVersion: 2022
   },
   env: {
     node: true,


### PR DESCRIPTION
**Summary**

This PR sets ESLint's parser's ECMAScript version to `2022`, which is a version the targeted nodejs (16.20) supports, and could cause problems like in #15163