### PR TITLE
fix(docs): prevent parser crash when prop.tags is undefined

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -269,7 +269,7 @@ function processFile(props) {
     if ('constructor' in ctx && ctx.constructor === undefined) {
       ctx.constructorWasUndefined = true;
     }
-
+    if (!prop.tags) continue;
     for (const __tag of prop.tags) {
       // the following has been done, because otherwise no type could be applied for intellisense
       /** @type {TagObject} */


### PR DESCRIPTION
### Summary

The docs parser crashed when it encountered documentation blocks where `prop.tags` was missing or undefined.  
This caused the following runtime error during docs generation:

TypeError: Cannot read properties of undefined (reading 'Symbol(Symbol.iterator)')


This PR adds a guard:

```js
if (!prop.tags) continue;
```

to safely skip entries without tags and prevent the crash.
Fixes #15764