### PR TITLE
fix(model): allow setting `statics` option on discriminator schema

### DIFF
--- a/lib/helpers/model/discriminator.js
+++ b/lib/helpers/model/discriminator.js
@@ -14,7 +14,8 @@ const CUSTOMIZABLE_DISCRIMINATOR_OPTIONS = {
   _id: true,
   id: true,
   virtuals: true,
-  methods: true
+  methods: true,
+  statics: true
 };
 
 /**

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -156,6 +156,30 @@ describe('model', function() {
       assert.equal(doc.virtualB, 'virtualB');
     });
 
+    it('can define statics using schema options (gh-15556)', function() {
+      const baseSchema = new mongoose.Schema({
+        name: String
+      }, {
+        statics: {
+          staticFunction: () => 'base'
+        }
+      });
+
+      const discriminatorSchema = new mongoose.Schema({
+        prop: String
+      }, {
+        statics: {
+          staticFunction: () => 'discriminator',
+          otherStaticFunction: () => 42
+        }
+      });
+      const BaseModel = db.model('Test', baseSchema);
+      const DiscriminatorModel = BaseModel.discriminator('Test1', discriminatorSchema);
+
+      assert.equal(DiscriminatorModel.staticFunction(), 'discriminator');
+      assert.equal(DiscriminatorModel.otherStaticFunction(), 42);
+    });
+
     it('sets schema root discriminator mapping', function(done) {
       assert.deepEqual(Person.schema.discriminatorMapping, { key: '__t', value: null, isRoot: true });
       done();

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -2120,7 +2120,7 @@ describe('model', function() {
     const childSchema = new Schema({}, { typeKey: 'bar' });
     assert.throws(() => {
       Base.discriminator('model-discriminator-custom1', childSchema);
-    }, { message: 'Can\'t customize discriminator option typeKey (can only modify toJSON, toObject, _id, id, virtuals, methods)' });
+    }, { message: 'Can\'t customize discriminator option typeKey (can only modify toJSON, toObject, _id, id, virtuals, methods, statics)' });
   });
   it('handles customizable discriminator options gh-12135', function() {
     const baseSchema = Schema({}, { toJSON: { virtuals: true } });


### PR DESCRIPTION
Fix #15556

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We allow discriminator schemas to set `methods` and `virtuals` options with #12246, I think `statics` should also be allowed.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
