### PR TITLE
docs: add Document#save to list of function with callbacks removed

### DIFF
--- a/docs/migrating_to_7.md
+++ b/docs/migrating_to_7.md
@@ -106,6 +106,7 @@ They always return promises.
 * `Connection.prototype.close`
 * `Connection.prototype.destroy`
 * `Document.prototype.populate`
+* `Document.prototype.save`
 * `Document.prototype.validate`
 * `Mongoose.prototype.connect`
 * `Mongoose.prototype.createConnection`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

_(This PR is very similar to my previous PR regarding `Model#count`, so I've largely copy and pasted the description over._)

I'm working on migrating from Mongoose v6 to Mongoose v7. Part of this includes dropping all callbacks in favor of Promises.

I noticed that `Document#save` is not in the list though, which according to the types, had a callback param in v6, which was removed in v7. This should be in the list of functions as well that the `callback` param was removed from too.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

N/A

**Notes for Reviewers**

The failed test case seems to be unrelated to this PR.