### PR TITLE
types(models): remove dead MapReduce and GeoSearch types

### DIFF
--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -82,59 +82,6 @@ declare module 'mongoose' {
   type UpdateResult = mongodb.UpdateResult;
   type DeleteResult = mongodb.DeleteResult;
 
-  interface MapReduceOptions<T, K, R> {
-    map: Function | string;
-    reduce: (key: K, vals: T[]) => R;
-    /** query filter object. */
-    query?: any;
-    /** sort input objects using this key */
-    sort?: any;
-    /** max number of documents */
-    limit?: number;
-    /** keep temporary data default: false */
-    keeptemp?: boolean;
-    /** finalize function */
-    finalize?: (key: K, val: R) => R;
-    /** scope variables exposed to map/reduce/finalize during execution */
-    scope?: any;
-    /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
-    jsMode?: boolean;
-    /** provide statistics on job execution time. default: false */
-    verbose?: boolean;
-    readPreference?: string;
-    /** sets the output target for the map reduce job. default: {inline: 1} */
-    out?: {
-      /** the results are returned in an array */
-      inline?: number;
-      /**
-       * {replace: 'collectionName'} add the results to collectionName: the
-       * results replace the collection
-       */
-      replace?: string;
-      /**
-       * {reduce: 'collectionName'} add the results to collectionName: if
-       * dups are detected, uses the reducer / finalize functions
-       */
-      reduce?: string;
-      /**
-       * {merge: 'collectionName'} add the results to collectionName: if
-       * dups exist the new docs overwrite the old
-       */
-      merge?: string;
-    };
-  }
-
-  interface GeoSearchOptions {
-    /** x,y point to search for */
-    near: number[];
-    /** the maximum distance from the point near that a result can be */
-    maxDistance: number;
-    /** The maximum number of results to return */
-    limit?: number;
-    /** return the raw object instead of the Mongoose Model */
-    lean?: boolean;
-  }
-
   interface ModifyResult<T> {
     value: Default__v<Require_id<T>> | null;
     /** see https://www.mongodb.com/docs/manual/reference/command/findAndModify/#lasterrorobject */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

These types are vestigial - they were used for the model `mapReduce()` and `geoSearch()` functions which no longer exist. I think it should be safe to remove them, WDYT?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
