### PR TITLE
types: make `init` hooks types accurately reflect runtime behavior

### DIFF
--- a/test/types/middleware.preposttypes.test.ts
+++ b/test/types/middleware.preposttypes.test.ts
@@ -67,47 +67,6 @@ schema.pre('init', function() {
   expectType<HydratedDocument<IDocument>>(this);
 });
 
-schema.post('init', function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre('init', { document: true, query: false }, function() {
-  expectType<HydratedDocument<IDocument>>(this);
-});
-
-schema.post('init', { document: true, query: false }, function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre('init', { document: true, query: true }, function() {
-  expectType<HydratedDocument<IDocument>>(this);
-});
-
-schema.post('init', { document: true, query: true }, function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre('init', { document: false, query: true }, function() {
-  expectType<never>(this);
-});
-
-schema.post('init', { document: false, query: true }, function(res) {
-  expectType<never>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre('init', { document: false, query: false }, function() {
-  expectType<never>(this);
-});
-
-schema.post('init', { document: false, query: false }, function(res) {
-  expectType<never>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
 schema.pre('estimatedDocumentCount', function() {
   expectType<Query<any, any>>(this);
 });
@@ -693,51 +652,6 @@ schema.post('deleteOne', { document: false, query: false }, function(res) {
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['save', 'init'], function() {
-  expectType<HydratedDocument<IDocument>>(this);
-});
-
-schema.post(['save', 'init'], function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init'], { document: true, query: false }, function() {
-  expectType<HydratedDocument<IDocument>>(this);
-});
-
-schema.post(['save', 'init'], { document: true, query: false }, function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init'], { document: true, query: true }, function() {
-  expectType<HydratedDocument<IDocument>>(this);
-});
-
-schema.post(['save', 'init'], { document: true, query: true }, function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init'], { document: false, query: true }, function() {
-  expectType<never>(this);
-});
-
-schema.post(['save', 'init'], { document: false, query: true }, function(res) {
-  expectType<never>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init'], { document: false, query: false }, function() {
-  expectType<never>(this);
-});
-
-schema.post(['save', 'init'], { document: false, query: false }, function(res) {
-  expectType<never>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
 schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany'], function() {
   expectType<Query<any, any>>(this);
 });
@@ -828,51 +742,6 @@ schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['save', 'init', 'updateOne', 'deleteOne', 'validate'], function() {
-  expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
-});
-
-schema.post(['save', 'init', 'updateOne', 'deleteOne', 'validate'], function(res) {
-  expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: true }, function() {
-  expectType<Query<any, any>>(this);
-});
-
-schema.post(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: true }, function(res) {
-  expectType<Query<any, any>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: false }, function() {
-  expectType<HydratedDocument<IDocument>>(this);
-});
-
-schema.post(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: false }, function(res) {
-  expectType<HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: true }, function() {
-  expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
-});
-
-schema.post(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: true }, function(res) {
-  expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
-schema.pre(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: false }, function() {
-  expectType<never>(this);
-});
-
-schema.post(['save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: false }, function(res) {
-  expectType<never>(this);
-  expectNotType<Query<any, any>>(res);
-});
-
 schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'updateOne', 'deleteOne', 'validate'], function() {
   expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
 });
@@ -918,47 +787,47 @@ schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], function() {
+schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], function() {
   expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
 });
 
-schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], function(res) {
+schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], function(res) {
   expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: true }, function() {
+schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: false, query: true }, function() {
   expectType<Query<any, any>>(this);
 });
 
-schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: true }, function(res) {
+schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: false, query: true }, function(res) {
   expectType<Query<any, any>>(this);
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: false }, function() {
+schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: true, query: false }, function() {
   expectType<HydratedDocument<IDocument>>(this);
 });
 
-schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: false }, function(res) {
+schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: true, query: false }, function(res) {
   expectType<HydratedDocument<IDocument>>(this);
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: true }, function() {
+schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: true, query: true }, function() {
   expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
 });
 
-schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: true, query: true }, function(res) {
+schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: true, query: true }, function(res) {
   expectType<Query<any, any>|HydratedDocument<IDocument>>(this);
   expectNotType<Query<any, any>>(res);
 });
 
-schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: false }, function() {
+schema.pre(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: false, query: false }, function() {
   expectType<never>(this);
 });
 
-schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'init', 'updateOne', 'deleteOne', 'validate'], { document: false, query: false }, function(res) {
+schema.post(['estimatedDocumentCount', 'countDocuments', 'deleteMany', 'distinct', 'find', 'findOne', 'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate', 'replaceOne', 'updateMany', 'save', 'updateOne', 'deleteOne', 'validate'], { document: false, query: false }, function(res) {
   expectType<never>(this);
   expectNotType<Query<any, any>>(res);
 });

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1746,3 +1746,34 @@ async function schemaDouble() {
   const doc = await TestModel.findOne().orFail();
   expectType<Types.Double | null | undefined>(doc.balance);
 }
+
+function gh15301() {
+  interface IUser {
+    time: { hours: number, minutes: number }
+  }
+  const userSchema = new Schema<IUser>({
+    time: {
+      type: new Schema(
+        {
+          hours: { type: Number, required: true },
+          minutes: { type: Number, required: true }
+        },
+        { _id: false }
+      ),
+      required: true
+    }
+  });
+
+  const timeStringToObject = (time) => {
+    if (typeof time !== 'string') return time;
+    const [hours, minutes] = time.split(':');
+    return { hours: parseInt(hours), minutes: parseInt(minutes) };
+  };
+
+  userSchema.pre('init', function(rawDoc) {
+    expectType<IUser>(rawDoc);
+    if (typeof rawDoc.time === 'string') {
+      rawDoc.time = timeStringToObject(rawDoc.time);
+    }
+  });
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -436,6 +436,7 @@ declare module 'mongoose' {
     ): this;
     // this = Document
     pre<T = THydratedDocumentType>(method: 'save', fn: PreSaveMiddlewareFunction<T>): this;
+    pre<T = THydratedDocumentType, U = RawDocType>(method: 'init', fn: (this: T, doc: U) => void): this;
     pre<T = THydratedDocumentType>(method: MongooseDistinctDocumentMiddleware|MongooseDistinctDocumentMiddleware[], fn: PreMiddlewareFunction<T>): this;
     pre<T = THydratedDocumentType>(method: MongooseDistinctDocumentMiddleware|MongooseDistinctDocumentMiddleware[], options: SchemaPreOptions, fn: PreMiddlewareFunction<T>): this;
     pre<T = THydratedDocumentType>(

--- a/types/middlewares.d.ts
+++ b/types/middlewares.d.ts
@@ -3,7 +3,7 @@ declare module 'mongoose' {
 
   type MongooseQueryAndDocumentMiddleware = 'updateOne' | 'deleteOne';
 
-  type MongooseDistinctDocumentMiddleware = 'save' | 'init' | 'validate';
+  type MongooseDistinctDocumentMiddleware = 'save' | 'validate';
   type MongooseDocumentMiddleware = MongooseDistinctDocumentMiddleware | MongooseQueryAndDocumentMiddleware;
 
   type MongooseRawResultQueryMiddleware = 'findOneAndUpdate' | 'findOneAndReplace' | 'findOneAndDelete';


### PR DESCRIPTION
Fix #15301

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Init hooks are special because they are synchronous, so there's no `next` callback. Also, the first parameter to `init` hooks is the raw data being hydrated, **not** the hydrated Mongoose document. This PR fixes that, although in the interest of caution it might be better to put this change in a minor release. WDYT @hasezoey ?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
