### PR TITLE
fix(model): remove unnecessary conversion of undefined -> null in findById

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2092,20 +2092,13 @@ Model.find = function find(conditions, projection, options) {
 };
 
 /**
- * Finds a single document by its _id field. `findById(id)` is almost*
- * equivalent to `findOne({ _id: id })`. If you want to query by a document's
- * `_id`, use `findById()` instead of `findOne()`.
+ * Finds a single document by its _id field. `findById(id)` is equivalent to `findOne({ _id: id })`.
  *
  * The `id` is cast based on the Schema before sending the command.
  *
  * This function triggers the following middleware.
  *
  * - `findOne()`
- *
- * \* Except for how it treats `undefined`. If you use `findOne()`, you'll see
- * that `findOne(undefined)` and `findOne({ _id: undefined })` are equivalent
- * to `findOne({})` and return arbitrary documents. However, mongoose
- * translates `findById(undefined)` into `findOne({ _id: null })`.
  *
  * #### Example:
  *
@@ -2129,10 +2122,6 @@ Model.findById = function findById(id, projection, options) {
   _checkContext(this, 'findById');
   if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
     throw new MongooseError('Model.findById() no longer accepts a callback');
-  }
-
-  if (typeof id === 'undefined') {
-    id = null;
   }
 
   return this.findOne({ _id: id }, projection, options);


### PR DESCRIPTION
Fix #15551

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The `findById()` documentation indicates that `findOne({ _id: undefined })` will return an arbitrary document, which is no longer accurate. I also removed the `undefined` check in `findById()`, which is no longer necessary because `findOne({ _id: undefined })` no longer returns an arbitrary document.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
