### PR TITLE
types: improve typing for `transform` option to toJSON and toObject

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1812,3 +1812,32 @@ function defaultReturnsUndefined() {
     }
   });
 }
+
+function gh15479() {
+  const TestSchema = new Schema({
+    name: String,
+    testField: {
+      type: String,
+      required: true,
+      default: 'blah'
+    }
+  });
+
+  function transform(doc: unknown, ret: InferSchemaType<typeof TestSchema>) {
+    const { testField, ...val } = ret;
+    return val;
+  }
+
+  TestSchema.set('toJSON', { transform });
+
+  const TestModel = model('Test', TestSchema);
+
+  const doc = new TestModel();
+
+  getTestField(doc.toJSON<ReturnType<typeof transform> & { testField: string }>());
+  expectError(getTestField(doc.toJSON<ReturnType<typeof transform>>()));
+
+  function getTestField(obj: { testField: string }) {
+    return obj.testField;
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -206,7 +206,7 @@ declare module 'mongoose' {
     [k: string]: string;
   }
 
-  export interface ToObjectOptions<THydratedDocumentType = HydratedDocument<unknown>> {
+  export interface ToObjectOptions<RawDocType = unknown, THydratedDocumentType = HydratedDocument<RawDocType>> {
     /** if `options.virtuals = true`, you can set `options.aliases = false` to skip applying aliases. This option is a no-op if `options.virtuals = false`. */
     aliases?: boolean;
     /** if true, replace any conventionally populated paths with the original id in the output. Has no affect on virtual populated paths. */
@@ -224,7 +224,7 @@ declare module 'mongoose' {
     /** if set, mongoose will call this function to allow you to transform the returned object */
     transform?: boolean | ((
       doc: THydratedDocumentType,
-      ret: Record<string, any>,
+      ret: RawDocType,
       options: ToObjectOptions<THydratedDocumentType>
     ) => any);
     /** If true, omits fields that are excluded in this document's projection. Unless you specified a projection, this will omit any field that has `select: false` in the schema. */
@@ -505,7 +505,7 @@ declare module 'mongoose' {
     requiredPaths(invalidate?: boolean): string[];
 
     /** Sets a schema option. */
-    set<K extends keyof SchemaOptions>(key: K, value: SchemaOptions[K], _tags?: any): this;
+    set<K extends keyof SchemaOptions>(key: K, value: SchemaOptions<DocType>[K], _tags?: any): this;
 
     /** Adds static "class" methods to Models compiled from this schema. */
     static<K extends keyof TStaticMethods>(name: K, fn: TStaticMethods[K]): this;

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -146,14 +146,14 @@ declare module 'mongoose' {
      */
     strictQuery?: boolean | 'throw';
     /** Exactly the same as the toObject option but only applies when the document's toJSON method is called. */
-    toJSON?: ToObjectOptions<THydratedDocumentType>;
+    toJSON?: ToObjectOptions<DocType, THydratedDocumentType>;
     /**
      * Documents have a toObject method which converts the mongoose document into a plain JavaScript object.
      * This method accepts a few options. Instead of applying these options on a per-document basis, we may
      * declare the options at the schema level and have them applied to all of the schema's documents by
      * default.
      */
-    toObject?: ToObjectOptions<THydratedDocumentType>;
+    toObject?: ToObjectOptions<DocType, THydratedDocumentType>;
     /**
      * By default, if you have an object with key 'type' in your schema, mongoose will interpret it as a
      * type declaration. However, for applications like geoJSON, the 'type' property is important. If you want to


### PR DESCRIPTION
Fix #15479

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Better typing for the `transform()` function, 2nd arg should be a raw doc type by default not `Record<string, any>`. 

Maybe worthwhile to postpone this for a minor release, WDYT @hasezoey ?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
