### PR TITLE
types: add _id and __v to toObject/toJSON transform type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -224,7 +224,7 @@ declare module 'mongoose' {
     /** if set, mongoose will call this function to allow you to transform the returned object */
     transform?: boolean | ((
       doc: THydratedDocumentType,
-      ret: RawDocType,
+      ret: Default__v<Require_id<RawDocType>>,
       options: ToObjectOptions<THydratedDocumentType>
     ) => any);
     /** If true, omits fields that are excluded in this document's projection. Unless you specified a projection, this will omit any field that has `select: false` in the schema. */


### PR DESCRIPTION
Fix #15479

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix to make `_id` and `__v` show up in the transform `ret` param

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
