### PR TITLE
fix(populate): handle virtual populate on array of UUIDs

### DIFF
--- a/lib/helpers/populate/assignRawDocsToIdStructure.js
+++ b/lib/helpers/populate/assignRawDocsToIdStructure.js
@@ -78,7 +78,12 @@ function assignRawDocsToIdStructure(rawIds, resultDocs, resultOrder, options, re
       continue;
     }
 
-    sid = String(id);
+    if (id?.constructor?.name === 'Binary' && id.sub_type === 4 && typeof id.toUUID === 'function') {
+      // Workaround for gh-15315 because Mongoose UUIDs don't use BSON UUIDs yet.
+      sid = String(id.toUUID());
+    } else {
+      sid = String(id);
+    }
     doc = resultDocs[sid];
     // If user wants separate copies of same doc, use this option
     if (options.clone && doc != null) {

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11452,13 +11452,12 @@ describe('model: populate:', function() {
 
     const category = await Category.create({ name: 'Tech', desc: 'Technology News' });
 
-    const announcement = new Announcement({
+    const announcement = await Announcement.create({
       title: 'New Tech Release',
       content: 'Details about the new tech release',
       validUntil: new Date(),
       categories: [category._id]
     });
-    await announcement.save();
 
     const populatedCategory = await Category.findOne({ _id: category._id }).populate('announcements');
     assert.strictEqual(populatedCategory.announcements.length, 1);

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11450,8 +11450,7 @@ describe('model: populate:', function() {
     const Category = db.model('Category', categorySchema);
     const Announcement = db.model('Announcement', announcementSchema);
 
-    const category = new Category({ name: 'Tech', desc: 'Technology News' });
-    await category.save();
+    const category = await Category.create({ name: 'Tech', desc: 'Technology News' });
 
     const announcement = new Announcement({
       title: 'New Tech Release',

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -7,6 +7,7 @@
 const start = require('./common');
 
 const assert = require('assert');
+const { randomUUID } = require('crypto');
 const utils = require('../lib/utils');
 const util = require('./util');
 const MongooseError = require('../lib/error/mongooseError');
@@ -11422,5 +11423,46 @@ describe('model: populate:', function() {
     assert.equal(parent.children[0].name, 'Child test updated 2');
 
     await m.disconnect();
+  });
+
+  it('handles populating UUID fields (gh-15315)', async function() {
+    const categorySchema = new Schema({
+      _id: { type: 'UUID', default: () => randomUUID() },
+      name: { type: String, required: true },
+      desc: { type: String, required: true }
+    });
+
+    categorySchema.virtual('announcements', {
+      ref: 'Announcement',
+      localField: '_id',
+      foreignField: 'categories'
+    });
+
+    const announcementSchema = new Schema({
+      _id: { type: 'UUID', default: () => randomUUID() },
+      title: { type: String, required: true },
+      content: { type: String, required: true },
+      validUntil: { type: Date, required: true },
+      important: { type: Boolean, default: false },
+      categories: [{ type: 'UUID', ref: 'Category' }]
+    });
+
+    const Category = db.model('Category', categorySchema);
+    const Announcement = db.model('Announcement', announcementSchema);
+
+    const category = new Category({ name: 'Tech', desc: 'Technology News' });
+    await category.save();
+
+    const announcement = new Announcement({
+      title: 'New Tech Release',
+      content: 'Details about the new tech release',
+      validUntil: new Date(),
+      categories: [category._id]
+    });
+    await announcement.save();
+
+    const populatedCategory = await Category.findOne({ _id: category._id }).populate('announcements');
+    assert.strictEqual(populatedCategory.announcements.length, 1);
+    assert.strictEqual(populatedCategory.announcements[0].title, 'New Tech Release');
   });
 });

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11452,7 +11452,7 @@ describe('model: populate:', function() {
 
     const category = await Category.create({ name: 'Tech', desc: 'Technology News' });
 
-    const announcement = await Announcement.create({
+    await Announcement.create({
       title: 'New Tech Release',
       content: 'Details about the new tech release',
       validUntil: new Date(),


### PR DESCRIPTION
Fix #15315

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A bit of a hack to unblock #15315 and allow virtual populate on array of UUIDs. `String()` on a `Binary` value returns a unicode string that isn't properly indexable when doing `doc = resultDocs[sid];`.

Future improvement: make Mongoose UUID types use BSON UUID class

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
