### PR TITLE
docs: Add closing backticks to code block in migration guide

### DIFF
--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -112,6 +112,7 @@ mongoose.isValidObjectId(6);
 
 // Works in Mongoose 8, throws in Mongoose 9
 new mongoose.Types.ObjectId(6);
+```
 
 ## Subdocument `deleteOne()` hooks execute only when subdocument is deleted
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I read migration guide and found out that it's broken due to missing backticks

**Examples**

<img width="694" height="452" alt="image" src="https://github.com/user-attachments/assets/f7955dd5-dbad-4268-8d36-1888bdb3c34e" />
