### PR TITLE
Throw error when lean() is used on updateOne()

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -2192,6 +2192,9 @@ Query.prototype._optionsForExec = function(model) {
  */
 
 Query.prototype.lean = function(v) {
+  if (this.op === 'updateOne') {
+    throw new MongooseError('`lean()` is not supported on updateOne() operations');
+  }
   this._mongooseOptions.lean = arguments.length ? v : true;
   return this;
 };

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -420,6 +420,17 @@ describe('model: updateOne:', function() {
     assert.equal(affected.modifiedCount, 1);
   });
 
+  it('throws error when using lean() on updateOne() (gh-13392)', async function() {
+    let err = null;
+    try {
+      BlogPost.updateOne({ _id: post._id }, { $set: { title: newTitle } }).lean();
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err);
+    assert.equal(err.message, '`lean()` is not supported on updateOne() operations');
+  });
+
   it('handles $push with $ positionals (gh-1057)', async function() {
     const taskSchema = new Schema({
       name: String


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

fixes #13392

This PR updates Query.prototype.lean to throw a clear error when used on updateOne() operations. Since updateOne() returns a write result rather than a document, applying lean() is not meaningful. The updated behavior provides a clear and consistent error message.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->



**Code Change**

in lib/query.js

```js
Query.prototype.lean = function(v) {
  if (this.op === 'updateOne') {
    throw new MongooseError('`lean()` is not supported on updateOne() operations');
  }
  this._mongooseOptions.lean = arguments.length ? v : true;
  return this;
};

```

In test/model.updateOne.test.js

```js
assert.equal(affected.modifiedCount, 1);
  });

  it('throws error when using lean() on updateOne() (gh-13392)', async function() {
    let err = null;
    try {
      BlogPost.updateOne({ _id: post._id }, { $set: { title: newTitle } }).lean();
    } catch (e) {
      err = e;
    }
    assert.ok(err);
    assert.equal(err.message, '`lean()` is not supported on updateOne() operations');
  });

  it('handles $push with $ positionals (gh-1057)', async function() {
    const taskSchema = new Schema({
      name: String
```

**Testing**
- All existing test cases Passed
- Added 1 new test case that verifies:
  - lean() throws an error when used with updateOne()
