### PR TITLE
types: make inferRawDocType correctly infer empty array type `[]` as `any[]`

### DIFF
--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -127,3 +127,10 @@ function HandlesAny() {
   type ActualNested = InferRawDocType<Record<string, any>>;
   expectType<{ [x: string]: any }>({} as ActualNested);
 }
+
+function gh15699() {
+  const schema = { unTypedArray: [] } as const;
+
+  type TSchema = InferRawDocType<typeof schema>;
+  expectType<any[] | null | undefined>({} as unknown as TSchema['unTypedArray']);
+}

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -60,7 +60,7 @@ declare module 'mongoose' {
     [PathValueType] extends [neverOrAny] ? PathValueType
     : PathValueType extends Schema ? InferSchemaType<PathValueType>
     : PathValueType extends ReadonlyArray<infer Item> ?
-      Item extends never ? any[]
+      [Item] extends [never] ? any[]
       : Item extends Schema ?
         // If Item is a schema, infer its type.
         Array<InferSchemaType<Item>>


### PR DESCRIPTION
Fix #15699

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Weird TypeScript quirk: when `Item` is `never`, `Item extends never ? any[] : ...` returns `never` if `Item` is a generic param:

<img width="528" height="179" alt="image" src="https://github.com/user-attachments/assets/3c814267-e857-4646-8bb3-e562cfdcd133" />

Workaround seems to be to wrap in a tuple.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
