### PR TITLE
docs+types(schema): add alternative optimisticConcurrency syntaxes to docs + types

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -77,7 +77,7 @@ const numberRE = /^\d+$/;
  * - [validateBeforeSave](https://mongoosejs.com/docs/guide.html#validateBeforeSave) - bool - defaults to `true`
  * - [validateModifiedOnly](https://mongoosejs.com/docs/api/document.html#Document.prototype.validate()) - bool - defaults to `false`
  * - [versionKey](https://mongoosejs.com/docs/guide.html#versionKey): string or object - defaults to "__v"
- * - [optimisticConcurrency](https://mongoosejs.com/docs/guide.html#optimisticConcurrency): bool - defaults to false. Set to true to enable [optimistic concurrency](https://thecodebarbarian.com/whats-new-in-mongoose-5-10-optimistic-concurrency.html).
+ * - [optimisticConcurrency](https://mongoosejs.com/docs/guide.html#optimisticConcurrency): bool or string[] or { exclude: string[] } - defaults to false. Set to true to enable [optimistic concurrency](https://thecodebarbarian.com/whats-new-in-mongoose-5-10-optimistic-concurrency.html). Set to string array to enable optimistic concurrency for only certain fields, or `{ exclude: string[] }` to define a list of fields to ignore for optimistic concurrency.
  * - [collation](https://mongoosejs.com/docs/guide.html#collation): object - defaults to null (which means use no collation)
  * - [timeseries](https://mongoosejs.com/docs/guide.html#timeseries): object - defaults to null (which means this schema's collection won't be a timeseries collection)
  * - [selectPopulatedPaths](https://mongoosejs.com/docs/guide.html#selectPopulatedPaths): boolean - defaults to `true`

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -107,9 +107,10 @@ declare module 'mongoose' {
     /**
      * Optimistic concurrency is a strategy to ensure the document you're updating didn't change between when you
      * loaded it using find() or findOne(), and when you update it using save(). Set to `true` to enable
-     * optimistic concurrency.
+     * optimistic concurrency. Set to string array to enable optimistic concurrency for only certain fields,
+     * or `{ exclude: string[] }` to define a list of fields to ignore for optimistic concurrency.
      */
-    optimisticConcurrency?: boolean;
+    optimisticConcurrency?: boolean | string[] | { exclude: string[] };
     /**
      * If `plugin()` called with tags, Mongoose will only apply plugins to schemas that have
      * a matching tag in `pluginTags`


### PR DESCRIPTION
Re: #10591

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Comments in #10591 mentioned that our docs and typescript types don't mention the `string[]` or `{ exclude: string[] }` syntaxes for `optimisticConcurrency`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
