### PR TITLE
types(connection): add `base` to connection type

### DIFF
--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -72,10 +72,14 @@ declare module 'mongoose' {
   }[keyof SchemaMap];
 
   class Connection extends events.EventEmitter implements SessionStarter {
+    /** Runs a [db-level aggregate()](https://www.mongodb.com/docs/manual/reference/method/db.aggregate/) on this connection's underlying `db` */
     aggregate<ResultType = unknown>(pipeline?: PipelineStage[] | null, options?: AggregateOptions): Aggregate<Array<ResultType>>;
 
     /** Returns a promise that resolves when this connection successfully connects to MongoDB */
     asPromise(): Promise<this>;
+
+    /** The Mongoose instance this connection is associated with */
+    base: Mongoose;
 
     bulkWrite<TSchemaMap extends Record<string, AnyObject>>(
       ops: Array<ConnectionBulkWriteModel<TSchemaMap>>,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick little issue I noticed - connections have a `base` property at runtime that points back to the Mongoose instance, but TypeScript types don't have that

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
