### PR TITLE
fix(connection): use correct collection name for model when using `useConnection()`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -192,7 +192,7 @@ Model.useConnection = function useConnection(connection) {
   }
 
   this.db = connection;
-  const collection = connection.collection(this.modelName, connection.options);
+  const collection = connection.collection(this.collection.collectionName, connection.options);
   this.prototype.collection = collection;
   this.prototype.$collection = collection;
   this.prototype[modelCollectionSymbol] = collection;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8314,7 +8314,7 @@ describe('Model', function() {
       const schema = new mongoose.Schema({
         name: String
       });
-      const Model = db.model('Test', schema);
+      const Model = db.model('Test', schema, 'tests');
       assert.equal(db.model('Test'), Model);
       const original = Model.find();
       assert.equal(original.model.collection.conn.name, 'mongoose_test');
@@ -8329,6 +8329,7 @@ describe('Model', function() {
       assert.equal(db.models[Model.modelName], undefined);
       assert(connection.models[Model.modelName]);
       const query = Model.find();
+      assert.equal(query.model.collection.collectionName, 'tests');
       assert.equal(query.model.collection.conn.name, 'mongoose_test_2');
 
       await Model.deleteMany({});


### PR DESCRIPTION
Fix #15629

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`useConnection()` hard-codes the model name as the model's collection name, which works in tests but isn't correct in general. Should copy the same collection name from the original model's collection.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
