### PR TITLE
fix(collection): avoid buffering if creating a collection during a connection interruption

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -29,7 +29,7 @@ function Collection(name, conn, opts) {
   this.collectionName = name;
   this.conn = conn;
   this.queue = [];
-  this.buffer = true;
+  this.buffer = !conn?._hasOpened;
   this.emitter = new EventEmitter();
 
   if (STATES.connected === this.conn.readyState) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Should be a fix for #14971.

In Mongoose 7+8, buffering should only happen before `mongoose.connect()` has been called. The reason why Mongoose still has buffering is that the MongoDB node driver will error out if you try to send a database operation on a MongoClient instance that you haven't called `connect()` on yet. But once the MongoDB Node driver has connected successfully to MongoDB at least once, database operations like `find()` etc. handle retries and disconnection via an internal server selection process, so Mongoose buffering is unnecessary.

When investigating #14971, I found that Mongoose may still buffer if the collection is created during a connection interruption. For example, in the following script, `console.log('Buffer', TestModel.collection.buffer);` will print "Buffer true" if you shut down the MongoDB server on 127.0.0.1:27017 when "Waiting 5 seconds, shut down the MongoDB server now" prints

```javascript
'use strict';

const mongoose = require('mongoose');

(async function main() {
  await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_test');

  console.log('Waiting 5 seconds, shut down the MongoDB server now');
  await new Promise(resolve => setTimeout(resolve, 5000));

  console.log('Executing find...');
  const TestModel = mongoose.model('Test', mongoose.Schema({ name: String }));
  console.log('Buffer', TestModel.collection.buffer);
  const promise = TestModel.find().exec();


  console.log(await promise);
  console.log('Done');
})();   
```

With this fix, buffering will not kick in, the above script will print "Buffer false". Which should prevent unintended buffering in the future.

`_hasOpened` is a property that Mongoose sets on the connection the first time the connection's `readyState` is set to `1` (connected)

In the interest of being cautious, I'm putting this and #14971 in the 8.10 milestone.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
