### PR TITLE
refactor: remove internal callbacks for buffering

### DIFF
--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -80,12 +80,6 @@ NativeCollection.prototype._getCollection = function _getCollection() {
   return null;
 };
 
-/*!
- * ignore
- */
-
-const syncCollectionMethods = { watch: true, find: true, aggregate: true };
-
 /**
  * Copy the collection methods and make them subject to queues
  * @param {Number|String} I
@@ -107,7 +101,6 @@ function iter(i) {
       _this.conn.options &&
       _this.conn.options.debug;
     const debug = connectionDebug == null ? globalDebug : connectionDebug;
-    const lastArg = arguments[arguments.length - 1];
     const opId = new ObjectId();
 
     // If user force closed, queueing will hang forever. See #5664
@@ -122,9 +115,8 @@ function iter(i) {
       }
     }
 
-    let _args = args;
-    let callback = null;
     let timeout = null;
+    let waitForBufferPromise = null;
     if (this._shouldBufferCommands() && this.buffer) {
       this.conn.emit('buffer', {
         _id: opId,
@@ -134,78 +126,28 @@ function iter(i) {
         args: args
       });
 
-      let callback;
-      let _args = args;
-      let promise = null;
-      if (syncCollectionMethods[i] && typeof lastArg === 'function') {
-        this.addQueue(i, _args);
-        callback = lastArg;
-      } else if (syncCollectionMethods[i]) {
-        promise = new this.Promise((resolve, reject) => {
-          callback = function collectionOperationCallback(err, res) {
-            if (timeout != null) {
-              clearTimeout(timeout);
-            }
-            if (err != null) {
-              return reject(err);
-            }
-            resolve(res);
-          };
-          _args = args.concat([callback]);
-          this.addQueue(i, _args);
-        });
-      } else if (typeof lastArg === 'function') {
-        callback = function collectionOperationCallback() {
-          if (timeout != null) {
-            clearTimeout(timeout);
-          }
-          return lastArg.apply(this, arguments);
-        };
-        _args = args.slice(0, args.length - 1).concat([callback]);
-      } else {
-        promise = new Promise((resolve, reject) => {
-          callback = function collectionOperationCallback(err, res) {
-            if (timeout != null) {
-              clearTimeout(timeout);
-            }
-            if (err != null) {
-              return reject(err);
-            }
-            resolve(res);
-          };
-          _args = args.concat([callback]);
-          this.addQueue(i, _args);
-        });
-      }
-
       const bufferTimeoutMS = this._getBufferTimeoutMS();
-      timeout = setTimeout(() => {
-        const removed = this.removeQueue(i, _args);
-        if (removed) {
-          const message = 'Operation `' + this.name + '.' + i + '()` buffering timed out after ' +
-            bufferTimeoutMS + 'ms';
-          const err = new MongooseError(message);
-          this.conn.emit('buffer-end', { _id: opId, modelName: _this.modelName, collectionName: _this.name, method: i, error: err });
-          callback(err);
-        }
-      }, bufferTimeoutMS);
+      waitForBufferPromise = new Promise((resolve, reject) => {
+        this.addQueue(resolve);
 
-      if (!syncCollectionMethods[i] && typeof lastArg === 'function') {
-        this.addQueue(i, _args);
-        return;
-      }
+        timeout = setTimeout(() => {
+          const removed = this.removeQueue(resolve);
+          if (removed) {
+            const message = 'Operation `' + this.name + '.' + i + '()` buffering timed out after ' +
+              bufferTimeoutMS + 'ms';
+            const err = new MongooseError(message);
+            this.conn.emit('buffer-end', { _id: opId, modelName: _this.modelName, collectionName: _this.name, method: i, error: err });
+            reject(err);
+          }
+        }, bufferTimeoutMS);
+      });
 
-      return promise;
-    } else if (!syncCollectionMethods[i] && typeof lastArg === 'function') {
-      callback = function collectionOperationCallback(err, res) {
-        if (err != null) {
-          _this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: _this.name, method: i, error: err });
-        } else {
-          _this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: _this.name, method: i, result: res });
+      return waitForBufferPromise.then(() => {
+        if (timeout) {
+          clearTimeout(timeout);
         }
-        return lastArg.apply(this, arguments);
-      };
-      _args = args.slice(0, args.length - 1).concat([callback]);
+        return this[i].apply(this, args);
+      });
     }
 
     if (debug) {
@@ -227,7 +169,7 @@ function iter(i) {
       }
     }
 
-    this.conn.emit('operation-start', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, params: _args });
+    this.conn.emit('operation-start', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, params: args });
 
     try {
       if (collection == null) {
@@ -237,60 +179,37 @@ function iter(i) {
         throw new MongooseError(message);
       }
 
-      if (syncCollectionMethods[i] && typeof lastArg === 'function') {
-        const result = collection[i].apply(collection, _args.slice(0, _args.length - 1));
-        if (timeout != null) {
-          clearTimeout(timeout);
-        }
-        this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result });
-        return lastArg.call(this, null, result);
-      }
-
-      const ret = collection[i].apply(collection, _args);
+      const ret = collection[i].apply(collection, args);
       if (ret != null && typeof ret.then === 'function') {
         return ret.then(
           result => {
             if (timeout != null) {
               clearTimeout(timeout);
             }
-            if (typeof lastArg === 'function') {
-              lastArg(null, result);
-            } else {
-              this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result });
-            }
+            this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result });
             return result;
           },
           error => {
             if (timeout != null) {
               clearTimeout(timeout);
             }
-            if (typeof lastArg === 'function') {
-              lastArg(error);
-              return;
-            } else {
-              this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error });
-            }
+            this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error });
             throw error;
           }
         );
       }
+
+      this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result: ret });
       if (timeout != null) {
         clearTimeout(timeout);
       }
       return ret;
     } catch (error) {
-      // Collection operation may throw because of max bson size, catch it here
-      // See gh-3906
       if (timeout != null) {
         clearTimeout(timeout);
       }
-      if (typeof lastArg === 'function') {
-        return lastArg(error);
-      } else {
-        this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error: error });
-
-        throw error;
-      }
+      this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error: error });
+      throw error;
     }
   };
 }

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -51,17 +51,18 @@ describe('collections:', function() {
     await db.close();
   });
 
-  it('returns a promise if buffering and callback with find() (gh-14184)', function(done) {
+  it('returns a promise if buffering and callback with find() (gh-14184)', function() {
     db = mongoose.createConnection();
     const collection = db.collection('gh14184');
     collection.opts.bufferTimeoutMS = 100;
 
-    collection.find({ foo: 'bar' }, {}, (err, docs) => {
-      assert.ok(err);
-      assert.ok(err.message.includes('buffering timed out after 100ms'));
-      assert.equal(docs, undefined);
-      done();
-    });
+    return collection.find({ foo: 'bar' }, {}).then(
+      () => assert.ok(false),
+      err => {
+        assert.ok(err);
+        assert.ok(err.message.includes('buffering timed out after 100ms'));
+      }
+    );
   });
 
   it('handles bufferTimeoutMS in schemaUserProvidedOptions', async function() {


### PR DESCRIPTION
Re: #15871

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

@AbdelrahmanHafez pointed out in #15871 that we don't use callbacks internally anymore - this PR removes internal callback-based logic for buffering collection operations in favor of promises.

Major difference is that, before, `findOne({ name: 'bill' })` would add `['findOne', { name: 'bill' }]` to the collection queue, whereas this PR would just add an anonymous promise `resolve()` function. However, collection queue is an internal structure and the documented public API doesn't explicitly list out the structure of buffered function calls in the queue, so I don't think the change in collection queue structure is an issue.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
