### PR TITLE
fix: fix validation for deeply nested maps of subdocuments

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2710,7 +2710,13 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
   Object.keys(doc.$__.activePaths.getStatePaths('init')).forEach(addToPaths);
   Object.keys(doc.$__.activePaths.getStatePaths('modify')).forEach(addToPaths);
   Object.keys(doc.$__.activePaths.getStatePaths('default')).forEach(addToPaths);
-  function addToPaths(p) { paths.add(p); }
+  function addToPaths(p) {
+    if (p.endsWith('.$*')) {
+      // Skip $* paths - they represent map schemas, not actual document paths
+      return;
+    }
+    paths.add(p);
+  }
 
   if (!isNestedValidate) {
     // If we're validating a subdocument, all this logic will run anyway on the top-level document, so skip for subdocuments.


### PR DESCRIPTION
This PR fixes #15447 

The issue was that mongoose was double validating nested maps of subdocuments, once as the correct path, but then trying to validate `.$*` which represents the map schema rather than the actual value of a path.

The bug was in the `_getPathsToValidate` function in `lib/document.js`. We were incorrectly treating map schema paths (paths ending with `.$*`) as actual document paths for validation. These `$*` paths represent the schema for Maps but are not actual document paths that should be validated.

This PR ignores the `.$*` "path" when getting paths to validate.