### PR TITLE
Add `lean` schema option to TypeScript types

### DIFF
--- a/docs/typescript/populate.md
+++ b/docs/typescript/populate.md
@@ -18,7 +18,7 @@ const ParentModel = model<Parent>('Parent', new Schema({
 interface Child {
   name: string;
 }
-const childSchema: Schema = new Schema({ name: String });
+const childSchema = new Schema({ name: String });
 const ChildModel = model<Child>('Child', childSchema);
 
 // Populate with `Paths` generic `{ child: Child }` to override `child` path
@@ -48,7 +48,7 @@ const ParentModel = model<Parent>('Parent', new Schema({
   child: { type: Schema.Types.ObjectId, ref: 'Child' },
   name: String
 }));
-const childSchema: Schema = new Schema({ name: String });
+const childSchema = new Schema({ name: String });
 const ChildModel = model<Child>('Child', childSchema);
 
 // Populate with `Paths` generic `{ child: Child }` to override `child` path
@@ -78,7 +78,7 @@ const ParentModel = model<Parent>('Parent', new Schema({
 interface Child {
   name?: string;
 }
-const childSchema: Schema = new Schema({ name: String });
+const childSchema = new Schema({ name: String });
 const ChildModel = model<Child>('Child', childSchema);
 
 ParentModel.findOne({}).populate('child').orFail().then((doc: Parent) => {

--- a/lib/model.js
+++ b/lib/model.js
@@ -4598,11 +4598,13 @@ async function _populatePath(model, docs, populateOptions) {
 
 function _execPopulateQuery(mod, match, select) {
   let subPopulate = clone(mod.options.populate);
-  const queryOptions = Object.assign({
-    skip: mod.options.skip,
-    limit: mod.options.limit,
-    perDocumentLimit: mod.options.perDocumentLimit
-  }, mod.options.options);
+  const queryOptions = Object.assign(
+    {},
+    (mod.options.skip !== undefined ? { skip: mod.options.skip } : {}),
+    (mod.options.limit !== undefined ? { limit: mod.options.limit } : {}),
+    (mod.options.perDocumentLimit !== undefined ? { perDocumentLimit: mod.options.perDocumentLimit } : {}),
+    mod.options.options
+  );
 
   if (mod.count) {
     delete queryOptions.skip;

--- a/test/types/aggregate.test.ts
+++ b/test/types/aggregate.test.ts
@@ -1,7 +1,7 @@
 import { Schema, model, Document, Expression, PipelineStage, Types, Model, Aggregate } from 'mongoose';
 import { expectType } from 'tsd';
 
-const schema: Schema = new Schema({ name: { type: 'String' } });
+const schema = new Schema({ name: { type: 'String' } });
 
 interface ITest {
   name?: string;

--- a/test/types/collection.test.ts
+++ b/test/types/collection.test.ts
@@ -1,6 +1,6 @@
 import { Schema, model, Document, connection, Collection } from 'mongoose';
 
-const schema: Schema = new Schema({ name: { type: 'String' } });
+const schema = new Schema({ name: { type: 'String' } });
 
 interface ITest {
   name?: string;

--- a/test/types/discriminator.test.ts
+++ b/test/types/discriminator.test.ts
@@ -1,7 +1,7 @@
 import mongoose, { Document, Model, Schema, SchemaDefinition, SchemaOptions, Types, model } from 'mongoose';
 import { expectType } from 'tsd';
 
-const schema: Schema = new Schema({ name: { type: 'String' } });
+const schema = new Schema({ name: { type: 'String' } });
 
 interface IBaseTest {
   name?: string;
@@ -42,13 +42,13 @@ function test(): void {
     type: CardType.Land;
   }
 
-  const cardDbBaseSchemaDefinition: SchemaDefinition = {
+  const cardDbBaseSchemaDefinition = {
     type: { type: String, required: true }
   };
 
   const cardDbSchemaOptions: SchemaOptions = { discriminatorKey: 'type' };
 
-  const cardDbSchema: Schema = new Schema(
+  const cardDbSchema = new Schema(
     cardDbBaseSchemaDefinition,
     cardDbSchemaOptions
   );
@@ -59,9 +59,9 @@ function test(): void {
     'card'
   );
 
-  const landDbAdditionalPropertiesSchemaDefinition: SchemaDefinition = {};
+  const landDbAdditionalPropertiesSchemaDefinition = {};
 
-  const landDbSchema: Schema = new Schema(
+  const landDbSchema = new Schema(
     landDbAdditionalPropertiesSchemaDefinition
   );
 

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -21,7 +21,7 @@ const Drink = model('Drink', new Schema({
   name: String
 }));
 
-const schema: Schema = new Schema({
+const schema = new Schema({
   name: { type: 'String', required: true },
   address: new Schema({ city: { type: String, required: true } }),
   favoritDrink: {

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -380,3 +380,57 @@ async function gh15583() {
   const testDoc = await TestModel.findOne().lean<TRawDocType & { transformed: boolean }>().orFail();
   expectType<boolean>(testDoc.transformed);
 }
+
+async function gh15583_2() {
+  const schema = new Schema(
+    { name: String },
+    { lean: true }
+  );
+  const TestModel = model('Test', schema);
+
+  const testDoc = await TestModel.findOne().orFail();
+  expectError(testDoc.save());
+
+  const testDoc2 = await TestModel.findById('anything').lean().orFail();
+  expectError(testDoc2.save());
+
+  const testDocs = await TestModel.find().lean().exec();
+  for (const doc of testDocs) {
+    expectError(doc.save());
+  }
+
+  const testDoc3 = await TestModel.findOneAndUpdate({}, { name: 'test' }).lean().orFail();
+  expectError(testDoc3.save());
+
+  const testDoc4 = await TestModel.findOneAndReplace({}, { name: 'test' }).lean().orFail();
+  expectError(testDoc4.save());
+
+  const testDoc5 = await TestModel.findOneAndDelete({}).lean().orFail();
+  expectError(testDoc5.save());
+
+  const schema2 = new Schema(
+    { name: String },
+    { lean: { virtuals: true } }
+  );
+  const TestModel2 = model('Test', schema);
+
+  const testDoc6 = await TestModel2.findOne().orFail();
+  expectError(testDoc6.save());
+
+  const testDoc7 = await TestModel2.findById('anything').lean().orFail();
+  expectError(testDoc7.save());
+
+  const testDocs2 = await TestModel2.find().lean().exec();
+  for (const doc of testDocs2) {
+    expectError(doc.save());
+  }
+
+  const testDoc8 = await TestModel2.findOneAndUpdate({}, { name: 'test' }).lean().orFail();
+  expectError(testDoc8.save());
+
+  const testDoc9 = await TestModel2.findOneAndReplace({}, { name: 'test' }).lean().orFail();
+  expectError(testDoc9.save());
+
+  const testDoc10 = await TestModel2.findOneAndDelete({}).lean().orFail();
+  expectError(testDoc10.save());
+}

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -349,3 +349,23 @@ async function gh15158() {
 
   createSomeModelAndDoSomething();
 }
+
+async function gh15583() {
+  const schema = new Schema(
+    { name: String },
+    {
+      lean: {
+        transform: doc => {
+          doc.transformed = true;
+          return doc;
+        }
+      }
+    }
+  );
+
+  type TRawDocType = InferSchemaType<typeof schema>;
+  const TestModel = model('Test', schema);
+
+  const testDoc = await TestModel.findOne().lean<TRawDocType & { transformed: boolean }>().orFail();
+  expectType<boolean>(testDoc.transformed);
+}

--- a/test/types/lean.test.ts
+++ b/test/types/lean.test.ts
@@ -350,6 +350,17 @@ async function gh15158() {
   createSomeModelAndDoSomething();
 }
 
+async function leanFalse() {
+  const schema = new Schema({
+    name: String
+  });
+  const Test = model('Test', schema);
+  type TestDocument = ReturnType<(typeof Test)['hydrate']>;
+
+  const doc = await Test.findOne().orFail().lean(false);
+  expectType<TestDocument>(doc);
+}
+
 async function gh15583() {
   const schema = new Schema(
     { name: String },

--- a/test/types/maps.test.ts
+++ b/test/types/maps.test.ts
@@ -7,7 +7,7 @@ interface ITest {
   map3: Map<string, number>
 }
 
-const schema: Schema = new Schema<ITest>({
+const schema = new Schema<ITest>({
   map1: {
     type: Map,
     of: Number

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -7,7 +7,7 @@ interface Child {
   name: string;
 }
 
-const childSchema: Schema = new Schema({ name: String });
+const childSchema = new Schema({ name: String });
 const ChildModel = model<Child>('Child', childSchema);
 
 interface Parent {
@@ -24,14 +24,14 @@ ParentModel.
   findOne({}).
   populate<{ child: Document<ObjectId> & Child }>('child').
   orFail().
-  then((doc: Document<ObjectId, {}, Parent> & Parent) => {
+  then((doc) => {
     const child = doc.child;
     if (child == null || child instanceof ObjectId) {
       throw new Error('should be populated');
     } else {
       useChildDoc(child);
     }
-    const lean = doc.toObject<typeof doc>();
+    const lean = doc.toObject<Parent & { child: Child }>();
     const leanChild = lean.child;
     if (leanChild == null || leanChild instanceof ObjectId) {
       throw new Error('should be populated');
@@ -119,7 +119,7 @@ function gh11014() {
       name: String
     })
   );
-  const childSchema: Schema = new Schema({ name: String });
+  const childSchema = new Schema({ name: String });
   const ChildModel = model<Child>('Child', childSchema);
 
   // Populate with `Paths` generic `{ child: Child }` to override `child` path
@@ -267,7 +267,7 @@ async function gh11710() {
     child: { type: Schema.Types.ObjectId, ref: 'Child' },
     name: String
   }));
-  const childSchema: Schema = new Schema({ name: String });
+  const childSchema = new Schema({ name: String });
   const ChildModel = model<Child>('Child', childSchema);
 
   // Populate with `Paths` generic `{ child: Child }` to override `child` path
@@ -280,7 +280,7 @@ async function gh11758() {
     name: string
     _id: Types.ObjectId
   }
-  const nestedChildSchema: Schema = new Schema({ name: String });
+  const nestedChildSchema = new Schema({ name: String });
 
   interface Parent {
     nestedChild: Types.ObjectId
@@ -319,7 +319,7 @@ async function gh11955() {
   interface Child {
     name: string;
   }
-  const childSchema: Schema = new Schema({ name: String });
+  const childSchema = new Schema({ name: String });
   model<Child>('Child', childSchema);
 
   const parent = await ParentModel.findOne({}).exec();
@@ -389,7 +389,7 @@ function gh14441() {
   interface Child {
     name: string;
   }
-  const childSchema: Schema = new Schema({ name: String });
+  const childSchema = new Schema({ name: String });
   model<Child>('Child', childSchema);
 
   ParentModel.findOne({})

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -28,7 +28,7 @@ interface QueryHelpers {
   byName(this: QueryWithHelpers<any, ITest, QueryHelpers>, name: string): QueryWithHelpers<Array<ITest>, ITest, QueryHelpers>;
 }
 
-const childSchema: Schema = new Schema({ name: String });
+const childSchema = new Schema({ name: String });
 const ChildModel = model<Child>('Child', childSchema);
 
 const schema: Schema<ITest, Model<ITest, QueryHelpers>, {}, QueryHelpers> = new Schema({
@@ -469,7 +469,7 @@ async function gh12342_auto() {
 }
 
 async function gh11602(): Promise<void> {
-  const query: Query<ITest | null, ITest> = Test.findOne();
+  const query = Test.findOne();
   query instanceof Query;
 
   const ModelType = model<ITest>('foo', schema);

--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -40,7 +40,7 @@ async function gh14374() {
   interface Child {
     name: string
   }
-  const childSchema: Schema = new Schema({ name: String });
+  const childSchema = new Schema({ name: String });
 
   const cursor = ParentModel.find({}).populate<{ child: Child }>('child').cursor();
   for await (const doc of cursor) {

--- a/test/types/subdocuments.test.ts
+++ b/test/types/subdocuments.test.ts
@@ -9,9 +9,9 @@ import {
 } from 'mongoose';
 import { expectAssignable } from 'tsd';
 
-const childSchema: Schema = new Schema({ name: String });
+const childSchema = new Schema({ name: String });
 
-const schema: Schema = new Schema({
+const schema = new Schema({
   child1: childSchema,
   child2: {
     type: childSchema,
@@ -24,7 +24,7 @@ const schema: Schema = new Schema({
   }]
 });
 
-interface ITest extends Document {
+interface ITest {
   child1: { _id: Types.ObjectId, name: string },
   child2: { name: string }
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -260,6 +260,12 @@ declare module 'mongoose' {
     hint?: mongodb.Hint;
   }
 
+  type HasLeanOption<TSchema> = 'lean' extends keyof ObtainSchemaGeneric<TSchema, 'TSchemaOptions'> ?
+    ObtainSchemaGeneric<TSchema, 'TSchemaOptions'>['lean'] extends Record<string, any> ?
+      true :
+      ObtainSchemaGeneric<TSchema, 'TSchemaOptions'>['lean'] :
+    false;
+
   /**
    * Models are fancy constructors compiled from `Schema` definitions.
    * An instance of a model is called a document.
@@ -480,11 +486,25 @@ declare module 'mongoose' {
       id: any,
       projection?: ProjectionType<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
     findById<ResultDoc = THydratedDocumentType>(
       id: any,
       projection?: ProjectionType<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Finds one document. */
     findOne<ResultDoc = THydratedDocumentType>(
@@ -503,14 +523,35 @@ declare module 'mongoose' {
       filter?: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> & mongodb.Abortable | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
     findOne<ResultDoc = THydratedDocumentType>(
       filter?: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
     findOne<ResultDoc = THydratedDocumentType>(
       filter?: RootFilterQuery<TRawDocType>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOne', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
 
     /**
      * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
@@ -734,16 +775,44 @@ declare module 'mongoose' {
       filter: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> & mongodb.Abortable | null | undefined
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[],
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
     find<ResultDoc = THydratedDocumentType>(
       filter: RootFilterQuery<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[],
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
     find<ResultDoc = THydratedDocumentType>(
       filter: RootFilterQuery<TRawDocType>
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[],
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
     find<ResultDoc = THydratedDocumentType>(
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[],
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
@@ -760,11 +829,25 @@ declare module 'mongoose' {
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
       id?: mongodb.ObjectId | any,
       options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
@@ -795,21 +878,49 @@ declare module 'mongoose' {
       id: mongodb.ObjectId | any,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType : ResultDoc,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
       id?: mongodb.ObjectId | any,
       update?: UpdateQuery<TRawDocType>,
       options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,
       update: UpdateQuery<TRawDocType>
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
@@ -826,11 +937,25 @@ declare module 'mongoose' {
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
       filter: RootFilterQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
       filter?: RootFilterQuery<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndDelete', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
@@ -849,17 +974,38 @@ declare module 'mongoose' {
       filter: RootFilterQuery<TRawDocType>,
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter: RootFilterQuery<TRawDocType>,
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType : ResultDoc,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter?: RootFilterQuery<TRawDocType>,
       replacement?: TRawDocType | AnyObject,
       options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndReplace', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
@@ -890,17 +1036,38 @@ declare module 'mongoose' {
       filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: RootFilterQuery<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<ResultDoc, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType : ResultDoc,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter?: RootFilterQuery<TRawDocType>,
       update?: UpdateQuery<TRawDocType>,
       options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<ResultDoc | null, ResultDoc, TQueryHelpers, TRawDocType, 'findOneAndUpdate', TInstanceMethods & TVirtuals>;
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TRawDocType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
 
     /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
     replaceOne<ResultDoc = THydratedDocumentType>(
@@ -936,9 +1103,9 @@ declare module 'mongoose' {
     where<ResultDoc = THydratedDocumentType>(
       path: string,
       val?: any
-    ): QueryWithHelpers<Array<ResultDoc>, ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods>;
+    ): QueryWithHelpers<HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[], ResultDoc, TQueryHelpers, TRawDocType, 'find', TInstanceMethods>;
     where<ResultDoc = THydratedDocumentType>(obj: object): QueryWithHelpers<
-      Array<ResultDoc>,
+      HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[],
       ResultDoc,
       TQueryHelpers,
       TRawDocType,
@@ -946,7 +1113,7 @@ declare module 'mongoose' {
       TInstanceMethods & TVirtuals
     >;
     where<ResultDoc = THydratedDocumentType>(): QueryWithHelpers<
-      Array<ResultDoc>,
+      HasLeanOption<TSchema> extends true ? TRawDocType[] : ResultDoc[],
       ResultDoc,
       TQueryHelpers,
       TRawDocType,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -568,8 +568,18 @@ declare module 'mongoose' {
     j(val: boolean | null): this;
 
     /** Sets the lean option. */
+    lean(): QueryWithHelpers<
+      ResultType extends null
+        ? GetLeanResultType<RawDocType, ResultType, QueryOp> | null
+        : GetLeanResultType<RawDocType, ResultType, QueryOp>,
+      DocType,
+      THelpers,
+      RawDocType,
+      QueryOp,
+      TDocOverrides
+      >;
     lean(
-      val?: boolean | LeanOptions
+      val: true | LeanOptions
     ): QueryWithHelpers<
       ResultType extends null
         ? GetLeanResultType<RawDocType, ResultType, QueryOp> | null
@@ -580,8 +590,32 @@ declare module 'mongoose' {
       QueryOp,
       TDocOverrides
       >;
+    lean(
+      val: false
+    ): QueryWithHelpers<
+      ResultType extends AnyArray<any>
+        ? DocType[]
+        : ResultType extends null
+          ? DocType | null
+          : DocType,
+      DocType,
+      THelpers,
+      RawDocType,
+      QueryOp,
+      TDocOverrides
+      >;
+    lean<LeanResultType>(): QueryWithHelpers<
+      ResultType extends null
+        ? LeanResultType | null
+        : LeanResultType,
+      DocType,
+      THelpers,
+      RawDocType,
+      QueryOp,
+      TDocOverrides
+      >;
     lean<LeanResultType>(
-      val?: boolean | LeanOptions
+      val: boolean | LeanOptions
     ): QueryWithHelpers<
       ResultType extends null
         ? LeanResultType | null

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -118,6 +118,15 @@ declare module 'mongoose' {
     updatedAt?: boolean;
   }
 
+  // Options that can be passed to Query.prototype.lean()
+  interface LeanOptions<RawDocType> {
+    // Set to false to strip out the version key
+    versionKey?: boolean;
+    // Transform the result document in place
+    transform?: (doc: RawDocType) => void;
+    [key: string]: any;
+  }
+
   interface QueryOptions<DocType = unknown> extends
     PopulateOption,
     SessionOption {
@@ -132,7 +141,7 @@ declare module 'mongoose' {
     /**
      * If truthy, mongoose will return the document as a plain JavaScript object rather than a mongoose document.
      */
-    lean?: boolean | Record<string, any>;
+    lean?: boolean | LeanOptions<any>;
     limit?: number;
     maxTimeMS?: number;
     multi?: boolean;
@@ -558,7 +567,7 @@ declare module 'mongoose' {
 
     /** Sets the lean option. */
     lean(
-      val?: boolean | any
+      val?: boolean | LeanOptions<RawDocType>
     ): QueryWithHelpers<
       ResultType extends null
         ? GetLeanResultType<RawDocType, ResultType, QueryOp> | null
@@ -570,7 +579,7 @@ declare module 'mongoose' {
       TDocOverrides
       >;
     lean<LeanResultType>(
-      val?: boolean | any
+      val?: boolean | LeanOptions<RawDocType>
     ): QueryWithHelpers<
       ResultType extends null
         ? LeanResultType | null

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -59,7 +59,7 @@ declare module 'mongoose' {
     collectionOptions?: mongodb.CreateCollectionOptions;
 
     /** Default lean options for queries */
-    lean?: boolean | Record<string, any>;
+    lean?: boolean | LeanOptions;
 
     /** The timeseries option to use when creating the model's collection. */
     timeseries?: mongodb.TimeSeriesCollectionOptions;

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -58,6 +58,9 @@ declare module 'mongoose' {
     /** Arbitrary options passed to `createCollection()` */
     collectionOptions?: mongodb.CreateCollectionOptions;
 
+    /** Default lean options for queries */
+    lean?: boolean | Record<string, any>;
+
     /** The timeseries option to use when creating the model's collection. */
     timeseries?: mongodb.TimeSeriesCollectionOptions;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

For #10090, we added support for a `lean` option in schema options that makes all queries lean by default. This PR adds that option to the TypeScript types, including making functions like `Model.find()` and `Model.findOne()` automatically apply `lean` if the lean option is set on the schema.

Adding this option proved to be very tricky for 2 reasons:

1. `lean.transform` updates the object in place, so TypeScript doesn't know anything about the return type
2. There's some inconsistencies between how Document sees `DocType` and how Schema sees `DocType`, especially with discriminators (with discriminators, the Model sees the merged object properties, but the schema does not)

I made a few other related changes that popped up while debugging (2):

1. Getting rid of `: Schema` type annotations in tests and docs. These are unnecessary and look awkward.
2. `QueryOptions<DocType>` rather than `QueryOptions<HydratedDocType>` in Query class

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
