### PR TITLE
docs(typescript): correct schema and model generic params in TS virtuals docs

### DIFF
--- a/docs/layout.pug
+++ b/docs/layout.pug
@@ -112,6 +112,8 @@ html(lang='en')
                         li.pure-menu-item.sub-item
                           a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/populate.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/populate.html` ? 'selected' : '') Populate
                         li.pure-menu-item.sub-item
+                          a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/virtuals.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/virtuals.html` ? 'selected' : '') Virtuals
+                        li.pure-menu-item.sub-item
                           a.pure-menu-link(href=`${versions.versionedPath}/docs/typescript/subdocuments.html`, class=outputUrl === `${versions.versionedPath}/docs/typescript/subdocuments.html` ? 'selected' : '') Subdocuments
               li.pure-menu-item
                 a.pure-menu-link(href=`${versions.versionedPath}/docs/api/mongoose.html`, class=outputUrl === `${versions.versionedPath}/docs/api/mongoose.html` ? 'selected' : '') API

--- a/docs/typescript/virtuals.md
+++ b/docs/typescript/virtuals.md
@@ -72,9 +72,9 @@ interface UserVirtuals {
   fullName: string;
 }
 
-type UserModel = Model<UserDoc, {}, UserVirtuals>; // <-- add virtuals here...
+type UserModel = Model<UserDoc, {}, {}, UserVirtuals>; // <-- add virtuals here...
 
-const schema = new Schema<UserDoc, UserModel, UserVirtuals>({ // <-- and here
+const schema = new Schema<UserDoc, UserModel, {}, {}, UserVirtuals>({ // <-- and here
   firstName: String,
   lastName: String
 });


### PR DESCRIPTION
Fix mongoosejs/mongoose-lean-virtuals#74

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In mongoosejs/mongoose-lean-virtuals#74, OP pointed out that https://mongoosejs.com/docs/typescript/virtuals.html#set-virtuals-type-manually sets virtuals using the incorrect generic param.

Also we originally added virtuals.html in #10754 but didn't add a link from navbar

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
