### PR TITLE
docs: update deleteOne & deleteMany API def

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3096,13 +3096,12 @@ function _handleSortValue(val, key) {
  *
  *     await Character.deleteOne({ name: 'Eddard Stark' });
  *
- * This function calls the MongoDB driver's [`Collection#deleteOne()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteOne).
+ * This function calls the MongoDB driver's [`Collection#deleteOne()` function](https://mongodb.github.io/node-mongodb-native/6.15/classes/Collection.html#deleteOne).
  * The returned [promise](https://mongoosejs.com/docs/queries.html) resolves to an
- * object that contains 3 properties:
+ * object that contains 2 properties:
  *
- * - `ok`: `1` if no errors occurred
+ * - `acknowledged`: boolean
  * - `deletedCount`: the number of documents deleted
- * - `n`: the number of documents deleted. Equal to `deletedCount`.
  *
  * #### Example:
  *
@@ -3113,8 +3112,8 @@ function _handleSortValue(val, key) {
  * @param {Object|Query} [filter] mongodb selector
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
  * @return {Query} this
- * @see DeleteResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/DeleteResult.html
- * @see deleteOne https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteOne
+ * @see DeleteResult https://mongodb.github.io/node-mongodb-native/6.15/interfaces/DeleteResult.html
+ * @see deleteOne https://mongodb.github.io/node-mongodb-native/6.15/classes/Collection.html#deleteOne
  * @api public
  */
 
@@ -3169,13 +3168,12 @@ Query.prototype._deleteOne = async function _deleteOne() {
  *
  *     await Character.deleteMany({ name: /Stark/, age: { $gte: 18 } });
  *
- * This function calls the MongoDB driver's [`Collection#deleteMany()` function](https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteMany).
+ * This function calls the MongoDB driver's [`Collection#deleteMany()` function](https://mongodb.github.io/node-mongodb-native/6.15/classes/Collection.html#deleteMany).
  * The returned [promise](https://mongoosejs.com/docs/queries.html) resolves to an
- * object that contains 3 properties:
+ * object that contains 2 properties:
  *
- * - `ok`: `1` if no errors occurred
+ * - `acknowledged`: boolean
  * - `deletedCount`: the number of documents deleted
- * - `n`: the number of documents deleted. Equal to `deletedCount`.
  *
  * #### Example:
  *
@@ -3186,8 +3184,8 @@ Query.prototype._deleteOne = async function _deleteOne() {
  * @param {Object|Query} [filter] mongodb selector
  * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
  * @return {Query} this
- * @see DeleteResult https://mongodb.github.io/node-mongodb-native/4.9/interfaces/DeleteResult.html
- * @see deleteMany https://mongodb.github.io/node-mongodb-native/4.9/classes/Collection.html#deleteMany
+ * @see DeleteResult https://mongodb.github.io/node-mongodb-native/6.15/interfaces/DeleteResult.html
+ * @see deleteMany https://mongodb.github.io/node-mongodb-native/6.15/classes/Collection.html#deleteMany
  * @api public
  */
 


### PR DESCRIPTION
**Summary**

The returned object of `deleteOne` & `deleteMany` comes directly from mongodb driver. 
The API definition was not updated.
