### PR TITLE
Add benchmark for large nested array documents (related to #9588)

### DIFF
--- a/benchmarks/nestedArrayLarge.js
+++ b/benchmarks/nestedArrayLarge.js
@@ -45,6 +45,6 @@ async function run() {
         'save() time ms': +(saveEnd - saveStart).toFixed(2)
     };
 
-    console.log(JSON.stringify(results, null, ' '));
+    console.log(JSON.stringify(results, null, '  '));
     process.exit(0);
 }


### PR DESCRIPTION
### Summary

This PR adds a new benchmark `benchmarks/nestedArrayLarge.js` that measures
Mongoose’s performance when constructing documents with large nested arrays,
matching the structure used in issue #9588 (`asks: [[Number]]`, `bids: [[Number]]`).

This benchmark also helps verify that the performance issue described in #9588
is no longer reproducible in current Mongoose versions.

While the original issue showed a significant CPU spike in Mongoose 5.x,
modern Mongoose (v8.x) performs well. This benchmark provides ongoing regression
coverage for nested-array casting performance.

### What this benchmark does

- Follows the same structure and conventions used in existing Mongoose benchmarks

- Creates a schema with nested arrays (`[[Number]]`)
- Generates 10,000 nested arrays in the document
- Measures construction performance using Benchmark.js
- Logs results when `MONGOOSE_DEV=1` or `PULL_REQUEST=1`
- Matches benchmark formatting used in the Mongoose repo

### Why this is useful

Issue #9588 was originally caused by heavy casting and atomic tracking in nested arrays.
Multiple optimizations since then have improved performance significantly.

This benchmark ensures:

- Nested-array casting remains fast in future releases  
- No regressions occur in deep array performance  
- Mongoose maintains visibility into a historically problematic case  

### Related Issue

Closes #9588 (performance regression appears resolved in Mongoose 8.x)
