### PR TITLE
types: correct type inference for maps of maps

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1950,3 +1950,19 @@ function gh10894() {
     expectType<string | number | null | undefined>({} as RawDocType['testProp']);
   }
 }
+
+function autoInferredNestedMaps() {
+  const schema = new Schema({
+    nestedMap: {
+      type: Map,
+      required: true,
+      of: {
+        type: Map,
+        of: String
+      }
+    }
+  });
+  const TestModel = model('Test', schema);
+  const doc = new TestModel({ nestedMap: new Map([['1', new Map([['2', 'value']])]]) });
+  expectType<Map<string, Map<string, string>>>(doc.nestedMap);
+}

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -111,8 +111,8 @@ declare module 'mongoose' {
                                             PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt ? bigint :
                                               PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
                                                 IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
-                                                  PathValueType extends MapConstructor | 'Map' ? Map<string, ResolveRawPathType<Options['of']>> :
-                                                    IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolveRawPathType<Options['of']>> :
+                                                  PathValueType extends MapConstructor | 'Map' ? Map<string, ObtainRawDocumentPathType<Options['of']>> :
+                                                    IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ObtainRawDocumentPathType<Options['of']>> :
                                                       PathValueType extends 'Union' | 'union' | typeof Schema.Types.Union ? Options['of'] extends readonly any[] ? UnionToRawPathType<Options['of']> : never :
                                                         PathValueType extends ArrayConstructor ? any[] :
                                                           PathValueType extends typeof Schema.Types.Mixed ? any:

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -316,8 +316,8 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
                                                   PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer :
                                                     PathValueType extends 'double' | 'Double' | typeof Schema.Types.Double ? Types.Double :
                                                       IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer :
-                                                        PathValueType extends MapConstructor | 'Map' ? Map<string, ResolvePathType<Options['of']>> :
-                                                          IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ResolvePathType<Options['of']>> :
+                                                        PathValueType extends MapConstructor | 'Map' ? Map<string, ObtainDocumentPathType<Options['of']>> :
+                                                          IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ObtainDocumentPathType<Options['of']>> :
                                                             PathValueType extends 'Union' | 'union' | typeof Schema.Types.Union ? Options['of'] extends readonly any[] ? UnionToType<Options['of']> : never :
                                                               PathValueType extends ArrayConstructor ? any[] :
                                                                 PathValueType extends typeof Schema.Types.Mixed ? any:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`InferSchemaType` and `InferRawDocType` don't infer the correct type for maps of maps currently

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
