### PR TITLE
Fix documentation link in connection.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1782,7 +1782,7 @@ Connection.prototype.syncIndexes = async function syncIndexes(options = {}) {
 };
 
 /**
- * Switches to a different database using the same [connection pool](https://mongoosejs.com/docs/api/connectionshtml#connection_pools).
+ * Switches to a different database using the same [connection pool](https://mongoosejs.com/docs/connections.html#connection_pools).
  *
  * Returns a new connection object, with the new db.
  *


### PR DESCRIPTION
Updated documentation link for connection pool.

**Summary**

Fixes a link in the docs to what I believe it's meant to point to.

**Examples**

N/A
