### PR TITLE
types: make type inference logic resilient to no Buffer type due to missing `@types/node`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -712,47 +712,53 @@ declare module 'mongoose' {
     [K in keyof T]: FlattenProperty<T[K]>;
   };
 
-  export type BufferToBinaryProperty<T> = T extends Buffer
-    ? mongodb.Binary
-    : T extends Types.DocumentArray<infer ItemType>
-      ? Types.DocumentArray<BufferToBinary<ItemType>>
-      : T extends Types.Subdocument<unknown, unknown, infer SubdocType>
-        ? HydratedSingleSubdocument<BufferToBinary<SubdocType>>
-        : BufferToBinary<T>;
+  export type BufferToBinaryProperty<T> = unknown extends Buffer
+    ? T
+    : T extends Buffer
+      ? mongodb.Binary
+      : T extends Types.DocumentArray<infer ItemType>
+        ? Types.DocumentArray<BufferToBinary<ItemType>>
+        : T extends Types.Subdocument<unknown, unknown, infer SubdocType>
+          ? HydratedSingleSubdocument<BufferToBinary<SubdocType>>
+          : BufferToBinary<T>;
 
   /**
    * Converts any Buffer properties into mongodb.Binary instances, which is what `lean()` returns
    */
-  export type BufferToBinary<T> = T extends Buffer
-    ? mongodb.Binary
-    : T extends Document
-      ? T
-      : T extends TreatAsPrimitives
-        ? T
-        : T extends Record<string, any>
-          ? {
-              [K in keyof T]: BufferToBinaryProperty<T[K]>
-            }
-          : T;
+   export type BufferToBinary<T> = unknown extends Buffer
+     ? T
+     : T extends Buffer
+       ? mongodb.Binary
+       : T extends Document
+         ? T
+         : T extends TreatAsPrimitives
+           ? T
+           : T extends Record<string, any>
+             ? {
+                 [K in keyof T]: BufferToBinaryProperty<T[K]>
+               }
+             : T;
 
   /**
-   * Converts any Buffer properties into { type: 'buffer', data: [1, 2, 3] } format for JSON serialization
-   */
-  export type BufferToJSON<T> = T extends Buffer
-    ? { type: 'buffer', data: number[] }
-    : T extends Document
-      ? T
-      : T extends TreatAsPrimitives
+  * Converts any Buffer properties into { type: 'buffer', data: [1, 2, 3] } format for JSON serialization
+  */
+  export type BufferToJSON<T> = unknown extends Buffer
+    ? T
+    : T extends Buffer
+      ? { type: 'buffer', data: number[] }
+      : T extends Document
         ? T
-        : T extends Record<string, any> ? {
-          [K in keyof T]: T[K] extends Buffer
-            ? { type: 'buffer', data: number[] }
-            : T[K] extends Types.DocumentArray<infer ItemType>
-                ? Types.DocumentArray<BufferToBinary<ItemType>>
-                : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
-                  ? HydratedSingleSubdocument<SubdocType>
-                  : BufferToBinary<T[K]>;
-        } : T;
+        : T extends TreatAsPrimitives
+          ? T
+          : T extends Record<string, any> ? {
+            [K in keyof T]: T[K] extends Buffer
+              ? { type: 'buffer', data: number[] }
+              : T[K] extends Types.DocumentArray<infer ItemType>
+                  ? Types.DocumentArray<BufferToBinary<ItemType>>
+                  : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
+                    ? HydratedSingleSubdocument<SubdocType>
+                    : BufferToBinary<T[K]>;
+          } : T;
 
   /**
    * Converts any ObjectId properties into strings for JSON serialization

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -235,13 +235,17 @@ type IsSchemaTypeFromBuiltinClass<T> = T extends (typeof String)
                               ? true
                               : T extends Types.Decimal128
                                 ? true
-                                : T extends Buffer
+                                : T extends NativeDate
                                   ? true
-                                  : T extends NativeDate
+                                  : T extends (typeof Schema.Types.Mixed)
                                     ? true
-                                    : T extends (typeof Schema.Types.Mixed)
+                                    : IfEquals<T, Schema.Types.ObjectId, true, false> extends true
                                       ? true
-                                      : IfEquals<T, Schema.Types.ObjectId, true, false>;
+                                      : unknown extends Buffer
+                                        ? false
+                                        : T extends Buffer
+                                          ? true
+                                          : false;
 
 /**
  * @summary Resolve path type by returning the corresponding type.


### PR DESCRIPTION
Fix #15121

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15121  points out an unpleasant edge case where our lean type inference breaks completely if `@types/node` isn't installed, because `Buffer === any`. Not something we can write tests for unfortunately. But this PR should make Mongoose more resilient to that case, I replaced all `extends Buffer` checks and we don't have any `: Buffer` or `?: Buffer` params or properties.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
