### PR TITLE
fix(model+plugins): correctly apply shard key on deleteOne()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -802,8 +802,18 @@ Model.prototype.deleteOne = function deleteOne(options) {
     }
   }
 
-  query.pre(function queryPreDeleteOne(cb) {
-    self.constructor._middleware.execPre('deleteOne', self, [self], cb);
+  query.pre(async function queryPreDeleteOne() {
+    await new Promise((resolve, reject) => {
+      self.constructor._middleware.execPre('deleteOne', self, [self], err => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    // Apply custom where conditions _after_ document deleteOne middleware for
+    // consistency with save() - sharding plugin needs to set $where
+    if (self.$where != null) {
+      this.where(self.$where);
+    }
   });
   query.pre(function callSubdocPreHooks(cb) {
     each(self.$getAllSubdocs(), (subdoc, cb) => {

--- a/lib/plugins/sharding.js
+++ b/lib/plugins/sharding.js
@@ -16,7 +16,7 @@ module.exports = function shardingPlugin(schema) {
     applyWhere.call(this);
     next();
   });
-  schema.pre('remove', function shardingPluginPreRemove(next) {
+  schema.pre('deleteOne', { document: true, query: false }, function shardingPluginPreRemove(next) {
     applyWhere.call(this);
     next();
   });

--- a/test/sharding.test.js
+++ b/test/sharding.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const start = require('./common');
+
+const mongoose = start.mongoose;
+
+describe('plugins.sharding', function() {
+  let db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  beforeEach(() => db.deleteModel(/.*/));
+  afterEach(() => require('./util').clearTestData(db));
+  afterEach(() => require('./util').stopRemainingOps(db));
+
+  it('applies shard key to deleteOne (gh-15701)', async function() {
+    const TestModel = db.model('Test', new mongoose.Schema({ name: String, shardKey: String }));
+    const doc = await TestModel.create({ name: 'test', shardKey: 'test1' });
+    doc.$__.shardval = { shardKey: 'test2' };
+    let res = await doc.deleteOne();
+    assert.strictEqual(res.deletedCount, 0);
+    doc.$__.shardval = { shardKey: 'test1' };
+    res = await doc.deleteOne();
+    assert.strictEqual(res.deletedCount, 1);
+
+    await TestModel.create({ name: 'test2', shardKey: 'test2' });
+    res = await TestModel.deleteOne({ name: 'test2' });
+    assert.strictEqual(res.deletedCount, 1);
+  });
+});


### PR DESCRIPTION
Fix #15701

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Couple of issues preventing shard key from getting set on `deleteOne()`:

1. Plugin still uses `pre('remove')` not `pre('deleteOne')`, even though `pre('remove')` is no longer supported
2. `deleteOne()` needs to handle custom `$where` property on documents similar to how `save()` does. That's what sharding plugin uses to indicate what the shard key is.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
