### PR TITLE
fix: expose validation errors in insertMany with ordered: false

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3152,15 +3152,27 @@ Model.insertMany = async function insertMany(arr, options) {
   }
 
   if (options.populate != null) {
-    return this.populate(docAttributes, options.populate).catch(err => {
+    res = await this.populate(docAttributes, options.populate).catch(err => {
       if (err != null) {
         err.insertedDocs = docAttributes;
       }
       throw err;
     });
+
+    if (ordered === false && validationErrors.length > 0) {
+      res.validationErrors = validationErrors;
+    }
+
+    return res;
   }
 
-  return await this._middleware.execPost('insertMany', this, [docAttributes]).then(res => res[0]);
+  res = await this._middleware.execPost('insertMany', this, [docAttributes]).then(res => res[0]);
+
+  if (ordered === false && validationErrors.length > 0) {
+    res.validationErrors = validationErrors;
+  }
+
+  return res;
 };
 
 /*!

--- a/test/model.insertMany.test.js
+++ b/test/model.insertMany.test.js
@@ -738,4 +738,22 @@ describe('insertMany()', function() {
     assert.equal(err.message, 'postInsertManyError');
     assert.ok(err.stack.includes('postInsertManyError'));
   });
+
+  it('insertMany() exposes validation errors with ordered false and rawResult false (gh-15771)', async function() {
+    const schema = new Schema({ name: { type: String, required: true } });
+    const Movie = db.model('Movie', schema);
+
+    const result = await Movie.insertMany([
+      { foo: 'invalid 1' },
+      { name: 'valid movie' },
+      { bar: 'invalid 2' }
+    ], { ordered: false, rawResult: false });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, 'valid movie');
+    assert.ok(result.validationErrors);
+    assert.equal(result.validationErrors.length, 2);
+    assert.ok(result.validationErrors[0].errors['name']);
+    assert.ok(result.validationErrors[1].errors['name']);
+  });
 });


### PR DESCRIPTION
Fixes #15771

**Summary**

Previously, when calling `Model.insertMany()` with `{ ordered: false, rawResult: false }`, any per-document validation errors were silently dropped. The method would return only the successfully inserted documents, making it impossible for the caller to know which documents failed validation or why.

This PR modifies `insertMany` to ensure that when `ordered: false` is used, validation errors are captured and attached to the result array as a property named `validationErrors`. This behavior is consistent with other error handling paths in Mongoose and allows developers to handle partial failures gracefully.

**Examples**

```javascript
const schema = new Schema({ name: { type: String, required: true } });
const Model = mongoose.model('Test', schema);

// Insert one valid document and one invalid document
const docs = [{ name: 'Valid' }, { foo: 'Invalid' }];

// Before this fix: validation errors were lost, and we only got the valid doc back.
// After this fix: result.validationErrors contains the error info.
const result = await Model.insertMany(docs, { 
  ordered: false, 
  rawResult: false 
});

console.log(result.length); 
// Output: 1 (The valid document)

console.log(result.validationErrors); 
// Output: [ValidationError: Path `name` is required.]