### PR TITLE
Respect currentTime schema option in bulkWrite updates

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -23,7 +23,7 @@ const setDefaultsOnInsert = require('../setDefaultsOnInsert');
 module.exports = function castBulkWrite(originalModel, op, options) {
   let now;
   const timestampOpts = originalModel.schema.get('timestamps');
-  if (timestampOpts && typeof timestampOpts === 'object' && typeof timestampOpts.currentTime === 'function') {
+  if (typeof timestampOpts?.currentTime === 'function') {
     now = timestampOpts.currentTime();
   } else {
     now = originalModel.base.now();

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9307,47 +9307,65 @@ describe('Model', function() {
     });
   });
 
-  describe('bulkWrite - custom currentTime', async function() {
+  describe('bulkWrite - custom currentTime', function() {
     it('should use custom currentTime', async function() {
-
-      const bulkPersonSchema = new Schema(
-        {
-          name: { type: String, required: true },
-          created_at: { type: Number },
-          updated_at: { type: Number }
-        },
-        {
-          timestamps: {
-            createdAt: 'created_at',
-            updatedAt: 'updated_at',
-            currentTime: () => Date.now().valueOf() / 1000
-          }
-        }
+      // Arrange
+      const FIXED_DATE = new Date('2026-01-01');
+      const schema = new Schema(
+        { name: { type: String, required: true } },
+        { timestamps: { currentTime: () => FIXED_DATE } }
       );
 
-      const isUnixSeconds = (value) => value > 1e9 && value < 1e10;
+      const Model = db.model('BulkPerson', schema);
 
-      const BulkPerson = db.model('BulkPerson', bulkPersonSchema);
+      await Model.insertMany([
+        { name: 'Alice' },
+        { name: 'Bob' },
+        { name: 'Eve' },
+        { name: 'Frank' }
+      ], { timestamps: false });
+      const [alice, bob, eve, frank] = await Model.find().sort({ name: 1 });
 
-      const alice = await BulkPerson.create({ name: 'Alice' });
-      const bob = await BulkPerson.create({ name: 'Bob' });
-
-
-      await BulkPerson.bulkWrite([
+      // Act
+      await Model.bulkWrite([
         { insertOne: { document: { name: 'David' } } },
-        { replaceOne: { filter: { _id: alice._id }, replacement: { name: 'Alice 2' } } },
-        { updateOne: { filter: { _id: bob._id }, update: { name: 'Bob 2' } } },
-        { updateOne: { filter: { name: 'Charlie' }, update: { name: 'Charlie' }, upsert: true } }
+        { replaceOne: { filter: { _id: alice._id }, replacement: { name: 'Alice' } } },
+        { updateOne: { filter: { _id: bob._id }, update: { $set: { name: 'Bob' } } } },
+        { updateOne: { filter: { name: 'Charlie' }, update: { $set: { name: 'Charlie' } }, upsert: true } },
+        { updateMany: { filter: { _id: { $in: [eve._id, frank._id] } }, update: { $set: { name: 'updated' } } } }
       ]);
 
-      const allPeople = await BulkPerson.find().lean().exec();
-      for (const person of allPeople) {
-        assert.ok(isUnixSeconds(person.created_at));
-        assert.ok(isUnixSeconds(person.updated_at));
-      }
+      // Assert
+      const [newDavid, newAlice, newBob, newCharlie, newEve, newFrank] = await Promise.all([
+        Model.findOne({ name: 'David' }),
+        Model.findById(alice._id),
+        Model.findById(bob._id),
+        Model.findOne({ name: 'Charlie' }),
+        Model.findById(eve._id),
+        Model.findById(frank._id)
+      ]);
 
-      await BulkPerson.deleteMany({});
+      // insertOne
+      assert.deepStrictEqual(newDavid.createdAt, FIXED_DATE);
+      assert.deepStrictEqual(newDavid.updatedAt, FIXED_DATE);
 
+      // replaceOne
+      assert.deepStrictEqual(newAlice.createdAt, FIXED_DATE);
+      assert.deepStrictEqual(newAlice.updatedAt, FIXED_DATE);
+
+      // updateOne (existing doc)
+      assert.strictEqual(newBob.createdAt, undefined);
+      assert.deepStrictEqual(newBob.updatedAt, FIXED_DATE);
+
+      // updateOne with upsert (new doc)
+      assert.deepStrictEqual(newCharlie.createdAt, FIXED_DATE);
+      assert.deepStrictEqual(newCharlie.updatedAt, FIXED_DATE);
+
+      // updateMany (existing docs)
+      assert.strictEqual(newEve.createdAt, undefined);
+      assert.deepStrictEqual(newEve.updatedAt, FIXED_DATE);
+      assert.strictEqual(newFrank.createdAt, undefined);
+      assert.deepStrictEqual(newFrank.updatedAt, FIXED_DATE);
     });
   });
 });


### PR DESCRIPTION
**Summary**

`Model.bulkWrite` has inconsistent behavior when it comes to filling in `createdAt` and `updatedAt` with the current timestamp. If custom property names and a custom `currentTime` function are specified in the schema, then:

- mongoose will respect the custom property names always
- only respect the custom `currentTime` function on `insertOne` and `replaceOne` operations, but not `updateOne` and `updateMany`

I propose to unify the behavior of the different operations within `bulkWrite` by calling the custom `currentTime` schema and passing the value into the `castUpdateOne` and `castUpdateMany`  functions.

**Reproducible example of the issue**

```ts
import mongoose from "mongoose";

type Person = {
  _id: mongoose.Types.ObjectId;
  name: string;
  created_at: number;
  updated_at: number;
};

const personSchema = new mongoose.Schema<Person>(
  {
    name: { type: String, required: true },
    created_at: { type: Number },
    updated_at: { type: Number },
  },
  {
    versionKey: false,
    timestamps: {
      createdAt: "created_at",
      updatedAt: "updated_at",
      currentTime: () => Date.now().valueOf() / 1000,
    },
  },
);

const Person = mongoose.model("Person", personSchema);

const main = async () => {
  await mongoose.connect("mongodb://localhost:27017/test");
  console.log("Connected to MongoDB");

  const alice = await Person.create({ name: "Alice" });
  const bob = await Person.create({ name: "Bob" });

  console.log("Everybody pre-changes:", JSON.stringify([alice, bob], null, 2));
  [
    {
      name: "Alice",
      _id: "696f29b40994418ab464eea6",
      created_at: 1768892852.062,
      updated_at: 1768892852.062,
    },
    {
      name: "Bob",
      _id: "696f29b40994418ab464eea8",
      created_at: 1768892852.082,
      updated_at: 1768892852.082,
    },
  ];

  await new Promise((resolve) => setTimeout(resolve, 1000));

  await Person.bulkWrite([
    { insertOne: { document: { name: "David" } } },
    { replaceOne: { filter: { _id: alice._id }, replacement: { name: "Alice 2" } } },
    { updateOne: { filter: { _id: bob._id }, update: { name: "Bob 2" } } },
    { updateOne: { filter: { name: "Charlie" }, update: { name: "Charlie" }, upsert: true } },
  ]);

  const everybody = await Person.find().sort({ name: 1 }).lean().exec();
  console.log("Everybody post-changes:", JSON.stringify(everybody, null, 2));

  [
    {
      _id: "696f29b40994418ab464eea6",
      name: "Alice 2",
      created_at: 1768892853.089, // replaceOne uses the currentTime custom function (it's increased by 1 second from the previous value)
      updated_at: 1768892853.089,
    },
    {
      _id: "696f29b40994418ab464eea8",
      name: "Bob 2",
      created_at: 1768892852.082,
      updated_at: 1768892853087, // updateOne/updateMany uses the default mongoose behavior of milliseconds, regardless of the currentTime custom function
    },
    {
      _id: "696f29b591bae2bde7a1d075",
      name: "Charlie",
      created_at: 1768892853087, // updateOne/updateMany uses the default behavior on upserts as well
      updated_at: 1768892853087,
    },
    {
      _id: "696f29b50994418ab464eeaa",
      name: "David",
      created_at: 1768892853.088, // insertOne uses the currentTime custom function
      updated_at: 1768892853.088,
    },
  ];

  await Person.deleteMany({});
  console.log("Deleted all people");
};

void main();

```
