### PR TITLE
fix(connection): propagate changes to _lastHeartbeatAt to `useDb()` child connections

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -118,7 +118,7 @@ NativeConnection.prototype.useDb = function(name, options) {
 
   newConn.name = name;
 
-  // push onto the otherDbs stack, this is used when state changes
+  // push onto the otherDbs stack, this is used when state changes and when heartbeat is received
   if (options.noListener !== true) {
     this.otherDbs.push(newConn);
   }
@@ -501,6 +501,9 @@ function _setClient(conn, client, options, dbName) {
 
   client.on('serverHeartbeatSucceeded', () => {
     conn._lastHeartbeatAt = Date.now();
+    for (const otherDb of conn.otherDbs) {
+      otherDb._lastHeartbeatAt = conn._lastHeartbeatAt;
+    }
   });
 
   if (options.monitorCommands) {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -871,7 +871,7 @@ describe('connections:', function() {
       await db.close();
     });
 
-    it('updates child dbs lastHeartbeatAt (gh-15635)', async function () {
+    it('updates child dbs lastHeartbeatAt (gh-15635)', async function() {
       const db = await mongoose.createConnection(start.uri).asPromise();
 
       const schema = mongoose.Schema({ name: String }, { autoCreate: false, autoIndex: false });

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -870,6 +870,22 @@ describe('connections:', function() {
 
       await db.close();
     });
+
+    it('updates child dbs lastHeartbeatAt (gh-15635)', async function () {
+      const db = await mongoose.createConnection(start.uri).asPromise();
+
+      const schema = mongoose.Schema({ name: String }, { autoCreate: false, autoIndex: false });
+      const Test = db.model('Test', schema);
+      await Test.deleteMany({});
+      await Test.create({ name: 'gh-11821' });
+
+      const db2 = db.useDb(start.databases[1]);
+
+      const now = Date.now();
+      db.client.emit('serverHeartbeatSucceeded');
+      assert.ok(db._lastHeartbeatAt >= now);
+      assert.ok(db2._lastHeartbeatAt >= now);
+    });
   });
 
   describe('shouldAuthenticate()', function() {


### PR DESCRIPTION
Fix #15635

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`useDb()` child connections have their own `_lastHeartbeatAt` property, but that property is not updated when the client receives a `serverHeartbeatSucceeded` event. The Connection class only updates the top-level connection's `_lastHeartbeatAt`. That means `useDb()` child connections' helpers that rely on `_waitForConnect()`, like `dropDatabase()`, will hang after `heartbeatFrequencyMS * 2`.

I didn't register a separate event listener for each `useDb()` child connection because of memory leak concerns. With this approach, we don't have to clean up the event listener. Also, this pattern of looping over `otherDbs` respects the `noListener` option.

One potential issue: as implemented, `noListener` means the child connection isn't added to the parent db's `otherDbs` list, meaning this fix won't work if `noListener` is set. However, as implemented, the `noListener` option doesn't work anyway. Setting `noListener` throws a `MongoParseError: option nolistener is not supported` error because Mongoose doesn't strip that option out before passing it to MongoDB. So I think the answer here is to just remove the noListener option for mongoose 9.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
