### PR TITLE
C: add Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20, 22]
+        node: [16, 18, 20, 22, 24]
         os: [ubuntu-22.04, ubuntu-24.04]
         mongodb: [6.0.15, 7.0.12, 8.0.0]
         include:

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1716,13 +1716,13 @@ describe('document', function() {
         }
       }));
       const doc = new Model({ name: 'test', profile: { age: 29 } });
-      assert.deepEqual(names, [null]);
-      assert.deepEqual(profiles, [null]);
+      assert.deepEqual(names, [undefined]);
+      assert.deepEqual(profiles, [undefined]);
 
       doc.name = 'test2';
       doc.profile = { age: 30 };
-      assert.deepEqual(names, [null, 'test']);
-      assert.deepEqual(profiles, [null, { age: 29 }]);
+      assert.deepEqual(names, [undefined, 'test']);
+      assert.deepEqual(profiles, [undefined, { age: 29 }]);
     });
 
     describe('on nested paths', function() {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3128,7 +3128,7 @@ describe('Query', function() {
     const Model = db.model('Test', schema);
 
     return Model.updateOne({}, { name: 'bar' }).exec().
-      then(() => assert.deepEqual(priorVals, [null]));
+      then(() => assert.deepEqual(priorVals, [undefined]));
   });
 
   describe('clone', function() {


### PR DESCRIPTION
Add Node 24 to version matrix, as it is the "current" and upcoming LTS version.

Required small change to two test cases:

The prevValue tests used "nulls" in expected values. This comparison fails in Node 24, as the actual value is "undefined".

However, the original value seems to be "undefined" in previous Node versions too. Therefore it does not seem like a change in behaviour, but only a change in how strict the assert is. Changing the expected value to "undefined" works in both Node 24 and previous Node versions.