### PR TITLE
fix(model): support timestamps option to `insertMany()` as both boolean and QueryTimestampsConfig

### DIFF
--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -51,15 +51,24 @@ module.exports = function setupTimestamps(schema, timestamps) {
     setDocumentTimestamps(this, timestampOption, currentTime, createdAt, updatedAt);
   });
 
-  schema.methods.initializeTimestamps = function() {
+  schema.methods.initializeTimestamps = function(timestampsOptions) {
+    if (timestampsOptions === false) {
+      return this;
+    }
     const ts = currentTime != null ?
       currentTime() : this.constructor.base.now();
 
+    const initTimestampsCreatedAt = timestampsOptions != null ?
+      handleTimestampOption(timestampsOptions, 'createdAt') :
+      createdAt;
+    const initTimestampsUpdatedAt = timestampsOptions != null ?
+      handleTimestampOption(timestampsOptions, 'updatedAt') :
+      updatedAt;
 
-    if (createdAt && !this.get(createdAt)) {
+    if (initTimestampsCreatedAt && !this.get(initTimestampsCreatedAt)) {
       this.$set(createdAt, ts);
     }
-    if (updatedAt && !this.get(updatedAt)) {
+    if (initTimestampsUpdatedAt && !this.get(initTimestampsUpdatedAt)) {
       this.$set(updatedAt, ts);
     }
     if (this.$isSubdocument) {
@@ -69,7 +78,7 @@ module.exports = function setupTimestamps(schema, timestamps) {
     const subdocs = this.$getAllSubdocs();
     for (const subdoc of subdocs) {
       if (subdoc.initializeTimestamps) {
-        subdoc.initializeTimestamps();
+        subdoc.initializeTimestamps(timestampsOptions);
       }
     }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3029,9 +3029,9 @@ Model.insertMany = async function insertMany(arr, options) {
     if (doc.$__schema.options.versionKey) {
       doc[doc.$__schema.options.versionKey] = 0;
     }
-    const shouldSetTimestamps = (!options || options.timestamps !== false) && doc.initializeTimestamps && (!doc.$__ || doc.$__.timestamps !== false);
+    const shouldSetTimestamps = options?.timestamps !== false && doc.initializeTimestamps && (!doc.$__ || doc.$__.timestamps !== false);
     if (shouldSetTimestamps) {
-      doc.initializeTimestamps();
+      doc.initializeTimestamps(options?.timestamps);
     }
     if (doc.$__hasOnlyPrimitiveValues()) {
       return doc.$__toObjectShallow();

--- a/test/model.insertMany.test.js
+++ b/test/model.insertMany.test.js
@@ -59,6 +59,132 @@ describe('insertMany()', function() {
     assert.ok(!docs[1].createdAt);
   });
 
+  it('insertMany() with timestamps option createdAt: false, updatedAt: true', async function() {
+    const schema = new Schema({ name: String }, { timestamps: true });
+    const User = db.model('User', schema);
+    const start = Date.now();
+
+    const data = [{ name: 'User1' }, { name: 'User2' }];
+    const result = await User.insertMany(data, {
+      timestamps: { createdAt: false, updatedAt: true }
+    });
+
+    assert.equal(result.length, 2);
+    assert.ok(!result[0].createdAt);
+    assert.ok(!result[1].createdAt);
+    assert.ok(result[0].updatedAt);
+    assert.ok(result[1].updatedAt);
+    assert.ok(result[0].updatedAt.valueOf() >= start);
+    assert.ok(result[1].updatedAt.valueOf() >= start);
+
+    const docs = await User.find();
+    assert.equal(docs.length, 2);
+    assert.ok(!docs[0].createdAt);
+    assert.ok(!docs[1].createdAt);
+    assert.ok(docs[0].updatedAt);
+    assert.ok(docs[1].updatedAt);
+  });
+
+  it('insertMany() with timestamps option createdAt: true, updatedAt: false', async function() {
+    const schema = new Schema({ name: String }, { timestamps: true });
+    const User = db.model('User', schema);
+    const start = Date.now();
+
+    const data = [{ name: 'User1' }, { name: 'User2' }];
+    const result = await User.insertMany(data, {
+      timestamps: { createdAt: true, updatedAt: false }
+    });
+
+    assert.equal(result.length, 2);
+    assert.ok(result[0].createdAt);
+    assert.ok(result[1].createdAt);
+    assert.ok(!result[0].updatedAt);
+    assert.ok(!result[1].updatedAt);
+    assert.ok(result[0].createdAt.valueOf() >= start);
+    assert.ok(result[1].createdAt.valueOf() >= start);
+
+    const docs = await User.find();
+    assert.equal(docs.length, 2);
+    assert.ok(docs[0].createdAt);
+    assert.ok(docs[1].createdAt);
+    assert.ok(!docs[0].updatedAt);
+    assert.ok(!docs[1].updatedAt);
+  });
+
+  it('insertMany() with timestamps option both false', async function() {
+    const schema = new Schema({ name: String }, { timestamps: true });
+    const User = db.model('User', schema);
+
+    const data = [{ name: 'User1' }, { name: 'User2' }];
+    const result = await User.insertMany(data, {
+      timestamps: { createdAt: false, updatedAt: false }
+    });
+
+    assert.equal(result.length, 2);
+    assert.ok(!result[0].createdAt);
+    assert.ok(!result[1].createdAt);
+    assert.ok(!result[0].updatedAt);
+    assert.ok(!result[1].updatedAt);
+
+    const docs = await User.find();
+    assert.equal(docs.length, 2);
+    assert.ok(!docs[0].createdAt);
+    assert.ok(!docs[1].createdAt);
+    assert.ok(!docs[0].updatedAt);
+    assert.ok(!docs[1].updatedAt);
+  });
+
+  it('insertMany() with timestamps: false disables all timestamps', async function() {
+    const schema = new Schema({ name: String }, { timestamps: true });
+    const User = db.model('User', schema);
+
+    const data = [{ name: 'User1' }, { name: 'User2' }];
+    const result = await User.insertMany(data, {
+      timestamps: false
+    });
+
+    assert.equal(result.length, 2);
+    assert.ok(!result[0].createdAt);
+    assert.ok(!result[1].createdAt);
+    assert.ok(!result[0].updatedAt);
+    assert.ok(!result[1].updatedAt);
+
+    const docs = await User.find();
+    assert.equal(docs.length, 2);
+    assert.ok(!docs[0].createdAt);
+    assert.ok(!docs[1].createdAt);
+    assert.ok(!docs[0].updatedAt);
+    assert.ok(!docs[1].updatedAt);
+  });
+
+  it('insertMany() with custom timestamp field names and timestamps option', async function() {
+    const schema = new Schema({ name: String }, {
+      timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' }
+    });
+    const User = db.model('User', schema);
+    const start = Date.now();
+
+    const data = [{ name: 'User1' }, { name: 'User2' }];
+    const result = await User.insertMany(data, {
+      timestamps: { createdAt: false, updatedAt: true }
+    });
+
+    assert.equal(result.length, 2);
+    assert.ok(!result[0].created_at);
+    assert.ok(!result[1].created_at);
+    assert.ok(result[0].updated_at);
+    assert.ok(result[1].updated_at);
+    assert.ok(result[0].updated_at.valueOf() >= start);
+    assert.ok(result[1].updated_at.valueOf() >= start);
+
+    const docs = await User.find();
+    assert.equal(docs.length, 2);
+    assert.ok(!docs[0].created_at);
+    assert.ok(!docs[1].created_at);
+    assert.ok(docs[0].updated_at);
+    assert.ok(docs[1].updated_at);
+  });
+
   it('insertMany() with nested timestamps (gh-12060)', async function() {
     const childSchema = new Schema({ name: { type: String } }, {
       _id: false,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -71,6 +71,7 @@ declare module 'mongoose' {
     ordered?: boolean;
     lean?: boolean;
     throwOnValidationError?: boolean;
+    timestamps?: boolean | QueryTimestampsConfig;
   }
 
   interface InsertManyResult<T> extends mongodb.InsertManyResult<T> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #15938. Support `timestamps: false` and `timestamps: { createdAt: false, updatedAt: true }` etc. as options for `insertMany()`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
