### PR TITLE
transactions: attach sessions to docs retrieved by cursor

### DIFF
--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -599,6 +599,9 @@ function _nextDoc(ctx, doc, pop, callback) {
     if (err != null) {
       return callback(err);
     }
+    if (options.session != null) {
+      doc.$session(options.session);
+    }
     ctx.model.hooks.execPost('find', ctx.query, [[doc]]).then(() => callback(null, doc), err => callback(err));
   });
 }


### PR DESCRIPTION
Fix #15949

This PR attaches sessions to document retrieved by the query cursor.

Full details in the above issue