### PR TITLE
fix(browser): expose "SchemaTypeOptions"

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -84,6 +84,15 @@ exports.VirtualType = require('./virtualType');
 exports.SchemaType = require('./schemaType.js');
 
 /**
+ * The constructor used for schematype options
+ *
+ * @method SchemaTypeOptions
+ * @api public
+ */
+
+exports.SchemaTypeOptions = require('./options/schemaTypeOptions');
+
+/**
  * Internal utils
  *
  * @property utils


### PR DESCRIPTION
**Summary**

This PR exposes `SchemaTypeOptions` on the browser build, like it is on the non-browser build.
As a workaround, it is already accessible via `mongoose.Schema.Types.Mixed.prototype.OptionsConstructor` (or similar) without this PR.

Btw, is the browser build still something that is supported?