### PR TITLE
Fix `schema` property type definition in SchemaType

### DIFF
--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -322,8 +322,8 @@ declare module 'mongoose' {
      */
     required(required: boolean, message?: string): this;
 
-    /** The schema this SchemaType instance is part of */
-    schema: Schema<any>;
+    /** If the SchemaType is a subdocument or document array, this is the schema of that subdocument */
+    schema?: Schema<any>;
 
     /** Sets default select() behavior for this path. */
     select(val: boolean): this;


### PR DESCRIPTION
**Summary**

Currently, the `SchemaType` property of `schema` is required in the type definition and its JSDoc describes the property as "The schema this SchemaType instance is part of".

Instead, based on how mongoose actually works, it should be optional and the JSDoc should be changed, since it's not actually the `Schema` that the `SchemaType` is part of. Instead, the `schema` property only exists when the `SchemaType` is for a subdocument or document array and it refers to the actual subdocument schema itself.

**Examples**

Here's an example showing how the `schema` property isn't present on every SchemaType, just to prove that the Typescript definition should be changed to optional and its JSDoc should be modified accordingly.

```ts
import mongoose from "mongoose";

type Person = {
  _id: mongoose.Types.ObjectId;
  name: string;
  doc: {
    _id: mongoose.Types.ObjectId;
    title: string;
  };
};

const personSchema = new mongoose.Schema<Person>(
  {
    name: { type: String, required: true },
    doc: {
      type: {
        title: String,
      },
    },
  },
  { versionKey: false },
);

const Person = mongoose.model("Person", personSchema);

for (const [path, schemaType] of Object.entries(personSchema.paths)) {
  let desc = "";
  if ("schema" in schemaType) {
    desc = Object.keys(schemaType.schema.paths).join(", ");
  } else {
    desc = "n/a";
  }
  console.log(`${path} --> ${desc}`);
  /* OUTPUT:
  name --> n/a
  doc --> title, _id
  _id --> n/a
  */
}
```
