### PR TITLE
types: support readonly array in query.select

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -758,7 +758,7 @@ declare module 'mongoose' {
 
     /** Specifies which document fields to include or exclude (also known as the query "projection") */
     select<RawDocTypeOverride extends { [P in keyof RawDocType]?: any } = {}>(
-      arg: string | string[] | Record<string, number | boolean | string | object>
+      arg: string | readonly string[] | Record<string, number | boolean | string | object>
     ): QueryWithHelpers<
       IfEquals<
         RawDocTypeOverride,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

Fixes #15526 

**Summary**

Support readonly array in `Query.select` as it allows passing in const arrays as well as mutable arrays.
