### PR TITLE
chore(dev-deps): update mongodb-memory-server to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mkdirp": "^3.0.1",
     "mocha": "11.7.5",
     "moment": "2.30.1",
-    "mongodb-memory-server": "10.3.0",
+    "mongodb-memory-server": "11.0.0",
     "mongodb-runner": "^6.0.0",
     "mongodb-client-encryption": "~7.0",
     "ncp": "^2.0.0",


### PR DESCRIPTION
**Summary**

Update `mongodb-memory-server` to its latest major once again.
This update entails dropping support for mongodb below 4.2 (which mongoose already did) plus upgrading the mongodb driver to 7.0 (resulting in less installed dependencies again)
Also since 10.3.0, MMS has gained 8.2.0 tests (which mongoose already made use of).

~~This is a DRAFT for now until mongodb-memory-server 11 is out of beta (scheduled for the 15th, if nothing comes up)~~