### PR TITLE
feat(model): make `syncIndexes()` not call `createIndex()` on indexes that already exist

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1256,7 +1256,7 @@ Model.syncIndexes = async function syncIndexes(options) {
     }
   }
 
-  const diffIndexesResult = await model.diffIndexes();
+  const diffIndexesResult = await model.diffIndexes({ indexOptionsToCreate: true });
   const dropped = await model.cleanIndexes({ ...options, toDrop: diffIndexesResult.toDrop });
   await model.createIndexes({ ...options, toCreate: diffIndexesResult.toCreate });
 
@@ -1361,13 +1361,14 @@ Model.listSearchIndexes = async function listSearchIndexes(options) {
  *
  *     const { toDrop, toCreate } = await Model.diffIndexes();
  *     toDrop; // Array of strings containing names of indexes that `syncIndexes()` will drop
- *     toCreate; // Array of strings containing names of indexes that `syncIndexes()` will create
+ *     toCreate; // Array of index specs containing the keys of indexes that `syncIndexes()` will create
  *
  * @param {Object} [options]
+ * @param {Boolean} [options.indexOptionsToCreate=false] If true, `toCreate` will include both the index spec and the index options, not just the index spec
  * @return {Promise<Object>} contains the indexes that would be dropped in MongoDB and indexes that would be created in MongoDB as `{ toDrop: string[], toCreate: string[] }`.
  */
 
-Model.diffIndexes = async function diffIndexes() {
+Model.diffIndexes = async function diffIndexes(options) {
   if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
     throw new MongooseError('Model.syncIndexes() no longer accepts a callback');
   }
@@ -1389,13 +1390,14 @@ Model.diffIndexes = async function diffIndexes() {
   const schemaIndexes = getRelatedSchemaIndexes(model, schema.indexes());
 
   const toDrop = getIndexesToDrop(schema, schemaIndexes, dbIndexes);
-  const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop);
+  const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop, options);
 
   return { toDrop, toCreate };
 };
 
-function getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop) {
+function getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop, options) {
   const toCreate = [];
+  const indexOptionsToCreate = options?.indexOptionsToCreate ?? false;
 
   for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
     let found = false;
@@ -1416,7 +1418,11 @@ function getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop) {
     }
 
     if (!found) {
-      toCreate.push(schemaIndexKeysObject);
+      if (indexOptionsToCreate) {
+        toCreate.push([schemaIndexKeysObject, schemaIndexOptions]);
+      } else {
+        toCreate.push(schemaIndexKeysObject);
+      }
     }
   }
 
@@ -1597,7 +1603,7 @@ Model.createIndexes = async function createIndexes(options) {
  */
 
 function _ensureIndexes(model, options, callback) {
-  const indexes = model.schema.indexes();
+  const indexes = Array.isArray(options?.toCreate) ? options.toCreate : model.schema.indexes();
   let indexError;
 
   options = options || {};
@@ -1679,12 +1685,6 @@ function _ensureIndexes(model, options, callback) {
 
     if ('background' in options) {
       indexOptions.background = options.background;
-    }
-
-    if ('toCreate' in options) {
-      if (options.toCreate.length === 0) {
-        return done();
-      }
     }
 
     // Just in case `createIndex()` throws a sync error

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5056,6 +5056,26 @@ describe('Model', function() {
         assert.strictEqual(indexes[1].background, false);
       });
 
+      it('syncIndexes() does not call createIndex for indexes that already exist', async function() {
+        const opts = { autoIndex: false };
+        const schema = new Schema({ name: String }, opts);
+        schema.index({ name: 1 }, { background: true });
+
+        const M = db.model('Test', schema);
+        await M.syncIndexes();
+
+        const indexes = await M.listIndexes();
+        assert.deepEqual(indexes[1].key, { name: 1 });
+
+        sinon.stub(M.collection, 'createIndex').callsFake(() => Promise.resolve());
+        try {
+          await M.syncIndexes();
+          assert.equal(M.collection.createIndex.getCalls().length, 0);
+        } finally {
+          sinon.restore();
+        }
+      });
+
       it('syncIndexes() supports hideIndexes (gh-14868)', async function() {
         const opts = { autoIndex: false };
         const schema = new Schema({ name: String }, opts);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Following up on #12250: `syncIndexes()` still calls `createIndex` on indexes that already exist - `toCreate` is ignored except for when `toCreate` is an empty array re: #12785. I recently ran into this issue again, and I figure it is worth fixing, at least in a minor release.

I also needed to add an option to `diffIndexes()` to make it return both index spec and index options in `toCreate()`, so we know what index options to use if using `toCreate`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
