### PR TITLE
docs: add version requirements to v7 migration docs

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -11,6 +11,7 @@ you should be aware of when migrating from Mongoose 6.x to Mongoose 7.x.
 
 If you're still on Mongoose 5.x, please read the [Mongoose 5.x to 6.x migration guide](migrating_to_6.html) and upgrade to Mongoose 6.x first.
 
+* [Version Requirements](#version-requirements)
 * [`strictQuery`](#strictquery)
 * [Removed `remove()`](#removed-remove)
 * [Dropped callback support](#dropped-callback-support)
@@ -27,6 +28,12 @@ If you're still on Mongoose 5.x, please read the [Mongoose 5.x to 6.x migration 
 * [TypeScript-specific changes](#typescript-specific-changes)
   * [Removed `LeanDocument` and support for `extends Document`](#removed-leandocument-and-support-for-extends-document)
   * [New parameters for `HydratedDocument`](#new-parameters-for-hydrateddocument)
+
+## Version Requirements {#version-requirements}
+
+Mongoose now requires Node.js >= 14.0.0 and MongoDB Node Driver >= 5.0.0.
+
+See [the MongoDB Node Driver migration guide](https://github.com/mongodb/node-mongodb-native/blob/main/etc/notes/CHANGES_5.0.0.md) for detailed info.
 
 ## `strictQuery` {#strictquery}
 


### PR DESCRIPTION
**Summary**

The migration guide from Mongoose v6 to Mongoose v7 does not clarify that it uses MongoDB v5 instead of MongoDB v4.

Looking at your migration guides historically, it looks like an upgrade in the MongoDB Node Driver is expected, so this tripped me up in this instance. To ensure the migration guide relays an accurate scope of the work to migrate, could it include clarification on this?

This is a breaking change as we can set the MongoDB client using `Connection#setClient`.

Reference: https://mongoosejs.com/docs/7.x/docs/api/connection.html#Connection.prototype.setClient()

If the versions don't align, we can get:

```
Error {
  error: [
    'MongooseError: Must call `setClient()` with an instance of MongoClient',
    '    at NativeConnection.setClient (/tmp/data-service/node_modules/mongoose/lib/connection.js:1530:11)',
    '    at MongooseAdapter.connect (/srv/data-service/src/client-adapters/mongoose-adapter.js:49:71)',
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)',
    '    at async Promise.all (index 2)'
  ],
  name: 'MongooseWrite'
}
```

The versions specified were taken from the `package.json` in your v7.0.0 tag on Git.

> ```
>   …
>   "dependencies": {
>     …
>     "mongodb": "5.1.0",
>     …
>   }
>   …
>   "engines": {
>     "node": ">=14.0.0"
>   },
>   …
> ```
> 
> — https://github.com/Automattic/mongoose/blob/7.0.0/package.json

The wording for the new section is taken from previous migration guides where a change in MongoDB version was clarified, except it's explicit that it refers to the MongoDB Node Driver, as opposed to potentially being confused with the MongoDB Server version.

Instead of what I have written, we could instead take from the Migration Guide for v7 to v8, which instead would look like:

> We also recommend reviewing the [MongoDB Node Driver release notes for v5.0.0](https://github.com/mongodb/node-mongodb-native/blob/main/etc/notes/CHANGES_5.0.0.md) before upgrading to Mongoose 7.

Let me know if you'd prefer that, I can amend the document accordingly.