### PR TITLE
fix: make DocumentArray SchemaType pass all options to embedded SchemaType

### DIFF
--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -62,6 +62,7 @@ function SchemaDocumentArray(key, schema, options, schemaOptions) {
   SchemaArray.call(this, key, EmbeddedDocument, options);
 
   this.schema = schema;
+  // EmbeddedDocument schematype options
   this.schemaOptions = schemaOptions || {};
   this.$isMongooseDocumentArray = true;
   this.Constructor = EmbeddedDocument;
@@ -83,9 +84,7 @@ function SchemaDocumentArray(key, schema, options, schemaOptions) {
 
   const $parentSchemaType = this;
   this.$embeddedSchemaType = new DocumentArrayElement(key + '.$', {
-    required: this &&
-      this.schemaOptions &&
-      this.schemaOptions.required || false,
+    ...(schemaOptions || {}),
     $parentSchemaType
   });
 

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -778,4 +778,14 @@ describe('types.documentarray', function() {
       /options.0.0.val: Path `val` is required./
     );
   });
+
+  it('stores all schematype options in the embedded schematype', function () {
+    const schema = new mongoose.Schema({
+      docArr: [{
+        type: new mongoose.Schema({ name: String }),
+        someCustomOption: 'test 42'
+      }]
+    });
+    assert.strictEqual(schema.path('docArr').$embeddedSchemaType.options.someCustomOption, 'test 42');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Just a small issue I ran into: document array embedded schematype doesn't have any of the schematype options, which is inconsistent with other schematypes.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
