### PR TITLE
feat(model): delay "Duplicate schema index" warning until createIndexes runs to include model name in the warning

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -50,6 +50,7 @@ const immediate = require('./helpers/immediate');
 const internalToObjectOptions = require('./options').internalToObjectOptions;
 const isDefaultIdIndex = require('./helpers/indexes/isDefaultIdIndex');
 const isIndexEqual = require('./helpers/indexes/isIndexEqual');
+const isIndexSpecEqual = require('./helpers/indexes/isIndexSpecEqual');
 const isTimeseriesIndex = require('./helpers/indexes/isTimeseriesIndex');
 const {
   getRelatedDBIndexes,
@@ -1627,6 +1628,25 @@ function _ensureIndexes(model, options, callback) {
         'MongoDB does not allow overwriting the default `_id` index. See ' +
         'https://bit.ly/mongodb-id-index');
     }
+  }
+
+  // Check for duplicate index definitions (gh-15056)
+  const seenIndexes = [];
+  for (const index of indexes) {
+    const fields = index[0];
+    const indexOptions = index[1];
+    if (indexOptions.name == null) {
+      for (const existingIndex of seenIndexes) {
+        if (existingIndex[1].name == null && isIndexSpecEqual(existingIndex[0], fields)) {
+          utils.warn('mongoose: Duplicate schema index on ' + JSON.stringify(fields) +
+            ' for model "' + model.modelName + '". ' +
+            'This is often due to declaring an index using both "index: true" and "schema.index()". ' +
+            'Please remove the duplicate index definition.');
+          break;
+        }
+      }
+    }
+    seenIndexes.push(index);
   }
 
   if (!indexes.length) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2344,12 +2344,6 @@ Schema.prototype.index = function(fields, options) {
     }
   }
 
-  for (const existingIndex of this.indexes()) {
-    if (options.name == null && existingIndex[1].name == null && isIndexSpecEqual(existingIndex[0], fields)) {
-      utils.warn(`Duplicate schema index on ${JSON.stringify(fields)} found. This is often due to declaring an index using both "index: true" and "schema.index()". Please remove the duplicate index definition.`);
-    }
-  }
-
   this._indexes.push([fields, options]);
   return this;
 };


### PR DESCRIPTION
Fix #15946

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I delayed the "Duplicate schema index" warning until we actually try to create indexes in a model (either using `syncIndexes()` or `createIndexes()` or `autoIndex`) so we can include the model name in the warning. I agree debugging this warning can be quite tricky with large schemas, and recommending people turn on the trace warnings flag isn't the best DX. Plus, technically you can delete indexes, so this warning may not be accurate in all cases unless we defer it until index build.

One potential caveat worth noting: with the changes in this PR, the "Duplicate schema index" warning will no longer print if `autoIndex` is disabled and the user does not run `syncIndexes()` or `createIndexes()`. That may be a good thing - duplicate schema indexes are a non-issue if you don't actually use the schema indexes. But worth thinking about.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
