### PR TITLE
fix(action): fix generate docs script

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -400,7 +400,7 @@ function processFile(props) {
       console.warn(`Property "${ctx.name}" in "${ctx.constructor}" has both instance and static JSDOC markings (most likely both @instance and @static)! (File: "${props.file}")`);
     }
 
-    // the following if-else-if statement is in this order, because there are more "instance" methods thans static
+    // the following if-else-if statement is in this order, because there are more "instance" methods than static
     // the following condition will be true if "isInstance = true" or if "isInstance = false && isStatic = false" AND "ctx.string" are empty or not defined
     // if "isStatic" and "isInstance" are falsy and "ctx.string" is not falsy, then rely on the "ctx.string" set by "dox"
     if (ctx.isInstance || (!ctx.isStatic && !ctx.isInstance && (!ctx.string || ctx.constructorWasUndefined))) {

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1782,8 +1782,7 @@ SchemaType.prototype._duplicateKeyErrorMessage = null;
  * @returns {Object} JSON schema properties
  */
 
-// eslint-disable-next-line no-unused-vars
-SchemaType.prototype.toJSONSchema = function toJSONSchema(_options) {
+SchemaType.prototype.toJSONSchema = function toJSONSchema(_options) { // eslint-disable-line no-unused-vars
   throw new Error(`Converting unsupported SchemaType to JSON Schema: ${this.instance} at path "${this.path}"`);
 };
 


### PR DESCRIPTION
This PR fixes [an error](https://github.com/Automattic/mongoose/actions/runs/16012011108/job/45171525787) in generating the docs, the error happens because `dox` tries to parse `// eslint-disable-next-line no-unused-vars` as a JSDoc when it's on top of the function, but ignores it when on the same line.