### PR TITLE
fix: consistent $conditionalHandlers setup between schematypes

### DIFF
--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -177,13 +177,18 @@ SchemaBigInt.prototype.cast = function(value) {
  * ignore
  */
 
-SchemaBigInt.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
   $lt: handleSingle,
   $lte: handleSingle
 };
+
+Object.defineProperty(SchemaBigInt.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /*!
  * ignore
@@ -204,7 +209,7 @@ function handleSingle(val, context) {
 SchemaBigInt.prototype.castForQuery = function($conditional, val, context) {
   let handler;
   if ($conditional != null) {
-    handler = SchemaBigInt.$conditionalHandlers[$conditional];
+    handler = this.$conditionalHandlers[$conditional];
 
     if (handler) {
       return handler.call(this, val);

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -235,7 +235,12 @@ SchemaBoolean.prototype.cast = function(value) {
   }
 };
 
-SchemaBoolean.$conditionalHandlers = { ...SchemaType.prototype.$conditionalHandlers };
+const $conditionalHandlers = { ...SchemaType.prototype.$conditionalHandlers };
+
+Object.defineProperty(SchemaBoolean.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /**
  * Casts contents for queries.
@@ -248,7 +253,7 @@ SchemaBoolean.$conditionalHandlers = { ...SchemaType.prototype.$conditionalHandl
 SchemaBoolean.prototype.castForQuery = function($conditional, val, context) {
   let handler;
   if ($conditional != null) {
-    handler = SchemaBoolean.$conditionalHandlers[$conditional];
+    handler = this.$conditionalHandlers[$conditional];
 
     if (handler) {
       return handler.call(this, val);

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -259,7 +259,7 @@ function handleSingle(val, context) {
   return this.castForQuery(null, val, context);
 }
 
-SchemaBuffer.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $bitsAllClear: handleBitwiseOperator,
   $bitsAnyClear: handleBitwiseOperator,
@@ -270,6 +270,12 @@ SchemaBuffer.prototype.$conditionalHandlers = {
   $lt: handleSingle,
   $lte: handleSingle
 };
+
+Object.defineProperty(SchemaBuffer.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
+
 
 /**
  * Casts contents for queries.

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -389,7 +389,7 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-SchemaDate.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
@@ -397,6 +397,10 @@ SchemaDate.prototype.$conditionalHandlers = {
   $lte: handleSingle
 };
 
+Object.defineProperty(SchemaDate.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /**
  * Casts contents for queries.

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -214,13 +214,18 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-SchemaDecimal128.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
   $lt: handleSingle,
   $lte: handleSingle
 };
+
+Object.defineProperty(SchemaDecimal128.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /**
  * Returns this schema type's representation in a JSON schema.

--- a/lib/schema/double.js
+++ b/lib/schema/double.js
@@ -197,13 +197,18 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-SchemaDouble.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
   $lt: handleSingle,
   $lte: handleSingle
 };
+
+Object.defineProperty(SchemaDouble.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /**
  * Returns this schema type's representation in a JSON schema.

--- a/lib/schema/int32.js
+++ b/lib/schema/int32.js
@@ -197,7 +197,7 @@ SchemaInt32.prototype.cast = function(value) {
  * ignore
  */
 
-SchemaInt32.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
@@ -208,6 +208,11 @@ SchemaInt32.$conditionalHandlers = {
   $bitsAllSet: handleBitwiseOperator,
   $bitsAnySet: handleBitwiseOperator
 };
+
+Object.defineProperty(SchemaInt32.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /*!
  * ignore
@@ -228,7 +233,7 @@ function handleSingle(val, context) {
 SchemaInt32.prototype.castForQuery = function($conditional, val, context) {
   let handler;
   if ($conditional != null) {
-    handler = SchemaInt32.$conditionalHandlers[$conditional];
+    handler = this.$conditionalHandlers[$conditional];
 
     if (handler) {
       return handler.call(this, val);

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -400,7 +400,7 @@ function handleArray(val) {
   });
 }
 
-SchemaNumber.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $bitsAllClear: handleBitwiseOperator,
   $bitsAnyClear: handleBitwiseOperator,
@@ -412,6 +412,11 @@ SchemaNumber.prototype.$conditionalHandlers = {
   $lte: handleSingle,
   $mod: handleArray
 };
+
+Object.defineProperty(SchemaNumber.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /**
  * Casts contents for queries.

--- a/lib/schema/objectId.js
+++ b/lib/schema/objectId.js
@@ -260,13 +260,18 @@ function handleSingle(val) {
   return this.cast(val);
 }
 
-SchemaObjectId.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $gt: handleSingle,
   $gte: handleSingle,
   $lt: handleSingle,
   $lte: handleSingle
 };
+
+Object.defineProperty(SchemaObjectId.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /*!
  * ignore

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -661,10 +661,8 @@ const $conditionalHandlers = {
 };
 
 Object.defineProperty(SchemaString.prototype, '$conditionalHandlers', {
-  configurable: false,
   enumerable: false,
-  writable: false,
-  value: Object.freeze($conditionalHandlers)
+  value: $conditionalHandlers
 });
 
 /**

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -242,7 +242,7 @@ function handleArray(val) {
   });
 }
 
-SchemaUUID.prototype.$conditionalHandlers = {
+const $conditionalHandlers = {
   ...SchemaType.prototype.$conditionalHandlers,
   $bitsAllClear: handleBitwiseOperator,
   $bitsAnyClear: handleBitwiseOperator,
@@ -257,6 +257,11 @@ SchemaUUID.prototype.$conditionalHandlers = {
   $ne: handleSingle,
   $nin: handleArray
 };
+
+Object.defineProperty(SchemaUUID.prototype, '$conditionalHandlers', {
+  enumerable: false,
+  value: $conditionalHandlers
+});
 
 /**
  * Casts contents for queries.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Mostly a minor refactor for consistency. The issue is that some schematypes define `$conditionalHandlers` (map of filter operators to handlers for filter operators) as a static and some as an instance property on `prototype`; furthermore, on strings the `$conditionalHandlers` property is frozen and not writeable, but on other schematypes it is enumerable and writable.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
