### PR TITLE
docs: adds Model#count to list of fns callback removed from

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -158,7 +158,7 @@ conn.startSession(function(err, session) {
 // After
 const session = await conn.startSession();
 // Or:
-conn.startSession().then(sesson => { /* ... */ });
+conn.startSession().then(session => { /* ... */ });
 
 // With error handling
 try {

--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -106,6 +106,7 @@ They always return promises.
 * `Model.aggregate`
 * `Model.bulkWrite`
 * `Model.cleanIndexes`
+* `Model.count`
 * `Model.countDocuments`
 * `Model.create`
 * `Model.createCollection`
@@ -130,6 +131,7 @@ They always return promises.
 * `Model.syncIndexes`
 * `Model.updateMany`
 * `Model.updateOne`
+* `Query.prototype.count`
 * `Query.prototype.find`
 * `Query.prototype.findOne`
 * `Query.prototype.findOneAndDelete`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

I'm working on migrating from Mongoose v6 to Mongoose v7. Part of this includes dropping all callbacks in favor of Promises.

I noticed that `Model#count` and `Query#count` is not in the list though, which according to the types, had a callback param in v6, which was removed in v7. This should be in the list of functions as well that the `callback` param was removed from too.

_(Also fixes a petty typo as well, since I was modifying this file anyway.)_

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

N/A