### PR TITLE
types: avoid making FilterQuery a conditional type because of how typescript handles distributed conditional unions

### DIFF
--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -1,4 +1,4 @@
-import {
+import mongoose, {
   Condition,
   HydratedDocument,
   Schema,
@@ -769,4 +769,32 @@ async function gh3230() {
   const test = await Test.create({ name: 'test', arr: [{ testRef: _id }] });
 
   console.log(await Test.findById(test._id).populate('arr.testRef', { name: 1, prop: 1, _id: 0, __t: 0 }));
+}
+
+function gh15671() {
+  interface DefaultQuery {
+    search?: string;
+  }
+
+  type QueryFeaturesProps = {
+    params: Partial<DefaultQuery>;
+  };
+
+  const queryFeatures = async <T, R, TQueryOp>(
+    query: mongoose.Query<R, T, object, T, TQueryOp>,
+    { params }: QueryFeaturesProps
+  ): Promise<{ content: mongoose.GetLeanResultType<T, R, TQueryOp>; result?: number }> => {
+    if (params.search) {
+      query.find({
+        $text: {
+          $search: params.search
+        }
+      });
+    }
+
+    const content = await query.lean().orFail().exec();
+    return {
+      content
+    };
+  };
 }

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -12,9 +12,7 @@ declare module 'mongoose' {
    */
   type RootFilterQuery<T> = FilterQuery<T> | Query<any, any> | Types.ObjectId;
 
-  type FilterQuery<T> = IsItRecordAndNotAny<T> extends true ?
-    ({ [P in keyof T]?: Condition<T[P]>; } & RootQuerySelector<T> & { _id?: Condition<string>; }) :
-    FilterQuery<Record<string, any>>;
+  type FilterQuery<T> = ({ [P in keyof T]?: Condition<T[P]>; } & RootQuerySelector<T> & { _id?: Condition<string>; });
 
   type MongooseBaseQueryOptionKeys =
     | 'context'
@@ -424,31 +422,16 @@ declare module 'mongoose' {
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find(
-      filter: RootFilterQuery<RawDocType>,
+      filter?: RootFilterQuery<RawDocType>,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TDocOverrides>;
-    find(
-      filter: RootFilterQuery<RawDocType>,
-      projection?: ProjectionType<RawDocType> | null
-    ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TDocOverrides>;
-    find(
-      filter: RootFilterQuery<RawDocType>
-    ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TDocOverrides>;
-    find(): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TDocOverrides>;
 
     /** Declares the query a findOne operation. When executed, returns the first found document. */
     findOne(
       filter?: RootFilterQuery<RawDocType>,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
-    findOne(
-      filter?: RootFilterQuery<RawDocType>,
-      projection?: ProjectionType<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
-    findOne(
-      filter?: RootFilterQuery<RawDocType>
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
@@ -483,13 +466,6 @@ declare module 'mongoose' {
       id: mongodb.ObjectId | any,
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
-    findById(
-      id: mongodb.ObjectId | any,
-      projection?: ProjectionType<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
-    findById(
-      id: mongodb.ObjectId | any
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */


### PR DESCRIPTION
Fix #15671

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types: "When conditional types act on a generic type, they become distributive when given a union type... If we plug a union type into ToArray, then the conditional type will be applied to each member of that union."

Which means when `FilterQuery` becomes a conditional type, that ends up breaking the `RootFilterQuery` union type. When FilterQuery isn't a trivial intersection, TypeScript ends up evaluating across every branch in `RootFilterQuery`. I don't entirely understand why, that seems to be the cause here.

I also removed a couple of unnecessary function signatures in the Query class. No need to also include `find(a: T1)` if we already have `find(a: T1, b?: T2)`

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
