### PR TITLE
types(connection+collection): make BaseCollection and BaseConnection usable as values

### DIFF
--- a/types/collection.d.ts
+++ b/types/collection.d.ts
@@ -1,46 +1,49 @@
 declare module 'mongoose' {
   import mongodb = require('mongodb');
 
-  /*
-   * section collection.js
-   */
-  interface CollectionBase<T extends mongodb.Document> extends mongodb.Collection<T> {
-    /*
-     * Abstract methods. Some of these are already defined on the
-     * mongodb.Collection interface so they've been commented out.
-     */
-    ensureIndex(...args: any[]): any;
-    findAndModify(...args: any[]): any;
-    getIndexes(...args: any[]): any;
-
-    /** The collection name */
-    collectionName: string;
-    /** The Connection instance */
-    conn: Connection;
-    /** The collection name */
-    name: string;
-  }
-
-  export type BaseCollection<T extends mongodb.Document> = CollectionBase<T>;
-
-  /*
-   * section drivers/node-mongodb-native/collection.js
-   */
-  interface Collection<T extends mongodb.Document = mongodb.Document> extends CollectionBase<T> {
+  export class BaseCollection<T extends mongodb.Document> extends mongodb.Collection<T> {
     /**
      * Collection constructor
      * @param name name of the collection
      * @param conn A MongooseConnection instance
      * @param opts optional collection options
      */
-    // eslint-disable-next-line @typescript-eslint/no-misused-new
-    new(name: string, conn: Connection, opts?: any): Collection<T>;
+    constructor(name: string, conn: Connection, opts?: any);
+
+    /*
+    * Abstract methods. Some of these are already defined on the
+    * mongodb.Collection interface so they've been commented out.
+    */
+    ensureIndex(...args: any[]): any;
+    findAndModify(...args: any[]): any;
+    getIndexes(...args: any[]): any;
+
     /** Formatter for debug print args */
     $format(arg: any, color?: boolean, shell?: boolean): string;
     /** Debug print helper */
     $print(name: string, i: string | number, args: any[], color?: boolean, shell?: boolean): void;
+
+    /** The collection name */
+    get collectionName(): string;
+    /** The Connection instance */
+    conn: Connection;
+    /** The collection name */
+    name: string;
+  }
+
+  /*
+   * section drivers/node-mongodb-native/collection.js
+   */
+  class Collection<T extends mongodb.Document = mongodb.Document> extends BaseCollection<T> {
+    /**
+     * Collection constructor
+     * @param name name of the collection
+     * @param conn A MongooseConnection instance
+     * @param opts optional collection options
+     */
+    constructor(name: string, conn: Connection, opts?: any);
+
     /** Retrieves information about this collections indexes. */
     getIndexes(): ReturnType<mongodb.Collection<T>['indexInformation']>;
   }
-  let Collection: Collection;
 }

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -71,8 +71,6 @@ declare module 'mongoose' {
       };
   }[keyof SchemaMap];
 
-  export type BaseConnection = Connection;
-
   class Connection extends events.EventEmitter implements SessionStarter {
     /** Runs a [db-level aggregate()](https://www.mongodb.com/docs/manual/reference/method/db.aggregate/) on this connection's underlying `db` */
     aggregate<ResultType = unknown>(pipeline?: PipelineStage[] | null, options?: AggregateOptions): Aggregate<Array<ResultType>>;
@@ -286,4 +284,5 @@ declare module 'mongoose' {
     withSession<T = any>(executor: (session: ClientSession) => Promise<T>): Promise<T>;
   }
 
+  export class BaseConnection extends Connection {}
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We recently added BaseConnection and BaseCollection in #15548, but that implementation has some oversights. With current implementation, you can't do `class MyCollection extends BaseCollection` because BaseCollection is an interface in TypeScript, not a class.

It is admittedly a bit strange that we have `BaseConnection extends Connection {}`, that's more to derisk breaking anything. In the future, I'd prefer if `BaseConnection` contained all the Connection definitions and we just had `Connection extends BaseConnection`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
