### PR TITLE
fix(populate): correctly get schematypes when deep populating under a map

### DIFF
--- a/lib/helpers/populate/getSchemaTypes.js
+++ b/lib/helpers/populate/getSchemaTypes.js
@@ -178,8 +178,8 @@ module.exports = function getSchemaTypes(model, schema, doc, path) {
       }
 
       const fullPath = nestedPath.concat([trypath]).join('.');
-      if (topLevelDoc != null && topLevelDoc.$__ && topLevelDoc.$populated(fullPath) && p < parts.length) {
-        const model = doc.$__.populated[fullPath].options[populateModelSymbol];
+      if (topLevelDoc != null && topLevelDoc.$__ && topLevelDoc.$populated(fullPath, true) && p < parts.length) {
+        const model = topLevelDoc.$populated(fullPath, true).options[populateModelSymbol];
         if (model != null) {
           const ret = search(
             parts.slice(p),

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -1115,4 +1115,42 @@ describe('document.populate', function() {
     assert.equal(docD.refB.title, 'test 2');
     assert.equal(docD.refC.content, 'test 3');
   });
+
+  it('handles re-populating map of array of refs (gh-9359)', async function() {
+    const UserSchema = mongoose.Schema({
+      columns: { type: Map, of: [{ type: 'ObjectId', ref: 'Test1' }] }
+    });
+    const CardSchema = mongoose.Schema({
+      title: { type: String },
+      sequence: { type: 'ObjectId', ref: 'Test2' }
+    });
+    const SequenceSchema = mongoose.Schema({
+      foo: { type: String }
+    });
+
+    const Sequence = db.model('Test2', SequenceSchema);
+    const Card = db.model('Test1', CardSchema);
+    const User = db.model('Test', UserSchema);
+
+    const sequence = await Sequence.create({ foo: 'bar' });
+    const card1 = await Card.create({ title: 'card1', sequence });
+    const card2 = await Card.create({ title: 'card2', sequence });
+    const card3 = await Card.create({ title: 'card3' });
+    const card4 = await Card.create({ title: 'card4', sequence });
+    await User.create({
+      columns: { key1: [card1, card2], key2: [card3, card4] }
+    });
+
+    const user = await User.findOne();
+    await user.populate('columns.$*.sequence');
+    await user.populate('columns.$*');
+    assert.deepStrictEqual(user.columns.get('key1').map(subdoc => subdoc.title), ['card1', 'card2']);
+    assert.deepStrictEqual(user.columns.get('key2').map(subdoc => subdoc.title), ['card3', 'card4']);
+    await user.populate('columns.$*.sequence');
+    assert.deepStrictEqual(user.columns.get('key1').map(subdoc => subdoc.title), ['card1', 'card2']);
+    assert.deepStrictEqual(user.columns.get('key1').map(subdoc => subdoc.sequence.foo), ['bar', 'bar']);
+    assert.deepStrictEqual(user.columns.get('key2').map(subdoc => subdoc.title), ['card3', 'card4']);
+    assert.deepStrictEqual(user.columns.get('key2').map(subdoc => subdoc.sequence?.foo), [undefined, 'bar']);
+
+  });
 });

--- a/test/document.populate.test.js
+++ b/test/document.populate.test.js
@@ -1142,7 +1142,6 @@ describe('document.populate', function() {
     });
 
     const user = await User.findOne();
-    await user.populate('columns.$*.sequence');
     await user.populate('columns.$*');
     assert.deepStrictEqual(user.columns.get('key1').map(subdoc => subdoc.title), ['card1', 'card2']);
     assert.deepStrictEqual(user.columns.get('key2').map(subdoc => subdoc.title), ['card3', 'card4']);


### PR DESCRIPTION
Fix #9359

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`doc.$__.populated[fullPath]` can be nullish in this context if `fullPath` includes `$*`, that is, if deep populating a path underneath a map. `topLevelDoc.$populated(fullPath, true)` is equivalent (the `true` makes $populated() return the full populated state rather than just the populated values) accounts for this case.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
