### PR TITLE
fix(document): ensure  is set to true after deleteOne()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -788,6 +788,7 @@ Model.prototype.deleteOne = function deleteOne(options) {
     return Promise.all(self.$getAllSubdocs().map(subdoc => subdoc.constructor._middleware.execPost('deleteOne', subdoc, [subdoc])));
   });
   query.post(function queryPostDeleteOne() {
+    self.$isDeleted(true);
     return self.constructor._middleware.execPost('deleteOne', self, [self], {});
   });
 


### PR DESCRIPTION
Summary

This PR fixes issue #15858, where Model.prototype.deleteOne() was not setting the $isDeleted property to true on the document instance after a successful deletion.

This behavior contradicted the documentation, which states that calling deleteOne() should set $isDeleted to true when the operation succeeds.
 

Examples
```js
const doc = await Model.create({ name: 'test' });
await doc.deleteOne();

console.log(doc.$isDeleted()); // Now prints 'true' (used to be 'false')
```
