### PR TITLE
fix: clear setTimeout in buffered syncCollectionMethods with callbacks

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -138,8 +138,14 @@ function iter(i) {
       let promise = null;
       let timeout = null;
       if (syncCollectionMethods[i] && typeof lastArg === 'function') {
+        callback = function collectionOperationCallback() {
+          if (timeout != null) {
+            clearTimeout(timeout);
+          }
+          return lastArg.apply(this, arguments);
+        };
+        _args = args.slice(0, args.length - 1).concat([callback]);
         this.addQueue(i, _args);
-        callback = lastArg;
       } else if (syncCollectionMethods[i]) {
         promise = new this.Promise((resolve, reject) => {
           callback = function collectionOperationCallback(err, res) {


### PR DESCRIPTION
**Summary**

When `syncCollectionMethods` (`find`, `watch`, `aggregate`) were called with a callback while buffering was enabled, the buffer timeout was never cleared after the operation completed successfully. This caused `setTimeout` references to accumulate in memory, leading to a memory leak.

The root cause was in `lib/drivers/node-mongodb-native/collection.js` lines 140-142, where the callback was not wrapped to call `clearTimeout()` - unlike all other buffered operation paths which properly clear the timeout.

**Examples**

Before this fix, the following code would leak memory:

```javascript
const mongoose = require('mongoose');

// Connection not yet established - buffering enabled
const db = mongoose.createConnection();
const Model = db.model('Test', new mongoose.Schema({ name: String }));

// Each find() with callback creates a setTimeout that's never cleared
for (let i = 0; i < 1000; i++) {
  Model.find({}, (err, docs) => {
    // setTimeout reference leaks even after callback executes
  });
}

// Connect - operations execute but timeouts remain in memory
await db.openUri('mongodb://localhost/test');
```

After this fix, `clearTimeout()` is properly called when the operation completes, preventing the memory leak.

Fixes #15851
