### PR TITLE
BREAKING CHANGE: make `id` a virtual in TypeScript rather than a property on Document base class

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -475,3 +475,47 @@ async function gh15316() {
   expectType<string>(doc.toJSON({ virtuals: true }).upper);
   expectType<string>(doc.toObject({ virtuals: true }).upper);
 }
+
+function gh13079() {
+  const schema = new Schema({
+    name: { type: String, required: true }
+  });
+  const TestModel = model('Test', schema);
+
+  const doc = new TestModel({ name: 'taco' });
+  expectType<string>(doc.id);
+
+  const schema2 = new Schema({
+    id: { type: Number, required: true },
+    name: { type: String, required: true }
+  });
+  const TestModel2 = model('Test', schema2);
+
+  const doc2 = new TestModel2({ name: 'taco' });
+  expectType<number>(doc2.id);
+
+  const schema3 = new Schema<{ name: string }>({
+    name: { type: String, required: true }
+  });
+  const TestModel3 = model('Test', schema3);
+
+  const doc3 = new TestModel3({ name: 'taco' });
+  expectType<string>(doc3.id);
+
+  const schema4 = new Schema<{ name: string, id: number }>({
+    id: { type: Number, required: true },
+    name: { type: String, required: true }
+  });
+  const TestModel4 = model('Test', schema4);
+
+  const doc4 = new TestModel4({ name: 'taco' });
+  expectType<number>(doc4.id);
+
+  const schema5 = new Schema({
+    name: { type: String, required: true }
+  }, { id: false });
+  const TestModel5 = model('Test', schema5);
+
+  const doc5 = new TestModel5({ name: 'taco' });
+  expectError(doc5.id);
+}

--- a/test/types/virtuals.test.ts
+++ b/test/types/virtuals.test.ts
@@ -89,7 +89,7 @@ function gh11543() {
 
 async function autoTypedVirtuals() {
   type AutoTypedSchemaType = InferSchemaType<typeof testSchema>;
-  type VirtualsType = { domain: string };
+  type VirtualsType = { domain: string } & { id: string };
   type InferredDocType = AutoTypedSchemaType & ObtainSchemaGeneric<typeof testSchema, 'TVirtuals'>;
 
   const testSchema = new Schema({

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -166,9 +166,6 @@ declare module 'mongoose' {
      */
     getChanges(): UpdateQuery<this>;
 
-    /** The string version of this documents _id. */
-    id?: any;
-
     /** Signal that we desire an increment of this documents version. */
     increment(): this;
 

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -63,7 +63,7 @@ declare module 'mongoose' {
        M: M;
        TInstanceMethods: TInstanceMethods;
        TQueryHelpers: TQueryHelpers;
-       TVirtuals: TVirtuals;
+       TVirtuals: (DocType extends { id: any } ? TVirtuals : TSchemaOptions extends { id: false } ? TVirtuals : TVirtuals & { id: string });
        TStaticMethods: TStaticMethods;
        TSchemaOptions: TSchemaOptions;
        DocType: DocType;


### PR DESCRIPTION
Fix #13079

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

At runtime, `id` is a virtual that Mongoose adds unless `id` option is disabled or there is already an `id` property on the schema. With this PR, TypeScript types will also add `id` as a virtual to `TVirtuals`. This removes the `id?: any` bit in the `Document` class, which is suboptimal developer experience.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
