### PR TITLE
fix(model): make bulkSave() rely on document.validate() to validate docs and skip bulkWrite casting

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3394,7 +3394,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
     return bulkWriteResult;
   }
 
-  const validations = ops.map(op => castBulkWrite(this, op, options));
+  const validations = options?._skipCastBulkWrite ? [] : ops.map(op => castBulkWrite(this, op, options));
   const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
   if ((!options || !options.hasOwnProperty('session')) && asyncLocalStorage?.session != null) {
     options = { ...options, session: asyncLocalStorage.session };
@@ -3431,6 +3431,9 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
     let validationErrors = [];
     const results = [];
     await new Promise((resolve) => {
+      if (validations.length === 0) {
+        return resolve();
+      }
       for (let i = 0; i < validations.length; ++i) {
         validations[i]((err) => {
           if (err == null) {
@@ -3568,8 +3571,9 @@ Model.bulkSave = async function bulkSave(documents, options) {
 
   await Promise.all(documents.map(doc => buildPreSavePromise(doc, options)));
 
-  const writeOperations = this.buildBulkWriteOperations(documents, { skipValidation: true, timestamps: options.timestamps });
-  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, { skipValidation: true, ...options }).then(
+  const writeOperations = await this.buildBulkWriteOperations(documents, options);
+  const opts = { skipValidation: true, _skipCastBulkWrite: true, ...options };
+  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, opts).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })
   );
@@ -3862,22 +3866,20 @@ Model.castObject = function castObject(obj, options) {
  * @api private
  */
 
-Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
+Model.buildBulkWriteOperations = async function buildBulkWriteOperations(documents, options) {
   if (!Array.isArray(documents)) {
     throw new Error(`bulkSave expects an array of documents to be passed, received \`${documents}\` instead`);
   }
 
   setDefaultOptions();
-  const discriminatorKey = this.schema.options.discriminatorKey;
 
-  const writeOperations = documents.reduce((accumulator, document, i) => {
+  const writeOperations = await Promise.all(documents.map(async(document, i) => {
     if (!options.skipValidation) {
       if (!(document instanceof Document)) {
         throw new Error(`documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`);
       }
-      const validationError = document.validateSync();
-      if (validationError) {
-        throw validationError;
+      if (options.validateBeforeSave == null || options.validateBeforeSave) {
+        await document.validate();
       }
     }
 
@@ -3885,9 +3887,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
     if (isANewDocument) {
       const writeOperation = { insertOne: { document } };
       utils.injectTimestampsOption(writeOperation.insertOne, options.timestamps);
-      accumulator.push(writeOperation);
-
-      return accumulator;
+      return writeOperation;
     }
 
     const delta = document.$__delta();
@@ -3910,22 +3910,14 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
         }
       }
 
-      // Set the discriminator key, so bulk write casting knows which
-      // schema to use re: gh-13907
-      if (document[discriminatorKey] != null && !(discriminatorKey in where)) {
-        where[discriminatorKey] = document[discriminatorKey];
-      }
-
       document.$__version(where, delta);
       const writeOperation = { updateOne: { filter: where, update: changes } };
       utils.injectTimestampsOption(writeOperation.updateOne, options.timestamps);
-      accumulator.push(writeOperation);
-
-      return accumulator;
+      return writeOperation;
     }
 
-    return accumulator;
-  }, []);
+    return null;
+  })).then(results => results.filter(op => op !== null));
 
   return writeOperations;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3571,7 +3571,7 @@ Model.bulkSave = async function bulkSave(documents, options) {
 
   await Promise.all(documents.map(doc => buildPreSavePromise(doc, options)));
 
-  const writeOperations = await this.buildBulkWriteOperations(documents, options);
+  const writeOperations = this.buildBulkWriteOperations(documents, options);
   const opts = { skipValidation: true, _skipCastBulkWrite: true, ...options };
   const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, opts).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
@@ -3866,20 +3866,23 @@ Model.castObject = function castObject(obj, options) {
  * @api private
  */
 
-Model.buildBulkWriteOperations = async function buildBulkWriteOperations(documents, options) {
+Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
   if (!Array.isArray(documents)) {
     throw new Error(`bulkSave expects an array of documents to be passed, received \`${documents}\` instead`);
   }
 
   setDefaultOptions();
 
-  const writeOperations = await Promise.all(documents.map(async(document, i) => {
+  const writeOperations = documents.map((document, i) => {
     if (!options.skipValidation) {
       if (!(document instanceof Document)) {
         throw new Error(`documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`);
       }
       if (options.validateBeforeSave == null || options.validateBeforeSave) {
-        await document.validate();
+        const err = document.validateSync();
+        if (err != null) {
+          throw err;
+        }
       }
     }
 
@@ -3917,7 +3920,7 @@ Model.buildBulkWriteOperations = async function buildBulkWriteOperations(documen
     }
 
     return null;
-  })).then(results => results.filter(op => op !== null));
+  }).filter(op => op !== null);
 
   return writeOperations;
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6780,7 +6780,7 @@ describe('Model', function() {
       await users[2].save();
       users[2].name = 'I am the updated third name';
 
-      const writeOperations = await User.buildBulkWriteOperations(users);
+      const writeOperations = User.buildBulkWriteOperations(users);
 
       const desiredWriteOperations = [
         { insertOne: { document: users[0] } },
@@ -6795,7 +6795,7 @@ describe('Model', function() {
 
     });
 
-    it('throws an error when one document is invalid', async() => {
+    it('throws an error when one document is invalid', () => {
       const userSchema = new Schema({
         name: { type: String, minLength: 5 }
       });
@@ -6808,14 +6808,10 @@ describe('Model', function() {
         new User({ name: 'b' })
       ];
 
-      let err;
-      try {
-        await User.buildBulkWriteOperations(users);
-      } catch (error) {
-        err = error;
-      }
-
-      assert.ok(err);
+      assert.throws(
+        () => User.buildBulkWriteOperations(users),
+        /name: Path `name` \(`a`\) is shorter than the minimum allowed length/
+      );
     });
 
     it('throws an error if documents is not an array', function() {
@@ -6826,8 +6822,8 @@ describe('Model', function() {
       const User = db.model('User', userSchema);
 
 
-      assert.rejects(
-        User.buildBulkWriteOperations(null),
+      assert.throws(
+        () => User.buildBulkWriteOperations(null),
         /bulkSave expects an array of documents to be passed/
       );
     });
@@ -6838,16 +6834,15 @@ describe('Model', function() {
 
       const User = db.model('User', userSchema);
 
-
-      assert.rejects(
-        User.buildBulkWriteOperations([
+      assert.throws(
+        () => User.buildBulkWriteOperations([
           new User({ name: 'Hafez' }),
           { name: 'I am not a document' }
         ]),
         /documents\.1 was not a mongoose document/
       );
     });
-    it('skips validation when given `skipValidation` true', async() => {
+    it('skips validation when given `skipValidation` true', () => {
       const userSchema = new Schema({
         name: { type: String, minLength: 5 }
       });
@@ -6860,7 +6855,7 @@ describe('Model', function() {
         new User({ name: 'b' })
       ];
 
-      const writeOperations = await User.buildBulkWriteOperations(users, { skipValidation: true });
+      const writeOperations = User.buildBulkWriteOperations(users, { skipValidation: true });
 
       assert.equal(writeOperations.length, 3);
     });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7080,10 +7080,9 @@ describe('Model', function() {
         rows: [rowSchema]
       }, { timestamps: true });
 
-      const Requirement = requirementSchema;
-      Requirement.discriminators = {};
-      Requirement.discriminators['ComponentRequirement'] = componentRequirementSchema;
-      Requirement.discriminators['ToolRequirement'] = toolRequirementSchema;
+      requirementSchema.discriminators = {};
+      requirementSchema.discriminators['ComponentRequirement'] = componentRequirementSchema;
+      requirementSchema.discriminators['ToolRequirement'] = toolRequirementSchema;
 
       subRowSchema.path('requirements').discriminator('ComponentRequirement', componentRequirementSchema);
       subRowSchema.path('requirements').discriminator('ToolRequirement', toolRequirementSchema);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6894,7 +6894,7 @@ describe('Model', function() {
       userToUpdate.name = 'John Doe';
 
       // Act
-      const writeOperations = await User.buildBulkWriteOperations([newUser, userToUpdate], { timestamps: false, skipValidation: true });
+      const writeOperations = User.buildBulkWriteOperations([newUser, userToUpdate], { timestamps: false, skipValidation: true });
 
       // Assert
       const timestampsOptions = writeOperations.map(writeOperationContainer => {
@@ -6916,7 +6916,7 @@ describe('Model', function() {
       userToUpdate.name = 'John Doe';
 
       // Act
-      const writeOperations = await User.buildBulkWriteOperations([newUser, userToUpdate], { timestamps: true, skipValidation: true });
+      const writeOperations = User.buildBulkWriteOperations([newUser, userToUpdate], { timestamps: true, skipValidation: true });
 
       // Assert
       const timestampsOptions = writeOperations.map(writeOperationContainer => {
@@ -6938,7 +6938,7 @@ describe('Model', function() {
       userToUpdate.name = 'John Doe';
 
       // Act
-      const writeOperations = await User.buildBulkWriteOperations([newUser, userToUpdate], { skipValidation: true });
+      const writeOperations = User.buildBulkWriteOperations([newUser, userToUpdate], { skipValidation: true });
 
       // Assert
       const timestampsOptions = writeOperations.map(writeOperationContainer => {


### PR DESCRIPTION
Fix #15410

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

@AbdelrahmanHafez please take a look at this one

The issue in #15410 is similar to the issue in #13907: `bulkSave()` currently relies on `bulkWrite()`'s `castBulkWrite()` logic to handle casting, which is inconsistent with `save()`. Further, it causes problems with discriminators (like in #13907  for top-level discriminators and #15410 for embedded discriminators) because you need to set the discriminator key on discriminator paths to tell `castBulkWrite()` which discriminator schema to use when casting.

We worked around the discriminator issue for top-level discriminators in #13907, but for embedded discriminators it is infeasible - needing to find every embedded discriminator in the doc will be complex and error prone. In the interest of simplifying things, we can just rely on `document.validate()` to ensure the document is valid before saving, which is consistent with how `save()` works. However, this change may also break user code because now async validators and `validate` middleware will run on `bulkSave()`.

Questions to consider:

1. Should we skip running `validate` middleware on `bulkSave()` for backwards compatibility?
2. Should we continue to use `validateSync()` instead of `validate()` for backwards compatibility?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
