### PR TITLE
fix(query): propagate read preference to populate if `read()` called after `populate()`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2133,6 +2133,15 @@ Query.prototype._optionsForExec = function(model) {
     }
   }
 
+  if (this._mongooseOptions.populate && options.readPreference) {
+    for (const pop of Object.values(this._mongooseOptions.populate)) {
+      if (!pop.options) {
+        pop.options = {};
+      }
+      pop.options.readPreference = options.readPreference;
+    }
+  }
+
   return options;
 };
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4469,6 +4469,14 @@ describe('Query', function() {
     });
   });
 
+  it('propagates readPreference to populate options if read() is called after populate() (gh-15553)', async function() {
+    const schema = new Schema({ name: String, age: Number, friends: [{ type: 'ObjectId', ref: 'Person' }] });
+    const Person = db.model('Person', schema);
+    const query = Person.find({}).populate('friends');
+    query.read('secondaryPreferred');
+    await query.exec();
+    assert.strictEqual(query._mongooseOptions.populate.friends.options.readPreference.mode, 'secondaryPreferred');
+  });
 
   describe('Query with requireFilter', function() {
     let Person;

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4472,8 +4472,18 @@ describe('Query', function() {
   it('propagates readPreference to populate options if read() is called after populate() (gh-15553)', async function() {
     const schema = new Schema({ name: String, age: Number, friends: [{ type: 'ObjectId', ref: 'Person' }] });
     const Person = db.model('Person', schema);
-    const query = Person.find({}).populate('friends');
+
+    let query = Person.find({}).populate('friends');
     query.read('secondaryPreferred');
+    await query.exec();
+    assert.strictEqual(query._mongooseOptions.populate.friends.options.readPreference.mode, 'secondaryPreferred');
+
+    query = Person.find({}).read('secondary').populate('friends');
+    query.read('secondaryPreferred');
+    await query.exec();
+    assert.strictEqual(query._mongooseOptions.populate.friends.options.readPreference.mode, 'secondaryPreferred');
+
+    query = Person.find({}).read('secondaryPreferred').populate('friends');
     await query.exec();
     assert.strictEqual(query._mongooseOptions.populate.friends.options.readPreference.mode, 'secondaryPreferred');
   });


### PR DESCRIPTION
Fix #15553

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15553 points out that `TestModel.findOne().read('secondaryPreferred').populate('friends')` applies read preference to populate queries, but `TestModel.findOne().populate('friends').read('secondaryPreferred')` currently does not. With this PR, we'll apply top-level read preference to all populate queries when executing the query.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
