### PR TITLE
deps(kareem): change dependency notation to be HTTPS and properly "git"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "bson": "^6.10.3",
-    "kareem": "git@github.com:mongoosejs/kareem.git#vkarpov15/v3",
+    "kareem": "git+https://github.com/mongoosejs/kareem.git#vkarpov15/v3",
     "mongodb": "~6.16.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",


### PR DESCRIPTION
**Summary**

This PR changes the git kareem dependency to be properly [marked `git`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies) which is necessary for example yarn v1.
Also changes from a SSH link to HTTPS so developers who dont have SSH setup can still install and run mongoose.
