### PR TITLE
docs(document): clarify that toObject() returns a POJO that may contain non-POJO values

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4069,7 +4069,7 @@ Document.prototype.$__toObjectShallow = function $__toObjectShallow() {
  * @param {Boolean} [options.flattenMaps=false] if true, convert Maps to POJOs. Useful if you want to `JSON.stringify()` the result of `toObject()`.
  * @param {Boolean} [options.flattenObjectIds=false] if true, convert any ObjectIds in the result to 24 character hex strings.
  * @param {Boolean} [options.useProjection=false] - If true, omits fields that are excluded in this document's projection. Unless you specified a projection, this will omit any field that has `select: false` in the schema.
- * @return {Object} js object (not a POJO)
+ * @return {Object} document as a plain old JavaScript object (POJO). This object may contain ObjectIds, Maps, Dates, mongodb.Binary, Buffers, and other non-POJO values.
  * @see mongodb.Binary https://mongodb.github.io/node-mongodb-native/4.9/classes/Binary.html
  * @api public
  * @memberOf Document


### PR DESCRIPTION
Fix #15208

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`toObject()` docs say that `toObject()` returns a POJO and also say that `toObject()` does not return a POJO. I think this new explanation clarifies things a little better: `toObject()` returns a POJO, but may contain non-POJO wrapper objects like ObjectId, etc.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
