### PR TITLE
fix: change autoIndex default to false

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -67,7 +67,7 @@ function Mongoose(options) {
   // default global options
   this.options = Object.assign({
     pluralization: true,
-    autoIndex: true,
+    autoIndex: false,
     autoCreate: true,
     autoSearchIndex: false
   }, options);

--- a/test/gh-15803.test.js
+++ b/test/gh-15803.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const start = require('./common');
+const assert = require('assert');
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('gh-15803', function () {
+    let db;
+
+    before(async function () {
+        db = await start();
+    });
+
+    after(async function () {
+        await db.close();
+    });
+
+    it('autoIndex should default to false', async function () {
+        const testSchema = new Schema({ name: { type: String, index: true } });
+        const Test = db.model('Test', testSchema);
+
+        await Test.init();
+
+        const indexes = await Test.collection.listIndexes().toArray();
+        const indexNames = indexes.map(idx => idx.name);
+
+        assert.ok(indexNames.includes('_id_'));
+        assert.ok(!indexNames.includes('name_1'));
+    });
+});


### PR DESCRIPTION
## Summary
Changes the default value of `autoIndex` from `true` to `false` to prevent performance issues in production environments.

Fixes #15803

## Changes
- Changed default `autoIndex` value to `false` in [lib/mongoose.js](cci:7://file:///Users/devendramishra/Desktop/mongoosed/lib/mongoose.js:0:0-0:0)
- Added test case in [test/gh-15803.test.js](cci:7://file:///Users/devendramishra/Desktop/mongoosed/test/gh-15803.test.js:0:0-0:0) to verify the new default behavior

## Breaking Change
**This is a breaking change.**
Users relying on automatic index creation will now need to explicitly set `autoIndex: true` in their schemas or connection options.

## Test Results
Added a new test file [test/gh-15803.test.js](cci:7://file:///Users/devendramishra/Desktop/mongoosed/test/gh-15803.test.js:0:0-0:0) which passes:
-  autoIndex should default to false