### PR TITLE
fix(document+schema): improve handling for setting paths underneath maps, including maps of maps

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1302,7 +1302,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
   let cur = this._doc;
   let curPath = '';
   for (i = 0; i < parts.length - 1; ++i) {
-    cur = cur[parts[i]];
+    cur = cur instanceof Map ? cur.get(parts[i]) : cur[parts[i]];
     curPath += (curPath.length !== 0 ? '.' : '') + parts[i];
     if (!cur) {
       this.$set(curPath, {});
@@ -1433,9 +1433,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
         setterContext = getDeepestSubdocumentForPath(this, parts, this.schema);
       }
       if (options != null && options.overwriteImmutable) {
-        val = schema.applySetters(val, setterContext, false, priorVal, { overwriteImmutable: true });
+        val = schema.applySetters(val, setterContext, false, priorVal, { path, overwriteImmutable: true });
       } else {
-        val = schema.applySetters(val, setterContext, false, priorVal);
+        val = schema.applySetters(val, setterContext, false, priorVal, { path });
       }
     }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1482,10 +1482,24 @@ function getMapPath(schema, path) {
     return null;
   }
   for (const val of schema.mapPaths) {
-    const _path = val.path;
-    const re = new RegExp('^' + _path.replace(/\.\$\*/g, '\\.[^.]+') + '$');
-    if (re.test(path)) {
-      return schema.paths[_path];
+    const cleanPath = val.path.replace(/\.\$\*/g, '');
+    if (path === cleanPath || (path.startsWith(cleanPath + '.') && path.slice(cleanPath.length + 1).indexOf('.') === -1)) {
+      return val;
+    } else if (val.schema && path.startsWith(cleanPath + '.')) {
+      let remnant = path.slice(cleanPath.length + 1);
+      remnant = remnant.slice(remnant.indexOf('.') + 1);
+      return val.schema.paths[remnant];
+    } else if (val.$isSchemaMap && path.startsWith(cleanPath + '.')) {
+      let remnant = path.slice(cleanPath.length + 1);
+      remnant = remnant.slice(remnant.indexOf('.') + 1);
+      const presplitPath = val.$__schemaType._presplitPath;
+      if (remnant.indexOf('.') === -1 && presplitPath[presplitPath.length - 1] === '$*') {
+        // Handle map of map of primitives
+        return val.$__schemaType;
+      } else if (remnant.indexOf('.') !== -1 && val.$__schemaType.schema && presplitPath[presplitPath.length - 1] === '$*') {
+        // map of map of subdocs (recursive)
+        return val.$__schemaType.schema.path(remnant.slice(remnant.indexOf('.') + 1));
+      }
     }
   }
 

--- a/test/schema.path.test.js
+++ b/test/schema.path.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const Schema = require('../lib/schema');
+const assert = require('assert');
+
+describe('Schema.prototype.path()', function() {
+  it('gets paths underneath maps', function() {
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: String
+      }
+    });
+
+    assert.equal(schema.path('myMap').$__schemaType.instance, 'String');
+    assert.equal(schema.path('myMap.$*').instance, 'String');
+  });
+
+  it('gets paths underneath maps of subdocuments', function() {
+    const personSchema = new Schema({ name: String, age: Number });
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: personSchema
+      }
+    });
+
+    assert.equal(schema.path('myMap').$__schemaType.schema.path('name').instance, 'String');
+    assert.equal(schema.path('myMap').$__schemaType.schema.path('age').instance, 'Number');
+
+    assert.equal(schema.path('myMap.key.name').instance, 'String');
+    assert.equal(schema.path('myMap.key.age').instance, 'Number');
+    assert.equal(schema.path('myMap.key.name').instance, 'String');
+    assert.equal(schema.path('myMap.key.age').instance, 'Number');
+  });
+
+  it('gets paths underneath maps of maps', function() {
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: {
+          type: Map,
+          of: String
+        }
+      }
+    });
+
+    assert.equal(schema.path('myMap').$__schemaType.instance, 'Map');
+    assert.equal(schema.path('myMap.key').instance, 'Map');
+    assert.equal(schema.path('myMap.key.key2').instance, 'String');
+    assert.ok(!schema.path('myMap.key.key2.key3'));
+  });
+
+  it('gets paths underneath maps of maps of subdocs', function() {
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: {
+          type: Map,
+          of: new Schema({
+            name: String
+          })
+        }
+      }
+    });
+
+    assert.equal(schema.path('myMap').$__schemaType.instance, 'Map');
+    assert.equal(schema.path('myMap.key').instance, 'Map');
+    assert.equal(schema.path('myMap.key.key2.name').instance, 'String');
+    assert.ok(!schema.path('myMap.key.key2.key3'));
+  });
+});

--- a/test/schema.path.test.js
+++ b/test/schema.path.test.js
@@ -30,7 +30,6 @@ describe('Schema.prototype.path()', function() {
 
     assert.equal(schema.path('myMap.key.name').instance, 'String');
     assert.equal(schema.path('myMap.key.age').instance, 'Number');
-    assert.equal(schema.path('myMap.key.age').instance, 'Number');
   });
 
   it('gets paths underneath maps of maps', function() {

--- a/test/schema.path.test.js
+++ b/test/schema.path.test.js
@@ -30,7 +30,6 @@ describe('Schema.prototype.path()', function() {
 
     assert.equal(schema.path('myMap.key.name').instance, 'String');
     assert.equal(schema.path('myMap.key.age').instance, 'Number');
-    assert.equal(schema.path('myMap.key.name').instance, 'String');
     assert.equal(schema.path('myMap.key.age').instance, 'Number');
   });
 

--- a/test/schema.pathType.test.js
+++ b/test/schema.pathType.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Schema = require('../lib/schema');
+const assert = require('assert');
+
+describe('Schema.prototype.pathType()', function() {
+  it('gets paths underneath maps', function() {
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: String
+      }
+    });
+
+    assert.equal(schema.pathType('myMap'), 'real');
+    assert.equal(schema.pathType('myMap.key'), 'real');
+  });
+
+  it('gets paths underneath maps of subdocuments', function() {
+    const personSchema = new Schema({ name: String, age: Number });
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: personSchema
+      }
+    });
+
+    assert.equal(schema.pathType('myMap'), 'real');
+    assert.equal(schema.pathType('myMap.key'), 'real');
+    assert.equal(schema.pathType('myMap.key.name'), 'real');
+    assert.equal(schema.pathType('myMap.key.age'), 'real');
+  });
+
+  it('gets paths underneath maps of maps', function() {
+    const schema = new Schema({
+      myMap: {
+        type: Map,
+        of: {
+          type: Map,
+          of: String
+        }
+      }
+    });
+
+    assert.equal(schema.pathType('myMap'), 'real');
+    assert.equal(schema.pathType('myMap.key'), 'real');
+    assert.equal(schema.pathType('myMap.key.key2'), 'real');
+  });
+});


### PR DESCRIPTION
Fix #15461

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Primary issue comes down to:

1. Need to pass the path being set into `applySetters()` because that is the most reliable way to get the actual path being set, with no `.$*`.
2. `Schema.prototype.path()` and `Schema.prototype.pathType()` not being able to get paths underneath maps correctly.

Fixed both of those, along with adding specialized testing for `path()` and `pathType()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
