### PR TITLE
fix(debug): avoid printing trusted symbol in debug output

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -13,6 +13,8 @@ const internalToObjectOptions = require('../../options').internalToObjectOptions
 const stream = require('stream');
 const util = require('util');
 
+const formatToObjectOptions = Object.freeze({ ...internalToObjectOptions, copyTrustedSymbol: false });
+
 /**
  * A [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) collection implementation.
  *
@@ -384,7 +386,9 @@ function format(obj, sub, color, shell) {
   }
 
   const clone = require('../../helpers/clone');
-  let x = clone(obj, internalToObjectOptions);
+  // `sub` indicates `format()` was called recursively, so skip cloning because we already
+  // did a deep clone on the top-level object.
+  let x = sub ? obj : clone(obj, formatToObjectOptions);
   const constructorName = getConstructorName(x);
 
   if (constructorName === 'Binary') {

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -147,7 +147,7 @@ function cloneObject(obj, options, isArrayChild) {
   } else if (seen) {
     seen.set(obj, ret);
   }
-  if (trustedSymbol in obj) {
+  if (trustedSymbol in obj && options?.copyTrustedSymbol !== false) {
     ret[trustedSymbol] = obj[trustedSymbol];
   }
 


### PR DESCRIPTION
Re: #15263

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now `trustedSymbol` shows up in debug output, which can be extra confusing when debugging populate issues because populate adds trusted symbol by default:

```
Mongoose: groups.find({ key: { '$in': [ ObjectId("67b887650fca90b537952220"), ObjectId("67b887650fca90b537952224") ], [Symbol(mongoose#trustedSymbol)]: true }}, { skip: undefined, limit: undefined, perDocumentLimit: undefined })
```

This PR removes `trustedSymbol` from debug output.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
