### PR TITLE
fix(connection): snapshot Date so stale heartbeat check protects against useFakeTimers

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -30,7 +30,7 @@ const sessionNewDocuments = require('./helpers/symbols').sessionNewDocuments;
 
 // Snapshot the native Date constructor to ensure both Date.now() and new Date() (and other Date methods)
 // bypass timer mocks such as those set up by useFakeTimers().
-const Date = global.Date;
+const Date = globalThis.Date;
 
 /**
  * A list of authentication mechanisms that don't require a password for authentication.


### PR DESCRIPTION
Fix #14949

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

In our jest docs https://mongoosejs.com/docs/jest.html we recommend importing mongoose before calling useFakeTimers(), which gives us a way to work around #14949: ensure we get the Node built in Date class before useFakeTimers clobbers it. Works well with our claim that importing mongoose before useFakeTimers is "Fine for basic cases"

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
