### PR TITLE
fix(model): disallow Model.findOneAndUpdate(update) and fix TypeScript types re: findOneAndUpdate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2307,9 +2307,14 @@ Model.$where = function $where() {
  *
  * #### Example:
  *
- *     A.findOneAndUpdate(conditions, update, options)  // returns Query
- *     A.findOneAndUpdate(conditions, update)           // returns Query
- *     A.findOneAndUpdate()                             // returns Query
+ *     A.findOneAndUpdate(filter, update, options);  // returns Query
+ *     A.findOneAndUpdate(filter, update);           // returns Query
+ *     A.findOneAndUpdate(filter);                   // returns Query
+ *     A.findOneAndUpdate();                         // returns Query
+ *
+ *     // Other supported syntaxes
+ *     // Note that calling `Query#findOneAndUpdate()` with 1 arg will treat the arg as `update`, NOT `filter`
+ *     A.find(filter).findOneAndUpdate(update);
  *
  * #### Note:
  *
@@ -2318,10 +2323,10 @@ Model.$where = function $where() {
  * #### Example:
  *
  *     const query = { name: 'borne' };
- *     Model.findOneAndUpdate(query, { name: 'jason bourne' }, options)
+ *     Model.findOneAndUpdate(query, { name: 'jason bourne' }, options);
  *
  *     // is sent as
- *     Model.findOneAndUpdate(query, { $set: { name: 'jason bourne' }}, options)
+ *     Model.findOneAndUpdate(query, { $set: { name: 'jason bourne' }}, options);
  *
  * #### Note:
  *
@@ -2364,12 +2369,6 @@ Model.findOneAndUpdate = function(conditions, update, options) {
   _checkContext(this, 'findOneAndUpdate');
   if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {
     throw new MongooseError('Model.findOneAndUpdate() no longer accepts a callback');
-  }
-
-  if (arguments.length === 1) {
-    update = conditions;
-    conditions = null;
-    options = null;
   }
 
   let fields;

--- a/lib/query.js
+++ b/lib/query.js
@@ -3309,17 +3309,18 @@ function prepareDiscriminatorCriteria(query) {
  * - `new`: bool - if true, return the modified document rather than the original. defaults to false (changed in 4.0)
  * - `upsert`: bool - creates the object if it doesn't exist. defaults to false.
  * - `fields`: {Object|String} - Field selection. Equivalent to `.select(fields).findOneAndUpdate()`
- * - `sort`: if multiple docs are found by the conditions, sets the sort order to choose which doc to update
+ * - `sort`: if multiple docs are found by the filter, sets the sort order to choose which doc to update
  * - `maxTimeMS`: puts a time limit on the query - requires mongodb >= 2.6.0
  * - `runValidators`: if true, runs [update validators](https://mongoosejs.com/docs/validation.html#update-validators) on this command. Update validators validate the update operation against the model's schema.
  * - `setDefaultsOnInsert`: `true` by default. If `setDefaultsOnInsert` and `upsert` are true, mongoose will apply the [defaults](https://mongoosejs.com/docs/defaults.html) specified in the model's schema if a new document is created.
  *
  * #### Example:
  *
- *     query.findOneAndUpdate(conditions, update, options)  // returns Query
- *     query.findOneAndUpdate(conditions, update)           // returns Query
- *     query.findOneAndUpdate(update)                       // returns Query
- *     query.findOneAndUpdate()                             // returns Query
+ *     query.findOneAndUpdate(filter, update, options);  // returns Query
+ *     query.findOneAndUpdate(filter, update);           // returns Query
+ *     // Note that `Query#findOneAndUpdate()` with 1 arg treats the first arg as the `update`, NOT the `filter`.
+ *     query.findOneAndUpdate(update);                   // returns Query
+ *     query.findOneAndUpdate();                         // returns Query
  *
  * @method findOneAndUpdate
  * @memberOf Query

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -326,11 +326,6 @@ describe('model: findOneAndUpdate:', function() {
     assert.equal(query._update.$set.date.toString(), now.toString());
     assert.strictEqual('aaron', query._conditions.author);
 
-    query = M.findOneAndUpdate({ $set: { date: now } });
-    assert.strictEqual(undefined, query.options.new);
-    assert.equal(query._update.$set.date.toString(), now.toString());
-    assert.strictEqual(undefined, query._conditions.author);
-
     query = M.findOneAndUpdate();
     assert.strictEqual(undefined, query.options.new);
     assert.equal(query._update, undefined);

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -466,10 +466,14 @@ declare module 'mongoose' {
       options: QueryOptions<DocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
     findOneAndUpdate(
-      filter?: RootFilterQuery<RawDocType>,
-      update?: UpdateQuery<RawDocType>,
+      filter: RootFilterQuery<RawDocType>,
+      update: UpdateQuery<RawDocType>,
       options?: QueryOptions<DocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
+    findOneAndUpdate(
+      update: UpdateQuery<RawDocType>
+    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
+    findOneAndUpdate(): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
 
     /** Declares the query a findById operation. When executed, returns the document with the given `_id`. */
     findById(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Apply #15199 to `findOneAndUpdate()`. This looks to be the last model function where we replace `conditions` with `update` if there's only 1 arg.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
