### PR TITLE
fix(DocumentArray): correctly clone subdocument when updating document array

### DIFF
--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -438,7 +438,11 @@ SchemaDocumentArray.prototype.cast = function(value, doc, init, prev, options) {
     }
 
     if (rawArray[i] instanceof Subdocument) {
-      if (rawArray[i][documentArrayParent] !== doc) {
+      // gh-15973: Clone if subdocument has a different parent, or if it already has a
+      // different __index (e.g. reordered or duplicated in the array). If __index is null,
+      // we can safely set it without cloning.
+      if (rawArray[i][documentArrayParent] !== doc ||
+          (rawArray[i].__index != null && rawArray[i].__index !== i)) {
         if (init) {
           const subdoc = new Constructor(null, value, initDocumentOptions, selected, i);
           rawArray[i] = subdoc.$init(rawArray[i]);


### PR DESCRIPTION
Fix #15973

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
