### PR TITLE
perf(query): skip recursive casting for simple equality filters

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2368,7 +2368,37 @@ Query.prototype._castConditions = function() {
 
   if (sanitizeFilterOpt) {
     sanitizeFilter(this._conditions);
+
   }
+  function _isSimpleEqualityFilter(filter, model) {
+    if (!filter || typeof filter !== 'object' || Array.isArray(filter)) return false;
+    const keys = Object.keys(filter);
+    if (keys.length === 0) return false;
+
+    for (let i = 0; i < keys.length; ++i) {
+      const k = keys[i];
+      if (k.charAt(0) === '$') return false;
+
+      const v = filter[k];
+      if (v === null) continue;
+
+      const t = typeof v;
+      if (t === 'string' || t === 'number' || t === 'boolean' || v instanceof RegExp) {
+        const schemaType = model && model.schema ? model.schema.path(k) : null;
+        if (schemaType && schemaType.instance && /ObjectId/i.test(schemaType.instance)) return false;
+        continue;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+
+  if (_isSimpleEqualityFilter(this._conditions, this.model)) {
+    return;
+  }
+
 
   try {
     this.cast(this.model);


### PR DESCRIPTION
## Summary

This PR introduces a conservative performance optimization in `Query.prototype._castConditions`.  
For simple equality filters (e.g. `{ name: "Alice" }`, `{ age: 20 }`), Mongoose currently performs the full recursive casting pipeline, which adds noticeable overhead compared to the native MongoDB driver.

This PR adds a fast-path that skips recursive casting when the filter meets all of the following conditions:
- plain object (not an array)
- no operator keys (`$...`)
- values are primitives (`string`, `number`, `boolean`), `RegExp`, or `null`
- the matching schema paths are **not** ObjectId fields (to avoid skipping required ObjectId casting)

If all conditions are satisfied, `_castConditions` returns early and avoids the expensive casting process.

---

## Motivation

Mongoose users have reported slower query performance compared to the native driver, especially for frequently-used simple lookups such as:
```js
Model.find({ name: "Alice" })
Model.findOne({ email: "abc@test.com" })