### PR TITLE
fix(model): disallow `updateMany(update)` and fix TypeScript types re: `updateMany()`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3878,6 +3878,10 @@ Model.hydrate = function(obj, projection, options) {
  *     res.upsertedId; // null or an id containing a document that had to be upserted.
  *     res.upsertedCount; // Number indicating how many documents had to be upserted. Will either be 0 or 1.
  *
+ *     // Other supported syntaxes
+ *     await Person.find({ name: /Stark$/ }).updateMany({ isDeleted: true }); // Using chaining syntax
+ *     await Person.find().updateMany({ isDeleted: true }); // Set `isDeleted` on _all_ Person documents
+ *
  * This function triggers the following middleware.
  *
  * - `updateMany()`
@@ -3898,10 +3902,14 @@ Model.hydrate = function(obj, projection, options) {
  * @api public
  */
 
-Model.updateMany = function updateMany(conditions, doc, options) {
+Model.updateMany = function updateMany(conditions, update, options) {
   _checkContext(this, 'updateMany');
 
-  return _update(this, 'updateMany', conditions, doc, options);
+  if (update == null) {
+    throw new MongooseError('updateMany `update` parameter cannot be nullish');
+  }
+
+  return _update(this, 'updateMany', conditions, update, options);
 };
 
 /**
@@ -3917,6 +3925,10 @@ Model.updateMany = function updateMany(conditions, doc, options) {
  *     res.acknowledged; // Boolean indicating the MongoDB server received the operation. This may be false if Mongoose did not send an update to the server because the update was empty.
  *     res.upsertedId; // null or an id containing a document that had to be upserted.
  *     res.upsertedCount; // Number indicating how many documents had to be upserted. Will either be 0 or 1.
+ *
+ *     // Other supported syntaxes
+ *     await Person.findOne({ name: 'Jean-Luc Picard' }).updateOne({ ship: 'USS Enterprise' }); // Using chaining syntax
+ *     await Person.updateOne({ ship: 'USS Enterprise' }); // Updates first doc's `ship` property
  *
  * This function triggers the following middleware.
  *

--- a/lib/query.js
+++ b/lib/query.js
@@ -3992,6 +3992,10 @@ Query.prototype._replaceOne = async function _replaceOne() {
  *     res.n; // Number of documents matched
  *     res.nModified; // Number of documents modified
  *
+ *     // Other supported syntaxes
+ *     await Person.find({ name: /Stark$/ }).updateMany({ isDeleted: true }); // Using chaining syntax
+ *     await Person.find().updateMany({ isDeleted: true }); // Set `isDeleted` on _all_ Person documents
+ *
  * This function triggers the following middleware.
  *
  * - `updateMany()`
@@ -4061,6 +4065,10 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  *     res.modifiedCount; // Number of documents that were modified
  *     res.upsertedCount; // Number of documents that were upserted
  *     res.upsertedId; // Identifier of the inserted document (if an upsert took place)
+ *
+ *     // Other supported syntaxes
+ *     await Person.findOne({ name: 'Jean-Luc Picard' }).updateOne({ ship: 'USS Enterprise' }); // Using chaining syntax
+ *     await Person.updateOne({ ship: 'USS Enterprise' }); // Updates first doc's `ship` property
  *
  * This function triggers the following middleware.
  *

--- a/test/model.middleware.preposttypes.test.js
+++ b/test/model.middleware.preposttypes.test.js
@@ -288,8 +288,8 @@ describe('pre/post hooks, type of this', function() {
       await Doc.findOneAndReplace({}, { data: 'valueRep' }).exec();
       await Doc.findOneAndUpdate({}, { data: 'valueUpd' }).exec();
       await Doc.replaceOne({}, { data: 'value' }).exec();
-      await Doc.updateOne({ data: 'value' }).exec();
-      await Doc.updateMany({ data: 'value' }).exec();
+      await Doc.updateOne({}, { data: 'value' }).exec();
+      await Doc.updateMany({}, { data: 'value' }).exec();
 
       // MongooseQueryOrDocumentMiddleware, use Query
       await Doc.deleteOne({}).exec(); await Doc.create({ data: 'value' });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8419,6 +8419,15 @@ describe('Model', function() {
       assert.deepStrictEqual(toDrop, []);
     });
   });
+
+  it('throws error if calling `updateMany()` with no update param (gh-15190)', async function() {
+    const Test = db.model('Test', mongoose.Schema({ foo: String }));
+
+    assert.throws(
+      () => Test.updateMany({ foo: 'bar' }),
+      { message: 'updateMany `update` parameter cannot be nullish' }
+    );
+  });
 });
 
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1962,7 +1962,7 @@ describe('Query', function() {
       });
 
       schema.pre('deleteOne', { document: true, query: false }, async function() {
-        await this.constructor.updateOne({ isDeleted: true });
+        await this.updateOne({ isDeleted: true });
         this.$isDeleted(true);
       });
 

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -869,16 +869,19 @@ declare module 'mongoose' {
 
     /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
     updateMany<ResultDoc = THydratedDocumentType>(
-      filter?: RootFilterQuery<TRawDocType>,
-      update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
+      filter: RootFilterQuery<TRawDocType>,
+      update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
       options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateMany', TInstanceMethods & TVirtuals>;
 
     /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
     updateOne<ResultDoc = THydratedDocumentType>(
-      filter?: RootFilterQuery<TRawDocType>,
-      update?: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
+      filter: RootFilterQuery<TRawDocType>,
+      update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
       options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
+    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateOne', TInstanceMethods & TVirtuals>;
+    updateOne<ResultDoc = THydratedDocumentType>(
+      update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TRawDocType, 'updateOne', TInstanceMethods & TVirtuals>;
 
     /** Creates a Query, applies the passed conditions, and returns the Query. */

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -850,9 +850,12 @@ declare module 'mongoose' {
      * the `multi` option.
      */
     updateMany(
-      filter?: RootFilterQuery<RawDocType>,
-      update?: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
+      filter: RootFilterQuery<RawDocType>,
+      update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<DocType> | null
+    ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateMany', TDocOverrides>;
+    updateMany(
+      update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateMany', TDocOverrides>;
 
     /**
@@ -860,9 +863,12 @@ declare module 'mongoose' {
      * `update()`, except it does not support the `multi` or `overwrite` options.
      */
     updateOne(
-      filter?: RootFilterQuery<RawDocType>,
-      update?: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
+      filter: RootFilterQuery<RawDocType>,
+      update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<DocType> | null
+    ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateOne', TDocOverrides>;
+    updateOne(
+      update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateOne', TDocOverrides>;
 
     /**


### PR DESCRIPTION
Fix #15190

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15190 points out that `Model.updateMany(obj)` updates all documents using `obj`, which is risky, especially given that our TypeScript types as written imply that `update` parameter is optional, meaning `updateMany(obj)` treats `obj` as `filter` rather than `update`, but the runtime behavior is different.

This PR specifically blocks `Model.updateMany(obj, null)`, while allowing `Model.updateOne(obj)` and `Query.prototype.updateMany(obj, null)`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
