### PR TITLE
fix: clone POJOs and arrays when casting query filter to avoid mutating objects

### DIFF
--- a/benchmarks/findOneWithCast.js
+++ b/benchmarks/findOneWithCast.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const mongoose = require('../');
+
+run().catch(err => {
+  console.error(err);
+  process.exit(-1);
+});
+
+async function run() {
+  await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_benchmark');
+
+  const SchemaParticipant = new mongoose.Schema(
+    {
+      user: mongoose.Schema.Types.UUID,
+    },
+    {
+      _id: false
+    }
+  );
+
+  const TestSchema = new mongoose.Schema(
+    {
+      participants1: { type: [SchemaParticipant] },
+      participants2: { type: [SchemaParticipant] },
+      participants3: { type: [SchemaParticipant] },
+      participants4: { type: [SchemaParticipant] },
+      participants5: { type: [SchemaParticipant] },
+      date: { type: Number },
+    },
+    {
+      collection: 'test_uuid_mutations',
+    }
+  );
+
+  const TestModel = mongoose.model('Test', TestSchema);
+
+  if (!process.env.MONGOOSE_BENCHMARK_SKIP_SETUP) {
+    await TestModel.deleteMany({});
+  }
+
+  const peer = {
+    user: '1583b99d-8462-4343-8dfd-9105252e5662',
+  };
+
+  const numIterations = 500;
+  const queryStart = Date.now();
+  for (let i = 0; i < numIterations; ++i) {
+    for (let j = 0; j < 10; ++j) {
+      await TestModel.findOne({
+        $or: [
+          { participants1: { $elemMatch: peer } },
+          { participants2: { $elemMatch: peer } },
+          { participants3: { $elemMatch: peer } },
+          { participants4: { $elemMatch: peer } },
+          { participants5: { $elemMatch: peer } }
+        ]
+      });
+    }
+  }
+  const queryEnd = Date.now();
+
+  const results = {
+    'Average findOne time ms': +((queryEnd - queryStart) / numIterations).toFixed(2)
+  };
+
+  console.log(JSON.stringify(results, null, '  '));
+  process.exit(0);
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -235,6 +235,38 @@ exports.omit = function omit(obj, keys) {
 };
 
 /**
+ * Simplified version of `clone()` that only clones POJOs and arrays. Skips documents, dates, objectids, etc.
+ * @param {*} val
+ * @returns
+*/
+
+exports.clonePOJOsAndArrays = function clonePOJOsAndArrays(val) {
+  if (val == null) {
+    return val;
+  }
+  // Skip documents because we assume they'll be cloned later. See gh-15312 for how documents are handled with `merge()`.
+  if (val.$__ != null) {
+    return val;
+  }
+  if (isPOJO(val)) {
+    val = { ...val };
+    for (const key of Object.keys(val)) {
+      val[key] = exports.clonePOJOsAndArrays(val[key]);
+    }
+    return val;
+  }
+  if (Array.isArray(val)) {
+    val = [...val];
+    for (let i = 0; i < val.length; ++i) {
+      val[i] = exports.clonePOJOsAndArrays(val[i]);
+    }
+    return val;
+  }
+
+  return val;
+};
+
+/**
  * Merges `from` into `to` without overwriting existing properties.
  *
  * @param {Object} to
@@ -271,13 +303,7 @@ exports.merge = function merge(to, from, options, path) {
       continue;
     }
     if (to[key] == null) {
-      if (isPOJO(from[key])) {
-        to[key] = { ...from[key] };
-      } else if (Array.isArray(from[key])) {
-        to[key] = [...from[key]];
-      } else {
-        to[key] = from[key];
-      }
+      to[key] = exports.clonePOJOsAndArrays(from[key]);
     } else if (exports.isObject(from[key])) {
       if (!exports.isObject(to[key])) {
         to[key] = {};


### PR DESCRIPTION
Fix #15364

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15364 points out that Mongoose casting mistakenly mutates objects passed in to `$elemMatch`. The core of this issue is that we only shallow clone using `{ ... }` in `utils.merge()`, which makes Mongoose casting mutate query filters that are at least 2 levels deep.

However, we unfortunately can't use `clone()` because `clone()` also clones Dates and ObjectIds, and we have tests which assert that Dates and ObjectIds are reference equal after being passed in to `findOneAndUpdate()`.

I wrote a quick benchmark which shows that the performance impact is negligible.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
