### PR TITLE
Avoid double calling validators on paths in document arrays underneath subdocuments

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2726,7 +2726,7 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
     const modifiedPaths = doc.modifiedPaths();
     for (const subdoc of subdocs) {
       if (subdoc.$basePath) {
-        const fullPathToSubdoc = subdoc.$isSingleNested ? subdoc.$__pathRelativeToParent() : subdoc.$__fullPathWithIndexes();
+        const fullPathToSubdoc = subdoc.$__pathRelativeToParent();
 
         // Remove child paths for now, because we'll be validating the whole
         // subdoc.
@@ -2736,11 +2736,12 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
           paths.delete(fullPathToSubdoc + '.' + modifiedPath);
         }
 
+        const subdocParent = subdoc.$parent();
         if (doc.$isModified(fullPathToSubdoc, null, modifiedPaths) &&
               // Avoid using isDirectModified() here because that does additional checks on whether the parent path
               // is direct modified, which can cause performance issues re: gh-14897
-              !doc.$__.activePaths.getStatePaths('modify').hasOwnProperty(fullPathToSubdoc) &&
-              !doc.$isDefault(fullPathToSubdoc)) {
+              !subdocParent.$__.activePaths.getStatePaths('modify').hasOwnProperty(fullPathToSubdoc) &&
+              !subdocParent.$isDefault(fullPathToSubdoc)) {
           paths.add(fullPathToSubdoc);
 
           if (doc.$__.pathsToScopes == null) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -2721,10 +2721,31 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
   function addToPaths(p) { paths.add(p); }
 
   if (!isNestedValidate) {
-    // If we're validating a subdocument, all this logic will run anyway on the top-level document, so skip for subdocuments
-    const subdocs = doc.$getAllSubdocs({ useCache: true });
+    // If we're validating a subdocument, all this logic will run anyway on the top-level document, so skip for subdocuments.
+    // But only run for top-level subdocuments, because we're looking for subdocuments that are not modified at top-level but
+    // have a modified path. If that is the case, we will run validation on the top-level subdocument, and via that run validation
+    // on any subdocuments down to the modified path.
+    const topLevelSubdocs = [];
+    for (const path of Object.keys(doc.$__schema.paths)) {
+      const schemaType = doc.$__schema.path(path);
+      if (schemaType.$isSingleNested) {
+        const subdoc = doc.$get(path);
+        if (subdoc) {
+          topLevelSubdocs.push(subdoc);
+        }
+      } else if (schemaType.$isMongooseDocumentArray) {
+        const arr = doc.$get(path);
+        if (arr && arr.length) {
+          for (const subdoc of arr) {
+            if (subdoc) {
+              topLevelSubdocs.push(subdoc);
+            }
+          }
+        }
+      }
+    }
     const modifiedPaths = doc.modifiedPaths();
-    for (const subdoc of subdocs) {
+    for (const subdoc of topLevelSubdocs) {
       if (subdoc.$basePath) {
         const fullPathToSubdoc = subdoc.$__pathRelativeToParent();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15335 points out that we double-run validation on document array elements if the document array is underneath a subdocument. This is because of some logic we added to run validation on intermediate subdocuments in cases where a nested subdocument is modified but the top-level subdocument is not.

This PR ensures that we only consider top-level subdocuments, not nested subdocuments, when adding documents to `pathsToValidate`. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
