### PR TITLE
fix(document): allow setting values to undefined with set(obj) syntax with strict: false

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1147,7 +1147,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
         } else if (pathtype === 'nested' && valForKey == null) {
           this.$set(pathName, valForKey, constructing, options);
         }
-      } else if (valForKey !== void 0) {
+      } else {
         this.$set(pathName, valForKey, constructing, options);
       }
     }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -7363,6 +7363,27 @@ describe('document', function() {
     assert.strictEqual(obj.subDoc.timestamp, date);
   });
 
+  it('supports setting values to undefined with strict: false (gh-15192)', async function() {
+    const helloSchema = new mongoose.Schema({
+      name: { type: String, required: true },
+      status: { type: Boolean, required: true },
+      optional: { type: Number }
+    }, { strict: false });
+    const Hello = db.model('Test', helloSchema);
+
+    const obj = new Hello({ name: 'abc', status: true, optional: 1 });
+    const doc = await obj.save();
+
+    doc.set({ optional: undefined });
+
+    assert.ok(doc.isModified());
+
+    await doc.save();
+
+    const { optional } = await Hello.findById(doc._id).orFail();
+    assert.strictEqual(optional, undefined);
+  });
+
   it('handles .set() on doc array within embedded discriminator (gh-7656)', function() {
     const pageElementSchema = new Schema({
       type: { type: String, required: true }


### PR DESCRIPTION
Fix #15192

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I'm not certain why this `!== void 0` check is there, but that behavior doesn't break any of our tests and goes back to at least 2013: https://github.com/Automattic/mongoose/commit/be7d9784cfe3c902aeca414ef87913eb04ff3b6b. Likely just a bug that was introduced when adding strict mode that was never fixed.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
