### PR TITLE
Reduce print length in `website.js` and dont exit early in `generateSearch`

### DIFF
--- a/scripts/generateSearch.js
+++ b/scripts/generateSearch.js
@@ -86,7 +86,7 @@ for (const [filename, file] of Object.entries(docsFilemap.fileMap)) {
     });
   } else if (file.guide) {
     let text = fs.readFileSync(filename, 'utf8');
-    text = text.substr(text.indexOf('block content') + 'block content\n'.length);
+    text = text.substring(text.indexOf('block content') + 'block content\n'.length);
     text = pug.render(`div\n${text}`, { filters: { markdown }, filename });
 
     const content = new Content({

--- a/scripts/website.js
+++ b/scripts/website.js
@@ -606,12 +606,23 @@ if (isMain) {
   (async function main() {
     console.log(`Processing ~${files.length} files`);
 
-    require('./generateSearch');
+    const generateSearch = require('./generateSearch');
+    let generateSearchPromise;
+    try {
+      const config = generateSearch.getConfig();
+      generateSearchPromise = generateSearch.generateSearch(config);
+    } catch (err) {
+      console.error("Generating Search failed:", err);
+    }
     await deleteAllHtmlFiles();
     await pugifyAllFiles();
     await copyAllRequiredFiles();
     if (!!process.env.DOCS_DEPLOY && !!versionObj.versionedPath) {
       await moveDocsToTemp();
+    }
+
+    if (!!generateSearchPromise) {
+      await generateSearchPromise;
     }
 
     console.log('Done Processing');

--- a/scripts/website.js
+++ b/scripts/website.js
@@ -506,7 +506,7 @@ async function pugify(filename, options, isReload = false) {
   await fs.promises.writeFile(newfile, str).catch((err) => {
     console.error('could not write', err.stack);
   }).then(() => {
-    console.log('%s : rendered ', new Date(), newfile);
+    console.log('%s : rendered %s', (new Date()).toISOString(), newfile);
   });
 }
 


### PR DESCRIPTION
**Summary**

This PR changes:
- `website.js` to print less per-line by changing the timestamp format and fixing double spaces
- `generateSearch.js` to be able be called from other scripts and not always run as a side-effect, which also fixes potentially exiting the process early due to `process.exit(-1 | 0)`
- `generateSearch.js` [to spam](https://github.com/Automattic/mongoose/actions/runs/14714708408/job/41295315309?pr=15377) less (only print on first, last and after 2 seconds)
- `generateSearch.js` to be able to save in parallel

Example lines of what is output now:
```txt
Processing ~98 files
Delete index.html
Delete docs/api/virtualtype.html
2025-04-29T09:08:01.666Z : rendered /mnt/ssd/projects/nodejs/mongoose/docs/tutorials/custom-casting.html
2025-04-29T09:08:01.669Z : rendered /mnt/ssd/projects/nodejs/mongoose/docs/version-support.html
Search Content to save: 717
1 / 717
717 / 717
[
  '/docs/validation.html',
  '/docs/schematypes.html#string-validators'
]
Added 717 Search Content
Done Processing
```

<details>
<summary>Before</summary>

```txt
Processing ~99 files
Delete index.html
Mon Apr 28 2025 18:09:33 GMT+0000 (Coordinated Universal Time) : rendered  /home/runner/work/mongoose/mongoose/docs/tutorials/custom-casting.html
Mon Apr 28 2025 18:09:33 GMT+0000 (Coordinated Universal Time) : rendered  /home/runner/work/mongoose/mongoose/docs/timestamps.html
Done Processing
1 / 718
2 / 718
...
641 / 718
...
717 / 718
718 / 718
[
  '/docs/validation.html',
  '/docs/schematypes.html#string-validators'
]
Added 718 Content
```

From the linked CI log.

</details>