### PR TITLE
fix(generateSearch): prevent #undefined in search URLs when heading lacks id

### DIFF
--- a/scripts/generateSearch.js
+++ b/scripts/generateSearch.js
@@ -71,10 +71,12 @@ function generateContents() {
         el = $(el);
         const title = el.text();
         const html = el.nextUntil('h3').html();
+        const id = el.prop('id');
+        const baseUrl = filename.replace('.md', '.html').replace(/^docs/, '');
         const content = new Content({
           title: `${file.title}: ${title}`,
           body: html,
-          url: `${filename.replace('.md', '.html').replace(/^docs/, '')}#${el.prop('id')}`
+          url: id ? `${baseUrl}#${id}` : baseUrl
         });
 
         content.validateSync();
@@ -102,10 +104,12 @@ function generateContents() {
         el = $(el);
         const title = el.text();
         const html = el.nextUntil('h3').html();
+        const id = el.prop('id');
+        const baseUrl = filename.replace('.pug', '.html').replace(/^docs/, '');
         const content = new Content({
           title: `${file.title}: ${title}`,
           body: html,
-          url: `${filename.replace('.pug', '.html').replace(/^docs/, '')}#${el.prop('id')}`
+          url: id ? `${baseUrl}#${id}` : baseUrl
         });
 
         content.validateSync();


### PR DESCRIPTION
### Summary
This pull request fixes an issue in the documentation search index generator
(`scripts/generateSearch.js`) where URLs containing headings without an `id`
attribute would incorrectly include `#undefined` in the final link. This caused
broken navigation when clicking certain results in the documentation search.

### What was the problem?
The script assumes all `<h3>` tags have an `id` and always appends
`#${el.prop('id')}` to the generated URL. When the `id` is missing, URLs like the
following were inserted:

### What does this PR change?
Adds a null/undefined check before appending URL hash fragments:

- If an id exists → append `#id`
- If not → return the base page URL

This prevents broken URLs in the search index.

### Verification
Verified locally by running:

```bash
node scripts/generateSearch.js


