### PR TITLE
fix(schema/index): expose "DocumentArrayElement"

### DIFF
--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -12,6 +12,7 @@ exports.Buffer = require('./buffer');
 exports.Date = require('./date');
 exports.Decimal128 = exports.Decimal = require('./decimal128');
 exports.DocumentArray = require('./documentArray');
+exports.DocumentArrayElement = require('./documentArrayElement');
 exports.Map = require('./map');
 exports.Mixed = require('./mixed');
 exports.Number = require('./number');


### PR DESCRIPTION
**Summary**

While doing the typegoose migration for #15587, i noticed that the type `SchemaDocumentArrayElement` was not publicly exposed, but typegoose tested against a path being something specific.
Though i dont know if this type is only meant as a private type. (though it is marked `@api public`)

[typegoose for mongoose 8.x](https://github.com/typegoose/typegoose/blob/c6653b7dc57da09aa738b9ee89673a7ef74911be/test/tests/shouldAdd.test.ts#L450)
[typegoose for mongoose 9.0](https://github.com/typegoose/typegoose/blob/6ca1ff703ebbe337cb6d101d1306d58a732468ee/test/tests/shouldAdd.test.ts#L452)

Note that this is DRAFT until figuring out if this is actually meant to be public, then i will try to fix the failing tests.