### PR TITLE
fix: prevent negative slice index in populate subdocPath calculation

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -239,7 +239,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
       modelNames = [modelNameFromQuery]; // query options
     } else if (refPath != null) {
       if (typeof refPath === 'function') {
-        const subdocPath = options.path.slice(0, options.path.length - schema.path.length - 1);
+        const subdocPath = options.path.slice(0, Math.max(0, options.path.length - schema.path.length - 1));
         const vals = mpath.get(subdocPath, doc, lookupLocalFields);
         const subdocsBeingPopulated = Array.isArray(vals) ?
           utils.array.flatten(vals) :
@@ -301,7 +301,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
           // Ensure correct context for ref functions: subdoc, not top-level doc. See gh-8469
           modelNames = new Set();
 
-          const subdocPath = options.path.slice(0, options.path.length - schemaForCurrentDoc.path.length - 1);
+          const subdocPath = options.path.slice(0, Math.max(0, options.path.length - schemaForCurrentDoc.path.length - 1));
           const vals = mpath.get(subdocPath, doc, lookupLocalFields);
           const subdocsBeingPopulated = Array.isArray(vals) ?
             utils.array.flatten(vals) :
@@ -322,7 +322,7 @@ module.exports = function getModelsMapForPopulate(model, docs, options) {
       } else if ((schemaForCurrentDoc = get(schema, 'options.refPath')) != null) {
         isRefPath = true;
         if (typeof refPath === 'function') {
-          const subdocPath = options.path.slice(0, options.path.length - schemaForCurrentDoc.path.length - 1);
+          const subdocPath = options.path.slice(0, Math.max(0, options.path.length - schemaForCurrentDoc.path.length - 1));
           const vals = mpath.get(subdocPath, doc, lookupLocalFields);
           const subdocsBeingPopulated = Array.isArray(vals) ?
             utils.array.flatten(vals) :


### PR DESCRIPTION
## Description
This PR fixes a bug where calculating `subdocPath` in populate operations could result in negative slice indices, causing incorrect path calculations.

Fixes #15861

## Problem
In `lib/helpers/populate/getModelsMapForPopulate.js`, lines 242, 304, and 325 use:
```javascript
const subdocPath = options.path.slice(0, options.path.length - schema.path.length - 1);
```

If `schema.path.length + 1 >= options.path.length`, the second argument becomes negative, causing `slice()` to count from the end instead of the beginning.

## Solution
Added `Math.max(0, ...)` to ensure the slice index never goes negative:
```javascript
const subdocPath = options.path.slice(0, Math.max(0, options.path.length - schema.path.length - 1));
```

## Changes
- Fixed line 242: Added `Math.max(0, ...)` wrapper
- Fixed line 304: Added `Math.max(0, ...)` wrapper
- Fixed line 325: Added `Math.max(0, ...)` wrapper

## Testing
- All existing populate tests pass (305 tests in `test/model.populate.test.js`)
- Lint passes (`npm run lint`)

## Impact
This fix prevents incorrect subdocPath calculations in edge cases where the schema path is longer than or equal to the options path, ensuring populate operations work correctly in all scenarios.