### PR TITLE
feat(error): set `cause` to MongoDB error `reason` on ServerSelection errors

### DIFF
--- a/lib/error/serverSelection.js
+++ b/lib/error/serverSelection.js
@@ -49,6 +49,7 @@ class MongooseServerSelectionError extends MongooseError {
         this[key] = err[key];
       }
     }
+    this.cause = reason;
 
     return this;
   }


### PR DESCRIPTION
Fix #15416

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

A reasonable request: propagate the original server selection error's `reason` property. [`cause` is JavaScript's official property for storing the original cause of an error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
