### PR TITLE
chore(workflows/test): drop nodejs 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
         os: [ubuntu-22.04, ubuntu-24.04]
         mongodb: [6.0.15, 7.0.12, 8.2.0]
         include:


### PR DESCRIPTION
**Summary**

Mongoose already requires 20.19 since 9.0.0. But the Node 18 tests still pass (though reporting unsupported engine)

https://github.com/Automattic/mongoose/blob/5f872fcc78fde68f491fca5e326d82cb08c36371/package.json#L109-L111

Noticed while doing #15859