### PR TITLE
types: include virtuals in toJSON and toObject output if `virtuals: true` set

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -459,3 +459,19 @@ async function gh15077() {
     foundFoo = createdFoo.toObject();
   }
 }
+
+async function gh15316() {
+  const schema = new Schema({
+    name: { type: String, required: true }
+  }, {
+    virtuals: {
+      upper: { get() { return this.name.toUpperCase(); } }
+    }
+  });
+  const TestModel = model('Test', schema);
+
+  const doc = new TestModel({ name: 'taco' });
+
+  expectType<string>(doc.toJSON({ virtuals: true }).upper);
+  expectType<string>(doc.toObject({ virtuals: true }).upper);
+}

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -18,7 +18,7 @@ declare module 'mongoose' {
    * *  TQueryHelpers - Object with any helpers that should be mixed into the Query type
    * *  DocType - the type of the actual Document created
    */
-  class Document<T = unknown, TQueryHelpers = any, DocType = any> {
+  class Document<T = unknown, TQueryHelpers = any, DocType = any, TVirtuals = Record<string, any>> {
     constructor(doc?: any);
 
     /** This documents _id. */
@@ -256,6 +256,7 @@ declare module 'mongoose' {
     set(value: string | Record<string, any>): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
+    toJSON(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>>;
     toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Default__v<Require_id<DocType>>>;
     toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Default__v<Require_id<DocType>>>;
     toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType>>>>;
@@ -269,6 +270,7 @@ declare module 'mongoose' {
     toJSON<T = Default__v<Require_id<DocType>>>(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<T>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
+    toObject(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>>;
     toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>>;
     toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,7 +90,8 @@ declare module 'mongoose' {
   HydratedDocument<
   InferSchemaType<TSchema>,
   ObtainSchemaGeneric<TSchema, 'TVirtuals'> & ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
-  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>
+  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
+  ObtainSchemaGeneric<TSchema, 'TVirtuals'>
   >,
   TSchema
   > & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
@@ -146,16 +147,17 @@ declare module 'mongoose' {
   export type HydratedDocument<
     DocType,
     TOverrides = {},
-    TQueryHelpers = {}
+    TQueryHelpers = {},
+    TVirtuals = {}
   > = IfAny<
     DocType,
     any,
     TOverrides extends Record<string, never> ?
-      Document<unknown, TQueryHelpers, DocType> & Default__v<Require_id<DocType>> :
+      Document<unknown, TQueryHelpers, DocType, TVirtuals> & Default__v<Require_id<DocType>> :
       IfAny<
         TOverrides,
-        Document<unknown, TQueryHelpers, DocType> & Default__v<Require_id<DocType>>,
-        Document<unknown, TQueryHelpers, DocType> & MergeType<
+        Document<unknown, TQueryHelpers, DocType, TVirtuals> & Default__v<Require_id<DocType>>,
+        Document<unknown, TQueryHelpers, DocType, TVirtuals> & MergeType<
           Default__v<Require_id<DocType>>,
           TOverrides
         >
@@ -196,7 +198,8 @@ declare module 'mongoose' {
   export type HydratedDocumentFromSchema<TSchema extends Schema> = HydratedDocument<
   InferSchemaType<TSchema>,
   ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
-  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>
+  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
+  ObtainSchemaGeneric<TSchema, 'TVirtuals'>
   >;
 
   export interface TagSet {
@@ -269,7 +272,7 @@ declare module 'mongoose' {
       ObtainDocumentType<any, RawDocType, ResolveSchemaOptions<TSchemaOptions>>,
       ResolveSchemaOptions<TSchemaOptions>
     >,
-    THydratedDocumentType = HydratedDocument<FlatRecord<DocType>, TVirtuals & TInstanceMethods>
+    THydratedDocumentType = HydratedDocument<FlatRecord<DocType>, TVirtuals & TInstanceMethods, {}, TVirtuals>
   >
     extends events.EventEmitter {
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -197,7 +197,7 @@ declare module 'mongoose' {
 
   export type HydratedDocumentFromSchema<TSchema extends Schema> = HydratedDocument<
   InferSchemaType<TSchema>,
-  ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
+  ObtainSchemaGeneric<TSchema, 'TInstanceMethods'> & ObtainSchemaGeneric<TSchema, 'TVirtuals'>,
   ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
   ObtainSchemaGeneric<TSchema, 'TVirtuals'>
   >;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -263,7 +263,7 @@ declare module 'mongoose' {
     TQueryHelpers = {},
     TInstanceMethods = {},
     TVirtuals = {},
-    THydratedDocumentType = HydratedDocument<TRawDocType, TVirtuals & TInstanceMethods, TQueryHelpers>,
+    THydratedDocumentType = HydratedDocument<TRawDocType, TVirtuals & TInstanceMethods, TQueryHelpers, TVirtuals>,
     TSchema = any> extends
     NodeJS.EventEmitter,
     AcceptsDiscriminator,


### PR DESCRIPTION
Fix #15316

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In TypeScript `toJSON({ virtuals: true })` and `toObject({ virtuals: true })` don't include virtuals even if virtuals are easy to infer.

To support this, I added a separate `TVirtuals` parameter to `HydratedDocument` in addition to `TOverrides`. Unfortunately this is somewhat redundant because virtuals are passed in to `HydratedDocument` twice. We can consider changing that for 9.0 so `TOverrides` becomes `TMethods`.

I'm putting this in 8.14 release because it seems to qualify as a new feature.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
