### PR TITLE
feat(types): add WithTimestamps utility type

### DIFF
--- a/test/types/utility.test.ts
+++ b/test/types/utility.test.ts
@@ -1,4 +1,4 @@
-import { MergeType } from 'mongoose';
+import { MergeType, WithTimestamps } from 'mongoose';
 import { expectType } from 'tsd';
 
 type A = { a: string, c: number };
@@ -11,3 +11,21 @@ expectType<number>({} as MergeType<B, A>['c']);
 expectType<number>({} as MergeType<A, B>['a']);
 expectType<string>({} as MergeType<A, B>['b']);
 expectType<number>({} as MergeType<A, B>['c']);
+
+type C = WithTimestamps<{ a: string; b: string }>;
+expectType<string>({} as C['a']);
+expectType<string>({} as C['b']);
+expectType<Date>({} as C['createdAt']);
+expectType<Date>({} as C['updatedAt']);
+
+type D = WithTimestamps<
+  { a: string; b: string },
+  {
+    createdAt: 'created';
+    updatedAt: 'modified';
+  }
+>;
+expectType<string>({} as D['a']);
+expectType<string>({} as D['b']);
+expectType<Date>({} as D['created']);
+expectType<Date>({} as D['modified']);

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -93,4 +93,12 @@ type AddThisParameter<T, D> = {
     : T[K];
 };
 
+  /**
+   * @summary Adds timestamp fields to a type
+   * @description Adds createdAt and updatedAt fields of type Date, or custom timestamp fields if specified
+   * @param {T} T The type to add timestamp fields to
+   * @param {P} P Optional SchemaTimestampsConfig or boolean to customize timestamp field names
+   * @returns T with timestamp fields added
+   */
+  export type WithTimestamps<T, P extends SchemaTimestampsConfig | boolean = true> = ResolveTimestamps<T, { timestamps: P }>;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

When working with TypeScript and Mongoose, it's useful to have a type that represents a document with timestamp fields. This is especially helpful when:
- Creating DTOs that will be stored with timestamps
- Working with document results from queries where timestamps are included

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```typescript
@Schema({
	timestamps: true,
})
class User {
	@Prop({ type: String, required: true })
	username: string;

	@Prop({ type: String, required: true })
	email: string;
}

export type UserDocument = WithId<WithTimestamp<User>>;
```

This utility type is inspired by the MongoDB driver's `WithId<T>` type and was originally discussed in a PR to the MongoDB driver repository: [mongodb/node-mongodb-native#4462](https://github.com/mongodb/node-mongodb-native/pull/4462), before determining Mongoose was the more appropriate place for this functionality since Mongoose (not the driver) is responsible for managing timestamp fields.
