### PR TITLE
fix(document): avoid stripping out fields in discriminator schema after select: false field

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -747,8 +747,8 @@ function init(self, obj, doc, opts, prefix) {
   for (let index = 0; index < len; ++index) {
     i = keys[index];
     // avoid prototype pollution
-    if (i === '__proto__' || i === 'constructor') {
-      return;
+    if (specialProperties.has(i)) {
+      continue;
     }
     path = prefix ? prefix + i : i;
     schemaType = docSchema.path(path);
@@ -1720,7 +1720,7 @@ Document.prototype.$__set = function(pathToMark, path, options, constructing, pa
     const last = next === l;
     cur += (cur ? '.' + parts[i] : parts[i]);
     if (specialProperties.has(parts[i])) {
-      return;
+      continue;
     }
 
     if (last) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -756,7 +756,7 @@ function init(self, obj, doc, opts, prefix) {
     // necessary. This is *only* to catch the case where we queried using the
     // base model and the discriminated model has a projection
     if (docSchema.$isRootDiscriminator && !self.$__isSelected(path)) {
-      return;
+      continue;
     }
 
     const value = obj[i];

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14422,6 +14422,39 @@ describe('document', function() {
       sinon.restore();
     }
   });
+
+  it('handles selected paths on root discriminator (gh-15308)', async function() {
+    const CarSchema = new mongoose.Schema(
+      {
+        make: {
+          type: String,
+          enum: ['mercedes']
+        }
+      },
+      {
+        discriminatorKey: 'make'
+      }
+    );
+    const MercedesSchema = new mongoose.Schema({
+      vin: {
+        type: String,
+        select: false
+      },
+      sunroof: Boolean
+    });
+    const CarModel = db.model('Car', CarSchema);
+    CarModel.discriminator('Car:mercedes', MercedesSchema, 'mercedes');
+
+    const newCar = await CarModel.create({
+      make: 'mercedes',
+      vin: 'someFakeVin',
+      sunroof: true
+    });
+
+    const car = await CarModel.findById(newCar._id);
+    assert.strictEqual(car.vin, undefined);
+    assert.strictEqual(car.sunroof, true);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {


### PR DESCRIPTION
Fix #15308

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When we refactored a `forEach()` into a `for` in `init()`, we left a `return` that should've become a `continue`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
