### PR TITLE
Update examples/statics/statics.js

### DIFF
--- a/examples/statics/statics.js
+++ b/examples/statics/statics.js
@@ -28,6 +28,6 @@ async function run() {
 }
 
 async function cleanup() {
-  await Person.remove();
+  await Person.deleteMany();
   mongoose.disconnect();
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Update `examples/statics/statics.js` to replace the deprecated `Person.remove()` call in the `cleanup()` function with `Person.deleteMany()`.  
The `remove()` API was removed in Mongoose 7+, causing the example to throw a runtime error.  
This change ensures compatibility with Mongoose 7 and 8.

**Examples**

Before:
```js
await Person.remove();

