### PR TITLE
fix: avoid connection buffering on init if autoCreate: false

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1103,16 +1103,28 @@ Model.init = function init() {
     return results;
   };
   const _createCollection = async() => {
-    await conn._waitForConnect();
-    const autoCreate = utils.getOption(
+    let autoCreate = utils.getOption(
       'autoCreate',
       this.schema.options,
-      conn.config,
-      conn.base.options
+      conn.config
+      // No base.options here because we don't want to take the base value if the connection hasn't
+      // set it yet
     );
+    if (autoCreate == null) {
+      // `autoCreate` may later be set when the connection is opened, so wait for connect before checking
+      await conn._waitForConnect();
+      autoCreate = utils.getOption(
+        'autoCreate',
+        this.schema.options,
+        conn.config,
+        conn.base.options
+      );
+    }
+
     if (!autoCreate) {
       return;
     }
+
     return await this.createCollection();
   };
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1637,6 +1637,19 @@ describe('connections:', function() {
     assert.ok(!res.map(c => c.name).includes('gh12940_Conn'));
   });
 
+  it('does not wait for buffering if autoCreate: false (gh-15241)', async function() {
+    const m = new mongoose.Mongoose();
+    m.set('bufferTimeoutMS', 100);
+
+    const schema = new Schema({ name: String }, {
+      autoCreate: false
+    });
+    const Model = m.model('gh15241_Conn', schema);
+
+    // Without gh-15241 changes, this would buffer and fail even though `autoCreate: false`
+    await Model.init();
+  });
+
   it('should not create default connection with createInitialConnection = false (gh-12965)', function() {
     const m = new mongoose.Mongoose({
       createInitialConnection: false


### PR DESCRIPTION
Re: #15241

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: discussiong from #15241, make it so that `autoCreate: false` prevents buffering in `init()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
