### PR TITLE
types(models): default _id type to ObjectId for Document

### DIFF
--- a/test/types/middleware.test.ts
+++ b/test/types/middleware.test.ts
@@ -192,15 +192,11 @@ function gh11257() {
 }
 
 function gh13601() {
-  interface ITest extends Document {
-    name?: string;
-  }
-
-  const testSchema = new Schema<ITest>({
+  const testSchema = new Schema({
     name: String
   });
 
-  testSchema.pre('deleteOne', { document: true }, function(this: ITest) {
+  testSchema.pre('deleteOne', { document: true }, function() {
     expectAssignable<Document>(this);
   });
 }


### PR DESCRIPTION
# Summary

This pull request changes the default generic type `T` for the `Document` class from `unknown` to `ObjectId`.

The motivation for this change is to improve the developer experience for TypeScript users by providing a more practical and intuitive default. In the vast majority of Mongoose schemas, the `_id` field is an `ObjectId` by default. Aligning the generic type `T` (which represents the type of `_id`) with this behavior reduces boilerplate and prevents potential type errors.

Currently, developers often have to explicitly define `Document<ObjectId>` to get proper type-safety on the `_id` field. By making `ObjectId` the default, the types will work out-of-the-box for the most common use case.

This also raises a question: I'm curious about the original rationale for choosing `unknown` as the default. There may be a design consideration I am not aware of, and understanding it would be valuable.

# Examples

This change directly impacts type inference on document instances.

## Current Behavior

With the default `T = unknown`, accessing methods on `_id` without explicit typing results in a TypeScript error.

```ts
import { Document, Schema, model } from 'mongoose';

// Interface extending `Document` uses the default generic `unknown` for the `_id`.
interface IUser extends Document {
  name: string;
}

const userSchema = new Schema<IUser>({ name: { type: String, required: true } });
const User = model<IUser>('User', userSchema);

const user = new User({ name: 'Jane Doe' });

// `user._id` is typed as `unknown`.
// The following line causes a TypeScript error:
// >> Property 'toString' does not exist on type 'unknown'.
const idString = user._id.toString();
```

## After this PR

With the default `T = ObjectId`, the `_id` property is correctly typed, and no errors occur.

```ts
import { Document, Schema, model } from 'mongoose';

// Interface extending `Document` now uses the new default generic `ObjectId` for the `_id`.
interface IUser extends Document {
  name: string;
}

const userSchema = new Schema<IUser>({ name: { type: String, required: true } });
const User = model<IUser>('User', userSchema);

const user = new User({ name: 'Jane Doe' });

// `user._id` is correctly typed as `ObjectId`.
// This code now works perfectly without any type errors.
const idString = user._id.toString(); // OK!
```