### PR TITLE
fix(types): allow partial statics in Schema.static()

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -623,7 +623,7 @@ declare module 'mongoose' {
 
     /** Adds static "class" methods to Models compiled from this schema. */
     static<K extends keyof TStaticMethods>(name: K, fn: TStaticMethods[K]): this;
-    static(obj: { [F in keyof TStaticMethods]: TStaticMethods[F] } & { [name: string]: (this: TModelType, ...args: any[]) => any }): this;
+    static(obj: { [F in keyof TStaticMethods]?: TStaticMethods[F] } & { [name: string]: (this: TModelType, ...args: any[]) => any }): this;
     static(name: string, fn: (this: TModelType, ...args: any[]) => any): this;
 
     /** Object of currently defined statics on this schema. */


### PR DESCRIPTION
Fixes #15780

### Problem
When using `Schema.static({...})` with TypeScript generics, TypeScript required
that all properties defined in `TStaticMethods` be present in the object passed
to `schema.static()`. This prevented users from adding statics one at a time.

### Solution
Make the mapped type keys optional:
`{ [F in keyof TStaticMethods]?: TStaticMethods[F] }`

This aligns `Schema.static()` with the behavior of `Schema.method()` and allows
incremental addition of static methods.

### Notes
- This change affects only TypeScript definitions.
- No runtime behavior is touched.
- Low risk, minimal change.
