### PR TITLE
fix(queryCursor): add _transformForAsyncIterator transform after user-defined transforms

### DIFF
--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -77,6 +77,9 @@ function QueryCursor(query) {
     if (this.options.transform) {
       this._transforms.push(this.options.transform);
     }
+    if (this._mongooseOptions._transformForAsyncIterator) {
+      this._transforms.push(_transformForAsyncIterator);
+    }
     // Re: gh-8039, you need to set the `cursor.batchSize` option, top-level
     // `batchSize` option doesn't work.
     if (this.options.batchSize) {
@@ -396,9 +399,7 @@ QueryCursor.prototype.transformNull = function(val) {
  */
 
 QueryCursor.prototype._transformForAsyncIterator = function() {
-  if (this._transforms.indexOf(_transformForAsyncIterator) === -1) {
-    this.map(_transformForAsyncIterator);
-  }
+  this._mongooseOptions._transformForAsyncIterator = true;
   return this;
 };
 

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -77,9 +77,6 @@ function QueryCursor(query) {
     if (this.options.transform) {
       this._transforms.push(this.options.transform);
     }
-    if (this._mongooseOptions._transformForAsyncIterator) {
-      this._transforms.push(_transformForAsyncIterator);
-    }
     // Re: gh-8039, you need to set the `cursor.batchSize` option, top-level
     // `batchSize` option doesn't work.
     if (this.options.batchSize) {
@@ -382,27 +379,6 @@ QueryCursor.prototype.addCursorFlag = function(flag, value) {
   return this;
 };
 
-/*!
- * ignore
- */
-
-QueryCursor.prototype.transformNull = function(val) {
-  if (arguments.length === 0) {
-    val = true;
-  }
-  this._mongooseOptions.transformNull = val;
-  return this;
-};
-
-/*!
- * ignore
- */
-
-QueryCursor.prototype._transformForAsyncIterator = function() {
-  this._mongooseOptions._transformForAsyncIterator = true;
-  return this;
-};
-
 /**
  * Returns an asyncIterator for use with [`for/await/of` loops](https://thecodebarbarian.com/getting-started-with-async-iterators-in-node-js).
  * You do not need to call this function explicitly, the JavaScript runtime
@@ -435,16 +411,9 @@ QueryCursor.prototype._transformForAsyncIterator = function() {
 
 if (Symbol.asyncIterator != null) {
   QueryCursor.prototype[Symbol.asyncIterator] = function() {
-    return this.transformNull()._transformForAsyncIterator();
+    this._mongooseOptions._asyncIterator = true;
+    return this;
   };
-}
-
-/*!
- * ignore
- */
-
-function _transformForAsyncIterator(doc) {
-  return doc == null ? { done: true } : { value: doc, done: false };
 }
 
 /**
@@ -457,16 +426,37 @@ function _transformForAsyncIterator(doc) {
 
 function _next(ctx, cb) {
   let callback = cb;
-  if (ctx._transforms.length) {
-    callback = function(err, doc) {
-      if (err || (doc === null && !ctx._mongooseOptions.transformNull)) {
-        return cb(err, doc);
+
+  // Create a custom callback to handle transforms, async iterator, and transformNull
+  callback = function(err, doc) {
+    if (err) {
+      return cb(err);
+    }
+
+    // Handle null documents - if asyncIterator, we need `done: true`, otherwise just
+    // skip. In either case, avoid transforms.
+    if (doc === null) {
+      if (ctx._mongooseOptions._asyncIterator) {
+        return cb(null, { done: true });
+      } else {
+        return cb(null, null);
       }
-      cb(err, ctx._transforms.reduce(function(doc, fn) {
+    }
+
+    // Apply transforms
+    if (ctx._transforms.length && doc !== null) {
+      doc = ctx._transforms.reduce(function(doc, fn) {
         return fn.call(ctx, doc);
-      }, doc));
-    };
-  }
+      }, doc);
+    }
+
+    // For async iterator, convert to {value, done} format
+    if (ctx._mongooseOptions._asyncIterator) {
+      return cb(null, { value: doc, done: false });
+    }
+
+    return cb(null, doc);
+  };
 
   if (ctx._error) {
     return immediate(function() {

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -83,6 +83,9 @@ function QueryCursor(query) {
       // Max out the number of documents we'll populate in parallel at 5000.
       this.options._populateBatchSize = Math.min(this.options.batchSize, 5000);
     }
+    if (query._mongooseOptions._asyncIterator) {
+      this._mongooseOptions._asyncIterator = true;
+    }
 
     if (model.collection._shouldBufferCommands() && model.collection.buffer) {
       model.collection.queue.push([
@@ -410,7 +413,8 @@ QueryCursor.prototype.addCursorFlag = function(flag, value) {
  */
 
 if (Symbol.asyncIterator != null) {
-  QueryCursor.prototype[Symbol.asyncIterator] = function() {
+  QueryCursor.prototype[Symbol.asyncIterator] = function queryCursorAsyncIterator() {
+    // Set so QueryCursor knows it should transform results for async iterators into `{ value, done }` syntax
     this._mongooseOptions._asyncIterator = true;
     return this;
   };
@@ -433,7 +437,7 @@ function _next(ctx, cb) {
       return cb(err);
     }
 
-    // Handle null documents - if asyncIterator, we need `done: true`, otherwise just
+    // Handle null documents - if asyncIterator, we need to return `done: true`, otherwise just
     // skip. In either case, avoid transforms.
     if (doc === null) {
       if (ctx._mongooseOptions._asyncIterator) {
@@ -450,7 +454,8 @@ function _next(ctx, cb) {
       }, doc);
     }
 
-    // For async iterator, convert to {value, done} format
+    // This option is set in `Symbol.asyncIterator` code paths.
+    // For async iterator, we need to convert to {value, done} format
     if (ctx._mongooseOptions._asyncIterator) {
       return cb(null, { value: doc, done: false });
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -5476,8 +5476,10 @@ Query.prototype.nearSphere = function() {
  */
 
 if (Symbol.asyncIterator != null) {
-  Query.prototype[Symbol.asyncIterator] = function() {
-    return this.cursor().transformNull()._transformForAsyncIterator();
+  Query.prototype[Symbol.asyncIterator] = function queryAsyncIterator() {
+    // Set so QueryCursor knows it should transform results for async iterators into `{ value, done }` syntax
+    this._mongooseOptions._asyncIterator = true;
+    return this.cursor();
   };
 }
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2358,7 +2358,7 @@ describe('Query', function() {
     const Model = db.model('Test', new Schema({ name: String }));
 
     await Model.create({ name: 'test' });
-    const cursor = Model.find().transform(doc => doc?.name.toUpperCase() ?? null).cursor();
+    const cursor = Model.find().transform(doc => doc.name.toUpperCase()).cursor();
     const names = [];
     for await (const name of cursor) {
       names.push(name);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2354,6 +2354,19 @@ describe('Query', function() {
     assert.strictEqual(called, 1);
   });
 
+  it('transform with for/await and cursor', async function() {
+    const Model = db.model('Test', new Schema({ name: String }));
+
+    await Model.create({ name: 'test' });
+    const cursor = Model.find().transform(doc => doc?.name.toUpperCase() ?? null).cursor();
+    const names = [];
+    for await (const name of cursor) {
+      names.push(name);
+    }
+
+    assert.deepStrictEqual(names, ['TEST']);
+  });
+
   describe('orFail (gh-6841)', function() {
     let Model;
 


### PR DESCRIPTION
Fix mongoosejs/mongoose-lean-getters#44

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

https://github.com/mongoosejs/mongoose-lean-getters/issues/44#issuecomment-2874010333 pointed out an issue which is caused by how we handle async iterators in queryCursor.js. Query cursors use a `_transformForAsyncIterator` transform which converts `doc` to `{ value: doc, done: false }` or `{ done: true }` depending on whether the cursor returned null. Because transforms pass the transformed value to the next transform, `_transformForAsyncIterator` breaks user-specified transforms if it gets added first.

This PR makes it so that user-specified transforms are applied before `_transformForAsyncIterator`, which means user-specified transforms won't see the `{ value: doc, done: false }` doc.

However, I want to do some further work to check if we can make `_transformForAsyncIterator` not rely on transforms. `transformNull()` also adds a weird edge case for user-specified transforms where user-specified transforms need to handle `null` if using cursors. Which is why the test added in this PR has `doc?.name.toUpperCase() ?? null`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
