### PR TITLE
fix(populate): handle populating deeply nested map paths 

### DIFF
--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -144,7 +144,24 @@ module.exports = function assignVals(o) {
       if (Array.isArray(valueToSet)) {
         valueToSet = valueToSet.map(v => v == null ? void 0 : v);
       }
-      mpath.set(_path, valueToSet, docs[i], void 0, setValue, false);
+      mpath.set(
+        _path,
+        valueToSet,
+        docs[i],
+        // Handle setting paths underneath maps using $* by converting arrays into maps of values
+        function lookup(obj, part, val) {
+          if (arguments.length >= 3) {
+            obj[part] = val;
+            return obj[part];
+          }
+          if (obj instanceof Map && part === '$*') {
+            return [...obj.values()].map(v => v && v._doc ? v._doc : v);
+          }
+          return obj[part];
+        },
+        setValue,
+        false
+      );
       continue;
     }
 

--- a/lib/helpers/populate/assignVals.js
+++ b/lib/helpers/populate/assignVals.js
@@ -155,7 +155,7 @@ module.exports = function assignVals(o) {
             return obj[part];
           }
           if (obj instanceof Map && part === '$*') {
-            return [...obj.values()].map(v => v && v._doc ? v._doc : v);
+            return [...obj.values()];
           }
           return obj[part];
         },

--- a/lib/helpers/populate/getVirtual.js
+++ b/lib/helpers/populate/getVirtual.js
@@ -58,6 +58,37 @@ function getVirtual(schema, name) {
       nestedSchemaPath += (nestedSchemaPath.length > 0 ? '.' : '') + cur;
       cur = '';
       continue;
+    } else if (schema.paths[cur]?.$isSchemaMap && schema.paths[cur].$__schemaType?.schema) {
+      schema = schema.paths[cur].$__schemaType.schema;
+      ++i;
+      const rest = parts.slice(i + 1).join('.');
+
+      if (schema.virtuals[rest]) {
+        if (i === parts.length - 2) {
+          return {
+            virtual: schema.virtuals[rest],
+            nestedSchemaPath: [nestedSchemaPath, cur, '$*'].filter(v => !!v).join('.')
+          };
+        }
+        continue;
+      }
+
+      if (i + 1 < parts.length && schema.discriminators) {
+        for (const key of Object.keys(schema.discriminators)) {
+          const res = getVirtual(schema.discriminators[key], rest);
+          if (res != null) {
+            const _path = [nestedSchemaPath, cur, res.nestedSchemaPath, '$*'].
+              filter(v => !!v).join('.');
+            return {
+              virtual: res.virtual,
+              nestedSchemaPath: _path
+            };
+          }
+        }
+      }
+
+      nestedSchemaPath += (nestedSchemaPath.length > 0 ? '.' : '') + '$*' + cur;
+      cur = '';
     }
 
     if (schema.discriminators) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2608,6 +2608,10 @@ Schema.prototype.virtual = function(name, options) {
         const remnant = parts.slice(i + 1).join('.');
         this.paths[cur].schema.virtual(remnant, options);
         break;
+      } else if (this.paths[cur].$isSchemaMap) {
+        const remnant = parts.slice(i + 2).join('.');
+        this.paths[cur].$__schemaType.schema.virtual(remnant, options);
+        break;
       }
 
       cur += '.' + parts[i + 1];

--- a/test/helpers/populate.getVirtual.test.js
+++ b/test/helpers/populate.getVirtual.test.js
@@ -114,4 +114,26 @@ describe('getVirtual', function() {
     assert.equal(res.virtual.options.ref, 'Users');
     assert.equal(res.nestedSchemaPath, 'events');
   });
+
+  it('handles virtuals defined under map (gh-15439)', function() {
+    const subSchema = new Schema({
+      name: String,
+      friends: [Number]
+    });
+    subSchema.virtual('friends_$', {
+      ref: 'User',
+      localField: 'users.$*.friends',
+      foreignField: 'userId'
+    });
+
+    const schema = new Schema({
+      users: {
+        type: Map,
+        of: subSchema
+      }
+    });
+
+    const res = getVirtual(schema, 'users.$*.friends_$');
+    assert.equal(res.virtual.options.ref, 'User');
+  });
 });

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11515,13 +11515,6 @@ describe('model: populate:', function() {
       sectionsToBeEvaluated: [String]
     });
 
-    projectRubricParameterSchema.virtual('rubric.parameters.$*.evaluationPrompt', {
-      ref: 'Prompt',
-      localField: 'rubric.parameters.$*.evaluationPromptId',
-      foreignField: '_id',
-      justOne: true
-    });
-
     // Rubric schema
     const projectRubricSchema = new Schema({
       parameters: {
@@ -11568,9 +11561,9 @@ describe('model: populate:', function() {
     });
 
     // Attempt population
-    const populated = await Submission.findById(submission._id).populate([
-      'rubric.parameters.$*.evaluationPrompt'
-    ]);
+    const populated = await Submission.findById(submission._id).populate(
+      { path: 'rubric.parameters.$*.evaluationPrompt' }
+    );
 
     assert.strictEqual(populated.rubric.parameters.get('param1').evaluationPrompt.name, 'Test Prompt');
 

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11500,4 +11500,138 @@ describe('model: populate:', function() {
       ['admin', 'user']
     );
   });
+
+  it('handles populating virtual underneath map of subdocs (gh-15439)', async function() {
+    // Prompt schema
+    const promptSchema = new Schema({
+      name: String,
+      model: String
+    });
+
+    const Prompt = db.model('Prompt', promptSchema);
+
+    // Rubric schema
+    const projectRubricSchema = new Schema({
+      parameters: {
+        type: Map,
+        of: {
+          evaluationPromptId: { type: Schema.Types.ObjectId, ref: 'Prompt' },
+          sectionsToBeEvaluated: [String]
+        }
+      }
+    });
+    // Submission schema
+    const submissionSchema = new Schema({
+      rubric: projectRubricSchema
+    });
+
+    submissionSchema.virtual('rubric.parameters.$*.evaluationPrompt', {
+      ref: 'Prompt',
+      localField: 'rubric.parameters.$*.evaluationPromptId',
+      foreignField: '_id',
+      justOne: true
+    });
+
+    submissionSchema.set('toObject', { virtuals: true });
+    submissionSchema.set('toJSON', { virtuals: true });
+
+    const Submission = db.model('Submission', submissionSchema);
+
+    // Seed data
+    const prompts = await Prompt.create([
+      { name: 'Test Prompt', model: 'gpt-4' },
+      { name: 'Test Prompt 2', model: 'gpt-4' }
+    ]);
+
+    const submission = await Submission.create({
+      rubric: {
+        parameters: {
+          param1: {
+            evaluationPromptId: prompts[0]._id,
+            sectionsToBeEvaluated: ['intro']
+          },
+          param2: {
+            evaluationPromptId: prompts[1]._id,
+            sectionsToBeEvaluated: ['intro']
+          }
+        }
+      }
+    });
+
+    // Attempt population
+    const populated = await Submission.findById(submission._id).populate([
+      'rubric.parameters.$*.evaluationPrompt'
+    ]);
+    const obj = JSON.parse(JSON.stringify(populated));
+    assert.strictEqual(obj.rubric.parameters.param1.evaluationPrompt.name, 'Test Prompt');
+    assert.strictEqual(obj.rubric.parameters.param2.evaluationPrompt.name, 'Test Prompt 2');
+  });
+
+  it('handles populating virtual of arrays underneath map of subdocs (gh-15439)', async function() {
+    // Prompt schema
+    const promptSchema = new Schema({
+      name: String,
+      model: String
+    });
+
+    const Prompt = db.model('Prompt', promptSchema);
+
+    // Rubric schema
+    const projectRubricSchema = new Schema({
+      parameters: {
+        type: Map,
+        of: {
+          evaluationPromptId: { type: Schema.Types.ObjectId, ref: 'Prompt' },
+          sectionsToBeEvaluated: [String]
+        }
+      }
+    });
+    // Submission schema
+    const submissionSchema = new Schema({
+      rubric: projectRubricSchema
+    });
+
+    submissionSchema.virtual('rubric.parameters.$*.evaluationPrompts', {
+      ref: 'Prompt',
+      localField: 'rubric.parameters.$*.evaluationPromptIds',
+      foreignField: '_id',
+      justOne: false
+    });
+
+    submissionSchema.set('toObject', { virtuals: true });
+    submissionSchema.set('toJSON', { virtuals: true });
+
+    const Submission = db.model('Submission', submissionSchema);
+
+    // Seed data
+    const prompts = await Prompt.create([
+      { name: 'Test Prompt', model: 'gpt-4' },
+      { name: 'Test Prompt 2', model: 'gpt-4' },
+      { name: 'Test Prompt 3', model: 'gpt-4' }
+    ]);
+
+    const submission = await Submission.create({
+      rubric: {
+        parameters: {
+          param1: {
+            evaluationPromptIds: [prompts[0]._id, prompts[1]._id],
+            sectionsToBeEvaluated: ['intro']
+          },
+          param2: {
+            evaluationPromptIds: [prompts[2]._id],
+            sectionsToBeEvaluated: ['intro']
+          }
+        }
+      }
+    });
+
+    // Attempt population
+    const populated = await Submission.findById(submission._id).populate([
+      'rubric.parameters.$*.evaluationPrompts'
+    ]);
+    const obj = JSON.parse(JSON.stringify(populated));
+    console.log(populated.rubric)
+    assert.deepStrictEqual(obj.rubric.parameters.param1.evaluationPrompts.map(prompt => prompt.name), ['Test Prompt', 'Test Prompt 2']);
+    assert.strictEqual(obj.rubric.parameters.param2.evaluationPrompts.name, ['Test Prompt 3']);
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

There are a few issues that pop up when you try to populate a deeply nested virtual like `rubric.parameters.$*.evaluationPrompt`: getting the virtual, setting with `.$*`, etc.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
