### PR TITLE
fix: report default paths in VersionError message because they can can cause VersionError

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -460,8 +460,8 @@ Model.prototype.$__handleSave = function(options, callback) {
     return;
   }
 
-  // store the modified paths before the document is reset
-  this.$__.modifiedPaths = this.modifiedPaths();
+  // store the modified paths before the document is reset in case we need to generate version error.
+  this.$__.modifiedPaths = this.modifiedPaths().concat(Object.keys(this.$__.activePaths.getStatePaths('default')));
   this.$__reset();
 
   _setIsNew(this, false);
@@ -562,13 +562,13 @@ Model.prototype.$__save = function(options, callback) {
  * ignore
  */
 
-function generateVersionError(doc, modifiedPaths) {
+function generateVersionError(doc, modifiedPaths, defaultPaths) {
   const key = doc.$__schema.options.versionKey;
   if (!key) {
     return null;
   }
   const version = doc.$__getValue(key) || 0;
-  return new VersionError(doc, version, modifiedPaths);
+  return new VersionError(doc, version, modifiedPaths.concat(defaultPaths));
 }
 
 /**
@@ -626,7 +626,11 @@ Model.prototype.save = async function save(options) {
   if (this.$__.timestamps != null) {
     options.timestamps = this.$__.timestamps;
   }
-  this.$__.$versionError = generateVersionError(this, this.modifiedPaths());
+  this.$__.$versionError = generateVersionError(
+    this,
+    this.modifiedPaths(),
+    Object.keys(this.$__.activePaths.getStatePaths('default'))
+  );
 
   if (parallelSave) {
     this.$__handleReject(parallelSave);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I ran into a `VersionError: No matching document found for id "xyz" version 1 modifiedPaths "lastPaidAt, totalRevenue"` error - that shouldn't happen because `lastPaidAt` and `totalRevenue` are both primitives, shouldn't trigger versioning.

The root cause was an array default was triggering versioning: an array value wasn't set in the db. Paths that are in default status can trigger versioning, but VersionError doesn't currently list those paths.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
