### PR TITLE
types: allow default function returning undefined with DocType override

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1746,3 +1746,12 @@ async function schemaDouble() {
   const doc = await TestModel.findOne().orFail();
   expectType<Types.Double | null | undefined>(doc.balance);
 }
+
+function defaultReturnsUndefined() {
+  const schema = new Schema<{ arr: number[] }>({
+    arr: {
+      type: [Number],
+      default: () => void 0
+    }
+  });
+}

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -97,7 +97,7 @@ declare module 'mongoose' {
      * The default value for this path. If a function, Mongoose executes the function
      * and uses the return value as the default.
      */
-    default?: DefaultType<T> | ((this: EnforcedDocType, doc: any) => DefaultType<T>) | null;
+    default?: DefaultType<T> | ((this: EnforcedDocType, doc: any) => DefaultType<T> | null | undefined) | null;
 
     /**
      * The model that `populate()` should use if populating this path.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

See test case: if defining `new Schema<DocType>`, TypeScript disallows `default: () => void 0`, which is a problem because we recommend using `default: () => void 0` to override Mongoose setting array paths to empty arrays by default.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
