### PR TITLE
Remove unnecessary --save flag from npm install instruction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 Next install Mongoose from the command line using `npm`:
 
 ```sh
-npm install mongoose --save
+npm install mongoose
 ```
 
 Now say we like fuzzy kittens and want to record every kitten we ever meet


### PR DESCRIPTION
The ```--save``` flag is no longer needed for ```npm install``` as of npm v5, because saving to ```package.json``` is the default behavior. This PR updates the Getting Started guide to reflect that.