### PR TITLE
types(schema): use user-provided THydratedDocumentType as context for virtual get() and set()

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1841,3 +1841,17 @@ function gh15479() {
     return obj.testField;
   }
 }
+
+function gh15516() {
+  interface IUser {
+    name: string;
+  }
+  type HydratedUserDoc = HydratedDocument<IUser & { customProperty: number, myVirtual: number }>;
+  const schema = new Schema<IUser, Model<IUser>, {}, {}, { myVirtual: number }, {}, DefaultSchemaOptions, any, HydratedUserDoc>({
+    name: String
+  });
+
+  schema.virtual('myVirtual').get(function () {
+    expectType<HydratedUserDoc>(this);
+  });
+}

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1851,7 +1851,7 @@ function gh15516() {
     name: String
   });
 
-  schema.virtual('myVirtual').get(function () {
+  schema.virtual('myVirtual').get(function() {
     expectType<HydratedUserDoc>(this);
   });
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -519,7 +519,7 @@ declare module 'mongoose' {
     toJSONSchema(options?: { useBsonType?: boolean }): Record<string, any>;
 
     /** Creates a virtual type with the given name. */
-    virtual<T = HydratedDocument<DocType, TVirtuals & TInstanceMethods, TQueryHelpers>>(
+    virtual<T = THydratedDocumentType>(
       name: keyof TVirtuals | string,
       options?: VirtualTypeOptions<T, DocType>
     ): VirtualType<T>;


### PR DESCRIPTION
Fix #15516

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix: should use user-specified THydratedDocumentType

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
