### PR TITLE
feat: support custom types exported from driver

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -179,6 +179,10 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
     }
   }
 
+  if (driver.Types != null) {
+    Object.assign(mongoose.Schema.Types, driver.Types);
+  }
+
   const Connection = driver.Connection;
   const oldDefaultConnection = _mongoose.connections[0];
   _mongoose.connections = [new Connection(_mongoose)];


### PR DESCRIPTION
Fix #15321

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In addition to drivers exporting `Connection`, `Collection`, and `plugins`, this PR allows drivers to export `Types`, and Mongoose will assign driver types automatically to `mongoose.Schema.Types` for use in schemas.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
