### PR TITLE
BREAKING CHANGE: make UUID schema type return bson UUIDs

### DIFF
--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -207,3 +207,32 @@ In Mongoose 9, this option is no longer necessary because Mongoose no longer sto
 ## Node.js version support
 
 Mongoose 9 requires Node.js 18 or higher.
+
+## UUID's are now MongoDB UUID objects
+
+Mongoose 9 now returns UUID objects as instances of `bson.UUID`. In Mongoose 8, UUIDs were Mongoose Buffers that were converted to strings via a getter.
+
+```javascript
+const schema = new Schema({ uuid: 'UUID' });
+const TestModel = mongoose.model('Test', schema);
+
+const test = new TestModel({ uuid: new bson.UUID() });
+await test.save();
+
+test.uuid; // string in Mongoose 8, bson.UUID instance in Mongoose 9
+```
+
+If you want to convert UUIDs to strings via a getter by default, you can use `mongoose.Schema.Types.UUID.get()`:
+
+```javascript
+// Configure all UUIDs to have a getter which converts the UUID to a string
+mongoose.Schema.Types.UUID.get(v => v == null ? v : v.toString());
+
+const schema = new Schema({ uuid: 'UUID' });
+const TestModel = mongoose.model('Test', schema);
+
+const test = new TestModel({ uuid: new bson.UUID() });
+await test.save();
+
+test.uuid; // string
+```

--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -222,6 +222,8 @@ await test.save();
 test.uuid; // string in Mongoose 8, bson.UUID instance in Mongoose 9
 ```
 
+With this change, UUIDs will be represented in hex string format in JSON, even if `getters: true` is not set.
+
 If you want to convert UUIDs to strings via a getter by default, you can use `mongoose.Schema.Types.UUID.get()`:
 
 ```javascript

--- a/lib/cast/uuid.js
+++ b/lib/cast/uuid.js
@@ -1,35 +1,23 @@
 'use strict';
 
-const MongooseBuffer = require('../types/buffer');
+const UUID = require('bson').UUID;
 
 const UUID_FORMAT = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
-const Binary = MongooseBuffer.Binary;
 
 module.exports = function castUUID(value) {
   if (value == null) {
     return value;
   }
 
-  function newBuffer(initbuff) {
-    const buff = new MongooseBuffer(initbuff);
-    buff._subtype = 4;
-    return buff;
+  if (value instanceof UUID) {
+    return value;
   }
-
   if (typeof value === 'string') {
     if (UUID_FORMAT.test(value)) {
-      return stringToBinary(value);
+      return new UUID(value);
     } else {
       throw new Error(`"${value}" is not a valid UUID string`);
     }
-  }
-
-  if (Buffer.isBuffer(value)) {
-    return newBuffer(value);
-  }
-
-  if (value instanceof Binary) {
-    return newBuffer(value.value(true));
   }
 
   // Re: gh-647 and gh-3030, we're ok with casting using `toString()`
@@ -37,7 +25,7 @@ module.exports = function castUUID(value) {
   // doesn't really qualify as useful data
   if (value.toString && value.toString !== Object.prototype.toString) {
     if (UUID_FORMAT.test(value.toString())) {
-      return stringToBinary(value.toString());
+      return new UUID(value.toString());
     }
   }
 
@@ -45,34 +33,3 @@ module.exports = function castUUID(value) {
 };
 
 module.exports.UUID_FORMAT = UUID_FORMAT;
-
-/**
- * Helper function to convert the input hex-string to a buffer
- * @param {String} hex The hex string to convert
- * @returns {Buffer} The hex as buffer
- * @api private
- */
-
-function hex2buffer(hex) {
-  // use buffer built-in function to convert from hex-string to buffer
-  const buff = hex != null && Buffer.from(hex, 'hex');
-  return buff;
-}
-
-/**
- * Convert a String to Binary
- * @param {String} uuidStr The value to process
- * @returns {MongooseBuffer} The binary to store
- * @api private
- */
-
-function stringToBinary(uuidStr) {
-  // Protect against undefined & throwing err
-  if (typeof uuidStr !== 'string') uuidStr = '';
-  const hex = uuidStr.replace(/[{}-]/g, ''); // remove extra characters
-  const bytes = hex2buffer(hex);
-  const buff = new MongooseBuffer(bytes);
-  buff._subtype = 4;
-
-  return buff;
-}

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -43,21 +43,6 @@ function binaryToString(uuidBin) {
 
 function SchemaUUID(key, options) {
   SchemaType.call(this, key, options, 'UUID');
-  this.getters.push(function(value) {
-    // For populated
-    if (value != null && value.$__ != null) {
-      return value;
-    }
-    if (Buffer.isBuffer(value)) {
-      return binaryToString(value);
-    } else if (value instanceof Binary) {
-      return binaryToString(value.buffer);
-    } else if (utils.isPOJO(value) && value.type === 'Buffer' && Array.isArray(value.data)) {
-      // Cloned buffers look like `{ type: 'Buffer', data: [5, 224, ...] }`
-      return binaryToString(Buffer.from(value.data));
-    }
-    return value;
-  });
 }
 
 /**
@@ -249,11 +234,7 @@ SchemaUUID.prototype.$conditionalHandlers = {
   $bitsAllSet: handleBitwiseOperator,
   $bitsAnySet: handleBitwiseOperator,
   $all: handleArray,
-  $gt: handleSingle,
-  $gte: handleSingle,
   $in: handleArray,
-  $lt: handleSingle,
-  $lte: handleSingle,
   $ne: handleSingle,
   $nin: handleArray
 };

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const MongooseBuffer = require('../types/buffer');
 const SchemaType = require('../schemaType');
 const CastError = SchemaType.CastError;
 const castUUID = require('../cast/uuid');
@@ -13,7 +12,6 @@ const utils = require('../utils');
 const handleBitwiseOperator = require('./operators/bitwise');
 
 const UUID_FORMAT = castUUID.UUID_FORMAT;
-const Binary = MongooseBuffer.Binary;
 
 /**
  * Convert binary to a uuid string

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11343,7 +11343,7 @@ describe('model: populate:', function() {
     assert.equal(fromDb.children[2].toHexString(), newChild._id.toHexString());
   });
 
-  it('handles converting uuid documents to strings when calling toObject() (gh-14869)', async function() {
+  it('handles populating uuids (gh-14869)', async function() {
     const nodeSchema = new Schema({ _id: { type: 'UUID' }, name: 'String' });
     const rootSchema = new Schema({
       _id: { type: 'UUID' },
@@ -11370,14 +11370,14 @@ describe('model: populate:', function() {
     const foundRoot = await Root.findById(root._id).populate('node');
 
     let doc = foundRoot.toJSON({ getters: true });
-    assert.strictEqual(doc._id, '05c7953e-c6e9-4c2f-8328-fe2de7df560d');
+    assert.strictEqual(doc._id.toString(), '05c7953e-c6e9-4c2f-8328-fe2de7df560d');
     assert.strictEqual(doc.node.length, 1);
-    assert.strictEqual(doc.node[0]._id, '65c7953e-c6e9-4c2f-8328-fe2de7df560d');
+    assert.strictEqual(doc.node[0]._id.toString(), '65c7953e-c6e9-4c2f-8328-fe2de7df560d');
 
     doc = foundRoot.toObject({ getters: true });
-    assert.strictEqual(doc._id, '05c7953e-c6e9-4c2f-8328-fe2de7df560d');
+    assert.strictEqual(doc._id.toString(), '05c7953e-c6e9-4c2f-8328-fe2de7df560d');
     assert.strictEqual(doc.node.length, 1);
-    assert.strictEqual(doc.node[0]._id, '65c7953e-c6e9-4c2f-8328-fe2de7df560d');
+    assert.strictEqual(doc.node[0]._id.toString(), '65c7953e-c6e9-4c2f-8328-fe2de7df560d');
   });
 
   it('avoids repopulating if forceRepopulate is disabled (gh-14979)', async function() {

--- a/test/schema.uuid.test.js
+++ b/test/schema.uuid.test.js
@@ -36,8 +36,8 @@ describe('SchemaUUID', function() {
   it('basic functionality should work', async function() {
     const doc = new Model({ x: '09190f70-3d30-11e5-8814-0f4df9a59c41' });
     assert.ifError(doc.validateSync());
-    assert.ok(typeof doc.x === 'string');
-    assert.strictEqual(doc.x, '09190f70-3d30-11e5-8814-0f4df9a59c41');
+    assert.ok(doc.x instanceof mongoose.Types.UUID);
+    assert.strictEqual(doc.x.toString(), '09190f70-3d30-11e5-8814-0f4df9a59c41');
     await doc.save();
 
     const query = Model.findOne({ x: '09190f70-3d30-11e5-8814-0f4df9a59c41' });
@@ -45,8 +45,8 @@ describe('SchemaUUID', function() {
 
     const res = await query;
     assert.ifError(res.validateSync());
-    assert.ok(typeof res.x === 'string');
-    assert.strictEqual(res.x, '09190f70-3d30-11e5-8814-0f4df9a59c41');
+    assert.ok(res.x instanceof mongoose.Types.UUID);
+    assert.strictEqual(res.x.toString(), '09190f70-3d30-11e5-8814-0f4df9a59c41');
 
     // check that the data is actually a buffer in the database with the correct subtype
     const col = db.client.db(db.name).collection(Model.collection.name);
@@ -54,6 +54,11 @@ describe('SchemaUUID', function() {
     assert.ok(rawDoc);
     assert.ok(rawDoc.x instanceof bson.Binary);
     assert.strictEqual(rawDoc.x.sub_type, 4);
+
+    const rawDoc2 = await col.findOne({ x: new bson.UUID('09190f70-3d30-11e5-8814-0f4df9a59c41') });
+    assert.ok(rawDoc2);
+    assert.ok(rawDoc2.x instanceof bson.UUID);
+    assert.strictEqual(rawDoc2.x.sub_type, 4);
   });
 
   it('should throw error in case of invalid string', function() {
@@ -80,9 +85,9 @@ describe('SchemaUUID', function() {
     assert.strictEqual(foundDocIn.length, 1);
     assert.ok(foundDocIn[0].y);
     assert.strictEqual(foundDocIn[0].y.length, 3);
-    assert.strictEqual(foundDocIn[0].y[0], 'f8010af3-bc2c-45e6-85c6-caa30c4a7d34');
-    assert.strictEqual(foundDocIn[0].y[1], 'c6f59133-4f84-45a8-bc1d-8f172803e4fe');
-    assert.strictEqual(foundDocIn[0].y[2], 'df1309e0-58c5-427a-b22f-6c0fc445ccc0');
+    assert.strictEqual(foundDocIn[0].y[0].toString(), 'f8010af3-bc2c-45e6-85c6-caa30c4a7d34');
+    assert.strictEqual(foundDocIn[0].y[1].toString(), 'c6f59133-4f84-45a8-bc1d-8f172803e4fe');
+    assert.strictEqual(foundDocIn[0].y[2].toString(), 'df1309e0-58c5-427a-b22f-6c0fc445ccc0');
 
     // test $nin
     const foundDocNin = await Model.find({ y: { $nin: ['f8010af3-bc2c-45e6-85c6-caa30c4a7d34'] } });
@@ -90,9 +95,9 @@ describe('SchemaUUID', function() {
     assert.strictEqual(foundDocNin.length, 1);
     assert.ok(foundDocNin[0].y);
     assert.strictEqual(foundDocNin[0].y.length, 3);
-    assert.strictEqual(foundDocNin[0].y[0], '13d51406-cd06-4fc2-93d1-4fad9b3eecd7');
-    assert.strictEqual(foundDocNin[0].y[1], 'f004416b-e02a-4212-ac77-2d3fcf04898b');
-    assert.strictEqual(foundDocNin[0].y[2], '5b544b71-8988-422b-a4df-bf691939fe4e');
+    assert.strictEqual(foundDocNin[0].y[0].toString(), '13d51406-cd06-4fc2-93d1-4fad9b3eecd7');
+    assert.strictEqual(foundDocNin[0].y[1].toString(), 'f004416b-e02a-4212-ac77-2d3fcf04898b');
+    assert.strictEqual(foundDocNin[0].y[2].toString(), '5b544b71-8988-422b-a4df-bf691939fe4e');
 
     // test for $all
     const foundDocAll = await Model.find({ y: { $all: ['13d51406-cd06-4fc2-93d1-4fad9b3eecd7', 'f004416b-e02a-4212-ac77-2d3fcf04898b'] } });
@@ -100,9 +105,9 @@ describe('SchemaUUID', function() {
     assert.strictEqual(foundDocAll.length, 1);
     assert.ok(foundDocAll[0].y);
     assert.strictEqual(foundDocAll[0].y.length, 3);
-    assert.strictEqual(foundDocAll[0].y[0], '13d51406-cd06-4fc2-93d1-4fad9b3eecd7');
-    assert.strictEqual(foundDocAll[0].y[1], 'f004416b-e02a-4212-ac77-2d3fcf04898b');
-    assert.strictEqual(foundDocAll[0].y[2], '5b544b71-8988-422b-a4df-bf691939fe4e');
+    assert.strictEqual(foundDocAll[0].y[0].toString(), '13d51406-cd06-4fc2-93d1-4fad9b3eecd7');
+    assert.strictEqual(foundDocAll[0].y[1].toString(), 'f004416b-e02a-4212-ac77-2d3fcf04898b');
+    assert.strictEqual(foundDocAll[0].y[2].toString(), '5b544b71-8988-422b-a4df-bf691939fe4e');
   });
 
   it('should not convert to string nullish UUIDs (gh-13032)', async function() {
@@ -152,6 +157,21 @@ describe('SchemaUUID', function() {
     await pop.save();
   });
 
+  it('works with lean', async function() {
+    const userSchema = new mongoose.Schema({
+      _id: { type: 'UUID' },
+      name: String
+    });
+    const User = db.model('User', userSchema);
+
+    const u1 = await User.create({ _id: randomUUID(), name: 'admin' });
+
+    const lean = await User.findById(u1._id).lean().orFail();
+    assert.equal(lean.name, 'admin');
+    assert.ok(lean._id instanceof mongoose.Types.UUID);
+    assert.equal(lean._id.toString(), u1._id.toString());
+  });
+
   it('handles built-in UUID type (gh-13103)', async function() {
     const schema = new Schema({
       _id: {
@@ -165,12 +185,12 @@ describe('SchemaUUID', function() {
     const uuid = new mongoose.Types.UUID();
     let { _id } = await Test.create({ _id: uuid });
     assert.ok(_id);
-    assert.equal(typeof _id, 'string');
+    assert.ok(_id instanceof mongoose.Types.UUID);
     assert.equal(_id, uuid.toString());
 
     ({ _id } = await Test.findById(uuid));
     assert.ok(_id);
-    assert.equal(typeof _id, 'string');
+    assert.ok(_id instanceof mongoose.Types.UUID);
     assert.equal(_id, uuid.toString());
   });
 
@@ -202,11 +222,56 @@ describe('SchemaUUID', function() {
     const exists = await Test.findOne({ 'doc_map.role_1': { $type: 'binData' } });
     assert.ok(exists);
 
-    assert.equal(typeof user.get('doc_map.role_1'), 'string');
+    assert.ok(user.get('doc_map.role_1') instanceof mongoose.Types.UUID);
   });
 
-  // the following are TODOs based on SchemaUUID.prototype.$conditionalHandlers which are not tested yet
-  it('should work with $bits* operators');
-  it('should work with $all operator');
-  it('should work with $lt, $lte, $gt, $gte operators');
+  it('should work with $bits* operators', async function() {
+    const schema = new Schema({
+      uuid: mongoose.Schema.Types.UUID
+    });
+    db.deleteModel(/Test/);
+    const Test = db.model('Test', schema);
+
+    const uuid = new mongoose.Types.UUID('ff' + '0'.repeat(30));
+    await Test.create({ uuid });
+
+    let doc = await Test.findOne({ uuid: { $bitsAllSet: [0, 4] } });
+    assert.ok(doc);
+    doc = await Test.findOne({ uuid: { $bitsAllSet: 2 ** 15 } });
+    assert.ok(!doc);
+
+    doc = await Test.findOne({ uuid: { $bitsAnySet: 3 } });
+    assert.ok(doc);
+    doc = await Test.findOne({ uuid: { $bitsAnySet: [8] } });
+    assert.ok(!doc);
+
+    doc = await Test.findOne({ uuid: { $bitsAnyClear: [0, 32] } });
+    assert.ok(doc);
+    doc = await Test.findOne({ uuid: { $bitsAnyClear: 7 } });
+    assert.ok(!doc);
+
+    doc = await Test.findOne({ uuid: { $bitsAllClear: [16, 17, 18] } });
+    assert.ok(doc);
+    doc = await Test.findOne({ uuid: { $bitsAllClear: 3 } });
+    assert.ok(!doc);
+  });
+
+  it('should work with $all operator', async function() {
+    const schema = new Schema({
+      uuids: [mongoose.Schema.Types.UUID]
+    });
+    db.deleteModel(/Test/);
+    const Test = db.model('Test', schema);
+
+    const uuid1 = new mongoose.Types.UUID();
+    const uuid2 = new mongoose.Types.UUID();
+    const uuid3 = new mongoose.Types.UUID();
+    await Test.create({ uuids: [uuid1, uuid2] });
+
+    let doc = await Test.findOne({ uuids: { $all: [uuid1, uuid2] } });
+    assert.ok(doc);
+
+    doc = await Test.findOne({ uuids: { $all: [uuid1, uuid3] } });
+    assert.ok(!doc);
+  });
 });

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -24,7 +24,7 @@ import {
   ValidateOpts,
   BufferToBinary
 } from 'mongoose';
-import { Binary } from 'mongodb';
+import { Binary, UUID } from 'mongodb';
 import { IsPathRequired } from '../../types/inferschematype';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
@@ -120,7 +120,7 @@ expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: false }); // tes
 // Using `SchemaDefinition`
 interface IProfile {
   age: number;
-}
+}Buffer
 const ProfileSchemaDef: SchemaDefinition<IProfile> = { age: Number };
 export const ProfileSchema = new Schema<IProfile, Model<IProfile>>(ProfileSchemaDef);
 
@@ -910,23 +910,23 @@ async function gh12593() {
   const testSchema = new Schema({ x: { type: Schema.Types.UUID } });
 
   type Example = InferSchemaType<typeof testSchema>;
-  expectType<{ x?: Buffer | null }>({} as Example);
+  expectType<{ x?: UUID | null }>({} as Example);
 
   const Test = model('Test', testSchema);
 
   const doc = await Test.findOne({ x: '4709e6d9-61fd-435e-b594-d748eb196d8f' }).orFail();
-  expectType<Buffer | undefined | null>(doc.x);
+  expectType<UUID | undefined | null>(doc.x);
 
   const doc2 = new Test({ x: '4709e6d9-61fd-435e-b594-d748eb196d8f' });
-  expectType<Buffer | undefined | null>(doc2.x);
+  expectType<UUID | undefined | null>(doc2.x);
 
   const doc3 = await Test.findOne({}).orFail().lean();
-  expectType<Binary | undefined | null>(doc3.x);
+  expectType<UUID | undefined | null>(doc3.x);
 
   const arrSchema = new Schema({ arr: [{ type: Schema.Types.UUID }] });
 
   type ExampleArr = InferSchemaType<typeof arrSchema>;
-  expectType<{ arr: Buffer[] }>({} as ExampleArr);
+  expectType<{ arr: UUID[] }>({} as ExampleArr);
 }
 
 function gh12562() {

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -120,7 +120,7 @@ expectError<Parameters<typeof movieSchema['index']>[0]>({ tile: false }); // tes
 // Using `SchemaDefinition`
 interface IProfile {
   age: number;
-}Buffer
+}
 const ProfileSchemaDef: SchemaDefinition<IProfile> = { age: Number };
 export const ProfileSchema = new Schema<IProfile, Model<IProfile>>(ProfileSchemaDef);
 

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1722,7 +1722,8 @@ async function gh14451() {
     myMap: {
       type: Map,
       of: String
-    }
+    },
+    myUUID: 'UUID'
   });
 
   const Test = model('Test', exampleSchema);
@@ -1736,7 +1737,8 @@ async function gh14451() {
       subdocProp?: string | undefined | null
     } | null,
     docArr: { nums: number[], times: string[] }[],
-    myMap?: Record<string, string> | null | undefined
+    myMap?: Record<string, string> | null | undefined,
+    myUUID?: string | null | undefined
   }>({} as TestJSON);
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,7 @@ declare module 'mongoose' {
   import events = require('events');
   import mongodb = require('mongodb');
   import mongoose = require('mongoose');
+  import bson = require('bson');
 
   export type Mongoose = typeof mongoose;
 
@@ -766,6 +767,25 @@ declare module 'mongoose' {
                     : BufferToBinary<T[K]>;
           } : T;
 
+    /**
+    * Converts any Buffer properties into { type: 'buffer', data: [1, 2, 3] } format for JSON serialization
+    */
+    export type UUIDToJSON<T> = T extends bson.UUID
+      ? string
+      : T extends Document
+        ? T
+        : T extends TreatAsPrimitives
+          ? T
+          : T extends Record<string, any> ? {
+            [K in keyof T]: T[K] extends bson.UUID
+              ? string
+              : T[K] extends Types.DocumentArray<infer ItemType>
+                  ? Types.DocumentArray<UUIDToJSON<ItemType>>
+                  : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
+                    ? HydratedSingleSubdocument<SubdocType>
+                    : UUIDToJSON<T[K]>;
+          } : T;
+
   /**
    * Converts any ObjectId properties into strings for JSON serialization
    */
@@ -825,7 +845,9 @@ declare module 'mongoose' {
     FlattenMaps<
       BufferToJSON<
         ObjectIdToString<
-          DateToString<T>
+          UUIDToJSON<
+            DateToString<T>
+          >
         >
       >
     >

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -768,7 +768,7 @@ declare module 'mongoose' {
           } : T;
 
     /**
-    * Converts any Buffer properties into { type: 'buffer', data: [1, 2, 3] } format for JSON serialization
+    * Converts any Buffer properties into "{ type: 'buffer', data: [1, 2, 3] }" format for JSON serialization
     */
     export type UUIDToJSON<T> = T extends bson.UUID
       ? string

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -245,7 +245,9 @@ type IsSchemaTypeFromBuiltinClass<T> = T extends (typeof String)
                                         ? false
                                         : T extends Buffer
                                           ? true
-                                          : false;
+                                          : T extends Types.UUID
+                                            ? true
+                                            : false;
 
 /**
  * @summary Resolve path type by returning the corresponding type.
@@ -311,9 +313,9 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
                                             IfEquals<PathValueType, Schema.Types.BigInt> extends true ? bigint :
                                               IfEquals<PathValueType, BigInt> extends true ? bigint :
                                                 PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt ? bigint :
-                                                  PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
+                                                  PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Types.UUID :
                                                     PathValueType extends 'double' | 'Double' | typeof Schema.Types.Double ? Types.Double :
-                                                      IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
+                                                      IfEquals<PathValueType, Schema.Types.UUID> extends true ? Types.UUID :
                                                         PathValueType extends MapConstructor | 'Map' ? Map<string, ResolvePathType<Options['of']>> :
                                                           IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
                                                             PathValueType extends ArrayConstructor ? any[] :


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently, `type: 'UUID'` makes Mongoose internally store Mongoose Buffers, which get converted to strings via a built-in getter. This is inconsistent for a few reasons:

1. We have a separate `mongoose.Types.UUID` type, but `mongoose.Schema.Types.UUID` paths don't cast into `mongoose.Types.UUID` instances
2. Because UUID paths are stored as buffers and converted to string via getters, `lean()` means UUIDs are returned as instances of `mongodb.Binary` by default (unless mongoose-lean-getters plugin is enabled), so you end up having to handle 3 different types when working with UUIDs (Binary if lean, Buffer if toObject() with getters false or bypassing getters, string otherwise). Also adds some confusion for TypeScript. 
3. TypeScript types convert 'UUID' -> 'Buffer', which isn't correct by default, should be string.

Additional benefit: MongoDB `UUID` class has a `toJSON()` that always serializes the UUID as a hex string, which seems like an improvement. Currently UUIDs end up as `{ type: 'buffer', data: number[] }` in JSON if `getters: false` and `string` if `getters: true`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
