### PR TITLE
BREAKING CHANGE: remove support for callbacks in pre middleware

### DIFF
--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -185,12 +185,14 @@ const { promiseOrCallback } = require('mongoose');
 promiseOrCallback; // undefined in Mongoose 9
 ```
 
-## In `isAsync` middleware `next()` errors take priority over `done()` errors
+## `isAsync` middleware no longer supported
 
-Due to Mongoose middleware now relying on promises and async/await, `next()` errors take priority over `done()` errors.
-If you use `isAsync` middleware, any errors in `next()` will be thrown first, and `done()` errors will only be thrown if there are no `next()` errors.
+Mongoose 9 no longer supports `isAsync` middleware. Middleware functions that use the legacy signature with both `next` and `done` callbacks (i.e., `function(next, done)`) are not supported. We recommend middleware now use promises or async/await.
+
+If you have code that uses `isAsync` middleware, you must refactor it to use async functions or return a promise instead.
 
 ```javascript
+// ❌ Not supported in Mongoose 9
 const schema = new Schema({});
 
 schema.pre('save', true, function(next, done) {
@@ -214,8 +216,16 @@ schema.pre('save', true, function(next, done) {
     25);
 });
 
-// In Mongoose 8, with the above middleware, `save()` would error with 'first done() error'
-// In Mongoose 9, with the above middleware, `save()` will error with 'second next() error'
+// ✅ Supported in Mongoose 9: use async functions or return a promise
+schema.pre('save', async function() {
+  execed.first = true;
+  await new Promise(resolve => setTimeout(resolve, 5));
+});
+
+schema.pre('save', async function() {
+  execed.second = true;
+  await new Promise(resolve => setTimeout(resolve, 25));
+});
 ```
 
 ## Removed `skipOriginalStackTraces` option

--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -42,15 +42,13 @@ module.exports = function setupTimestamps(schema, timestamps) {
 
   schema.add(schemaAdditions);
 
-  schema.pre('save', function timestampsPreSave(next) {
+  schema.pre('save', function timestampsPreSave() {
     const timestampOption = get(this, '$__.saveOptions.timestamps');
     if (timestampOption === false) {
-      return next();
+      return;
     }
 
     setDocumentTimestamps(this, timestampOption, currentTime, createdAt, updatedAt);
-
-    next();
   });
 
   schema.methods.initializeTimestamps = function() {
@@ -88,7 +86,7 @@ module.exports = function setupTimestamps(schema, timestamps) {
   schema.pre('updateOne', opts, _setTimestampsOnUpdate);
   schema.pre('updateMany', opts, _setTimestampsOnUpdate);
 
-  function _setTimestampsOnUpdate(next) {
+  function _setTimestampsOnUpdate() {
     const now = currentTime != null ?
       currentTime() :
       this.model.base.now();
@@ -105,6 +103,5 @@ module.exports = function setupTimestamps(schema, timestamps) {
       replaceOps.has(this.op)
     );
     applyTimestampsToChildren(now, this.getUpdate(), this.model.schema);
-    next();
   }
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -2914,7 +2914,6 @@ Model.insertMany = async function insertMany(arr, options) {
     await this._middleware.execPost('insertMany', this, [arr], { error });
   }
 
-
   options = options || {};
   const ThisModel = this;
   const limit = options.limit || 1000;

--- a/lib/plugins/validateBeforeSave.js
+++ b/lib/plugins/validateBeforeSave.js
@@ -6,7 +6,7 @@
 
 module.exports = function validateBeforeSave(schema) {
   const unshift = true;
-  schema.pre('save', false, async function validateBeforeSave(_next, options) {
+  schema.pre('save', false, async function validateBeforeSave(options) {
     // Nested docs have their own presave
     if (this.$isSubdocument) {
       return;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "commonjs",
   "license": "MIT",
   "dependencies": {
-    "kareem": "git+https://github.com/mongoosejs/kareem.git#vkarpov15/v3",
+    "kareem": "git+https://github.com/mongoosejs/kareem.git#vkarpov15/remove-isasync",
     "mongodb": "~6.18.0",
     "mpath": "0.9.0",
     "mquery": "5.0.0",

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -886,9 +886,9 @@ describe('aggregate: ', function() {
         const s = new Schema({ name: String });
 
         let called = 0;
-        s.pre('aggregate', function(next) {
+        s.pre('aggregate', function() {
           ++called;
-          next();
+          return Promise.resolve();
         });
 
         const M = db.model('Test', s);
@@ -902,9 +902,9 @@ describe('aggregate: ', function() {
       it('setting option in pre (gh-7606)', async function() {
         const s = new Schema({ name: String });
 
-        s.pre('aggregate', function(next) {
+        s.pre('aggregate', function() {
           this.options.collation = { locale: 'en_US', strength: 1 };
-          next();
+          return Promise.resolve();
         });
 
         const M = db.model('Test', s);
@@ -920,9 +920,9 @@ describe('aggregate: ', function() {
       it('adding to pipeline in pre (gh-8017)', async function() {
         const s = new Schema({ name: String });
 
-        s.pre('aggregate', function(next) {
+        s.pre('aggregate', function() {
           this.append({ $limit: 1 });
-          next();
+          return Promise.resolve();
         });
 
         const M = db.model('Test', s);
@@ -980,8 +980,8 @@ describe('aggregate: ', function() {
         const s = new Schema({ name: String });
 
         const calledWith = [];
-        s.pre('aggregate', function(next) {
-          next(new Error('woops'));
+        s.pre('aggregate', function() {
+          return Promise.reject(new Error('woops'));
         });
         s.post('aggregate', function(error, res, next) {
           calledWith.push(error);
@@ -1003,9 +1003,9 @@ describe('aggregate: ', function() {
 
         let calledPre = 0;
         let calledPost = 0;
-        s.pre('aggregate', function(next) {
+        s.pre('aggregate', function() {
           ++calledPre;
-          next();
+          return Promise.resolve();
         });
         s.post('aggregate', function(res, next) {
           ++calledPost;
@@ -1030,9 +1030,9 @@ describe('aggregate: ', function() {
 
         let calledPre = 0;
         const calledPost = [];
-        s.pre('aggregate', function(next) {
+        s.pre('aggregate', function() {
           ++calledPre;
-          next();
+          return Promise.resolve();
         });
         s.post('aggregate', function(res, next) {
           calledPost.push(res);
@@ -1295,11 +1295,10 @@ describe('aggregate: ', function() {
   it('cursor() errors out if schema pre aggregate hook throws an error (gh-15279)', async function() {
     const schema = new Schema({ name: String });
 
-    schema.pre('aggregate', function(next) {
+    schema.pre('aggregate', function() {
       if (!this.options.allowed) {
         throw new Error('Unauthorized aggregate operation: only allowed operations are permitted');
       }
-      next();
     });
 
     const Test = db.model('Test', schema);

--- a/test/docs/discriminators.test.js
+++ b/test/docs/discriminators.test.js
@@ -164,17 +164,15 @@ describe('discriminator docs', function() {
 
     const eventSchema = new mongoose.Schema({ time: Date }, options);
     let eventSchemaCalls = 0;
-    eventSchema.pre('validate', function(next) {
+    eventSchema.pre('validate', function() {
       ++eventSchemaCalls;
-      next();
     });
     const Event = mongoose.model('GenericEvent', eventSchema);
 
     const clickedLinkSchema = new mongoose.Schema({ url: String }, options);
     let clickedSchemaCalls = 0;
-    clickedLinkSchema.pre('validate', function(next) {
+    clickedLinkSchema.pre('validate', function() {
       ++clickedSchemaCalls;
-      next();
     });
     const ClickedLinkEvent = Event.discriminator('ClickedLinkEvent',
       clickedLinkSchema);

--- a/test/document.modified.test.js
+++ b/test/document.modified.test.js
@@ -323,9 +323,8 @@ describe('document modified', function() {
       });
 
       let preCalls = 0;
-      childSchema.pre('save', function(next) {
+      childSchema.pre('save', function() {
         ++preCalls;
-        next();
       });
 
       let postCalls = 0;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -2210,9 +2210,8 @@ describe('document', function() {
       }, { _id: false, id: false });
 
       let userHookCount = 0;
-      userSchema.pre('save', function(next) {
+      userSchema.pre('save', function() {
         ++userHookCount;
-        next();
       });
 
       const eventSchema = new mongoose.Schema({
@@ -2221,9 +2220,8 @@ describe('document', function() {
       });
 
       let eventHookCount = 0;
-      eventSchema.pre('save', function(next) {
+      eventSchema.pre('save', function() {
         ++eventHookCount;
-        next();
       });
 
       const Event = db.model('Event', eventSchema);
@@ -2785,9 +2783,8 @@ describe('document', function() {
       const childSchema = new Schema({ count: Number });
 
       let preCalls = 0;
-      childSchema.pre('save', function(next) {
+      childSchema.pre('save', function() {
         ++preCalls;
-        next();
       });
 
       const SingleNestedSchema = new Schema({
@@ -2981,10 +2978,9 @@ describe('document', function() {
         name: String
       });
 
-      ChildSchema.pre('save', function(next) {
+      ChildSchema.pre('save', function() {
         assert.ok(this.isModified('name'));
         ++called;
-        next();
       });
 
       const ParentSchema = new Schema({
@@ -3316,9 +3312,8 @@ describe('document', function() {
       });
 
       const called = {};
-      ChildSchema.pre('deleteOne', { document: true, query: false }, function(next) {
+      ChildSchema.pre('deleteOne', { document: true, query: false }, function() {
         called[this.name] = true;
-        next();
       });
 
       const ParentSchema = new Schema({
@@ -4245,9 +4240,8 @@ describe('document', function() {
         name: String
       }, { timestamps: true, versionKey: null });
 
-      schema.pre('save', function(next) {
+      schema.pre('save', function() {
         this.$where = { updatedAt: this.updatedAt };
-        next();
       });
 
       schema.post('save', function(error, res, next) {
@@ -4331,9 +4325,8 @@ describe('document', function() {
       });
       let count = 0;
 
-      childSchema.pre('validate', function(next) {
+      childSchema.pre('validate', function() {
         ++count;
-        next();
       });
 
       const parentSchema = new Schema({
@@ -4371,9 +4364,8 @@ describe('document', function() {
       });
       let count = 0;
 
-      childSchema.pre('validate', function(next) {
+      childSchema.pre('validate', function() {
         ++count;
-        next();
       });
 
       const parentSchema = new Schema({
@@ -4949,8 +4941,8 @@ describe('document', function() {
     it('handles errors in subdoc pre validate (gh-5215)', async function() {
       const childSchema = new mongoose.Schema({});
 
-      childSchema.pre('validate', function(next) {
-        next(new Error('child pre validate'));
+      childSchema.pre('validate', function() {
+        throw new Error('child pre validate');
       });
 
       const parentSchema = new mongoose.Schema({
@@ -6034,11 +6026,10 @@ describe('document', function() {
         e: { type: String }
       });
 
-      MainSchema.pre('save', function(next) {
+      MainSchema.pre('save', function() {
         if (this.isModified()) {
           this.set('a.c', 100, Number);
         }
-        next();
       });
 
       const Main = db.model('Test', MainSchema);
@@ -8561,13 +8552,12 @@ describe('document', function() {
     const owners = [];
 
     // Middleware to set a default location name derived from the parent organization doc
-    locationSchema.pre('validate', function(next) {
+    locationSchema.pre('validate', function() {
       const owner = this.ownerDocument();
       owners.push(owner);
       if (this.isNew && !this.get('name') && owner.get('name')) {
         this.set('name', `${owner.get('name')} Office`);
       }
-      next();
     });
 
     const organizationSchema = Schema({
@@ -10101,9 +10091,8 @@ describe('document', function() {
       }
     }, {});
     let count = 0;
-    SubSchema.pre('deleteOne', { document: true, query: false }, function(next) {
+    SubSchema.pre('deleteOne', { document: true, query: false }, function() {
       count++;
-      next();
     });
     const thisSchema = new Schema({
       foo: {
@@ -10301,10 +10290,8 @@ describe('document', function() {
       observers: [observerSchema]
     });
 
-    entrySchema.pre('save', function(next) {
+    entrySchema.pre('save', function() {
       this.observers = [{ user: this.creator }];
-
-      next();
     });
 
     const Test = db.model('Test', entrySchema);
@@ -10984,15 +10971,13 @@ describe('document', function() {
 
     const Book = db.model('Test', BookSchema);
 
-    function disallownumflows(next) {
+    function disallownumflows() {
       const self = this;
-      if (self.isNew) return next();
+      if (self.isNew) return;
 
       if (self.quantity === 27) {
-        return next(new Error('Wrong Quantity'));
+        throw new Error('Wrong Quantity');
       }
-
-      next();
     }
 
     const { _id } = await Book.create({ name: 'Hello', price: 50, quantity: 25 });
@@ -13859,17 +13844,15 @@ describe('document', function() {
       postDeleteOne: 0
     };
     let postDeleteOneError = null;
-    ChildSchema.pre('save', function(next) {
+    ChildSchema.pre('save', function() {
       ++called.preSave;
-      next();
     });
     ChildSchema.post('save', function(subdoc, next) {
       ++called.postSave;
       next();
     });
-    ChildSchema.pre('deleteOne', { document: true, query: false }, function(next) {
+    ChildSchema.pre('deleteOne', { document: true, query: false }, function() {
       ++called.preDeleteOne;
-      next();
     });
     ChildSchema.post('deleteOne', { document: true, query: false }, function(subdoc, next) {
       ++called.postDeleteOne;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -302,9 +302,8 @@ describe('mongoose module:', function() {
     mong.plugin(function(s) {
       calls.push(s);
 
-      s.pre('save', function(next) {
+      s.pre('save', function() {
         ++preSaveCalls;
-        next();
       });
 
       s.methods.testMethod = function() { return 42; };

--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -79,14 +79,15 @@ describe('model', function() {
       });
 
       let startTime, endTime;
-      SchemaWithPreSaveHook.pre('save', true, function hook(next, done) {
-        setTimeout(function() {
-          countPre++;
-          if (countPre === 1) startTime = Date.now();
-          else if (countPre === 4) endTime = Date.now();
-          next();
-          done();
-        }, 100);
+      SchemaWithPreSaveHook.pre('save', function hook() {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            countPre++;
+            if (countPre === 1) startTime = Date.now();
+            else if (countPre === 4) endTime = Date.now();
+            resolve();
+          }, 100);
+        });
       });
       SchemaWithPreSaveHook.post('save', function() {
         countPost++;
@@ -182,10 +183,9 @@ describe('model', function() {
 
         const Count = db.model('gh4038', countSchema);
 
-        testSchema.pre('save', async function(next) {
+        testSchema.pre('save', async function() {
           const doc = await Count.findOneAndUpdate({}, { $inc: { n: 1 } }, { new: true, upsert: true });
           this.reference = doc.n;
-          next();
         });
 
         const Test = db.model('gh4038Test', testSchema);

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -55,8 +55,7 @@ EmployeeSchema.statics.findByDepartment = function() {
 EmployeeSchema.path('department').validate(function(value) {
   return /[a-zA-Z]/.test(value);
 }, 'Invalid name');
-const employeeSchemaPreSaveFn = function(next) {
-  next();
+const employeeSchemaPreSaveFn = function() {
 };
 EmployeeSchema.pre('save', employeeSchemaPreSaveFn);
 EmployeeSchema.set('toObject', { getters: true, virtuals: false });
@@ -396,9 +395,8 @@ describe('model', function() {
 
       it('deduplicates hooks (gh-2945)', function() {
         let called = 0;
-        function middleware(next) {
+        function middleware() {
           ++called;
-          next();
         }
 
         function ActivityBaseSchema() {
@@ -584,14 +582,12 @@ describe('model', function() {
         });
         let childCalls = 0;
         let childValidateCalls = 0;
-        const preValidate = function preValidate(next) {
+        const preValidate = function preValidate() {
           ++childValidateCalls;
-          next();
         };
         childSchema.pre('validate', preValidate);
-        childSchema.pre('save', function(next) {
+        childSchema.pre('save', function() {
           ++childCalls;
-          next();
         });
 
         const personSchema = new Schema({
@@ -603,9 +599,8 @@ describe('model', function() {
           heir: childSchema
         });
         let parentCalls = 0;
-        parentSchema.pre('save', function(next) {
+        parentSchema.pre('save', function() {
           ++parentCalls;
-          next();
         });
 
         const Person = db.model('Person', personSchema);
@@ -1258,18 +1253,16 @@ describe('model', function() {
         { message: String },
         { discriminatorKey: 'kind', _id: false }
       );
-      eventSchema.pre('validate', function(next) {
+      eventSchema.pre('validate', function() {
         counters.eventPreValidate++;
-        next();
       });
 
       eventSchema.post('validate', function() {
         counters.eventPostValidate++;
       });
 
-      eventSchema.pre('save', function(next) {
+      eventSchema.pre('save', function() {
         counters.eventPreSave++;
-        next();
       });
 
       eventSchema.post('save', function() {
@@ -1280,18 +1273,16 @@ describe('model', function() {
         product: String
       }, { _id: false });
 
-      purchasedSchema.pre('validate', function(next) {
+      purchasedSchema.pre('validate', function() {
         counters.purchasePreValidate++;
-        next();
       });
 
       purchasedSchema.post('validate', function() {
         counters.purchasePostValidate++;
       });
 
-      purchasedSchema.pre('save', function(next) {
+      purchasedSchema.pre('save', function() {
         counters.purchasePreSave++;
-        next();
       });
 
       purchasedSchema.post('save', function() {
@@ -2348,9 +2339,8 @@ describe('model', function() {
     });
 
     const subdocumentPreSaveHooks = [];
-    subdocumentSchema.pre('save', function(next) {
+    subdocumentSchema.pre('save', function() {
       subdocumentPreSaveHooks.push(this);
-      next();
     });
 
     const schema = mongoose.Schema({
@@ -2359,9 +2349,8 @@ describe('model', function() {
     }, { discriminatorKey: 'type' });
 
     const documentPreSaveHooks = [];
-    schema.pre('save', function(next) {
+    schema.pre('save', function() {
       documentPreSaveHooks.push(this);
-      next();
     });
 
     const Document = db.model('Document', schema);
@@ -2369,9 +2358,8 @@ describe('model', function() {
     const discriminatorSchema = mongoose.Schema({});
 
     const discriminatorPreSaveHooks = [];
-    discriminatorSchema.pre('save', function(next) {
+    discriminatorSchema.pre('save', function() {
       discriminatorPreSaveHooks.push(this);
-      next();
     });
 
     const Discriminator = Document.discriminator('Discriminator', discriminatorSchema);

--- a/test/model.insertMany.test.js
+++ b/test/model.insertMany.test.js
@@ -279,18 +279,16 @@ describe('insertMany()', function() {
     });
     let calledPre = 0;
     let calledPost = 0;
-    schema.pre('insertMany', function(next, docs) {
+    schema.pre('insertMany', function(docs) {
       assert.equal(docs.length, 2);
       assert.equal(docs[0].name, 'Star Wars');
       ++calledPre;
-      next();
     });
-    schema.pre('insertMany', function(next, docs) {
+    schema.pre('insertMany', function(docs) {
       assert.equal(docs.length, 2);
       assert.equal(docs[0].name, 'Star Wars');
       docs[0].name = 'A New Hope';
       ++calledPre;
-      next();
     });
     schema.post('insertMany', function() {
       ++calledPost;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -408,9 +408,8 @@ describe('Model', function() {
       name: String
     });
 
-    childSchema.pre('save', function(next) {
+    childSchema.pre('save', function() {
       child_hook = this.name;
-      next();
     });
 
     const parentSchema = new Schema({
@@ -418,9 +417,8 @@ describe('Model', function() {
       children: [childSchema]
     });
 
-    parentSchema.pre('save', function(next) {
+    parentSchema.pre('save', function() {
       parent_hook = this.name;
-      next();
     });
 
     const Parent = db.model('Parent', parentSchema);
@@ -1016,11 +1014,10 @@ describe('Model', function() {
           baz: { type: String }
         });
 
-        ValidationMiddlewareSchema.pre('validate', function(next) {
+        ValidationMiddlewareSchema.pre('validate', function() {
           if (this.get('baz') === 'bad') {
             this.invalidate('baz', 'bad');
           }
-          next();
         });
 
         Post = db.model('Test', ValidationMiddlewareSchema);
@@ -2096,14 +2093,12 @@ describe('Model', function() {
         const schema = new Schema({ name: String });
         let called = 0;
 
-        schema.pre('save', function(next) {
+        schema.pre('save', function() {
           called++;
-          next(undefined);
         });
 
-        schema.pre('save', function(next) {
+        schema.pre('save', function() {
           called++;
-          next(null);
         });
 
         const S = db.model('Test', schema);
@@ -2115,22 +2110,19 @@ describe('Model', function() {
 
       it('called on all sub levels', async function() {
         const grandSchema = new Schema({ name: String });
-        grandSchema.pre('save', function(next) {
+        grandSchema.pre('save', function() {
           this.name = 'grand';
-          next();
         });
 
         const childSchema = new Schema({ name: String, grand: [grandSchema] });
-        childSchema.pre('save', function(next) {
+        childSchema.pre('save', function() {
           this.name = 'child';
-          next();
         });
 
         const schema = new Schema({ name: String, child: [childSchema] });
 
-        schema.pre('save', function(next) {
+        schema.pre('save', function() {
           this.name = 'parent';
-          next();
         });
 
         const S = db.model('Test', schema);
@@ -2144,21 +2136,19 @@ describe('Model', function() {
 
       it('error on any sub level', async function() {
         const grandSchema = new Schema({ name: String });
-        grandSchema.pre('save', function(next) {
-          next(new Error('Error 101'));
+        grandSchema.pre('save', function() {
+          throw new Error('Error 101');
         });
 
         const childSchema = new Schema({ name: String, grand: [grandSchema] });
-        childSchema.pre('save', function(next) {
+        childSchema.pre('save', function() {
           this.name = 'child';
-          next();
         });
 
         let schemaPostSaveCalls = 0;
         const schema = new Schema({ name: String, child: [childSchema] });
-        schema.pre('save', function(next) {
+        schema.pre('save', function() {
           this.name = 'parent';
-          next();
         });
         schema.post('save', function testSchemaPostSave(err, res, next) {
           ++schemaPostSaveCalls;
@@ -2480,8 +2470,8 @@ describe('Model', function() {
     describe('when no callback is passed', function() {
       it('should emit error on its Model when there are listeners', async function() {
         const DefaultErrSchema = new Schema({});
-        DefaultErrSchema.pre('save', function(next) {
-          next(new Error());
+        DefaultErrSchema.pre('save', function() {
+          throw new Error();
         });
 
         const DefaultErr = db.model('Test', DefaultErrSchema);
@@ -6072,9 +6062,8 @@ describe('Model', function() {
     };
 
     let called = 0;
-    schema.pre('aggregate', function(next) {
+    schema.pre('aggregate', function() {
       ++called;
-      next();
     });
     const Model = db.model('Test', schema);
 
@@ -6101,9 +6090,8 @@ describe('Model', function() {
     };
 
     let called = 0;
-    schema.pre('insertMany', function(next) {
+    schema.pre('insertMany', function() {
       ++called;
-      next();
     });
     const Model = db.model('Test', schema);
 
@@ -6126,9 +6114,8 @@ describe('Model', function() {
     };
 
     let called = 0;
-    schema.pre('save', function(next) {
+    schema.pre('save', function() {
       ++called;
-      next();
     });
 
     const Model = db.model('Test', schema);
@@ -8144,9 +8131,8 @@ describe('Model', function() {
         name: String
       });
       let bypass = true;
-      testSchema.pre('findOne', function(next) {
+      testSchema.pre('findOne', function() {
         bypass = false;
-        next();
       });
       const Test = db.model('gh13250', testSchema);
       const doc = await Test.create({

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -902,9 +902,8 @@ describe('model: updateOne:', function() {
       let numPres = 0;
       let numPosts = 0;
       const band = new Schema({ members: [String] });
-      band.pre('updateOne', function(next) {
+      band.pre('updateOne', function() {
         ++numPres;
-        next();
       });
       band.post('updateOne', function() {
         ++numPosts;
@@ -1237,9 +1236,8 @@ describe('model: updateOne:', function() {
     it('middleware update with exec (gh-3549)', async function() {
       const Schema = mongoose.Schema({ name: String });
 
-      Schema.pre('updateOne', function(next) {
+      Schema.pre('updateOne', function() {
         this.updateOne({ name: 'Val' });
-        next();
       });
 
       const Model = db.model('Test', Schema);

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -209,9 +209,8 @@ describe('QueryCursor', function() {
     it('with pre-find hooks (gh-5096)', async function() {
       const schema = new Schema({ name: String });
       let called = 0;
-      schema.pre('find', function(next) {
+      schema.pre('find', function() {
         ++called;
-        next();
       });
 
       db.deleteModel(/Test/);
@@ -883,8 +882,8 @@ describe('QueryCursor', function() {
   it('throws if calling skipMiddlewareFunction() with non-empty array (gh-13411)', async function() {
     const schema = new mongoose.Schema({ name: String });
 
-    schema.pre('find', (next) => {
-      next(mongoose.skipMiddlewareFunction([{ name: 'bar' }]));
+    schema.pre('find', () => {
+      throw mongoose.skipMiddlewareFunction([{ name: 'bar' }]);
     });
 
     const Movie = db.model('Movie', schema);

--- a/test/query.middleware.test.js
+++ b/test/query.middleware.test.js
@@ -58,9 +58,8 @@ describe('query middleware', function() {
 
   it('has a pre find hook', async function() {
     let count = 0;
-    schema.pre('find', function(next) {
+    schema.pre('find', function() {
       ++count;
-      next();
     });
 
     await initializeData();
@@ -87,9 +86,8 @@ describe('query middleware', function() {
 
   it('works when using a chained query builder', async function() {
     let count = 0;
-    schema.pre('find', function(next) {
+    schema.pre('find', function() {
       ++count;
-      next();
     });
 
     let postCount = 0;
@@ -110,9 +108,8 @@ describe('query middleware', function() {
 
   it('has separate pre-findOne() and post-findOne() hooks', async function() {
     let count = 0;
-    schema.pre('findOne', function(next) {
+    schema.pre('findOne', function() {
       ++count;
-      next();
     });
 
     let postCount = 0;
@@ -132,9 +129,8 @@ describe('query middleware', function() {
   it('with regular expression (gh-6680)', async function() {
     let count = 0;
     let postCount = 0;
-    schema.pre(/find/, function(next) {
+    schema.pre(/find/, function() {
       ++count;
-      next();
     });
 
     schema.post(/find/, function(result, next) {
@@ -163,9 +159,8 @@ describe('query middleware', function() {
   });
 
   it('can populate in pre hook', async function() {
-    schema.pre('findOne', function(next) {
+    schema.pre('findOne', function() {
       this.populate('publisher');
-      next();
     });
 
     await initializeData();
@@ -442,8 +437,8 @@ describe('query middleware', function() {
     const schema = new Schema({});
     let called = false;
 
-    schema.pre('find', function(next) {
-      next(new Error('test'));
+    schema.pre('find', function() {
+      throw new Error('test');
     });
 
     schema.post('find', function(res, next) {
@@ -468,9 +463,8 @@ describe('query middleware', function() {
     let calledPre = 0;
     let calledPost = 0;
 
-    schema.pre('find', function(next) {
+    schema.pre('find', function() {
       ++calledPre;
-      next();
     });
 
     schema.post('find', function(res, next) {
@@ -552,8 +546,8 @@ describe('query middleware', function() {
     const schema = Schema({ name: String });
     const now = Date.now();
 
-    schema.pre('find', function(next) {
-      next(mongoose.skipMiddlewareFunction([{ name: 'from cache' }]));
+    schema.pre('find', function() {
+      throw mongoose.skipMiddlewareFunction([{ name: 'from cache' }]);
     });
     schema.post('find', function(res) {
       res.forEach(doc => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1923,9 +1923,8 @@ describe('Query', function() {
       ];
 
       ops.forEach(function(op) {
-        TestSchema.pre(op, function(next) {
+        TestSchema.pre(op, function() {
           this.error(new Error(op + ' error'));
-          next();
         });
       });
 

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -301,9 +301,8 @@ describe('types.documentarray', function() {
   describe('push()', function() {
     it('does not re-cast instances of its embedded doc', async function() {
       const child = new Schema({ name: String, date: Date });
-      child.pre('save', function(next) {
+      child.pre('save', function() {
         this.date = new Date();
-        next();
       });
       const schema = new Schema({ children: [child] });
       const M = db.model('Test', schema);
@@ -469,10 +468,9 @@ describe('types.documentarray', function() {
   describe('invalidate()', function() {
     it('works', async function() {
       const schema = new Schema({ docs: [{ name: 'string' }] });
-      schema.pre('validate', function(next) {
+      schema.pre('validate', function() {
         const subdoc = this.docs[this.docs.length - 1];
         subdoc.invalidate('name', 'boo boo', '%');
-        next();
       });
       mongoose.deleteModel(/Test/);
       const T = mongoose.model('Test', schema);

--- a/test/types/middleware.preposttypes.test.ts
+++ b/test/types/middleware.preposttypes.test.ts
@@ -5,12 +5,10 @@ interface IDocument extends Document {
   name?: string;
 }
 
-const preMiddlewareFn: PreSaveMiddlewareFunction<Document> = function(next, opts) {
+const preMiddlewareFn: PreSaveMiddlewareFunction<Document> = function(opts) {
   this.$markValid('name');
-  if (opts.session) {
-    next();
-  } else {
-    next(new Error('Operation must be in Session.'));
+  if (!opts.session) {
+    throw new Error('Operation must be in Session.');
   }
 };
 

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1209,15 +1209,15 @@ function gh13633() {
   schema.pre('updateOne', { document: true, query: false }, function(next) {
   });
 
-  schema.pre('updateOne', { document: true, query: false }, function(next, options) {
+  schema.pre('updateOne', { document: true, query: false }, function(options) {
     expectType<Record<string, any> | undefined>(options);
   });
 
   schema.post('save', function(res, next) {
   });
-  schema.pre('insertMany', function(next, docs) {
+  schema.pre('insertMany', function(docs) {
   });
-  schema.pre('insertMany', function(next, docs, options) {
+  schema.pre('insertMany', function(docs, options) {
     expectType<(InsertManyOptions & { lean?: boolean }) | undefined>(options);
   });
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -497,7 +497,6 @@ declare module 'mongoose' {
       method: 'insertMany' | RegExp,
       fn: (
         this: T,
-        next: (err?: CallbackError) => void,
         docs: any | Array<any>,
         options?: InsertManyOptions & { lean?: boolean }
       ) => void | Promise<void>
@@ -507,7 +506,6 @@ declare module 'mongoose' {
       method: 'bulkWrite' | RegExp,
       fn: (
         this: T,
-        next: (err?: CallbackError) => void,
         ops: Array<AnyBulkWriteOperation<any>>,
         options?: mongodb.BulkWriteOptions & MongooseBulkWriteOptions
       ) => void | Promise<void>
@@ -517,7 +515,6 @@ declare module 'mongoose' {
       method: 'createCollection' | RegExp,
       fn: (
         this: T,
-        next: (err?: CallbackError) => void,
         options?: mongodb.CreateCollectionOptions & Pick<SchemaOptions, 'expires'>
       ) => void | Promise<void>
     ): this;

--- a/types/middlewares.d.ts
+++ b/types/middlewares.d.ts
@@ -36,12 +36,10 @@ declare module 'mongoose' {
 
   type PreMiddlewareFunction<ThisType = any> = (
     this: ThisType,
-    next: CallbackWithoutResultAndOptionalError,
     opts?: Record<string, any>
   ) => void | Promise<void> | Kareem.SkipWrappedFunction;
   type PreSaveMiddlewareFunction<ThisType = any> = (
     this: ThisType,
-    next: CallbackWithoutResultAndOptionalError,
     opts: SaveOptions
   ) => void | Promise<void> | Kareem.SkipWrappedFunction;
   type PostMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, res: ResType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void> | Kareem.OverwriteMiddlewareResult;


### PR DESCRIPTION
Fix #11531

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The key issue in #11531 is that `next()` takes up some prime real estate in `pre()` middleware as the first parameter to the middleware function. With `pre('insertMany')` and `pre('bulkWrite')`, you can't do anything non-trival without putting `next`.

This PR removes support for `next()`: all pre middleware just gets the parameters to the wrapped function, no callbacks. This is consistent with our removing of callbacks throughout Mongoose.

@hasezoey @AbdelrahmanHafez what do you think?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
