### PR TITLE
Update browser.md with Mongoose limitations

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -38,5 +38,5 @@ console.log(doc.validateSync());
 
 **Note:** The browser version of Mongoose supports only schema-based validation.
 Built-in validators (like `required`, `enum`, `minlength`) and custom validators work as expected using `validate()` or `validateSync()`.
-However, browser Mongoose does **not** support models, queries, defaults, middleware (hooks), or any database operations.
-Only document validation is available in the browser build.
+However, browser Mongoose does **not** support database operations, queries, or populate. Some features, like simplified models, document hooks (middleware), and defaults, are available in a limited capacity.
+Only document validation and limited model/document features are available in the browser build.


### PR DESCRIPTION
The current browser.md explains that the browser build is limited, but it doesn’t clearly list what actually works. This update adds a short note to make the behavior more understandable.

The note now clarifies that:
• Browser build supports only schema-based validation. • Built-in validators and custom validators work with validate()/validateSync(). • Setters/getters work as expected.
• Models, queries, defaults, middleware, and all database operations are not
  available in the browser build.

This makes the browser section clearer and reduces confusion for developers using validation on the frontend.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
