### PR TITLE
fix(document): clean modified subpaths if unsetting map

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1517,6 +1517,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
   if (schema.$isSingleNested && (this.isDirectModified(path) || val == null)) {
     cleanModifiedSubpaths(this, path);
+  } else if (schema.$isSchemaMap && val == null) {
+    cleanModifiedSubpaths(this, path);
   }
 
   return this;

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1347,4 +1347,31 @@ describe('Map', function() {
     assert.ok(error);
     assert.strictEqual(error.errors['a.b.c.d.e'].message.includes('Path `e`'), true);
   });
+
+  it('handles setting then unsetting the same map (gh-15519)', async function() {
+    const debugSchema = new Schema({
+      settings: {
+        type: Map,
+        of: String
+      }
+    });
+
+    const Debug = db.model('Test', debugSchema);
+    const empty = new Debug();
+    await empty.save();
+
+    let doc = await Debug.findById(empty._id);
+    doc.settings = new Map();
+
+    doc.settings.set('test', 'value');
+
+    doc.settings = undefined;
+    assert.deepStrictEqual(doc.getChanges(), { $unset: { settings: 1 } });
+
+    await doc.save();
+
+    // reload and check settings is undefined
+    doc = await Debug.findById(empty._id);
+    assert.strictEqual(doc.settings, undefined);
+  });
 });

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1374,4 +1374,34 @@ describe('Map', function() {
     doc = await Debug.findById(empty._id);
     assert.strictEqual(doc.settings, undefined);
   });
+
+  it('handles setting then unsetting the same map of subdocs with a required field (gh-15519)', async function() {
+    const debugSchema = new Schema({
+      settings: {
+        type: Map,
+        of: new Schema({
+          value: { type: String, required: true }
+        }, { _id: false })
+      }
+    });
+
+    const Debug = db.model('Test', debugSchema);
+    const empty = new Debug();
+    await empty.save();
+
+    let doc = await Debug.findById(empty._id);
+    doc.settings = new Map();
+
+    doc.settings.set('test', { value: 'abc' });
+
+    doc.settings = undefined;
+    assert.deepStrictEqual(doc.getChanges(), { $unset: { settings: 1 } });
+
+    // Should not throw, even though the subdoc has a required field
+    await doc.save();
+
+    // reload and check settings is undefined
+    doc = await Debug.findById(empty._id);
+    assert.strictEqual(doc.settings, undefined);
+  });
 });


### PR DESCRIPTION
Fix #15519

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If setting a map to null/undefined, need to clean modified subpaths. Otherwise we have dangling modified paths which cause issues like #15519.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
