### PR TITLE
types(models): correct type overload for insertMany() with lean and rawResult

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1053,6 +1053,6 @@ async function gh16526() {
   const schema = new Schema({ name: String });
   const Tank = model('Tank', schema);
 
-  const insertManyResult = await Tank.insertMany([{ name: 'test' }], { lean: true, rawResult: true })
+  const insertManyResult = await Tank.insertMany([{ name: 'test' }], { lean: true, rawResult: true });
   expectType<number>(insertManyResult.insertedCount);
 }

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1048,3 +1048,11 @@ async function customModelInstanceWithStatics() {
     }
   );
 }
+
+async function gh16526() {
+  const schema = new Schema({ name: String });
+  const Tank = model('Tank', schema);
+
+  const insertManyResult = await Tank.insertMany([{ name: 'test' }], { lean: true, rawResult: true })
+  expectType<number>(insertManyResult.insertedCount);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -533,10 +533,6 @@ declare module 'mongoose' {
       docs: Array<TRawDocType>
     ): Promise<Array<THydratedDocumentType>>;
     insertMany(
-      docs: Array<TRawDocType>,
-      options: InsertManyOptions & { lean: true; }
-    ): Promise<Array<Require_id<TRawDocType>>>;
-    insertMany(
       doc: Array<TRawDocType>,
       options: InsertManyOptions & { ordered: false; rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<TRawDocType>> & {
@@ -553,6 +549,23 @@ declare module 'mongoose' {
       docs: Array<TRawDocType>,
       options: InsertManyOptions & { lean: true, rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<TRawDocType>>>;
+    insertMany<DocContents = TRawDocType>(
+      doc: DocContents | TRawDocType,
+      options: InsertManyOptions & { ordered: false; rawResult: true; }
+    ): Promise<mongodb.InsertManyResult<Require_id<DocContents>> & {
+      mongoose: {
+        validationErrors: (CastError | Error.ValidatorError)[];
+        results: Array<
+          Error |
+          Object |
+          MergeType<THydratedDocumentType, DocContents>
+        >
+      }
+    }>;
+    insertMany(
+      docs: Array<TRawDocType>,
+      options: InsertManyOptions & { lean: true; }
+    ): Promise<Array<Require_id<TRawDocType>>>;
     insertMany(
       docs: Array<TRawDocType>,
       options: InsertManyOptions & { rawResult: true; }
@@ -569,19 +582,6 @@ declare module 'mongoose' {
       docs: DocContents | TRawDocType,
       options: InsertManyOptions & { lean: true; }
     ): Promise<Array<Require_id<DocContents>>>;
-    insertMany<DocContents = TRawDocType>(
-      doc: DocContents | TRawDocType,
-      options: InsertManyOptions & { ordered: false; rawResult: true; }
-    ): Promise<mongodb.InsertManyResult<Require_id<DocContents>> & {
-      mongoose: {
-        validationErrors: (CastError | Error.ValidatorError)[];
-        results: Array<
-          Error |
-          Object |
-          MergeType<THydratedDocumentType, DocContents>
-        >
-      }
-    }>;
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>,
       options: InsertManyOptions & { rawResult: true; }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -570,10 +570,6 @@ declare module 'mongoose' {
       docs: Array<TRawDocType>,
       options: InsertManyOptions & { rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<THydratedDocumentType>>>;
-    insertMany(
-      doc: Array<TRawDocType>,
-      options: InsertManyOptions
-    ): Promise<Array<THydratedDocumentType>>;
     insertMany<DocContents = TRawDocType>(
       docs: Array<DocContents | TRawDocType>,
       options: InsertManyOptions & { lean: true; }
@@ -587,9 +583,6 @@ declare module 'mongoose' {
       options: InsertManyOptions & { rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<DocContents>>>;
     insertMany<DocContents = TRawDocType>(
-      docs: Array<DocContents | TRawDocType>
-    ): Promise<Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>>;
-    insertMany<DocContents = TRawDocType>(
       doc: DocContents,
       options: InsertManyOptions & { lean: true; }
     ): Promise<Array<Require_id<DocContents>>>;
@@ -597,6 +590,13 @@ declare module 'mongoose' {
       doc: DocContents,
       options: InsertManyOptions & { rawResult: true; }
     ): Promise<mongodb.InsertManyResult<Require_id<DocContents>>>;
+    insertMany(
+      doc: Array<TRawDocType>,
+      options: InsertManyOptions
+    ): Promise<Array<THydratedDocumentType>>;
+    insertMany<DocContents = TRawDocType>(
+      docs: Array<DocContents | TRawDocType>
+    ): Promise<Array<MergeType<THydratedDocumentType, Omit<DocContents, '_id'>>>>;
     insertMany<DocContents = TRawDocType>(
       doc: DocContents,
       options: InsertManyOptions


### PR DESCRIPTION
Fix #15626

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Move more specific overrides for `insertMany()` up

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
