### PR TITLE
feat(subdocument): support schematype-level minimize option to disable minimizing empty subdocuments

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3796,6 +3796,8 @@ Document.prototype.$toObject = function(options, json) {
   let _minimize;
   if (options._calledWithOptions.minimize != null) {
     _minimize = options.minimize;
+  } else if (this.$__schemaTypeOptions?.minimize != null) {
+    _minimize = this.$__schemaTypeOptions.minimize;
   } else if (defaultOptions != null && defaultOptions.minimize != null) {
     _minimize = defaultOptions.minimize;
   } else {

--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -57,7 +57,6 @@ function clone(obj, options, isArrayChild) {
         return clonedDoc;
       }
     }
-    const isSingleNested = obj.$isSingleNested;
 
     if (isPOJO(obj) && obj.$__ != null && obj._doc != null) {
       return obj._doc;
@@ -68,10 +67,6 @@ function clone(obj, options, isArrayChild) {
       ret = obj.toJSON(options);
     } else {
       ret = obj.toObject(options);
-    }
-
-    if (options && options.minimize && !obj.constructor.$__required && isSingleNested && Object.keys(ret).length === 0) {
-      return undefined;
     }
 
     return ret;

--- a/lib/options/schemaSubdocumentOptions.js
+++ b/lib/options/schemaSubdocumentOptions.js
@@ -31,12 +31,36 @@ const opts = require('./propertyOptions');
  *     parentSchema.path('child').schema.options._id; // false
  *
  * @api public
- * @property of
+ * @property _id
  * @memberOf SchemaSubdocumentOptions
  * @type {Function|string}
  * @instance
  */
 
 Object.defineProperty(SchemaSubdocumentOptions.prototype, '_id', opts);
+
+/**
+ * If set, overwrites the child schema's `minimize` option. In addition, configures whether the entire
+ * subdocument can be minimized out.
+ *
+ * #### Example:
+ *
+ *     const childSchema = Schema({ name: String });
+ *     const parentSchema = Schema({
+ *       child: { type: childSchema, minimize: false }
+ *     });
+ *     const ParentModel = mongoose.model('Parent', parentSchema);
+ *     // Saves `{ child: {} }` to the db. Without `minimize: false`, Mongoose would remove the empty
+ *     // object and save `{}` to the db.
+ *     await ParentModel.create({ child: {} });
+ *
+ * @api public
+ * @property minimize
+ * @memberOf SchemaSubdocumentOptions
+ * @type {Function|string}
+ * @instance
+ */
+
+Object.defineProperty(SchemaSubdocumentOptions.prototype, 'minimize', opts);
 
 module.exports = SchemaSubdocumentOptions;

--- a/lib/schema/subdocument.js
+++ b/lib/schema/subdocument.js
@@ -90,6 +90,7 @@ function _createConstructor(schema, baseClass, options) {
   _embedded.prototype = Object.create(proto);
   _embedded.prototype.$__setSchema(schema);
   _embedded.prototype.constructor = _embedded;
+  _embedded.prototype.$__schemaTypeOptions = options;
   _embedded.$__required = options?.required;
   _embedded.base = schema.base;
   _embedded.schema = schema;

--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -413,6 +413,25 @@ if (util.inspect.custom) {
 }
 
 /**
+ * Override `$toObject()` to handle minimizing the whole path. Should not minimize if schematype-level minimize
+ * is set to false re: gh-11247, gh-14058, gh-14151
+ */
+
+Subdocument.prototype.$toObject = function $toObject(options, json) {
+  const ret = Document.prototype.$toObject.call(this, options, json);
+
+  // If `$toObject()` was called recursively, respect the minimize option, including schematype level minimize.
+  // If minimize is set, then we can minimize out the whole object.
+  if (Object.keys(ret).length === 0 && options?._calledWithOptions != null) {
+    const minimize = options._calledWithOptions?.minimize ?? this?.$__schemaTypeOptions?.minimize ?? options.minimize;
+    if (minimize && !this.constructor.$__required) {
+      return undefined;
+    }
+  }
+  return ret;
+};
+
+/**
  * Registers remove event listeners for triggering
  * on subdocuments.
  *

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -97,4 +97,13 @@ describe('types.subdocument', function() {
       assert.ok(doc.child.isModified('id'));
     });
   });
+
+  it('respects schematype-level minimize (gh-15313)', function() {
+    const MySubSchema = new Schema({}, { _id: false });
+    const MySchema = new Schema({ myfield: { type: MySubSchema, minimize: false } });
+    const MyModel = db.model('MyModel', MySchema);
+
+    const doc = new MyModel({ myfield: {} });
+    assert.deepStrictEqual(doc.toObject().myfield, {});
+  });
 });

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -99,11 +99,14 @@ describe('types.subdocument', function() {
   });
 
   it('respects schematype-level minimize (gh-15313)', function() {
-    const MySubSchema = new Schema({}, { _id: false });
+    const MySubSchema = new Schema({}, { strict: false, _id: false });
     const MySchema = new Schema({ myfield: { type: MySubSchema, minimize: false } });
     const MyModel = db.model('MyModel', MySchema);
 
     const doc = new MyModel({ myfield: {} });
     assert.deepStrictEqual(doc.toObject().myfield, {});
+
+    const doc2 = new MyModel({ myfield: { empty: {} } });
+    assert.deepStrictEqual(doc2.toObject().myfield, { empty: {} });
   });
 });

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -173,6 +173,9 @@ declare module 'mongoose' {
     /** The maximum value allowed for this path. Only allowed for numbers and dates. */
     max?: number | NativeDate | [number, string] | [NativeDate, string] | readonly [number, string] | readonly [NativeDate, string];
 
+    /** Set to false to disable minimizing empty single nested subdocuments by default */
+    minimize?: boolean;
+
     /** Defines a TTL index on this path. Only allowed for dates. */
     expires?: string | number;
 


### PR DESCRIPTION
Fix #15313

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In #11247, we made it so that Mongoose would minimize empty subdocuments by default. However, there isn't a great way to configure that behavior right now: #14151 disabled that behavior for required subdocs, but you might not want to make the field required.

This PR lets you set a `minimize` option on the schematype itself, like `subdoc: { type: Schema, minimize: false }` to disable minimize on the full subdocument. Setting `minimize: false` on the schematype will also override the child schema's `minimize`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
