### PR TITLE
docs: fix inline doc typo in schematypes.d.ts

### DIFF
--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -97,7 +97,7 @@ declare module 'mongoose' {
 
     /**
      * If true, attach a required validator to this path, which ensures this path
-     * path cannot be set to a nullish value. If a function, Mongoose calls the
+     * cannot be set to a nullish value. If a function, Mongoose calls the
      * function and only checks for nullish values if the function returns a truthy value.
      */
     required?:


### PR DESCRIPTION
**Summary**

the word 'path' is repeated twice (once in the end first line and again in the beginning of the second line) in the comment for the 'required' property in schematypes.d.ts

