### PR TITLE
perf(schema): clear childSchemas when overwriting existing path to avoid performance degradations

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1118,6 +1118,9 @@ Schema.prototype.path = function(path, obj) {
   this.paths[path] = this.interpretAsType(path, obj, this.options);
   const schemaType = this.paths[path];
 
+  // If overwriting an existing path, make sure to clear the childSchemas
+  this.childSchemas = this.childSchemas.filter(childSchema => childSchema.path !== path);
+
   if (schemaType.$isSchemaMap) {
     // Maps can have arbitrary keys, so `$*` is internal shorthand for "any key"
     // The '$' is to imply this path should never be stored in MongoDB so we


### PR DESCRIPTION
Fix #15253

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently, overwriting an existing recursive path using `Schema.prototype.path()` leads to an exponential performance blowup because we're adding a separate recursive path to `childSchemas` on every `path()` call. For example, in the test case added, the document has 1092 subdocuments, but with 2 duplicate `childSchemas` entry Mongoose thinks there's over 56k subdocuments. With 3, Mongoose thinks there's about 560k subdocuments. I haven't been able to figure out a more complete explanation of the exact mathematical model of this growth, but suffice to say cleaning up duplicate childSchemas fixes the issue.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
