### PR TITLE
fix(map): avoid throwing required error if saving map of primitives with required: true

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2703,6 +2703,10 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
     if (!doc.$__isSelected(path) && !doc.$isModified(path)) {
       return false;
     }
+    if (path.endsWith('.$*')) {
+      // Skip $* paths - they represent map schemas, not actual document paths
+      return false;
+    }
     if (doc.$__.cachedRequired != null && path in doc.$__.cachedRequired) {
       return doc.$__.cachedRequired[path];
     }

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -86,7 +86,7 @@ describe('Map', function() {
     assert.ok(threw);
   });
 
-  it('deep set', function(done) {
+  it('deep set', async function() {
     const userSchema = new mongoose.Schema({
       socialMediaHandles: {
         type: Schema.Types.Map,
@@ -102,8 +102,33 @@ describe('Map', function() {
 
     assert.equal(user.socialMediaHandles.get('github'), 'vkarpov15');
     assert.equal(user.get('socialMediaHandles.github'), 'vkarpov15');
+    await user.validate();
+  });
 
-    done();
+  it('handles required in maps', async function() {
+    const userSchema = new mongoose.Schema({
+      socialMediaHandles: {
+        type: Schema.Types.Map,
+        of: { type: String, required: true }
+      }
+    });
+
+    const User = db.model('Test', userSchema);
+
+    const user = new User({ socialMediaHandles: {} });
+    user.set('socialMediaHandles.github', null);
+    assert.strictEqual(user.socialMediaHandles.get('github'), null);
+    assert.strictEqual(user.get('socialMediaHandles.github'), null);
+    await assert.rejects(
+      user.validate(),
+      /socialMediaHandles.github: Path `socialMediaHandles.github` is required./
+    );
+
+    const user2 = new User({ socialMediaHandles: {} });
+    user2.set('socialMediaHandles.github', 'vkarpov15');
+    assert.equal(user2.socialMediaHandles.get('github'), 'vkarpov15');
+    assert.equal(user2.get('socialMediaHandles.github'), 'vkarpov15');
+    await user2.validate();
   });
 
   it('supports delete() (gh-7743)', async function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If you create a map path using `type: { Map, of: String }`, you can store `null` values in that map. However, currently, if you try to set `required: true` on a map value path you get a validation error on `map.$*` whenever you try to validate a document.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
