### PR TITLE
Update lint dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "devDependencies": {
     "@babel/core": "7.26.0",
     "@babel/preset-env": "7.26.0",
-    "@typescript-eslint/eslint-plugin": "^8.18.0",
-    "@typescript-eslint/parser": "^8.18.0",
+    "@typescript-eslint/eslint-plugin": "^8.19.1",
+    "@typescript-eslint/parser": "^8.19.1",
     "acquit": "1.3.0",
     "acquit-ignore": "0.2.1",
     "acquit-require": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cheerio": "1.0.0",
     "crypto-browserify": "3.12.1",
     "dox": "1.0.0",
-    "eslint": "8.57.0",
+    "eslint": "8.57.1",
     "eslint-plugin-markdown": "^5.0.0",
     "eslint-plugin-mocha-no-only": "1.2.0",
     "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "crypto-browserify": "3.12.1",
     "dox": "1.0.0",
     "eslint": "8.57.1",
-    "eslint-plugin-markdown": "^5.0.0",
+    "eslint-plugin-markdown": "^5.1.0",
     "eslint-plugin-mocha-no-only": "1.2.0",
     "express": "^4.19.2",
     "fs-extra": "~11.2.0",


### PR DESCRIPTION
**Summary**

This PR updates some lint dev-dependencies to their latest version. ESLint 8.x is EOL, so we might as well use the latest version.
Should we upgrade ESLint to 9.x within mongoose 8.x (which requires node 18+), as we only run lint in higher node environments and also already have other things that require higher node versions?