### PR TITLE
fix(types): handle versionKey in ApplySchemaOptions

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -2086,3 +2086,11 @@ function gh15751() {
   const doc = new TestModel();
   expectType<Types.ObjectId>(doc.myId);
 }
+
+function gh15798() {
+  const schema1 = new Schema({ name: String }, { statics: { testMe() { } }, versionKey: false });
+  model("M1", schema1).testMe();
+
+  const schema2 = new Schema({ name: String }, { statics: { testMe() { } }, timestamps: true });
+  model("M2", schema2).testMe();
+}

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -114,7 +114,7 @@ declare module 'mongoose' {
 
   type ResolveSchemaOptions<T> = MergeType<DefaultSchemaOptions, T>;
 
-  type ApplySchemaOptions<T, O = DefaultSchemaOptions> = ResolveTimestamps<T, O>;
+  type ApplySchemaOptions<T, O = DefaultSchemaOptions> = Default__v<ResolveTimestamps<T, O>, O>;
 
   type DefaultTimestampProps = {
     createdAt: NativeDate;


### PR DESCRIPTION
Fixes #15798

**Summary**

Fixed TypeScript type error when calling static methods on models with `versionKey: false` or `timestamps: true` schema options.

The issue was that [ApplySchemaOptions](cci:2://file:///Users/devendramishra/mongoose/types/inferschematype.d.ts:116:2-116:96) type only handled `timestamps` option but not `versionKey`. This caused a mismatch where static methods expected documents with [__v](cci:2://file:///Users/devendramishra/mongoose/types/index.d.ts:151:2-165:30) field, but schemas with `versionKey: false` didn't have it.

The fix wraps [ResolveTimestamps](cci:2://file:///Users/devendramishra/mongoose/types/inferschematype.d.ts:123:2-135:8) with [Default__v](cci:2://file:///Users/devendramishra/mongoose/types/index.d.ts:151:2-165:30) to properly apply both timestamp and versionKey schema options to the document type.

**Examples**

Before this fix, the following code would cause a TypeScript error:

```typescript
const MySchema = new Schema({
  name: { type: String, required: true },
}, {
  statics: {
    testMe: function() {
      console.log(`I'm a static method`);
    }
  },
  versionKey: false,
});

const MyModel = mongoose.model("MyModel", MySchema);
MyModel.testMe(); // TS2684: The 'this' context is not assignable