### PR TITLE
types(SchemaOptions): disallow versionKey: true, which fails at runtime

### DIFF
--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -180,7 +180,7 @@ declare module 'mongoose' {
      *
      * @default '__v'
      */
-    versionKey?: string | boolean;
+    versionKey?: string | false;
     /**
      * By default, Mongoose will automatically select() any populated paths for you, unless you explicitly exclude them.
      *


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Setting `versionKey: true` at runtime throws the following error, so we might as well catch this potential issue at compile time.

```
MongooseError: `versionKey` must be falsy or string, got `boolean`
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
