### PR TITLE
chore: add copilot code review instructions for type tests

### DIFF
--- a/.github/instructions/type-tests.instructions.md
+++ b/.github/instructions/type-tests.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "test/types/**/*.ts"
+---
+
+These are TypeScript type tests that verify compile-time type correctness. Functions here are intentionally unused since they exist only to test that types compile correctly. The function names act as test descriptions.
+
+Do not suggest:
+- Calling unused functions
+- Removing "unused" code
+- Adding runtime assertions


### PR DESCRIPTION
## Summary
re: https://github.com/Automattic/mongoose/pull/15927#discussion_r2653463124

- Adds `.github/instructions/type-tests.instructions.md` to configure GitHub Copilot code review
- Instructs Copilot that functions in `test/types/**/*.ts` are intentionally unused since they exist only to verify compile-time type correctness
- Prevents false positive suggestions about "unused functions" in type tests
