### PR TITLE
docs: fix typo - change 'prodecure' to 'procedure'

### DIFF
--- a/release-items.md
+++ b/release-items.md
@@ -1,4 +1,4 @@
-# Release prodecure
+# Release procedure
 
 ## mongoose release procedure
 


### PR DESCRIPTION
## docs: fix typo - change 'prodecure' to 'procedure'

**Summary**

The `release-items.md` file contains a typo which is `prodecure` should be `procedure`, I fixed it with this PR
