### PR TITLE
fix(document): avoid 'Cannot mix array and object updates' on doc.updateOne() with pipeline

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4032,7 +4032,13 @@ Query.prototype._mergeUpdate = function(update) {
     }
   } else if (Array.isArray(update)) {
     if (!Array.isArray(this._update)) {
-      throw new MongooseError('Cannot mix array and object updates');
+      // `_update` may be empty object by default, like in `doc.updateOne()`
+      // because we create the query first, then run hooks, then apply the update.
+      if (this._update == null || utils.isEmptyObject(this._update)) {
+        this._update = [];
+      } else {
+        throw new MongooseError('Cannot mix array and object updates');
+      }
     }
     this._update = this._update.concat(update);
   } else {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -15127,6 +15127,28 @@ describe('document', function() {
     await user.validate(null);
     await assert.rejects(() => user.validate({}), /Path `test` is required/);
   });
+
+  it('supports updateOne with update pipeline', async function() {
+    const schema = new Schema({ name: String, age: Number });
+    const Person = db.model('Person', schema);
+
+    const doc = new Person({ name: 'test' });
+    await doc.updateOne(
+      [
+        {
+          $set: {
+            age: {
+              $round: [
+                { $add: ['age', 1] },
+                0
+              ]
+            }
+          }
+        }
+      ],
+      { updatePipeline: true }
+    );
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

calling `doc.updateOne()` with an update pipeline currently fails in 9.1.0

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
