### PR TITLE
Implement Query findById methods

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3748,13 +3748,6 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
  */
 
 Query.prototype.findById = function(id, projection, options) {
-  if (typeof id === 'function' ||
-      typeof projection === 'function' ||
-      typeof options === 'function' ||
-      typeof arguments[3] === 'function') {
-    throw new MongooseError('Query.prototype.findById() no longer accepts a callback');
-  }
-
   return this.findOne({ _id: id }, projection, options);
 };
 
@@ -3796,13 +3789,6 @@ Query.prototype.findById = function(id, projection, options) {
  */
 
 Query.prototype.findByIdAndUpdate = function(id, update, options) {
-  if (typeof id === 'function' ||
-    typeof update === 'function' ||
-    typeof options === 'function' ||
-    typeof arguments[3] === 'function') {
-    throw new MongooseError('Query.prototype.findByIdAndUpdate() no longer accepts a callback');
-  }
-
   return this.findOneAndUpdate({ _id: id }, update, options);
 };
 
@@ -3828,12 +3814,6 @@ Query.prototype.findByIdAndUpdate = function(id, update, options) {
  */
 
 Query.prototype.findByIdAndDelete = function(id, options) {
-  if (typeof id === 'function' ||
-      typeof options === 'function' ||
-      typeof arguments[2] === 'function') {
-    throw new MongooseError('Query.prototype.findByIdAndDelete() no longer accepts a callback');
-  }
-
   return this.findOneAndDelete({ _id: id }, options);
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -3333,8 +3333,6 @@ function prepareDiscriminatorCriteria(query) {
  * @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
  * @param {Boolean} [options.new=false] By default, `findOneAndUpdate()` returns the document as it was **before** `update` was applied. If you set `new: true`, `findOneAndUpdate()` will instead give you the object after `update` was applied.
  * @param {Object} [options.lean] if truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document. See [`Query.lean()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.lean()) and [the Mongoose lean tutorial](https://mongoosejs.com/docs/tutorials/lean.html).
- * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
- * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
  * @param {Boolean} [options.returnOriginal=null] An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
  * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `filter`, `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
@@ -3724,6 +3722,119 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
       resolve(res);
     });
   });
+};
+
+/**
+ * Finds a single document by its _id field. `findById(id)` is equivalent to
+ * `findOne({ _id: id })`.
+ *
+ * The `id` is cast based on the Schema before sending the command.
+ *
+ * This function triggers the following middleware.
+ *
+ * - `findOne()`
+ *
+ * @method findById
+ * @memberOf Query
+ * @instance
+ * @param {Any} id value of `_id` to query by
+ * @param {Object} [projection] optional fields to return
+ * @param {Object} [options] see [`setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
+ * @return {Query} this
+ * @see findOne https://www.mongodb.com/docs/manual/reference/method/db.collection.findOne/
+ * @see Query.select https://mongoosejs.com/docs/api/query.html#Query.prototype.select()
+ * @api public
+ */
+
+Query.prototype.findById = function(id, projection, options) {
+  if (typeof id === 'function' ||
+      typeof projection === 'function' ||
+      typeof options === 'function' ||
+      typeof arguments[3] === 'function') {
+    throw new MongooseError('Query.prototype.findById() no longer accepts a callback');
+  }
+
+  return this.findOne({ _id: id }, projection, options);
+};
+
+
+/**
+ * Issues a mongodb findOneAndUpdate command by a document's _id field.
+ * `findByIdAndUpdate(id, ...)` is equivalent to `findOneAndUpdate({ _id: id }, ...)`.
+ *
+ * Finds a matching document, updates it according to the `update` arg,
+ * passing any `options`, and returns the found document (if any).
+ *
+ * This function triggers the following middleware.
+ *
+ * - `findOneAndUpdate()`
+ *
+ * @method findByIdAndUpdate
+ * @memberOf Query
+ * @instance
+ * @param {Any} id value of `_id` to query by
+ * @param {Object} [doc]
+ * @param {Object} [options]
+ * @param {Boolean} [options.includeResultMetadata] if true, returns the full [ModifyResult from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html) rather than just the document
+ * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
+ * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
+ * @param {Boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
+ * @param {Boolean} [options.new=false] By default, `findOneAndUpdate()` returns the document as it was **before** `update` was applied. If you set `new: true`, `findOneAndUpdate()` will instead give you the object after `update` was applied.
+ * @param {Object} [options.lean] if truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document. See [`Query.lean()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.lean()) and [the Mongoose lean tutorial](https://mongoosejs.com/docs/tutorials/lean.html).
+ * @param {Boolean} [options.timestamps=null] If set to `false` and [schema-level timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this update. Note that this allows you to overwrite timestamps. Does nothing if schema-level timestamps are not set.
+ * @param {Boolean} [options.returnOriginal=null] An alias for the `new` option. `returnOriginal: false` is equivalent to `new: true`.
+ * @param {Boolean} [options.translateAliases=null] If set to `true`, translates any schema-defined aliases in `projection`, `update`, and `distinct`. Throws an error if there are any conflicts where both alias and raw property are defined on the same object.
+ * @param {Boolean} [options.overwriteDiscriminatorKey=false] Mongoose removes discriminator key updates from `update` by default, set `overwriteDiscriminatorKey` to `true` to allow updating the discriminator key
+ * @param {Boolean} [options.overwriteImmutable=false] Mongoose removes updated immutable properties from `update` by default (excluding $setOnInsert). Set `overwriteImmutable` to `true` to allow updating immutable properties using other update operators.
+ * @see Tutorial https://mongoosejs.com/docs/tutorials/findoneandupdate.html
+ * @see findAndModify command https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+ * @see ModifyResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html
+ * @see findOneAndUpdate https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#findOneAndUpdate
+ * @return {Query} this
+ * @api public
+ */
+
+Query.prototype.findByIdAndUpdate = function(id, update, options) {
+  if (typeof id === 'function' ||
+    typeof update === 'function' ||
+    typeof options === 'function' ||
+    typeof arguments[3] === 'function') {
+    throw new MongooseError('Query.prototype.findByIdAndUpdate() no longer accepts a callback');
+  }
+
+  return this.findOneAndUpdate({ _id: id }, update, options);
+};
+
+/**
+ * Issue a MongoDB `findOneAndDelete()` command by a document's _id field.
+ * In other words, `findByIdAndDelete(id)` is a shorthand for
+ * `findOneAndDelete({ _id: id })`.
+ *
+ * This function triggers the following middleware.
+ *
+ * - `findOneAndDelete()`
+ *
+ * @method findByIdAndDelete
+ * @memberOf Query
+ * @param {any} id value of `_id` to query by
+ * @param {Object} [options]
+ * @param {Boolean} [options.includeResultMetadata] if true, returns the full [ModifyResult from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/ModifyResult.html) rather than just the document
+ * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
+ * @param {Boolean|String} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
+ * @return {Query} this
+ * @see findAndModify command https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+ * @api public
+ */
+
+Query.prototype.findByIdAndDelete = function(id, options) {
+  if (typeof id === 'function' ||
+      typeof options === 'function' ||
+      typeof arguments[2] === 'function') {
+    throw new MongooseError('Query.prototype.findByIdAndDelete() no longer accepts a callback');
+  }
+
+  return this.findOneAndDelete({ _id: id }, options);
 };
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4412,4 +4412,47 @@ describe('Query', function() {
       assert.strictEqual(doc.passwordHash, undefined);
     });
   });
+
+  describe('findById(andUpdate/andDelete)', function() {
+    let Person;
+    let _id;
+    const targetName = 'Charlie';
+
+    beforeEach(async function() {
+      const schema = new Schema({ name: String, age: Number });
+      Person = db.model('Person', schema);
+
+      const people = await Person.create([
+        { name: 'Alice', age: 10 },
+        { name: 'Bob', age: 20 },
+        { name: targetName, age: 30 },
+        { name: 'Dave', age: 40 }
+      ]);
+      _id = people[2]._id;
+    });
+
+    it('findById returns null for undefined', async function() {
+      const queryUndefined = await Person.find({}).findById(undefined);
+      assert.strictEqual(queryUndefined, null);
+    });
+
+    it('findById returns document for valid _id', async function() {
+      const target = await Person.find({}).findById(_id);
+      assert.strictEqual(target?.name, targetName);
+    });
+
+    it('findByIdAndUpdate updates and returns the updated document', async function() {
+      const updatedAge = 50;
+      const updatedTarget = await Person.find({}).findByIdAndUpdate(_id, { age: updatedAge }, { new: true });
+      assert.strictEqual(updatedTarget?.age, updatedAge);
+    });
+
+    it('findByIdAndDelete deletes and returns the deleted document', async function() {
+      const deletedTarget = await Person.find({}).findByIdAndDelete(_id);
+      assert.strictEqual(deletedTarget?.name, targetName);
+
+      const target = await Person.find({}).findById(_id);
+      assert.strictEqual(target, null);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Even though [query.d.ts says otherwise](https://github.com/Automattic/mongoose/blob/5325a8544bce24a6994576e7b6d5ee4500469652/types/query.d.ts#L474-L517), `Query` does NOT in fact have the following methods:
- `findById`
- `findByIdAndUpdate`
- `findByIdAndDelete`

You can see as much if you try to call them. Here's a reproducible example:
```ts
import mongoose from "mongoose";

type Person = {
  _id: mongoose.Types.ObjectId;
  name: string;
  email: string;
  archived: boolean;
  createdAt: number;
  updatedAt: number;
};

const personSchema = new mongoose.Schema<Person>({
  name: { type: String, required: true },
  email: { type: String, required: true, index: true },
  archived: { type: Boolean, default: false },

  createdAt: { type: Number },
  updatedAt: { type: Number },
});

const Person = mongoose.model("Person", personSchema);

async function run() {
  await mongoose.connect("mongodb://127.0.0.1:27017");

  await mongoose.connection.dropDatabase();
  console.log("Database dropped");

  const person = await Person.create({ name: "Alice", email: "alice@example.com" });
  console.log("Person created");

  try {
    const p = await Person.find({}).findById(person._id);
    console.log("[success] Query.prototype.findById", p?.id);
  } catch (err: any) {
    console.error("[error] Query.prototype.findById failed:", err.message);
  }

  try {
    await Person.find({}).findByIdAndUpdate(person._id, { email: "a@b.com" });
    console.log("[success] Query.prototype.findByIdAndUpdate");
  } catch (err: any) {
    console.error("[error] Query.prototype.findByIdAndUpdate failed:", err.message);
  }

  try {
    await Person.find({}).findByIdAndDelete(person._id);
    console.log("[success] Query.prototype.findByIdAndDelete");
  } catch (err: any) {
    console.error("[error] Query.prototype.findByIdAndDelete failed:", err.message);
  }

  try {
    const p = await Person.find({}).findOne({ _id: person._id });
    console.log("[success] Query.prototype.findOne", p?.id);
  } catch (err: any) {
    console.error("[error] Query.prototype.findOne failed:", err.message);
  }

  try {
    const p = await Person.find({}).findOneAndUpdate({ _id: person._id }, { email: "a@b.com" });
    console.log("[success] Query.prototype.findOneAndUpdate", p?.id);
  } catch (err: any) {
    console.error("[error] Query.prototype.findOneAndUpdate failed:", err.message);
  }

  try {
    const p = await Person.find({}).findOneAndDelete({ _id: person._id });
    console.log("[success] Query.prototype.findOneAndDelete", p?.id);
  } catch (err: any) {
    console.error("[error] Query.prototype.findOneAndDelete failed:", err.message);
  }
}

void run()
```

That example gives zero Typescript warnings because it thinks `findById`, `findByIdAndUpdate`, and `findByIdAndDelete` are all valid methods on `Query`. But when you actually run it, you get the following output:
```
Database dropped
Person created
[error] Query.prototype.findById failed: Person.find(...).findById is not a function
[error] Query.prototype.findByIdAndUpdate failed: Person.find(...).findByIdAndUpdate is not a function
[error] Query.prototype.findByIdAndDelete failed: Person.find(...).findByIdAndDelete is not a function
[success] Query.prototype.findOne 67ec4b44052e05360699693f
[success] Query.prototype.findOneAndUpdate 67ec4b44052e05360699693f
[success] Query.prototype.findOneAndDelete 67ec4b44052e05360699693f
```

One place where this distinction matters is with the `accessibleBy` casl plugin. [This comment](https://github.com/stalniy/casl/issues/662#issuecomment-1268041296) references the problem, but no action was taken to address the root cause.

I'm not sure if the type declarations were included by mistake ([here](https://github.com/Automattic/mongoose/commit/374a50bc7c64a049830dae7d999ec76240aaefbc) and [here](https://github.com/Automattic/mongoose/commit/59dd6af78f8a4ce73125669dd7192f0b79be4d2e)), or if the implementations used to exist and were deleted at some point.

I don't see the harm in including the implementations, so that's what this PR adds. Basic tests included.
