### PR TITLE
types: correct handling of `_id` in ProjectionType

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -187,6 +187,8 @@ expectError(Test.find({}, { 'docs.profiles': { name: 'aa' } })); // should suppo
 expectError(Test.find({}, { endDate: { toString: 1 } }));
 expectError(Test.find({}, { tags: { trim: 1 } }));
 expectError(Test.find({}, { child: { toJSON: 1 } }));
+Test.find({}, { age: 1, _id: 0 });
+Test.find({}, { name: 0, age: 0, _id: 1 });
 
 // Manual Casting using ProjectionType
 Test.find({}, { docs: { unknownParams: 1 } } as ProjectionType<ITest>);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -684,10 +684,16 @@ declare module 'mongoose' {
         }
         : Element;
   type _IDType = { _id?: boolean | 1 | 0 };
-  export type InclusionProjection<T> = IsItRecordAndNotAny<T> extends true ? Projector<WithLevel1NestedPaths<T>, true | 1> & _IDType : AnyObject;
-  export type ExclusionProjection<T> = IsItRecordAndNotAny<T> extends true ? Projector<WithLevel1NestedPaths<T>, false | 0> & _IDType : AnyObject;
+  export type InclusionProjection<T> = IsItRecordAndNotAny<T> extends true
+    ? Omit<Projector<WithLevel1NestedPaths<T>, true | 1>, '_id'> & _IDType
+    : AnyObject;
+  export type ExclusionProjection<T> = IsItRecordAndNotAny<T> extends true
+    ? Omit<Projector<WithLevel1NestedPaths<T>, false | 0>, '_id'> & _IDType
+    : AnyObject;
 
-  export type ProjectionType<T> = (InclusionProjection<T> & AnyObject) | (ExclusionProjection<T> & AnyObject) | string;
+  export type ProjectionType<T> = (InclusionProjection<T> & AnyObject)
+    | (ExclusionProjection<T> & AnyObject)
+    | string;
   export type SortValues = SortOrder;
 
   export type SortOrder = -1 | 1 | 'asc' | 'ascending' | 'desc' | 'descending';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix for #15418: looks like we need to explicitly `Omit<T, '_id'>` to avoid TypeScript getting tripped up by `_id` in `InclusionProjection` and `ExclusionProjection`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
