### PR TITLE
fix(model): avoid returning `null` from bulkSave() if error doesn't have writeErrors property

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3603,7 +3603,7 @@ Model.bulkSave = async function bulkSave(documents, options) {
   }
   await Promise.all(successfulDocuments.map(document => handleSuccessfulWrite(document)));
 
-  if (bulkWriteError && bulkWriteError.writeErrors && bulkWriteError.writeErrors.length) {
+  if (bulkWriteError != null) {
     throw bulkWriteError;
   }
 


### PR DESCRIPTION
Re: #15314

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Potential edge case that can lead `bulkSave()` to return `null`. Not likely because AFAIK `MongoBulkWriteError` should always have `writeErrors` property, but I don't think the `writeErrors` check adds anything here.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
