### PR TITLE
Fix: Robust Null Safety for Internal Utility Functions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -190,6 +190,9 @@ exports.deepEqual = function deepEqual(a, b) {
  */
 
 exports.last = function(arr) {
+  if (arr == null) {
+    return void 0;
+  }
   if (arr.length > 0) {
     return arr[arr.length - 1];
   }
@@ -271,6 +274,10 @@ exports.clonePOJOsAndArrays = function clonePOJOsAndArrays(val) {
 
 exports.merge = function merge(to, from, options, path) {
   options = options || {};
+
+  if (from == null) {
+    return to;
+  }
 
   const keys = Object.keys(from);
   let i = 0;
@@ -690,6 +697,9 @@ exports.setValue = function(path, val, obj, map, _copying) {
 
 exports.object = {};
 exports.object.vals = function vals(o) {
+  if (o == null) {
+    return [];
+  }
   const keys = Object.keys(o);
   let i = keys.length;
   const ret = [];

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -351,4 +351,26 @@ describe('utils', function() {
       assert.equal(utils.toCollectionName('test', pluralize), 'tests');
     });
   });
+
+  describe('null checks', function() {
+    // regression test: previously these would crash with "Cannot read property 'length' of null"
+    // or similar errors. now they should fail gracefully.
+    it('utils.last() handles null/undefined inputs', function() {
+      assert.strictEqual(utils.last(null), undefined);
+      assert.strictEqual(utils.last(undefined), undefined);
+    });
+
+    // merge shouldn't blow up if the source object is missing
+    it('utils.merge() returns target if source is null/undefined', function() {
+      const target = { foo: 'bar' };
+      assert.strictEqual(utils.merge(target, null), target);
+      assert.strictEqual(utils.merge(target, undefined), target);
+    });
+
+    // just return empty array if we can't get values from nothing
+    it('utils.object.vals() returns empty array for null/undefined', function() {
+      assert.deepStrictEqual(utils.object.vals(null), []);
+      assert.deepStrictEqual(utils.object.vals(undefined), []);
+    });
+  });
 });


### PR DESCRIPTION
# Fix: Preventing crashes on empty inputs in utils

### Summary!

I noticed a few spots in the internal utility functions ([lib/utils.js](cci:7://file:///Users/deepeshdey/Desktop/mongoose/lib/utils.js:0:0-0:0)) that were a bit fragile. If you accidentally passed `null` or `undefined` to them, they would immediately crash with a `TypeError` (like trying to read `.length` of null).

**What I fixed:**
I added some simple guard checks to these three functions so they handle empty inputs gracefully instead of blowing up:
*   **`utils.last`**: Now returns `undefined` if the array is missing.
*   **`utils.merge`**: Now just returns the original target object if there's nothing to merge from.
*   **`utils.object.vals`**: Now returns an empty array `[]` if the input is empty.

**Testing:**
I added a few regression tests in [test/utils.test.js](cci:7://file:///Users/deepeshdey/Desktop/mongoose/test/utils.test.js:0:0-0:0) to confirm these edge cases are covered and won't regress. All tests are passing locally!

### Kindly review my PR and merge it
## Thank You!