### PR TITLE
Bugfix: `Model.validate()` hangs when all paths fail casting

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4304,6 +4304,10 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
   let remaining = paths.size;
 
   return new Promise((resolve, reject) => {
+    if (remaining === 0) {
+      return settle();
+    }
+
     for (const path of paths) {
       const schemaType = schema.path(path);
       if (schemaType == null) {
@@ -4328,13 +4332,17 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
       }, context, { path: path });
     }
 
+    function settle() {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(obj);
+      }
+    }
+
     function _checkDone() {
       if (--remaining <= 0) {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(obj);
-        }
+        return settle();
       }
     }
   });

--- a/test/model.validate.test.js
+++ b/test/model.validate.test.js
@@ -227,6 +227,7 @@ describe('model: validate: ', function() {
       then(() => null, err => err);
     assert.ok(err);
     assert.deepEqual(Object.keys(err.errors).sort(), ['invalidPath1', 'invalidPath2']);
-    assert.equal(err.errors['invalidPath1', 'invalidPath2'].name, 'CastError');
+    assert.equal(err.errors['invalidPath1'].name, 'CastError');
+    assert.equal(err.errors['invalidPath2'].name, 'CastError');
   });
 });

--- a/test/model.validate.test.js
+++ b/test/model.validate.test.js
@@ -206,4 +206,27 @@ describe('model: validate: ', function() {
     assert.equal(err.errors['myNumber'].name, 'CastError');
     assert.equal(err.errors['invalid1'].name, 'ValidatorError');
   });
+
+  it('should return cast errors when validating only paths that fail casting', async function() {
+    const Model = mongoose.model('Test', new Schema({
+      validPath: {
+        type: String,
+        required: true
+      },
+      invalidPath1: {
+        type: Number,
+        required: true
+      },
+      invalidPath2: {
+        type: Number,
+        required: true
+      }
+    }));
+
+    const err = await Model.validate({ validPath: 'foo', invalidPath1: 'not a number', invalidPath2: 'not a number' }, ['invalidPath1', 'invalidPath2']).
+      then(() => null, err => err);
+    assert.ok(err);
+    assert.deepEqual(Object.keys(err.errors).sort(), ['invalidPath1', 'invalidPath2']);
+    assert.equal(err.errors['invalidPath1', 'invalidPath2'].name, 'CastError');
+  });
 });


### PR DESCRIPTION
### Problem
`Model.validate()` hangs indefinitely when all specified validation paths fail type casting. The Promise never resolves or rejects, causing timeouts.

### Root cause
1. `castObject()` throws a ValidationError and removes failed paths from the validation queue
2. The main validation loop becomes empty (`remaining = 0`)
3. `_checkDone()` is never called because the loop doesn't execute
4. The Promise hangs indefinitely

### Solution
Refactored the Promise handling logic to properly handle the case when all validation paths are removed due to casting errors. The key changes:
Early settlement check: Added `if (remaining === 0) { return settle(); }` immediately after creating the Promise to handle the case where no paths need validation
Extracted settlement logic: Created a `settle()` helper function to centralize Promise resolution/rejection logic