### PR TITLE
types: allow passing in projections without `as const`

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -155,10 +155,10 @@ const p2: Record<string, number> | null = Test.find().projection();
 const p3: null = Test.find().projection(null);
 
 expectError(Test.find({ }, { name: 'ss' })); // Only 0 and 1 are allowed
-expectError(Test.find({ }, { name: 3 })); // Only 0 and 1 are allowed
-expectError(Test.find({ }, { name: true, age: false, endDate: true, tags: 1 })); // Exclusion in a inclusion projection is not allowed
-expectError(Test.find({ }, { name: true, age: false, endDate: true })); // Inclusion in a exclusion projection is not allowed
-expectError(Test.find({ }, { name: false, age: false, tags: false, child: { name: false }, docs: { myId: false, id: true } })); // Inclusion in a exclusion projection is not allowed in nested objects and arrays
+Test.find({}, { name: 3 });
+Test.find({}, { name: true, age: false, endDate: true, tags: 1 });
+Test.find({}, { name: true, age: false, endDate: true });
+Test.find({}, { name: false, age: false, tags: false, child: { name: false }, docs: { myId: false, id: true } });
 expectError(Test.find({ }, { tags: { something: 1 } })); // array of strings or numbers should only be allowed to be a boolean or 1 and 0
 Test.find({}, { name: true, age: true, endDate: true, tags: 1, child: { name: true }, docs: { myId: true, id: true } }); // This should be allowed
 Test.find({}, { name: 1, age: 1, endDate: 1, tags: 1, child: { name: 1 }, docs: { myId: 1, id: 1 } }); // This should be allowed
@@ -177,7 +177,7 @@ Test.find({}, { age: 1, tags: { $slice: 5 } }); // $slice should be allowed in i
 Test.find({}, { age: 0, tags: { $slice: 5 } }); // $slice should be allowed in exclusion projection
 Test.find({}, { age: 1, tags: { $elemMatch: {} } }); // $elemMatch should be allowed in inclusion projection
 Test.find({}, { age: 0, tags: { $elemMatch: {} } }); // $elemMatch should be allowed in exclusion projection
-expectError(Test.find({}, { 'docs.id': 11 })); // Dot notation should be allowed and does not accept any
+expectError(Test.find({}, { 'docs.id': 'taco' })); // Dot notation should be allowed and does not accept any
 expectError(Test.find({}, { docs: { id: '1' } })); // Dot notation should be able to use a combination with objects
 Test.find({}, { docs: { id: false } }); // Dot notation should be allowed with valid values - should correctly handle arrays
 Test.find({}, { docs: { id: true } }); // Dot notation should be allowed with valid values - should correctly handle arrays

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -704,9 +704,9 @@ declare module 'mongoose' {
           [K in keyof T]?: T[K] extends Record<string, any> ? Projector<T[K], Element> | Element : Element;
         }
         : Element;
-  type _IDType = { _id?: boolean | 1 | 0 };
+  type _IDType = { _id?: boolean | number };
   export type InclusionProjection<T> = IsItRecordAndNotAny<T> extends true
-    ? Omit<Projector<WithLevel1NestedPaths<T>, true | 1>, '_id'> & _IDType
+    ? Omit<Projector<WithLevel1NestedPaths<T>, boolean | number>, '_id'> & _IDType
     : AnyObject;
   export type ExclusionProjection<T> = IsItRecordAndNotAny<T> extends true
     ? Omit<Projector<WithLevel1NestedPaths<T>, false | 0>, '_id'> & _IDType


### PR DESCRIPTION
Fix #15557
Re: #13840
Re: #15327

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#13840 made it so that Mongoose requires `as const` for projections defined using `const projection = { /* fields here */ }`. That can cause some problems like in #15557. I'm not 100% convinced we want to make the change in this PR, I'd like to hear @hasezoey and @AbdelrahmanHafez 's thoughts

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
