### PR TITLE
feat: add skipOriginalStackTraces option to avoid stack trace performance overhead

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2620,7 +2620,6 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
   if (typeof pathsToValidate === 'function' || typeof options === 'function' || typeof arguments[2] === 'function') {
     throw new MongooseError('Document.prototype.validate() no longer accepts a callback');
   }
-  let parallelValidate;
   this.$op = 'validate';
 
   if (arguments.length === 1) {
@@ -2641,10 +2640,6 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
     throw new ParallelValidateError(this);
   } else if (!_skipParallelValidateCheck) {
     this.$__.validating = true;
-  }
-
-  if (parallelValidate != null) {
-    throw parallelValidate;
   }
 
   return new Promise((resolve, reject) => {

--- a/lib/document.js
+++ b/lib/document.js
@@ -2638,12 +2638,9 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
   if (this.$isSubdocument != null) {
     // Skip parallel validate check for subdocuments
   } else if (this.$__.validating && !_skipParallelValidateCheck) {
-    parallelValidate = new ParallelValidateError(this, {
-      parentStack: options && options.parentStack,
-      conflictStack: this.$__.validating.stack
-    });
+    throw new ParallelValidateError(this);
   } else if (!_skipParallelValidateCheck) {
-    this.$__.validating = new ParallelValidateError(this, { parentStack: options && options.parentStack });
+    this.$__.validating = true;
   }
 
   if (parallelValidate != null) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4431,10 +4431,12 @@ Query.prototype.exec = async function exec(op) {
       str = str.slice(0, 60) + '...';
     }
     const err = new MongooseError('Query was already executed: ' + str);
-    err.originalStack = this._executionStack;
+    if (!this.model.base.options.skipOriginalStackTraces) {
+      err.originalStack = this._executionStack;
+    }
     throw err;
   } else {
-    this._executionStack = new Error().stack;
+    this._executionStack = this.model.base.options.skipOriginalStackTraces ? true : new Error().stack;
   }
 
   let skipWrappedFunction = null;

--- a/lib/validOptions.js
+++ b/lib/validOptions.js
@@ -29,6 +29,7 @@ const VALID_OPTIONS = Object.freeze([
   'sanitizeProjection',
   'selectPopulatedPaths',
   'setDefaultsOnInsert',
+  'skipOriginalStackTraces',
   'strict',
   'strictPopulate',
   'strictQuery',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1228,4 +1228,19 @@ describe('mongoose module:', function() {
       assert.equal(m.connection.readyState, 1);
     });
   });
+
+  it('supports skipOriginalStackTraces option (gh-15194)', async function() {
+    const schema = new Schema({ name: { type: String, required: true } });
+    const m = new mongoose.Mongoose();
+    m.set('skipOriginalStackTraces', true);
+    await m.connect(start.uri);
+
+    const TestModel = m.model('Test', schema);
+    const q = TestModel.find({});
+    await q.exec();
+    assert.strictEqual(q._executionStack, true);
+
+    const err = await q.exec().then(() => null, err => err);
+    assert.strictEqual(err.originalStack, undefined);
+  });
 });

--- a/types/mongooseoptions.d.ts
+++ b/types/mongooseoptions.d.ts
@@ -215,5 +215,13 @@ declare module 'mongoose' {
      * to their database property names. Defaults to false.
      */
     translateAliases?: boolean;
+
+    /**
+     * Mongoose queries currently store an `_executionStack` property that stores the stack trace
+     * of where the query was originally executed for debugging `Query was already executed` errors.
+     * This behavior can cause performance issues with bundlers and source maps. Set this option to
+     * `true` to disable Mongoose query stack trace collection.
+     */
+    skipOriginalStackTraces?: boolean;
   }
 }


### PR DESCRIPTION
Re: #15194

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Pulling in some work from 9.0 to hopefully address #15194. Given that users have bisected the issue to Mongoose 8.8.2, the most likely culprit is #15039. We plan on removing `_executionStack` in 9.0 because we don't think `_executionStack` provides enough value now that callback support is gone. This PR adds a `skipOriginalStackTraces` option that opts into skipping `_executionStack`, which should hopefully address the performance issues from #15194.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
