### PR TITLE
fix: resolve static methods type compatibility with schema options

### DIFF
--- a/test/types/issue-15798.test.ts
+++ b/test/types/issue-15798.test.ts
@@ -1,0 +1,15 @@
+import { Schema, model } from 'mongoose';
+
+const schema1 = new Schema({
+  name: { type: String, required: true }
+}, {
+  versionKey: false,
+  statics: {
+    testMe() {
+      return this.findOne({ name: 'test' });
+    }
+  }
+});
+
+const TestModel1 = model('TestModel1', schema1);
+TestModel1.testMe();

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -17,7 +17,7 @@ declare module 'mongoose' {
     TStaticMethods = {},
     TVirtuals = {},
     THydratedDocumentType = HydratedDocument<DocType, TVirtuals & TInstanceMethods, QueryHelpers>,
-    TModelType = Model<DocType, QueryHelpers, TInstanceMethods, TVirtuals, THydratedDocumentType>
+    TModelType = Model<DocType, QueryHelpers, TInstanceMethods, TVirtuals, any, any>
   > {
     /**
      * By default, Mongoose's init() function creates all the indexes defined in your model's schema by


### PR DESCRIPTION
Fixes #15798

This change fixes TypeScript type compatibility issues when using static methods with schema options like `versionKey: false` or `timestamps: true`.

**Changes:**

Modified `TModelType` parameter in [SchemaOptions](cci:2://file:///Users/ayushkumar/Desktop/mongoose/types/schemaoptions.d.ts:12:2-270:3) interface ([types/schemaoptions.d.ts](cci:7://file:///Users/ayushkumar/Desktop/mongoose/types/schemaoptions.d.ts:0:0-0:0)):
- Changed from: `Model<DocType, QueryHelpers, TInstanceMethods, TVirtuals, THydratedDocumentType>`
- Changed to: `Model<DocType, QueryHelpers, TInstanceMethods, TVirtuals, any, any>`

This ensures the `this` context in static methods is compatible across different schema options by using [any](cci:1://file:///Users/ayushkumar/Desktop/mongoose/types/models.d.ts:561:4-573:6) for `THydratedDocumentType` and `TSchema` parameters.

**Example usage:**

```typescript
const schema = new Schema({
  name: { type: String, required: true }
}, {
  versionKey: false,
  statics: {
    testMe() {
      return this.findOne({ name: 'test' }); // ✅ No more type error!
    }
  }
});

const TestModel = model('TestModel', schema);
TestModel.testMe(); // Works correctly now