### PR TITLE
fix(model): avoid adding timeout on `Model.init()` buffering to avoid unintentional dangling open handles

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -818,32 +818,40 @@ Connection.prototype.dropCollection = async function dropCollection(collection) 
 /**
  * Waits for connection to be established, so the connection has a `client`
  *
+ * @param {Boolean} [noTimeout=false] if set, don't put a timeout on the operation. Used internally so `mongoose.model()` doesn't leave open handles.
  * @return Promise
  * @api private
  */
 
-Connection.prototype._waitForConnect = async function _waitForConnect() {
+Connection.prototype._waitForConnect = async function _waitForConnect(noTimeout) {
   if ((this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands()) {
     const bufferTimeoutMS = this._getBufferTimeoutMS();
     let timeout = null;
     let timedOut = false;
     // The element that this function pushes onto `_queue`, stored to make it easy to remove later
     const queueElement = {};
-    await Promise.race([
-      new Promise(resolve => {
+    if (noTimeout) {
+      await new Promise(resolve => {
         queueElement.fn = resolve;
         this._queue.push(queueElement);
-      }),
-      new Promise(resolve => {
-        timeout = setTimeout(
-          () => {
-            timedOut = true;
-            resolve();
-          },
-          bufferTimeoutMS
-        );
-      })
-    ]);
+      });
+    } else {
+      await Promise.race([
+        new Promise(resolve => {
+          queueElement.fn = resolve;
+          this._queue.push(queueElement);
+        }),
+        new Promise(resolve => {
+          timeout = setTimeout(
+            () => {
+              timedOut = true;
+              resolve();
+            },
+            bufferTimeoutMS
+          );
+        })
+      ]);
+    }
 
     if (timedOut) {
       const index = this._queue.indexOf(queueElement);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -830,17 +830,18 @@ Connection.prototype._waitForConnect = async function _waitForConnect(noTimeout)
     let timedOut = false;
     // The element that this function pushes onto `_queue`, stored to make it easy to remove later
     const queueElement = {};
+
+    // Mongoose executes all elements in `_queue` when initial connection succeeds in `onOpen()`.
+    const waitForConnectPromise = new Promise(resolve => {
+      queueElement.fn = resolve;
+      this._queue.push(queueElement);
+    });
+
     if (noTimeout) {
-      await new Promise(resolve => {
-        queueElement.fn = resolve;
-        this._queue.push(queueElement);
-      });
+      await waitForConnectPromise;
     } else {
       await Promise.race([
-        new Promise(resolve => {
-          queueElement.fn = resolve;
-          this._queue.push(queueElement);
-        }),
+        waitForConnectPromise,
         new Promise(resolve => {
           timeout = setTimeout(
             () => {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1112,7 +1112,7 @@ Model.init = function init() {
     );
     if (autoCreate == null) {
       // `autoCreate` may later be set when the connection is opened, so wait for connect before checking
-      await conn._waitForConnect();
+      await conn._waitForConnect(true);
       autoCreate = utils.getOption(
         'autoCreate',
         this.schema.options,


### PR DESCRIPTION
Fix #15241

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Make `Model.init()` skip buffering timeouts introduced in #15229

Based on discussion from #15241, I think this is a reasonable approach which gives us the benefits of #15229 without the implicit dangling handles. The following Jest test won't complain about open handles:

```js
const mongoose = require('mongoose');

// Define a User schema and model
const userSchema = new mongoose.Schema({
  name: String,
  email: String,
  age: Number
});

const User = mongoose.model('User', userSchema);

describe('Database connection', () => {
  it('test', function () {

  });
});
```

However, the following script will still error out with buffering timeout, as opposed to silently exiting with no error.

```js
'use strict';

const mongoose = require('mongoose');

(async function() {
  await mongoose.connection.listCollections();
})();
```

So explicit connection helper calls will be subject to buffer timeouts, but we will ignore buffer timeouts for `Model.init()` because `Model.init()` is called implicitly and there are use cases where you may want to create a model without opening the underlying connection, like testing document functionality.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
