### PR TITLE
types(model): copy base model statics onto discriminator model

### DIFF
--- a/test/types/discriminator.test.ts
+++ b/test/types/discriminator.test.ts
@@ -116,3 +116,28 @@ function gh15535() {
   expectType<string | null | undefined>(doc.field3);
   expectType<string | null | undefined>(doc.getField3());
 }
+
+async function gh15600() {
+  // Base model with custom static method
+  const baseSchema = new Schema(
+    { name: String },
+    {
+      statics: {
+        findByName(name: string) {
+          return this.findOne({ name });
+        }
+      }
+    }
+  );
+  const BaseModel = model('Base', baseSchema);
+
+  const baseRes = await BaseModel.findByName('test');
+  expectType<string | null | undefined>(baseRes!.name);
+
+  // Discriminator model inheriting base static methods
+  const discriminatorSchema = new Schema({ extra: String });
+  const DiscriminatorModel = BaseModel.discriminator('Discriminator', discriminatorSchema);
+
+  const res = await DiscriminatorModel.findByName('test');
+  expectType<string | null | undefined>(res!.name);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -435,7 +435,7 @@ declare module 'mongoose' {
       TQueryHelpers & ObtainSchemaGeneric<TDiscriminatorSchema, 'TQueryHelpers'>,
       TInstanceMethods & ObtainSchemaGeneric<TDiscriminatorSchema, 'TInstanceMethods'>,
       TVirtuals & ObtainSchemaGeneric<TDiscriminatorSchema, 'TVirtuals'>
-    > & ObtainSchemaGeneric<TDiscriminatorSchema, 'TStaticMethods'>;
+    > & ObtainSchemaGeneric<TSchema, 'TStaticMethods'> & ObtainSchemaGeneric<TDiscriminatorSchema, 'TStaticMethods'>;
     discriminator<D>(
       name: string | number,
       schema: Schema,


### PR DESCRIPTION
Fix #15600

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Finally found a use for the `TSchema` parameter to `Model<>`! When using auto inferred schemas, we can infer the base model's `TStaticMethods` and attach it to the discriminator model. All without changing `Model` generics.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
