### PR TITLE
fix(update): avoid throwing error if update has a top-level $addToSet

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -213,9 +213,9 @@ function castPipelineOperator(op, val) {
  * @api private
  */
 
-function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
+function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
   const strict = options.strict;
-  const prefix = pref ? pref + '.' : '';
+  prefix = prefix ? prefix + '.' : '';
   const keys = Object.keys(obj);
   let i = keys.length;
   let hasKeys = false;
@@ -380,7 +380,7 @@ function walkUpdatePath(schema, obj, op, options, context, filter, pref) {
       }
     } else {
       const checkPath = (key === '$each' || key === '$or' || key === '$and' || key === '$in') ?
-        pref : prefix + key;
+        prefix : prefix + key;
       schematype = schema._getSchema(checkPath);
 
       // You can use `$setOnInsert` with immutable keys

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3189,6 +3189,15 @@ describe('model: updateOne: ', function() {
     assert.equal(validateDetailsCalls, 1);
     assert.equal(validateNameCalls, 1);
   });
+
+  it('casts top level $each (gh-15642)', async function() {
+    const schema = new Schema({ tags: [String] });
+    const Model = db.model('Test', schema);
+
+    await Model.create({ tags: [] });
+    // This is a no-op, but should not cause an error
+    await Model.updateOne({}, { $addToSet: { $each: ['test'] } });
+  });
 });
 
 async function delay(ms) {


### PR DESCRIPTION
Fix #15642

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15642 is caused by `pref` being undefined, which is expected because logic should be using `prefix` instead. I removed the `pref` vs `prefix` distinction to prevent future confusion.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
