### PR TITLE
types: fix signature of DocumentArray.id

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -70,7 +70,7 @@ declare module 'mongoose' {
       create(obj: any): THydratedDocumentType;
 
       /** Searches array items for the first document with a matching _id. */
-      id(id: any): THydratedDocumentType | null;
+      id(id: ObjectId | string | number | Buffer): THydratedDocumentType | null;
 
       push(...args: (AnyKeys<T> & AnyObject)[]): number;
 


### PR DESCRIPTION
My main issue with this was that 'undefined' was a valid argument. Now it matches <https://mongoosejs.com/docs/api/documentarray.html#MongooseDocumentArray.prototype.id()>.