### PR TITLE
refactor: remove unnecessary async iterator checks

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1139,24 +1139,15 @@ Aggregate.prototype.finally = function(onFinally) {
  *       console.log(doc.name);
  *     }
  *
- * Node.js 10.x supports async iterators natively without any flags. You can
- * enable async iterators in Node.js 8.x using the [`--harmony_async_iteration` flag](https://github.com/tc39/proposal-async-iteration/issues/117#issuecomment-346695187).
- *
- * **Note:** This function is not set if `Symbol.asyncIterator` is undefined. If
- * `Symbol.asyncIterator` is undefined, that means your Node.js version does not
- * support async iterators.
- *
  * @method [Symbol.asyncIterator]
  * @memberOf Aggregate
  * @instance
  * @api public
  */
 
-if (Symbol.asyncIterator != null) {
-  Aggregate.prototype[Symbol.asyncIterator] = function() {
-    return this.cursor({ useMongooseAggCursor: true }).transformNull()._transformForAsyncIterator();
-  };
-}
+ Aggregate.prototype[Symbol.asyncIterator] = function() {
+   return this.cursor({ useMongooseAggCursor: true }).transformNull()._transformForAsyncIterator();
+ };
 
 /*!
  * Helpers

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1145,9 +1145,9 @@ Aggregate.prototype.finally = function(onFinally) {
  * @api public
  */
 
- Aggregate.prototype[Symbol.asyncIterator] = function() {
-   return this.cursor({ useMongooseAggCursor: true }).transformNull()._transformForAsyncIterator();
- };
+Aggregate.prototype[Symbol.asyncIterator] = function() {
+  return this.cursor({ useMongooseAggCursor: true }).transformNull()._transformForAsyncIterator();
+};
 
 /*!
  * Helpers

--- a/lib/query.js
+++ b/lib/query.js
@@ -5406,26 +5406,17 @@ Query.prototype.nearSphere = function() {
  *       console.log(doc.name);
  *     }
  *
- * Node.js 10.x supports async iterators natively without any flags. You can
- * enable async iterators in Node.js 8.x using the [`--harmony_async_iteration` flag](https://github.com/tc39/proposal-async-iteration/issues/117#issuecomment-346695187).
- *
- * **Note:** This function is not if `Symbol.asyncIterator` is undefined. If
- * `Symbol.asyncIterator` is undefined, that means your Node.js version does not
- * support async iterators.
- *
  * @method [Symbol.asyncIterator]
  * @memberOf Query
  * @instance
  * @api public
  */
 
-if (Symbol.asyncIterator != null) {
-  Query.prototype[Symbol.asyncIterator] = function queryAsyncIterator() {
-    // Set so QueryCursor knows it should transform results for async iterators into `{ value, done }` syntax
-    this._mongooseOptions._asyncIterator = true;
-    return this.cursor();
-  };
-}
+ Query.prototype[Symbol.asyncIterator] = function queryAsyncIterator() {
+   // Set so QueryCursor knows it should transform results for async iterators into `{ value, done }` syntax
+   this._mongooseOptions._asyncIterator = true;
+   return this.cursor();
+ };
 
 /**
  * Specifies a `$polygon` condition

--- a/lib/query.js
+++ b/lib/query.js
@@ -5412,11 +5412,11 @@ Query.prototype.nearSphere = function() {
  * @api public
  */
 
- Query.prototype[Symbol.asyncIterator] = function queryAsyncIterator() {
-   // Set so QueryCursor knows it should transform results for async iterators into `{ value, done }` syntax
-   this._mongooseOptions._asyncIterator = true;
-   return this.cursor();
- };
+Query.prototype[Symbol.asyncIterator] = function queryAsyncIterator() {
+  // Set so QueryCursor knows it should transform results for async iterators into `{ value, done }` syntax
+  this._mongooseOptions._asyncIterator = true;
+  return this.cursor();
+};
 
 /**
  * Specifies a `$polygon` condition


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Good point by @hasezoey in #15430: `if (Symbol.asyncIterator != null)` checks are no longer necessary because `Symbol.asyncIterator` was introduced in node 10.x, and Mongoose 9 requires Node `>= 18` currently (may change before we formally release Mongoose 9).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
