### PR TITLE
types(utility): make WithLevel1NestedPaths correctly handle PopulatedDoc and other TypeScript unions with Document members

### DIFF
--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -15,7 +15,7 @@ declare module 'mongoose' {
         // If not a document, then return the type. Otherwise, get the DocType.
         ? NonNullable<T[P]>
         : Extract<NonNullable<T[P]>, Document> extends Document<any, any, infer DocType, any>
-          ? DocType
+          ? DocType | Exclude<NonNullable<T[P]>, Document>
           : never
       // Handle nested paths
       : P extends `${infer Key}.${infer Rest}`


### PR DESCRIPTION
Fix #15923

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`WithLevel1NestedPaths` currently uses `Extract` to pull out `Document` members of a union, but unfortunately that logic strips out all non-Document members from the union. This PR adds those back.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
