### PR TITLE
types(document): better support for `flattenObjectIds` and `versionKey` options for toObject() and toJSON()

### DIFF
--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14587,7 +14587,7 @@ describe('document', function() {
     assert.strictEqual(updatedItem.nested.get('inserted2').map.get('a1'), 1);
   });
 
-  it('removes versionKey from output if versionKey: false set on toObject() or toJSON() (gh-15578)', async function () {
+  it('removes versionKey from output if versionKey: false set on toObject() or toJSON() (gh-15578)', async function() {
     const schema = new mongoose.Schema({ name: String }, { versionKey: '__v' });
     const Model = db.model('Test', schema);
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14597,6 +14597,9 @@ describe('document', function() {
     let obj = doc.toObject();
     assert.ok(obj.hasOwnProperty('__v'));
 
+    obj = doc.toObject();
+    assert.ok(obj.hasOwnProperty('__v'));
+
     // toObject({ versionKey: false }) removes versionKey
     obj = doc.toObject({ versionKey: false });
     assert.ok(!obj.hasOwnProperty('__v'));

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -14586,6 +14586,32 @@ describe('document', function() {
     assert.strictEqual(updatedItem.nested.get('inserted').map.get('a1'), 1);
     assert.strictEqual(updatedItem.nested.get('inserted2').map.get('a1'), 1);
   });
+
+  it('removes versionKey from output if versionKey: false set on toObject() or toJSON() (gh-15578)', async function () {
+    const schema = new mongoose.Schema({ name: String }, { versionKey: '__v' });
+    const Model = db.model('Test', schema);
+
+    const doc = await Model.create({ name: 'test' });
+
+    // Default: versionKey present
+    let obj = doc.toObject();
+    assert.ok(obj.hasOwnProperty('__v'));
+
+    // toObject({ versionKey: false }) removes versionKey
+    obj = doc.toObject({ versionKey: false });
+    assert.ok(!obj.hasOwnProperty('__v'));
+
+    // toJSON({ versionKey: false }) removes versionKey
+    obj = doc.toJSON({ versionKey: false });
+    assert.ok(!obj.hasOwnProperty('__v'));
+
+    // If versionKey: false in schema, versionKey should not be present
+    const schemaNoVersion = new mongoose.Schema({ name: String }, { versionKey: false });
+    const ModelNoVersion = db.model('TestNoVersion', schemaNoVersion);
+    const docNoVersion = await ModelNoVersion.create({ name: 'test2' });
+    obj = docNoVersion.toObject();
+    assert.ok(!obj.hasOwnProperty('__v'));
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -7,7 +7,8 @@ import {
   HydratedDocument,
   HydratedArraySubdocument,
   HydratedSingleSubdocument,
-  DefaultSchemaOptions
+  DefaultSchemaOptions,
+  ObtainSchemaGeneric
 } from 'mongoose';
 import { DeleteResult } from 'mongodb';
 import { expectAssignable, expectError, expectNotAssignable, expectType } from 'tsd';
@@ -495,4 +496,14 @@ async function gh15578() {
   const toJSONFlattened: Omit<RawDocType, '_id'> & { _id: string } = a.toJSON({ flattenObjectIds: true });
   const toJSONWithVirtuals: Omit<RawDocType, '_id'> & { _id: string } = a.toJSON({ virtuals: true, flattenObjectIds: true });
   const toJSONWithoutVirtuals: Omit<RawDocType, '_id'> & { _id: string } = a.toJSON({ virtuals: false, flattenObjectIds: true });
+
+  const objWithoutVersionKey = a.toObject({ versionKey: false });
+  const jsonWithoutVersionKey = a.toJSON({ versionKey: false });
+  expectError(objWithoutVersionKey.__v);
+  expectError(jsonWithoutVersionKey.__v);
+
+  const objWithVersionKey = a.toObject();
+  const jsonWithVersionKey = a.toJSON();
+  expectType<number>(objWithVersionKey.__v);
+  expectType<number>(jsonWithVersionKey.__v);
 }

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -475,3 +475,24 @@ async function gh15316() {
   expectType<string>(doc.toJSON({ virtuals: true }).upper);
   expectType<string>(doc.toObject({ virtuals: true }).upper);
 }
+
+async function gh15578() {
+  interface RawDocType {
+      _id: Types.ObjectId;
+      testProperty: number;
+  }
+
+  const ASchema = new Schema<RawDocType>({
+    testProperty: Number
+  });
+
+  const AModel = model<RawDocType>('YourModel', ASchema);
+
+  const a = new AModel({ testProperty: 8 });
+  const toObjectFlattened: Omit<RawDocType, '_id'> & { _id: string } = a.toObject({ flattenObjectIds: true });
+  const toObjectWithVirtuals: Omit<RawDocType, '_id'> & { _id: string } = a.toObject({ virtuals: true, flattenObjectIds: true });
+  const toObjectWithoutVirtuals: Omit<RawDocType, '_id'> & { _id: string } = a.toObject({ virtuals: false, flattenObjectIds: true });
+  const toJSONFlattened: Omit<RawDocType, '_id'> & { _id: string } = a.toJSON({ flattenObjectIds: true });
+  const toJSONWithVirtuals: Omit<RawDocType, '_id'> & { _id: string } = a.toJSON({ virtuals: true, flattenObjectIds: true });
+  const toJSONWithoutVirtuals: Omit<RawDocType, '_id'> & { _id: string } = a.toJSON({ virtuals: false, flattenObjectIds: true });
+}

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -643,7 +643,7 @@ function gh11997() {
 function gh12003() {
   const baseSchemaOptions = {
     versionKey: false
-  };
+  } as const;
 
   const BaseSchema = new Schema({
     name: String
@@ -653,6 +653,7 @@ function gh12003() {
 
   type TSchemaOptions = ResolveSchemaOptions<ObtainSchemaGeneric<typeof BaseSchema, 'TSchemaOptions'>>;
   expectType<'type'>({} as TSchemaOptions['typeKey']);
+  expectType<false>({} as TSchemaOptions['versionKey']);
 
   expectType<{ name?: string | null }>({} as BaseSchemaType);
 }

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -256,8 +256,12 @@ declare module 'mongoose' {
     set(value: string | Record<string, any>): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
+    toJSON(options: ToObjectOptions & { versionKey: false, virtuals: true, flattenObjectIds: true }): Omit<ObjectIdToString<FlattenMaps<Require_id<DocType & TVirtuals>>>, '__v'>;
     toJSON(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>>;
+    toJSON(options: ToObjectOptions & { versionKey: false, virtuals: true }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
+    toJSON(options: ToObjectOptions & { versionKey: false, flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Omit<Require_id<DocType>, '__v'>>>;
     toJSON(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>;
+    toJSON(options: ToObjectOptions & { versionKey: false }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
     toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>;
     toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>;
     toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>>;
@@ -271,8 +275,12 @@ declare module 'mongoose' {
     toJSON<T = Default__v<Require_id<DocType>, TSchemaOptions>>(options: ToObjectOptions & { flattenMaps: false, flattenObjectIds: true }): ObjectIdToString<T>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
+    toObject(options: ToObjectOptions & { versionKey: false, virtuals: true, flattenObjectIds: true }): Omit<ObjectIdToString<Require_id<DocType & TVirtuals>>, '__v'>;
     toObject(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>;
+    toObject(options: ToObjectOptions & { versionKey: false, flattenObjectIds: true }): Omit<ObjectIdToString<Require_id<DocType & TVirtuals>>, '__v'>;
+    toObject(options: ToObjectOptions & { versionKey: false, virtuals: true }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
     toObject(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>;
+    toObject(options: ToObjectOptions & { versionKey: false }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
     toObject(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>;
     toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
     toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, TSchemaOptions>;

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -256,6 +256,7 @@ declare module 'mongoose' {
     set(value: string | Record<string, any>): this;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
+    toJSON(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>>;
     toJSON(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>;
     toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>;
     toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>;
@@ -270,7 +271,9 @@ declare module 'mongoose' {
     toJSON<T = Default__v<Require_id<DocType>, TSchemaOptions>>(options: ToObjectOptions & { flattenMaps: false, flattenObjectIds: true }): ObjectIdToString<T>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
+    toObject(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>;
     toObject(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>;
+    toObject(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>;
     toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
     toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, TSchemaOptions>;
 

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -257,16 +257,16 @@ declare module 'mongoose' {
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
     toJSON(options: ToObjectOptions & { versionKey: false, virtuals: true, flattenObjectIds: true }): Omit<ObjectIdToString<FlattenMaps<Require_id<DocType & TVirtuals>>>, '__v'>;
-    toJSON(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>>;
+    toJSON(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType & TVirtuals>, ResolveSchemaOptions<TSchemaOptions>>>>;
     toJSON(options: ToObjectOptions & { versionKey: false, virtuals: true }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
     toJSON(options: ToObjectOptions & { versionKey: false, flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Omit<Require_id<DocType>, '__v'>>>;
-    toJSON(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>;
+    toJSON(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, ResolveSchemaOptions<TSchemaOptions>>;
     toJSON(options: ToObjectOptions & { versionKey: false }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
-    toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>;
-    toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>;
-    toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType>, TSchemaOptions>>>;
-    toJSON(options: ToObjectOptions & { flattenMaps: false }): Default__v<Require_id<DocType>, TSchemaOptions>;
-    toJSON(options: ToObjectOptions & { flattenMaps: false; flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType>, TSchemaOptions>>;
+    toJSON(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<Default__v<Require_id<DocType>, ResolveSchemaOptions<TSchemaOptions>>>;
+    toJSON(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<Default__v<Require_id<DocType>, ResolveSchemaOptions<TSchemaOptions>>>;
+    toJSON(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<FlattenMaps<Default__v<Require_id<DocType>, ResolveSchemaOptions<TSchemaOptions>>>>;
+    toJSON(options: ToObjectOptions & { flattenMaps: false }): Default__v<Require_id<DocType>, ResolveSchemaOptions<TSchemaOptions>>;
+    toJSON(options: ToObjectOptions & { flattenMaps: false, flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType>, ResolveSchemaOptions<TSchemaOptions>>>;
 
     toJSON<T = Default__v<Require_id<DocType>, TSchemaOptions>>(options?: ToObjectOptions & { flattenMaps?: true, flattenObjectIds?: false }): FlattenMaps<T>;
     toJSON<T = Default__v<Require_id<DocType>, TSchemaOptions>>(options: ToObjectOptions & { flattenObjectIds: false }): FlattenMaps<T>;
@@ -276,14 +276,14 @@ declare module 'mongoose' {
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
     toObject(options: ToObjectOptions & { versionKey: false, virtuals: true, flattenObjectIds: true }): Omit<ObjectIdToString<Require_id<DocType & TVirtuals>>, '__v'>;
-    toObject(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>;
+    toObject(options: ToObjectOptions & { virtuals: true, flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, ResolveSchemaOptions<TSchemaOptions>>>;
     toObject(options: ToObjectOptions & { versionKey: false, flattenObjectIds: true }): Omit<ObjectIdToString<Require_id<DocType & TVirtuals>>, '__v'>;
     toObject(options: ToObjectOptions & { versionKey: false, virtuals: true }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
-    toObject(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>;
+    toObject(options: ToObjectOptions & { virtuals: true }): Default__v<Require_id<DocType & TVirtuals>, ResolveSchemaOptions<TSchemaOptions>>;
     toObject(options: ToObjectOptions & { versionKey: false }): Omit<Require_id<DocType & TVirtuals>, '__v'>;
-    toObject(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, TSchemaOptions>>;
-    toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
-    toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, TSchemaOptions>;
+    toObject(options: ToObjectOptions & { flattenObjectIds: true }): ObjectIdToString<Default__v<Require_id<DocType & TVirtuals>, ResolveSchemaOptions<TSchemaOptions>>>;
+    toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>, ResolveSchemaOptions<TSchemaOptions>>;
+    toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
 
     /** Clears the modified state on the specified path. */
     unmarkModified<T extends keyof DocType>(path: T): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -140,9 +140,21 @@ declare module 'mongoose' {
     ? IfAny<U, T & { _id: Types.ObjectId }, T & Required<{ _id: U }>>
     : T & { _id: Types.ObjectId };
 
-  export type Default__v<T, TSchemaOptions = {}> = TSchemaOptions extends { versionKey: false } ? T : T extends { __v?: infer U }
+  export type Default__v<T, TSchemaOptions = {}> = TSchemaOptions extends { versionKey: false }
     ? T
-    : T & { __v: number };
+    : TSchemaOptions extends { versionKey: infer VK }
+      ? (
+          // If VK is a *literal* string, add that property
+          T & {
+            [K in VK as K extends string
+              ? (string extends K ? never : K) // drop if wide string
+              : never
+            ]: number
+          }
+        )
+      : T extends { __v?: infer U }
+        ? T
+        : T & { __v: number };
 
   /** Helper type for getting the hydrated document type from the raw document type. The hydrated document type is what `new MyModel()` returns. */
   export type HydratedDocument<


### PR DESCRIPTION
Fix #15578

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`toJSON()` converts ObjectIds to strings using `ObjectIdToString` helper, but `toObject()` currently does not.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
