### PR TITLE
refactor: remove custom toString from ValidatorError

### DIFF
--- a/lib/error/validator.js
+++ b/lib/error/validator.js
@@ -34,15 +34,6 @@ class ValidatorError extends MongooseError {
   }
 
   /**
-   * toString helper
-   * TODO remove? This defaults to `${this.name}: ${this.message}`
-   * @api private
-   */
-  toString() {
-    return this.message;
-  }
-
-  /**
    * Ensure `name` and `message` show up in toJSON output re: gh-9296
    * @api private
    */

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -583,7 +583,7 @@ describe('schema', function() {
             await m.validate();
             assert.ok(false);
           } catch (err) {
-            assert.equal(err.errors.x.toString(), 'Error code 25');
+            assert.equal(err.errors.x.toString(), 'ValidatorError: Error code 25');
             assert.equal(err.errors.x.properties.message, 'Error code 25');
             assert.equal(err.errors.x.properties.errorCode, 25);
           }
@@ -605,7 +605,7 @@ describe('schema', function() {
 
           const m = new M({ x: 'whatever' });
           const err = await m.validate().then(() => null, err => err);
-          assert.equal(err.errors.x.toString(), 'Custom message');
+          assert.equal(err.errors.x.toString(), 'ValidatorError: Custom message');
         });
       });
     });
@@ -628,7 +628,7 @@ describe('schema', function() {
             await m.validate();
             assert.ok(false);
           } catch (err) {
-            assert.equal(String(err.errors.x), 'x failed validation (3,4,5,6)');
+            assert.equal(String(err.errors.x), 'ValidatorError: x failed validation (3,4,5,6)');
             assert.equal(err.errors.x.properties.message, 'x failed validation (3,4,5,6)');
             assert.equal(err.errors.x.kind, 'customType');
           }
@@ -651,7 +651,7 @@ describe('schema', function() {
             await m.validate();
             assert.ok(false);
           } catch (err) {
-            assert.equal(String(err.errors.x), 'x failed validation (3,4,5,6)');
+            assert.equal(String(err.errors.x), 'ValidatorError: x failed validation (3,4,5,6)');
             assert.equal(err.errors.x.kind, 'customType');
           }
         });
@@ -969,7 +969,7 @@ describe('schema', function() {
       } catch (error) {
         assert.ok(error);
         const errorMessage = 'foods: Cast to Object failed for value ' +
-            '"waffles" (type string) at path "foods"';
+          '"waffles" (type string) at path "foods"';
         assert.ok(error.toString().indexOf(errorMessage) !== -1, error.toString());
       }
     });


### PR DESCRIPTION
This PR addresses a TODO in
lib/error/validator.js
by removing the custom toString() method from the
ValidatorError
class.

Changes:

Removed the custom toString() method in
lib/error/validator.js
which was overriding the default Error.prototype.toString() behavior.
ValidatorError
instances now inherit the standard toString() behavior, resulting in output like "ValidatorError: message" instead of just "message".
Updated unit tests in
test/schema.validation.test.js
to reflect this change in string representation.
