### PR TITLE
fix: trim long strings in minLength and maxLength error messages and display the string length

### DIFF
--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -43,5 +43,5 @@ msg.Date.max = 'Path `{PATH}` ({VALUE}) is after maximum allowed value ({MAX}).'
 msg.String = {};
 msg.String.enum = '`{VALUE}` is not a valid enum value for path `{PATH}`.';
 msg.String.match = 'Path `{PATH}` is invalid ({VALUE}).';
-msg.String.minlength = 'Path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).';
-msg.String.maxlength = 'Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length ({MAXLENGTH}).';
+msg.String.minlength = 'Path `{PATH}` (`{VALUE}`, length {LENGTH}) is shorter than the minimum allowed length ({MINLENGTH}).';
+msg.String.maxlength = 'Path `{PATH}` (`{VALUE}`, length {LENGTH}) is longer than the maximum allowed length ({MAXLENGTH}).';

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1349,6 +1349,12 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     validatorProperties.path = options && options.path ? options.path : path;
     validatorProperties.fullPath = this.$fullPath;
     validatorProperties.value = value;
+    if (typeof value === 'string') {
+      validatorProperties.length = value.length;
+      if (validatorProperties.value.length > 30) {
+        validatorProperties.value = validatorProperties.value.slice(0, 30) + '...';
+      }
+    }
 
     if (validator instanceof RegExp) {
       validate(validator.test(value), validatorProperties, scope);
@@ -1470,6 +1476,12 @@ SchemaType.prototype.doValidateSync = function(value, scope, options) {
     validatorProperties.path = options && options.path ? options.path : path;
     validatorProperties.fullPath = this.$fullPath;
     validatorProperties.value = value;
+    if (typeof value === 'string') {
+      validatorProperties.length = value.length;
+      if (validatorProperties.value.length > 30) {
+        validatorProperties.value = validatorProperties.value.slice(0, 30) + '...';
+      }
+    }
     let ok = false;
 
     // Skip any explicit async validators. Validators that return a promise

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -176,6 +176,24 @@ describe('ValidationError', function() {
       // should pass validation
       await model.validate();
     });
+
+    it('can include custom error message with string length', async function() {
+      const AddressSchema = new Schema({
+        postalCode: { type: String, maxlength: [10, 'Postal code must be at most 10 characters, got {LENGTH}'] }
+      });
+
+      const Address = mongoose.model('gh15550', AddressSchema);
+
+      const model = new Address({
+        postalCode: '95125012345'
+      });
+
+      // should fail validation
+      const err = await model.validate().then(() => null, err => err);
+
+      assert.notEqual(err, null, 'String maxLength validation failed.');
+      assert.ok(err.message.endsWith('Postal code must be at most 10 characters, got 11'), err.message);
+    });
   });
 
   describe('#toString', function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -6810,7 +6810,7 @@ describe('Model', function() {
 
       assert.throws(
         () => User.buildBulkWriteOperations(users),
-        /name: Path `name` \(`a`\) is shorter than the minimum allowed length/
+        /name: Path `name` \(`a`, length 1\) is shorter than the minimum allowed length/
       );
     });
 


### PR DESCRIPTION
Fix #15550

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

minLength and maxLength validators currently display the full string output, which can be problematic in the case of very long strings. This PR trims the output if more than 30 chars, and also displays the length of the string.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
