### PR TITLE
Introduce populate ordered option for populating in series rather than in parallel

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4508,6 +4508,8 @@ Document.prototype.equals = function(doc) {
  * @param {Object|Function} [options.match=null] Add an additional filter to the populate query. Can be a filter object containing [MongoDB query syntax](https://www.mongodb.com/docs/manual/tutorial/query-documents/), or a function that returns a filter object.
  * @param {Function} [options.transform=null] Function that Mongoose will call on every populated document that allows you to transform the populated document.
  * @param {Object} [options.options=null] Additional options like `limit` and `lean`.
+ * @param {Boolean} [options.forceRepopulate=true] Set to `false` to prevent Mongoose from repopulating paths that are already populated
+ * @param {Boolean} [options.ordered=false] Set to `true` to execute any populate queries one at a time, as opposed to in parallel. We recommend setting this option to `true` if using transactions, especially if also populating multiple paths or paths with multiple models. MongoDB server does **not** support multiple operations in parallel on a single transaction.
  * @param {Function} [callback] Callback
  * @see population https://mongoosejs.com/docs/populate.html
  * @see Query#select https://mongoosejs.com/docs/api/query.html#Query.prototype.select()
@@ -4525,20 +4527,15 @@ Document.prototype.populate = async function populate() {
     throw new MongooseError('Document.prototype.populate() no longer accepts a callback');
   }
 
-  let ordered = null;
   if (args.length !== 0) {
     // use hash to remove duplicate paths
     const res = utils.populate.apply(null, args);
-    ordered = res.ordered;
     for (const populateOptions of res) {
       pop[populateOptions.path] = populateOptions;
     }
   }
 
   const paths = utils.object.vals(pop);
-  if (ordered) {
-    paths.ordered = ordered;
-  }
 
   let topLevelModel = this.constructor;
   if (this.$__isNested) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -4525,15 +4525,21 @@ Document.prototype.populate = async function populate() {
     throw new MongooseError('Document.prototype.populate() no longer accepts a callback');
   }
 
+  let ordered = null;
   if (args.length !== 0) {
     // use hash to remove duplicate paths
     const res = utils.populate.apply(null, args);
+    ordered = res.ordered;
     for (const populateOptions of res) {
       pop[populateOptions.path] = populateOptions;
     }
   }
 
   const paths = utils.object.vals(pop);
+  if (ordered) {
+    paths.ordered = ordered;
+  }
+
   let topLevelModel = this.constructor;
   if (this.$__isNested) {
     topLevelModel = this.$__[scopeSymbol].constructor;

--- a/lib/model.js
+++ b/lib/model.js
@@ -4275,11 +4275,20 @@ Model.populate = async function populate(docs, paths) {
   }
 
   // each path has its own query options and must be executed separately
-  const promises = [];
-  for (const path of paths) {
-    promises.push(_populatePath(this, docs, path));
+  if (paths.ordered) {
+    // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
+    // one transaction in parallel.
+    for (const path of paths) {
+      await _populatePath(this, docs, path);
+    }
+  } else {
+    // By default, populate in parallel
+    const promises = [];
+    for (const path of paths) {
+      promises.push(_populatePath(this, docs, path));
+    }
+    await Promise.all(promises);
   }
-  await Promise.all(promises);
 
   return docs;
 };
@@ -4399,12 +4408,22 @@ async function _populatePath(model, docs, populateOptions) {
     return;
   }
 
-  const promises = [];
-  for (const arr of params) {
-    promises.push(_execPopulateQuery.apply(null, arr).then(valsFromDb => { vals = vals.concat(valsFromDb); }));
+  if (populateOptions.ordered) {
+    // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
+    // one transaction in parallel.
+    for (const arr of params) {
+      await _execPopulateQuery.apply(null, arr).then(valsFromDb => { vals = vals.concat(valsFromDb); });
+    }
+  } else {
+    // By default, populate in parallel
+    const promises = [];
+    for (const arr of params) {
+      promises.push(_execPopulateQuery.apply(null, arr).then(valsFromDb => { vals = vals.concat(valsFromDb); }));
+    }
+
+    await Promise.all(promises);
   }
 
-  await Promise.all(promises);
 
   for (const arr of params) {
     const mod = arr[0];

--- a/lib/model.js
+++ b/lib/model.js
@@ -4258,6 +4258,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
  * @param {Object} [options.options=null] Additional options like `limit` and `lean`.
  * @param {Function} [options.transform=null] Function that Mongoose will call on every populated document that allows you to transform the populated document.
  * @param {Boolean} [options.forceRepopulate=true] Set to `false` to prevent Mongoose from repopulating paths that are already populated
+ * @param {Boolean} [options.ordered=false] Set to `true` to execute any populate queries one at a time, as opposed to in parallel. Set this option to `true` if populating multiple paths or paths with multiple models in transactions.
  * @return {Promise}
  * @api public
  */
@@ -4275,9 +4276,10 @@ Model.populate = async function populate(docs, paths) {
   }
 
   // each path has its own query options and must be executed separately
-  if (paths.ordered) {
+  if (paths.find(p => p.ordered)) {
     // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
     // one transaction in parallel.
+    // Note that if _any_ path has `ordered`, we make the top-level populate `ordered` as well.
     for (const path of paths) {
       await _populatePath(this, docs, path);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -523,11 +523,7 @@ exports.populate = function populate(path, select, model, match, options, subPop
 
     if (Array.isArray(path)) {
       const singles = makeSingles(path);
-      const ret = singles.map(o => exports.populate(o)[0]);
-      if (path.ordered) {
-        ret.ordered = path.ordered;
-      }
-      return ret;
+      return singles.map(o => exports.populate(o)[0]);
     }
 
     if (exports.isObject(path)) {
@@ -615,13 +611,6 @@ function _populateObj(obj) {
 
   for (const path of paths) {
     ret.push(new PopulateOptions(Object.assign({}, obj, { path: path })));
-  }
-
-  if (obj.ordered) {
-    ret.ordered = true;
-    for (const path of ret) {
-      path.ordered = true;
-    }
   }
 
   return ret;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -523,7 +523,11 @@ exports.populate = function populate(path, select, model, match, options, subPop
 
     if (Array.isArray(path)) {
       const singles = makeSingles(path);
-      return singles.map(o => exports.populate(o)[0]);
+      const ret = singles.map(o => exports.populate(o)[0]);
+      if (path.ordered) {
+        ret.ordered = path.ordered;
+      }
+      return ret;
     }
 
     if (exports.isObject(path)) {
@@ -551,8 +555,8 @@ exports.populate = function populate(path, select, model, match, options, subPop
     };
   }
 
-  if (typeof obj.path !== 'string') {
-    throw new TypeError('utils.populate: invalid path. Expected string. Got typeof `' + typeof path + '`');
+  if (typeof obj.path !== 'string' && !(Array.isArray(obj.path) && obj.path.every(el => typeof el === 'string'))) {
+    throw new TypeError('utils.populate: invalid path. Expected string or array of strings. Got typeof `' + typeof path + '`');
   }
 
   return _populateObj(obj);
@@ -600,13 +604,24 @@ function _populateObj(obj) {
   }
 
   const ret = [];
-  const paths = oneSpaceRE.test(obj.path) ? obj.path.split(manySpaceRE) : [obj.path];
+  const paths = oneSpaceRE.test(obj.path)
+    ? obj.path.split(manySpaceRE)
+    : Array.isArray(obj.path)
+      ? obj.path
+      : [obj.path];
   if (obj.options != null) {
     obj.options = clone(obj.options);
   }
 
   for (const path of paths) {
     ret.push(new PopulateOptions(Object.assign({}, obj, { path: path })));
+  }
+
+  if (obj.ordered) {
+    ret.ordered = true;
+    for (const path of ret) {
+      path.ordered = true;
+    }
   }
 
   return ret;

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -39,6 +39,12 @@ declare module 'mongoose' {
     foreignField?: string;
     /** Set to `false` to prevent Mongoose from repopulating paths that are already populated */
     forceRepopulate?: boolean;
+    /**
+     * Set to `true` to execute any populate queries one at a time, as opposed to in parallel.
+     * We recommend setting this option to `true` if using transactions, especially if also populating multiple paths or paths with multiple models.
+     * MongoDB server does **not** support multiple operations in parallel on a single transaction.
+     */
+    ordered?: boolean;
   }
 
   interface PopulateOption {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently Mongoose executes all populate queries in parallel, which is problematic for transactions. Re: #15091, #15100, etc., MongoDB server does not support multiple operations in parallel within a single transaction. With this PR, you can populate with `ordered: true` as follows

Fix #15210

```javascript
// Document.prototype.populate() with multiple paths
await docD
  .populate({
          path: ['refA', 'refB', 'refC'], 
          ordered: true
  })

// query.populate() with options
await Model.find().populate([{ path: 'refA', ordered: true }, { path: 'refB', ordered: true }]);

```

A couple of noteworthy caveats:

1. The options passed to `populate()` is always an array, because `ordered` is the only option we have that configures the top-level `populate()` call, as opposed to the individual `_populatePaths()` calls. That makes it somewhat tricky to pass `ordered` as a top-level option: assigning `ordered` as a property on the `paths` array is a bit error prone because it is easy to copy the array and lose `ordered`. So we made it so that we treat top-level populate as `ordered` if _any_ of the populate `paths` are set to `ordered`, which seems like a reasonable workaround.
2. Before this PR, you couldn't pass an array of strings as populate `path` option. This PR allows passing an array of strings as `path`.

```javascript
// This is fine in Mongoose 8.9, will populate `refA`, `refB`, `refC` as expected
await docD
  .populate({
          path: 'refA refB refC'
  })

// In Mongoose 8.9, the following would throw an error. With this PR, the following will be equivalent to the above
await docD
  .populate({
          path: ['refA', 'refB', 'refC'],
  })
```

This PR may be helpful for #13985, but I need to double check.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
