### PR TITLE
feat(model): make bulkWrite `results` include MongoDB bulk write errors as well as validation errors

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3104,11 +3104,9 @@ Model.$__insertMany = function(arr, options, callback) {
         const res = {
           acknowledged: true,
           insertedCount: 0,
-          insertedIds: {},
-          mongoose: {
-            validationErrors: validationErrors
-          }
+          insertedIds: {}
         };
+        decorateBulkWriteResult(res, validationErrors, validationErrors);
         return callback(null, res);
       }
       callback(null, []);
@@ -3161,10 +3159,7 @@ Model.$__insertMany = function(arr, options, callback) {
 
             // Decorate with mongoose validation errors in case of unordered,
             // because then still do `insertMany()`
-            res.mongoose = {
-              validationErrors: validationErrors,
-              results: results
-            };
+            decorateBulkWriteResult(res, validationErrors, results);
           }
           return callback(null, res);
         }
@@ -3198,10 +3193,7 @@ Model.$__insertMany = function(arr, options, callback) {
         if (error.writeErrors != null) {
           for (let i = 0; i < error.writeErrors.length; ++i) {
             const originalIndex = validDocIndexToOriginalIndex.get(error.writeErrors[i].index);
-            error.writeErrors[i] = {
-              ...error.writeErrors[i],
-              index: originalIndex
-            };
+            error.writeErrors[i] = { ...error.writeErrors[i], index: originalIndex };
             if (!ordered) {
               results[originalIndex] = error.writeErrors[i];
             }
@@ -3245,10 +3237,7 @@ Model.$__insertMany = function(arr, options, callback) {
           });
 
         if (rawResult && ordered === false) {
-          error.mongoose = {
-            validationErrors: validationErrors,
-            results: results
-          };
+          decorateBulkWriteResult(error, validationErrors, results);
         }
 
         callback(error, null);
@@ -3486,8 +3475,14 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
       then(res => ([res, null])).
       catch(error => ([null, error]));
 
+    const writeErrorsByIndex = {};
+    if (error?.writeErrors) {
+      for (const writeError of error.writeErrors) {
+        writeErrorsByIndex[writeError.err.index] = writeError;
+      }
+    }
     for (let i = 0; i < validOpIndexes.length; ++i) {
-      results[validOpIndexes[i]] = null;
+      results[validOpIndexes[i]] = writeErrorsByIndex[i] ?? null;
     }
     if (error) {
       if (validationErrors.length > 0) {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -308,7 +308,7 @@ declare module 'mongoose' {
     bulkWrite<DocContents = TRawDocType>(
       writes: Array<AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
       options: MongooseBulkWriteOptions & { ordered: false }
-    ): Promise<mongodb.BulkWriteResult & { mongoose?: { validationErrors: Error[], results: Array<Error | null> } }>;
+    ): Promise<mongodb.BulkWriteResult & { mongoose?: { validationErrors: Error[], results: Array<Error | mongodb.WriteError | null> } }>;
     bulkWrite<DocContents = TRawDocType>(
       writes: Array<AnyBulkWriteOperation<DocContents extends Document ? any : (DocContents extends {} ? DocContents : any)>>,
       options?: MongooseBulkWriteOptions


### PR DESCRIPTION
Fix #15265

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When we return `mongoose.results` property from `bulkWrite()`, the results property doesn't currently include any MongoDB write errors that occurred. That makes it a multi-step process to determine whether a given bulk write operation succeeded or failed.

This is more consistent with how `insertMany()` handles errors: `insertMany()` already adds write errors to `results`. However, `insertMany()` has some logic where it modifies the WriteError's index, which we should consider removing because that makes the result not an instance of MongoDB's `WriteError` class.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
