### PR TITLE
types(schematype): make defaultOptions static and add schemaOptions to DocumentArray

### DIFF
--- a/test/types/schemaTypeOptions.test.ts
+++ b/test/types/schemaTypeOptions.test.ts
@@ -58,22 +58,22 @@ function index() {
 function defaultOptions() {
   // property "defaultOptions" may not be defined on the base "SchemaType", but is explicitly defined on all mongoose provided Schema.Types
   // https://github.com/Automattic/mongoose/blob/5528a6428bb08091c03d868e249c2e5a30144a71/lib/schematype.js#L55
-  expectType<Record<string, any> | undefined>(new SchemaType('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.String('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Boolean('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Array('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Buffer('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Date('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Decimal128('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Int32('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.DocumentArray('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Map('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Mixed('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Number('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.ObjectId('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Double('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.Subdocument('none').defaultOptions);
-  expectType<Record<string, any>>(new Schema.Types.UUID('none').defaultOptions);
+  expectType<Record<string, any> | undefined>(SchemaType.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.String.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Boolean.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Array.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Buffer.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Date.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Decimal128.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Int32.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.DocumentArray.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Map.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Mixed.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Number.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.ObjectId.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Double.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.Subdocument.defaultOptions);
+  expectType<Record<string, any>>(Schema.Types.UUID.defaultOptions);
 }
 
 function encrypt() {

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -350,7 +350,7 @@ declare module 'mongoose' {
     validateAll(validators: Array<RegExp | ValidatorFunction<DocType> | Validator<DocType>>): this;
 
     /** Default options for this SchemaType */
-    defaultOptions?: Record<string, any>;
+    static defaultOptions?: Record<string, any>;
   }
 
   namespace Schema {
@@ -368,7 +368,7 @@ declare module 'mongoose' {
         caster?: SchemaType;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
 
         /**
          * Adds an enum validator if this is an array of strings or numbers. Equivalent to
@@ -382,7 +382,7 @@ declare module 'mongoose' {
         static schemaName: 'BigInt';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Boolean extends SchemaType {
@@ -396,7 +396,7 @@ declare module 'mongoose' {
         static convertToFalse: Set<any>;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Buffer extends SchemaType {
@@ -410,7 +410,7 @@ declare module 'mongoose' {
         subtype(subtype: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 128): this;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Date extends SchemaType {
@@ -427,7 +427,7 @@ declare module 'mongoose' {
         min(value: NativeDate, message?: string): this;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Decimal128 extends SchemaType {
@@ -435,7 +435,7 @@ declare module 'mongoose' {
         static schemaName: 'Decimal128';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Int32 extends SchemaType {
@@ -443,7 +443,7 @@ declare module 'mongoose' {
         static schemaName: 'Int32';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class DocumentArray extends SchemaType implements AcceptsDiscriminator {
@@ -451,6 +451,8 @@ declare module 'mongoose' {
         static schemaName: 'DocumentArray';
 
         static options: { castNonArrays: boolean; };
+
+        schemaOptions?: SchemaOptions;
 
         discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
@@ -462,7 +464,7 @@ declare module 'mongoose' {
         caster?: typeof Types.Subdocument;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Map extends SchemaType {
@@ -470,7 +472,7 @@ declare module 'mongoose' {
         static schemaName: 'Map';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Mixed extends SchemaType {
@@ -478,7 +480,7 @@ declare module 'mongoose' {
         static schemaName: 'Mixed';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Number extends SchemaType {
@@ -495,7 +497,7 @@ declare module 'mongoose' {
         min(value: number, message?: string): this;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Double extends SchemaType {
@@ -503,7 +505,7 @@ declare module 'mongoose' {
         static schemaName: 'Double';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class ObjectId extends SchemaType {
@@ -514,7 +516,7 @@ declare module 'mongoose' {
         auto(turnOn: boolean): this;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class Subdocument<DocType = unknown> extends SchemaType implements AcceptsDiscriminator {
@@ -525,7 +527,7 @@ declare module 'mongoose' {
         schema: Schema;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
 
         discriminator<T, U>(name: string | number, schema: Schema<T, U>, value?: string): U;
         discriminator<D>(name: string | number, schema: Schema, value?: string): Model<D>;
@@ -559,7 +561,7 @@ declare module 'mongoose' {
         uppercase(shouldApply?: boolean): this;
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
 
       class UUID extends SchemaType {
@@ -567,7 +569,7 @@ declare module 'mongoose' {
         static schemaName: 'UUID';
 
         /** Default options for this SchemaType */
-        defaultOptions: Record<string, any>;
+        static defaultOptions: Record<string, any>;
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Some followup work for #15524: `defaultOptions` is actually a static property on SchemaTypes, not an instance property. Also, add `schemaOptions`. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
