### PR TITLE
fix(query): handle casting array filter paths underneath array filter paths with embedded discriminators

### DIFF
--- a/lib/helpers/query/getEmbeddedDiscriminatorPath.js
+++ b/lib/helpers/query/getEmbeddedDiscriminatorPath.js
@@ -17,7 +17,7 @@ const updatedPathsByArrayFilter = require('../update/updatedPathsByArrayFilter')
  */
 
 module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, path, options) {
-  const parts = path.split('.');
+  const parts = path.indexOf('.') === -1 ? [path] : path.split('.');
   let schematype = null;
   let type = 'adhocOrUndefined';
 
@@ -26,9 +26,10 @@ module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, p
   const arrayFilters = options != null && Array.isArray(options.arrayFilters) ?
     options.arrayFilters : [];
   const updatedPathsByFilter = updatedPathsByArrayFilter(update);
+  let startIndex = 0;
 
   for (let i = 0; i < parts.length; ++i) {
-    const originalSubpath = parts.slice(0, i + 1).join('.');
+    const originalSubpath = parts.slice(startIndex, i + 1).join('.');
     const subpath = cleanPositionalOperators(originalSubpath);
     schematype = schema.path(subpath);
     if (schematype == null) {
@@ -89,6 +90,8 @@ module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, p
 
       const rest = parts.slice(i + 1).join('.');
       schematype = discriminatorSchema.path(rest);
+      schema = discriminatorSchema;
+      startIndex = i + 1;
       if (schematype != null) {
         type = discriminatorSchema._getPathType(rest);
         break;

--- a/lib/helpers/schema/getPath.js
+++ b/lib/helpers/schema/getPath.js
@@ -8,7 +8,7 @@ const numberRE = /^\d+$/;
  * @api private
  */
 
-module.exports = function getPath(schema, path) {
+module.exports = function getPath(schema, path, discriminatorValueMap) {
   let schematype = schema.path(path);
   if (schematype != null) {
     return schematype;
@@ -26,9 +26,13 @@ module.exports = function getPath(schema, path) {
     schematype = schema.path(cur);
     if (schematype != null && schematype.schema) {
       schema = schematype.schema;
+      const currentPath = cur;
       cur = '';
       if (!isArray && schematype.$isMongooseDocumentArray) {
         isArray = true;
+      }
+      if (discriminatorValueMap && discriminatorValueMap[currentPath]) {
+        schema = schema.discriminators[discriminatorValueMap[currentPath]] ?? schema;
       }
     }
   }

--- a/lib/helpers/update/castArrayFilters.js
+++ b/lib/helpers/update/castArrayFilters.js
@@ -33,6 +33,9 @@ function _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilt
     return;
   }
 
+  // Map of embedded discriminator values set in the array filters
+  const discriminatorValueMap = {};
+
   for (const filter of arrayFilters) {
     if (filter == null) {
       throw new Error(`Got null array filter in ${arrayFilters}`);
@@ -58,12 +61,13 @@ function _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilt
       updatedPathsByFilter[filterWildcardPath]
     );
 
-    const baseSchematype = getPath(schema, baseFilterPath);
+    const baseSchematype = getPath(schema, baseFilterPath, discriminatorValueMap);
     let filterBaseSchema = baseSchematype != null ? baseSchematype.schema : null;
     if (filterBaseSchema != null &&
         filterBaseSchema.discriminators != null &&
         filter[filterWildcardPath + '.' + filterBaseSchema.options.discriminatorKey]) {
       filterBaseSchema = filterBaseSchema.discriminators[filter[filterWildcardPath + '.' + filterBaseSchema.options.discriminatorKey]] || filterBaseSchema;
+      discriminatorValueMap[baseFilterPath] = filter[filterWildcardPath + '.' + filterBaseSchema.options.discriminatorKey];
     }
 
     for (const key of keys) {
@@ -83,7 +87,7 @@ function _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilt
         // If there are multiple array filters in the path being updated, make sure
         // to replace them so we can get the schema path.
         filterPathRelativeToBase = cleanPositionalOperators(filterPathRelativeToBase);
-        schematype = getPath(filterBaseSchema, filterPathRelativeToBase);
+        schematype = getPath(filterBaseSchema, filterPathRelativeToBase, discriminatorValueMap);
       }
 
       if (schematype == null) {


### PR DESCRIPTION
Fix #15386

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The issue in #15386 is that `events.$[event].products.$[product].price` updates don't quite work if `products` is a path on an embedded discriminator where the discriminator key is set in the `event` array filter.

To get that to work, we needed to first fix `castArrayFilters()` to handle this pattern when casting array filters, and then improve how we handle casting the update in `castUpdate()` (`getEmbeddedDiscriminatorPath()` changes).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
