### PR TITLE
test(encryption): fix flaky encryption test

### DIFF
--- a/test/encryption/encryption.test.js
+++ b/test/encryption/encryption.test.js
@@ -1368,8 +1368,15 @@ describe('encryption integration tests', () => {
         collections.sort((a, b) => {
           // depending on what letter name starts with, `name` might come before the two queryable encryption collections or after them.
           // this sort function always puts the `name` collection first, and the two QE collections after it.
-          if (!a.includes('enxcol_')) return -1;
+          const aIsEnxcol = a.includes('enxcol_');
+          const bIsEnxcol = b.includes('enxcol_');
 
+          if (!aIsEnxcol && bIsEnxcol) {
+            return -1;
+          }
+          if (aIsEnxcol && !bIsEnxcol) {
+            return 1;
+          }
           return a.localeCompare(b);
         });
         assert.deepEqual(collections, [


### PR DESCRIPTION
## Summary
- Fix flaky test in `test/encryption/encryption.test.js`.
- The sort function only checked if `a` didn't include 'enxcol_' but didn't handle the case when `b` was the non-enxcol collection
- This caused flaky behavior depending on the initial order returned by `listCollections()`

  | Date       | Run                                                                             |
  |------------|---------------------------------------------------------------------------------|
  | 2025-12-26 | https://github.com/Automattic/mongoose/actions/runs/20526806676/job/58971531361 |
  | 2025-12-17 | https://github.com/Automattic/mongoose/actions/runs/20313631233/job/58351255120 |
  | 2025-12-04 | https://github.com/Automattic/mongoose/actions/runs/19914141564/job/57089258036 |
  | 2025-12-03 | https://github.com/Automattic/mongoose/actions/runs/19906389997/job/57063568369 |
  | 2025-11-30 | https://github.com/Automattic/mongoose/actions/runs/19791300910/job/56704656359 |
