### PR TITLE
fix: correct return type of discriminator to Model<U>

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -20,7 +20,7 @@ declare module 'mongoose' {
       name: string | number,
       schema: Schema<T, U>,
       value?: string | number | ObjectId | DiscriminatorOptions
-    ): U;
+    ): Model<U>;
   }
 
   export type MongooseBulkWriteResult = mongodb.BulkWriteResult & {


### PR DESCRIPTION
**Summary**
Fix the return type of `discriminator` so that it correctly returns a `Model<U>` instead of a plain object.
This ensures TypeScript correctly infers the returned type when using generics with discriminators.

**Examples**
Before:
```typescript
type TBaseSchema = { name: string };
type TSchema = { age: number };

const model = BaseModel.discriminator<TSchema, TBaseSchema & TSchema>(
    'example',
    new Schema({ age: { type: Number } })
);

model;
// ^? const model: { name: string; } & { age: number; }
```

After:
```typescript
model;
/* ^? const model: Model<TBaseSchema & TSchema, {}, {}, {}, Document<unknown, {}, TBaseSchema & TSchema, {}, {}> & TBaseSchema & TSchema & {
    _id: Types.ObjectId;
} & {
    __v: number;
}, any>
*/
```