### PR TITLE
fix(bulkWrite): pass overwriteImmutable option to castUpdate fixes #15781

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -118,7 +118,9 @@ module.exports.castUpdateOne = function castUpdateOne(originalModel, updateOne, 
   if (model.schema.$timestamps != null && doInitTimestamps) {
     const createdAt = model.schema.$timestamps.createdAt;
     const updatedAt = model.schema.$timestamps.updatedAt;
-    applyTimestampsToUpdate(now, createdAt, updatedAt, update, {});
+    applyTimestampsToUpdate(now, createdAt, updatedAt, update, {
+      timestamps: updateOne.timestamps
+    });
   }
 
   if (doInitTimestamps) {
@@ -150,7 +152,8 @@ module.exports.castUpdateOne = function castUpdateOne(originalModel, updateOne, 
     strict: strict,
     upsert: updateOne.upsert,
     arrayFilters: updateOne.arrayFilters,
-    overwriteDiscriminatorKey: updateOne.overwriteDiscriminatorKey
+    overwriteDiscriminatorKey: updateOne.overwriteDiscriminatorKey,
+    overwriteImmutable: updateOne.overwriteImmutable
   }, model, updateOne['filter']);
 
   return updateOne;
@@ -185,7 +188,9 @@ module.exports.castUpdateMany = function castUpdateMany(originalModel, updateMan
   if (model.schema.$timestamps != null && doInitTimestamps) {
     const createdAt = model.schema.$timestamps.createdAt;
     const updatedAt = model.schema.$timestamps.updatedAt;
-    applyTimestampsToUpdate(now, createdAt, updatedAt, updateMany['update'], {});
+    applyTimestampsToUpdate(now, createdAt, updatedAt, updateMany['update'], {
+      timestamps: updateMany.timestamps
+    });
   }
   if (doInitTimestamps) {
     applyTimestampsToChildren(now, updateMany['update'], model.schema);
@@ -208,7 +213,8 @@ module.exports.castUpdateMany = function castUpdateMany(originalModel, updateMan
     strict: strict,
     upsert: updateMany.upsert,
     arrayFilters: updateMany.arrayFilters,
-    overwriteDiscriminatorKey: updateMany.overwriteDiscriminatorKey
+    overwriteDiscriminatorKey: updateMany.overwriteDiscriminatorKey,
+    overwriteImmutable: updateMany.overwriteImmutable
   }, model, updateMany['filter']);
 };
 

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -2680,6 +2680,36 @@ describe('model: updateOne: ', function() {
     assert.equal(doc.age, 20);
   });
 
+  it('overwriting immutable createdAt with bulkWrite (gh-15781)', async function() {
+    const start = new Date().valueOf();
+    const schema = Schema({
+      createdAt: {
+        type: mongoose.Schema.Types.Date,
+        immutable: true
+      },
+      name: String
+    }, { timestamps: true });
+
+    const Model = db.model('Test', schema);
+
+    await Model.create({ name: 'gh-15781' });
+    let doc = await Model.collection.findOne({ name: 'gh-15781' });
+    assert.ok(doc.createdAt.valueOf() >= start);
+
+    const createdAt = new Date('2011-06-01');
+    assert.ok(createdAt.valueOf() < start.valueOf());
+    await Model.bulkWrite([{
+      updateOne: {
+        filter: { _id: doc._id },
+        update: { name: 'gh-15781 update', createdAt },
+        overwriteImmutable: true,
+        timestamps: false
+      }
+    }]);
+    doc = await Model.collection.findOne({ name: 'gh-15781 update' });
+    assert.equal(doc.createdAt.valueOf(), createdAt.valueOf());
+  });
+
   it('updates buffers with `runValidators` successfully (gh-8580)', async function() {
     const Test = db.model('Test', Schema({
       data: { type: Buffer, required: true }


### PR DESCRIPTION
Fixes #15781

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

When using `bulkWrite` with `updateOne` or `updateMany` operations, the `overwriteImmutable` option was not being passed through to `castUpdate`. This prevented users from updating immutable timestamp fields like `createdAt` even when explicitly setting `overwriteImmutable: true` and `timestamps: false`.

The issue was that in `castBulkWrite.js`, the `overwriteImmutable` option from the operation was not included in the options object passed to `castUpdate`, causing `handleImmutable` to remove the immutable field from the update.

This PR fixes the issue by:
1. Passing `overwriteImmutable` option from the operation to `castUpdate` in both `castUpdateOne` and `castUpdateMany`
2. Passing `timestamps` option to `applyTimestampsToUpdate` to prevent deletion of `createdAt` when `timestamps: false` is set

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```javascript
const personSchema = new mongoose.Schema(
  { name: { type: String, required: true } },
  { timestamps: true }
);
const PersonModel = mongoose.model('Person', personSchema);

const person = await PersonModel.create({ name: 'John' });

// Before this fix: createdAt would NOT be updated
// After this fix: createdAt IS updated to new Date(0)
await PersonModel.bulkWrite([{
  updateOne: {
    filter: { name: 'John' },
    update: { createdAt: new Date(0) },
    timestamps: false,
    overwriteImmutable: true
  }
}]);