### PR TITLE
fix(schema): handle bitwise operators on Int32

### DIFF
--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -209,7 +209,7 @@ SchemaBigInt.prototype.castForQuery = function($conditional, val, context) {
       return handler.call(this, val);
     }
 
-    return this.applySetters(null, val, context);
+    return this.applySetters(val, context);
   }
 
   try {

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -253,7 +253,7 @@ SchemaBoolean.prototype.castForQuery = function($conditional, val, context) {
       return handler.call(this, val);
     }
 
-    return this.applySetters(null, val, context);
+    return this.applySetters(val, context);
   }
 
   try {

--- a/lib/schema/int32.js
+++ b/lib/schema/int32.js
@@ -7,6 +7,7 @@
 const CastError = require('../error/cast');
 const SchemaType = require('../schemaType');
 const castInt32 = require('../cast/int32');
+const handleBitwiseOperator = require('./operators/bitwise');
 
 /**
  * Int32 SchemaType constructor.
@@ -200,7 +201,11 @@ SchemaInt32.$conditionalHandlers = {
   $gt: handleSingle,
   $gte: handleSingle,
   $lt: handleSingle,
-  $lte: handleSingle
+  $lte: handleSingle,
+  $bitsAllClear: handleBitwiseOperator,
+  $bitsAnyClear: handleBitwiseOperator,
+  $bitsAllSet: handleBitwiseOperator,
+  $bitsAnySet: handleBitwiseOperator
 };
 
 /*!
@@ -228,7 +233,7 @@ SchemaInt32.prototype.castForQuery = function($conditional, val, context) {
       return handler.call(this, val);
     }
 
-    return this.applySetters(null, val, context);
+    return this.applySetters(val, context);
   }
 
   try {

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -259,7 +259,7 @@ describe('cast: ', function() {
 
   it('treats unknown operators as passthrough (gh-15170)', function() {
     const schema = new Schema({ x: Boolean });
-    assert.deepEqual(cast(schema, { x: { $someConditional: true } }),
+    assert.deepEqual(cast(schema, { x: { $someConditional: 'true' } }),
       { x: { $someConditional: true } });
   });
 });

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -123,6 +123,12 @@ describe('cast: ', function() {
         { x: { $bitsAnyClear: Buffer.from([3]) } });
     });
 
+    it('with int32 (gh-15170)', function() {
+      const schema = new Schema({ x: 'Int32' });
+      assert.deepEqual(cast(schema, { x: { $bitsAnySet: 3 } }),
+        { x: { $bitsAnySet: 3 } });
+    });
+
     it('throws when invalid', function() {
       const schema = new Schema({ x: Number });
       assert.throws(function() {
@@ -249,5 +255,11 @@ describe('cast: ', function() {
       'state.type': { $in: ['FOO'] },
       'state.fieldFoo': '44'
     });
+  });
+
+  it('treats unknown operators as passthrough (gh-15170)', function() {
+    const schema = new Schema({ x: Boolean });
+    assert.deepEqual(cast(schema, { x: { $someConditional: true } }),
+      { x: { $someConditional: true } });
   });
 });


### PR DESCRIPTION
Fix #15170

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Added bitwise operator support to int32. Also fixed a couple of invalid `applySetters()` calls: `this.applySetters(null, val, context);` is incorrect args, first param to applySetters is value and 2nd is context. This makes it so that any operators that we don't have an explicit definition for are casted to the given schematype. For example, if `x` is a boolean, then `{ x: { $someConditional: 'true' } }` will get casted to `$someConditional: true`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
