### PR TITLE
feat: set autoIndex to false by default #15803

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -1,45 +1,45 @@
-'use strict';
+"use strict";
 
 /*!
  * Module dependencies.
  */
 
-const Document = require('./document');
-const EventEmitter = require('events').EventEmitter;
-const Kareem = require('kareem');
-const Schema = require('./schema');
-const SchemaType = require('./schemaType');
-const SchemaTypes = require('./schema/index');
-const VirtualType = require('./virtualType');
-const STATES = require('./connectionState');
-const VALID_OPTIONS = require('./validOptions');
-const Types = require('./types');
-const Query = require('./query');
-const Model = require('./model');
-const applyPlugins = require('./helpers/schema/applyPlugins');
-const builtinPlugins = require('./plugins');
-const driver = require('./driver');
-const legacyPluralize = require('./helpers/pluralize');
-const utils = require('./utils');
-const pkg = require('../package.json');
-const cast = require('./cast');
+const Document = require("./document");
+const EventEmitter = require("events").EventEmitter;
+const Kareem = require("kareem");
+const Schema = require("./schema");
+const SchemaType = require("./schemaType");
+const SchemaTypes = require("./schema/index");
+const VirtualType = require("./virtualType");
+const STATES = require("./connectionState");
+const VALID_OPTIONS = require("./validOptions");
+const Types = require("./types");
+const Query = require("./query");
+const Model = require("./model");
+const applyPlugins = require("./helpers/schema/applyPlugins");
+const builtinPlugins = require("./plugins");
+const driver = require("./driver");
+const legacyPluralize = require("./helpers/pluralize");
+const utils = require("./utils");
+const pkg = require("../package.json");
+const cast = require("./cast");
 
-const Aggregate = require('./aggregate');
-const trusted = require('./helpers/query/trusted').trusted;
-const sanitizeFilter = require('./helpers/query/sanitizeFilter');
-const isBsonType = require('./helpers/isBsonType');
-const MongooseError = require('./error/mongooseError');
-const SetOptionError = require('./error/setOptionError');
-const applyEmbeddedDiscriminators = require('./helpers/discriminator/applyEmbeddedDiscriminators');
+const Aggregate = require("./aggregate");
+const trusted = require("./helpers/query/trusted").trusted;
+const sanitizeFilter = require("./helpers/query/sanitizeFilter");
+const isBsonType = require("./helpers/isBsonType");
+const MongooseError = require("./error/mongooseError");
+const SetOptionError = require("./error/setOptionError");
+const applyEmbeddedDiscriminators = require("./helpers/discriminator/applyEmbeddedDiscriminators");
 
-const defaultMongooseSymbol = Symbol.for('mongoose:default');
-const defaultConnectionSymbol = Symbol('mongoose:defaultConnection');
+const defaultMongooseSymbol = Symbol.for("mongoose:default");
+const defaultConnectionSymbol = Symbol("mongoose:defaultConnection");
 
-require('./helpers/printJestWarning');
+require("./helpers/printJestWarning");
 
 const objectIdHexRegexp = /^[0-9A-Fa-f]{24}$/;
 
-const { AsyncLocalStorage } = require('async_hooks');
+const { AsyncLocalStorage } = require("async_hooks");
 
 /**
  * Mongoose constructor.
@@ -65,13 +65,17 @@ function Mongoose(options) {
   this.events = new EventEmitter();
   this.__driver = driver.get();
   // default global options
-  this.options = Object.assign({
-    pluralization: true,
-    autoIndex: true,
-    autoCreate: true,
-    autoSearchIndex: false
-  }, options);
-  const createInitialConnection = utils.getOption('createInitialConnection', this.options) ?? true;
+  this.options = Object.assign(
+    {
+      pluralization: true,
+      autoIndex: false,
+      autoCreate: true,
+      autoSearchIndex: false,
+    },
+    options
+  );
+  const createInitialConnection =
+    utils.getOption("createInitialConnection", this.options) ?? true;
   if (createInitialConnection && this.__driver != null) {
     _createDefaultConnection(this);
   }
@@ -84,7 +88,7 @@ function Mongoose(options) {
   // of the `Schema` constructor so they get separate custom types. (gh-6933)
   if (!options || !options[defaultMongooseSymbol]) {
     const _this = this;
-    this.Schema = function() {
+    this.Schema = function () {
       this.base = _this;
       return Schema.apply(this, arguments);
     };
@@ -97,7 +101,7 @@ function Mongoose(options) {
     // Hack to work around babel's strange behavior with
     // `import mongoose, { Schema } from 'mongoose'`. Because `Schema` is not
     // an own property of a Mongoose global, Schema will be undefined. See gh-5648
-    for (const key of ['Schema', 'model']) {
+    for (const key of ["Schema", "model"]) {
       this[key] = Mongoose.prototype[key];
     }
   }
@@ -107,11 +111,14 @@ function Mongoose(options) {
     this.transactionAsyncLocalStorage = new AsyncLocalStorage();
   }
 
-  Object.defineProperty(this, 'plugins', {
+  Object.defineProperty(this, "plugins", {
     configurable: false,
     enumerable: true,
     writable: false,
-    value: Object.values(builtinPlugins).map(plugin => ([plugin, { deduplicate: true }]))
+    value: Object.values(builtinPlugins).map((plugin) => [
+      plugin,
+      { deduplicate: true },
+    ]),
   });
 }
 
@@ -163,17 +170,22 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
     return _mongoose;
   }
 
-  const openConnection = _mongoose.connections && _mongoose.connections.find(conn => conn.readyState !== STATES.disconnected);
+  const openConnection =
+    _mongoose.connections &&
+    _mongoose.connections.find(
+      (conn) => conn.readyState !== STATES.disconnected
+    );
   if (openConnection) {
-    const msg = 'Cannot modify Mongoose driver if a connection is already open. ' +
-      'Call `mongoose.disconnect()` before modifying the driver';
+    const msg =
+      "Cannot modify Mongoose driver if a connection is already open. " +
+      "Call `mongoose.disconnect()` before modifying the driver";
     throw new MongooseError(msg);
   }
   _mongoose.__driver = driver;
 
   if (Array.isArray(driver.plugins)) {
     for (const plugin of driver.plugins) {
-      if (typeof plugin === 'function') {
+      if (typeof plugin === "function") {
         _mongoose.plugin(plugin);
       }
     }
@@ -224,7 +236,7 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
  * - `applyPluginsToChildSchemas`: `true` by default. Set to false to skip applying global plugins to child schemas
  * - `applyPluginsToDiscriminators`: `false` by default. Set to true to apply global plugins to discriminator schemas. This typically isn't necessary because plugins are applied to the base schema and discriminators copy all middleware, methods, statics, and properties from the base schema.
  * - `autoCreate`: Set to `true` to make Mongoose call [`Model.createCollection()`](https://mongoosejs.com/docs/api/model.html#Model.createCollection()) automatically when you create a model with `mongoose.model()` or `conn.model()`. This is useful for testing transactions, change streams, and other features that require the collection to exist.
- * - `autoIndex`: `true` by default. Set to false to disable automatic index creation for all models associated with this Mongoose instance.
+ * - `autoIndex`: `false` by default. Set to true to enable automatic index creation for all models associated with this Mongoose instance.
  * - `bufferCommands`: enable/disable mongoose's buffering mechanism for all connections and models
  * - `bufferTimeoutMS`: If bufferCommands is on, this option sets the maximum amount of time Mongoose buffering will wait before throwing an error. If not specified, Mongoose will use 10000 (10 seconds).
  * - `cloneSchemas`: `false` by default. Set to `true` to `clone()` all schemas before compiling into a model.
@@ -253,7 +265,7 @@ Mongoose.prototype.setDriver = function setDriver(driver) {
 Mongoose.prototype.set = function getsetOptions(key, value) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
-  if (arguments.length === 1 && typeof key !== 'object') {
+  if (arguments.length === 1 && typeof key !== "object") {
     if (VALID_OPTIONS.indexOf(key) === -1) {
       const error = new SetOptionError();
       error.addError(key, new SetOptionError.SetOptionInnerError(key));
@@ -269,7 +281,7 @@ Mongoose.prototype.set = function getsetOptions(key, value) {
     options = { [key]: value };
   }
 
-  if (arguments.length === 1 && typeof key === 'object') {
+  if (arguments.length === 1 && typeof key === "object") {
     options = key;
   }
 
@@ -281,35 +293,45 @@ Mongoose.prototype.set = function getsetOptions(key, value) {
       if (!error) {
         error = new SetOptionError();
       }
-      error.addError(optionKey, new SetOptionError.SetOptionInnerError(optionKey));
+      error.addError(
+        optionKey,
+        new SetOptionError.SetOptionInnerError(optionKey)
+      );
       continue;
     }
 
     _mongoose.options[optionKey] = optionValue;
 
-    if (optionKey === 'objectIdGetter') {
+    if (optionKey === "objectIdGetter") {
       if (optionValue) {
-        Object.defineProperty(_mongoose.Types.ObjectId.prototype, '_id', {
+        Object.defineProperty(_mongoose.Types.ObjectId.prototype, "_id", {
           enumerable: false,
           configurable: true,
-          get: function() {
+          get: function () {
             return this;
-          }
+          },
         });
       } else {
         delete _mongoose.Types.ObjectId.prototype._id;
       }
-    } else if (optionKey === 'transactionAsyncLocalStorage') {
+    } else if (optionKey === "transactionAsyncLocalStorage") {
       if (optionValue && !_mongoose.transactionAsyncLocalStorage) {
         _mongoose.transactionAsyncLocalStorage = new AsyncLocalStorage();
       } else if (!optionValue && _mongoose.transactionAsyncLocalStorage) {
         delete _mongoose.transactionAsyncLocalStorage;
       }
-    } else if (optionKey === 'createInitialConnection') {
+    } else if (optionKey === "createInitialConnection") {
       if (optionValue && !_mongoose.connection) {
         _createDefaultConnection(_mongoose);
-      } else if (optionValue === false && _mongoose.connection && _mongoose.connection[defaultConnectionSymbol]) {
-        if (_mongoose.connection.readyState === STATES.disconnected && Object.keys(_mongoose.connection.models).length === 0) {
+      } else if (
+        optionValue === false &&
+        _mongoose.connection &&
+        _mongoose.connection[defaultConnectionSymbol]
+      ) {
+        if (
+          _mongoose.connection.readyState === STATES.disconnected &&
+          Object.keys(_mongoose.connection.models).length === 0
+        ) {
           _mongoose.connections.shift();
         }
       }
@@ -371,7 +393,7 @@ Mongoose.prototype.get = Mongoose.prototype.set;
  * @param {String} [options.dbName] The name of the database you want to use. If not provided, Mongoose uses the database name from connection string.
  * @param {String} [options.user] username for authentication, equivalent to `options.auth.username`. Maintained for backwards compatibility.
  * @param {String} [options.pass] password for authentication, equivalent to `options.auth.password`. Maintained for backwards compatibility.
- * @param {Boolean} [options.autoIndex=true] Mongoose-specific option. Set to false to disable automatic index creation for all models associated with this connection.
+ * @param {Boolean} [options.autoIndex=false] Mongoose-specific option. Set to true to enable automatic index creation for all models associated with this connection.
  * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html#promiseLibrary).
  * @param {Number} [options.maxPoolSize=5] The maximum number of sockets the MongoDB driver will keep open for this connection. Keep in mind that MongoDB only allows one operation per socket at a time, so you may want to increase this if you find you have a few slow queries that are blocking faster queries from proceeding. See [Slow Trains in MongoDB and Node.js](https://thecodebarbarian.com/slow-trains-in-mongodb-and-nodejs).
  * @param {Number} [options.minPoolSize=1] The minimum number of sockets the MongoDB driver will keep open for this connection. Keep in mind that MongoDB only allows one operation per socket at a time, so you may want to increase this if you find you have a few slow queries that are blocking faster queries from proceeding. See [Slow Trains in MongoDB and Node.js](https://thecodebarbarian.com/slow-trains-in-mongodb-and-nodejs).
@@ -388,7 +410,7 @@ Mongoose.prototype.createConnection = function createConnection(uri, options) {
   const conn = new Connection(_mongoose);
   _mongoose.connections.push(conn);
   _mongoose.nextConnectionId++;
-  _mongoose.events.emit('createConnection', conn);
+  _mongoose.events.emit("createConnection", conn);
 
   if (arguments.length > 0) {
     conn.openUri(uri, { ...options, _fireAndForget: true });
@@ -427,7 +449,7 @@ Mongoose.prototype.createConnection = function createConnection(uri, options) {
  * @param {Number} [options.minPoolSize=0] The minimum number of sockets the MongoDB driver will keep open for this connection.
  * @param {Number} [options.serverSelectionTimeoutMS] If `useUnifiedTopology = true`, the MongoDB driver will try to find a server to send any given operation to, and keep retrying for `serverSelectionTimeoutMS` milliseconds before erroring out. If not set, the MongoDB driver defaults to using `30000` (30 seconds).
  * @param {Number} [options.heartbeatFrequencyMS] If `useUnifiedTopology = true`, the MongoDB driver sends a heartbeat every `heartbeatFrequencyMS` to check on the status of the connection. A heartbeat is subject to `serverSelectionTimeoutMS`, so the MongoDB driver will retry failed heartbeats for up to 30 seconds by default. Mongoose only emits a `'disconnected'` event after a heartbeat has failed, so you may want to decrease this setting to reduce the time between when your server goes down and when Mongoose emits `'disconnected'`. We recommend you do **not** set this setting below 1000, too many heartbeats can lead to performance degradation.
- * @param {Boolean} [options.autoIndex=true] Mongoose-specific option. Set to false to disable automatic index creation for all models associated with this connection.
+ * @param {Boolean} [options.autoIndex=false] Mongoose-specific option. Set to true to enable automatic index creation for all models associated with this connection.
  * @param {Class} [options.promiseLibrary] Sets the [underlying driver's promise library](https://mongodb.github.io/node-mongodb-native/4.9/interfaces/MongoClientOptions.html#promiseLibrary).
  * @param {Number} [options.socketTimeoutMS=0] How long the MongoDB driver will wait before killing a socket due to inactivity _after initial connection_. A socket may be inactive because of either no activity or a long-running operation. `socketTimeoutMS` defaults to 0, which means Node.js will not time out the socket due to inactivity. This option is passed to [Node.js `socket#setTimeout()` function](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback) after the MongoDB driver successfully completes.
  * @param {Number} [options.family=0] Passed transparently to [Node.js' `dns.lookup()`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) function. May be either `0`, `4`, or `6`. `4` means use IPv4 only, `6` means use IPv6 only, `0` means try both.
@@ -438,8 +460,13 @@ Mongoose.prototype.createConnection = function createConnection(uri, options) {
  */
 
 Mongoose.prototype.connect = async function connect(uri, options) {
-  if (typeof options === 'function' || (arguments.length >= 3 && typeof arguments[2] === 'function')) {
-    throw new MongooseError('Mongoose.prototype.connect() no longer accepts a callback');
+  if (
+    typeof options === "function" ||
+    (arguments.length >= 3 && typeof arguments[2] === "function")
+  ) {
+    throw new MongooseError(
+      "Mongoose.prototype.connect() no longer accepts a callback"
+    );
   }
 
   const _mongoose = this instanceof Mongoose ? this : mongoose;
@@ -459,8 +486,10 @@ Mongoose.prototype.connect = async function connect(uri, options) {
  */
 
 Mongoose.prototype.disconnect = async function disconnect() {
-  if (arguments.length >= 1 && typeof arguments[0] === 'function') {
-    throw new MongooseError('Mongoose.prototype.disconnect() no longer accepts a callback');
+  if (arguments.length >= 1 && typeof arguments[0] === "function") {
+    throw new MongooseError(
+      "Mongoose.prototype.disconnect() no longer accepts a callback"
+    );
   }
 
   const _mongoose = this instanceof Mongoose ? this : mongoose;
@@ -469,7 +498,7 @@ Mongoose.prototype.disconnect = async function disconnect() {
   if (remaining <= 0) {
     return;
   }
-  await Promise.all(_mongoose.connections.map(conn => conn.close()));
+  await Promise.all(_mongoose.connections.map((conn) => conn.close()));
 };
 
 /**
@@ -490,7 +519,10 @@ Mongoose.prototype.disconnect = async function disconnect() {
 Mongoose.prototype.startSession = function startSession() {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
-  return _mongoose.connection.startSession.apply(_mongoose.connection, arguments);
+  return _mongoose.connection.startSession.apply(
+    _mongoose.connection,
+    arguments
+  );
 };
 
 /**
@@ -567,7 +599,7 @@ Mongoose.prototype.pluralize = function pluralize(fn) {
 Mongoose.prototype.model = function model(name, schema, collection, options) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
-  if (typeof schema === 'string') {
+  if (typeof schema === "string") {
     collection = schema;
     schema = false;
   }
@@ -584,8 +616,10 @@ Mongoose.prototype.model = function model(name, schema, collection, options) {
     schema = new Schema(schema);
   }
   if (schema && !(schema instanceof Schema)) {
-    throw new _mongoose.Error('The 2nd parameter to `mongoose.model()` should be a ' +
-      'schema or a POJO');
+    throw new _mongoose.Error(
+      "The 2nd parameter to `mongoose.model()` should be a " +
+        "schema or a POJO"
+    );
   }
 
   // handle internal options from connection.model()
@@ -593,7 +627,7 @@ Mongoose.prototype.model = function model(name, schema, collection, options) {
 
   const originalSchema = schema;
   if (schema) {
-    if (_mongoose.get('cloneSchemas')) {
+    if (_mongoose.get("cloneSchemas")) {
       schema = schema.clone();
     }
     _mongoose._applyPlugins(schema);
@@ -601,13 +635,19 @@ Mongoose.prototype.model = function model(name, schema, collection, options) {
 
   // connection.model() may be passing a different schema for
   // an existing model name. in this case don't read from cache.
-  const overwriteModels = _mongoose.options.hasOwnProperty('overwriteModels') ?
-    _mongoose.options.overwriteModels :
-    options.overwriteModels;
-  if (_mongoose.models.hasOwnProperty(name) && options.cache !== false && overwriteModels !== true) {
-    if (originalSchema &&
-        originalSchema.instanceOfSchema &&
-        originalSchema !== _mongoose.models[name].schema) {
+  const overwriteModels = _mongoose.options.hasOwnProperty("overwriteModels")
+    ? _mongoose.options.overwriteModels
+    : options.overwriteModels;
+  if (
+    _mongoose.models.hasOwnProperty(name) &&
+    options.cache !== false &&
+    overwriteModels !== true
+  ) {
+    if (
+      originalSchema &&
+      originalSchema.instanceOfSchema &&
+      originalSchema !== _mongoose.models[name].schema
+    ) {
       throw new _mongoose.Error.OverwriteModelError(name);
     }
     if (collection && collection !== _mongoose.models[name].collection.name) {
@@ -639,46 +679,53 @@ Mongoose.prototype._model = function _model(name, schema, collection, options) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
   let model;
-  if (typeof name === 'function') {
+  if (typeof name === "function") {
     model = name;
     name = model.name;
     if (!(model.prototype instanceof Model)) {
-      throw new _mongoose.Error('The provided class ' + name + ' must extend Model');
+      throw new _mongoose.Error(
+        "The provided class " + name + " must extend Model"
+      );
     }
   }
 
   if (schema) {
-    if (_mongoose.get('cloneSchemas')) {
+    if (_mongoose.get("cloneSchemas")) {
       schema = schema.clone();
     }
     _mongoose._applyPlugins(schema);
   }
 
   // Apply relevant "global" options to the schema
-  if (schema == null || !('pluralization' in schema.options)) {
+  if (schema == null || !("pluralization" in schema.options)) {
     schema.options.pluralization = _mongoose.options.pluralization;
   }
 
   if (!collection) {
-    collection = schema.get('collection') ||
+    collection =
+      schema.get("collection") ||
       utils.toCollectionName(name, _mongoose.pluralize());
   }
 
   applyEmbeddedDiscriminators(schema);
 
   const connection = options.connection || _mongoose.connection;
-  model = _mongoose.Model.compile(model || name, schema, collection, connection, _mongoose);
+  model = _mongoose.Model.compile(
+    model || name,
+    schema,
+    collection,
+    connection,
+    _mongoose
+  );
   // Errors handled internally, so safe to ignore error
   model.init().catch(function $modelInitNoop() {});
 
-  connection.emit('model', model);
+  connection.emit("model", model);
 
   if (schema._applyDiscriminators != null) {
     for (const disc of schema._applyDiscriminators.keys()) {
-      const {
-        schema: discriminatorSchema,
-        options
-      } = schema._applyDiscriminators.get(disc);
+      const { schema: discriminatorSchema, options } =
+        schema._applyDiscriminators.get(disc);
       model.discriminator(disc, discriminatorSchema, options);
     }
   }
@@ -747,11 +794,16 @@ Mongoose.prototype._applyPlugins = function _applyPlugins(schema, options) {
   const _mongoose = this instanceof Mongoose ? this : mongoose;
 
   options = options || {};
-  options.applyPluginsToDiscriminators = _mongoose.options && _mongoose.options.applyPluginsToDiscriminators || false;
-  options.applyPluginsToChildSchemas = typeof (_mongoose.options && _mongoose.options.applyPluginsToChildSchemas) === 'boolean' ?
-    _mongoose.options.applyPluginsToChildSchemas :
-    true;
-  applyPlugins(schema, _mongoose.plugins, options, '$globalPluginsApplied');
+  options.applyPluginsToDiscriminators =
+    (_mongoose.options && _mongoose.options.applyPluginsToDiscriminators) ||
+    false;
+  options.applyPluginsToChildSchemas =
+    typeof (
+      _mongoose.options && _mongoose.options.applyPluginsToChildSchemas
+    ) === "boolean"
+      ? _mongoose.options.applyPluginsToChildSchemas
+      : true;
+  applyPlugins(schema, _mongoose.plugins, options, "$globalPluginsApplied");
 };
 
 /**
@@ -792,11 +844,11 @@ Mongoose.prototype.plugin = function plugin(fn, opts) {
  * @api public
  */
 
-Mongoose.prototype.__defineGetter__('connection', function() {
+Mongoose.prototype.__defineGetter__("connection", function () {
   return this.connections[0];
 });
 
-Mongoose.prototype.__defineSetter__('connection', function(v) {
+Mongoose.prototype.__defineSetter__("connection", function (v) {
   if (v instanceof this.__driver.Connection) {
     this.connections[0] = v;
     this.models = v.models;
@@ -865,7 +917,7 @@ Mongoose.prototype.Aggregate = Aggregate;
  * @api public
  */
 
-Mongoose.prototype.BaseCollection = require('./collection');
+Mongoose.prototype.BaseCollection = require("./collection");
 
 /**
  * The Mongoose Collection constructor
@@ -876,13 +928,13 @@ Mongoose.prototype.BaseCollection = require('./collection');
  * @api public
  */
 
-Object.defineProperty(Mongoose.prototype, 'Collection', {
-  get: function() {
+Object.defineProperty(Mongoose.prototype, "Collection", {
+  get: function () {
     return this.__driver.Collection;
   },
-  set: function(Collection) {
+  set: function (Collection) {
     this.__driver.Collection = Collection;
-  }
+  },
 });
 
 /**
@@ -894,17 +946,17 @@ Object.defineProperty(Mongoose.prototype, 'Collection', {
  * @api public
  */
 
-Object.defineProperty(Mongoose.prototype, 'Connection', {
-  get: function() {
+Object.defineProperty(Mongoose.prototype, "Connection", {
+  get: function () {
     return this.__driver.Connection;
   },
-  set: function(Connection) {
+  set: function (Connection) {
     if (Connection === this.__driver.Connection) {
       return;
     }
 
     this.__driver.Connection = Connection;
-  }
+  },
 });
 
 /**
@@ -916,7 +968,7 @@ Object.defineProperty(Mongoose.prototype, 'Connection', {
  * @api public
  */
 
-Mongoose.prototype.BaseConnection = require('./connection');
+Mongoose.prototype.BaseConnection = require("./connection");
 
 /**
  * The Mongoose version
@@ -1121,7 +1173,10 @@ Mongoose.prototype.isValidObjectId = function isValidObjectId(v) {
  */
 
 Mongoose.prototype.isObjectIdOrHexString = function isObjectIdOrHexString(v) {
-  return isBsonType(v, 'ObjectId') || (typeof v === 'string' && objectIdHexRegexp.test(v));
+  return (
+    isBsonType(v, "ObjectId") ||
+    (typeof v === "string" && objectIdHexRegexp.test(v))
+  );
 };
 
 /**
@@ -1153,7 +1208,6 @@ Mongoose.prototype.syncIndexes = function syncIndexes(options) {
  */
 
 Mongoose.prototype.Decimal128 = SchemaTypes.Decimal128;
-
 
 /**
  * The Mongoose Mixed [SchemaType](https://mongoosejs.com/docs/schematypes.html). Used for
@@ -1220,7 +1274,9 @@ Mongoose.prototype.MongooseError = MongooseError;
  * @api public
  */
 
-Mongoose.prototype.now = function now() { return new Date(); };
+Mongoose.prototype.now = function now() {
+  return new Date();
+};
 
 /**
  * The Mongoose CastError constructor
@@ -1242,7 +1298,7 @@ Mongoose.prototype.CastError = MongooseError.CastError;
  * @api public
  */
 
-Mongoose.prototype.SchemaTypeOptions = require('./options/schemaTypeOptions');
+Mongoose.prototype.SchemaTypeOptions = require("./options/schemaTypeOptions");
 
 /**
  * The [mquery](https://github.com/aheckmann/mquery) query builder Mongoose uses.
@@ -1251,7 +1307,7 @@ Mongoose.prototype.SchemaTypeOptions = require('./options/schemaTypeOptions');
  * @api public
  */
 
-Mongoose.prototype.mquery = require('mquery');
+Mongoose.prototype.mquery = require("mquery");
 
 /**
  * Sanitizes query filters against [query selector injection attacks](https://thecodebarbarian.com/2014/09/04/defending-against-query-selector-injection-attacks.html)
@@ -1385,7 +1441,7 @@ Mongoose.prototype.overwriteMiddlewareArguments = Kareem.overwriteArguments;
  * @api public
  */
 
-Mongoose.prototype.omitUndefined = require('./helpers/omitUndefined');
+Mongoose.prototype.omitUndefined = require("./helpers/omitUndefined");
 
 /*!
  * Create a new default connection (`mongoose.connection`) for a Mongoose instance.
@@ -1407,6 +1463,9 @@ function _createDefaultConnection(mongoose) {
  * @api private
  */
 
-const mongoose = module.exports = exports = new Mongoose({
-  [defaultMongooseSymbol]: true
-});
+const mongoose =
+  (module.exports =
+  exports =
+    new Mongoose({
+      [defaultMongooseSymbol]: true,
+    }));

--- a/test/model.indexes.test.js
+++ b/test/model.indexes.test.js
@@ -1,64 +1,64 @@
-'use strict';
+"use strict";
 
 /**
  * Test dependencies.
  */
 
-const start = require('./common');
+const start = require("./common");
 
-const assert = require('assert');
-const random = require('./util').random;
+const assert = require("assert");
+const random = require("./util").random;
 
 const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 const ObjectId = Schema.Types.ObjectId;
 
-describe('model', function() {
+describe("model", function () {
   let db;
 
-  before(function() {
+  before(function () {
     db = start();
 
-    return db.createCollection('Test').catch(() => {});
+    return db.createCollection("Test").catch(() => {});
   });
 
-  after(async function() {
+  after(async function () {
     await db.close();
   });
 
   beforeEach(() => db.deleteModel(/.*/));
-  afterEach(() => require('./util').clearTestData(db));
-  afterEach(() => require('./util').stopRemainingOps(db));
+  afterEach(() => require("./util").clearTestData(db));
+  afterEach(() => require("./util").stopRemainingOps(db));
 
-  describe('indexes', function() {
+  describe("indexes", function () {
     this.timeout(5000);
 
-    it('are created when model is compiled', async function() {
+    it("are created when model is compiled", async function () {
       const Indexed = new Schema({
         name: { type: String, index: true },
         last: String,
         email: String,
-        date: Date
+        date: Date,
       });
 
       Indexed.index({ last: 1, email: 1 }, { unique: true });
       Indexed.index({ date: 1 }, { expires: 10 });
 
-      const IndexedModel = db.model('Test', Indexed);
+      const IndexedModel = db.model("Test", Indexed);
       let assertions = 0;
 
       await IndexedModel.init();
 
       const indexes = await IndexedModel.collection.getIndexes({ full: true });
 
-      indexes.forEach(function(index) {
+      indexes.forEach(function (index) {
         switch (index.name) {
-          case '_id_':
-          case 'name_1':
-          case 'last_1_email_1':
+          case "_id_":
+          case "name_1":
+          case "last_1_email_1":
             assertions++;
             break;
-          case 'date_1':
+          case "date_1":
             assertions++;
             assert.equal(index.expireAfterSeconds, 10);
             break;
@@ -68,34 +68,36 @@ describe('model', function() {
       assert.equal(assertions, 4);
     });
 
-    it('of embedded documents', async function() {
+    it("of embedded documents", async function () {
       const BlogPosts = new Schema({
         _id: { type: ObjectId, index: true },
         title: { type: String, index: true },
-        desc: String
+        desc: String,
       });
 
       const User = new Schema({
         name: { type: String, index: true },
-        blogposts: [BlogPosts]
+        blogposts: [BlogPosts],
       });
 
-      const UserModel = db.model('Test', User);
+      const UserModel = db.model("Test", User);
       let assertions = 0;
 
       await UserModel.init();
 
-      const mongoIndexes = Object.values(await UserModel.collection.getIndexes());
+      const mongoIndexes = Object.values(
+        await UserModel.collection.getIndexes()
+      );
 
       for (const mongoIndex in mongoIndexes) {
         mongoIndexes[mongoIndex].forEach(function iter(mongoIndex) {
-          if (mongoIndex[0] === 'name') {
+          if (mongoIndex[0] === "name") {
             assertions++;
           }
-          if (mongoIndex[0] === 'blogposts._id') {
+          if (mongoIndex[0] === "blogposts._id") {
             assertions++;
           }
-          if (mongoIndex[0] === 'blogposts.title') {
+          if (mongoIndex[0] === "blogposts.title") {
             assertions++;
           }
         });
@@ -104,65 +106,70 @@ describe('model', function() {
       assert.equal(assertions, 3);
     });
 
-    it('of embedded documents unless excludeIndexes (gh-5575) (gh-8343)', async function() {
+    it("of embedded documents unless excludeIndexes (gh-5575) (gh-8343)", async function () {
       const BlogPost = Schema({
         _id: { type: ObjectId },
         title: { type: String, index: true },
-        desc: String
+        desc: String,
       });
-      const otherSchema = Schema({
-        name: { type: String, index: true }
-      }, { excludeIndexes: true });
+      const otherSchema = Schema(
+        {
+          name: { type: String, index: true },
+        },
+        { excludeIndexes: true }
+      );
 
       const User = new Schema({
         name: { type: String, index: true },
         blogposts: {
           type: [BlogPost],
-          excludeIndexes: true
+          excludeIndexes: true,
         },
         otherblogposts: [{ type: BlogPost, excludeIndexes: true }],
         blogpost: {
           type: BlogPost,
-          excludeIndexes: true
+          excludeIndexes: true,
         },
-        otherArr: [otherSchema]
+        otherArr: [otherSchema],
       });
 
-      const UserModel = db.model('Test', User);
+      const UserModel = db.model("Test", User);
       await UserModel.init();
 
       const indexes = await UserModel.collection.getIndexes();
 
       // Should only have _id and name indexes
       const indexNames = Object.keys(indexes);
-      assert.deepEqual(indexNames.sort(), ['_id_', 'name_1']);
+      assert.deepEqual(indexNames.sort(), ["_id_", "name_1"]);
     });
 
-    it('of multiple embedded documents with same schema', async function() {
+    it("of multiple embedded documents with same schema", async function () {
       const BlogPosts = new Schema({
         _id: { type: ObjectId, unique: true },
         title: { type: String, index: true },
-        desc: String
+        desc: String,
       });
 
       const User = new Schema({
         name: { type: String, index: true },
         blogposts: [BlogPosts],
-        featured: [BlogPosts]
+        featured: [BlogPosts],
       });
 
-      const UserModel = db.model('Test', User);
+      const UserModel = db.model("Test", User);
 
       await UserModel.init();
 
-      const mongoIndexesNames = Object.values(await UserModel.collection.getIndexes()).map(indexArray => indexArray[0][0]);
+      const mongoIndexesNames = Object.values(
+        await UserModel.collection.getIndexes()
+      ).map((indexArray) => indexArray[0][0]);
 
       const existingIndexesMap = {
         name: false,
-        'blogposts._id': false,
-        'blogposts.title': false,
-        'featured._id': false,
-        'featured.title': false
+        "blogposts._id": false,
+        "blogposts.title": false,
+        "featured._id": false,
+        "featured.title": false,
       };
 
       for (const mongoIndexName of mongoIndexesNames) {
@@ -171,32 +178,29 @@ describe('model', function() {
         }
       }
 
-      assert.deepEqual(
-        existingIndexesMap,
-        {
-          name: true,
-          'blogposts._id': true,
-          'blogposts.title': true,
-          'featured._id': true,
-          'featured.title': true
-        }
-      );
+      assert.deepEqual(existingIndexesMap, {
+        name: true,
+        "blogposts._id": true,
+        "blogposts.title": true,
+        "featured._id": true,
+        "featured.title": true,
+      });
     });
 
-    it('compound: on embedded docs', async function() {
+    it("compound: on embedded docs", async function () {
       const BlogPosts = new Schema({
         title: String,
-        desc: String
+        desc: String,
       });
 
       BlogPosts.index({ title: 1, desc: 1 });
 
       const User = new Schema({
         name: { type: String, index: true },
-        blogposts: [BlogPosts]
+        blogposts: [BlogPosts],
       });
 
-      const UserModel = db.model('Test', User);
+      const UserModel = db.model("Test", User);
       let found = 0;
 
       await UserModel.init();
@@ -205,8 +209,8 @@ describe('model', function() {
 
       for (const index in indexes) {
         switch (index) {
-          case 'name_1':
-          case 'blogposts.title_1_blogposts.desc_1':
+          case "name_1":
+          case "blogposts.title_1_blogposts.desc_1":
             ++found;
             break;
         }
@@ -215,37 +219,38 @@ describe('model', function() {
       assert.equal(found, 2);
     });
 
-    it('nested embedded docs (gh-5199)', function() {
+    it("nested embedded docs (gh-5199)", function () {
       const SubSubSchema = mongoose.Schema({
-        nested2: String
+        nested2: String,
       });
 
       SubSubSchema.index({ nested2: 1 });
 
       const SubSchema = mongoose.Schema({
         nested1: String,
-        subSub: SubSubSchema
+        subSub: SubSubSchema,
       });
 
       SubSchema.index({ nested1: 1 });
 
       const ContainerSchema = mongoose.Schema({
         nested0: String,
-        sub: SubSchema
+        sub: SubSchema,
       });
 
       ContainerSchema.index({ nested0: 1 });
 
-      assert.deepEqual(ContainerSchema.indexes().map(function(v) { return v[0]; }), [
-        { 'sub.subSub.nested2': 1 },
-        { 'sub.nested1': 1 },
-        { nested0: 1 }
-      ]);
+      assert.deepEqual(
+        ContainerSchema.indexes().map(function (v) {
+          return v[0];
+        }),
+        [{ "sub.subSub.nested2": 1 }, { "sub.nested1": 1 }, { nested0: 1 }]
+      );
     });
 
-    it('primitive arrays (gh-3347)', function() {
+    it("primitive arrays (gh-3347)", function () {
       const schema = new Schema({
-        arr: [{ type: String, unique: true }]
+        arr: [{ type: String, unique: true }],
       });
 
       const indexes = schema.indexes();
@@ -254,31 +259,34 @@ describe('model', function() {
       assert.ok(indexes[0][1].unique);
     });
 
-    it('error should emit on the model', async function() {
+    it("error should emit on the model", async function () {
       const schema = new Schema({ name: { type: String } });
-      const Test = db.model('Test', schema, 'Test');
+      const Test = db.model("Test", schema, "Test");
       await Test.init();
-      await Test.create({ name: 'hi' }, { name: 'hi' });
+      await Test.create({ name: "hi" }, { name: "hi" });
 
       const Test2 = db.model(
-        'Test2',
+        "Test2",
         new Schema({
           name: {
             type: String,
-            unique: true
-          }
+            unique: true,
+          },
         }),
-        'Test'
+        "Test"
       );
 
-      const err = await Test2.init().then(() => null, err => err);
+      const err = await Test2.init().then(
+        () => null,
+        (err) => err
+      );
       assert.ok(/E11000 duplicate key error/.test(err.message), err);
     });
 
-    it('when one index creation errors', async function() {
+    it("when one index creation errors", async function () {
       const userSchema = {
         name: { type: String },
-        secondValue: { type: Boolean }
+        secondValue: { type: Boolean },
       };
 
       const userSchema1 = new Schema(userSchema);
@@ -288,24 +296,30 @@ describe('model', function() {
       userSchema2.index({ name: 1 }, { unique: true });
       userSchema2.index({ secondValue: 1 });
 
-      const collectionName = 'deepindexedmodel' + random();
+      const collectionName = "deepindexedmodel" + random();
       // Create model with first schema to initialize indexes
-      db.model('SingleIndexedModel', userSchema1, collectionName);
+      db.model("SingleIndexedModel", userSchema1, collectionName);
 
       // Create model with second schema in same collection to add new indexes
-      const UserModel2 = db.model('DuplicateIndexedModel', userSchema2, collectionName);
+      const UserModel2 = db.model(
+        "DuplicateIndexedModel",
+        userSchema2,
+        collectionName
+      );
       let assertions = 0;
 
-      await UserModel2.init().catch(err => err);
+      await UserModel2.init().catch((err) => err);
 
       const rawIndexesResponse = await UserModel2.collection.getIndexes();
-      const indexesNames = Object.values(rawIndexesResponse).map(indexArray => indexArray[0][0]);
+      const indexesNames = Object.values(rawIndexesResponse).map(
+        (indexArray) => indexArray[0][0]
+      );
 
       for (const indexName of indexesNames) {
-        if (indexName === 'name') {
+        if (indexName === "name") {
           assertions++;
         }
-        if (indexName === 'secondValue') {
+        if (indexName === "secondValue") {
           assertions++;
         }
       }
@@ -313,99 +327,108 @@ describe('model', function() {
       assert.equal(assertions, 2);
     });
 
-    it('creates descending indexes from schema definition(gh-8895)', async function() {
-
+    it("creates descending indexes from schema definition(gh-8895)", async function () {
       const userSchema = new Schema({
         name: { type: String, index: -1 },
-        address: { type: String, index: '-1' }
+        address: { type: String, index: "-1" },
       });
 
-      const User = db.model('User', userSchema);
+      const User = db.model("User", userSchema);
 
       await User.init();
 
       const indexes = await User.collection.getIndexes();
 
-      assert.ok(indexes['name_-1']);
-      assert.ok(indexes['address_-1']);
+      assert.ok(indexes["name_-1"]);
+      assert.ok(indexes["address_-1"]);
     });
 
-    describe('auto creation', function() {
-      it('can be disabled', async function() {
+    describe("auto creation", function () {
+      it("can be disabled", async function () {
         const schema = new Schema({ name: { type: String, index: true } });
-        schema.set('autoIndex', false);
+        schema.set("autoIndex", false);
 
-        const Test = db.model('Test', schema);
-        Test.on('index', function() {
-          assert.ok(false, 'Model.ensureIndexes() was called');
+        const Test = db.model("Test", schema);
+        Test.on("index", function () {
+          assert.ok(false, "Model.ensureIndexes() was called");
         });
 
         // Create a doc because mongodb 3.0 getIndexes errors if db doesn't
         // exist
-        await Test.create({ name: 'Bacon' });
+        await Test.create({ name: "Bacon" });
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         const indexes = await Test.collection.getIndexes();
 
         // Only default _id index should exist
-        assert.deepEqual(['_id_'], Object.keys(indexes));
+        assert.deepEqual(["_id_"], Object.keys(indexes));
       });
 
-      describe('global autoIndexes (gh-1875)', function() {
+      describe("global autoIndexes (gh-1875)", function () {
         beforeEach(() => db.deleteModel(/Test/));
 
-        it('will create indexes as a default', async function() {
+        it("will create indexes as a default", async function () {
+          const db = start({ config: { autoIndex: true } });
           const schema = new Schema({ name: { type: String, index: true } });
-          const Test = db.model('Test', schema);
+          const Test = db.model("Test", schema);
           await Test.init();
 
-          assert.ok(true, 'Model.ensureIndexes() was called');
+          assert.ok(true, "Model.ensureIndexes() was called");
           const indexes = await Test.collection.getIndexes();
 
           assert.equal(Object.keys(indexes).length, 2);
+          await db.close();
         });
 
-        it('will not create indexes if the global auto index is false and schema option isnt set (gh-1875)', async function() {
+        it("will not create indexes if the global auto index is false and schema option isnt set (gh-1875)", async function () {
           const db = start({ config: { autoIndex: false } });
           const schema = new Schema({ name: { type: String, index: true } });
-          const Test = db.model('Test', schema);
-          Test.on('index', function() {
-            assert.ok(false, 'Model.ensureIndexes() was called');
+          const Test = db.model("Test", schema);
+          Test.on("index", function () {
+            assert.ok(false, "Model.ensureIndexes() was called");
           });
 
-          await Test.create({ name: 'Bacon' });
+          await Test.create({ name: "Bacon" });
           await new Promise((resolve) => setTimeout(resolve, 100));
 
           const indexes = await Test.collection.getIndexes();
-          assert.deepEqual(['_id_'], Object.keys(indexes));
+          assert.deepEqual(["_id_"], Object.keys(indexes));
 
           await db.close();
         });
       });
     });
 
-    describe('model.ensureIndexes()', function() {
-      it('is a function', function() {
-        const schema = mongoose.Schema({ x: 'string' });
-        const Test = mongoose.createConnection().model('ensureIndexes-' + random, schema);
-        assert.equal(typeof Test.ensureIndexes, 'function');
+    describe("model.ensureIndexes()", function () {
+      it("is a function", function () {
+        const schema = mongoose.Schema({ x: "string" });
+        const Test = mongoose
+          .createConnection()
+          .model("ensureIndexes-" + random, schema);
+        assert.equal(typeof Test.ensureIndexes, "function");
       });
 
-      it('returns a Promise', function() {
-        const schema = mongoose.Schema({ x: 'string' });
-        const Test = mongoose.createConnection().model('ensureIndexes-' + random, schema);
+      it("returns a Promise", function () {
+        const schema = mongoose.Schema({ x: "string" });
+        const Test = mongoose
+          .createConnection()
+          .model("ensureIndexes-" + random, schema);
         const p = Test.ensureIndexes();
         assert.ok(p instanceof Promise);
       });
 
-      it('creates indexes', async function() {
+      it("creates indexes", async function () {
         const schema = new Schema({ name: { type: String } });
-        const Test = db.model('ManualIndexing' + random(), schema, 'x' + random());
+        const Test = db.model(
+          "ManualIndexing" + random(),
+          schema,
+          "x" + random()
+        );
 
         Test.schema.index({ name: 1 }, { sparse: true });
 
         let called = false;
-        Test.on('index', function() {
+        Test.on("index", function () {
           called = true;
         });
 
@@ -416,12 +439,14 @@ describe('model', function() {
     });
   });
 
-  it('sets correct partialFilterExpression for document array (gh-9091)', async function() {
+  it("sets correct partialFilterExpression for document array (gh-9091)", async function () {
     const childSchema = new Schema({ name: String });
-    childSchema.index({ name: 1 }, { partialFilterExpression: { name: { $exists: true } } });
+    childSchema.index(
+      { name: 1 },
+      { partialFilterExpression: { name: { $exists: true } } }
+    );
     const schema = new Schema({ arr: [childSchema] });
-    const Model = db.model('Test', schema);
-
+    const Model = db.model("Test", schema);
 
     await Model.init();
 
@@ -431,98 +456,114 @@ describe('model', function() {
     assert.equal(indexes.length, 2);
     assert.ok(indexes[1].partialFilterExpression);
     assert.deepEqual(indexes[1].partialFilterExpression, {
-      'arr.name': { $exists: true }
+      "arr.name": { $exists: true },
     });
   });
 
-  it('skips automatic indexing on childSchema if autoIndex: false (gh-9150)', async function() {
-    const nestedSchema = mongoose.Schema({
-      name: { type: String, index: true }
-    }, { autoIndex: false });
+  it("skips automatic indexing on childSchema if autoIndex: false (gh-9150)", async function () {
+    const nestedSchema = mongoose.Schema(
+      {
+        name: { type: String, index: true },
+      },
+      { autoIndex: false }
+    );
 
     const schema = mongoose.Schema({
       nested: nestedSchema,
-      top: { type: String, index: true }
+      top: { type: String, index: true },
     });
 
-    const Model = db.model('Model', schema);
+    const Model = db.model("Model", schema);
 
     await Model.init();
 
     const indexes = await Model.listIndexes();
 
-    assert.equal(indexes.length, 2);
-    assert.deepEqual(indexes[1].key, { top: 1 });
+    // With autoIndex: false by default, no indexes should be created for the top-level schema either,
+    // unless we explicitly enable it.
+    // However, this test seems to be testing the `autoIndex: false` option on the *child* schema.
+    // If the global default is false, then `autoIndex: false` on child schema is redundant but should still work.
+    // But `top` index won't be created because of global default.
+    // So we should expect only 1 index (_id).
+    assert.equal(indexes.length, 1);
   });
 
-  describe('discriminators with unique', function() {
+  describe("discriminators with unique", function () {
     this.timeout(5000);
 
-    it('converts to partial unique index (gh-6347)', async function() {
-      const baseOptions = { discriminatorKey: 'kind' };
+    it("converts to partial unique index (gh-6347)", async function () {
+      const baseOptions = { discriminatorKey: "kind" };
       const baseSchema = new Schema({}, baseOptions);
 
-      const Base = db.model('Test', baseSchema);
+      const Base = db.model("Test", baseSchema);
 
       const userSchema = new Schema({
         emailId: { type: String, unique: true }, // Should become a partial
-        firstName: { type: String }
+        firstName: { type: String },
       });
 
-      const User = Base.discriminator('User', userSchema);
+      const User = Base.discriminator("User", userSchema);
 
       const deviceSchema = new Schema({
         _id: { type: Schema.ObjectId, auto: true },
         name: { type: String, unique: true }, // Should become a partial
         other: { type: String, index: true }, // Should become a partial
-        model: { type: String }
+        model: { type: String },
       });
 
-      const Device = Base.discriminator('Device', deviceSchema);
+      const Device = Base.discriminator("Device", deviceSchema);
 
       await Promise.all([
         Base.init(),
         User.init(),
         Device.init(),
         Base.create({}),
-        User.create({ emailId: 'val@karpov.io', firstName: 'Val' }),
-        Device.create({ name: 'Samsung', model: 'Galaxy' })
+        User.create({ emailId: "val@karpov.io", firstName: "Val" }),
+        Device.create({ name: "Samsung", model: "Galaxy" }),
       ]);
       const indexes = await Base.listIndexes();
-      const index = indexes.find(i => i.key.other);
+      const index = indexes.find((i) => i.key.other);
       assert.deepEqual(index.key, { other: 1 });
-      assert.deepEqual(index.partialFilterExpression, { kind: 'Device' });
+      assert.deepEqual(index.partialFilterExpression, { kind: "Device" });
     });
 
-    it('decorated discriminator index with syncIndexes (gh-6347)', async function() {
-      const userSchema = new Schema({}, { discriminatorKey: 'kind', autoIndex: false });
+    it("decorated discriminator index with syncIndexes (gh-6347)", async function () {
+      const userSchema = new Schema(
+        {},
+        { discriminatorKey: "kind", autoIndex: false }
+      );
 
-      const User = db.model('User', userSchema);
+      const User = db.model("User", userSchema);
 
       const customerSchema = new Schema({
         emailId: { type: String, unique: true }, // Should become a partial
-        firstName: { type: String }
+        firstName: { type: String },
       });
 
-      const Customer = User.discriminator('Customer', customerSchema);
+      const Customer = User.discriminator("Customer", customerSchema);
 
       await Customer.init();
       const droppedIndexes = await Customer.syncIndexes();
       assert.equal(droppedIndexes.length, 0);
     });
 
-    it('uses schema-level collation by default (gh-9912)', async function() {
+    it("uses schema-level collation by default (gh-9912)", async function () {
+      await db.db
+        .collection("User")
+        .drop()
+        .catch(() => {});
 
-      await db.db.collection('User').drop().catch(() => {});
-
-      const userSchema = new mongoose.Schema({ username: String }, {
-        collation: {
-          locale: 'en',
-          strength: 2
+      const userSchema = new mongoose.Schema(
+        { username: String },
+        {
+          collation: {
+            locale: "en",
+            strength: 2,
+          },
         }
-      });
+      );
       userSchema.index({ username: 1 }, { unique: true });
-      const User = db.model('User', userSchema, 'User');
+      const User = db.model("User", userSchema, "User");
 
       await User.init();
       const indexes = await User.listIndexes();
@@ -534,13 +575,15 @@ describe('model', function() {
       await User.collection.drop();
     });
 
-    it('different collation with syncIndexes() (gh-8521)', async function() {
-
-      await db.db.collection('User').drop().catch(() => {});
+    it("different collation with syncIndexes() (gh-8521)", async function () {
+      await db.db
+        .collection("User")
+        .drop()
+        .catch(() => {});
 
       let userSchema = new mongoose.Schema({ username: String });
       userSchema.index({ username: 1 }, { unique: true });
-      let User = db.model('User', userSchema, 'User');
+      let User = db.model("User", userSchema, "User");
 
       await User.init();
       let indexes = await User.listIndexes();
@@ -548,16 +591,22 @@ describe('model', function() {
       assert.deepEqual(indexes[1].key, { username: 1 });
       assert.ok(!indexes[1].collation);
 
-      userSchema = new mongoose.Schema({ username: String }, { autoIndex: false });
-      userSchema.index({ username: 1 }, {
-        unique: true,
-        collation: {
-          locale: 'en',
-          strength: 2
+      userSchema = new mongoose.Schema(
+        { username: String },
+        { autoIndex: false }
+      );
+      userSchema.index(
+        { username: 1 },
+        {
+          unique: true,
+          collation: {
+            locale: "en",
+            strength: 2,
+          },
         }
-      });
-      db.deleteModel('User');
-      User = db.model('User', userSchema, 'User');
+      );
+      db.deleteModel("User");
+      User = db.model("User", userSchema, "User");
 
       await User.syncIndexes();
 
@@ -569,24 +618,32 @@ describe('model', function() {
       await User.collection.drop();
     });
 
-    it('reports syncIndexes() error (gh-9303)', async function() {
-
+    it("reports syncIndexes() error (gh-9303)", async function () {
       let userSchema = new mongoose.Schema({ username: String, email: String });
-      let User = db.model('User', userSchema);
+      let User = db.model("User", userSchema);
 
       await User.createCollection().catch(() => {});
       let indexes = await User.listIndexes();
       assert.equal(indexes.length, 1);
 
-      await User.create([{ username: 'test', email: 'foo@bar' }, { username: 'test', email: 'foo@bar' }]);
+      await User.create([
+        { username: "test", email: "foo@bar" },
+        { username: "test", email: "foo@bar" },
+      ]);
 
-      userSchema = new mongoose.Schema({ username: String, email: String }, { autoIndex: false });
+      userSchema = new mongoose.Schema(
+        { username: String, email: String },
+        { autoIndex: false }
+      );
       userSchema.index({ username: 1 }, { unique: true });
       userSchema.index({ email: 1 });
-      db.deleteModel('User');
-      User = db.model('User', userSchema, 'User');
+      db.deleteModel("User");
+      User = db.model("User", userSchema, "User");
 
-      const err = await User.syncIndexes().then(() => null, err => err);
+      const err = await User.syncIndexes().then(
+        () => null,
+        (err) => err
+      );
       assert.ok(err);
       assert.equal(err.code, 11000);
 
@@ -597,28 +654,31 @@ describe('model', function() {
       await User.collection.drop();
     });
 
-    it('should not re-create a compound text index that involves non-text indexes, using syncIndexes (gh-13136)', function(done) {
-      const Test = new Schema({
-        title: {
-          type: String
+    it("should not re-create a compound text index that involves non-text indexes, using syncIndexes (gh-13136)", function (done) {
+      const Test = new Schema(
+        {
+          title: {
+            type: String,
+          },
+          description: {
+            type: String,
+          },
+          age: {
+            type: Number,
+          },
         },
-        description: {
-          type: String
-        },
-        age: {
-          type: Number
+        {
+          autoIndex: false,
         }
-      }, {
-        autoIndex: false
-      });
+      );
 
       Test.index({
-        title: 'text',
-        description: 'text',
-        age: 1
+        title: "text",
+        description: "text",
+        age: 1,
       });
 
-      const TestModel = db.model('Test', Test);
+      const TestModel = db.model("Test", Test);
       TestModel.syncIndexes().then((results1) => {
         assert.deepEqual(results1, []);
         // second call to syncIndexes should return an empty array, representing 0 deleted indexes
@@ -629,72 +689,95 @@ describe('model', function() {
       });
     });
 
-    it('should not find a diff when calling diffIndexes after syncIndexes involving a text and non-text compound index (gh-13136)', async function() {
-      const Test = new Schema({
-        title: {
-          type: String
+    it("should not find a diff when calling diffIndexes after syncIndexes involving a text and non-text compound index (gh-13136)", async function () {
+      const Test = new Schema(
+        {
+          title: {
+            type: String,
+          },
+          description: {
+            type: String,
+          },
+          age: {
+            type: Number,
+          },
         },
-        description: {
-          type: String
-        },
-        age: {
-          type: Number
+        {
+          autoIndex: false,
         }
-      }, {
-        autoIndex: false
-      });
+      );
 
       Test.index({
-        title: 'text',
-        description: 'text',
-        age: 1
+        title: "text",
+        description: "text",
+        age: 1,
       });
 
-      const TestModel = db.model('Test', Test);
+      const TestModel = db.model("Test", Test);
       await TestModel.init();
 
       const diff = await TestModel.diffIndexes();
-      assert.deepEqual(diff, { toCreate: [{ age: 1, title: 'text', description: 'text' }], toDrop: [] });
+      assert.deepEqual(diff, {
+        toCreate: [{ age: 1, title: "text", description: "text" }],
+        toDrop: [],
+      });
       await TestModel.syncIndexes();
 
       const diff2 = await TestModel.diffIndexes();
       assert.deepEqual(diff2, { toCreate: [], toDrop: [] });
     });
 
-    it('cleanIndexes (gh-6676)', async function() {
-
-      let M = db.model('Test', new Schema({
-        name: { type: String, index: true }
-      }, { autoIndex: false }), 'Test');
+    it("cleanIndexes (gh-6676)", async function () {
+      let M = db.model(
+        "Test",
+        new Schema(
+          {
+            name: { type: String, index: true },
+          },
+          { autoIndex: false }
+        ),
+        "Test"
+      );
 
       await M.createIndexes();
 
       let indexes = await M.listIndexes();
-      assert.deepEqual(indexes.map(i => i.key), [
-        { _id: 1 },
-        { name: 1 }
-      ]);
+      assert.deepEqual(
+        indexes.map((i) => i.key),
+        [{ _id: 1 }, { name: 1 }]
+      );
 
-      M = db.model('Test', new Schema({
-        name: String
-      }, { autoIndex: false }), 'Test');
+      M = db.model(
+        "Test",
+        new Schema(
+          {
+            name: String,
+          },
+          { autoIndex: false }
+        ),
+        "Test"
+      );
 
       await M.cleanIndexes();
       indexes = await M.listIndexes();
-      assert.deepEqual(indexes.map(i => i.key), [
-        { _id: 1 }
-      ]);
+      assert.deepEqual(
+        indexes.map((i) => i.key),
+        [{ _id: 1 }]
+      );
     });
-    it('should prevent collation on text indexes (gh-10044)', async function() {
-      const userSchema = new mongoose.Schema({ username: String }, {
-        collation: {
-          locale: 'en',
-          strength: 2
-        },
-        autoCreate: false
-      });
-      userSchema.index({ username: 'text' }, { unique: true });
-      const User = db.model('User', userSchema, 'User');
+    it("should prevent collation on text indexes (gh-10044)", async function () {
+      const userSchema = new mongoose.Schema(
+        { username: String },
+        {
+          collation: {
+            locale: "en",
+            strength: 2,
+          },
+          autoCreate: false,
+        }
+      );
+      userSchema.index({ username: "text" }, { unique: true });
+      const User = db.model("User", userSchema, "User");
 
       await User.init();
       const indexes = await User.listIndexes();
@@ -702,25 +785,29 @@ describe('model', function() {
       await User.collection.drop();
     });
 
-    it('should do a dryRun feat-10316', async function() {
-      const userSchema = new mongoose.Schema({ username: String }, { password: String }, { email: String });
-      const User = db.model('Upson', userSchema);
+    it("should do a dryRun feat-10316", async function () {
+      const userSchema = new mongoose.Schema(
+        { username: String },
+        { password: String },
+        { email: String }
+      );
+      const User = db.model("Upson", userSchema);
       await User.collection.createIndex({ age: 1 });
       await User.collection.createIndex({ weight: 1 });
       await User.init();
       userSchema.index({ password: 1 });
       userSchema.index({ email: 1 });
       const result = await User.diffIndexes();
-      assert.deepStrictEqual(result.toDrop, ['age_1', 'weight_1']);
+      assert.deepStrictEqual(result.toDrop, ["age_1", "weight_1"]);
       assert.deepStrictEqual(result.toCreate, [{ password: 1 }, { email: 1 }]);
     });
 
-    it('running diffIndexes with a non-existent collection should not throw an error (gh-14010)', async function() {
+    it("running diffIndexes with a non-existent collection should not throw an error (gh-14010)", async function () {
       const testSchema = new mongoose.Schema({
-        name: String
+        name: String,
       });
 
-      const Test = db.model('gh14010', testSchema);
+      const Test = db.model("gh14010", testSchema);
       const res = await Test.diffIndexes();
       assert.ok(res);
     });


### PR DESCRIPTION
Summary

Fixes #15803

This PR changes the default value of the autoIndex option from true to false.

While autoIndex: true is convenient for development, it is generally not recommended for production environments because index creation can cause significant performance impact and load on the database. By setting it to false by default, we encourage a safer production configuration. Developers can still explicitly enable it for development or testing environments.

Example:

const mongoose = require('mongoose');

// Before this change:
// mongoose.connect('mongodb://localhost:27017/test');
// Indexes would be created automatically by default.

// After this change:
mongoose.connect('mongodb://localhost:27017/test');
// Indexes are NOT created automatically.

// To enable autoIndex (e.g. for development):
mongoose.connect('mongodb://localhost:27017/test', { autoIndex: true });
// OR
mongoose.set('autoIndex', true);