### PR TITLE
test(model): enable and fix skipped hydrate strict option test

### DIFF
--- a/test/model.hydrate.test.js
+++ b/test/model.hydrate.test.js
@@ -357,13 +357,13 @@ describe('model', function() {
       assert.strictEqual(doc2.matrix[0][0].computed, undefined);
     });
 
-    it.skip('handles strict option to control non-schema properties', function() {
+    it('handles strict option to control non-schema properties', function() {
       const strictSchema = new Schema({
         name: String,
         age: Number
       }, { strict: true });
 
-      const Model = db.model('Test3', strictSchema);
+      const Model = db.model('TestHydrateStrict', strictSchema);
 
       // Test with strict: false - should allow extra fields
       const doc1 = Model.hydrate({


### PR DESCRIPTION
## Description
This PR enables a test case for `Model.hydrate()` handling of the `strict` option that was previously skipped.

The test was failing due to a model name conflict (`OverwriteModelError: Cannot overwrite Test3 model once compiled`) because the model name 'Test3' was already used in a previous test.

I have:
- Enabled the test (changed `it.skip` to [it](cci:1://file:///Users/divyapahuja/Desktop/mongoose/lib/document.js:5296:2-5300:3)).
- Renamed the test model from 'Test3' to 'TestHydrateStrict' to avoid the collision.
- Verified that the `strict` option correctly controls non-schema properties as expected.