### PR TITLE
feat(schema): support for union types

### DIFF
--- a/lib/options/schemaUnionOptions.js
+++ b/lib/options/schemaUnionOptions.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const SchemaTypeOptions = require('./schemaTypeOptions');
+
+/**
+ * The options defined on a Union schematype.
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaUnionOptions
+ */
+
+class SchemaUnionOptions extends SchemaTypeOptions {}
+
+const opts = require('./propertyOptions');
+
+/**
+ * If set, specifies the type of this map's values. Mongoose will cast
+ * this map's values to the given type.
+ *
+ * If not set, Mongoose will not cast the map's values.
+ *
+ * @api public
+ * @property of
+ * @memberOf SchemaUnionOptions
+ * @type {Function|string}
+ * @instance
+ */
+
+Object.defineProperty(SchemaUnionOptions.prototype, 'of', opts);
+
+module.exports = SchemaUnionOptions;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1525,7 +1525,7 @@ Object.defineProperty(Schema.prototype, 'base', {
  *
  * @param {String} path
  * @param {Object} obj constructor
- * @param {Object} options
+ * @param {Object} options schema options
  * @api private
  */
 
@@ -1538,7 +1538,6 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
     clone.path = path;
     return clone;
   }
-
 
   // If this schema has an associated Mongoose object, use the Mongoose object's
   // copy of SchemaTypes re: gh-7158 gh-6933
@@ -1740,7 +1739,8 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
       'https://bit.ly/mongoose-schematypes for a list of valid schema types.');
   }
 
-  const schemaType = new MongooseTypes[name](path, obj);
+  obj.parentSchema = this;
+  const schemaType = new MongooseTypes[name](path, obj, options);
 
   if (schemaType.$isSchemaMap) {
     createMapNestedSchemaType(this, schemaType, path, obj, options);

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -12,6 +12,8 @@ exports.Buffer = require('./buffer');
 exports.Date = require('./date');
 exports.Decimal128 = exports.Decimal = require('./decimal128');
 exports.DocumentArray = require('./documentArray');
+exports.Double = require('./double');
+exports.Int32 = require('./int32');
 exports.Map = require('./map');
 exports.Mixed = require('./mixed');
 exports.Number = require('./number');
@@ -19,8 +21,7 @@ exports.ObjectId = require('./objectId');
 exports.String = require('./string');
 exports.Subdocument = require('./subdocument');
 exports.UUID = require('./uuid');
-exports.Double = require('./double');
-exports.Int32 = require('./int32');
+exports.Union = require('./union');
 
 // alias
 

--- a/lib/schema/union.js
+++ b/lib/schema/union.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/*!
+ * ignore
+ */
+
+const MongooseMap = require('../types/map');
+const SchemaUnionOptions = require('../options/schemaUnionOptions');
+const SchemaType = require('../schemaType');
+const createJSONSchemaTypeDefinition = require('../helpers/createJSONSchemaTypeDefinition');
+
+const firstValueSymbol = Symbol('firstValue');
+
+/*!
+ * ignore
+ */
+
+class Union extends SchemaType {
+  constructor(key, options, schemaOptions) {
+    super(key, options, 'Union');
+    if (!options || !Array.isArray(options.of) || options.of.length === 0) {
+      throw new Error('Union schema type requires an array of types');
+    }
+    if (options && Array.isArray(options.of)) {
+      this.schemaTypes = options.of.map(obj => options.parentSchema.interpretAsType(key, obj, schemaOptions));
+    }
+  }
+
+  cast(val, doc, init, prev, options) {
+    let firstValue = firstValueSymbol;
+    let lastError;
+    // Loop through each schema type in the union. If one of the schematypes returns a value that is `=== val`, then
+    // use `val`. Otherwise, if one of the schematypes casted successfully, use the first successfully casted value.
+    // Finally, if none of the schematypes casted successfully, throw the error from the last schema type in the union.
+    // The `=== val` check is a workaround to ensure that the original value is returned if it matches one of the schema types,
+    // avoiding cases like where numbers are casted to strings or dates even if the schema type is a number.
+    for (let i = 0; i < this.schemaTypes.length; ++i) {
+      try {
+        const casted = this.schemaTypes[i].cast(val, doc, init, prev, options);
+        if (casted === val) {
+          return casted;
+        }
+        if (firstValue === firstValueSymbol) {
+          firstValue = casted;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (firstValue !== firstValueSymbol) {
+      return firstValue;
+    }
+    throw lastError;
+  }
+
+  // Setters also need to be aware of casting - we need to apply the setters of the entry in the union we choose.
+  applySetters(val, doc, init, prev, options) {
+    let firstValue = firstValueSymbol;
+    let lastError;
+    // Loop through each schema type in the union. If one of the schematypes returns a value that is `=== val`, then
+    // use `val`. Otherwise, if one of the schematypes casted successfully, use the first successfully casted value.
+    // Finally, if none of the schematypes casted successfully, throw the error from the last schema type in the union.
+    // The `=== val` check is a workaround to ensure that the original value is returned if it matches one of the schema types,
+    // avoiding cases like where numbers are casted to strings or dates even if the schema type is a number.
+    for (let i = 0; i < this.schemaTypes.length; ++i) {
+      try {
+        let castedVal = this.schemaTypes[i]._applySetters(val, doc, init, prev, options);
+        if (castedVal == null) {
+          castedVal = this.schemaTypes[i]._castNullish(castedVal);
+        } else {
+          castedVal = this.schemaTypes[i].cast(castedVal, doc, init, prev, options);
+        }
+        if (castedVal === val) {
+          return castedVal;
+        }
+        if (firstValue === firstValueSymbol) {
+          firstValue = castedVal;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (firstValue !== firstValueSymbol) {
+      return firstValue;
+    }
+    throw lastError;
+  }
+
+  clone() {
+    const schematype = super.clone();
+
+    schematype.schemaTypes = this.schemaTypes.map(schemaType => schemaType.clone());
+    return schematype;
+  }
+}
+
+/**
+ * This schema type's name, to defend against minifiers that mangle
+ * function names.
+ *
+ * @api public
+ */
+Union.schemaName = 'Union';
+
+Union.defaultOptions = {};
+
+Union.prototype.OptionsConstructor = SchemaUnionOptions;
+
+module.exports = Union;

--- a/test/schema.union.test.js
+++ b/test/schema.union.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const start = require('./common');
+const util = require('./util');
+
+const assert = require('assert');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('Union', function() {
+  let db;
+
+  before(async function() {
+    db = await start().asPromise();
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  afterEach(() => db.deleteModel(/Test/));
+  afterEach(() => util.clearTestData(db));
+  afterEach(() => util.stopRemainingOps(db));
+
+  it('basic functionality should work', async function() {
+    const schema = new Schema({
+      test: {
+        type: 'Union',
+        of: [Number, String]
+      }
+    });
+    const TestModel = db.model('Test', schema);
+
+    const doc1 = new TestModel({ test: 1 });
+    assert.strictEqual(doc1.test, 1);
+    await doc1.save();
+
+    const doc1FromDb = await TestModel.collection.findOne({ _id: doc1._id });
+    assert.strictEqual(doc1FromDb.test, 1);
+
+    const doc2 = new TestModel({ test: 'abc' });
+    assert.strictEqual(doc2.test, 'abc');
+    await doc2.save();
+
+    const doc2FromDb = await TestModel.collection.findOne({ _id: doc2._id });
+    assert.strictEqual(doc2FromDb.test, 'abc');
+  });
+
+  it('should report last cast error', async function() {
+    const schema = new Schema({
+      test: {
+        type: 'Union',
+        of: [Number, Boolean]
+      }
+    });
+    const TestModel = db.model('Test', schema);
+
+    const doc1 = new TestModel({ test: 'taco tuesday' });
+    assert.strictEqual(doc1.test, undefined);
+    await assert.rejects(
+      doc1.save(),
+      'ValidationError: test: Cast to Boolean failed for value "taco tuesday" (type string) at path "test" because of "CastError"'
+    )
+  });
+
+  it('should cast for query', async function() {
+    const schema = new Schema({
+      test: {
+        type: 'Union',
+        of: [Number, Date]
+      }
+    });
+    const TestModel = db.model('Test', schema);
+
+    const doc1 = new TestModel({ test: 1 });
+    assert.strictEqual(doc1.test, 1);
+    await doc1.save();
+
+    let res = await TestModel.findOne({ test: 1 });
+    assert.strictEqual(res.test, 1);
+
+    res = await TestModel.findOne({ test: '1' });
+    assert.strictEqual(res.test, 1);
+
+    await TestModel.create({ test: new Date('2025-06-01') });
+    res = await TestModel.findOne({ test: '2025-06-01' });
+    assert.strictEqual(res.test.valueOf(), new Date('2025-06-01').valueOf());
+  });
+
+  it('should cast updates', async function() {
+    const schema = new Schema({
+      test: {
+        type: 'Union',
+        of: [Number, Date]
+      }
+    });
+    const TestModel = db.model('Test', schema);
+
+    const doc1 = new TestModel({ test: 1 });
+    assert.strictEqual(doc1.test, 1);
+    await doc1.save();
+
+    let res = await TestModel.findOneAndUpdate({ _id: doc1._id }, { test: '1' }, { returnDocument: 'after' });
+    assert.strictEqual(res.test, 1);
+
+    res = await TestModel.findOneAndUpdate({ _id: doc1._id }, { test: new Date('2025-06-01') }, { returnDocument: 'after' });
+    assert.strictEqual(res.test.valueOf(), new Date('2025-06-01').valueOf());
+  });
+
+  it('should handle setters', async function() {
+    const schema = new Schema({
+      test: {
+        type: 'Union',
+        of: [
+          Number,
+          {
+            type: String,
+            trim: true
+          }
+        ]
+      }
+    });
+    const TestModel = db.model('Test', schema);
+
+    const doc1 = new TestModel({ test: 1 });
+    assert.strictEqual(doc1.test, 1);
+    await doc1.save();
+
+    const doc2 = new TestModel({ test: '   bbb  ' });
+    assert.strictEqual(doc2.test, 'bbb');
+    await doc2.save();
+
+    const doc2FromDb = await TestModel.collection.findOne({ _id: doc2._id });
+    assert.strictEqual(doc2FromDb.test, 'bbb');
+  });
+});


### PR DESCRIPTION
Fix #10894. There's still work to do on this PR (TypeScript types, options testing, thinking about how to handle getters/setters on unions) but I wanted to get this out there for review.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`type: 'Union'` means a given path can be one of multiple types.

For example, in the following schema, `purchased` can be either a Boolean or a Date.

```javascript
const schema = new Schema({
  purchased: {
    type: 'Union',
    of: [Boolean, Date]
  }
});
```

Order matters in `of`: Mongoose will loop through the `Of` schema types and take the first one that casts successfully, _unless_ one of the schema types returns the original value, in which case Mongoose just takes the original value.

For example, in the above case, `purchased: 1` would get converted to a boolean (true) because Mongoose can cast 1 -> true. But `purchased: 2` would get converted to a Date, because `2` is not a value Mongoose can cast to a Boolean by default.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
