### PR TITLE
fix: Support $expr clauses with a boolean literal as an expression

### DIFF
--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -69,7 +69,7 @@ const dateOperators = new Set([
 const expressionOperator = new Set(['$not']);
 
 module.exports = function cast$expr(val, schema, strictQuery) {
-  if ((typeof val !== 'object' || val === null) && val !== true && val !== false) {
+  if ((typeof val !== 'object' || val === null) && typeof val !== 'boolean') {
     throw new Error('`$expr` must be an object or boolean literal');
   }
 

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -69,8 +69,8 @@ const dateOperators = new Set([
 const expressionOperator = new Set(['$not']);
 
 module.exports = function cast$expr(val, schema, strictQuery) {
-  if (typeof val !== 'object' || val === null) {
-    throw new Error('`$expr` must be an object');
+  if ((typeof val !== 'object' || val === null) && val !== true && val !== false) {
+    throw new Error('`$expr` must be an object or boolean literal');
   }
 
   return _castExpression(val, schema, strictQuery);

--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -69,7 +69,10 @@ const dateOperators = new Set([
 const expressionOperator = new Set(['$not']);
 
 module.exports = function cast$expr(val, schema, strictQuery) {
-  if ((typeof val !== 'object' || val === null) && typeof val !== 'boolean') {
+  if (typeof val === 'boolean') {
+    return val;
+  }
+  if (typeof val !== 'object' || val === null) {
     throw new Error('`$expr` must be an object or boolean literal');
   }
 


### PR DESCRIPTION
Support queries of the form `{ $expr: true }` or `{ $expr: false }`, as boolean literals are valid expressions.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When trying to execute a query containing a `{ $expr: true }` or `{ $expr: false }` clause, I get an error `` `$expr` must be an object ``. Since `true` is a valid expression in the mongo query language, this seems like a mistake.

**Examples**

The following query will now work correctly:
```
model.findOne({ $and: [{ foo: bar }, { $expr: true }] })
```
