### PR TITLE
fix(connection): unref the "_waitForConnect"

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -842,6 +842,11 @@ Connection.prototype._waitForConnect = async function _waitForConnect() {
           },
           bufferTimeoutMS
         );
+
+        // dont cause this timeout to keep the js process alive
+        if ('unref' in timeout) {
+          timeout.unref();
+        }
       })
     ]);
 


### PR DESCRIPTION
**Summary**

The recent change in #15229 has added a timeout, which can lead to having the node process around for longer than expected (ie until the timeout has fired), which can cause jest to detect open handles.
(I had also encountered this while upgrading typegoose)

Also the check of `unref` existing is made for alternative engines like deno and bun, where i had previously encountered that `unref` may not always be implemented.

fixes #15241