### PR TITLE
types: relax `model<T>` type signature to allow any schema

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1056,3 +1056,23 @@ async function gh16526() {
   const insertManyResult = await Tank.insertMany([{ name: 'test' }], { lean: true, rawResult: true });
   expectType<number>(insertManyResult.insertedCount);
 }
+
+async function gh15681() {
+  function getMongooseModel<T>(resName: string): mongoose.Model<T> {
+    if (mongoose.models[resName]) {
+      return mongoose.models[resName];
+    }
+
+    const schema = new mongoose.Schema({
+      example: String
+    });
+
+    return mongoose.model<T>(resName, schema);
+  }
+
+  type Example = {
+    name: string;
+  };
+
+  const Model = getMongooseModel<Example>('Example');
+}

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -202,7 +202,7 @@ declare module 'mongoose' {
       collection?: string,
       options?: CompileModelOptions
     ): U;
-    model<T>(name: string, schema?: Schema<T, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
+    model<T>(name: string, schema?: Schema<any, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
 
     /** Returns an array of model names created on this connection. */
     modelNames(): Array<string>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,7 +97,7 @@ declare module 'mongoose' {
     TSchema
   > & ObtainSchemaGeneric<TSchema, 'TStaticMethods'>;
 
-  export function model<T>(name: string, schema?: Schema<T, any, any> | Schema<T & Document, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
+  export function model<T>(name: string, schema?: Schema<any, any, any>, collection?: string, options?: CompileModelOptions): Model<T>;
 
   export function model<T, U, TQueryHelpers = {}>(
     name: string,


### PR DESCRIPTION
Fix #15681

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Something in 8.19.0 release started causing the following script to OOM crash:

```ts
import mongoose from "mongoose";

function getMongooseModel<T>(resName: string): mongoose.Model<T> {
  if (mongoose.models[resName]) {
    return mongoose.models[resName];
  }

  const schema = new mongoose.Schema({
    example: String,
  });

  return mongoose.model<T>(resName, schema);
}

type Example = {
  name: string;
};

const Model = getMongooseModel<Example>("Example");
```

I haven't been able to figure out exactly what, but there are two easy fixes:

1. Update user code to do `const schema = new mongoose.Schema<T>(...)`
2. Allow `model<T>` to take in `Schema<any>` as opposed to `Schema<T>`

(2) seems reasonable to do, although we will also suggest (1). These fixes unfortunately seem to be exclusive - applying (2) makes (1) fail with OOM :(

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
