### PR TITLE
fix(map): validate map subdocument when loaded with init

### DIFF
--- a/lib/schema/map.js
+++ b/lib/schema/map.js
@@ -159,34 +159,6 @@ class SchemaMap extends SchemaType {
 
 SchemaMap.schemaName = 'Map';
 
-/**
- * Performs local validations first, then validations on each map entry if the
- * map contains subdocuments.
- *
- * @api private
- */
-
-SchemaMap.prototype.doValidate = async function doValidate(map, scope, options) {
-  await SchemaType.prototype.doValidate.call(this, map, scope);
-
-  if (!this.$__schemaType?.$isSingleNested || map == null) {
-    return;
-  }
-
-  const promises = [];
-  for (const doc of map.values()) {
-    if (doc == null) {
-      continue;
-    }
-    if (options?.validateModifiedOnly && !doc.$isModified()) {
-      continue;
-    }
-    promises.push(doc.$__validate(null, options));
-  }
-
-  await Promise.all(promises);
-};
-
 SchemaMap.prototype.OptionsConstructor = SchemaMapOptions;
 
 SchemaMap.defaultOptions = {};

--- a/test/types.map.test.js
+++ b/test/types.map.test.js
@@ -1822,7 +1822,7 @@ describe('Map', function() {
   describe('validates nested map subdocuments loaded via init() (gh-15957)', function() {
     it('fails validation for invalid data', async function() {
       // Arrange
-      const { company } = createTestContext({ employeeMinLength: 2, employeeName: 'X' });
+      const { company } = createTestContext({ employeeNameMinLength: 2, employeeName: 'X' });
 
       // Act
       const error = await company.validate().then(() => null, err => err);
@@ -1834,7 +1834,7 @@ describe('Map', function() {
 
     it('passes validation for valid data', async function() {
       // Arrange
-      const { company } = createTestContext({ employeeMinLength: 2, employeeName: 'John' });
+      const { company } = createTestContext({ employeeNameMinLength: 2, employeeName: 'John' });
 
       // Act
       const error = await company.validate().then(() => null, err => err);
@@ -1845,7 +1845,7 @@ describe('Map', function() {
 
     it('works with validateSync()', function() {
       // Arrange
-      const { company } = createTestContext({ employeeMinLength: 2, employeeName: 'X' });
+      const { company } = createTestContext({ employeeNameMinLength: 2, employeeName: 'X' });
 
       // Act
       const error = company.validateSync();
@@ -1855,9 +1855,9 @@ describe('Map', function() {
       assert.ok(error.errors['teams.engineering.employees.john.name']);
     });
 
-    function createTestContext({ employeeMinLength, employeeName }) {
+    function createTestContext({ employeeNameMinLength, employeeName }) {
       const employeeSchema = new Schema({
-        name: { type: String, minlength: employeeMinLength }
+        name: { type: String, minlength: employeeNameMinLength }
       });
       const teamSchema = new Schema({
         employees: { type: Map, of: employeeSchema }


### PR DESCRIPTION
Fixes #15957

When a document with nested Maps is loaded from the db via `findOne()` etc., `validate()` silently passes even for invalid data.

The issue is in `_getPathsToValidate()`, which has an optimization that removes paths with no validators. SchemaMap has no direct validators, so map paths were getting removed entirely before validation could recurse into subdocuments.

The reason constructor-created docs worked fine is they track paths like `myMap.someKey` in `activePaths.modify`, which gets validated through SchemaSubdocument. But init only tracks `myMap` in `activePaths.init`, which was getting skipped by the optimization.

Fix: skip the optimization for SchemaMap paths. The existing `$*` schema path (SchemaSubdocument) already handles recursive validation of map entries and their nested subdocuments, so no additional `doValidate` method was needed.
