### PR TITLE
fix(cursor): populate after hydrating in queryCursor so populated docs get parent()

### DIFF
--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -505,15 +505,16 @@ function _next(ctx, cb) {
           if (!ctx.query._mongooseOptions.populate) {
             return _nextDoc(ctx, doc, null, callback);
           }
-
-          ctx.query.model.populate(doc, ctx._pop).then(
-            doc => {
-              _nextDoc(ctx, doc, ctx._pop, callback);
-            },
-            err => {
-              callback(err);
+    
+          _nextDoc(ctx, doc, ctx._pop, (err, doc) => {
+            if (err != null) {
+              return callback(err);
             }
-          );
+            ctx.query.model.populate(doc, ctx._pop).then(
+              doc => callback(null, doc),
+              err => callback(err)
+            );
+          });
         },
         error => {
           callback(error);

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -505,7 +505,7 @@ function _next(ctx, cb) {
           if (!ctx.query._mongooseOptions.populate) {
             return _nextDoc(ctx, doc, null, callback);
           }
-    
+
           _nextDoc(ctx, doc, ctx._pop, (err, doc) => {
             if (err != null) {
               return callback(err);

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -9202,7 +9202,7 @@ describe('model: populate:', function() {
       assert.equal(docs[1].items[0].foo.title, 'doc1');
     });
 
-    it('Sets the populated document\'s parent() (gh-8092)', async function() {
+    it('Sets the populated document\'s parent() (gh-15494) (gh-8092)', async function() {
       const schema = new Schema({
         single: { type: Number, ref: 'Child' },
         arr: [{ type: Number, ref: 'Child' }],
@@ -9244,6 +9244,16 @@ describe('model: populate:', function() {
       await doc.populate('single');
       assert.ok(doc.single.parent() === doc);
       assert.ok(doc.single.$parent() === doc);
+
+      let cursor = await Parent.find().populate('single').cursor();
+      doc = await cursor.next();
+      assert.ok(doc.single.parent() === doc);
+      assert.ok(doc.single.$parent() === doc);
+
+      cursor = await Parent.find().populate('arr').cursor();
+      doc = await cursor.next();
+      assert.ok(doc.arr[0].parent() === doc);
+      assert.ok(doc.arr[0].$parent() === doc);
     });
 
     it('populates single nested discriminator underneath doc array when populated docs have different model but same id (gh-9244)', async function() {


### PR DESCRIPTION
Fix #15494

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Query hydrates document first then populates, but query cursor populates then hydrates. That leads to `$__.parent` not getting set in `assignVals()`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
