### PR TITLE
fix(model): correctly handle falsy version key

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4001,7 +4001,7 @@ function _update(model, op, conditions, doc, options) {
   }
   options = typeof options === 'function' ? options : clone(options);
 
-  const versionKey = model?.schema?.options?.versionKey || null;
+  const versionKey = model?.schema?.options?.versionKey ?? null;
   decorateUpdateWithVersionKey(doc, options, versionKey);
 
   return mq[op](conditions, doc, options);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

This doesn't seem to cause any issues because versionKey is enabled/disabled based on truthy/falsy values, but has the potential for counterintuitive behavior if user-specified `false` is replaced with `null`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
