### PR TITLE
Add tests covering vector search and text search using Atlas CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,10 +113,8 @@ jobs:
       MONGOOSE_TEST_URI: mongodb://127.0.0.1:27017/mongoose_test?directConnection=true
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Install Atlas CLI
-        run: |
-          curl -s https://www.mongodb.com/atlascli/atlascli-install.sh | sh
-          echo "$HOME/.mongodb/bin" >> $GITHUB_PATH
+      - name: Setup AtlasCLI
+        uses: mongodb/atlas-github-action@v0.2.0
       - name: Setup local Atlas deployment
         run: atlas deployments setup mycluster --type local --force --port 27017
       - name: Setup node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         node: [16, 18, 20, 22, 24]
         os: [ubuntu-22.04, ubuntu-24.04]
-        mongodb: [6.0.15, 7.0.12, 8.0.0]
+        mongodb: [6.0.15, 7.0.12, 8.2.0]
         include:
           - os: ubuntu-22.04 # customize on which matrix the coverage will be collected on
             mongodb: 6.0.15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,30 @@ jobs:
       - name: Run Deno tests
         run: npm run test-deno
 
+  test-atlas-cli:
+    runs-on: ubuntu-22.04
+    name: Atlas CLI tests
+    env:
+      IS_ATLAS: true
+      MONGOOSE_TEST_URI: mongodb://127.0.0.1:27017/mongoose_test?directConnection=true
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install Atlas CLI
+        run: |
+          curl -s https://www.mongodb.com/atlascli/atlascli-install.sh | sh
+          echo "$HOME/.mongodb/bin" >> $GITHUB_PATH
+      - name: Setup local Atlas deployment
+        run: atlas deployments setup mycluster --type local --force --port 27017
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - run: npm install
+      - name: Run tests
+        run: npm test
+      - name: Stop deployment
+        run: atlas deployments stop mycluster
+
   test-replica-sets:
     needs:
       - test

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -25,7 +25,13 @@ describe('connections:', function() {
 
   describe('openUri (gh-5304)', function() {
     it('with mongoose.createConnection()', function() {
-      const conn = mongoose.createConnection(start.uri.slice(0, start.uri.lastIndexOf('/')) + '/' + start.databases[0]);
+      // Handle start.uri with potential query string parameters
+      const uriWithoutDb = start.uri.slice(0, start.uri.lastIndexOf('/'));
+      const dbAndQuery = start.uri.slice(start.uri.lastIndexOf('/') + 1);
+      const queryIndex = dbAndQuery.indexOf('?');
+      const query = queryIndex !== -1 ? dbAndQuery.slice(queryIndex) : '';
+      const newUri = uriWithoutDb + '/' + start.databases[0] + query;
+      const conn = mongoose.createConnection(newUri);
       assert.equal(conn.constructor.name, 'NativeConnection');
 
       const Test = conn.model('Test', new Schema({ name: String }));
@@ -553,13 +559,16 @@ describe('connections:', function() {
       });
   });
 
-  it('uses default database in uri if options.dbName is not provided', function() {
-    return mongoose.createConnection(start.uri.slice(0, start.uri.lastIndexOf('/')) + '/default-db-name').
-      asPromise().
-      then(db => {
-        assert.equal(db.name, 'default-db-name');
-        db.close();
-      });
+  it('uses default database in uri if options.dbName is not provided', async function() {
+    // Handle possible query string parameters in start.uri
+    const uriWithoutDb = start.uri.slice(0, start.uri.lastIndexOf('/'));
+    const dbAndQuery = start.uri.slice(start.uri.lastIndexOf('/') + 1);
+    const queryIndex = dbAndQuery.indexOf('?');
+    const query = queryIndex !== -1 ? dbAndQuery.slice(queryIndex) : '';
+    const newUri = uriWithoutDb + '/default-db-name' + query;
+    const db = await mongoose.createConnection(newUri).asPromise();
+    assert.equal(db.name, 'default-db-name');
+    await db.close();
   });
 
   it('startSession() (gh-6653)', function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8755,6 +8755,9 @@ describe('Model', function() {
     });
 
     afterEach(async function() {
+      if (this.currentTest.pending) {
+        return; // Test was skipped
+      }
       const indexes = await TestModel.listSearchIndexes().catch(() => []);
       for (const idx of indexes) {
         await TestModel.dropSearchIndex(idx.name);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8742,30 +8742,148 @@ describe('Model', function() {
   });
 
   it('createSearchIndexes creates an index for each search index in schema (gh-15465)', async function() {
-    const sinon = require('sinon');
+    this.timeout(20000);
+    const version = await start.mongodVersion();
+    if (version[0] < 8 || !process.env.IS_ATLAS) {
+      this.skip();
+      return;
+    }
     const schema = new mongoose.Schema({
       name: String,
       description: String
     });
 
-    schema.searchIndex({ name: 'test', definition: { mappings: { dynamic: true } } });
+    schema.searchIndex({
+      name: 'test',
+      definition: {
+        mappings: {
+          dynamic: false,
+          fields: { name: { type: 'string' }, description: { type: 'string' } }
+        }
+      }
+    });
 
     const TestModel = db.model('Test', schema);
 
-    const createSearchIndexStub = sinon.stub(TestModel, 'createSearchIndex').resolves({ acknowledged: true });
+    await TestModel.init();
+    const results = await TestModel.createSearchIndexes();
 
     try {
-      const results = await TestModel.createSearchIndexes();
-
-      assert.equal(createSearchIndexStub.callCount, 1);
       assert.equal(results.length, 1);
-      assert.deepEqual(results, [{ acknowledged: true }]);
+      assert.deepEqual(results, ['test']);
 
-      // Verify that createSearchIndex was called with the correct arguments
-      assert.ok(createSearchIndexStub.firstCall.calledWithMatch({ name: 'test', definition: { mappings: { dynamic: true } } }));
+      let indexes = await TestModel.listSearchIndexes();
+      assert.equal(indexes.length, 1);
+      assert.equal(indexes[0].name, 'test');
+
+      let isQueryable = indexes[0].queryable;
+      while (!isQueryable) {
+        await delay(100);
+        indexes = await TestModel.listSearchIndexes();
+        isQueryable = indexes[0].queryable;
+      }
+
+      // Insert a document to search.
+      await TestModel.create({ name: 'Atlas Search Example', description: 'This is a test for MongoDB Atlas Search.' });
+
+      // Retry aggregate up to 10 times every 500ms because Lucene index is not immediately queryable
+      let searchResults;
+      for (let tries = 0; tries < 10; ++tries) {
+        searchResults = await TestModel.aggregate([
+          {
+            $search: {
+              index: 'test',
+              text: {
+                query: 'Atlas',
+                path: 'name'
+              }
+            }
+          }
+        ]);
+        if (searchResults.length > 0) {
+          break;
+        }
+        await delay(500);
+      }
+      assert.ok(searchResults.length > 0);
+      assert.strictEqual(searchResults[0].name, 'Atlas Search Example');
     } finally {
-      sinon.restore();
+      await TestModel.dropSearchIndex('test');
     }
+  });
+
+  it('can create a vector search index (gh-15465)', async function() {
+    this.timeout(10000);
+    const version = await start.mongodVersion();
+    if (version[0] < 8 || !process.env.IS_ATLAS) {
+      this.skip();
+      return;
+    }
+    const schema = new mongoose.Schema({
+      name: String,
+      myVector: [Number]
+    });
+    schema.searchIndex({
+      name: 'vector_index',
+      type: 'vectorSearch',
+      definition: {
+        fields: [
+          {
+            type: 'vector',
+            numDimensions: 2,
+            path: 'myVector',
+            similarity: 'dotProduct',
+            quantization: 'scalar'
+          }
+        ]
+      }
+    });
+
+    const TestModel = db.model('Test', schema);
+
+    await TestModel.init();
+    const results = await TestModel.createSearchIndexes();
+
+    assert.equal(results.length, 1);
+    assert.deepEqual(results, ['vector_index']);
+
+    await TestModel.create([{ name: 'Test1', myVector: [0, 99] }, { name: 'Test2', myVector: [99, 0] }])
+
+    let indexes = await TestModel.listSearchIndexes();
+    let isQueryable = indexes[0].queryable;
+    while (!isQueryable) {
+      await delay(100);
+      indexes = await TestModel.listSearchIndexes();
+      isQueryable = indexes[0].queryable;
+    }
+
+    let [doc] = await TestModel.aggregate([
+      {
+        $vectorSearch: {
+          index: 'vector_index',
+          path: 'myVector',
+          queryVector: [0, 100],
+          numCandidates: 10,
+          limit: 1
+        }
+      }
+    ]);
+    assert.strictEqual(doc.name, 'Test1');
+
+    [doc] = await TestModel.aggregate([
+      {
+        $vectorSearch: {
+          index: 'vector_index',
+          path: 'myVector',
+          queryVector: [100, 1],
+          numCandidates: 10,
+          limit: 1
+        }
+      }
+    ]);
+    assert.strictEqual(doc.name, 'Test2');
+
+    await TestModel.dropSearchIndex('vector_index');
   });
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

MongoDB's Atlas CLI now supports running Atlas-like deployments locally, which includes support for text search and vector search. In the interest of completeness re: #15645, I added tests covering using `createSearchIndexes()`, `listSearchIndex()`, and `dropSearchIndex()` against Atlas CLI.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
