### PR TITLE
allow passing arbitrary options

### DIFF
--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -31,7 +31,7 @@ declare module 'mongoose' {
     | 'strictQuery'
     | 'translateAliases';
 
-  type MongooseBaseQueryOptions<DocType = unknown> = Pick<QueryOptions<DocType>, MongooseBaseQueryOptionKeys> & {
+  type MongooseBaseQueryOptions<DocType = unknown> = Pick<QueryOptions<DocType>, MongooseBaseQueryOptionKeys | 'timestamps' | 'lean'> & {
     [other: string]: any;
   };
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -31,7 +31,9 @@ declare module 'mongoose' {
     | 'strictQuery'
     | 'translateAliases';
 
-  type MongooseBaseQueryOptions<DocType = unknown> = Pick<QueryOptions<DocType>, MongooseBaseQueryOptionKeys>;
+  type MongooseBaseQueryOptions<DocType = unknown> = Pick<QueryOptions<DocType>, MongooseBaseQueryOptionKeys> & {
+    [other: string]: any;
+  };
 
   type MongooseUpdateQueryOptions<DocType = unknown> = Pick<QueryOptions<DocType>, MongooseBaseQueryOptionKeys | 'timestamps'>;
 


### PR DESCRIPTION
**Summary**

Resolves issue https://github.com/Automattic/mongoose/issues/15643

**Examples**

Restores the ability to pass arbitrary options and the `timestamps` and `lean` properties to various model query methods.  This feature was removed in 8.17 with [this PR](https://github.com/Automattic/mongoose/pull/15547/files#diff-75b797f8e57c257285bf701a1832cded31d4a5fddb7a38a290a0c6fbf33b114fL34-R34).