### PR TITLE
fix(model): make Model.validate() static correctly cast document arrays

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3667,6 +3667,7 @@ Model.castObject = function castObject(obj, options) {
     const val = get(obj, path);
     pushNestedArrayPaths(paths, val, path);
   }
+  console.log('AB', obj, paths);
 
   let error = null;
 
@@ -3704,8 +3705,9 @@ Model.castObject = function castObject(obj, options) {
             Model.castObject.call(schemaType.caster, val)
           ];
         }
+
+        continue;
       }
-      continue;
     }
     if (schemaType.$isSingleNested || schemaType.$isMongooseDocumentArrayElement) {
       try {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3667,7 +3667,6 @@ Model.castObject = function castObject(obj, options) {
     const val = get(obj, path);
     pushNestedArrayPaths(paths, val, path);
   }
-  console.log('AB', obj, paths);
 
   let error = null;
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7796,6 +7796,29 @@ describe('Model', function() {
       const obj = { sampleArray: { name: 'Taco' } };
       assert.throws(() => Test.castObject(obj), /Tried to set nested object field `sampleArray` to primitive value/);
     });
+    it('handles document arrays (gh-15164)', function() {
+      const barSchema = new mongoose.Schema({
+        foo: {
+          type: mongoose.Schema.Types.String,
+          required: true
+        }
+      }, { _id: false });
+
+      const fooSchema = new mongoose.Schema({
+        bars: {
+          type: [barSchema],
+          required: true
+        }
+      });
+
+      const Test = db.model('Test', fooSchema);
+
+      let obj = Test.castObject({ bars: [] });
+      assert.deepStrictEqual(obj.bars, []);
+
+      obj = Test.castObject({ bars: [{ foo: 'bar' }] });
+      assert.deepStrictEqual(obj.bars, [{ foo: 'bar' }]);
+    });
   });
 
   it('works if passing class that extends Document to `loadClass()` (gh-12254)', async function() {


### PR DESCRIPTION
Fix #15164

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15075 fix unintentionally made it so that `Model.validate()` skips document arrays if the value being casted is an array. This PR fixes that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
