### PR TITLE
Fix typo in text search error path and variable bug in double casting

### DIFF
--- a/lib/cast/double.js
+++ b/lib/cast/double.js
@@ -34,7 +34,7 @@ module.exports = function castDouble(val) {
     // ex: { a: 'im an object, valueOf: () => 'helloworld' } // throw an error
     if (typeof tempVal === 'string') {
       try {
-        coercedVal = BSON.Double.fromString(val);
+        coercedVal = BSON.Double.fromString(tempVal);
         return coercedVal;
       } catch {
         assert.ok(false);

--- a/lib/schema/operators/text.js
+++ b/lib/schema/operators/text.js
@@ -28,7 +28,7 @@ module.exports = function castTextSearch(val, path) {
   }
   if (val.$caseSensitive != null) {
     val.$caseSensitive = castBoolean(val.$caseSensitive,
-      path + '.$castSensitive');
+      path + '.$caseSensitive');
   }
   if (val.$diacriticSensitive != null) {
     val.$diacriticSensitive = castBoolean(val.$diacriticSensitive,


### PR DESCRIPTION
- Fix typo in lib/schema/operators/text.js: '' -> '' This ensures error messages correctly reference the  field

- Fix variable reference bug in lib/cast/double.js: use 'tempVal' instead of 'val' When casting objects with valueOf()/toString() methods, the extracted string value should be used instead of the original object

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
