### PR TITLE
fix(model): call correct function in autoSearchIndex

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1099,7 +1099,7 @@ Model.init = function init() {
       return;
     }
 
-    return await this.ensureSearchIndexes();
+    return await this.createSearchIndexes();
   };
   const _createCollection = async() => {
     let autoCreate = utils.getOption(


### PR DESCRIPTION
Fix #15565

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Sloppy mistake from https://github.com/Automattic/mongoose/commit/dd41187a3afd81b13d05fa465afe6a9632365576: I missed a spot when renaming ensureSearchIndexes -> createSearchIndexes internally.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
