### PR TITLE
fix(schema): handle casting array filters underneath maps of Mixed

### DIFF
--- a/lib/helpers/schema/getPath.js
+++ b/lib/helpers/schema/getPath.js
@@ -24,7 +24,7 @@ module.exports = function getPath(schema, path, discriminatorValueMap) {
     cur = cur.length === 0 ? piece : cur + '.' + piece;
 
     schematype = schema.path(cur);
-    if (schematype != null && schematype.schema) {
+    if (schematype?.schema) {
       schema = schematype.schema;
       if (!isArray && schematype.$isMongooseDocumentArray) {
         isArray = true;
@@ -33,6 +33,9 @@ module.exports = function getPath(schema, path, discriminatorValueMap) {
         schema = schema.discriminators[discriminatorValueMap[cur]] ?? schema;
       }
       cur = '';
+    } else if (schematype?.instance === 'Mixed') {
+      // If we found a mixed path, no point in digging further, the end result is always Mixed
+      break;
     }
   }
 

--- a/test/helpers/schema.getPath.test.js
+++ b/test/helpers/schema.getPath.test.js
@@ -22,4 +22,14 @@ describe('getPath()', function() {
     assert.equal(getPath(schema, 'nested.docs.el').constructor.name, 'SchemaString');
     assert.equal(getPath(schema, 'nested.0.docs.el').constructor.name, 'SchemaString');
   });
+
+  it('handles getting paths underneath Mixed array (gh-15653)', function() {
+    const schema = new Schema({
+      any: [Schema.Types.Mixed]
+    });
+    assert.strictEqual(getPath(schema, 'any.0.foo').constructor.name, 'SchemaMixed');
+    assert.strictEqual(getPath(schema, 'any.0.foo.bar.baz').constructor.name, 'SchemaMixed');
+
+    assert.strictEqual(getPath(schema, 'any.0').constructor.name, 'SchemaMixed');
+  });
 });


### PR DESCRIPTION
Fix #15653

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The root issue of #15653 is that `getPath()` currently doesn't look out for Mixed paths, this PR adds that fix.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
