### PR TITLE
fix(insertMany): surface per-document validation errors for unordered inserts

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2987,6 +2987,16 @@ Model.insertMany = async function insertMany(arr, options) {
   }
 
   const docs = await parallelLimit(arr, validateDoc, limit);
+  const assignResultsForUnordered = () => {
+    if (results == null) {
+      return;
+    }
+    for (let i = 0; i < results.length; ++i) {
+      if (results[i] === void 0) {
+        results[i] = docs[i];
+      }
+    }
+  };
 
   const originalDocIndex = new Map();
   const validDocIndexToOriginalIndex = new Map();
@@ -3031,6 +3041,10 @@ Model.insertMany = async function insertMany(arr, options) {
       decorateBulkWriteResult(res, validationErrors, validationErrors);
       return res;
     }
+    if (ordered === false) {
+      assignResultsForUnordered();
+      return decorateBulkWriteResult([], validationErrors, results);
+    }
     return [];
   }
   const docObjects = lean ? docAttributes : docAttributes.map(function(doc) {
@@ -3073,12 +3087,7 @@ Model.insertMany = async function insertMany(arr, options) {
     }
 
     if (!ordered) {
-      for (let i = 0; i < results.length; ++i) {
-        if (results[i] === void 0) {
-          results[i] = docs[i];
-        }
-      }
-
+      assignResultsForUnordered();
       error.results = results;
     }
 
@@ -3108,7 +3117,7 @@ Model.insertMany = async function insertMany(arr, options) {
         return doc;
       });
 
-    if (rawResult && ordered === false) {
+    if (ordered === false && (rawResult || validationErrors.length > 0)) {
       decorateBulkWriteResult(error, validationErrors, results);
     }
 
@@ -3123,11 +3132,7 @@ Model.insertMany = async function insertMany(arr, options) {
   }
 
   if (ordered === false && throwOnValidationError && validationErrors.length > 0) {
-    for (let i = 0; i < results.length; ++i) {
-      if (results[i] === void 0) {
-        results[i] = docs[i];
-      }
-    }
+    assignResultsForUnordered();
     throw new MongooseBulkWriteError(
       validationErrors,
       results,
@@ -3138,17 +3143,17 @@ Model.insertMany = async function insertMany(arr, options) {
 
   if (rawResult) {
     if (ordered === false) {
-      for (let i = 0; i < results.length; ++i) {
-        if (results[i] === void 0) {
-          results[i] = docs[i];
-        }
-      }
-
+      assignResultsForUnordered();
       // Decorate with mongoose validation errors in case of unordered,
       // because then still do `insertMany()`
       decorateBulkWriteResult(res, validationErrors, results);
     }
     return res;
+  }
+
+  if (ordered === false && validationErrors.length > 0) {
+    assignResultsForUnordered();
+    decorateBulkWriteResult(docAttributes, validationErrors, results);
   }
 
   if (options.populate != null) {


### PR DESCRIPTION
Summary

Unordered insertMany() silently dropped per-document validation errors unless rawResult: true was set, so users couldn’t tell which documents failed. This change decorates every unordered outcome (empty arrays, successful document arrays, and Mongo bulk errors) with mongoose.validationErrors/mongoose.results, ensuring parity with the rawResult path. Targeted regression tests have been added to lock down this new behavior.

Examples

The new tests in test/model.insertMany.test.js demonstrate that await Model.insertMany([...], { ordered: false }) now returns the successful documents plus docs.mongoose.validationErrors listing the failed indexes. A failing unordered insert (MongoBulkWriteError) now carries the same mongoose.validationErrors/results metadata even when rawResult is false.

This pull request addresses issue https://github.com/Automattic/mongoose/issues/15771.