### PR TITLE
BREAKING CHANGE: remove _executionStack, make validate() async function and call Kareem hooks directly vs through wrappers

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,6 +5,7 @@
 require('./driver').set(require('./drivers/browser'));
 
 const DocumentProvider = require('./documentProvider.js');
+const applyHooks = require('./helpers/model/applyHooks.js');
 
 DocumentProvider.setBrowser(true);
 
@@ -127,6 +128,7 @@ exports.model = function(name, schema) {
     }
   }
   Model.modelName = name;
+  applyHooks(Model, schema);
 
   return Model;
 };

--- a/lib/browserDocument.js
+++ b/lib/browserDocument.js
@@ -94,6 +94,37 @@ Document.$emitter = new EventEmitter();
 });
 
 /*!
+ * ignore
+ */
+
+Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName) {
+  return new Promise((resolve, reject) => {
+    this._middleware.execPre(opName, this, [], (error) => {
+      if (error != null) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+};
+
+/*!
+ * ignore
+ */
+
+Document.prototype._execDocumentPostHooks = function _execDocumentPostHooks(opName, error) {
+  return new Promise((resolve, reject) => {
+    this._middleware.execPost(opName, this, [this], { error }, function(error) {
+      if (error) {
+        return reject(error);
+      }
+      resolve();
+    });
+  });
+};
+
+/*!
  * Module exports.
  */
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -2655,7 +2655,8 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
       this.$op = null;
       this.$__.validating = null;
       if (error != null) {
-        return reject(error);
+        reject(error);
+        return;
       }
       resolve();
     });
@@ -3012,13 +3013,14 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
   }
 
   const validated = {};
-  let total = 0;
+  let total = paths.length;
 
   let pathsToSave = this.$__.saveOptions?.pathsToSave;
   if (Array.isArray(pathsToSave)) {
     pathsToSave = new Set(pathsToSave);
     for (const path of paths) {
       if (!pathsToSave.has(path)) {
+        --total || complete();
         continue;
       }
       validatePath(path);
@@ -3031,67 +3033,62 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
 
   function validatePath(path) {
     if (path == null || validated[path]) {
-      return;
+      return --total || complete();
     }
 
     validated[path] = true;
-    total++;
+    const schemaType = _this.$__schema.path(path);
 
-    immediate(function() {
-      const schemaType = _this.$__schema.path(path);
+    if (!schemaType) {
+      return --total || complete();
+    }
 
-      if (!schemaType) {
-        return --total || complete();
-      }
+    // If user marked as invalid or there was a cast error, don't validate
+    if (!_this.$isValid(path)) {
+      return --total || complete();
+    }
 
-      // If user marked as invalid or there was a cast error, don't validate
-      if (!_this.$isValid(path)) {
-        --total || complete();
-        return;
-      }
+    // If setting a path under a mixed path, avoid using the mixed path validator (gh-10141)
+    if (schemaType[schemaMixedSymbol] != null && path !== schemaType.path) {
+      return --total || complete();
+    }
 
-      // If setting a path under a mixed path, avoid using the mixed path validator (gh-10141)
-      if (schemaType[schemaMixedSymbol] != null && path !== schemaType.path) {
-        return --total || complete();
-      }
+    let val = _this.$__getValue(path);
 
-      let val = _this.$__getValue(path);
+    // If you `populate()` and get back a null value, required validators
+    // shouldn't fail (gh-8018). We should always fall back to the populated
+    // value.
+    let pop;
+    if ((pop = _this.$populated(path))) {
+      val = pop;
+    } else if (val != null && val.$__ != null && val.$__.wasPopulated) {
+      // Array paths, like `somearray.1`, do not show up as populated with `$populated()`,
+      // so in that case pull out the document's id
+      val = val._doc._id;
+    }
+    const scope = _this.$__.pathsToScopes != null && path in _this.$__.pathsToScopes ?
+      _this.$__.pathsToScopes[path] :
+      _this;
 
-      // If you `populate()` and get back a null value, required validators
-      // shouldn't fail (gh-8018). We should always fall back to the populated
-      // value.
-      let pop;
-      if ((pop = _this.$populated(path))) {
-        val = pop;
-      } else if (val != null && val.$__ != null && val.$__.wasPopulated) {
-        // Array paths, like `somearray.1`, do not show up as populated with `$populated()`,
-        // so in that case pull out the document's id
-        val = val._doc._id;
-      }
-      const scope = _this.$__.pathsToScopes != null && path in _this.$__.pathsToScopes ?
-        _this.$__.pathsToScopes[path] :
-        _this;
+    const doValidateOptions = {
+      ...doValidateOptionsByPath[path],
+      path: path,
+      validateAllPaths,
+      _nestedValidate: true
+    };
 
-      const doValidateOptions = {
-        ...doValidateOptionsByPath[path],
-        path: path,
-        validateAllPaths,
-        _nestedValidate: true
-      };
-
-      schemaType.doValidate(val, function(err) {
-        if (err) {
-          const isSubdoc = schemaType.$isSingleNested ||
-              schemaType.$isArraySubdocument ||
-              schemaType.$isMongooseDocumentArray;
-          if (isSubdoc && err instanceof ValidationError) {
-            return --total || complete();
-          }
-          _this.invalidate(path, err, undefined, true);
+    schemaType.doValidate(val, function(err) {
+      if (err) {
+        const isSubdoc = schemaType.$isSingleNested ||
+            schemaType.$isArraySubdocument ||
+            schemaType.$isMongooseDocumentArray;
+        if (isSubdoc && err instanceof ValidationError) {
+          return --total || complete();
         }
-        --total || complete();
-      }, scope, doValidateOptions);
-    });
+        _this.invalidate(path, err, undefined, true);
+      }
+      --total || complete();
+    }, scope, doValidateOptions);
   }
 
   function complete() {

--- a/lib/document.js
+++ b/lib/document.js
@@ -30,7 +30,6 @@ const getEmbeddedDiscriminatorPath = require('./helpers/document/getEmbeddedDisc
 const getKeysInSchemaOrder = require('./helpers/schema/getKeysInSchemaOrder');
 const getSubdocumentStrictValue = require('./helpers/schema/getSubdocumentStrictValue');
 const handleSpreadDoc = require('./helpers/document/handleSpreadDoc');
-const immediate = require('./helpers/immediate');
 const isBsonType = require('./helpers/isBsonType');
 const isDefiningProjection = require('./helpers/projection/isDefiningProjection');
 const isExclusive = require('./helpers/projection/isExclusive');
@@ -2650,17 +2649,12 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
     throw parallelValidate;
   }
 
-  return new Promise((resolve, reject) => {
-    this.$__validate(pathsToValidate, options, (error) => {
-      this.$op = null;
-      this.$__.validating = null;
-      if (error != null) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
+  try {
+    await this.$__validate(pathsToValidate, options);
+  } finally {
+    this.$op = null;
+    this.$__.validating = null;
+  }
 };
 
 /**
@@ -2894,16 +2888,42 @@ function _pushNestedArrayPaths(val, paths, path) {
  * ignore
  */
 
-Document.prototype.$__validate = function(pathsToValidate, options, callback) {
+Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName) {
+  return new Promise((resolve, reject) => {
+    this.constructor._middleware.execPre(opName, this, [], (error) => {
+      if (error != null) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+};
+
+/*!
+ * ignore
+ */
+
+Document.prototype._execDocumentPostHooks = function _execDocumentPostHooks(opName, error) {
+  return new Promise((resolve, reject) => {
+    this.constructor._middleware.execPost(opName, this, [this], { error }, function(error) {
+      if (error) {
+        return reject(error);
+      }
+      resolve();
+    });
+  });
+};
+
+/*!
+ * ignore
+ */
+
+Document.prototype.$__validate = async function $__validate(pathsToValidate, options) {
+  await this._execDocumentPreHooks('validate');
+
   if (this.$__.saveOptions && this.$__.saveOptions.pathsToSave && !pathsToValidate) {
     pathsToValidate = [...this.$__.saveOptions.pathsToSave];
-  } else if (typeof pathsToValidate === 'function') {
-    callback = pathsToValidate;
-    options = null;
-    pathsToValidate = null;
-  } else if (typeof options === 'function') {
-    callback = options;
-    options = null;
   }
 
   const hasValidateModifiedOnlyOption = options &&
@@ -3001,56 +3021,52 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
   }
 
   if (paths.length === 0) {
-    return immediate(function() {
-      const error = _complete();
-      if (error) {
-        return _this.$__schema.s.hooks.execPost('validate:error', _this, [_this], { error: error }, function(error) {
-          callback(error);
-        });
-      }
-      callback(null, _this);
-    });
+    const error = _complete();
+    await this._execDocumentPostHooks('validate', error);
+    return;
   }
 
   const validated = {};
-  let total = paths.length;
 
   let pathsToSave = this.$__.saveOptions?.pathsToSave;
+  const promises = [];
   if (Array.isArray(pathsToSave)) {
     pathsToSave = new Set(pathsToSave);
     for (const path of paths) {
       if (!pathsToSave.has(path)) {
-        --total || complete();
         continue;
       }
-      validatePath(path);
+      promises.push(validatePath(path));
     }
   } else {
     for (const path of paths) {
-      validatePath(path);
+      promises.push(validatePath(path));
     }
   }
+  await Promise.all(promises);
+  const error = _complete();
+  await this._execDocumentPostHooks('validate', error);
 
-  function validatePath(path) {
+  async function validatePath(path) {
     if (path == null || validated[path]) {
-      return --total || complete();
+      return;
     }
 
     validated[path] = true;
     const schemaType = _this.$__schema.path(path);
 
     if (!schemaType) {
-      return --total || complete();
+      return;
     }
 
     // If user marked as invalid or there was a cast error, don't validate
     if (!_this.$isValid(path)) {
-      return --total || complete();
+      return;
     }
 
     // If setting a path under a mixed path, avoid using the mixed path validator (gh-10141)
     if (schemaType[schemaMixedSymbol] != null && path !== schemaType.path) {
-      return --total || complete();
+      return;
     }
 
     let val = _this.$__getValue(path);
@@ -3077,30 +3093,23 @@ Document.prototype.$__validate = function(pathsToValidate, options, callback) {
       _nestedValidate: true
     };
 
-    schemaType.doValidate(val, function(err) {
-      if (err) {
-        const isSubdoc = schemaType.$isSingleNested ||
-            schemaType.$isArraySubdocument ||
-            schemaType.$isMongooseDocumentArray;
-        if (isSubdoc && err instanceof ValidationError) {
-          return --total || complete();
+    await new Promise((resolve) => {
+      schemaType.doValidate(val, function doValidateCallback(err) {
+        if (err) {
+          const isSubdoc = schemaType.$isSingleNested ||
+              schemaType.$isArraySubdocument ||
+              schemaType.$isMongooseDocumentArray;
+          if (isSubdoc && err instanceof ValidationError) {
+            return resolve();
+          }
+          _this.invalidate(path, err, undefined, true);
+          resolve();
+        } else {
+          resolve();
         }
-        _this.invalidate(path, err, undefined, true);
-      }
-      --total || complete();
-    }, scope, doValidateOptions);
+      }, scope, doValidateOptions);
+    });
   }
-
-  function complete() {
-    const error = _complete();
-    if (error) {
-      return _this.$__schema.s.hooks.execPost('validate:error', _this, [_this], { error: error }, function(error) {
-        callback(error);
-      });
-    }
-    callback(null, _this);
-  }
-
 };
 
 /*!

--- a/lib/document.js
+++ b/lib/document.js
@@ -2619,7 +2619,6 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
   if (typeof pathsToValidate === 'function' || typeof options === 'function' || typeof arguments[2] === 'function') {
     throw new MongooseError('Document.prototype.validate() no longer accepts a callback');
   }
-  let parallelValidate;
   this.$op = 'validate';
 
   if (arguments.length === 1) {
@@ -2637,16 +2636,9 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
   if (this.$isSubdocument != null) {
     // Skip parallel validate check for subdocuments
   } else if (this.$__.validating && !_skipParallelValidateCheck) {
-    parallelValidate = new ParallelValidateError(this, {
-      parentStack: options && options.parentStack,
-      conflictStack: this.$__.validating.stack
-    });
+    throw new ParallelValidateError(this);
   } else if (!_skipParallelValidateCheck) {
-    this.$__.validating = new ParallelValidateError(this, { parentStack: options && options.parentStack });
-  }
-
-  if (parallelValidate != null) {
-    throw parallelValidate;
+    this.$__.validating = true;
   }
 
   try {

--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -45,14 +45,6 @@ class ValidationError extends MongooseError {
   }
 
   /**
-   * inspect helper
-   * @api private
-   */
-  inspect() {
-    return Object.assign(new Error(this.message), this);
-  }
-
-  /**
   * add message
   * @param {String} path
   * @param {String|Error} error

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -16,7 +16,6 @@ module.exports = applyHooks;
 applyHooks.middlewareFunctions = [
   'deleteOne',
   'save',
-  'validate',
   'remove',
   'updateOne',
   'init'
@@ -47,15 +46,29 @@ function applyHooks(model, schema, options) {
     contextParameter: true
   };
   const objToDecorate = options.decorateDoc ? model : model.prototype;
-
   model.$appliedHooks = true;
   for (const key of Object.keys(schema.paths)) {
-    const type = schema.paths[key];
+    let type = schema.paths[key];
     let childModel = null;
     if (type.$isSingleNested) {
       childModel = type.caster;
     } else if (type.$isMongooseDocumentArray) {
       childModel = type.Constructor;
+    } else if (type.instance === 'Array') {
+      let curType = type;
+      // Drill into nested arrays to check if nested array contains document array
+      while (curType.instance === 'Array') {
+        if (curType.$isMongooseDocumentArray) {
+          childModel = curType.Constructor;
+          type = curType;
+          break;
+        }
+        curType = curType.getEmbeddedSchemaType();
+      }
+
+      if (childModel == null) {
+        continue;
+      }
     } else {
       continue;
     }
@@ -64,7 +77,11 @@ function applyHooks(model, schema, options) {
       continue;
     }
 
-    applyHooks(childModel, type.schema, { ...options, isChildSchema: true });
+    applyHooks(childModel, type.schema, {
+      ...options,
+      decorateDoc: false, // Currently subdocs inherit directly from NodeJSDocument in browser
+      isChildSchema: true
+    });
     if (childModel.discriminators != null) {
       const keys = Object.keys(childModel.discriminators);
       for (const key of keys) {
@@ -102,11 +119,9 @@ function applyHooks(model, schema, options) {
 
   model._middleware = middleware;
 
-  objToDecorate.$__originalValidate = objToDecorate.$__originalValidate || objToDecorate.$__validate;
-
-  const internalMethodsToWrap = options && options.isChildSchema ? ['save', 'validate', 'deleteOne'] : ['save', 'validate'];
+  const internalMethodsToWrap = options && options.isChildSchema ? ['save', 'deleteOne'] : ['save'];
   for (const method of internalMethodsToWrap) {
-    const toWrap = method === 'validate' ? '$__originalValidate' : `$__${method}`;
+    const toWrap = `$__${method}`;
     const wrapped = middleware.
       createWrapper(method, objToDecorate[toWrap], null, kareemOptions);
     objToDecorate[`$__${method}`] = wrapped;

--- a/lib/query.js
+++ b/lib/query.js
@@ -116,7 +116,7 @@ function Query(conditions, options, model, collection) {
 
   this._transforms = [];
   this._hooks = new Kareem();
-  this._executionStack = null;
+  this._execCount = 0;
 
   // this is the case where we have a CustomQuery, we need to check if we got
   // options passed in, and if we did, merge them in
@@ -274,7 +274,6 @@ Query.prototype.toConstructor = function toConstructor() {
   p.setOptions(options);
 
   p.op = this.op;
-  p._validateOp();
   p._conditions = clone(this._conditions);
   p._fields = clone(this._fields);
   p._update = clone(this._update, {
@@ -323,7 +322,6 @@ Query.prototype.clone = function() {
   q.setOptions(options);
 
   q.op = this.op;
-  q._validateOp();
   q._conditions = clone(this._conditions);
   q._fields = clone(this._fields);
   q._update = clone(this._update, {
@@ -488,7 +486,7 @@ Query.prototype._validateOp = function() {
     this.error(new Error('Query has invalid `op`: "' + this.op + '"'));
   }
 
-  if (this.op !== 'estimatedDocumentCount' && this._conditions === null) {
+  if (this.op !== 'estimatedDocumentCount' && this._conditions == null) {
     throw new ObjectParameterError(this._conditions, 'filter', this.op);
   }
 };
@@ -2716,7 +2714,6 @@ Query.prototype.findOne = function(conditions, projection, options) {
   }
 
   this.op = 'findOne';
-  this._validateOp();
 
   if (options) {
     this.setOptions(options);
@@ -2843,7 +2840,6 @@ Query.prototype.estimatedDocumentCount = function(options) {
   }
 
   this.op = 'estimatedDocumentCount';
-  this._validateOp();
 
   if (options != null) {
     this.setOptions(options);
@@ -2898,7 +2894,6 @@ Query.prototype.countDocuments = function(conditions, options) {
   }
 
   this.op = 'countDocuments';
-  this._validateOp();
 
   if (canMerge(conditions)) {
     this.merge(conditions);
@@ -2964,7 +2959,6 @@ Query.prototype.distinct = function(field, conditions, options) {
   }
 
   this.op = 'distinct';
-  this._validateOp();
 
   if (canMerge(conditions)) {
     this.merge(conditions);
@@ -3366,7 +3360,6 @@ Query.prototype.findOneAndUpdate = function(filter, doc, options) {
   }
 
   this.op = 'findOneAndUpdate';
-  this._validateOp();
   this._validate();
 
   switch (arguments.length) {
@@ -3459,7 +3452,7 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
       delete $set._id;
       this._update = { $set };
     } else {
-      this._executionStack = null;
+      this._execCount = 0;
       const res = await this._findOne();
       return res;
     }
@@ -3539,7 +3532,6 @@ Query.prototype.findOneAndDelete = function(filter, options) {
   }
 
   this.op = 'findOneAndDelete';
-  this._validateOp();
   this._validate();
 
   if (canMerge(filter)) {
@@ -3637,7 +3629,6 @@ Query.prototype.findOneAndReplace = function(filter, replacement, options) {
   }
 
   this.op = 'findOneAndReplace';
-  this._validateOp();
   this._validate();
 
   if (canMerge(filter)) {
@@ -4229,7 +4220,6 @@ Query.prototype.replaceOne = function(conditions, doc, options, callback) {
 function _update(query, op, filter, doc, options, callback) {
   // make sure we don't send in the whole Document to merge()
   query.op = op;
-  query._validateOp();
   doc = doc || {};
 
   // strict is an option used in the update checking, make sure it gets set
@@ -4414,6 +4404,7 @@ Query.prototype.exec = async function exec(op) {
     throw new MongooseError('Query.prototype.exec() no longer accepts a callback');
   }
 
+  this._validateOp();
   if (typeof op === 'string') {
     this.op = op;
   }
@@ -4434,17 +4425,14 @@ Query.prototype.exec = async function exec(op) {
     throw new Error('Invalid field "" passed to sort()');
   }
 
-  if (this._executionStack != null) {
+  if (this._execCount > 0) {
     let str = this.toString();
     if (str.length > 60) {
       str = str.slice(0, 60) + '...';
     }
-    const err = new MongooseError('Query was already executed: ' + str);
-    err.originalStack = this._executionStack;
-    throw err;
-  } else {
-    this._executionStack = new Error().stack;
+    throw new MongooseError('Query was already executed: ' + str);
   }
+  this._execCount++;
 
   let skipWrappedFunction = null;
   try {

--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -283,7 +283,7 @@ SchemaDocumentArray.prototype.doValidate = function(array, fn, scope, options) {
         continue;
       }
 
-      doc.$__validate(null, options, callback);
+      doc.$__validate(null, options).then(() => callback(), err => callback(err));
     }
   }
 };

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -12,7 +12,6 @@ const clone = require('./helpers/clone');
 const handleImmutable = require('./helpers/schematype/handleImmutable');
 const isAsyncFunction = require('./helpers/isAsyncFunction');
 const isSimpleValidator = require('./helpers/isSimpleValidator');
-const immediate = require('./helpers/immediate');
 const schemaTypeSymbol = require('./helpers/symbols').schemaTypeSymbol;
 const utils = require('./utils');
 const validatorErrorSymbol = require('./helpers/symbols').validatorErrorSymbol;
@@ -1395,17 +1394,13 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     }
     if (ok === undefined || ok) {
       if (--count <= 0) {
-        immediate(function() {
-          fn(null);
-        });
+        fn(null);
       }
     } else {
       const ErrorConstructor = validatorProperties.ErrorConstructor || ValidatorError;
       err = new ErrorConstructor(validatorProperties, scope);
       err[validatorErrorSymbol] = true;
-      immediate(function() {
-        fn(err);
-      });
+      fn(err);
     }
   }
 };

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1725,7 +1725,6 @@ describe('document', function() {
       assert.equal(d.nested.setr, 'undefined setter');
       dateSetterCalled = false;
       d.date = undefined;
-      await d.validate();
       assert.ok(dateSetterCalled);
     });
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3314,7 +3314,6 @@ describe('Query', function() {
       quiz_title: String,
       questions: [questionSchema]
     }, { strict: 'throw' });
-    const Quiz = db.model('Test', quizSchema);
 
     const mcqQuestionSchema = new Schema({
       text: String,
@@ -3322,6 +3321,7 @@ describe('Query', function() {
     }, { strict: 'throw' });
 
     quizSchema.path('questions').discriminator('mcq', mcqQuestionSchema);
+    const Quiz = db.model('Test', quizSchema);
 
     const id1 = new mongoose.Types.ObjectId();
     const id2 = new mongoose.Types.ObjectId();

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3081,7 +3081,6 @@ describe('Query', function() {
   it('throws an error if executed multiple times (gh-7398)', async function() {
     const Test = db.model('Test', Schema({ name: String }));
 
-
     const q = Test.findOne();
 
     await q;
@@ -3090,7 +3089,6 @@ describe('Query', function() {
     assert.ok(err);
     assert.equal(err.name, 'MongooseError');
     assert.equal(err.message, 'Query was already executed: Test.findOne({})');
-    assert.ok(err.originalStack);
 
     err = await q.clone().then(() => null, err => err);
     assert.ifError(err);

--- a/test/types.document.test.js
+++ b/test/types.document.test.js
@@ -7,11 +7,13 @@
 
 const start = require('./common');
 
-const assert = require('assert');
-const mongoose = start.mongoose;
 const ArraySubdocument = require('../lib/types/arraySubdocument');
 const EventEmitter = require('events').EventEmitter;
 const DocumentArray = require('../lib/types/documentArray');
+const applyHooks = require('../lib/helpers/model/applyHooks');
+const assert = require('assert');
+
+const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 const ValidationError = mongoose.Document.ValidationError;
 
@@ -53,6 +55,8 @@ describe('types.document', function() {
       test: { type: String, required: true },
       work: { type: String, validate: /^good/ }
     }));
+
+    applyHooks(Subdocument, Subdocument.prototype.schema);
 
     RatingSchema = new Schema({
       stars: Number,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Partially a fix for #14906, but also includes some related followup work because, in addition to removing `_executionStack`, we should do the same for parallel validation error. However, I took the time to refactor `validate()` to be an async function, to take advantage of async stack traces. With this PR, you get async stack traces when calling document.validate():

```javascript
Error.stackTraceLimit = 20;

const mongoose = require("mongoose");
mongoose.connect("mongodb://localhost:27017/mongoose_test");


const userSchema = new mongoose.Schema({
  name: { type: String, required: true, validate: v => v.length > 3 },
  age: Number,
});
userSchema.pre('validate', function() {
  if (this.name === 'secret') {
    throw new Error('name cannot be secret');
  }
});

const User = mongoose.model("User", userSchema);

async function runDemo() {
  const doc = new User({ name: 'A' });
  await doc.validate();

  //doc.name = 'secret';
  //await doc.validate();
  // await doc.save();
}

runDemo().catch(err => console.log(err.stack));

```

Output:

```
$ node gh-14250.js 
ValidationError: User validation failed: name: Validator failed for path `name` with value `A`
    at Document.invalidate (/mongoose/lib/document.js:3335:32)
    at doValidateCallback (/mongoose/lib/document.js:3105:17)
    at validate (/mongoose/lib/schemaType.js:1403:7)
    at SchemaType.doValidate (/mongoose/lib/schemaType.js:1387:7)
    at /mongoose/lib/document.js:3097:18
    at new Promise (<anonymous>)
    at validatePath (/mongoose/lib/document.js:3096:11)
    at model.$__validate (/mongoose/lib/document.js:3043:21)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async model.validate (/mongoose/lib/document.js:2653:5)
    at async runDemo (/gh-14250.js:22:3)
```

Without this PR, stack trace is not helpful:

```
$ node gh-14250.js 
ValidationError: User validation failed: name: Validator failed for path `name` with value `A`
    at Document.invalidate (/mongoose/lib/document.js:3329:32)
    at /mongoose/lib/document.js:3090:17
    at /mongoose/lib/schemaType.js:1407:9
    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
