### PR TITLE
chore(deps): match bson version with mongodb's bson version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "commonjs",
   "license": "MIT",
   "dependencies": {
-    "bson": "^6.10.1",
+    "bson": "^6.10.3",
     "kareem": "2.6.3",
     "mongodb": "~6.14.0",
     "mpath": "0.9.0",


### PR DESCRIPTION
**Summary**

This PR updates mongoose's `bson` dependency version to match [mongodb's bson version](https://github.com/mongodb/node-mongodb-native/blob/44bc5a880230a5be93afc9e2a4fa0a4586481edd/package.json#L29).
Because package managers that upgrade *might* decide to stay on the old version for mongoose but use newer for mongodb (like yarn 1x), as i had encountered while updating typegoose.
Mismatched version can cause (runtime) type check failures, like:
```txt
    expect(received).toBeInstanceOf(expected)

    Expected constructor: ObjectId
    Received constructor: ObjectId

      422 |
      423 |   found.mapped.forEach((v) => {
    > 424 |     expect(v).toBeInstanceOf(mongoose.Types.ObjectId);
          |               ^
      425 |   });
      426 |
      427 |   await found.populate('mapped.$*');

      at test/tests/ref.test.ts:424:15
          at MongooseMap.forEach (<anonymous>)
      at Object.<anonymous> (test/tests/ref.test.ts:423:16)
```