### PR TITLE
Fix docs jsdoc tags and add UUID to be listed.

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -29,6 +29,7 @@ const files = [
   'lib/schema/number.js',
   'lib/schema/objectId.js',
   'lib/schema/string.js',
+  'lib/schema/uuid.js',
   'lib/options/schemaTypeOptions.js',
   'lib/options/schemaArrayOptions.js',
   'lib/options/schemaBufferOptions.js',
@@ -42,7 +43,8 @@ const files = [
   'lib/types/buffer.js',
   'lib/types/decimal128.js',
   'lib/types/map.js',
-  'lib/types/array/methods/index.js'
+  'lib/types/array/methods/index.js',
+  'lib/types/uuid.js'
 ];
 
 /** @type {Map.<string, DocsObj>} */

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -654,6 +654,8 @@ function cast$elemMatch(val, context) {
  * For example, `$conditionalHandlers.$all` is the function Mongoose calls to cast `$all` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaArray
+ * @instance
  * @api public
  */
 

--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -100,7 +100,7 @@ SchemaBigInt.get = SchemaType.get;
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -190,6 +190,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$in` is the function Mongoose calls to cast `$in` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaBigInt
+ * @instance
  * @api public
  */
 

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -105,7 +105,7 @@ SchemaBoolean.get = SchemaType.get;
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -242,6 +242,8 @@ const $conditionalHandlers = { ...SchemaType.prototype.$conditionalHandlers };
  * For example, `$conditionalHandlers.$in` is the function Mongoose calls to cast `$in` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaBoolean
+ * @instance
  * @api public
  */
 

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -276,6 +276,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$exists` is the function Mongoose calls to cast `$exists` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaBuffer
+ * @instance
  * @api public
  */
 

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -111,7 +111,7 @@ SchemaDate.get = SchemaType.get;
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -402,6 +402,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$gte` is the function Mongoose calls to cast `$gte` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaDate
+ * @instance
  * @api public
  */
 

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -227,6 +227,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$lte` is the function Mongoose calls to cast `$lte` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaDecimal128
+ * @instance
  * @api public
  */
 

--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -122,6 +122,8 @@ SchemaDocumentArray.prototype.OptionsConstructor = SchemaDocumentArrayOptions;
  * For example, `$conditionalHandlers.$size` is the function Mongoose calls to cast `$size` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaDocumentArray
+ * @instance
  * @api public
  */
 

--- a/lib/schema/double.js
+++ b/lib/schema/double.js
@@ -115,7 +115,7 @@ SchemaDouble._defaultCaster = v => {
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -210,6 +210,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$lt` is the function Mongoose calls to cast `$lt` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaDouble
+ * @instance
  * @api public
  */
 

--- a/lib/schema/int32.js
+++ b/lib/schema/int32.js
@@ -119,7 +119,7 @@ SchemaInt32._defaultCaster = v => {
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -214,6 +214,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$gt` is the function Mongoose calls to cast `$gt` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaInt32
+ * @instance
  * @api public
  */
 

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -93,7 +93,7 @@ SchemaNumber._cast = castNumber;
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -418,6 +418,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$gte` is the function Mongoose calls to cast `$gte` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaNumber
+ * @instance
  * @api public
  */
 

--- a/lib/schema/objectId.js
+++ b/lib/schema/objectId.js
@@ -143,7 +143,7 @@ SchemaObjectId._cast = castObjectId;
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -273,6 +273,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$in` is the function Mongoose calls to cast `$in` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaObjectId
+ * @instance
  * @api public
  */
 
@@ -310,6 +312,7 @@ function resetId(v) {
  * @param [options]
  * @param [options.useBsonType=false] If true, return a representation with `bsonType` for use with MongoDB's `$jsonSchema`.
  * @returns {Object} JSON schema properties
+ * @api public
  */
 
 SchemaObjectId.prototype.toJSONSchema = function toJSONSchema(options) {

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -75,7 +75,7 @@ SchemaString._cast = castString;
  *
  * @param {Function} caster
  * @return {Function}
- * @function get
+ * @function cast
  * @static
  * @api public
  */
@@ -665,6 +665,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$exists` is the function Mongoose calls to cast `$exists` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaString
+ * @instance
  * @api public
  */
 

--- a/lib/schema/subdocument.js
+++ b/lib/schema/subdocument.js
@@ -158,6 +158,8 @@ $conditionalHandlers.$exists = $exists;
  * For example, `$conditionalHandlers.$exists` is the function Mongoose calls to cast `$exists` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaSubdocument
+ * @instance
  * @api public
  */
 

--- a/lib/schema/uuid.js
+++ b/lib/schema/uuid.js
@@ -263,6 +263,8 @@ const $conditionalHandlers = {
  * For example, `$conditionalHandlers.$exists` is the function Mongoose calls to cast `$exists` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaUUID
+ * @instance
  * @api public
  */
 

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1643,6 +1643,8 @@ function handle$in(val, context) {
  * For example, `$conditionalHandlers.$exists` is the function Mongoose calls to cast `$exists` filter operators.
  *
  * @property $conditionalHandlers
+ * @memberOf SchemaType
+ * @instance
  * @api public
  */
 


### PR DESCRIPTION
**Summary**

This PR fixes some issues i came across in the docs once again:
- functions `cast` were labeled as `get`
- property `$conditionalHandlers` did not have the proper jsdoc tags, so at parse time it did not know where it belonged to (resulting in `function Object() { [native code] }.prototype.$conditionalHandlers`)

Additionally, i added `Types.UUID` and `Schema.Types.UUID` to be listed in the sidebar.