### PR TITLE
BREAKING CHANGE: use kareem@v3 promise-based execPre() for document hooks

### DIFF
--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -36,3 +36,17 @@ try {
   // Handle validation error
 }
 ```
+
+## Errors in middleware functions take priority over `next()` calls
+
+In Mongoose 8.x, if a middleware function threw an error after calling `next()`, that error would be ignored.
+
+```javascript
+schema.pre('save', function(next) {
+  next();
+  // In Mongoose 8, this error will not get reported, because you already called next()
+  throw new Error('woops!');
+});
+```
+
+In Mongoose 9, errors in the middleware function take priority, so the above `save()` would throw an error.

--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -50,3 +50,20 @@ schema.pre('save', function(next) {
 ```
 
 In Mongoose 9, errors in the middleware function take priority, so the above `save()` would throw an error.
+
+## `next()` no longer supports passing arguments to the next middleware
+
+Previously, you could call `next(null, 'new arg')` in a hook and the args to the next middleware would get overwritten by 'new arg'.
+
+```javascript
+schema.pre('save', function(next, options) {
+  options; // options passed to `save()`
+  next(null, 'new arg');
+});
+
+schema.pre('save', function(next, arg) {
+  arg; // In Mongoose 8, this would be 'new arg', overwrote the options passed to `save()`
+});
+```
+
+In Mongoose 9, `next(null, 'new arg')` doesn't overwrite the args to the next middleware.

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -800,18 +800,19 @@ Aggregate.prototype.explain = async function explain(verbosity) {
 
   prepareDiscriminatorPipeline(this._pipeline, this._model.schema);
 
-  await new Promise((resolve, reject) => {
-    model.hooks.execPre('aggregate', this, error => {
-      if (error) {
-        const _opts = { error: error };
-        return model.hooks.execPost('aggregate', this, [null], _opts, error => {
-          reject(error);
-        });
-      } else {
+  try {
+    await model.hooks.execPre('aggregate', this);
+  } catch (error) {
+    const _opts = { error: error };
+    return await new Promise((resolve, reject) => {
+      model.hooks.execPost('aggregate', this, [null], _opts, error => {
+        if (error) {
+          return reject(error);
+        }
         resolve();
-      }
+      });
     });
-  });
+  }
 
   const cursor = model.collection.aggregate(this._pipeline, this.options);
 
@@ -1079,18 +1080,19 @@ Aggregate.prototype.exec = async function exec() {
   prepareDiscriminatorPipeline(this._pipeline, this._model.schema);
   stringifyFunctionOperators(this._pipeline);
 
-  await new Promise((resolve, reject) => {
-    model.hooks.execPre('aggregate', this, error => {
-      if (error) {
-        const _opts = { error: error };
-        return model.hooks.execPost('aggregate', this, [null], _opts, error => {
-          reject(error);
-        });
-      } else {
+  try {
+    await model.hooks.execPre('aggregate', this);
+  } catch (error) {
+    const _opts = { error: error };
+    return await new Promise((resolve, reject) => {
+      model.hooks.execPost('aggregate', this, [null], _opts, error => {
+        if (error) {
+          return reject(error);
+        }
         resolve();
-      }
+      });
     });
-  });
+  }
 
   if (!this._pipeline.length) {
     throw new MongooseError('Aggregate has empty pipeline');

--- a/lib/browserDocument.js
+++ b/lib/browserDocument.js
@@ -98,15 +98,7 @@ Document.$emitter = new EventEmitter();
  */
 
 Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName) {
-  return new Promise((resolve, reject) => {
-    this._middleware.execPre(opName, this, [], (error) => {
-      if (error != null) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
+  return this._middleware.execPre(opName, this, []);
 };
 
 /*!

--- a/lib/browserDocument.js
+++ b/lib/browserDocument.js
@@ -97,7 +97,7 @@ Document.$emitter = new EventEmitter();
  * ignore
  */
 
-Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName) {
+Document.prototype._execDocumentPreHooks = async function _execDocumentPreHooks(opName) {
   return this._middleware.execPre(opName, this, []);
 };
 

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -63,34 +63,24 @@ util.inherits(AggregationCursor, Readable);
 
 function _init(model, c, agg) {
   if (!model.collection.buffer) {
-    model.hooks.execPre('aggregate', agg, function(err) {
-      if (err != null) {
-        _handlePreHookError(c, err);
-        return;
-      }
-      if (typeof agg.options?.cursor?.transform === 'function') {
-        c._transforms.push(agg.options.cursor.transform);
-      }
-
-      c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
-      c.emit('cursor', c.cursor);
-    });
+    model.hooks.execPre('aggregate', agg).then(() => onPreComplete(null), err => onPreComplete(err));
   } else {
     model.collection.emitter.once('queue', function() {
-      model.hooks.execPre('aggregate', agg, function(err) {
-        if (err != null) {
-          _handlePreHookError(c, err);
-          return;
-        }
-
-        if (typeof agg.options?.cursor?.transform === 'function') {
-          c._transforms.push(agg.options.cursor.transform);
-        }
-
-        c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
-        c.emit('cursor', c.cursor);
-      });
+      model.hooks.execPre('aggregate', agg).then(() => onPreComplete(null), err => onPreComplete(err));
     });
+  }
+
+  function onPreComplete(err) {
+    if (err != null) {
+      _handlePreHookError(c, err);
+      return;
+    }
+    if (typeof agg.options?.cursor?.transform === 'function') {
+      c._transforms.push(agg.options.cursor.transform);
+    }
+
+    c.cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
+    c.emit('cursor', c.cursor);
   }
 }
 

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -49,7 +49,8 @@ function QueryCursor(query) {
   this._transforms = [];
   this.model = model;
   this.options = {};
-  model.hooks.execPre('find', query, (err) => {
+
+  const onPreComplete = (err) => {
     if (err != null) {
       if (err instanceof kareem.skipWrappedFunction) {
         const resultValue = err.args[0];
@@ -91,7 +92,9 @@ function QueryCursor(query) {
     } else {
       _getRawCursor(query, this);
     }
-  });
+  };
+
+  model.hooks.execPre('find', query).then(() => onPreComplete(null), err => onPreComplete(err));
 }
 
 util.inherits(QueryCursor, Readable);

--- a/lib/document.js
+++ b/lib/document.js
@@ -2882,6 +2882,7 @@ function _pushNestedArrayPaths(val, paths, path) {
 
 Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName, ...args) {
   return new Promise((resolve, reject) => {
+    // console.log('ABB', this.constructor._middleware, this.constructor.schema?.obj, this.$__fullPath());
     this.constructor._middleware.execPre(opName, this, [...args], (error) => {
       if (error != null) {
         reject(error);

--- a/lib/document.js
+++ b/lib/document.js
@@ -847,8 +847,8 @@ function init(self, obj, doc, opts, prefix) {
 Document.prototype.updateOne = function updateOne(doc, options, callback) {
   const query = this.constructor.updateOne({ _id: this._doc._id }, doc, options);
   const self = this;
-  query.pre(function queryPreUpdateOne(cb) {
-    self.constructor._middleware.execPre('updateOne', self, [self], cb);
+  query.pre(function queryPreUpdateOne() {
+    return self.constructor._middleware.execPre('updateOne', self, [self]);
   });
   query.post(function queryPostUpdateOne(cb) {
     self.constructor._middleware.execPost('updateOne', self, [self], {}, cb);
@@ -2880,17 +2880,8 @@ function _pushNestedArrayPaths(val, paths, path) {
  * ignore
  */
 
-Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName, ...args) {
-  return new Promise((resolve, reject) => {
-    // console.log('ABB', this.constructor._middleware, this.constructor.schema?.obj, this.$__fullPath());
-    this.constructor._middleware.execPre(opName, this, [...args], (error) => {
-      if (error != null) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
+Document.prototype._execDocumentPreHooks = async function _execDocumentPreHooks(opName, ...args) {
+  return this.constructor._middleware.execPre(opName, this, [...args]);
 };
 
 /*!

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -51,25 +51,11 @@ function applyHooks(model, schema, options) {
   for (const key of Object.keys(schema.paths)) {
     let type = schema.paths[key];
     let childModel = null;
-    if (type.$isSingleNested) {
-      childModel = type.caster;
-    } else if (type.$isMongooseDocumentArray) {
-      childModel = type.Constructor;
-    } else if (type.instance === 'Array') {
-      let curType = type;
-      // Drill into nested arrays to check if nested array contains document array
-      while (curType.instance === 'Array') {
-        if (curType.$isMongooseDocumentArray) {
-          childModel = curType.Constructor;
-          type = curType;
-          break;
-        }
-        curType = curType.getEmbeddedSchemaType();
-      }
 
-      if (childModel == null) {
-        continue;
-      }
+    const result = findChildModel(type);
+    if (result) {
+      childModel = result.childModel;
+      type = result.type;
     } else {
       continue;
     }
@@ -163,4 +149,34 @@ function applyHooks(model, schema, options) {
     objToDecorate[`$__${method}`] = middleware.
       createWrapper(method, originalMethod, null, customMethodOptions);
   }
+}
+
+/**
+ * Check if there is an embedded schematype in the given schematype. Handles drilling down into primitive
+ * arrays and maps in case of array of array of subdocs or map of subdocs.
+ *
+ * @param {SchemaType} curType
+ * @returns { childModel: Model | typeof Subdocument, curType: SchemaType } | null
+ */
+
+function findChildModel(curType) {
+  if (curType.$isSingleNested) {
+    return { childModel: curType.caster, type: curType };
+  }
+  if (curType.$isMongooseDocumentArray) {
+    return { childModel: curType.Constructor, type: curType };
+  }
+  if (curType.instance === 'Array') {
+    const embedded = curType.getEmbeddedSchemaType();
+    if (embedded) {
+      return findChildModel(embedded);
+    }
+  }
+  if (curType.instance === 'Map') {
+    const mapType = curType.getEmbeddedSchemaType();
+    if (mapType) {
+      return findChildModel(mapType);
+    }
+  }
+  return null;
 }

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -156,7 +156,7 @@ function applyHooks(model, schema, options) {
  * arrays and maps in case of array of array of subdocs or map of subdocs.
  *
  * @param {SchemaType} curType
- * @returns { childModel: Model | typeof Subdocument, curType: SchemaType } | null
+ * @returns {{ childModel: Model | typeof Subdocument, curType: SchemaType } | null}
  */
 
 function findChildModel(curType) {

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -42,8 +42,6 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
         const cb = typeof lastArg === 'function' ? lastArg : null;
         const args = Array.prototype.slice.
           call(arguments, 0, cb == null ? numArgs : numArgs - 1);
-        // Special case: can't use `Kareem#wrap()` because it doesn't currently
-        // support wrapped functions that return a promise.
         return promiseOrCallback(cb, callback => {
           hooks.execPre(key, model, args).then(() => onPreComplete(null), err => onPreComplete(err));
 

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -45,7 +45,9 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
         // Special case: can't use `Kareem#wrap()` because it doesn't currently
         // support wrapped functions that return a promise.
         return promiseOrCallback(cb, callback => {
-          hooks.execPre(key, model, args, function(err) {
+          hooks.execPre(key, model, args).then(() => onPreComplete(null), err => onPreComplete(err));
+
+          function onPreComplete(err) {
             if (err != null) {
               return callback(err);
             }
@@ -72,7 +74,7 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
                 callback(null, res);
               });
             }
-          });
+          }
         }, model.events);
       };
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -810,19 +810,16 @@ Model.prototype.deleteOne = function deleteOne(options) {
     }
   }
 
-  query.pre(function queryPreDeleteOne(cb) {
-    self.constructor._middleware.execPre('deleteOne', self, [self], cb);
+  query.pre(function queryPreDeleteOne() {
+    return self.constructor._middleware.execPre('deleteOne', self, [self]);
   });
-  query.pre(function callSubdocPreHooks(cb) {
-    each(self.$getAllSubdocs(), (subdoc, cb) => {
-      subdoc.constructor._middleware.execPre('deleteOne', subdoc, [subdoc], cb);
-    }, cb);
+  query.pre(function callSubdocPreHooks() {
+    return Promise.all(self.$getAllSubdocs().map(subdoc => subdoc.constructor._middleware.execPre('deleteOne', subdoc, [subdoc])));
   });
-  query.pre(function skipIfAlreadyDeleted(cb) {
+  query.pre(function skipIfAlreadyDeleted() {
     if (self.$__.isDeleted) {
-      return cb(Kareem.skipWrappedFunction());
+      throw new Kareem.skipWrappedFunction();
     }
-    return cb();
   });
   query.post(function callSubdocPostHooks(cb) {
     each(self.$getAllSubdocs(), (subdoc, cb) => {
@@ -1185,16 +1182,11 @@ Model.createCollection = async function createCollection(options) {
     throw new MongooseError('Model.createCollection() no longer accepts a callback');
   }
 
-  const shouldSkip = await new Promise((resolve, reject) => {
-    this.hooks.execPre('createCollection', this, [options], (err) => {
-      if (err != null) {
-        if (err instanceof Kareem.skipWrappedFunction) {
-          return resolve(true);
-        }
-        return reject(err);
-      }
-      resolve();
-    });
+  const shouldSkip = await this.hooks.execPre('createCollection', this, [options]).catch(err => {
+    if (err instanceof Kareem.skipWrappedFunction) {
+      return true;
+    }
+    throw err;
   });
 
   const collectionOptions = this &&
@@ -3380,17 +3372,15 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   }
   options = options || {};
 
-  const shouldSkip = await new Promise((resolve, reject) => {
-    this.hooks.execPre('bulkWrite', this, [ops, options], (err) => {
-      if (err != null) {
-        if (err instanceof Kareem.skipWrappedFunction) {
-          return resolve(err);
-        }
-        return reject(err);
+  const shouldSkip = await this.hooks.execPre('bulkWrite', this, [ops, options]).then(
+    () => null,
+    err => {
+      if (err instanceof Kareem.skipWrappedFunction) {
+        return err;
       }
-      resolve();
-    });
-  });
+      throw err;
+    }
+  );
 
   if (shouldSkip) {
     return shouldSkip.args[0];
@@ -3622,15 +3612,7 @@ Model.bulkSave = async function bulkSave(documents, options) {
 };
 
 function buildPreSavePromise(document, options) {
-  return new Promise((resolve, reject) => {
-    document.schema.s.hooks.execPre('save', document, [options], (err) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve();
-    });
-  });
+  return document.schema.s.hooks.execPre('save', document, [options]);
 }
 
 function handleSuccessfulWrite(document) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3372,9 +3372,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   }
   options = options || {};
 
-  const shouldSkip = await this.hooks.execPre('bulkWrite', this, [ops, options]).then(
-    () => null,
-    err => {
+  const shouldSkip = await this.hooks.execPre('bulkWrite', this, [ops, options]).catch(err => {
       if (err instanceof Kareem.skipWrappedFunction) {
         return err;
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3611,7 +3611,7 @@ Model.bulkSave = async function bulkSave(documents, options) {
   return bulkWriteResult;
 };
 
-function buildPreSavePromise(document, options) {
+async function buildPreSavePromise(document, options) {
   return document.schema.s.hooks.execPre('save', document, [options]);
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3373,11 +3373,11 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   options = options || {};
 
   const shouldSkip = await this.hooks.execPre('bulkWrite', this, [ops, options]).catch(err => {
-      if (err instanceof Kareem.skipWrappedFunction) {
-        return err;
-      }
-      throw err;
+    if (err instanceof Kareem.skipWrappedFunction) {
+      return err;
     }
+    throw err;
+  }
   );
 
   if (shouldSkip) {

--- a/lib/plugins/saveSubdocs.js
+++ b/lib/plugins/saveSubdocs.js
@@ -11,25 +11,17 @@ module.exports = function saveSubdocs(schema) {
       return;
     }
 
-    const _this = this;
     const subdocs = this.$getAllSubdocs({ useCache: true });
 
     if (!subdocs.length) {
       return;
     }
 
-    await Promise.all(subdocs.map(async(subdoc) => {
-      return new Promise((resolve, reject) => {
-        subdoc.$__schema.s.hooks.execPre('save', subdoc, function(err) {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
-    }));
+    await Promise.all(subdocs.map(subdoc => subdoc._execDocumentPreHooks('save')));
 
     // Invalidate subdocs cache because subdoc pre hooks can add new subdocuments
-    if (_this.$__.saveOptions) {
-      _this.$__.saveOptions.__subdocs = null;
+    if (this.$__.saveOptions) {
+      this.$__.saveOptions.__subdocs = null;
     }
   }, null, unshift);
 
@@ -41,14 +33,7 @@ module.exports = function saveSubdocs(schema) {
 
     const promises = [];
     for (const subdoc of removedSubdocs) {
-      promises.push(new Promise((resolve, reject) => {
-        subdoc.$__schema.s.hooks.execPost('deleteOne', subdoc, [subdoc], function(err) {
-          if (err) {
-            return reject(err);
-          }
-          resolve();
-        });
-      }));
+      promises.push(subdoc._execDocumentPostHooks('deleteOne'));
     }
 
     this.$__.removedSubdocs = null;
@@ -68,14 +53,7 @@ module.exports = function saveSubdocs(schema) {
 
     const promises = [];
     for (const subdoc of subdocs) {
-      promises.push(new Promise((resolve, reject) => {
-        subdoc.$__schema.s.hooks.execPost('save', subdoc, [subdoc], function(err) {
-          if (err) {
-            return reject(err);
-          }
-          resolve();
-        });
-      }));
+      promises.push(subdoc._execDocumentPostHooks('save'));
     }
 
     await Promise.all(promises);

--- a/lib/plugins/sharding.js
+++ b/lib/plugins/sharding.js
@@ -12,13 +12,11 @@ module.exports = function shardingPlugin(schema) {
     storeShard.call(this);
     return this;
   });
-  schema.pre('save', function shardingPluginPreSave(next) {
+  schema.pre('save', function shardingPluginPreSave() {
     applyWhere.call(this);
-    next();
   });
-  schema.pre('remove', function shardingPluginPreRemove(next) {
+  schema.pre('remove', function shardingPluginPreRemove() {
     applyWhere.call(this);
-    next();
   });
   schema.post('save', function shardingPluginPostSave() {
     storeShard.call(this);

--- a/lib/query.js
+++ b/lib/query.js
@@ -4510,7 +4510,7 @@ function _executePostHooks(query, res, error, op) {
  * ignore
  */
 
-function _executePreExecHooks(query) {
+async function _executePreExecHooks(query) {
   return query._hooks.execPre('exec', query, []);
 }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -4511,14 +4511,7 @@ function _executePostHooks(query, res, error, op) {
  */
 
 function _executePreExecHooks(query) {
-  return new Promise((resolve, reject) => {
-    query._hooks.execPre('exec', query, [], (error) => {
-      if (error != null) {
-        return reject(error);
-      }
-      resolve();
-    });
-  });
+  return query._hooks.execPre('exec', query, []);
 }
 
 /*!
@@ -4530,14 +4523,7 @@ function _executePreHooks(query, op) {
     return;
   }
 
-  return new Promise((resolve, reject) => {
-    query._queryMiddleware.execPre(op || query.op, query, [], (error) => {
-      if (error != null) {
-        return reject(error);
-      }
-      resolve();
-    });
-  });
+  return query._queryMiddleware.execPre(op || query.op, query, []);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^6.10.3",
-    "kareem": "2.6.3",
+    "kareem": "git@github.com:mongoosejs/kareem.git#vkarpov15/v3",
     "mongodb": "~6.14.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14423,6 +14423,20 @@ describe('document', function() {
       sinon.restore();
     }
   });
+
+  describe('async stack traces (gh-15317)', function() {
+    it('works with save() validation errors', async function() {
+      const userSchema = new mongoose.Schema({
+        name: { type: String, required: true, validate: v => v.length > 3 },
+        age: Number
+      });
+      const User = db.model('User', userSchema);
+      const doc = new User({ name: 'A' });
+      const err = await doc.save().then(() => null, err => err);
+      assert.ok(err instanceof Error);
+      assert.ok(err.stack.includes('document.test.js'), err.stack);
+    });
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14424,8 +14424,8 @@ describe('document', function() {
     }
   });
 
-  describe('async stack traces (gh-15317)', function () {
-    it('works with save() validation errors', async function () {
+  describe('async stack traces (gh-15317)', function() {
+    it('works with save() validation errors', async function() {
       const userSchema = new mongoose.Schema({
         name: { type: String, required: true, validate: v => v.length > 3 },
         age: Number

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -320,7 +320,7 @@ describe('model middleware', function() {
 
     schema.pre('save', function(next) {
       next();
-      // This error will not get reported, because you already called next()
+      // Error takes precedence over next()
       throw new Error('woops!');
     });
 
@@ -333,8 +333,10 @@ describe('model middleware', function() {
 
     const test = new TestMiddleware({ title: 'Test' });
 
-    await test.save();
-    assert.equal(called, 1);
+    const err = await test.save().then(() => null, err => err);
+    assert.ok(err);
+    assert.equal(err.message, 'woops!');
+    assert.equal(called, 0);
   });
 
   it('validate + remove', async function() {

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -333,9 +333,7 @@ describe('model middleware', function() {
 
     const test = new TestMiddleware({ title: 'Test' });
 
-    const err = await test.save().then(() => null, err => err);
-    assert.ok(err);
-    assert.equal(err.message, 'woops!');
+    await assert.rejects(test.save(), /woops!/);
     assert.equal(called, 0);
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: https://github.com/mongoosejs/kareem/pull/39. With this change, we get async stack traces for validation errors in 9.0 branch :+1:

```javascript

Error.stackTraceLimit = 20;

const mongoose = require("mongoose");
mongoose.connect("mongodb://localhost:27017/mongoose_test");


const userSchema = new mongoose.Schema({
  name: { type: String, required: true, validate: v => v.length > 3 },
  age: Number,
});
userSchema.pre('validate', function() {
  if (this.name === 'secret') {
    throw new Error('name cannot be secret');
  }
});

const User = mongoose.model("User", userSchema);

async function runDemo() {
  const doc = new User({ name: 'A' });
  // await doc.validate().catch(err => console.log('Validate', err));
  await doc.save().catch(err => console.log('Save', err));
}

runDemo().catch(err => console.log(err.stack));

```

Output:

```
Save ValidationError: User validation failed: name: Validator failed for path `name` with value `A`
    at Document.invalidate (/home/v/Desktop/MongoDB/mongoose/lib/document.js:3319:32)
    at validatePath (/home/v/Desktop/MongoDB/mongoose/lib/document.js:3094:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at async model.$__validate (/home/v/Desktop/MongoDB/mongoose/lib/document.js:3035:3)
    at async model.validate (/home/v/Desktop/MongoDB/mongoose/lib/document.js:2645:5)
    at async model.validateBeforeSave (/home/v/Desktop/MongoDB/mongoose/lib/plugins/validateBeforeSave.js:34:7)
    at async Kareem.execPre (/home/v/Desktop/MongoDB/mongoose/node_modules/kareem/index.js:95:11)
    at async model.$__save (/home/v/Desktop/MongoDB/mongoose/lib/model.js:498:5)
    at async model.save (/home/v/Desktop/MongoDB/mongoose/lib/model.js:654:5)
    at async runDemo (/home/v/Desktop/MongoDB/troubleshoot-mongoose/gh-14250.js:23:3) {
  errors: {
    name: ValidatorError: Validator failed for path `name` with value `A`
        at SchemaString.doValidate (/home/v/Desktop/MongoDB/mongoose/lib/schemaType.js:1392:13)
        at validatePath (/home/v/Desktop/MongoDB/mongoose/lib/document.js:3086:24)
        at model.$__validate (/home/v/Desktop/MongoDB/mongoose/lib/document.js:3032:21)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async model.validate (/home/v/Desktop/MongoDB/mongoose/lib/document.js:2645:5)
        at async model.validateBeforeSave (/home/v/Desktop/MongoDB/mongoose/lib/plugins/validateBeforeSave.js:34:7)
        at async Kareem.execPre (/home/v/Desktop/MongoDB/mongoose/node_modules/kareem/index.js:95:11)
        at async model.$__save (/home/v/Desktop/MongoDB/mongoose/lib/model.js:498:5)
        at async model.save (/home/v/Desktop/MongoDB/mongoose/lib/model.js:654:5)
        at async runDemo (/home/v/Desktop/MongoDB/troubleshoot-mongoose/gh-14250.js:23:3) {
      properties: [Object],
      kind: 'user defined',
      path: 'name',
      value: 'A',
      reason: undefined,
      [Symbol(mongoose#validatorError)]: true
    }
  },
  _message: 'User validation failed'
}
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
