### PR TITLE
Pass TModelType down to schema statics

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1033,3 +1033,18 @@ async function gh15437() {
   expectType<number>(doc1.age);
   expectAssignable<undefined | null | string>(doc1.address);
 }
+
+async function customModelInstanceWithStatics() {
+  type RawDocType = { name: string };
+  type ModelType = mongoose.Model<RawDocType> & { someCustomProp: number };
+  const schema = new Schema<RawDocType, ModelType>(
+    { name: { type: String, required: true } },
+    {
+      statics: {
+        function() {
+          expectType<number>(this.someCustomProp);
+        }
+      }
+    }
+  )
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -83,17 +83,17 @@ declare module 'mongoose' {
     collection?: string,
     options?: CompileModelOptions
   ): Model<
-  InferSchemaType<TSchema>,
-  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
-  ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
-  ObtainSchemaGeneric<TSchema, 'TVirtuals'>,
-  HydratedDocument<
-  InferSchemaType<TSchema>,
-  ObtainSchemaGeneric<TSchema, 'TVirtuals'> & ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
-  ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
-  ObtainSchemaGeneric<TSchema, 'TVirtuals'>
-  >,
-  TSchema
+    InferSchemaType<TSchema>,
+    ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
+    ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
+    ObtainSchemaGeneric<TSchema, 'TVirtuals'>,
+    HydratedDocument<
+      InferSchemaType<TSchema>,
+      ObtainSchemaGeneric<TSchema, 'TVirtuals'> & ObtainSchemaGeneric<TSchema, 'TInstanceMethods'>,
+      ObtainSchemaGeneric<TSchema, 'TQueryHelpers'>,
+      ObtainSchemaGeneric<TSchema, 'TVirtuals'>
+    >,
+    TSchema
   > & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
   export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
@@ -278,7 +278,23 @@ declare module 'mongoose' {
     /**
      * Create a new schema
      */
-    constructor(definition?: SchemaDefinition<SchemaDefinitionType<RawDocType>, RawDocType, THydratedDocumentType> | DocType, options?: SchemaOptions<FlatRecord<DocType>, TInstanceMethods, TQueryHelpers, TStaticMethods, TVirtuals, THydratedDocumentType> | ResolveSchemaOptions<TSchemaOptions>);
+    constructor(
+      definition?: SchemaDefinition<SchemaDefinitionType<RawDocType>, RawDocType, THydratedDocumentType> | DocType,
+      options?: SchemaOptions<
+        FlatRecord<DocType>,
+        TInstanceMethods,
+        TQueryHelpers,
+        TStaticMethods,
+        TVirtuals,
+        THydratedDocumentType,
+        IfEquals<
+          TModelType,
+          Model<any, any, any, any>,
+          Model<DocType, TQueryHelpers, TInstanceMethods, TVirtuals, THydratedDocumentType>,
+          TModelType
+        >
+      > | ResolveSchemaOptions<TSchemaOptions>
+    );
 
     /** Adds key path / schema type pairs to this schema. */
     add(obj: SchemaDefinition<SchemaDefinitionType<RawDocType>, RawDocType> | Schema, prefix?: string): this;

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -56,8 +56,8 @@ declare module 'mongoose' {
    * @param {TSchema} TSchema A generic of schema type instance.
    * @param {alias} alias Targeted generic alias.
    */
-  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TSchemaOptions' | 'DocType'> =
-   TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TStaticMethods, infer TSchemaOptions, infer DocType>
+  type ObtainSchemaGeneric<TSchema, alias extends 'EnforcedDocType' | 'M' | 'TInstanceMethods' | 'TQueryHelpers' | 'TVirtuals' | 'TStaticMethods' | 'TSchemaOptions' | 'DocType' | 'THydratedDocumentType'> =
+   TSchema extends Schema<infer EnforcedDocType, infer M, infer TInstanceMethods, infer TQueryHelpers, infer TVirtuals, infer TStaticMethods, infer TSchemaOptions, infer DocType, infer THydratedDocumentType>
      ? {
        EnforcedDocType: EnforcedDocType;
        M: M;
@@ -67,6 +67,7 @@ declare module 'mongoose' {
        TStaticMethods: TStaticMethods;
        TSchemaOptions: TSchemaOptions;
        DocType: DocType;
+       THydratedDocumentType: THydratedDocumentType;
      }[alias]
      : unknown;
 

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -16,7 +16,8 @@ declare module 'mongoose' {
     QueryHelpers = {},
     TStaticMethods = {},
     TVirtuals = {},
-    THydratedDocumentType = HydratedDocument<DocType, TInstanceMethods, QueryHelpers>
+    THydratedDocumentType = HydratedDocument<DocType, TInstanceMethods, QueryHelpers>,
+    TModelType = Model<DocType, QueryHelpers, TInstanceMethods, TVirtuals, THydratedDocumentType>
   > {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by
@@ -219,8 +220,8 @@ declare module 'mongoose' {
     statics?: IfEquals<
       TStaticMethods,
       {},
-      { [name: string]: (this: Model<DocType>, ...args: any[]) => unknown },
-      AddThisParameter<TStaticMethods, Model<DocType>>
+      { [name: string]: (this: TModelType, ...args: any[]) => unknown },
+      AddThisParameter<TStaticMethods, TModelType>
     >
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Working on #15532, spotted this potential issue: if you pass a custom model to `new Schema<>`, that custom model doesn't make it down to statics. Unfortunately #15532 still persists after this change, but at least a step in the right direction.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
