### PR TITLE
Fix 15694 avoid cloning minimize false

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -380,7 +380,7 @@ Model.prototype.$__save = async function $__save(options) {
 
     if (this.$isNew) {
       // send entire doc
-      const obj = this.toObject(saveToObjectOptions);
+      const obj = this.$__schema.options.minimize === false ? this._doc : this.toObject(saveToObjectOptions);
       if ((obj || {})._id === void 0) {
         // documents must have an _id else mongoose won't know
         // what to update later if more changes are made. the user


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This PR implements a performance optimization for saving new documents when `minimize: false` is set in the schema options.

Currently, when saving a new document (`isNew: true`), Mongoose always calls `toObject()` to clone the document before sending it to MongoDB. However, when `minimize: false` is set, this cloning is unnecessary because the MongoDB driver already clones the document and applies `toBSON()` transformations.

This change adds a conditional check: if `minimize === false`, we skip the `toObject()` call and use `this._doc` directly, providing a significant performance improvement for schemas with `minimize: false`.

Fixes #15694

**Examples**

The optimization is transparent to users - no API changes are required. For schemas with `minimize: false`, document saves will now be faster:

```javascript
const schema = new Schema({ name: String, data: {} }, { minimize: false });
const Model = mongoose.model('Test', schema);

const doc = new Model({ name: 'test', data: {} });
await doc.save(); // Now faster - skips unnecessary toObject() cloning