### PR TITLE
fix(query): throw error if using update operator with modifier and no path

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -379,8 +379,13 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
           (utils.isObject(val) && Object.keys(val).length === 0);
       }
     } else {
-      const checkPath = (key === '$each' || key === '$or' || key === '$and' || key === '$in') ?
-        prefix : prefix + key;
+      const isModifier = (key === '$each' || key === '$or' || key === '$and' || key === '$in');
+      if (isModifier && !prefix) {
+        throw new MongooseError('Invalid update: Unexpected modifier "' + key + '" as a key in operator. '
+          + 'Did you mean something like { $addToSet: { fieldName: { $each: [...] } } }? '
+          + 'Modifiers such as "$each", "$or", "$and", "$in" must appear under a valid field path.');
+      }
+      const checkPath = isModifier ? prefix : prefix + key;
       schematype = schema._getSchema(checkPath);
 
       // You can use `$setOnInsert` with immutable keys

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3195,8 +3195,10 @@ describe('model: updateOne: ', function() {
     const Model = db.model('Test', schema);
 
     await Model.create({ tags: [] });
-    // This is a no-op, but should not cause an error
-    await Model.updateOne({}, { $addToSet: { $each: ['test'] } });
+    await assert.rejects(
+      Model.updateOne({}, { $addToSet: { $each: ['test'] } }),
+      /Modifiers such as "\$each", "\$or", "\$and", "\$in" must appear under a valid field path/
+    );
   });
 });
 


### PR DESCRIPTION
Fix #15642

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Make `Model.updateOne({}, { $addToSet: { $each: ['test'] } })` throw an error, because this update attempts to update a path `$each`. By default, Mongoose strips out the `$each` update and makes this update a no-op, but we should likely throw an error. MongoDB doesn't allow this update, the MongoDB server errors out with `The dollar ($) prefixed field '$each' in '$each' is not allowed in the context of an update's replacement document. Consider using an aggregation pipeline with $replaceWith.`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
