### PR TITLE
fix(model): avoid stripping out operations in bulkWrite() when ordered: false and _skipCastBulkWrite: true

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3454,35 +3454,36 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
       });
     }
   } else {
-    let remaining = validations.length;
-    let validOps = [];
+    let validOpIndexes = [];
     let validationErrors = [];
     const results = [];
-    await new Promise((resolve) => {
-      if (validations.length === 0) {
-        return resolve();
-      }
-      for (let i = 0; i < validations.length; ++i) {
-        validations[i]((err) => {
-          if (err == null) {
-            validOps.push(i);
-          } else {
-            validationErrors.push({ index: i, error: err });
-            results[i] = err;
-          }
-          if (--remaining <= 0) {
+    if (validations.length > 0) {
+      validOpIndexes = await Promise.all(ops.map((op, i) => {
+        if (i >= validations.length) {
+          return i;
+        }
+        return new Promise((resolve) => {
+          validations[i]((err) => {
+            if (err == null) {
+              resolve(i);
+            } else {
+              validationErrors.push({ index: i, error: err });
+              results[i] = err;
+            }
             resolve();
-          }
+          });
         });
-      }
-    });
+      }));
+      validOpIndexes = validOpIndexes.filter(index => index != null);
+    } else {
+      validOpIndexes = ops.map((op, i) => i);
+    }
 
     validationErrors = validationErrors.
       sort((v1, v2) => v1.index - v2.index).
       map(v => v.error);
 
-    const validOpIndexes = validOps;
-    validOps = validOps.sort().map(index => ops[index]);
+    const validOps = validOpIndexes.sort().map(index => ops[index]);
 
     if (validOps.length === 0) {
       if (options.throwOnValidationError && validationErrors.length) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6992,7 +6992,6 @@ describe('Model', function() {
 
   describe('bulkSave() (gh-9673)', function() {
     it('saves new documents', async function() {
-
       const userSchema = new Schema({
         name: { type: String }
       });
@@ -7014,11 +7013,33 @@ describe('Model', function() {
           'Hafez2_gh-9673-1'
         ]
       );
+    });
 
+    it('saves new documents with ordered: false (gh-15495)', async function() {
+      const userSchema = new Schema({
+        name: { type: String }
+      });
+
+      const User = db.model('User', userSchema);
+
+
+      await User.bulkSave([
+        new User({ name: 'Hafez1_gh-9673-1' }),
+        new User({ name: 'Hafez2_gh-9673-1' })
+      ], { ordered: false });
+
+      const users = await User.find().sort('name');
+
+      assert.deepEqual(
+        users.map(user => user.name),
+        [
+          'Hafez1_gh-9673-1',
+          'Hafez2_gh-9673-1'
+        ]
+      );
     });
 
     it('updates documents', async function() {
-
       const userSchema = new Schema({
         name: { type: String }
       });
@@ -7038,6 +7059,38 @@ describe('Model', function() {
       users[1].name = 'Hafez2_gh-9673-2-updated';
 
       await User.bulkSave(users);
+
+      const usersAfterUpdate = await User.find().sort('name');
+
+      assert.deepEqual(
+        usersAfterUpdate.map(user => user.name),
+        [
+          'Hafez1_gh-9673-2-updated',
+          'Hafez2_gh-9673-2-updated',
+          'Hafez3_gh-9673-2'
+        ]
+      );
+    });
+
+    it('updates documents with ordered: false (gh-15495)', async function() {
+      const userSchema = new Schema({
+        name: { type: String }
+      });
+
+      const User = db.model('User', userSchema);
+
+      await User.insertMany([
+        new User({ name: 'Hafez1_gh-9673-2' }),
+        new User({ name: 'Hafez2_gh-9673-2' }),
+        new User({ name: 'Hafez3_gh-9673-2' })
+      ]);
+
+      const users = await User.find().sort('name');
+
+      users[0].name = 'Hafez1_gh-9673-2-updated';
+      users[1].name = 'Hafez2_gh-9673-2-updated';
+
+      await User.bulkSave(users, { ordered: false });
 
       const usersAfterUpdate = await User.find().sort('name');
 


### PR DESCRIPTION
Fix #15495

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

As implemented, `bulkWrite()` will filter out all ops if `ordered: false` and `_skipBulkWriteCasting: true`. This PR fixes that, and also makes `validOps` vs `validOpsIndexes` more consistent

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
