### PR TITLE
fix(model): make sure post save error handler gets doc as param on VersionError

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -532,7 +532,7 @@ Model.prototype.$__save = function(options, callback) {
           this.$__undoReset();
           const err = this.$__.$versionError ||
             new VersionError(this, version, this.$__.modifiedPaths);
-          return callback(err);
+          return callback(err, this);
         }
 
         // increment version if was successful

--- a/test/model.middleware.test.js
+++ b/test/model.middleware.test.js
@@ -571,6 +571,46 @@ describe('model middleware', function() {
       assert.ok(errors[0].message.includes('duplicate key error'), errors[0].message);
     });
 
+    it('post save error handler gets doc as param (gh-15480)', async function() {
+      const userSchema = new mongoose.Schema({
+        name: String,
+        arr: [String]
+      });
+
+      let postSaveErrorCalled = false;
+      let postSaveErrorName = null;
+      let postSaveErrorDoc = undefined;
+
+      // Add post-save error handler
+      userSchema.post('save', function(err, doc, next) {
+        postSaveErrorCalled = true;
+        postSaveErrorName = err && err.name;
+        postSaveErrorDoc = doc;
+        next();
+      });
+
+      const User = db.model('User', userSchema);
+
+      const original = await User.create({ name: 'Alice' });
+      await User.updateOne({ _id: original._id }, { $unset: { arr: 1 } });
+
+      const docA = await User.findById(original._id);
+      const docB = await User.findById(original._id);
+
+      // Modify and save docA to bump __v
+      docA.name = 'Alice A';
+      await docA.save();
+
+      // Now attempt to save docB, which has stale __v
+      docB.name = 'Alice B';
+      const err = await docB.save().then(() => null, err => err);
+      assert.ok(err);
+
+      assert.ok(postSaveErrorCalled, 'post save error handler should be called');
+      assert.equal(postSaveErrorName, 'VersionError');
+      assert.strictEqual(postSaveErrorDoc, docB);
+    });
+
     it('supports skipping wrapped function', async function() {
       const schema = new Schema({ name: String, prop: String });
 


### PR DESCRIPTION
Fix #15480

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix - apparently need `callback(err, this)`, `callback(err)` means a `null` result gets passed to error handling middleware.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
