### PR TITLE
types: fix definition of VectorSearch.$vectorSearch

### DIFF
--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -319,10 +319,11 @@ declare module 'mongoose' {
     export interface VectorSearch {
       /** [`$vectorSearch` reference](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/) */
       $vectorSearch: {
+        exact?: boolean;
         index: string,
         path: string,
         queryVector: number[],
-        numCandidates: number,
+        numCandidates?: number,
         limit: number,
         filter?: Expression,
       }


### PR DESCRIPTION
**Summary**

The `exact` field was missing from the interface, and the `numCandidates` field was typed as required. Neither of these match [the docs](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/).

**Examples**

Previously, any use of the interface that directly used an object literal with `exact: true`, or any version that omitted `numCandidates` would fail.
