### PR TITLE
fix(DocumentArray): correctly set parent if instantiated with schema from another Mongoose instance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.mongodb }}
 
       - run: npm install
+      # Create ./node_modules/mongoose-separate-require-instance for testing multiple require instances
+      - run: npm run create-separate-require-instance
       - name: NPM Test without Coverage
         run: npm test
         if: matrix.coverage != true

--- a/lib/document.js
+++ b/lib/document.js
@@ -2756,6 +2756,9 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
         }
 
         const subdocParent = subdoc.$parent();
+        if (subdocParent == null) {
+          throw new Error('Cannot validate subdocument that does not have a parent');
+        }
         if (doc.$isModified(fullPathToSubdoc, null, modifiedPaths) &&
               // Avoid using isDirectModified() here because that does additional checks on whether the parent path
               // is direct modified, which can cause performance issues re: gh-14897

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -73,11 +73,7 @@ function MongooseArray(values, path, doc, schematype) {
     internals[arrayAtomicsSymbol] = values[arrayAtomicsSymbol];
   }
 
-  // Because doc comes from the context of another function, doc === global
-  // can happen if there was a null somewhere up the chain (see #3020)
-  // RB Jun 17, 2015 updated to check for presence of expected paths instead
-  // to make more proof against unusual node environments
-  if (doc != null && doc instanceof Document) {
+  if (doc != null && doc.$__) {
     internals[arrayParentSymbol] = doc;
     internals[arraySchemaSymbol] = schematype || doc.schema.path(path);
   }

--- a/lib/types/array/index.js
+++ b/lib/types/array/index.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const Document = require('../../document');
 const mongooseArrayMethods = require('./methods');
 
 const arrayAtomicsSymbol = require('../../helpers/symbols').arrayAtomicsSymbol;

--- a/lib/types/documentArray/index.js
+++ b/lib/types/documentArray/index.js
@@ -6,7 +6,6 @@
 
 const ArrayMethods = require('../array/methods');
 const DocumentArrayMethods = require('./methods');
-const Document = require('../../document');
 
 const arrayAtomicsSymbol = require('../../helpers/symbols').arrayAtomicsSymbol;
 const arrayAtomicsBackupSymbol = require('../../helpers/symbols').arrayAtomicsBackupSymbol;

--- a/lib/types/documentArray/index.js
+++ b/lib/types/documentArray/index.js
@@ -51,11 +51,7 @@ function MongooseDocumentArray(values, path, doc, schematype) {
   internals[arrayPathSymbol] = path;
   internals.__array = __array;
 
-  // Because doc comes from the context of another function, doc === global
-  // can happen if there was a null somewhere up the chain (see #3020 && #3034)
-  // RB Jun 17, 2015 updated to check for presence of expected paths instead
-  // to make more proof against unusual node environments
-  if (doc && doc instanceof Document) {
+  if (doc && doc.$__) {
     internals[arrayParentSymbol] = doc;
     internals[arraySchemaSymbol] = doc.$__schema.path(path);
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "release-6x": "git pull origin 6.x && git push origin 6.x && git push origin 6.x --tags && npm publish --tag 6x",
     "mongo": "node ./tools/repl.js",
     "publish-7x": "npm publish --tag 7x",
+    "create-separate-require-instance": "rm -rf ./node_modules/mongoose-separate-require-instance && node ./scripts/create-tarball && tar -xzf mongoose.tgz -C ./node_modules && mv ./node_modules/package ./node_modules/mongoose-separate-require-instance",
     "test": "mocha --exit ./test/*.test.js",
     "test-deno": "deno run --allow-env --allow-read --allow-net --allow-run --allow-sys --allow-write ./test/deno.mjs",
     "test-rs": "START_REPLICA_SET=1 mocha --timeout 30000 --exit ./test/*.test.js",

--- a/test/multiple-require-instance.test.js
+++ b/test/multiple-require-instance.test.js
@@ -4,12 +4,14 @@ const start = require('./common');
 
 let mongoose2;
 
-describe('multi instance', function() {
-  try {
-    mongoose2 = require('mongoose-separate-require-instance');
-  } catch (err) {
-    return this.skip();
-  }
+describe('multiple require instance', function() {
+  before(function() {
+    try {
+      mongoose2 = require('mongoose-separate-require-instance');
+    } catch (err) {
+      return this.skip();
+    }
+  });
 
   let db;
   beforeEach(function() {

--- a/test/multiple-require-instance.test.js
+++ b/test/multiple-require-instance.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const start = require('./common');
+
+let mongoose2;
+
+describe('multi instance', function() {
+  try {
+    mongoose2 = require('mongoose-separate-require-instance');
+  } catch (err) {
+    return this.skip();
+  }
+
+  let db;
+  beforeEach(function() {
+    db = start();
+  });
+  afterEach(() => db.close());
+
+  it('supports arrays defined using schemas from separate instance (gh-15466)', async function() {
+    const nestedSchema = new mongoose2.Schema(
+      { name: String },
+      { _id: false }
+    );
+
+    const schema = new mongoose2.Schema({
+      subDoc: nestedSchema,
+      docArray: [nestedSchema] // this array of nestedSchema causes the error
+    });
+
+    const document = {
+      subDoc: { name: 'Alpha' },
+      docArray: [
+        { name: 'Bravo' },
+        { name: 'Charlie' }
+      ]
+    };
+
+    const TestModel = db.model('Test', schema);
+    const doc = new TestModel(document);
+    await doc.validate();
+
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15466 points out that Mongoose throws an unreadable error if creating a document array that was defined with `Schema()` from a different Mongoose instance.

I added tests to cover this case automatically - historically we haven't tested the multiple `require()` instance setup, but we should since it is so common.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
