### PR TITLE
fix(test): add missing Test.init() to fix flaky ordered create test

### DIFF
--- a/test/model.create.test.js
+++ b/test/model.create.test.js
@@ -189,6 +189,7 @@ describe('model', function() {
         });
 
         const Test = db.model('gh4038Test', testSchema);
+        await Test.init();
         const data = [];
         for (let i = 0; i < 11; i++) {
           data.push({ name: 'Test' + Math.abs(i - 4) });


### PR DESCRIPTION
The test for `Model.create()` with `ordered: true` (gh-4038) was flaky because it wasn't waiting for the unique index to be created before inserting documents. Without the index ready, all 11 docs get inserted instead of stopping at 5 when the first duplicate occurs.

Added `await Test.init()` to fix.

Examples of this flaky failure:
- https://github.com/Automattic/mongoose/actions/runs/21071975907/job/60603989655
- https://github.com/Automattic/mongoose/actions/runs/20978547122/job/60298605107