### PR TITLE
feat: upgrade MongoDB driver -> 6.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bson": "^6.10.3",
     "kareem": "2.6.3",
-    "mongodb": "~6.16.0",
+    "mongodb": "~6.17.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",
     "ms": "2.1.3",


### PR DESCRIPTION
Updated driver from mongodb, released this week.

**Summary**

The new version resolves issues of a cached OIDC token in the driver causing initial authentication to fail when the token had expired. The affected environments were "azure", "gcp", and "k8s" 
ref: https://github.com/mongodb/node-mongodb-native/releases/tag/v6.17.0