### PR TITLE
fix(document): avoid setting _skipMarkModified when setting nested path with merge option

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1114,7 +1114,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
       }
 
       if (utils.isNonBuiltinObject(valForKey) && pathtype === 'nested') {
-        this.$set(pathName, valForKey, constructing, Object.assign({}, options, { _skipMarkModified: true }));
+        this.$set(pathName, valForKey, constructing, options);
         $applyDefaultsToNested(this.$get(pathName), pathName, this);
         continue;
       } else if (strict) {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14423,6 +14423,44 @@ describe('document', function() {
     assert.strictEqual(car.sunroof, true);
   });
 
+  it('merge option for set() only marks changed subpaths as modified (gh-11913)', async function() {
+    const personSchema = new mongoose.Schema({
+      name: {
+        first: String,
+        last: String
+      },
+      haircolor: String,
+      eyecolor: String
+    });
+    const Person = db.model('Person', personSchema);
+
+    const h = {
+      name: {
+        first: 'bob',
+        last: 'jones'
+      },
+      haircolor: 'brown',
+      eyecolor: 'brown'
+    };
+
+    const human = new Person(h);
+    await human.save();
+
+    h.name.first = 'Larry';
+    human.set(h, null, null, { merge: true });
+
+    assert.deepStrictEqual(
+      human.modifiedPaths({ includeChildren: true }).sort(),
+      ['name', 'name.first']
+    );
+    assert.strictEqual(human.isModified('haircolor'), false);
+    assert.strictEqual(human.isModified('eyecolor'), false);
+    assert.strictEqual(human.isModified('name.first'), true);
+    assert.strictEqual(human.isModified('name.last'), false);
+
+    assert.deepStrictEqual(human.getChanges().$set, { 'name.first': 'Larry' });
+  });
+
   it('avoids double validating document arrays underneath single nested (gh-15335)', async function() {
     let arraySubdocValidateCalls = 0;
     let strValidateCalls = 0;


### PR DESCRIPTION
Fix #11913

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Looks like this `_skipMarkModified` option isn't necessary - it was intended to prevent marking subpaths as modified before when we added the `merge` option. It was introduced here: https://github.com/Automattic/mongoose/commit/98150ac002e709cc80fa76c67f0c7b9c43c0e6b8 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
