### PR TITLE
refactor: remove redundant ValidatorError.prototype.toString()

### DIFF
--- a/lib/error/validator.js
+++ b/lib/error/validator.js
@@ -33,14 +33,6 @@ class ValidatorError extends MongooseError {
     this.reason = properties.reason;
   }
 
-  /**
-   * toString helper
-   * TODO remove? This defaults to `${this.name}: ${this.message}`
-   * @api private
-   */
-  toString() {
-    return this.message;
-  }
 
   /**
    * Ensure `name` and `message` show up in toJSON output re: gh-9296

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1060,7 +1060,7 @@ describe('model: findOneAndUpdate:', function() {
 
       assert.equal(Object.keys(error.errors).length, 1);
       assert.equal(Object.keys(error.errors)[0], 'steak');
-      assert.equal(error.errors.steak, '`tofu` is not a valid enum value for path `steak`.');
+      assert.equal(error.errors.steak, 'ValidatorError: `tofu` is not a valid enum value for path `steak`.');
 
       error = await Breakfast.findOneAndUpdate(
         {},

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -777,7 +777,7 @@ describe('model: updateOne:', function() {
       assert.ok(!!error);
       assert.equal(Object.keys(error.errors).length, 1);
       assert.equal(Object.keys(error.errors)[0], 'steak');
-      assert.equal(error.errors.steak, '`tofu` is not a valid enum value for path `steak`.');
+      assert.equal(error.errors.steak, 'ValidatorError: `tofu` is not a valid enum value for path `steak`.');
 
       error = await Breakfast.updateOne({}, { $set: { steak: 'sirloin', eggs: 6, bacon: 'none' } }, updateOptions).then(() => null, err => err);
       assert.ok(!!error);

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -583,7 +583,7 @@ describe('schema', function() {
             await m.validate();
             assert.ok(false);
           } catch (err) {
-            assert.equal(err.errors.x.toString(), 'Error code 25');
+            assert.equal(err.errors.x.toString(), 'ValidatorError: Error code 25');
             assert.equal(err.errors.x.properties.message, 'Error code 25');
             assert.equal(err.errors.x.properties.errorCode, 25);
           }
@@ -605,7 +605,7 @@ describe('schema', function() {
 
           const m = new M({ x: 'whatever' });
           const err = await m.validate().then(() => null, err => err);
-          assert.equal(err.errors.x.toString(), 'Custom message');
+          assert.equal(err.errors.x.toString(), 'ValidatorError: Custom message');
         });
       });
     });
@@ -628,7 +628,7 @@ describe('schema', function() {
             await m.validate();
             assert.ok(false);
           } catch (err) {
-            assert.equal(String(err.errors.x), 'x failed validation (3,4,5,6)');
+            assert.equal(String(err.errors.x), 'ValidatorError: x failed validation (3,4,5,6)');
             assert.equal(err.errors.x.properties.message, 'x failed validation (3,4,5,6)');
             assert.equal(err.errors.x.kind, 'customType');
           }
@@ -651,7 +651,7 @@ describe('schema', function() {
             await m.validate();
             assert.ok(false);
           } catch (err) {
-            assert.equal(String(err.errors.x), 'x failed validation (3,4,5,6)');
+            assert.equal(String(err.errors.x), 'ValidatorError: x failed validation (3,4,5,6)');
             assert.equal(err.errors.x.kind, 'customType');
           }
         });
@@ -969,7 +969,7 @@ describe('schema', function() {
       } catch (error) {
         assert.ok(error);
         const errorMessage = 'foods: Cast to Object failed for value ' +
-            '"waffles" (type string) at path "foods"';
+          '"waffles" (type string) at path "foods"';
         assert.ok(error.toString().indexOf(errorMessage) !== -1, error.toString());
       }
     });


### PR DESCRIPTION
Summary

Removes the redundant `toString() `method from the `ValidatorError class` in [lib/error/validator.js](https://github.com/Automattic/mongoose/blob/master/lib/error/validator.js).
A TODO comment in the code noted that this method was likely unnecessary as it duplicates the default behavior of `Error.prototype.toString() (returning ${name}: ${message})`, with the minor difference that the custom method returned only the message.