### PR TITLE
test: fix flaky timeseries TTL test #11229

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -5774,7 +5774,7 @@ describe('Model', function() {
         timeseries: {
           timeField: 'timestamp',
           metaField: 'metadata',
-          granularity: 'seconds' // 1-hour bucket span
+          granularity: 'seconds' // results in 1-hour bucket span
         },
         autoCreate: false
       });


### PR DESCRIPTION
The `mongodb actually removes expired documents (gh-11229)` test was flaky because it asserted document count immediately after insert, but the TTL monitor could delete documents before the assertion ran. I had a false negative failure when running this test.

The issue is that timeseries TTL deletes entire buckets, not individual documents, and the TTL monitor runs every 60 seconds by default, so timing was unpredictable.

Fixed by setting `ttlMonitorSleepSecs: 1` for deterministic timing and removing the racy `beforeExpirationCount` assertion since `insertMany` throws on failure anyway.

Test now runs in ~1 second instead of potentially up to a minute.

**Edit:**
Coincidentally had this test fail in [this run](https://github.com/Automattic/mongoose/actions/runs/21595884071/job/62228382413) on #16004