### PR TITLE
fix: increase timeout in flaky aggregation cursor test (gh-8835)

### DIFF
--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -539,7 +539,7 @@ describe('QueryCursor', function() {
     setTimeout(() => {
       assert.equal(closeEventTriggeredCount, 1);
       done();
-    }, 20);
+    }, 200);
   });
 
   it('closing query cursor emits `close` event only once with stream pause/resume (gh-10876)', function(done) {


### PR DESCRIPTION

This PR fixes the flaky test "closing aggregation cursor emits close event only once (gh-8835)".

### Problem
The test in `test/query.cursor.test.js` used a 20ms timeout to wait for the `close` event.
In slower CI environments, the event was not always emitted within this short window, causing:
  
  AssertionError: 0 == 1

This made the test unreliable and caused intermittent CI failures.

### Fix
Increased the timeout from 20ms to 200ms, matching other similar cursor-related tests in the same file.
setTimeout(() => {
  assert.equal(closeEventTriggeredCount, 1);
  done();
}, 200);
This provides sufficient time for the event to fire in CI environments.

### Result
This change stabilizes the test and prevents false negatives during CI runs.

### Branch
`fix-flaky-aggregation-cursor-test`

Commit: `215c7fa29`
