### PR TITLE
Fix types for a string of enums.

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -1063,6 +1063,30 @@ function stringEnumInfer() {
   type StringEnumRequiredExample = InferSchemaType<typeof stringEnumSchemaRequired>;
   expectAssignable<StringEnum>({} as StringEnumRequiredExample['active']);
 }
+function stringEnumArrayInfer() {
+  enum StringEnum {
+    Foo = 'foo',
+    Bar = 'bar'
+  }
+
+  const stringEnumSchema = new Schema(
+    {
+      active: { type: [String], enum: StringEnum, required: false }
+    }
+  );
+
+  type StringEnumExample = InferSchemaType<typeof stringEnumSchema>;
+  expectAssignable<StringEnum[] | null | undefined>({} as StringEnumExample['active']);
+
+  const stringEnumSchemaRequired = new Schema(
+    {
+      active: { type: [String], enum: StringEnum, required: true }
+    }
+  );
+
+  type StringEnumRequiredExample = InferSchemaType<typeof stringEnumSchemaRequired>;
+  expectAssignable<StringEnum[]>({} as StringEnumRequiredExample['active']);
+}
 
 function gh12882() {
   // Array of strings

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -272,7 +272,7 @@ type ResolvePathType<PathValueType, Options extends SchemaTypeOptions<PathValueT
               // we need to call ObtainDocumentType to correctly infer its type.
               Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>> :
             IsSchemaTypeFromBuiltinClass<Item> extends true ?
-              ObtainDocumentPathType<Item, TypeKey>[] :
+              ResolvePathType<Item, { enum: Options['enum'] }, TypeKey>[] :
               IsItRecordAndNotAny<Item> extends true ?
                 Item extends Record<string, never> ?
                   ObtainDocumentPathType<Item, TypeKey>[] :


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
When using an array of enum, the types inferred was an array string.

The reason is that when resolving the type, we drop the options information by using `ObtainDocumentPathType`. 
The fix was for the Scalar case to recursively use ResolvePathType again and jam in the Options by forwarding the enum value. While not elegant, it works so here is my proposal.