### PR TITLE
types(schema): handle `required: string` in schema definitions

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1881,3 +1881,14 @@ function gh15516() {
     expectType<HydratedUserDoc>(this);
   });
 }
+
+function gh15536() {
+  const UserModelNameRequiredCustom = model('User', new Schema(
+    {
+      name: { type: String, required: 'This is a custom error message' }
+    }
+  ));
+
+  const user3 = new UserModelNameRequiredCustom({ name: null });
+  expectType<string>(user3.name);
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -107,7 +107,7 @@ type IsPathDefaultUndefined<PathType> = PathType extends { default: undefined } 
  * @param {TypeKey} TypeKey A generic of literal string type."Refers to the property used for path type definition".
  */
 type IsPathRequired<P, TypeKey extends string = DefaultTypeKey> =
-  P extends { required: true | [true, string | undefined] | { isRequired: true } } | ArrayConstructor | any[]
+  P extends { required: true | string | [true, string | undefined] | { isRequired: true } } | ArrayConstructor | any[]
     ? true
     : P extends { required: boolean }
       ? P extends { required: false }


### PR DESCRIPTION
Fix #15536

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`required: 'my custom message'` makes a path required with a custom error message in JS, I updated TypeScript types to reflect that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
