### PR TITLE
fix(schema): correctly cache text indexes as 'text' not 1

### DIFF
--- a/lib/helpers/schema/getIndexes.js
+++ b/lib/helpers/schema/getIndexes.js
@@ -72,7 +72,7 @@ module.exports = function getIndexes(schema) {
       if (index !== false && index !== null && index !== undefined) {
         const field = {};
         const isObject = helperIsObject(index);
-        const options = isObject ? index : {};
+        const options = isObject ? { ...index } : {};
         const type = typeof index === 'string' ? index :
           isObject ? index.type :
             false;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3950,4 +3950,13 @@ describe('schema', function() {
     await doc.save();
 
   });
+
+  it('retains text index when caching indexes', async function() {
+    const schema = new Schema({ content: { type: String, index: { text: true } } });
+    const firstCall = schema.indexes();
+    const secondCall = schema.indexes();
+
+    assert.deepStrictEqual(firstCall, [[{ content: 'text' }, { background: true }]]);
+    assert.deepStrictEqual(secondCall, [[{ content: 'text' }, { background: true }]]);
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Spotted an inconsistency in how text indexes are handled in `schema.indexes()`. `schema.indexes()` incorrectly modifies state that future calls depend on, so without this fix, the first `schema.index()` call will correctly return `{ content: 'text' }` but the 2nd would return `{ content: 1 }`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
