### PR TITLE
fix(model): increment version key in bulkSave on successful write #15800

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,83 +1,83 @@
-'use strict';
+"use strict";
 
 /*!
  * Module dependencies.
  */
 
-const Aggregate = require('./aggregate');
-const ChangeStream = require('./cursor/changeStream');
-const Document = require('./document');
-const DocumentNotFoundError = require('./error/notFound');
-const EventEmitter = require('events').EventEmitter;
-const Kareem = require('kareem');
-const MongooseBulkWriteError = require('./error/bulkWriteError');
-const MongooseError = require('./error/index');
-const ObjectParameterError = require('./error/objectParameter');
-const OverwriteModelError = require('./error/overwriteModel');
-const Query = require('./query');
-const SaveOptions = require('./options/saveOptions');
-const Schema = require('./schema');
-const ValidationError = require('./error/validation');
-const VersionError = require('./error/version');
-const ParallelSaveError = require('./error/parallelSave');
-const applyDefaultsHelper = require('./helpers/document/applyDefaults');
-const applyDefaultsToPOJO = require('./helpers/model/applyDefaultsToPOJO');
-const applyEmbeddedDiscriminators = require('./helpers/discriminator/applyEmbeddedDiscriminators');
-const applyHooks = require('./helpers/model/applyHooks');
-const applyMethods = require('./helpers/model/applyMethods');
-const applyProjection = require('./helpers/projection/applyProjection');
-const applyReadConcern = require('./helpers/schema/applyReadConcern');
-const applySchemaCollation = require('./helpers/indexes/applySchemaCollation');
-const applyStaticHooks = require('./helpers/model/applyStaticHooks');
-const applyStatics = require('./helpers/model/applyStatics');
-const applyTimestampsHelper = require('./helpers/document/applyTimestamps');
-const applyWriteConcern = require('./helpers/schema/applyWriteConcern');
-const applyVirtualsHelper = require('./helpers/document/applyVirtuals');
-const assignVals = require('./helpers/populate/assignVals');
-const castBulkWrite = require('./helpers/model/castBulkWrite');
-const clone = require('./helpers/clone');
-const createPopulateQueryFilter = require('./helpers/populate/createPopulateQueryFilter');
-const decorateUpdateWithVersionKey = require('./helpers/update/decorateUpdateWithVersionKey');
-const getDefaultBulkwriteResult = require('./helpers/getDefaultBulkwriteResult');
-const getSchemaDiscriminatorByValue = require('./helpers/discriminator/getSchemaDiscriminatorByValue');
-const discriminator = require('./helpers/model/discriminator');
-const each = require('./helpers/each');
-const get = require('./helpers/get');
-const getConstructorName = require('./helpers/getConstructorName');
-const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminatorByValue');
-const getModelsMapForPopulate = require('./helpers/populate/getModelsMapForPopulate');
-const immediate = require('./helpers/immediate');
-const internalToObjectOptions = require('./options').internalToObjectOptions;
-const isDefaultIdIndex = require('./helpers/indexes/isDefaultIdIndex');
-const isIndexEqual = require('./helpers/indexes/isIndexEqual');
-const isTimeseriesIndex = require('./helpers/indexes/isTimeseriesIndex');
+const Aggregate = require("./aggregate");
+const ChangeStream = require("./cursor/changeStream");
+const Document = require("./document");
+const DocumentNotFoundError = require("./error/notFound");
+const EventEmitter = require("events").EventEmitter;
+const Kareem = require("kareem");
+const MongooseBulkWriteError = require("./error/bulkWriteError");
+const MongooseError = require("./error/index");
+const ObjectParameterError = require("./error/objectParameter");
+const OverwriteModelError = require("./error/overwriteModel");
+const Query = require("./query");
+const SaveOptions = require("./options/saveOptions");
+const Schema = require("./schema");
+const ValidationError = require("./error/validation");
+const VersionError = require("./error/version");
+const ParallelSaveError = require("./error/parallelSave");
+const applyDefaultsHelper = require("./helpers/document/applyDefaults");
+const applyDefaultsToPOJO = require("./helpers/model/applyDefaultsToPOJO");
+const applyEmbeddedDiscriminators = require("./helpers/discriminator/applyEmbeddedDiscriminators");
+const applyHooks = require("./helpers/model/applyHooks");
+const applyMethods = require("./helpers/model/applyMethods");
+const applyProjection = require("./helpers/projection/applyProjection");
+const applyReadConcern = require("./helpers/schema/applyReadConcern");
+const applySchemaCollation = require("./helpers/indexes/applySchemaCollation");
+const applyStaticHooks = require("./helpers/model/applyStaticHooks");
+const applyStatics = require("./helpers/model/applyStatics");
+const applyTimestampsHelper = require("./helpers/document/applyTimestamps");
+const applyWriteConcern = require("./helpers/schema/applyWriteConcern");
+const applyVirtualsHelper = require("./helpers/document/applyVirtuals");
+const assignVals = require("./helpers/populate/assignVals");
+const castBulkWrite = require("./helpers/model/castBulkWrite");
+const clone = require("./helpers/clone");
+const createPopulateQueryFilter = require("./helpers/populate/createPopulateQueryFilter");
+const decorateUpdateWithVersionKey = require("./helpers/update/decorateUpdateWithVersionKey");
+const getDefaultBulkwriteResult = require("./helpers/getDefaultBulkwriteResult");
+const getSchemaDiscriminatorByValue = require("./helpers/discriminator/getSchemaDiscriminatorByValue");
+const discriminator = require("./helpers/model/discriminator");
+const each = require("./helpers/each");
+const get = require("./helpers/get");
+const getConstructorName = require("./helpers/getConstructorName");
+const getDiscriminatorByValue = require("./helpers/discriminator/getDiscriminatorByValue");
+const getModelsMapForPopulate = require("./helpers/populate/getModelsMapForPopulate");
+const immediate = require("./helpers/immediate");
+const internalToObjectOptions = require("./options").internalToObjectOptions;
+const isDefaultIdIndex = require("./helpers/indexes/isDefaultIdIndex");
+const isIndexEqual = require("./helpers/indexes/isIndexEqual");
+const isTimeseriesIndex = require("./helpers/indexes/isTimeseriesIndex");
 const {
   getRelatedDBIndexes,
-  getRelatedSchemaIndexes
-} = require('./helpers/indexes/getRelatedIndexes');
-const decorateDiscriminatorIndexOptions = require('./helpers/indexes/decorateDiscriminatorIndexOptions');
-const isPathSelectedInclusive = require('./helpers/projection/isPathSelectedInclusive');
-const leanPopulateMap = require('./helpers/populate/leanPopulateMap');
-const parallelLimit = require('./helpers/parallelLimit');
-const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscriminatorPipeline');
-const pushNestedArrayPaths = require('./helpers/model/pushNestedArrayPaths');
-const removeDeselectedForeignField = require('./helpers/populate/removeDeselectedForeignField');
-const setDottedPath = require('./helpers/path/setDottedPath');
-const util = require('util');
-const utils = require('./utils');
-const minimize = require('./helpers/minimize');
-const MongooseBulkSaveIncompleteError = require('./error/bulkSaveIncompleteError');
-const ObjectExpectedError = require('./error/objectExpected');
-const decorateBulkWriteResult = require('./helpers/model/decorateBulkWriteResult');
-const modelCollectionSymbol = Symbol('mongoose#Model#collection');
-const modelDbSymbol = Symbol('mongoose#Model#db');
-const modelSymbol = require('./helpers/symbols').modelSymbol;
-const subclassedSymbol = Symbol('mongoose#Model#subclassed');
+  getRelatedSchemaIndexes,
+} = require("./helpers/indexes/getRelatedIndexes");
+const decorateDiscriminatorIndexOptions = require("./helpers/indexes/decorateDiscriminatorIndexOptions");
+const isPathSelectedInclusive = require("./helpers/projection/isPathSelectedInclusive");
+const leanPopulateMap = require("./helpers/populate/leanPopulateMap");
+const parallelLimit = require("./helpers/parallelLimit");
+const prepareDiscriminatorPipeline = require("./helpers/aggregate/prepareDiscriminatorPipeline");
+const pushNestedArrayPaths = require("./helpers/model/pushNestedArrayPaths");
+const removeDeselectedForeignField = require("./helpers/populate/removeDeselectedForeignField");
+const setDottedPath = require("./helpers/path/setDottedPath");
+const util = require("util");
+const utils = require("./utils");
+const minimize = require("./helpers/minimize");
+const MongooseBulkSaveIncompleteError = require("./error/bulkSaveIncompleteError");
+const ObjectExpectedError = require("./error/objectExpected");
+const decorateBulkWriteResult = require("./helpers/model/decorateBulkWriteResult");
+const modelCollectionSymbol = Symbol("mongoose#Model#collection");
+const modelDbSymbol = Symbol("mongoose#Model#db");
+const modelSymbol = require("./helpers/symbols").modelSymbol;
+const subclassedSymbol = Symbol("mongoose#Model#subclassed");
 
 const { VERSION_INC, VERSION_WHERE, VERSION_ALL } = Document;
 
 const saveToObjectOptions = Object.assign({}, internalToObjectOptions, {
-  bson: true
+  bson: true,
 });
 
 /**
@@ -117,14 +117,18 @@ const saveToObjectOptions = Object.assign({}, internalToObjectOptions, {
 
 function Model(doc, fields, options) {
   if (fields instanceof Schema) {
-    throw new TypeError('2nd argument to `Model` constructor must be a POJO or string, ' +
-      '**not** a schema. Make sure you\'re calling `mongoose.model()`, not ' +
-      '`mongoose.Model()`.');
+    throw new TypeError(
+      "2nd argument to `Model` constructor must be a POJO or string, " +
+        "**not** a schema. Make sure you're calling `mongoose.model()`, not " +
+        "`mongoose.Model()`."
+    );
   }
-  if (typeof doc === 'string') {
-    throw new TypeError('First argument to `Model` constructor must be an object, ' +
-      '**not** a string. Make sure you\'re calling `mongoose.model()`, not ' +
-      '`mongoose.Model()`.');
+  if (typeof doc === "string") {
+    throw new TypeError(
+      "First argument to `Model` constructor must be an object, " +
+        "**not** a string. Make sure you're calling `mongoose.model()`, not " +
+        "`mongoose.Model()`."
+    );
   }
   Document.call(this, doc, fields, options);
 }
@@ -182,7 +186,7 @@ Model.prototype.db;
 
 Model.useConnection = function useConnection(connection) {
   if (!connection) {
-    throw new Error('Please provide a connection.');
+    throw new Error("Please provide a connection.");
   }
   if (this.db) {
     delete this.db.models[this.modelName];
@@ -194,7 +198,10 @@ Model.useConnection = function useConnection(connection) {
   }
 
   this.db = connection;
-  const collection = connection.collection(this.collection.collectionName, connection.options);
+  const collection = connection.collection(
+    this.collection.collectionName,
+    connection.options
+  );
   this.prototype.collection = collection;
   this.prototype.$collection = collection;
   this.prototype[modelCollectionSymbol] = collection;
@@ -232,7 +239,6 @@ Model.prototype.collection;
  * @memberOf Model
  * @instance
  */
-
 
 Model.prototype.$__collection;
 
@@ -322,37 +328,41 @@ function _createSaveOptions(doc, options) {
   const saveOptions = {};
 
   applyWriteConcern(doc.$__schema, options);
-  if (typeof options.writeConcern !== 'undefined') {
+  if (typeof options.writeConcern !== "undefined") {
     saveOptions.writeConcern = {};
-    if ('w' in options.writeConcern) {
+    if ("w" in options.writeConcern) {
       saveOptions.writeConcern.w = options.writeConcern.w;
     }
-    if ('j' in options.writeConcern) {
+    if ("j" in options.writeConcern) {
       saveOptions.writeConcern.j = options.writeConcern.j;
     }
-    if ('wtimeout' in options.writeConcern) {
+    if ("wtimeout" in options.writeConcern) {
       saveOptions.writeConcern.wtimeout = options.writeConcern.wtimeout;
     }
   } else {
-    if ('w' in options) {
+    if ("w" in options) {
       saveOptions.w = options.w;
     }
-    if ('j' in options) {
+    if ("j" in options) {
       saveOptions.j = options.j;
     }
-    if ('wtimeout' in options) {
+    if ("wtimeout" in options) {
       saveOptions.wtimeout = options.wtimeout;
     }
   }
-  if ('checkKeys' in options) {
+  if ("checkKeys" in options) {
     saveOptions.checkKeys = options.checkKeys;
   }
 
   const session = doc.$session();
-  const asyncLocalStorage = doc[modelDbSymbol].base.transactionAsyncLocalStorage?.getStore();
+  const asyncLocalStorage =
+    doc[modelDbSymbol].base.transactionAsyncLocalStorage?.getStore();
   if (session != null) {
     saveOptions.session = session;
-  } else if (!options.hasOwnProperty('session') && asyncLocalStorage?.session != null) {
+  } else if (
+    !options.hasOwnProperty("session") &&
+    asyncLocalStorage?.session != null
+  ) {
     // Only set session from asyncLocalStorage if `session` option wasn't originally passed in options
     saveOptions.session = asyncLocalStorage.session;
   }
@@ -366,12 +376,11 @@ function _createSaveOptions(doc, options) {
 
 Model.prototype.$__save = async function $__save(options) {
   try {
-    await this._execDocumentPreHooks('save', options);
+    await this._execDocumentPreHooks("save", options);
   } catch (error) {
-    await this._execDocumentPostHooks('save', error);
+    await this._execDocumentPostHooks("save", error);
     return;
   }
-
 
   let result = null;
   let where = null;
@@ -387,7 +396,7 @@ Model.prototype.$__save = async function $__save(options) {
         // wouldn't know what _id was generated by mongodb either
         // nor would the ObjectId generated by mongodb necessarily
         // match the schema definition.
-        throw new MongooseError('document must have an _id before saving');
+        throw new MongooseError("document must have an _id before saving");
       }
 
       this.$__version(true, obj);
@@ -395,10 +404,12 @@ Model.prototype.$__save = async function $__save(options) {
       _setIsNew(this, false);
       // Make it possible to retry the insert
       this.$__.inserting = true;
-      result = await this[modelCollectionSymbol].insertOne(obj, saveOptions).catch(err => {
-        _setIsNew(this, true);
-        throw err;
-      });
+      result = await this[modelCollectionSymbol]
+        .insertOne(obj, saveOptions)
+        .catch((err) => {
+          _setIsNew(this, true);
+          throw err;
+        });
     } else {
       // Make sure we don't treat it as a new object on error,
       // since it already exists
@@ -406,13 +417,19 @@ Model.prototype.$__save = async function $__save(options) {
       const delta = this.$__delta();
 
       if (options.pathsToSave) {
-        for (const key in delta[1]['$set']) {
+        for (const key in delta[1]["$set"]) {
           if (options.pathsToSave.includes(key)) {
             continue;
-          } else if (options.pathsToSave.some(pathToSave => key.slice(0, pathToSave.length) === pathToSave && key.charAt(pathToSave.length) === '.')) {
+          } else if (
+            options.pathsToSave.some(
+              (pathToSave) =>
+                key.slice(0, pathToSave.length) === pathToSave &&
+                key.charAt(pathToSave.length) === "."
+            )
+          ) {
             continue;
           } else {
-            delete delta[1]['$set'][key];
+            delete delta[1]["$set"][key];
           }
         }
       }
@@ -427,7 +444,7 @@ Model.prototype.$__save = async function $__save(options) {
               continue;
             }
             for (const key of Object.keys(updateOp)) {
-              if (updateOp[key] == null || typeof updateOp[key] !== 'object') {
+              if (updateOp[key] == null || typeof updateOp[key] !== "object") {
                 continue;
               }
               if (!utils.isPOJO(updateOp[key])) {
@@ -448,10 +465,12 @@ Model.prototype.$__save = async function $__save(options) {
         this.$__reset();
 
         _setIsNew(this, false);
-        result = await this[modelCollectionSymbol].updateOne(where, update, saveOptions).catch(err => {
-          this.$__undoReset();
-          throw err;
-        });
+        result = await this[modelCollectionSymbol]
+          .updateOne(where, update, saveOptions)
+          .catch((err) => {
+            this.$__undoReset();
+            throw err;
+          });
       } else {
         where = this.$__where();
         _applyCustomWhere(this, where);
@@ -460,22 +479,26 @@ Model.prototype.$__save = async function $__save(options) {
         }
 
         applyReadConcern(this.$__schema, saveOptions);
-        result = await this.constructor.collection.findOne(where, saveOptions)
-          .then(documentExists => ({ matchedCount: !documentExists ? 0 : 1 }));
+        result = await this.constructor.collection
+          .findOne(where, saveOptions)
+          .then((documentExists) => ({
+            matchedCount: !documentExists ? 0 : 1,
+          }));
       }
     }
   } catch (err) {
     const error = this.$__schema._transformDuplicateKeyError(err);
-    await this._execDocumentPostHooks('save', error);
+    await this._execDocumentPostHooks("save", error);
     return;
   }
 
   let numAffected = 0;
-  const writeConcern = options != null ?
-    options.writeConcern != null ?
-      options.writeConcern.w :
-      options.w :
-    0;
+  const writeConcern =
+    options != null
+      ? options.writeConcern != null
+        ? options.writeConcern.w
+        : options.w
+      : 0;
   if (writeConcern !== 0) {
     // Skip checking if write succeeded if writeConcern is set to
     // unacknowledged writes, because otherwise `numAffected` will always be 0
@@ -499,9 +522,10 @@ Model.prototype.$__save = async function $__save(options) {
       if (numAffected <= 0) {
         // the update failed. pass an error back
         this.$__undoReset();
-        const err = this.$__.$versionError ||
+        const err =
+          this.$__.$versionError ||
           new VersionError(this, version, this.$__.modifiedPaths);
-        await this._execDocumentPostHooks('save', err);
+        await this._execDocumentPostHooks("save", err);
         return;
       }
 
@@ -512,16 +536,21 @@ Model.prototype.$__save = async function $__save(options) {
     }
     if (result != null && numAffected <= 0) {
       this.$__undoReset();
-      const error = new DocumentNotFoundError(where, this.constructor.modelName, numAffected, result);
-      await this._execDocumentPostHooks('save', error);
+      const error = new DocumentNotFoundError(
+        where,
+        this.constructor.modelName,
+        numAffected,
+        result
+      );
+      await this._execDocumentPostHooks("save", error);
       return;
     }
   }
   this.$__.saving = undefined;
   this.$__.savedState = {};
-  this.$emit('save', this, numAffected);
-  this.constructor.emit('save', this, numAffected);
-  await this._execDocumentPostHooks('save');
+  this.$emit("save", this, numAffected);
+  this.constructor.emit("save", this, numAffected);
+  await this._execDocumentPostHooks("save");
 };
 
 /*!
@@ -572,12 +601,14 @@ function generateVersionError(doc, modifiedPaths, defaultPaths) {
  */
 
 Model.prototype.save = async function save(options) {
-  if (typeof options === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.prototype.save() no longer accepts a callback');
+  if (typeof options === "function" || typeof arguments[1] === "function") {
+    throw new MongooseError(
+      "Model.prototype.save() no longer accepts a callback"
+    );
   }
 
   let parallelSave;
-  this.$op = 'save';
+  this.$op = "save";
 
   if (this.$__.saving) {
     parallelSave = new ParallelSaveError(this);
@@ -586,7 +617,7 @@ Model.prototype.save = async function save(options) {
   }
 
   options = new SaveOptions(options);
-  if (options.hasOwnProperty('session')) {
+  if (options.hasOwnProperty("session")) {
     this.$session(options.session);
   }
   if (this.$__.timestamps != null) {
@@ -595,7 +626,7 @@ Model.prototype.save = async function save(options) {
   this.$__.$versionError = generateVersionError(
     this,
     this.modifiedPaths(),
-    Object.keys(this.$__.activePaths.getStatePaths('default'))
+    Object.keys(this.$__.activePaths.getStatePaths("default"))
   );
 
   if (parallelSave) {
@@ -631,7 +662,7 @@ Model.prototype.$save = Model.prototype.save;
  * @instance
  */
 
-Model.prototype.$__version = function(where, delta) {
+Model.prototype.$__version = function (where, delta) {
   const key = this.$__schema.options.versionKey;
   if (where === true) {
     // this is an insert
@@ -713,7 +744,7 @@ Model.prototype.$__where = function _where(where) {
   }
 
   if (this._doc._id === void 0) {
-    throw new MongooseError('No _id found on document!');
+    throw new MongooseError("No _id found on document!");
   }
 
   return where;
@@ -739,16 +770,17 @@ Model.prototype.$__where = function _where(where) {
  */
 
 Model.prototype.deleteOne = function deleteOne(options) {
-  if (typeof options === 'function' ||
-      typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.prototype.deleteOne() no longer accepts a callback');
+  if (typeof options === "function" || typeof arguments[1] === "function") {
+    throw new MongooseError(
+      "Model.prototype.deleteOne() no longer accepts a callback"
+    );
   }
 
   if (!options) {
     options = {};
   }
 
-  if (options.hasOwnProperty('session')) {
+  if (options.hasOwnProperty("session")) {
     this.$session(options.session);
   }
 
@@ -757,17 +789,21 @@ Model.prototype.deleteOne = function deleteOne(options) {
   const query = self.constructor.deleteOne(where, options);
 
   if (this.$session() != null) {
-    if (!('session' in query.options)) {
+    if (!("session" in query.options)) {
       query.options.session = this.$session();
     }
   }
 
   query.pre(async function queryPreDeleteOne() {
-    const res = await self.constructor._middleware.execPre('deleteOne', self, [self]);
+    const res = await self.constructor._middleware.execPre("deleteOne", self, [
+      self,
+    ]);
     // `self` is passed to pre hooks as argument for backwards compatibility, but that
     // isn't the actual arguments passed to the wrapped function.
     if (res?.length !== 1 || res[0] !== self) {
-      throw new Error('Document deleteOne pre hooks cannot overwrite arguments');
+      throw new Error(
+        "Document deleteOne pre hooks cannot overwrite arguments"
+      );
     }
     // Apply custom where conditions _after_ document deleteOne middleware for
     // consistency with save() - sharding plugin needs to set $where
@@ -777,7 +813,13 @@ Model.prototype.deleteOne = function deleteOne(options) {
     return res;
   });
   query.pre(function callSubdocPreHooks() {
-    return Promise.all(self.$getAllSubdocs().map(subdoc => subdoc.constructor._middleware.execPre('deleteOne', subdoc, [subdoc])));
+    return Promise.all(
+      self
+        .$getAllSubdocs()
+        .map((subdoc) =>
+          subdoc.constructor._middleware.execPre("deleteOne", subdoc, [subdoc])
+        )
+    );
   });
   query.pre(function skipIfAlreadyDeleted() {
     if (self.$__.isDeleted) {
@@ -785,10 +827,16 @@ Model.prototype.deleteOne = function deleteOne(options) {
     }
   });
   query.post(function callSubdocPostHooks() {
-    return Promise.all(self.$getAllSubdocs().map(subdoc => subdoc.constructor._middleware.execPost('deleteOne', subdoc, [subdoc])));
+    return Promise.all(
+      self
+        .$getAllSubdocs()
+        .map((subdoc) =>
+          subdoc.constructor._middleware.execPost("deleteOne", subdoc, [subdoc])
+        )
+    );
   });
   query.post(function queryPostDeleteOne() {
-    return self.constructor._middleware.execPost('deleteOne', self, [self], {});
+    return self.constructor._middleware.execPost("deleteOne", self, [self], {});
   });
 
   return query;
@@ -860,15 +908,15 @@ Model.prototype.model = Model.prototype.$model;
  */
 
 Model.exists = function exists(filter, options) {
-  _checkContext(this, 'exists');
-  if (typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.exists() no longer accepts a callback');
+  _checkContext(this, "exists");
+  if (typeof arguments[2] === "function") {
+    throw new MongooseError("Model.exists() no longer accepts a callback");
   }
 
-  const query = this.findOne(filter).
-    select({ _id: 1 }).
-    lean().
-    setOptions(options);
+  const query = this.findOne(filter)
+    .select({ _id: 1 })
+    .lean()
+    .setOptions(options);
 
   return query;
 };
@@ -911,23 +959,29 @@ Model.exists = function exists(filter, options) {
  * @api public
  */
 
-Model.discriminator = function(name, schema, options) {
+Model.discriminator = function (name, schema, options) {
   let model;
-  if (typeof name === 'function') {
+  if (typeof name === "function") {
     model = name;
     name = utils.getFunctionName(model);
     if (!(model.prototype instanceof Model)) {
-      throw new MongooseError('The provided class ' + name + ' must extend Model');
+      throw new MongooseError(
+        "The provided class " + name + " must extend Model"
+      );
     }
   }
 
   options = options || {};
   const value = utils.isPOJO(options) ? options.value : options;
-  const clone = typeof options.clone === 'boolean' ? options.clone : true;
-  const mergePlugins = typeof options.mergePlugins === 'boolean' ? options.mergePlugins : true;
-  const overwriteModels = typeof options.overwriteModels === 'boolean' ? options.overwriteModels : false;
+  const clone = typeof options.clone === "boolean" ? options.clone : true;
+  const mergePlugins =
+    typeof options.mergePlugins === "boolean" ? options.mergePlugins : true;
+  const overwriteModels =
+    typeof options.overwriteModels === "boolean"
+      ? options.overwriteModels
+      : false;
 
-  _checkContext(this, 'discriminator');
+  _checkContext(this, "discriminator");
 
   if (utils.isObject(schema) && !schema.instanceOfSchema) {
     schema = new Schema(schema);
@@ -936,8 +990,20 @@ Model.discriminator = function(name, schema, options) {
     schema = schema.clone();
   }
 
-  schema = discriminator(this, name, schema, value, mergePlugins, options.mergeHooks, overwriteModels);
-  if (this.db.models[name] && !schema.options.overwriteModels && !overwriteModels) {
+  schema = discriminator(
+    this,
+    name,
+    schema,
+    value,
+    mergePlugins,
+    options.mergeHooks,
+    overwriteModels
+  );
+  if (
+    this.db.models[name] &&
+    !schema.options.overwriteModels &&
+    !overwriteModels
+  ) {
     throw new OverwriteModelError(name);
   }
 
@@ -948,10 +1014,10 @@ Model.discriminator = function(name, schema, options) {
   this.discriminators[name] = model;
   const d = this.discriminators[name];
   Object.setPrototypeOf(d.prototype, this.prototype);
-  Object.defineProperty(d, 'baseModelName', {
+  Object.defineProperty(d, "baseModelName", {
     value: this.modelName,
     configurable: true,
-    writable: false
+    writable: false,
   });
 
   // apply methods and statics
@@ -961,8 +1027,11 @@ Model.discriminator = function(name, schema, options) {
   if (this[subclassedSymbol] != null) {
     for (const submodel of this[subclassedSymbol]) {
       submodel.discriminators = submodel.discriminators || {};
-      submodel.discriminators[name] =
-        model.__subclass(model.db, schema, submodel.collection.name);
+      submodel.discriminators[name] = model.__subclass(
+        model.db,
+        schema,
+        submodel.collection.name
+      );
     }
   }
 
@@ -978,13 +1047,25 @@ function _checkContext(ctx, fnName) {
   // Check context, because it is easy to mistakenly type
   // `new Model.discriminator()` and get an incomprehensible error
   if (ctx == null || ctx === global) {
-    throw new MongooseError('`Model.' + fnName + '()` cannot run without a ' +
-      'model as `this`. Make sure you are calling `MyModel.' + fnName + '()` ' +
-      'where `MyModel` is a Mongoose model.');
+    throw new MongooseError(
+      "`Model." +
+        fnName +
+        "()` cannot run without a " +
+        "model as `this`. Make sure you are calling `MyModel." +
+        fnName +
+        "()` " +
+        "where `MyModel` is a Mongoose model."
+    );
   } else if (ctx[modelSymbol] == null) {
-    throw new MongooseError('`Model.' + fnName + '()` cannot run without a ' +
-      'model as `this`. Make sure you are not calling ' +
-      '`new Model.' + fnName + '()`');
+    throw new MongooseError(
+      "`Model." +
+        fnName +
+        "()` cannot run without a " +
+        "model as `this`. Make sure you are not calling " +
+        "`new Model." +
+        fnName +
+        "()`"
+    );
   }
 }
 
@@ -1030,21 +1111,21 @@ for (const i in EventEmitter.prototype) {
  */
 
 Model.init = function init() {
-  _checkContext(this, 'init');
-  if (typeof arguments[0] === 'function') {
-    throw new MongooseError('Model.init() no longer accepts a callback');
+  _checkContext(this, "init");
+  if (typeof arguments[0] === "function") {
+    throw new MongooseError("Model.init() no longer accepts a callback");
   }
 
-  this.schema.emit('init', this);
+  this.schema.emit("init", this);
 
   if (this.$init != null) {
     return this.$init;
   }
 
   const conn = this.db;
-  const _ensureIndexes = async() => {
+  const _ensureIndexes = async () => {
     const autoIndex = utils.getOption(
-      'autoIndex',
+      "autoIndex",
       this.schema.options,
       conn.config,
       conn.base.options
@@ -1054,9 +1135,9 @@ Model.init = function init() {
     }
     return await this.ensureIndexes({ _automatic: true });
   };
-  const _createSearchIndexes = async() => {
+  const _createSearchIndexes = async () => {
     const autoSearchIndex = utils.getOption(
-      'autoSearchIndex',
+      "autoSearchIndex",
       this.schema.options,
       conn.config,
       conn.base.options
@@ -1067,9 +1148,9 @@ Model.init = function init() {
 
     return await this.createSearchIndexes();
   };
-  const _createCollection = async() => {
+  const _createCollection = async () => {
     let autoCreate = utils.getOption(
-      'autoCreate',
+      "autoCreate",
       this.schema.options,
       conn.config
       // No base.options here because we don't want to take the base value if the connection hasn't
@@ -1079,7 +1160,7 @@ Model.init = function init() {
       // `autoCreate` may later be set when the connection is opened, so wait for connect before checking
       await conn._waitForConnect(true);
       autoCreate = utils.getOption(
-        'autoCreate',
+        "autoCreate",
         this.schema.options,
         conn.config,
         conn.base.options
@@ -1093,20 +1174,19 @@ Model.init = function init() {
     return await this.createCollection();
   };
 
-  this.$init = _createCollection().
-    then(() => _ensureIndexes()).
-    then(() => _createSearchIndexes());
+  this.$init = _createCollection()
+    .then(() => _ensureIndexes())
+    .then(() => _createSearchIndexes());
 
   const _catch = this.$init.catch;
   const _this = this;
-  this.$init.catch = function() {
+  this.$init.catch = function () {
     _this.$caught = true;
     return _catch.apply(_this.$init, arguments);
   };
 
   return this.$init;
 };
-
 
 /**
  * Create the collection for this model. By default, if no indexes are specified,
@@ -1134,19 +1214,27 @@ Model.init = function init() {
  */
 
 Model.createCollection = async function createCollection(options) {
-  _checkContext(this, 'createCollection');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.createCollection() no longer accepts a callback');
+  _checkContext(this, "createCollection");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.createCollection() no longer accepts a callback"
+    );
   }
 
-  [options] = await this.hooks.execPre('createCollection', this, [options]).catch(err => {
-    if (err instanceof Kareem.skipWrappedFunction) {
-      return [err];
-    }
-    throw err;
-  });
+  [options] = await this.hooks
+    .execPre("createCollection", this, [options])
+    .catch((err) => {
+      if (err instanceof Kareem.skipWrappedFunction) {
+        return [err];
+      }
+      throw err;
+    });
 
-  const collectionOptions = this &&
+  const collectionOptions =
+    this &&
     this.schema &&
     this.schema.options &&
     this.schema.options.collectionOptions;
@@ -1154,25 +1242,22 @@ Model.createCollection = async function createCollection(options) {
     options = Object.assign({}, collectionOptions, options);
   }
 
-  const schemaCollation = this &&
-    this.schema &&
-    this.schema.options &&
-    this.schema.options.collation;
+  const schemaCollation =
+    this && this.schema && this.schema.options && this.schema.options.collation;
   if (schemaCollation != null) {
     options = Object.assign({ collation: schemaCollation }, options);
   }
-  const capped = this &&
-    this.schema &&
-    this.schema.options &&
-    this.schema.options.capped;
+  const capped =
+    this && this.schema && this.schema.options && this.schema.options.capped;
   if (capped != null) {
-    if (typeof capped === 'number') {
+    if (typeof capped === "number") {
       options = Object.assign({ capped: true, size: capped }, options);
-    } else if (typeof capped === 'object') {
+    } else if (typeof capped === "object") {
       options = Object.assign({ capped: true }, capped, options);
     }
   }
-  const timeseries = this &&
+  const timeseries =
+    this &&
     this.schema &&
     this.schema.options &&
     this.schema.options.timeseries;
@@ -1190,25 +1275,34 @@ Model.createCollection = async function createCollection(options) {
     }
   }
 
-  const clusteredIndex = this &&
+  const clusteredIndex =
+    this &&
     this.schema &&
     this.schema.options &&
     this.schema.options.clusteredIndex;
   if (clusteredIndex != null) {
-    options = Object.assign({ clusteredIndex: { ...clusteredIndex, unique: true } }, options);
+    options = Object.assign(
+      { clusteredIndex: { ...clusteredIndex, unique: true } },
+      options
+    );
   }
 
   try {
     if (!(options instanceof Kareem.skipWrappedFunction)) {
-      await this.db.createCollection(this.$__collection.collectionName, options);
+      await this.db.createCollection(
+        this.$__collection.collectionName,
+        options
+      );
     }
   } catch (err) {
-    if (err != null && (err.name !== 'MongoServerError' || err.code !== 48)) {
-      await this.hooks.execPost('createCollection', this, [null], { error: err });
+    if (err != null && (err.name !== "MongoServerError" || err.code !== 48)) {
+      await this.hooks.execPost("createCollection", this, [null], {
+        error: err,
+      });
     }
   }
 
-  await this.hooks.execPost('createCollection', this, [this.$__collection]);
+  await this.hooks.execPost("createCollection", this, [this.$__collection]);
 
   return this.$__collection;
 };
@@ -1248,12 +1342,16 @@ Model.createCollection = async function createCollection(options) {
  */
 
 Model.syncIndexes = async function syncIndexes(options) {
-  _checkContext(this, 'syncIndexes');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.syncIndexes() no longer accepts a callback');
+  _checkContext(this, "syncIndexes");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function"
+  ) {
+    throw new MongooseError("Model.syncIndexes() no longer accepts a callback");
   }
 
-  const autoCreate = options?.autoCreate ??
+  const autoCreate =
+    options?.autoCreate ??
     this.schema.options?.autoCreate ??
     this.db.config.autoCreate ??
     this.db.base?.options?.autoCreate ??
@@ -1263,15 +1361,23 @@ Model.syncIndexes = async function syncIndexes(options) {
     try {
       await this.createCollection();
     } catch (err) {
-      if (err != null && (err.name !== 'MongoServerError' || err.code !== 48)) {
+      if (err != null && (err.name !== "MongoServerError" || err.code !== 48)) {
         throw err;
       }
     }
   }
 
-  const diffIndexesResult = await this.diffIndexes({ indexOptionsToCreate: true });
-  const dropped = await this.cleanIndexes({ ...options, toDrop: diffIndexesResult.toDrop });
-  await this.createIndexes({ ...options, toCreate: diffIndexesResult.toCreate });
+  const diffIndexesResult = await this.diffIndexes({
+    indexOptionsToCreate: true,
+  });
+  const dropped = await this.cleanIndexes({
+    ...options,
+    toDrop: diffIndexesResult.toDrop,
+  });
+  await this.createIndexes({
+    ...options,
+    toCreate: diffIndexesResult.toCreate,
+  });
 
   return dropped;
 };
@@ -1294,7 +1400,7 @@ Model.syncIndexes = async function syncIndexes(options) {
  */
 
 Model.createSearchIndex = async function createSearchIndex(description) {
-  _checkContext(this, 'createSearchIndex');
+  _checkContext(this, "createSearchIndex");
 
   return await this.$__collection.createSearchIndex(description);
 };
@@ -1316,7 +1422,7 @@ Model.createSearchIndex = async function createSearchIndex(description) {
  */
 
 Model.updateSearchIndex = async function updateSearchIndex(name, definition) {
-  _checkContext(this, 'updateSearchIndex');
+  _checkContext(this, "updateSearchIndex");
 
   return await this.$__collection.updateSearchIndex(name, definition);
 };
@@ -1337,7 +1443,7 @@ Model.updateSearchIndex = async function updateSearchIndex(name, definition) {
  */
 
 Model.dropSearchIndex = async function dropSearchIndex(name) {
-  _checkContext(this, 'dropSearchIndex');
+  _checkContext(this, "dropSearchIndex");
 
   return await this.$__collection.dropSearchIndex(name);
 };
@@ -1360,7 +1466,7 @@ Model.dropSearchIndex = async function dropSearchIndex(name) {
  */
 
 Model.listSearchIndexes = async function listSearchIndexes(options) {
-  _checkContext(this, 'listSearchIndexes');
+  _checkContext(this, "listSearchIndexes");
 
   const cursor = await this.$__collection.listSearchIndexes(options);
 
@@ -1382,14 +1488,17 @@ Model.listSearchIndexes = async function listSearchIndexes(options) {
  */
 
 Model.diffIndexes = async function diffIndexes(options) {
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.syncIndexes() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function"
+  ) {
+    throw new MongooseError("Model.syncIndexes() no longer accepts a callback");
   }
 
   const model = this;
 
-  let dbIndexes = await model.listIndexes().catch(err => {
-    if (err.codeName == 'NamespaceNotFound') {
+  let dbIndexes = await model.listIndexes().catch((err) => {
+    if (err.codeName == "NamespaceNotFound") {
       return undefined;
     }
     throw err;
@@ -1403,7 +1512,13 @@ Model.diffIndexes = async function diffIndexes(options) {
   const schemaIndexes = getRelatedSchemaIndexes(model, schema.indexes());
 
   const toDrop = getIndexesToDrop(schema, schemaIndexes, dbIndexes);
-  const toCreate = getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop, options);
+  const toCreate = getIndexesToCreate(
+    schema,
+    schemaIndexes,
+    dbIndexes,
+    toDrop,
+    options
+  );
 
   return { toDrop, toCreate };
 };
@@ -1415,7 +1530,10 @@ function getIndexesToCreate(schema, schemaIndexes, dbIndexes, toDrop, options) {
   for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
     let found = false;
 
-    const options = decorateDiscriminatorIndexOptions(schema, clone(schemaIndexOptions));
+    const options = decorateDiscriminatorIndexOptions(
+      schema,
+      clone(schemaIndexOptions)
+    );
 
     for (const index of dbIndexes) {
       if (isDefaultIdIndex(index)) {
@@ -1457,7 +1575,10 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
     }
 
     for (const [schemaIndexKeysObject, schemaIndexOptions] of schemaIndexes) {
-      const options = decorateDiscriminatorIndexOptions(schema, clone(schemaIndexOptions));
+      const options = decorateDiscriminatorIndexOptions(
+        schema,
+        clone(schemaIndexOptions)
+      );
       applySchemaCollation(schemaIndexKeysObject, options, schema.options);
 
       if (isIndexEqual(schemaIndexKeysObject, options, dbIndex)) {
@@ -1489,9 +1610,14 @@ function getIndexesToDrop(schema, schemaIndexes, dbIndexes) {
  */
 
 Model.cleanIndexes = async function cleanIndexes(options) {
-  _checkContext(this, 'cleanIndexes');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.cleanIndexes() no longer accepts a callback');
+  _checkContext(this, "cleanIndexes");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.cleanIndexes() no longer accepts a callback"
+    );
   }
   const model = this;
 
@@ -1511,14 +1637,18 @@ async function _dropIndexes(toDrop, model, options) {
 
   const collection = model.$__collection;
   if (options && options.hideIndexes) {
-    await Promise.all(toDrop.map(indexName => {
-      return model.db.db.command({
-        collMod: collection.collectionName,
-        index: { name: indexName, hidden: true }
-      });
-    }));
+    await Promise.all(
+      toDrop.map((indexName) => {
+        return model.db.db.command({
+          collMod: collection.collectionName,
+          index: { name: indexName, hidden: true },
+        });
+      })
+    );
   } else {
-    await Promise.all(toDrop.map(indexName => collection.dropIndex(indexName)));
+    await Promise.all(
+      toDrop.map((indexName) => collection.dropIndex(indexName))
+    );
   }
 
   return toDrop;
@@ -1535,13 +1665,13 @@ async function _dropIndexes(toDrop, model, options) {
  */
 
 Model.listIndexes = async function listIndexes() {
-  _checkContext(this, 'listIndexes');
-  if (typeof arguments[0] === 'function') {
-    throw new MongooseError('Model.listIndexes() no longer accepts a callback');
+  _checkContext(this, "listIndexes");
+  if (typeof arguments[0] === "function") {
+    throw new MongooseError("Model.listIndexes() no longer accepts a callback");
   }
 
   if (this.$__collection.buffer) {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       this.$__collection.addQueue(resolve);
     });
   }
@@ -1576,9 +1706,14 @@ Model.listIndexes = async function listIndexes() {
  */
 
 Model.ensureIndexes = async function ensureIndexes(options) {
-  _checkContext(this, 'ensureIndexes');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.ensureIndexes() no longer accepts a callback');
+  _checkContext(this, "ensureIndexes");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.ensureIndexes() no longer accepts a callback"
+    );
   }
 
   await new Promise((resolve, reject) => {
@@ -1601,61 +1736,71 @@ Model.ensureIndexes = async function ensureIndexes(options) {
  */
 
 Model.createIndexes = async function createIndexes(options) {
-  _checkContext(this, 'createIndexes');
+  _checkContext(this, "createIndexes");
 
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function') {
-    throw new MongooseError('Model.createIndexes() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.createIndexes() no longer accepts a callback"
+    );
   }
 
   return this.ensureIndexes(options);
 };
-
 
 /*!
  * ignore
  */
 
 function _ensureIndexes(model, options, callback) {
-  const indexes = Array.isArray(options?.toCreate) ? options.toCreate : model.schema.indexes();
+  const indexes = Array.isArray(options?.toCreate)
+    ? options.toCreate
+    : model.schema.indexes();
   let indexError;
 
   options = options || {};
-  const done = function(err) {
+  const done = function (err) {
     if (err && !model.$caught) {
-      model.emit('error', err);
+      model.emit("error", err);
     }
-    model.emit('index', err || indexError);
+    model.emit("index", err || indexError);
     callback && callback(err || indexError);
   };
 
   for (const index of indexes) {
     if (isDefaultIdIndex(index)) {
-      utils.warn('mongoose: Cannot specify a custom index on `_id` for ' +
-        'model name "' + model.modelName + '", ' +
-        'MongoDB does not allow overwriting the default `_id` index. See ' +
-        'https://bit.ly/mongodb-id-index');
+      utils.warn(
+        "mongoose: Cannot specify a custom index on `_id` for " +
+          'model name "' +
+          model.modelName +
+          '", ' +
+          "MongoDB does not allow overwriting the default `_id` index. See " +
+          "https://bit.ly/mongodb-id-index"
+      );
     }
   }
 
   if (!indexes.length) {
-    immediate(function() {
+    immediate(function () {
       done();
     });
     return;
   }
   // Indexes are created one-by-one
 
-  const indexSingleDone = function(err, fields, options, name) {
-    model.emit('index-single-done', err, fields, options, name);
+  const indexSingleDone = function (err, fields, options, name) {
+    model.emit("index-single-done", err, fields, options, name);
   };
-  const indexSingleStart = function(fields, options) {
-    model.emit('index-single-start', fields, options);
+  const indexSingleStart = function (fields, options) {
+    model.emit("index-single-start", fields, options);
   };
 
   const baseSchema = model.schema._baseSchema;
   const baseSchemaIndexes = baseSchema ? baseSchema.indexes() : [];
 
-  immediate(function() {
+  immediate(function () {
     // If buffering is off, do this manually.
     if (options._automatic && !model.collection.collection) {
       model.collection.addQueue(create, []);
@@ -1664,11 +1809,13 @@ function _ensureIndexes(model, options, callback) {
     }
   });
 
-
   function create() {
     if (options._automatic) {
-      if (model.schema.options.autoIndex === false ||
-          (model.schema.options.autoIndex == null && model.db.config.autoIndex === false)) {
+      if (
+        model.schema.options.autoIndex === false ||
+        (model.schema.options.autoIndex == null &&
+          model.db.config.autoIndex === false)
+      ) {
         return done();
       }
     }
@@ -1681,7 +1828,7 @@ function _ensureIndexes(model, options, callback) {
       return create();
     }
 
-    if (baseSchemaIndexes.find(i => utils.deepEqual(i, index))) {
+    if (baseSchemaIndexes.find((i) => utils.deepEqual(i, index))) {
       return create();
     }
 
@@ -1704,7 +1851,7 @@ function _ensureIndexes(model, options, callback) {
         indexError = err;
       }
       if (!model.$caught) {
-        model.emit('error', err);
+        model.emit("error", err);
       }
 
       indexSingleDone(err, indexFields, indexOptions);
@@ -1713,16 +1860,16 @@ function _ensureIndexes(model, options, callback) {
     }
 
     promise.then(
-      name => {
+      (name) => {
         indexSingleDone(null, indexFields, indexOptions, name);
         create();
       },
-      err => {
+      (err) => {
         if (!indexError) {
           indexError = err;
         }
         if (!model.$caught) {
-          model.emit('error', err);
+          model.emit("error", err);
         }
 
         indexSingleDone(err, indexFields, indexOptions);
@@ -1753,7 +1900,7 @@ function _ensureIndexes(model, options, callback) {
  */
 
 Model.createSearchIndexes = async function createSearchIndexes() {
-  _checkContext(this, 'createSearchIndexes');
+  _checkContext(this, "createSearchIndexes");
   const results = [];
   for (const searchIndex of this.schema._searchIndexes) {
     results.push(await this.createSearchIndex(searchIndex));
@@ -1845,19 +1992,21 @@ Model.discriminators;
  * @return {Object} the translated 'pure' fields/conditions
  */
 Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
-  _checkContext(this, 'translateAliases');
+  _checkContext(this, "translateAliases");
 
   const translate = (key, value) => {
     let alias;
     const translated = [];
-    const fieldKeys = key.split('.');
+    const fieldKeys = key.split(".");
     let currentSchema = this.schema;
     for (const i in fieldKeys) {
       const name = fieldKeys[i];
       if (currentSchema && currentSchema.aliases[name]) {
         alias = currentSchema.aliases[name];
         if (errorOnDuplicates && alias in fields) {
-          throw new MongooseError(`Provided object has both field "${name}" and its alias "${alias}"`);
+          throw new MongooseError(
+            `Provided object has both field "${name}" and its alias "${alias}"`
+          );
         }
         // Alias found,
         translated.push(alias);
@@ -1870,16 +2019,12 @@ Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
       // Check if aliased path is a schema
       if (currentSchema && currentSchema.paths[alias]) {
         currentSchema = currentSchema.paths[alias].schema;
-      }
-      else
-        currentSchema = null;
+      } else currentSchema = null;
     }
 
-    const translatedKey = translated.join('.');
-    if (fields instanceof Map)
-      fields.set(translatedKey, value);
-    else
-      fields[translatedKey] = value;
+    const translatedKey = translated.join(".");
+    if (fields instanceof Map) fields.set(translatedKey, value);
+    else fields[translatedKey] = value;
 
     if (translatedKey !== key) {
       // We'll be using the translated key instead
@@ -1894,7 +2039,7 @@ Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
     return fields;
   };
 
-  if (typeof fields === 'object') {
+  if (typeof fields === "object") {
     // Fields is an object (query conditions or document fields)
     if (fields instanceof Map) {
       // A Map was supplied
@@ -1905,7 +2050,7 @@ Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
       // Infer a regular object was supplied
       for (const key of Object.keys(fields)) {
         fields = translate(key, fields[key]);
-        if (key[0] === '$') {
+        if (key[0] === "$") {
           if (Array.isArray(fields[key])) {
             for (const i in fields[key]) {
               // Recursively translate nested queries
@@ -1946,10 +2091,16 @@ Model.translateAliases = function translateAliases(fields, errorOnDuplicates) {
  */
 
 Model.deleteOne = function deleteOne(conditions, options) {
-  _checkContext(this, 'deleteOne');
+  _checkContext(this, "deleteOne");
 
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.prototype.deleteOne() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.prototype.deleteOne() no longer accepts a callback"
+    );
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
@@ -1979,10 +2130,14 @@ Model.deleteOne = function deleteOne(conditions, options) {
  */
 
 Model.deleteMany = function deleteMany(conditions, options) {
-  _checkContext(this, 'deleteMany');
+  _checkContext(this, "deleteMany");
 
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.deleteMany() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError("Model.deleteMany() no longer accepts a callback");
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
@@ -2023,9 +2178,14 @@ Model.deleteMany = function deleteMany(conditions, options) {
  */
 
 Model.find = function find(conditions, projection, options) {
-  _checkContext(this, 'find');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {
-    throw new MongooseError('Model.find() no longer accepts a callback');
+  _checkContext(this, "find");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function" ||
+    typeof arguments[3] === "function"
+  ) {
+    throw new MongooseError("Model.find() no longer accepts a callback");
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
@@ -2063,9 +2223,13 @@ Model.find = function find(conditions, projection, options) {
  */
 
 Model.findById = function findById(id, projection, options) {
-  _checkContext(this, 'findById');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.findById() no longer accepts a callback');
+  _checkContext(this, "findById");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError("Model.findById() no longer accepts a callback");
   }
 
   return this.findOne({ _id: id }, projection, options);
@@ -2101,9 +2265,13 @@ Model.findById = function findById(id, projection, options) {
  */
 
 Model.findOne = function findOne(conditions, projection, options) {
-  _checkContext(this, 'findOne');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.findOne() no longer accepts a callback');
+  _checkContext(this, "findOne");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError("Model.findOne() no longer accepts a callback");
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
@@ -2129,7 +2297,7 @@ Model.findOne = function findOne(conditions, projection, options) {
  */
 
 Model.estimatedDocumentCount = function estimatedDocumentCount(options) {
-  _checkContext(this, 'estimatedDocumentCount');
+  _checkContext(this, "estimatedDocumentCount");
 
   const mq = new this.Query({}, {}, this, this.$__collection);
 
@@ -2164,9 +2332,15 @@ Model.estimatedDocumentCount = function estimatedDocumentCount(options) {
  */
 
 Model.countDocuments = function countDocuments(conditions, options) {
-  _checkContext(this, 'countDocuments');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.countDocuments() no longer accepts a callback');
+  _checkContext(this, "countDocuments");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.countDocuments() no longer accepts a callback"
+    );
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
@@ -2176,7 +2350,6 @@ Model.countDocuments = function countDocuments(conditions, options) {
 
   return mq.countDocuments(conditions);
 };
-
 
 /**
  * Creates a Query for a `distinct` operation.
@@ -2194,9 +2367,13 @@ Model.countDocuments = function countDocuments(conditions, options) {
  */
 
 Model.distinct = function distinct(field, conditions, options) {
-  _checkContext(this, 'distinct');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.distinct() no longer accepts a callback');
+  _checkContext(this, "distinct");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError("Model.distinct() no longer accepts a callback");
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);
@@ -2232,7 +2409,7 @@ Model.distinct = function distinct(field, conditions, options) {
  */
 
 Model.where = function where(path, val) {
-  _checkContext(this, 'where');
+  _checkContext(this, "where");
 
   void val; // eslint
   const mq = new this.Query({}, {}, this, this.$__collection).find({});
@@ -2255,7 +2432,7 @@ Model.where = function where(path, val) {
  */
 
 Model.$where = function $where() {
-  _checkContext(this, '$where');
+  _checkContext(this, "$where");
 
   const mq = new this.Query({}, {}, this, this.$__collection).find({});
   return mq.$where.apply(mq, arguments);
@@ -2326,10 +2503,17 @@ Model.$where = function $where() {
  * @api public
  */
 
-Model.findOneAndUpdate = function(conditions, update, options) {
-  _checkContext(this, 'findOneAndUpdate');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {
-    throw new MongooseError('Model.findOneAndUpdate() no longer accepts a callback');
+Model.findOneAndUpdate = function (conditions, update, options) {
+  _checkContext(this, "findOneAndUpdate");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function" ||
+    typeof arguments[3] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.findOneAndUpdate() no longer accepts a callback"
+    );
   }
 
   let fields;
@@ -2339,7 +2523,7 @@ Model.findOneAndUpdate = function(conditions, update, options) {
 
   update = clone(update, {
     depopulate: true,
-    _isNested: true
+    _isNested: true,
   });
 
   decorateUpdateWithVersionKey(update, options, this.schema.options.versionKey);
@@ -2413,10 +2597,17 @@ Model.findOneAndUpdate = function(conditions, update, options) {
  * @api public
  */
 
-Model.findByIdAndUpdate = function(id, update, options) {
-  _checkContext(this, 'findByIdAndUpdate');
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {
-    throw new MongooseError('Model.findByIdAndUpdate() no longer accepts a callback');
+Model.findByIdAndUpdate = function (id, update, options) {
+  _checkContext(this, "findByIdAndUpdate");
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function" ||
+    typeof arguments[3] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.findByIdAndUpdate() no longer accepts a callback"
+    );
   }
 
   // if a model is passed in instead of an id
@@ -2466,11 +2657,17 @@ Model.findByIdAndUpdate = function(id, update, options) {
  * @api public
  */
 
-Model.findOneAndDelete = function(conditions, options) {
-  _checkContext(this, 'findOneAndDelete');
+Model.findOneAndDelete = function (conditions, options) {
+  _checkContext(this, "findOneAndDelete");
 
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.findOneAndDelete() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.findOneAndDelete() no longer accepts a callback"
+    );
   }
 
   let fields;
@@ -2503,11 +2700,17 @@ Model.findOneAndDelete = function(conditions, options) {
  * @see mongodb https://www.mongodb.com/docs/manual/reference/command/findAndModify/
  */
 
-Model.findByIdAndDelete = function(id, options) {
-  _checkContext(this, 'findByIdAndDelete');
+Model.findByIdAndDelete = function (id, options) {
+  _checkContext(this, "findByIdAndDelete");
 
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.findByIdAndDelete() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.findByIdAndDelete() no longer accepts a callback"
+    );
   }
 
   return this.findOneAndDelete({ _id: id }, options);
@@ -2546,11 +2749,18 @@ Model.findByIdAndDelete = function(id, options) {
  * @api public
  */
 
-Model.findOneAndReplace = function(filter, replacement, options) {
-  _checkContext(this, 'findOneAndReplace');
+Model.findOneAndReplace = function (filter, replacement, options) {
+  _checkContext(this, "findOneAndReplace");
 
-  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {
-    throw new MongooseError('Model.findOneAndReplace() no longer accepts a callback');
+  if (
+    typeof arguments[0] === "function" ||
+    typeof arguments[1] === "function" ||
+    typeof arguments[2] === "function" ||
+    typeof arguments[3] === "function"
+  ) {
+    throw new MongooseError(
+      "Model.findOneAndReplace() no longer accepts a callback"
+    );
   }
 
   let fields;
@@ -2596,27 +2806,27 @@ Model.findOneAndReplace = function(filter, replacement, options) {
  */
 
 Model.create = async function create(doc, options) {
-  if (typeof options === 'function' ||
-      typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.create() no longer accepts a callback');
+  if (typeof options === "function" || typeof arguments[2] === "function") {
+    throw new MongooseError("Model.create() no longer accepts a callback");
   }
 
-  _checkContext(this, 'create');
+  _checkContext(this, "create");
 
   let args;
   const discriminatorKey = this.schema.options.discriminatorKey;
 
   if (Array.isArray(doc)) {
     args = doc;
-    options = options != null && typeof options === 'object' ? options : {};
+    options = options != null && typeof options === "object" ? options : {};
   } else {
     const last = arguments[arguments.length - 1];
     options = {};
-    const hasCallback = typeof last === 'function' ||
-      typeof options === 'function' ||
-      typeof arguments[2] === 'function';
+    const hasCallback =
+      typeof last === "function" ||
+      typeof options === "function" ||
+      typeof arguments[2] === "function";
     if (hasCallback) {
-      throw new MongooseError('Model.create() no longer accepts a callback');
+      throw new MongooseError("Model.create() no longer accepts a callback");
     } else {
       args = [...arguments];
       // For backwards compatibility with 6.x, because of gh-5061 Mongoose 6.x and
@@ -2628,18 +2838,22 @@ Model.create = async function create(doc, options) {
       }
     }
 
-    if (args.length === 2 &&
-        args[0] != null &&
-        args[1] != null &&
-        args[0].session == null &&
-        last &&
-        getConstructorName(last.session) === 'ClientSession' &&
-        !this.schema.path('session')) {
+    if (
+      args.length === 2 &&
+      args[0] != null &&
+      args[1] != null &&
+      args[0].session == null &&
+      last &&
+      getConstructorName(last.session) === "ClientSession" &&
+      !this.schema.path("session")
+    ) {
       // Probably means the user is running into the common mistake of trying
       // to use a spread to specify options, see gh-7535
-      utils.warn('WARNING: to pass a `session` to `Model.create()` in ' +
-        'Mongoose, you **must** pass an array as the first argument. See: ' +
-        'https://mongoosejs.com/docs/api/model.html#Model.create()');
+      utils.warn(
+        "WARNING: to pass a `session` to `Model.create()` in " +
+          "Mongoose, you **must** pass an array as the first argument. See: " +
+          "https://mongoosejs.com/docs/api/model.html#Model.create()"
+      );
     }
   }
 
@@ -2647,24 +2861,36 @@ Model.create = async function create(doc, options) {
     return Array.isArray(doc) ? [] : null;
   }
   let res = [];
-  const immediateError = typeof options.aggregateErrors === 'boolean' ? !options.aggregateErrors : true;
+  const immediateError =
+    typeof options.aggregateErrors === "boolean"
+      ? !options.aggregateErrors
+      : true;
 
   delete options.aggregateErrors; // dont pass on the option to "$save"
 
   if (options.session && !options.ordered && args.length > 1) {
-    throw new MongooseError('Cannot call `create()` with a session and multiple documents unless `ordered: true` is set');
+    throw new MongooseError(
+      "Cannot call `create()` with a session and multiple documents unless `ordered: true` is set"
+    );
   }
 
   if (options.ordered) {
     for (let i = 0; i < args.length; i++) {
       try {
         const doc = args[i];
-        const Model = this.discriminators && doc[discriminatorKey] != null ?
-          this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
-          this;
+        const Model =
+          this.discriminators && doc[discriminatorKey] != null
+            ? this.discriminators[doc[discriminatorKey]] ||
+              getDiscriminatorByValue(
+                this.discriminators,
+                doc[discriminatorKey]
+              )
+            : this;
         if (Model == null) {
-          throw new MongooseError(`Discriminator "${doc[discriminatorKey]}" not ` +
-          `found for model "${this.modelName}"`);
+          throw new MongooseError(
+            `Discriminator "${doc[discriminatorKey]}" not ` +
+              `found for model "${this.modelName}"`
+          );
         }
         let toSave = doc;
         if (!(toSave instanceof Model)) {
@@ -2683,36 +2909,22 @@ Model.create = async function create(doc, options) {
     }
     return res;
   } else if (!immediateError) {
-    res = await Promise.allSettled(args.map(async doc => {
-      const Model = this.discriminators && doc[discriminatorKey] != null ?
-        this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
-        this;
-      if (Model == null) {
-        throw new MongooseError(`Discriminator "${doc[discriminatorKey]}" not ` +
-            `found for model "${this.modelName}"`);
-      }
-      let toSave = doc;
-
-      if (!(toSave instanceof Model)) {
-        toSave = new Model(toSave);
-      }
-
-      await toSave.$save(options);
-
-      return toSave;
-    }));
-    res = res.map(result => result.status === 'fulfilled' ? result.value : result.reason);
-  } else {
-    let firstError = null;
-    res = await Promise.all(args.map(async doc => {
-      const Model = this.discriminators && doc[discriminatorKey] != null ?
-        this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
-        this;
-      if (Model == null) {
-        throw new MongooseError(`Discriminator "${doc[discriminatorKey]}" not ` +
-            `found for model "${this.modelName}"`);
-      }
-      try {
+    res = await Promise.allSettled(
+      args.map(async (doc) => {
+        const Model =
+          this.discriminators && doc[discriminatorKey] != null
+            ? this.discriminators[doc[discriminatorKey]] ||
+              getDiscriminatorByValue(
+                this.discriminators,
+                doc[discriminatorKey]
+              )
+            : this;
+        if (Model == null) {
+          throw new MongooseError(
+            `Discriminator "${doc[discriminatorKey]}" not ` +
+              `found for model "${this.modelName}"`
+          );
+        }
         let toSave = doc;
 
         if (!(toSave instanceof Model)) {
@@ -2722,17 +2934,50 @@ Model.create = async function create(doc, options) {
         await toSave.$save(options);
 
         return toSave;
-      } catch (err) {
-        if (!firstError) {
-          firstError = err;
+      })
+    );
+    res = res.map((result) =>
+      result.status === "fulfilled" ? result.value : result.reason
+    );
+  } else {
+    let firstError = null;
+    res = await Promise.all(
+      args.map(async (doc) => {
+        const Model =
+          this.discriminators && doc[discriminatorKey] != null
+            ? this.discriminators[doc[discriminatorKey]] ||
+              getDiscriminatorByValue(
+                this.discriminators,
+                doc[discriminatorKey]
+              )
+            : this;
+        if (Model == null) {
+          throw new MongooseError(
+            `Discriminator "${doc[discriminatorKey]}" not ` +
+              `found for model "${this.modelName}"`
+          );
         }
-      }
-    }));
+        try {
+          let toSave = doc;
+
+          if (!(toSave instanceof Model)) {
+            toSave = new Model(toSave);
+          }
+
+          await toSave.$save(options);
+
+          return toSave;
+        } catch (err) {
+          if (!firstError) {
+            firstError = err;
+          }
+        }
+      })
+    );
     if (firstError) {
       throw firstError;
     }
   }
-
 
   if (!Array.isArray(doc) && args.length === 1) {
     return res[0];
@@ -2766,12 +3011,14 @@ Model.create = async function create(doc, options) {
  */
 
 Model.insertOne = async function insertOne(doc, options) {
-  _checkContext(this, 'insertOne');
+  _checkContext(this, "insertOne");
 
   const discriminatorKey = this.schema.options.discriminatorKey;
-  const Model = this.discriminators && doc[discriminatorKey] != null ?
-    this.discriminators[doc[discriminatorKey]] || getDiscriminatorByValue(this.discriminators, doc[discriminatorKey]) :
-    this;
+  const Model =
+    this.discriminators && doc[discriminatorKey] != null
+      ? this.discriminators[doc[discriminatorKey]] ||
+        getDiscriminatorByValue(this.discriminators, doc[discriminatorKey])
+      : this;
   if (Model == null) {
     throw new MongooseError(
       `Discriminator "${doc[discriminatorKey]}" not found for model "${this.modelName}"`
@@ -2817,29 +3064,35 @@ Model.insertOne = async function insertOne(doc, options) {
  * @api public
  */
 
-Model.watch = function(pipeline, options) {
-  _checkContext(this, 'watch');
+Model.watch = function (pipeline, options) {
+  _checkContext(this, "watch");
 
   options = options || {};
-  const watchOptions = options?.hydrate !== undefined ?
-    utils.omit(options, ['hydrate']) :
-    { ...options };
+  const watchOptions =
+    options?.hydrate !== undefined
+      ? utils.omit(options, ["hydrate"])
+      : { ...options };
   options.model = this;
 
-
-  const changeStreamThunk = cb => {
+  const changeStreamThunk = (cb) => {
     pipeline = pipeline || [];
-    prepareDiscriminatorPipeline(pipeline, this.schema, 'fullDocument');
+    prepareDiscriminatorPipeline(pipeline, this.schema, "fullDocument");
     if (this.$__collection.buffer) {
       this.$__collection.addQueue(() => {
         if (this.closed) {
           return;
         }
-        const driverChangeStream = this.$__collection.watch(pipeline, watchOptions);
+        const driverChangeStream = this.$__collection.watch(
+          pipeline,
+          watchOptions
+        );
         cb(null, driverChangeStream);
       });
     } else {
-      const driverChangeStream = this.$__collection.watch(pipeline, watchOptions);
+      const driverChangeStream = this.$__collection.watch(
+        pipeline,
+        watchOptions
+      );
       cb(null, driverChangeStream);
     }
   };
@@ -2873,8 +3126,8 @@ Model.watch = function(pipeline, options) {
  * @api public
  */
 
-Model.startSession = function() {
-  _checkContext(this, 'startSession');
+Model.startSession = function () {
+  _checkContext(this, "startSession");
 
   return this.db.startSession.apply(this.db, arguments);
 };
@@ -2923,28 +3176,34 @@ Model.startSession = function() {
  */
 
 Model.insertMany = async function insertMany(arr, options) {
-  _checkContext(this, 'insertMany');
-  if (typeof options === 'function' ||
-    typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.insertMany() no longer accepts a callback');
+  _checkContext(this, "insertMany");
+  if (typeof options === "function" || typeof arguments[2] === "function") {
+    throw new MongooseError("Model.insertMany() no longer accepts a callback");
   }
 
   try {
-    [arr] = await this._middleware.execPre('insertMany', this, [arr]);
+    [arr] = await this._middleware.execPre("insertMany", this, [arr]);
   } catch (error) {
-    await this._middleware.execPost('insertMany', this, [arr], { error });
+    await this._middleware.execPost("insertMany", this, [arr], { error });
   }
 
   options = options || {};
   const ThisModel = this;
   const limit = options.limit || 1000;
   const rawResult = !!options.rawResult;
-  const ordered = typeof options.ordered === 'boolean' ? options.ordered : true;
-  const throwOnValidationError = typeof options.throwOnValidationError === 'boolean' ? options.throwOnValidationError : false;
+  const ordered = typeof options.ordered === "boolean" ? options.ordered : true;
+  const throwOnValidationError =
+    typeof options.throwOnValidationError === "boolean"
+      ? options.throwOnValidationError
+      : false;
   const lean = !!options.lean;
 
-  const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
-  if ((!options || !options.hasOwnProperty('session')) && asyncLocalStorage?.session != null) {
+  const asyncLocalStorage =
+    this.db.base.transactionAsyncLocalStorage?.getStore();
+  if (
+    (!options || !options.hasOwnProperty("session")) &&
+    asyncLocalStorage?.session != null
+  ) {
     options = { ...options, session: asyncLocalStorage.session };
   }
 
@@ -2962,8 +3221,8 @@ Model.insertMany = async function insertMany(arr, options) {
     }
     let createdNewDoc = false;
     if (!(doc instanceof ThisModel)) {
-      if (doc != null && typeof doc !== 'object') {
-        throw new ObjectParameterError(doc, 'arr.' + index, 'insertMany');
+      if (doc != null && typeof doc !== "object") {
+        throw new ObjectParameterError(doc, "arr." + index, "insertMany");
       }
       doc = new ThisModel(doc);
       createdNewDoc = true;
@@ -2972,9 +3231,10 @@ Model.insertMany = async function insertMany(arr, options) {
     if (options.session != null) {
       doc.$session(options.session);
     }
-    return doc.$validate(createdNewDoc ? { _skipParallelValidateCheck: true } : null)
+    return doc
+      .$validate(createdNewDoc ? { _skipParallelValidateCheck: true } : null)
       .then(() => doc)
-      .catch(error => {
+      .catch((error) => {
         if (ordered === false) {
           error.index = index;
           validationErrors.push(error);
@@ -2995,7 +3255,7 @@ Model.insertMany = async function insertMany(arr, options) {
   }
 
   // We filter all failed pre-validations by removing nulls
-  const docAttributes = docs.filter(function(doc) {
+  const docAttributes = docs.filter(function (doc) {
     return doc != null;
   });
   for (let i = 0; i < docAttributes.length; ++i) {
@@ -3008,7 +3268,10 @@ Model.insertMany = async function insertMany(arr, options) {
   // error before doc2's. Re: gh-12791.
   if (validationErrors.length > 0) {
     validationErrors.sort((err1, err2) => {
-      return validationErrorsToOriginalOrder.get(err1) - validationErrorsToOriginalOrder.get(err2);
+      return (
+        validationErrorsToOriginalOrder.get(err1) -
+        validationErrorsToOriginalOrder.get(err2)
+      );
     });
   }
 
@@ -3019,33 +3282,38 @@ Model.insertMany = async function insertMany(arr, options) {
         validationErrors,
         results,
         null,
-        'insertMany'
+        "insertMany"
       );
     }
     if (rawResult) {
       const res = {
         acknowledged: true,
         insertedCount: 0,
-        insertedIds: {}
+        insertedIds: {},
       };
       decorateBulkWriteResult(res, validationErrors, validationErrors);
       return res;
     }
     return [];
   }
-  const docObjects = lean ? docAttributes : docAttributes.map(function(doc) {
-    if (doc.$__schema.options.versionKey) {
-      doc[doc.$__schema.options.versionKey] = 0;
-    }
-    const shouldSetTimestamps = (!options || options.timestamps !== false) && doc.initializeTimestamps && (!doc.$__ || doc.$__.timestamps !== false);
-    if (shouldSetTimestamps) {
-      doc.initializeTimestamps();
-    }
-    if (doc.$__hasOnlyPrimitiveValues()) {
-      return doc.$__toObjectShallow();
-    }
-    return doc.toObject(internalToObjectOptions);
-  });
+  const docObjects = lean
+    ? docAttributes
+    : docAttributes.map(function (doc) {
+        if (doc.$__schema.options.versionKey) {
+          doc[doc.$__schema.options.versionKey] = 0;
+        }
+        const shouldSetTimestamps =
+          (!options || options.timestamps !== false) &&
+          doc.initializeTimestamps &&
+          (!doc.$__ || doc.$__.timestamps !== false);
+        if (shouldSetTimestamps) {
+          doc.initializeTimestamps();
+        }
+        if (doc.$__hasOnlyPrimitiveValues()) {
+          return doc.$__toObjectShallow();
+        }
+        return doc.toObject(internalToObjectOptions);
+      });
 
   let res;
   try {
@@ -3053,19 +3321,30 @@ Model.insertMany = async function insertMany(arr, options) {
   } catch (error) {
     // `writeErrors` is a property reported by the MongoDB driver,
     // just not if there's only 1 error.
-    if (error.writeErrors == null &&
-        (error.result && error.result.result && error.result.result.writeErrors) != null) {
+    if (
+      error.writeErrors == null &&
+      (error.result &&
+        error.result.result &&
+        error.result.result.writeErrors) != null
+    ) {
       error.writeErrors = error.result.result.writeErrors;
     }
 
     // `insertedDocs` is a Mongoose-specific property
     const hasWriteErrors = error && error.writeErrors;
-    const erroredIndexes = new Set((error && error.writeErrors || []).map(err => err.index));
+    const erroredIndexes = new Set(
+      ((error && error.writeErrors) || []).map((err) => err.index)
+    );
 
     if (error.writeErrors != null) {
       for (let i = 0; i < error.writeErrors.length; ++i) {
-        const originalIndex = validDocIndexToOriginalIndex.get(error.writeErrors[i].index);
-        error.writeErrors[i] = { ...error.writeErrors[i], index: originalIndex };
+        const originalIndex = validDocIndexToOriginalIndex.get(
+          error.writeErrors[i].index
+        );
+        error.writeErrors[i] = {
+          ...error.writeErrors[i],
+          index: originalIndex,
+        };
         if (!ordered) {
           results[originalIndex] = error.writeErrors[i];
         }
@@ -3083,8 +3362,8 @@ Model.insertMany = async function insertMany(arr, options) {
     }
 
     let firstErroredIndex = -1;
-    error.insertedDocs = docAttributes.
-      filter((doc, i) => {
+    error.insertedDocs = docAttributes
+      .filter((doc, i) => {
         const isErrored = !hasWriteErrors || erroredIndexes.has(i);
 
         if (ordered) {
@@ -3098,8 +3377,8 @@ Model.insertMany = async function insertMany(arr, options) {
         }
 
         return !isErrored;
-      }).
-      map(function setIsNewForInsertedDoc(doc) {
+      })
+      .map(function setIsNewForInsertedDoc(doc) {
         if (lean) {
           return doc;
         }
@@ -3112,7 +3391,7 @@ Model.insertMany = async function insertMany(arr, options) {
       decorateBulkWriteResult(error, validationErrors, results);
     }
 
-    await this._middleware.execPost('insertMany', this, [arr], { error });
+    await this._middleware.execPost("insertMany", this, [arr], { error });
   }
 
   if (!lean) {
@@ -3122,7 +3401,11 @@ Model.insertMany = async function insertMany(arr, options) {
     }
   }
 
-  if (ordered === false && throwOnValidationError && validationErrors.length > 0) {
+  if (
+    ordered === false &&
+    throwOnValidationError &&
+    validationErrors.length > 0
+  ) {
     for (let i = 0; i < results.length; ++i) {
       if (results[i] === void 0) {
         results[i] = docs[i];
@@ -3132,7 +3415,7 @@ Model.insertMany = async function insertMany(arr, options) {
       validationErrors,
       results,
       res,
-      'insertMany'
+      "insertMany"
     );
   }
 
@@ -3152,7 +3435,7 @@ Model.insertMany = async function insertMany(arr, options) {
   }
 
   if (options.populate != null) {
-    return this.populate(docAttributes, options.populate).catch(err => {
+    return this.populate(docAttributes, options.populate).catch((err) => {
       if (err != null) {
         err.insertedDocs = docAttributes;
       }
@@ -3160,7 +3443,9 @@ Model.insertMany = async function insertMany(arr, options) {
     });
   }
 
-  return await this._middleware.execPost('insertMany', this, [docAttributes]).then(res => res[0]);
+  return await this._middleware
+    .execPost("insertMany", this, [docAttributes])
+    .then((res) => res[0]);
 };
 
 /*!
@@ -3169,13 +3454,13 @@ Model.insertMany = async function insertMany(arr, options) {
 
 function _setIsNew(doc, val) {
   doc.$isNew = val;
-  doc.$emit('isNew', val);
-  doc.constructor.emit('isNew', val);
+  doc.$emit("isNew", val);
+  doc.constructor.emit("isNew", val);
 
   const subdocs = doc.$getAllSubdocs({ useCache: true });
   for (const subdoc of subdocs) {
     subdoc.$isNew = val;
-    subdoc.$emit('isNew', val);
+    subdoc.$emit("isNew", val);
   }
 }
 
@@ -3278,20 +3563,21 @@ function _setIsNew(doc, val) {
  */
 
 Model.bulkWrite = async function bulkWrite(ops, options) {
-  _checkContext(this, 'bulkWrite');
+  _checkContext(this, "bulkWrite");
 
-  if (typeof options === 'function' ||
-      typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.bulkWrite() no longer accepts a callback');
+  if (typeof options === "function" || typeof arguments[2] === "function") {
+    throw new MongooseError("Model.bulkWrite() no longer accepts a callback");
   }
   options = options || {};
 
-  [ops, options] = await this.hooks.execPre('bulkWrite', this, [ops, options]).catch(err => {
-    if (err instanceof Kareem.skipWrappedFunction) {
-      return [err];
-    }
-    throw err;
-  });
+  [ops, options] = await this.hooks
+    .execPre("bulkWrite", this, [ops, options])
+    .catch((err) => {
+      if (err instanceof Kareem.skipWrappedFunction) {
+        return [err];
+      }
+      throw err;
+    });
 
   if (ops instanceof Kareem.skipWrappedFunction) {
     return ops.args[0];
@@ -3301,66 +3587,81 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
 
   if (ops.length === 0) {
     const BulkWriteResult = this.base.driver.get().BulkWriteResult;
-    const bulkWriteResult = new BulkWriteResult(getDefaultBulkwriteResult(), false);
+    const bulkWriteResult = new BulkWriteResult(
+      getDefaultBulkwriteResult(),
+      false
+    );
     bulkWriteResult.n = 0;
     decorateBulkWriteResult(bulkWriteResult, [], []);
     return bulkWriteResult;
   }
 
-  const validations = options?._skipCastBulkWrite ? [] : ops.map(op => castBulkWrite(this, op, options));
-  const asyncLocalStorage = this.db.base.transactionAsyncLocalStorage?.getStore();
-  if ((!options || !options.hasOwnProperty('session')) && asyncLocalStorage?.session != null) {
+  const validations = options?._skipCastBulkWrite
+    ? []
+    : ops.map((op) => castBulkWrite(this, op, options));
+  const asyncLocalStorage =
+    this.db.base.transactionAsyncLocalStorage?.getStore();
+  if (
+    (!options || !options.hasOwnProperty("session")) &&
+    asyncLocalStorage?.session != null
+  ) {
     options = { ...options, session: asyncLocalStorage.session };
   }
 
   let res = null;
   if (ordered) {
     await new Promise((resolve, reject) => {
-      each(validations, (fn, cb) => fn(cb), error => {
-        if (error) {
-          return reject(error);
-        }
+      each(
+        validations,
+        (fn, cb) => fn(cb),
+        (error) => {
+          if (error) {
+            return reject(error);
+          }
 
-        resolve();
-      });
+          resolve();
+        }
+      );
     });
 
     try {
       res = await this.$__collection.bulkWrite(ops, options);
     } catch (error) {
-      await this.hooks.execPost('bulkWrite', this, [null], { error });
+      await this.hooks.execPost("bulkWrite", this, [null], { error });
     }
   } else {
     let validOpIndexes = [];
     let validationErrors = [];
     const results = [];
     if (validations.length > 0) {
-      validOpIndexes = await Promise.all(ops.map((op, i) => {
-        if (i >= validations.length) {
-          return i;
-        }
-        return new Promise((resolve) => {
-          validations[i]((err) => {
-            if (err == null) {
-              resolve(i);
-            } else {
-              validationErrors.push({ index: i, error: err });
-              results[i] = err;
-            }
-            resolve();
+      validOpIndexes = await Promise.all(
+        ops.map((op, i) => {
+          if (i >= validations.length) {
+            return i;
+          }
+          return new Promise((resolve) => {
+            validations[i]((err) => {
+              if (err == null) {
+                resolve(i);
+              } else {
+                validationErrors.push({ index: i, error: err });
+                results[i] = err;
+              }
+              resolve();
+            });
           });
-        });
-      }));
-      validOpIndexes = validOpIndexes.filter(index => index != null);
+        })
+      );
+      validOpIndexes = validOpIndexes.filter((index) => index != null);
     } else {
       validOpIndexes = ops.map((op, i) => i);
     }
 
-    validationErrors = validationErrors.
-      sort((v1, v2) => v1.index - v2.index).
-      map(v => v.error);
+    validationErrors = validationErrors
+      .sort((v1, v2) => v1.index - v2.index)
+      .map((v) => v.error);
 
-    const validOps = validOpIndexes.sort().map(index => ops[index]);
+    const validOps = validOpIndexes.sort().map((index) => ops[index]);
 
     if (validOps.length === 0) {
       if (options.throwOnValidationError && validationErrors.length) {
@@ -3368,20 +3669,24 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
           validationErrors,
           results,
           res,
-          'bulkWrite'
+          "bulkWrite"
         );
       }
       const BulkWriteResult = this.base.driver.get().BulkWriteResult;
-      const bulkWriteResult = new BulkWriteResult(getDefaultBulkwriteResult(), false);
+      const bulkWriteResult = new BulkWriteResult(
+        getDefaultBulkwriteResult(),
+        false
+      );
       bulkWriteResult.result = getDefaultBulkwriteResult();
       decorateBulkWriteResult(bulkWriteResult, validationErrors, results);
       return bulkWriteResult;
     }
 
     let error;
-    [res, error] = await this.$__collection.bulkWrite(validOps, options).
-      then(res => ([res, null])).
-      catch(error => ([null, error]));
+    [res, error] = await this.$__collection
+      .bulkWrite(validOps, options)
+      .then((res) => [res, null])
+      .catch((error) => [null, error]);
 
     const writeErrorsByIndex = {};
     if (error?.writeErrors) {
@@ -3397,7 +3702,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
         decorateBulkWriteResult(error, validationErrors, results);
       }
 
-      await this.hooks.execPost('bulkWrite', this, [null], { error });
+      await this.hooks.execPost("bulkWrite", this, [null], { error });
     }
 
     if (validationErrors.length > 0) {
@@ -3406,7 +3711,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
           validationErrors,
           results,
           res,
-          'bulkWrite'
+          "bulkWrite"
         );
       } else {
         decorateBulkWriteResult(res, validationErrors, results);
@@ -3414,7 +3719,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
     }
   }
 
-  await this.hooks.execPost('bulkWrite', this, [res]);
+  await this.hooks.execPost("bulkWrite", this, [res]);
 
   return res;
 };
@@ -3460,22 +3765,29 @@ Model.bulkSave = async function bulkSave(documents, options) {
     }
   }
 
-  await Promise.all(documents.map(doc => buildPreSavePromise(doc, options)));
+  await Promise.all(documents.map((doc) => buildPreSavePromise(doc, options)));
 
   const writeOperations = this.buildBulkWriteOperations(documents, options);
   const opts = { skipValidation: true, _skipCastBulkWrite: true, ...options };
-  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(writeOperations, opts).then(
+  const { bulkWriteResult, bulkWriteError } = await this.bulkWrite(
+    writeOperations,
+    opts
+  ).then(
     (res) => ({ bulkWriteResult: res, bulkWriteError: null }),
     (err) => ({ bulkWriteResult: null, bulkWriteError: err })
   );
   // If not a MongoBulkWriteError, treat this as all documents failed to save.
-  if (bulkWriteError != null && bulkWriteError.name !== 'MongoBulkWriteError') {
+  if (bulkWriteError != null && bulkWriteError.name !== "MongoBulkWriteError") {
     throw bulkWriteError;
   }
 
   const matchedCount = bulkWriteResult?.matchedCount ?? 0;
   const insertedCount = bulkWriteResult?.insertedCount ?? 0;
-  if (writeOperations.length > 0 && matchedCount + insertedCount < writeOperations.length && !bulkWriteError) {
+  if (
+    writeOperations.length > 0 &&
+    matchedCount + insertedCount < writeOperations.length &&
+    !bulkWriteError
+  ) {
     throw new MongooseBulkSaveIncompleteError(
       this.modelName,
       documents,
@@ -3486,16 +3798,21 @@ Model.bulkSave = async function bulkSave(documents, options) {
   const successfulDocuments = [];
   for (let i = 0; i < documents.length; i++) {
     const document = documents[i];
-    const documentError = bulkWriteError && bulkWriteError.writeErrors.find(writeError => {
-      const writeErrorDocumentId = writeError.err.op._id || writeError.err.op.q._id;
-      return writeErrorDocumentId.toString() === document._doc._id.toString();
-    });
+    const documentError =
+      bulkWriteError &&
+      bulkWriteError.writeErrors.find((writeError) => {
+        const writeErrorDocumentId =
+          writeError.err.op._id || writeError.err.op.q._id;
+        return writeErrorDocumentId.toString() === document._doc._id.toString();
+      });
 
     if (documentError == null) {
       successfulDocuments.push(document);
     }
   }
-  await Promise.all(successfulDocuments.map(document => handleSuccessfulWrite(document)));
+  await Promise.all(
+    successfulDocuments.map((document) => handleSuccessfulWrite(document))
+  );
 
   if (bulkWriteError != null) {
     throw bulkWriteError;
@@ -3505,19 +3822,34 @@ Model.bulkSave = async function bulkSave(documents, options) {
 };
 
 async function buildPreSavePromise(document, options) {
-  const [newOptions] = await document.schema.s.hooks.execPre('save', document, [options]);
+  const [newOptions] = await document.schema.s.hooks.execPre("save", document, [
+    options,
+  ]);
   if (newOptions !== options) {
-    throw new Error('Cannot overwrite options in pre("save") hook on bulkSave()');
+    throw new Error(
+      'Cannot overwrite options in pre("save") hook on bulkSave()'
+    );
   }
 }
 
 async function handleSuccessfulWrite(document) {
+  const versionBump = document.$__.version;
+  if (versionBump && !document.$isNew) {
+    const doIncrement =
+      Document.VERSION_INC === (Document.VERSION_INC & versionBump);
+    const key = document.$__schema.options.versionKey;
+    const version = document.$__getValue(key) || 0;
+    if (doIncrement) {
+      document.$__setValue(key, version + 1);
+    }
+  }
+
   if (document.$isNew) {
     _setIsNew(document, false);
   }
 
   document.$__reset();
-  return document.schema.s.hooks.execPost('save', document, [document]);
+  return document.schema.s.hooks.execPost("save", document, [document]);
 }
 
 /**
@@ -3642,8 +3974,13 @@ Model.castObject = function castObject(obj, options) {
 
   let schema = this.schema;
   const discriminatorKey = schema.options.discriminatorKey;
-  if (schema.discriminators != null && obj != null && obj[discriminatorKey] != null) {
-    schema = getSchemaDiscriminatorByValue(schema, obj[discriminatorKey]) || schema;
+  if (
+    schema.discriminators != null &&
+    obj != null &&
+    obj[discriminatorKey] != null
+  ) {
+    schema =
+      getSchemaDiscriminatorByValue(schema, obj[discriminatorKey]) || schema;
   }
   const paths = Object.keys(schema.paths);
 
@@ -3671,7 +4008,7 @@ Model.castObject = function castObject(obj, options) {
       continue;
     }
 
-    const pieces = path.indexOf('.') === -1 ? [path] : path.split('.');
+    const pieces = path.indexOf(".") === -1 ? [path] : path.split(".");
     let cur = ret;
     for (let i = 0; i < pieces.length - 1; ++i) {
       if (cur[pieces[i]] == null) {
@@ -3681,7 +4018,9 @@ Model.castObject = function castObject(obj, options) {
     }
 
     if (schemaType.$isMongooseDocumentArray) {
-      const castNonArraysOption = schemaType.options?.castNonArrays ?? schemaType.constructor.options.castNonArrays;
+      const castNonArraysOption =
+        schemaType.options?.castNonArrays ??
+        schemaType.constructor.options.castNonArrays;
       if (!Array.isArray(val)) {
         if (!castNonArraysOption) {
           if (!options.ignoreCastErrors) {
@@ -3690,14 +4029,17 @@ Model.castObject = function castObject(obj, options) {
           }
         } else {
           cur[pieces[pieces.length - 1]] = [
-            Model.castObject.call(schemaType.Constructor, val)
+            Model.castObject.call(schemaType.Constructor, val),
           ];
         }
 
         continue;
       }
     }
-    if (schemaType.$isSingleNested || schemaType.$isMongooseDocumentArrayElement) {
+    if (
+      schemaType.$isSingleNested ||
+      schemaType.$isMongooseDocumentArrayElement
+    ) {
       try {
         val = Model.castObject.call(schemaType.Constructor, val);
       } catch (err) {
@@ -3743,64 +4085,81 @@ Model.castObject = function castObject(obj, options) {
  * @api private
  */
 
-Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
+Model.buildBulkWriteOperations = function buildBulkWriteOperations(
+  documents,
+  options
+) {
   if (!Array.isArray(documents)) {
-    throw new Error(`bulkSave expects an array of documents to be passed, received \`${documents}\` instead`);
+    throw new Error(
+      `bulkSave expects an array of documents to be passed, received \`${documents}\` instead`
+    );
   }
 
   setDefaultOptions();
 
-  const writeOperations = documents.map((document, i) => {
-    if (!options.skipValidation) {
-      if (!(document instanceof Document)) {
-        throw new Error(`documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`);
-      }
-      if (options.validateBeforeSave == null || options.validateBeforeSave) {
-        const err = document.validateSync();
-        if (err != null) {
-          throw err;
+  const writeOperations = documents
+    .map((document, i) => {
+      if (!options.skipValidation) {
+        if (!(document instanceof Document)) {
+          throw new Error(
+            `documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`
+          );
         }
-      }
-    }
-
-    const isANewDocument = document.isNew;
-    if (isANewDocument) {
-      const writeOperation = { insertOne: { document } };
-      utils.injectTimestampsOption(writeOperation.insertOne, options.timestamps);
-      return writeOperation;
-    }
-
-    const delta = document.$__delta();
-    const isDocumentWithChanges = delta != null && !utils.isEmptyObject(delta[0]);
-
-    if (isDocumentWithChanges) {
-      const where = document.$__where(delta[0]);
-      const changes = delta[1];
-
-      _applyCustomWhere(document, where);
-
-      // If shard key is set, add shard keys to _filter_ condition to right shard is targeted
-      const shardKey = this.schema.options.shardKey;
-      if (shardKey) {
-        const paths = Object.keys(shardKey);
-        const len = paths.length;
-
-        for (let i = 0; i < len; ++i) {
-          where[paths[i]] = document[paths[i]];
+        if (options.validateBeforeSave == null || options.validateBeforeSave) {
+          const err = document.validateSync();
+          if (err != null) {
+            throw err;
+          }
         }
       }
 
-      document.$__version(where, delta);
-      const writeOperation = { updateOne: { filter: where, update: changes } };
-      utils.injectTimestampsOption(writeOperation.updateOne, options.timestamps);
-      return writeOperation;
-    }
+      const isANewDocument = document.isNew;
+      if (isANewDocument) {
+        const writeOperation = { insertOne: { document } };
+        utils.injectTimestampsOption(
+          writeOperation.insertOne,
+          options.timestamps
+        );
+        return writeOperation;
+      }
 
-    return null;
-  }).filter(op => op !== null);
+      const delta = document.$__delta();
+      const isDocumentWithChanges =
+        delta != null && !utils.isEmptyObject(delta[0]);
+
+      if (isDocumentWithChanges) {
+        const where = document.$__where(delta[0]);
+        const changes = delta[1];
+
+        _applyCustomWhere(document, where);
+
+        // If shard key is set, add shard keys to _filter_ condition to right shard is targeted
+        const shardKey = this.schema.options.shardKey;
+        if (shardKey) {
+          const paths = Object.keys(shardKey);
+          const len = paths.length;
+
+          for (let i = 0; i < len; ++i) {
+            where[paths[i]] = document[paths[i]];
+          }
+        }
+
+        document.$__version(where, delta);
+        const writeOperation = {
+          updateOne: { filter: where, update: changes },
+        };
+        utils.injectTimestampsOption(
+          writeOperation.updateOne,
+          options.timestamps
+        );
+        return writeOperation;
+      }
+
+      return null;
+    })
+    .filter((op) => op !== null);
 
   return writeOperations;
-
 
   function setDefaultOptions() {
     options = options || {};
@@ -3809,7 +4168,6 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
     }
   }
 };
-
 
 /**
  * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
@@ -3830,11 +4188,13 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
  * @api public
  */
 
-Model.hydrate = function(obj, projection, options) {
-  _checkContext(this, 'hydrate');
+Model.hydrate = function (obj, projection, options) {
+  _checkContext(this, "hydrate");
 
   if (options?.virtuals && options?.hydratedPopulatedDocs === false) {
-    throw new MongooseError('Cannot set `hydratedPopulatedDocs` option to false if `virtuals` option is truthy because `virtuals: true` also sets populated virtuals');
+    throw new MongooseError(
+      "Cannot set `hydratedPopulatedDocs` option to false if `virtuals` option is truthy because `virtuals: true` also sets populated virtuals"
+    );
   }
 
   if (projection != null) {
@@ -3843,7 +4203,7 @@ Model.hydrate = function(obj, projection, options) {
     }
     obj = applyProjection(obj, projection);
   }
-  const document = require('./queryHelpers').createModel(this, obj, projection);
+  const document = require("./queryHelpers").createModel(this, obj, projection);
   document.$init(obj, options);
   return document;
 };
@@ -3890,13 +4250,13 @@ Model.hydrate = function(obj, projection, options) {
  */
 
 Model.updateMany = function updateMany(conditions, update, options) {
-  _checkContext(this, 'updateMany');
+  _checkContext(this, "updateMany");
 
   if (update == null) {
-    throw new MongooseError('updateMany `update` parameter cannot be nullish');
+    throw new MongooseError("updateMany `update` parameter cannot be nullish");
   }
 
-  return _update(this, 'updateMany', conditions, update, options);
+  return _update(this, "updateMany", conditions, update, options);
 };
 
 /**
@@ -3938,9 +4298,9 @@ Model.updateMany = function updateMany(conditions, update, options) {
  */
 
 Model.updateOne = function updateOne(conditions, doc, options) {
-  _checkContext(this, 'updateOne');
+  _checkContext(this, "updateOne");
 
-  return _update(this, 'updateOne', conditions, doc, options);
+  return _update(this, "updateOne", conditions, doc, options);
 };
 
 /**
@@ -3975,14 +4335,19 @@ Model.updateOne = function updateOne(conditions, doc, options) {
  */
 
 Model.replaceOne = function replaceOne(conditions, doc, options) {
-  _checkContext(this, 'replaceOne');
+  _checkContext(this, "replaceOne");
 
-  const versionKey = this && this.schema && this.schema.options && this.schema.options.versionKey || null;
+  const versionKey =
+    (this &&
+      this.schema &&
+      this.schema.options &&
+      this.schema.options.versionKey) ||
+    null;
   if (versionKey && !doc[versionKey]) {
     doc[versionKey] = 0;
   }
 
-  return _update(this, 'replaceOne', conditions, doc, options);
+  return _update(this, "replaceOne", conditions, doc, options);
 };
 
 /**
@@ -4001,12 +4366,14 @@ function _update(model, op, conditions, doc, options) {
   } else {
     conditions = clone(conditions);
   }
-  options = typeof options === 'function' ? options : clone(options);
+  options = typeof options === "function" ? options : clone(options);
 
-  const versionKey = model &&
-  model.schema &&
-  model.schema.options &&
-  model.schema.options.versionKey || null;
+  const versionKey =
+    (model &&
+      model.schema &&
+      model.schema.options &&
+      model.schema.options.versionKey) ||
+    null;
   decorateUpdateWithVersionKey(doc, options, versionKey);
 
   return mq[op](conditions, doc, options);
@@ -4058,10 +4425,10 @@ function _update(model, op, conditions, doc, options) {
  */
 
 Model.aggregate = function aggregate(pipeline, options) {
-  _checkContext(this, 'aggregate');
+  _checkContext(this, "aggregate");
 
-  if (typeof options === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.aggregate() no longer accepts a callback');
+  if (typeof options === "function" || typeof arguments[2] === "function") {
+    throw new MongooseError("Model.aggregate() no longer accepts a callback");
   }
 
   const aggregate = new Aggregate(pipeline || []);
@@ -4099,44 +4466,57 @@ Model.aggregate = function aggregate(pipeline, options) {
  */
 
 Model.validate = async function validate(obj, pathsOrOptions, context) {
-  if ((arguments.length < 3) || (arguments.length === 3 && typeof arguments[2] === 'function')) {
+  if (
+    arguments.length < 3 ||
+    (arguments.length === 3 && typeof arguments[2] === "function")
+  ) {
     // For convenience, if we're validating a document or an object, make `context` default to
     // the model so users don't have to always pass `context`, re: gh-10132, gh-10346
     context = obj;
   }
-  if (typeof context === 'function' || typeof arguments[3] === 'function') {
-    throw new MongooseError('Model.validate() no longer accepts a callback');
+  if (typeof context === "function" || typeof arguments[3] === "function") {
+    throw new MongooseError("Model.validate() no longer accepts a callback");
   }
 
   let schema = this.schema;
   const discriminatorKey = schema.options.discriminatorKey;
-  if (schema.discriminators != null && obj != null && obj[discriminatorKey] != null) {
-    schema = getSchemaDiscriminatorByValue(schema, obj[discriminatorKey]) || schema;
+  if (
+    schema.discriminators != null &&
+    obj != null &&
+    obj[discriminatorKey] != null
+  ) {
+    schema =
+      getSchemaDiscriminatorByValue(schema, obj[discriminatorKey]) || schema;
   }
   let paths = Object.keys(schema.paths);
 
   if (pathsOrOptions != null) {
-    const _pathsToValidate = typeof pathsOrOptions === 'string' ? new Set(pathsOrOptions.split(' ')) : Array.isArray(pathsOrOptions) ? new Set(pathsOrOptions) : new Set(paths);
-    paths = paths.filter(p => {
+    const _pathsToValidate =
+      typeof pathsOrOptions === "string"
+        ? new Set(pathsOrOptions.split(" "))
+        : Array.isArray(pathsOrOptions)
+          ? new Set(pathsOrOptions)
+          : new Set(paths);
+    paths = paths.filter((p) => {
       if (pathsOrOptions.pathsToSkip) {
         if (Array.isArray(pathsOrOptions.pathsToSkip)) {
-          if (pathsOrOptions.pathsToSkip.find(x => x == p)) {
+          if (pathsOrOptions.pathsToSkip.find((x) => x == p)) {
             return false;
           }
-        } else if (typeof pathsOrOptions.pathsToSkip == 'string') {
+        } else if (typeof pathsOrOptions.pathsToSkip == "string") {
           if (pathsOrOptions.pathsToSkip.includes(p)) {
             return false;
           }
         }
       }
-      const pieces = p.split('.');
+      const pieces = p.split(".");
       let cur = pieces[0];
 
       for (const piece of pieces) {
         if (_pathsToValidate.has(cur)) {
           return true;
         }
-        cur += '.' + piece;
+        cur += "." + piece;
       }
 
       return _pathsToValidate.has(p);
@@ -4145,7 +4525,11 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
 
   for (const path of paths) {
     const schemaType = schema.path(path);
-    if (!schemaType || !schemaType.$isMongooseArray || schemaType.$isMongooseDocumentArray) {
+    if (
+      !schemaType ||
+      !schemaType.$isMongooseArray ||
+      schemaType.$isMongooseDocumentArray
+    ) {
       continue;
     }
 
@@ -4172,7 +4556,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
       continue;
     }
 
-    const pieces = path.indexOf('.') === -1 ? [path] : path.split('.');
+    const pieces = path.indexOf(".") === -1 ? [path] : path.split(".");
     let cur = obj;
     for (let i = 0; i < pieces.length - 1; ++i) {
       cur = cur[pieces[i]];
@@ -4180,7 +4564,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
 
     const val = get(obj, path, void 0);
     promises.push(
-      schemaType.doValidate(val, context, { path: path }).catch(err => {
+      schemaType.doValidate(val, context, { path: path }).catch((err) => {
         error = error || new ValidationError();
         error.addError(path, err);
       })
@@ -4254,9 +4638,9 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
  */
 
 Model.populate = async function populate(docs, paths) {
-  _checkContext(this, 'populate');
-  if (typeof paths === 'function' || typeof arguments[2] === 'function') {
-    throw new MongooseError('Model.populate() no longer accepts a callback');
+  _checkContext(this, "populate");
+  if (typeof paths === "function" || typeof arguments[2] === "function") {
+    throw new MongooseError("Model.populate() no longer accepts a callback");
   }
   // normalized paths
   paths = utils.populate(paths);
@@ -4266,7 +4650,7 @@ Model.populate = async function populate(docs, paths) {
   }
 
   // each path has its own query options and must be executed separately
-  if (paths.find(p => p.ordered)) {
+  if (paths.find((p) => p.ordered)) {
     // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
     // one transaction in parallel.
     // Note that if _any_ path has `ordered`, we make the top-level populate `ordered` as well.
@@ -4293,9 +4677,17 @@ const excludeIdRegGlobal = /\s?-_id\s?/g;
 
 async function _populatePath(model, docs, populateOptions) {
   if (populateOptions.strictPopulate == null) {
-    if (populateOptions._localModel != null && populateOptions._localModel.schema._userProvidedOptions.strictPopulate != null) {
-      populateOptions.strictPopulate = populateOptions._localModel.schema._userProvidedOptions.strictPopulate;
-    } else if (populateOptions._localModel != null && model.base.options.strictPopulate != null) {
+    if (
+      populateOptions._localModel != null &&
+      populateOptions._localModel.schema._userProvidedOptions.strictPopulate !=
+        null
+    ) {
+      populateOptions.strictPopulate =
+        populateOptions._localModel.schema._userProvidedOptions.strictPopulate;
+    } else if (
+      populateOptions._localModel != null &&
+      model.base.options.strictPopulate != null
+    ) {
       populateOptions.strictPopulate = model.base.options.strictPopulate;
     } else if (model.base.options.strictPopulate != null) {
       populateOptions.strictPopulate = model.base.options.strictPopulate;
@@ -4331,19 +4723,21 @@ async function _populatePath(model, docs, populateOptions) {
     ids = utils.array.unique(ids);
 
     const assignmentOpts = {};
-    assignmentOpts.sort = mod &&
-      mod.options &&
-      mod.options.options &&
-      mod.options.options.sort || void 0;
-    assignmentOpts.excludeId = excludeIdReg.test(select) || (select && select._id === 0);
+    assignmentOpts.sort =
+      (mod && mod.options && mod.options.options && mod.options.options.sort) ||
+      void 0;
+    assignmentOpts.excludeId =
+      excludeIdReg.test(select) || (select && select._id === 0);
 
     // Lean transform may delete `_id`, which would cause assignment
     // to fail. So delay running lean transform until _after_
     // `_assign()`
-    if (mod.options &&
-        mod.options.options &&
-        mod.options.options.lean &&
-        mod.options.options.lean.transform) {
+    if (
+      mod.options &&
+      mod.options.options &&
+      mod.options.options.lean &&
+      mod.options.options.lean.transform
+    ) {
       mod.options.options._leanTransform = mod.options.options.lean.transform;
       mod.options.options.lean = true;
     }
@@ -4357,19 +4751,25 @@ async function _populatePath(model, docs, populateOptions) {
     }
 
     hasOne = true;
-    if (typeof populateOptions.foreignField === 'string') {
+    if (typeof populateOptions.foreignField === "string") {
       mod.foreignField.clear();
       mod.foreignField.add(populateOptions.foreignField);
     }
-    const match = createPopulateQueryFilter(ids, mod.match, mod.foreignField, mod.model, mod.options.skipInvalidIds);
+    const match = createPopulateQueryFilter(
+      ids,
+      mod.match,
+      mod.foreignField,
+      mod.model,
+      mod.options.skipInvalidIds
+    );
     if (assignmentOpts.excludeId) {
       // override the exclusion from the query so we can use the _id
       // for document matching during assignment. we'll delete the
       // _id back off before returning the result.
-      if (typeof select === 'string') {
-        select = select.replace(excludeIdRegGlobal, ' ');
+      if (typeof select === "string") {
+        select = select.replace(excludeIdRegGlobal, " ");
       } else if (Array.isArray(select)) {
-        select = select.filter(field => field !== '-_id');
+        select = select.filter((field) => field !== "-_id");
       } else {
         // preserve original select conditions by copying
         select = { ...select };
@@ -4392,9 +4792,11 @@ async function _populatePath(model, docs, populateOptions) {
     // If no models and no docs to populate but we have a nested populate,
     // probably a case of unnecessarily populating a non-ref path re: gh-8946
     if (populateOptions.populate != null) {
-      const opts = utils.populate(populateOptions.populate).map(pop => Object.assign({}, pop, {
-        path: populateOptions.path + '.' + pop.path
-      }));
+      const opts = utils.populate(populateOptions.populate).map((pop) =>
+        Object.assign({}, pop, {
+          path: populateOptions.path + "." + pop.path,
+        })
+      );
       return model.populate(docs, opts);
     }
     return;
@@ -4404,18 +4806,23 @@ async function _populatePath(model, docs, populateOptions) {
     // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
     // one transaction in parallel.
     for (const arr of params) {
-      await _execPopulateQuery.apply(null, arr).then(valsFromDb => { vals = vals.concat(valsFromDb); });
+      await _execPopulateQuery.apply(null, arr).then((valsFromDb) => {
+        vals = vals.concat(valsFromDb);
+      });
     }
   } else {
     // By default, populate in parallel
     const promises = [];
     for (const arr of params) {
-      promises.push(_execPopulateQuery.apply(null, arr).then(valsFromDb => { vals = vals.concat(valsFromDb); }));
+      promises.push(
+        _execPopulateQuery.apply(null, arr).then((valsFromDb) => {
+          vals = vals.concat(valsFromDb);
+        })
+      );
     }
 
     await Promise.all(promises);
   }
-
 
   for (const arr of params) {
     const mod = arr[0];
@@ -4431,7 +4838,11 @@ async function _populatePath(model, docs, populateOptions) {
   }
   for (const arr of params) {
     const mod = arr[0];
-    if (mod.options && mod.options.options && mod.options.options._leanTransform) {
+    if (
+      mod.options &&
+      mod.options.options &&
+      mod.options.options._leanTransform
+    ) {
       for (const doc of vals) {
         mod.options.options._leanTransform(doc);
       }
@@ -4474,9 +4885,11 @@ function _execPopulateQuery(mod, match, select) {
   // If projection is exclusive and client explicitly unselected the foreign
   // field, that's the client's fault.
   for (const foreignField of mod.foreignField) {
-    if (foreignField !== '_id' &&
-        query.selectedInclusively() &&
-        !isPathSelectedInclusive(query._fields, foreignField)) {
+    if (
+      foreignField !== "_id" &&
+      query.selectedInclusively() &&
+      !isPathSelectedInclusive(query._fields, foreignField)
+    ) {
       query.select(foreignField);
     }
   }
@@ -4495,8 +4908,10 @@ function _execPopulateQuery(mod, match, select) {
     // paths. Because the discriminator may not have the path defined.
     if (mod.model.baseModelName != null) {
       if (Array.isArray(subPopulate)) {
-        subPopulate.forEach(pop => { pop.strictPopulate = false; });
-      } else if (typeof subPopulate === 'string') {
+        subPopulate.forEach((pop) => {
+          pop.strictPopulate = false;
+        });
+      } else if (typeof subPopulate === "string") {
         subPopulate = { path: subPopulate, strictPopulate: false };
       } else {
         subPopulate.strictPopulate = false;
@@ -4506,23 +4921,21 @@ function _execPopulateQuery(mod, match, select) {
 
     if (Array.isArray(subPopulate)) {
       for (const pop of subPopulate) {
-        pop._fullPath = basePath + '.' + pop.path;
+        pop._fullPath = basePath + "." + pop.path;
       }
-    } else if (typeof subPopulate === 'object') {
-      subPopulate._fullPath = basePath + '.' + subPopulate.path;
+    } else if (typeof subPopulate === "object") {
+      subPopulate._fullPath = basePath + "." + subPopulate.path;
     }
 
     query.populate(subPopulate);
   }
 
-  return query.exec().then(
-    docs => {
-      for (const val of docs) {
-        leanPopulateMap.set(val, mod.model);
-      }
-      return docs;
+  return query.exec().then((docs) => {
+    for (const val of docs) {
+      leanPopulateMap.set(val, mod.model);
     }
-  );
+    return docs;
+  });
 }
 
 /*!
@@ -4534,9 +4947,7 @@ function _assign(model, vals, mod, assignmentOpts) {
   const isVirtual = mod.isVirtual;
   const justOne = mod.justOne;
   let _val;
-  const lean = options &&
-    options.options &&
-    options.options.lean || false;
+  const lean = (options && options.options && options.options.lean) || false;
   const len = vals.length;
   const rawOrder = {};
   const rawDocs = {};
@@ -4590,9 +5001,14 @@ function _assign(model, vals, mod, assignmentOpts) {
           if (Array.isArray(rawDocs[key])) {
             rawDocs[key].push(val);
             rawOrder[key].push(i);
-          } else if (isVirtual ||
+          } else if (
+            isVirtual ||
             rawDocs[key].constructor !== val.constructor ||
-            (rawDocs[key] instanceof Document ? String(rawDocs[key]._doc._id) : String(rawDocs[key]._id)) !== (val instanceof Document ? String(val._doc._id) : String(val._id))) {
+            (rawDocs[key] instanceof Document
+              ? String(rawDocs[key]._doc._id)
+              : String(rawDocs[key]._id)) !==
+              (val instanceof Document ? String(val._doc._id) : String(val._id))
+          ) {
             // May need to store multiple docs with the same id if there's multiple models
             // if we have discriminators or a ref function. But avoid converting to an array
             // if we have multiple queries on the same model because of `perDocumentLimit` re: gh-9906
@@ -4630,7 +5046,7 @@ function _assign(model, vals, mod, assignmentOpts) {
     lean: lean,
     virtual: mod.virtual,
     count: mod.count,
-    match: mod.match
+    match: mod.match,
   });
 }
 
@@ -4645,7 +5061,13 @@ function _assign(model, vals, mod, assignmentOpts) {
  * @api private
  */
 
-Model.compile = function compile(name, schema, collectionName, connection, base) {
+Model.compile = function compile(
+  name,
+  schema,
+  collectionName,
+  connection,
+  base
+) {
   const versioningEnabled = schema.options.versionKey !== false;
 
   if (versioningEnabled && !schema.paths[schema.options.versionKey]) {
@@ -4655,7 +5077,7 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
     schema.add(o);
   }
   let model;
-  if (typeof name === 'function' && name.prototype instanceof Model) {
+  if (typeof name === "function" && name.prototype instanceof Model) {
     model = name;
     name = model.name;
     schema.loadClass(model, false);
@@ -4663,19 +5085,24 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   } else {
     // generate new class
     model = function model(doc, fields, skipId) {
-      model.hooks.execPreSync('createModel', doc);
+      model.hooks.execPreSync("createModel", doc);
       if (!(this instanceof model)) {
         return new model(doc, fields, skipId);
       }
       const discriminatorKey = model.schema.options.discriminatorKey;
 
-      if (model.discriminators == null || doc == null || doc[discriminatorKey] == null) {
+      if (
+        model.discriminators == null ||
+        doc == null ||
+        doc[discriminatorKey] == null
+      ) {
         Model.call(this, doc, fields, skipId);
         return;
       }
 
       // If discriminator key is set, use the discriminator instead (gh-7586)
-      const Discriminator = model.discriminators[doc[discriminatorKey]] ||
+      const Discriminator =
+        model.discriminators[doc[discriminatorKey]] ||
         getDiscriminatorByValue(model.discriminators, doc[discriminatorKey]);
       if (Discriminator != null) {
         return new Discriminator(doc, fields, skipId);
@@ -4713,16 +5140,13 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
     schemaUserProvidedOptions: _userProvidedOptions,
     capped: schema.options.capped,
     Promise: model.base.Promise,
-    modelName: name
+    modelName: name,
   };
   if (schema.options.autoCreate !== void 0) {
     collectionOptions.autoCreate = schema.options.autoCreate;
   }
 
-  const collection = connection.collection(
-    collectionName,
-    collectionOptions
-  );
+  const collection = connection.collection(collectionName, collectionOptions);
 
   model.prototype.collection = collection;
   model.prototype.$collection = collection;
@@ -4741,7 +5165,7 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
   model.$__collection = collection;
 
   // Create custom query constructor
-  model.Query = function() {
+  model.Query = function () {
     Query.apply(this, arguments);
   };
   Object.setPrototypeOf(model.Query.prototype, Query.prototype);
@@ -4762,7 +5186,9 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
 Model.clientEncryption = function clientEncryption() {
   const ClientEncryption = this.base.driver.get().ClientEncryption;
   if (!ClientEncryption) {
-    throw new Error('The mongodb driver must be used to obtain a ClientEncryption object.');
+    throw new Error(
+      "The mongodb driver must be used to obtain a ClientEncryption object."
+    );
   }
 
   const client = this.collection?.conn?.client;
@@ -4779,11 +5205,15 @@ Model.clientEncryption = function clientEncryption() {
     kmsProviders,
     credentialProviders,
     proxyOptions,
-    tlsOptions
+    tlsOptions,
   } = autoEncryptionOptions;
-  return new ClientEncryption(keyVaultClient ?? client,
-    { keyVaultNamespace, kmsProviders, credentialProviders, proxyOptions, tlsOptions }
-  );
+  return new ClientEncryption(keyVaultClient ?? client, {
+    keyVaultNamespace,
+    kmsProviders,
+    credentialProviders,
+    proxyOptions,
+    tlsOptions,
+  });
 };
 
 /**
@@ -4863,26 +5293,29 @@ Model.__subclass = function subclass(conn, schema, collection) {
   if (_this.discriminators != null) {
     Model.discriminators = {};
     for (const key of Object.keys(_this.discriminators)) {
-      Model.discriminators[key] = _this.discriminators[key].
-        __subclass(_this.db, _this.discriminators[key].schema, collection);
+      Model.discriminators[key] = _this.discriminators[key].__subclass(
+        _this.db,
+        _this.discriminators[key].schema,
+        collection
+      );
     }
   }
 
-  const s = schema && typeof schema !== 'string'
-    ? schema
-    : _this.prototype.$__schema;
+  const s =
+    schema && typeof schema !== "string" ? schema : _this.prototype.$__schema;
 
   const options = s.options || {};
   const _userProvidedOptions = s._userProvidedOptions || {};
 
   if (!collection) {
-    collection = _this.prototype.$__schema.get('collection') ||
+    collection =
+      _this.prototype.$__schema.get("collection") ||
       utils.toCollectionName(_this.modelName, this.base.pluralize());
   }
 
   const collectionOptions = {
     schemaUserProvidedOptions: _userProvidedOptions,
-    capped: s && options.capped
+    capped: s && options.capped,
   };
 
   Model.prototype.collection = conn.collection(collection, collectionOptions);
@@ -4947,7 +5380,7 @@ Model.recompileSchema = function recompileSchema() {
  * @api public
  */
 
-Model.inspect = function() {
+Model.inspect = function () {
   return `Model { ${this.modelName} }`;
 };
 
@@ -4965,7 +5398,7 @@ Model.inspect = function() {
  */
 
 Model.namespace = function namespace() {
-  return this.db.name + '.' + this.collection.collectionName;
+  return this.db.name + "." + this.collection.collectionName;
 };
 
 if (util.inspect.custom) {
@@ -4980,12 +5413,12 @@ if (util.inspect.custom) {
 
 Model._applyQueryMiddleware = function _applyQueryMiddleware() {
   const Query = this.Query;
-  const queryMiddleware = this.schema.s.hooks.filter(hook => {
+  const queryMiddleware = this.schema.s.hooks.filter((hook) => {
     const contexts = _getContexts(hook);
-    if (hook.name === 'validate') {
+    if (hook.name === "validate") {
       return !!contexts.query;
     }
-    if (hook.name === 'deleteOne' || hook.name === 'updateOne') {
+    if (hook.name === "deleteOne" || hook.name === "updateOne") {
       return !!contexts.query || Object.keys(contexts).length === 0;
     }
     if (hook.query != null || hook.document != null) {
@@ -4999,10 +5432,10 @@ Model._applyQueryMiddleware = function _applyQueryMiddleware() {
 
 function _getContexts(hook) {
   const ret = {};
-  if (hook.hasOwnProperty('query')) {
+  if (hook.hasOwnProperty("query")) {
     ret.query = hook.query;
   }
-  if (hook.hasOwnProperty('document')) {
+  if (hook.hasOwnProperty("document")) {
     ret.document = hook.document;
   }
   return ret;


### PR DESCRIPTION
Summary

Fixes #15800

This PR fixes an issue where Model.bulkSave() would not update the version key (e.g. 
__v
) on the document instance after a successful write. This caused subsequent saves on the same document instance to fail with a 
VersionError
 or MongooseBulkSaveIncompleteError because the document's version in memory would lag behind the version in the database.

The fix ensures that 
handleSuccessfulWrite
 increments the version key on the document if the write operation resulted in a version bump, matching the behavior of document.save().

Examples: 
<img width="530" height="445" alt="image" src="https://github.com/user-attachments/assets/34e06b87-353f-4aff-a989-7e72ab57b239" />
