### PR TITLE
fix(model): respect autoCreate set on global after creating connection

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1318,7 +1318,11 @@ Model.syncIndexes = async function syncIndexes(options) {
     throw new MongooseError('Model.syncIndexes() no longer accepts a callback');
   }
 
-  const autoCreate = options?.autoCreate ?? this.schema.options?.autoCreate ?? this.db.config.autoCreate ?? true;
+  const autoCreate = options?.autoCreate ??
+    this.schema.options?.autoCreate ??
+    this.db.config.autoCreate ??
+    this.db.base?.options?.autoCreate ??
+    true;
 
   if (autoCreate) {
     try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently global `autoCreate` option isn't respected on `syncIndexes()` if you set `autoCreate` after the connection is already created (like if you set `mongoose.set('autoCreate', false)` and then use `mongoose.connect()`)

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
