### PR TITLE
fix(document): prevent $clone() from converting mongoose arrays into vanilla arrays

### DIFF
--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -40,7 +40,7 @@ function clone(obj, options, isArrayChild) {
   }
 
   if (Array.isArray(obj)) {
-    return cloneArray(isMongooseArray(obj) ? obj.__array : obj, options);
+    return cloneArray(obj, options);
   }
 
   if (isMongooseObject(obj)) {
@@ -172,7 +172,21 @@ function cloneObject(obj, options, isArrayChild) {
 function cloneArray(arr, options) {
   let i = 0;
   const len = arr.length;
-  const ret = new Array(len);
+
+  let ret = null;
+  if (options?.retainDocuments) {
+    if (arr.isMongooseDocumentArray) {
+      ret = new (arr.$schemaType().schema.base.Types.DocumentArray)([], arr.$path(), arr.$parent(), arr.$schemaType());
+    } else if (arr.isMongooseArray) {
+      ret = new (arr.$parent().schema.base.Types.Array)([], arr.$path(), arr.$parent(), arr.$schemaType());
+    } else {
+      ret = new Array(len);
+    }
+  } else {
+    ret = new Array(len);
+  }
+
+  arr = isMongooseArray(arr) ? arr.__array : arr;
   for (i = 0; i < len; ++i) {
     ret[i] = clone(arr[i], options, true);
   }

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -99,6 +99,13 @@ const methods = {
     return this[arrayPathSymbol];
   },
 
+  /*!
+   * ignore
+   */
+  $schemaType() {
+    return this[arraySchemaSymbol];
+  },
+
   /**
    * Atomically shifts the array at most one time per document `save()`.
    *

--- a/lib/types/documentArray/methods/index.js
+++ b/lib/types/documentArray/methods/index.js
@@ -41,6 +41,13 @@ const methods = {
     return this[arrayParentSymbol];
   },
 
+  /*!
+   * ignore
+   */
+  $schemaType() {
+    return this[arraySchemaSymbol];
+  },
+
   /**
    * Overrides MongooseArray#cast
    *

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12275,25 +12275,31 @@ describe('document', function() {
     assert.strictEqual(clonedDoc.$session(), session);
   });
 
-  it('$clone() with single nested and doc array (gh-14353) (gh-11849)', async function() {
+  it('$clone() with single nested and doc array (gh-15625) (gh-14353) (gh-11849)', async function() {
     const schema = new mongoose.Schema({
       subdocArray: [{
         name: String
       }],
-      subdoc: new mongoose.Schema({ name: String })
+      subdoc: new mongoose.Schema({ name: String }),
+      arr: [Number]
     });
     const Test = db.model('Test', schema);
 
-    const item = await Test.create({ subdocArray: [{ name: 'test 1' }], subdoc: { name: 'test 2' } });
+    const item = await Test.create({ subdocArray: [{ name: 'test 1' }], subdoc: { name: 'test 2' }, arr: [99] });
 
     const doc = await Test.findById(item._id);
     const clonedDoc = doc.$clone();
 
     assert.ok(clonedDoc.subdocArray[0].$__);
     assert.ok(clonedDoc.subdoc.$__);
+    assert.ok(clonedDoc.subdocArray.isMongooseDocumentArray);
+    assert.equal(typeof clonedDoc.subdocArray.id, 'function');
+    assert.ok(clonedDoc.arr.isMongooseArray);
+    assert.ok(!clonedDoc.arr.isMongooseDocumentArray);
 
     assert.deepEqual(doc.subdocArray[0], clonedDoc.subdocArray[0]);
     assert.deepEqual(doc.subdoc, clonedDoc.subdoc);
+    assert.deepEqual(doc.arr, [99]);
   });
 
   it('can create document with document array and top-level key named `schema` (gh-12480)', async function() {


### PR DESCRIPTION
Fix #15625

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`clone()` with `retainDocuments: true` needs to create new MongooseArray and DocumentArray instances, otherwise `$clone()` converts document arrays into vanilla arrays.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
