### PR TITLE
fix: avoid applying defaults on map embedded paths

### DIFF
--- a/lib/helpers/document/applyDefaults.js
+++ b/lib/helpers/document/applyDefaults.js
@@ -19,6 +19,9 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
     const type = doc.$__schema.paths[p];
     const path = type.splitPath();
     const len = path.length;
+    if (path[len - 1] === '$*') {
+      continue;
+    }
     let included = false;
     let doc_ = doc._doc;
     for (let j = 0; j < len; ++j) {

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1168,14 +1168,11 @@ describe('Map', function() {
     let doc1 = new Test({ name: 'name1', test_map: new Map() });
     await doc1.save();
 
-    // 1. Refresh the document from the db
     doc1 = await Test.findOne({ _id: doc1._id });
 
-    // 2. Modify the document (add a new key in the test_map map)
     doc1.test_map.set('key1', []);
     await doc1.save();
 
-    // 3. Now, the document is wrong in the db and we cannot access the test_map anymore.
     doc1 = await Test.findOne({ _id: doc1._id });
     assert.deepStrictEqual(doc1.toObject().test_map, new Map([['key1', []]]));
 


### PR DESCRIPTION
Fix #15196

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Because arrays implicitly have a default value of `[]`, maps of arrays currently have incorrect change tracking when loaded from the db because `map.$*` is marked as state `default`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
