### PR TITLE
fix: suppress MongoDB connection logs to prevent memory leak

### DIFF
--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -314,6 +314,12 @@ NativeConnection.prototype.createClient = async function createClient(uri, optio
     };
   }
 
+
+  if (!utils.hasUserDefinedProperty(options, 'mongodbLogComponentSeverities')) {
+    options.mongodbLogComponentSeverities = {
+      connection: 'off'
+    };
+  }
   const { schemaMap, encryptedFieldsMap } = this._buildEncryptionSchemas();
 
   if ((Object.keys(schemaMap).length > 0 || Object.keys(encryptedFieldsMap).length) && !options.autoEncryption) {


### PR DESCRIPTION
Fix #15785
Addresses memory leak caused by excessive MongoDB connection logs when connecting without authentication.

Adds `mongodbLogComponentSeverities` configuration to suppress client-side connection pool logs.

## Changes
- Added `mongodbLogComponentSeverities` option in [lib/drivers/node-mongodb-native/connection.js](cci:7://file:///Users/devendramishra/Desktop/mongoose/lib/drivers/node-mongodb-native/connection.js:0:0-0:0)
- Sets connection component logging to `'off'` by default
- Uses `hasUserDefinedProperty` check to respect user overrides

## Technical Details
- Based on MongoDB Node.js Driver v7.0+ logging configuration
- Suppresses connection pool event logs
- Maintains backward compatibility
- Does not affect custom logging configurations

## Note
This addresses client-side logging. If server-side MongoDB logs continue to accumulate, server logging configuration may need adjustment.

## Testing
- Verified against MongoDB Driver documentation
- Maintains backward compatibility
- Respects user-defined logging options