### PR TITLE
feat(mongoose): export base Connection and Collection classes

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -856,6 +856,17 @@ Mongoose.prototype.nextConnectionId;
 Mongoose.prototype.Aggregate = Aggregate;
 
 /**
+ * The Base Mongoose Collection class. `mongoose.Collection` extends from this class.
+ *
+ * @memberOf Mongoose
+ * @instance
+ * @method Collection
+ * @api public
+ */
+
+Mongoose.prototype.BaseCollection = require('./collection');
+
+/**
  * The Mongoose Collection constructor
  *
  * @memberOf Mongoose
@@ -894,6 +905,17 @@ Object.defineProperty(Mongoose.prototype, 'Connection', {
     this.__driver.Connection = Connection;
   }
 });
+
+/**
+ * The Base Mongoose Connection class. `mongoose.Connection` extends from this class.
+ *
+ * @memberOf Mongoose
+ * @instance
+ * @method Connection
+ * @api public
+ */
+
+Mongoose.prototype.BaseConnection = require('./connection');
 
 /**
  * The Mongoose version

--- a/test/types/base.test.ts
+++ b/test/types/base.test.ts
@@ -71,3 +71,8 @@ function setAsObject() {
 }
 
 const x: { name: string } = mongoose.omitUndefined({ name: 'foo' });
+
+function baseConnectionAndCollection() {
+  const conn: mongoose.BaseConnection = mongoose.createConnection();
+  const coll: mongoose.BaseCollection<any> = conn.collection('test1');
+}

--- a/types/collection.d.ts
+++ b/types/collection.d.ts
@@ -21,6 +21,8 @@ declare module 'mongoose' {
     name: string;
   }
 
+  export type BaseCollection<T extends mongodb.Document> = CollectionBase<T>;
+
   /*
    * section drivers/node-mongodb-native/collection.js
    */

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -71,6 +71,8 @@ declare module 'mongoose' {
       };
   }[keyof SchemaMap];
 
+  export type BaseConnection = Connection;
+
   class Connection extends events.EventEmitter implements SessionStarter {
     /** Runs a [db-level aggregate()](https://www.mongodb.com/docs/manual/reference/method/db.aggregate/) on this connection's underlying `db` */
     aggregate<ResultType = unknown>(pipeline?: PipelineStage[] | null, options?: AggregateOptions): Aggregate<Array<ResultType>>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now the Mongoose global doesn't export the base `Connection` and `Collection` classes, which makes things tricky for drivers looking to integrate against the base Connection and Collection classes without the node-mongodb-native driver. That's because `import { Connection } from 'mongoose';` triggers `lib/index.js`'s `setDriver()` call, and `Connection` is just a getter around the current driver's `Connection`, so there's no way to get the base Connection class without importing `mongoose/lib/connection`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
