### PR TITLE
types: improve performance on inferSchemaType re: #15588

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -576,7 +576,8 @@ declare module 'mongoose' {
   export type BigintSchemaDefinition = 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | Schema.Types.BigInt | typeof BigInt | BigInt;
   export type UuidSchemaDefinition = 'uuid' | 'UUID' | typeof Schema.Types.UUID | Schema.Types.UUID;
   export type MapSchemaDefinition = MapConstructor | 'Map' | typeof Schema.Types.Map;
-  export type UnionSchemaDefinition = 'Union' | 'union' | typeof Schema.Types.Union;
+  export type UnionSchemaDefinition = 'Union' | 'union' | typeof Schema.Types.Union | Schema.Types.Union;
+  export type DoubleSchemaDefinition = 'double' | 'Double' | typeof Schema.Types.Double | Schema.Types.Double;
 
   export type SchemaDefinitionWithBuiltInClass<T> = T extends number
     ? NumberSchemaDefinition

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -91,6 +91,7 @@ declare module 'mongoose' {
     : PathValueType extends Decimal128SchemaDefinition ? Types.Decimal128
     : PathValueType extends BigintSchemaDefinition ? bigint
     : PathValueType extends UuidSchemaDefinition ? Buffer
+    : PathValueType extends DoubleSchemaDefinition ? Types.Double
     : PathValueType extends MapSchemaDefinition ? Map<string, ObtainRawDocumentPathType<Options['of']>>
     : PathValueType extends UnionSchemaDefinition ?
       ResolveRawPathType<Options['of'] extends ReadonlyArray<infer Item> ? Item : never>

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -1,4 +1,5 @@
 import {
+  AnyArray,
   BooleanSchemaDefinition,
   DateSchemaDefinition,
   DefaultSchemaOptions,
@@ -246,12 +247,9 @@ type IsSchemaTypeFromBuiltinClass<T> =
   : T extends Types.Decimal128 ? true
   : T extends NativeDate ? true
   : T extends typeof Schema.Types.Mixed ? true
-  : IfEquals<T, Schema.Types.ObjectId, true, false> extends true ? true
   : unknown extends Buffer ? false
   : T extends Buffer ? true
   : false;
-
-type UnionToType<T extends readonly any[]> = T[number] extends infer U ? ResolvePathType<U> : never;
 
 /**
  * @summary Resolve path type by returning the corresponding type.
@@ -269,12 +267,10 @@ type ResolvePathType<
   TypeHint,
   never,
   PathValueType extends Schema ? InferSchemaType<PathValueType>
-  : PathValueType extends (infer Item)[] ?
-    IfEquals<
-      Item,
-      never,
-      any[],
-      Item extends Schema ?
+  : PathValueType extends AnyArray<infer Item> ?
+    IfEquals<Item, never> extends true
+      ? any[]
+      : Item extends Schema ?
         // If Item is a schema, infer its type.
         Types.DocumentArray<InferSchemaType<Item>>
       : Item extends Record<TypeKey, any> ?
@@ -291,54 +287,23 @@ type ResolvePathType<
           ObtainDocumentPathType<Item, TypeKey>[]
         : Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>>
       : ObtainDocumentPathType<Item, TypeKey>[]
-    >
-  : PathValueType extends ReadonlyArray<infer Item> ?
-    IfEquals<
-      Item,
-      never,
-      any[],
-      Item extends Schema ? Types.DocumentArray<InferSchemaType<Item>>
-      : Item extends Record<TypeKey, any> ?
-        Item[TypeKey] extends Function | String ?
-          ObtainDocumentPathType<Item, TypeKey>[]
-        : ObtainDocumentType<Item, any, { typeKey: TypeKey }>[]
-      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolvePathType<Item, { enum: Options['enum'] }, TypeKey>[]
-      : IsItRecordAndNotAny<Item> extends true ?
-        Item extends Record<string, never> ?
-          ObtainDocumentPathType<Item, TypeKey>[]
-        : Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>>
-      : ObtainDocumentPathType<Item, TypeKey>[]
-    >
   : PathValueType extends StringSchemaDefinition ? PathEnumOrString<Options['enum']>
-  : IfEquals<PathValueType, Schema.Types.String> extends true ? PathEnumOrString<Options['enum']>
   : IfEquals<PathValueType, String> extends true ? PathEnumOrString<Options['enum']>
   : PathValueType extends NumberSchemaDefinition ?
     Options['enum'] extends ReadonlyArray<any> ?
       Options['enum'][number]
     : number
-  : IfEquals<PathValueType, Schema.Types.Number> extends true ? number
   : PathValueType extends DateSchemaDefinition ? NativeDate
-  : IfEquals<PathValueType, Schema.Types.Date> extends true ? NativeDate
-  : PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer ? Buffer
+  : PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer | Schema.Types.Buffer ? Buffer
   : PathValueType extends BooleanSchemaDefinition ? boolean
-  : IfEquals<PathValueType, Schema.Types.Boolean> extends true ? boolean
   : PathValueType extends ObjectIdSchemaDefinition ? Types.ObjectId
-  : IfEquals<PathValueType, Types.ObjectId> extends true ? Types.ObjectId
-  : IfEquals<PathValueType, Schema.Types.ObjectId> extends true ? Types.ObjectId
-  : PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 ? Types.Decimal128
-  : IfEquals<PathValueType, Schema.Types.Decimal128> extends true ? Types.Decimal128
-  : IfEquals<PathValueType, Types.Decimal128> extends true ? Types.Decimal128
-  : IfEquals<PathValueType, Schema.Types.BigInt> extends true ? bigint
-  : IfEquals<PathValueType, BigInt> extends true ? bigint
-  : PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt ? bigint
-  : PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID ? Buffer
+  : PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 | Types.Decimal128 | Schema.Types.Decimal128 ? Types.Decimal128
+  : PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt | Schema.Types.BigInt ? bigint
+  : PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID | Schema.Types.UUID ? Buffer
   : PathValueType extends 'double' | 'Double' | typeof Schema.Types.Double ? Types.Double
-  : IfEquals<PathValueType, Schema.Types.UUID> extends true ? Buffer
-  : PathValueType extends MapConstructor | 'Map' ? Map<string, ObtainDocumentPathType<Options['of']>>
-  : IfEquals<PathValueType, typeof Schema.Types.Map> extends true ? Map<string, ObtainDocumentPathType<Options['of']>>
+  : PathValueType extends MapConstructor | 'Map' | typeof Schema.Types.Map | Schema.Types.Map ? Map<string, ObtainDocumentPathType<Options['of']>>
   : PathValueType extends 'Union' | 'union' | typeof Schema.Types.Union ?
-    Options['of'] extends readonly any[] ?
-      UnionToType<Options['of']>
+    Options['of'] extends AnyArray<infer U> ? ResolvePathType<U>
     : never
   : PathValueType extends ArrayConstructor ? any[]
   : PathValueType extends typeof Schema.Types.Mixed ? any

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -1,12 +1,17 @@
 import {
   AnyArray,
   BooleanSchemaDefinition,
+  BigintSchemaDefinition,
+  BufferSchemaDefinition,
   DateSchemaDefinition,
+  Decimal128SchemaDefinition,
   DefaultSchemaOptions,
   DefaultTypeKey,
+  DoubleSchemaDefinition,
   IfEquals,
   InferSchemaType,
   IsItRecordAndNotAny,
+  MapSchemaDefinition,
   NumberSchemaDefinition,
   ObjectIdSchemaDefinition,
   ObtainDocumentType,
@@ -14,7 +19,9 @@ import {
   SchemaType,
   SchemaTypeOptions,
   StringSchemaDefinition,
-  Types
+  Types,
+  UnionSchemaDefinition,
+  UuidSchemaDefinition
 } from 'mongoose';
 
 declare module 'mongoose' {
@@ -294,15 +301,15 @@ type ResolvePathType<
       Options['enum'][number]
     : number
   : PathValueType extends DateSchemaDefinition ? NativeDate
-  : PathValueType extends typeof Buffer | 'buffer' | 'Buffer' | typeof Schema.Types.Buffer | Schema.Types.Buffer ? Buffer
+  : PathValueType extends BufferSchemaDefinition ? Buffer
   : PathValueType extends BooleanSchemaDefinition ? boolean
   : PathValueType extends ObjectIdSchemaDefinition ? Types.ObjectId
-  : PathValueType extends 'decimal128' | 'Decimal128' | typeof Schema.Types.Decimal128 | Types.Decimal128 | Schema.Types.Decimal128 ? Types.Decimal128
-  : PathValueType extends 'bigint' | 'BigInt' | typeof Schema.Types.BigInt | typeof BigInt | Schema.Types.BigInt ? bigint
-  : PathValueType extends 'uuid' | 'UUID' | typeof Schema.Types.UUID | Schema.Types.UUID ? Buffer
-  : PathValueType extends 'double' | 'Double' | typeof Schema.Types.Double ? Types.Double
-  : PathValueType extends MapConstructor | 'Map' | typeof Schema.Types.Map | Schema.Types.Map ? Map<string, ObtainDocumentPathType<Options['of']>>
-  : PathValueType extends 'Union' | 'union' | typeof Schema.Types.Union ?
+  : PathValueType extends Decimal128SchemaDefinition ? Types.Decimal128
+  : PathValueType extends BigintSchemaDefinition ? bigint
+  : PathValueType extends UuidSchemaDefinition ? Buffer
+  : PathValueType extends DoubleSchemaDefinition ? Types.Double
+  : PathValueType extends MapSchemaDefinition ? Map<string, ObtainDocumentPathType<Options['of']>>
+  : PathValueType extends UnionSchemaDefinition ?
     Options['of'] extends AnyArray<infer U> ? ResolvePathType<U>
     : never
   : PathValueType extends ArrayConstructor ? any[]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Various performance improvements related to #15588 to make it so that top-line instantiations and memory usage for #15588 are roughly equivalent to master.

1. Consolidate array and readonly array paths
2. Minimize use of `IfEquals`: `IfEquals<>` is only necessary for `String` because of TypeScript's implicit boxing/unboxing (see below screenshot), there's no risk of TypeScript inferring container types for ObjectIds or Decimal128. There is a chance with `Boolean` and `Number`, but only if someone does `type: true` or `type: 42`, I don't think it is worth checking for that case though.
3. Consolidate `UnionToType`

@ssalbdivad can you also please take a look?

<img width="1019" height="349" alt="image" src="https://github.com/user-attachments/assets/0bf80b69-2eee-4164-a6b2-cd8bbe95c8d5" />


<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
