### PR TITLE
perf: avoid getting all modified paths in update when checking if versionKey needs to be set

### DIFF
--- a/lib/helpers/update/decorateUpdateWithVersionKey.js
+++ b/lib/helpers/update/decorateUpdateWithVersionKey.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const modifiedPaths = require('./modifiedPaths');
-
 /**
  * Decorate the update with a version key, if necessary
  * @api private
@@ -12,15 +10,26 @@ module.exports = function decorateUpdateWithVersionKey(update, options, versionK
     return;
   }
 
-  const updatedPaths = modifiedPaths(update);
-  if (!updatedPaths[versionKey]) {
-    if (options.overwrite) {
+  if (options.overwrite) {
+    if (!hasKey(update, versionKey)) {
       update[versionKey] = 0;
-    } else {
-      if (!update.$setOnInsert) {
-        update.$setOnInsert = {};
-      }
-      update.$setOnInsert[versionKey] = 0;
     }
+  } else if (
+    !hasKey(update, versionKey) &&
+    !hasKey(update?.$set, versionKey) &&
+    !hasKey(update?.$inc, versionKey) &&
+    !hasKey(update?.$setOnInsert, versionKey)
+  ) {
+    if (!update.$setOnInsert) {
+      update.$setOnInsert = {};
+    }
+    update.$setOnInsert[versionKey] = 0;
   }
 };
+
+function hasKey(obj, key) {
+  if (obj == null || typeof obj !== 'object') {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}


### PR DESCRIPTION
Fix #15672

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#15672 is right, we don't need to check every single path in the update to check if the version key is being set. This PR simplifies and checks if Mongoose has already set the versionKey (Mongoose will only $set, $inc, or $setOnInsert the versionKey).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
