### PR TITLE
fix: correct change tracking with maps of arrays of primitives and maps of maps

### DIFF
--- a/lib/schema/map.js
+++ b/lib/schema/map.js
@@ -23,12 +23,12 @@ class SchemaMap extends SchemaType {
     return SchemaType.set(option, value);
   }
 
-  cast(val, doc, init) {
+  cast(val, doc, init, prev, options) {
     if (val instanceof MongooseMap) {
       return val;
     }
 
-    const path = this.path;
+    const path = options?.path ?? this.path;
 
     if (init) {
       const map = new MongooseMap({}, path, doc, this.$__schemaType);

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -136,7 +136,7 @@ class MongooseMap extends Map {
       }
     } else {
       try {
-        const options = this.$__schemaType.$isMongooseDocumentArray || this.$__schemaType.$isSingleNested ?
+        const options = this.$__schemaType.$isMongooseDocumentArray || this.$__schemaType.$isSingleNested || this.$__schemaType.$isMongooseArray || this.$__schemaType.$isSchemaMap ?
           { path: fullPath.call(this) } :
           null;
         value = this.$__schemaType.applySetters(


### PR DESCRIPTION
Fix #15350

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In some perf improvements for #13191 (see https://github.com/Automattic/mongoose/commit/7bec5064d0a39032192be93df53e832f948207d8) we missed a spot where we need to calculate the full path for maps of maps and maps of primitive arrays. Otherwise, Mongoose will track changes to the map pseudo-path `myMap.$*`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
