### PR TITLE
perf(document): only call `undoReset()` 1x/document

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3540,9 +3540,6 @@ Document.prototype.$__reset = function reset() {
  */
 
 Document.prototype.$__undoReset = function $__undoReset() {
-  if (this.$isSubdocument) {
-    return;
-  }
   if (this.$__.backup == null || this.$__.backup.activePaths == null) {
     return;
   }
@@ -3561,8 +3558,10 @@ Document.prototype.$__undoReset = function $__undoReset() {
     }
   }
 
-  for (const subdoc of this.$getAllSubdocs()) {
-    subdoc.$__undoReset();
+  if (!this.$isSubdocument) {
+    for (const subdoc of this.$getAllSubdocs()) {
+      subdoc.$__undoReset();
+    }
   }
 };
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -3540,6 +3540,9 @@ Document.prototype.$__reset = function reset() {
  */
 
 Document.prototype.$__undoReset = function $__undoReset() {
+  if (this.$isSubdocument) {
+    return;
+  }
   if (this.$__.backup == null || this.$__.backup.activePaths == null) {
     return;
   }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12,6 +12,7 @@ const ArraySubdocument = require('../lib/types/arraySubdocument');
 const Query = require('../lib/query');
 const assert = require('assert');
 const idGetter = require('../lib/helpers/schema/idGetter');
+const sinon = require('sinon');
 const util = require('./util');
 const utils = require('../lib/utils');
 
@@ -14295,6 +14296,47 @@ describe('document', function() {
     assert.deepStrictEqual(doc.toObject(), { _id, value: 1 });
 
     delete mongoose.Schema.Types.CustomType;
+  });
+
+  it('handles undoReset() on deep recursive subdocuments (gh-15255)', async function() {
+    const RecursiveSchema = new mongoose.Schema({});
+
+    const s = [RecursiveSchema];
+    RecursiveSchema.path('nested', s);
+
+    const generateRecursiveDocument = (depth, curr = 0) => {
+      return {
+        name: `Document of depth ${curr}`,
+        nested: depth > 0 ? new Array(2).fill().map(() => generateRecursiveDocument(depth - 1, curr + 1)) : [],
+        __v: 5
+      };
+    };
+    const TestModel = db.model('Test', RecursiveSchema);
+    const data = generateRecursiveDocument(10);
+    const doc = new TestModel(data);
+    await doc.save();
+
+    sinon.spy(Document.prototype, '$__undoReset');
+
+    try {
+      const d = await TestModel.findById(doc._id);
+      d.increment();
+      d.data = 'asd';
+      // Force a version error by updating the document directly
+      await TestModel.collection.updateOne({ _id: doc._id }, { $inc: { __v: 1 } });
+      const err = await d.save().then(() => null, err => err);
+      assert.ok(err);
+      assert.equal(err.name, 'VersionError');
+      // `$__undoReset()` should be called 1x per subdoc, plus 1x for top-level doc. Without fix for gh-15255,
+      // this would fail because `$__undoReset()` is called nearly 700k times for only 2046 subdocs
+      assert.strictEqual(Document.prototype.$__undoReset.getCalls().length, d.$getAllSubdocs().length + 1);
+      assert.ok(Document.prototype.$__undoReset.getCalls().find(call => call.thisValue === d), 'top level doc was not reset');
+      for (const subdoc of d.$getAllSubdocs()) {
+        assert.ok(Document.prototype.$__undoReset.getCalls().find(call => call.thisValue === subdoc), `${subdoc.name} was not reset`);
+      }
+    } finally {
+      sinon.restore();
+    }
   });
 });
 


### PR DESCRIPTION
Fix #15255

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now we call `$__undoReset()` for every subdoc multiple times, because each `$__undoReset()` call recursively calls `$__undoReset()` on all of its subdocuments. So skip the recursive call for subdocuments.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
