### PR TITLE
chore(workflows/encryption-tests): only run if tests related files changed

### DIFF
--- a/.github/workflows/encryption-tests.yml
+++ b/.github/workflows/encryption-tests.yml
@@ -1,10 +1,22 @@
 name: Encryption Tests 
 
 on:
-  push: 
-    branches: ['master']
   pull_request:
-    branches: [ 'master', 'csfle' ]
+    paths:
+      - ".github/workflows/encryption-tests.yml"
+      - "package.json"
+      - "index.js"
+      - "lib/**"
+      - "test/encryption/**.js"
+      - "scripts/setup-encryption-tests.js"
+  push:
+    paths:
+      - ".github/workflows/encryption-tests.yml"
+      - "package.json"
+      - "index.js"
+      - "lib/**"
+      - "test/encryption/**.js"
+      - "scripts/setup-encryption-tests.js"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
**Summary**

Basically just the tile, only run the `encryption-tests` when necessary, similar to how `test.yml` only gets run at specific changes.
For example the encryption tests dont need to run if the PR only modifies documentation, like #15487.

Btw, i also noticed that `encryption-tests.yml` has more permissions than it actually seems to need, are they really required?

https://github.com/Automattic/mongoose/blob/62d13499dcc6e2e805b04e0759a4fb423a07a4da/.github/workflows/encryption-tests.yml#L10-L13