### PR TITLE
fix(connection): avoid calling `connection.close()` internally with `force: Object`

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1324,8 +1324,10 @@ Connection.prototype.onClose = function onClose(force) {
 
   this.emit('close', force);
 
+  const wasForceClosed = typeof force === 'object' && force !== null ? force.force : force;
+
   for (const db of this.otherDbs) {
-    this._destroyCalled ? db.destroy({ force: force, skipCloseClient: true }) : db.close({ force: force, skipCloseClient: true });
+    this._destroyCalled ? db.destroy({ force: wasForceClosed, skipCloseClient: true }) : db.close({ force: wasForceClosed, skipCloseClient: true });
   }
 };
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -463,6 +463,18 @@ describe('connections:', function() {
     }
   });
 
+  it('can re-open after close with useDb() (gh-15531)', async function() {
+    const opts = {};
+    const conn = await mongoose.createConnection(start.uri, opts).asPromise();
+
+    conn.useDb('test-db');
+
+    await conn.close();
+    await conn.openUri(start.uri);
+    assert.strictEqual(conn.readyState, 1);
+    await conn.collection('Test').insertOne({ x: 1 });
+  });
+
   it('verify that attempt to re-open destroyed connection throws error, via callback', async function() {
     const opts = {};
     const conn = await mongoose.createConnection(start.uri, opts).asPromise();


### PR DESCRIPTION
Fix #15531

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The crux of #15531 is that we're setting `force` to an object when connection.close() expects `force` to be a boolean.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
