### PR TITLE
types(inferschematype):  Infer Typescript string enums

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1035,6 +1035,32 @@ function gh12869() {
   expectType<'foo' | 'bar'>({} as Example['active']);
 }
 
+
+function stringEnumInfer() {
+  enum StringEnum {
+    Foo = 'foo',
+    Bar = 'bar'
+  }
+
+  const stringEnumSchema = new Schema(
+    {
+      active: { type: String, enum: StringEnum }
+    }
+  );
+
+  type StringEnumExample = InferSchemaType<typeof stringEnumSchema>;
+  expectType<StringEnum | null | undefined>({} as StringEnumExample['active']);
+
+  const stringEnumSchemaRequired = new Schema(
+    {
+      active: { type: String, enum: StringEnum, required: true }
+    }
+  );
+
+  type StringEnumRequiredExample = InferSchemaType<typeof stringEnumSchemaRequired>;
+  expectAssignable<StringEnum>({} as StringEnumRequiredExample['active']);
+}
+
 function gh12882() {
   // Array of strings
   const arrString = new Schema({

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -203,7 +203,7 @@ TypeHint<PathValueType>
  * @param {T} T A generic refers to string path enums.
  * @returns Path enum values type as literal strings or string.
  */
-type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends ReadonlyArray<infer E> ? E : T extends { values: any } ? PathEnumOrString<T['values']> : string;
+type PathEnumOrString<T extends SchemaTypeOptions<string>['enum']> = T extends ReadonlyArray<infer E> ? E : T extends { values: any } ? PathEnumOrString<T['values']> : T extends Record<string, infer V> ? V : string;
 
 type IsSchemaTypeFromBuiltinClass<T> = T extends (typeof String)
   ? true


### PR DESCRIPTION
**Summary**

We are using InferSchemaType to derive types from the models from the schema definition.
For fields with Typescript enum, the types are currently `string` which creates unnecessary casting.

I had to use `expectAssignable` for the required case and it is not completely clear why, but it will solve my problem which is around assignment.
