### PR TITLE
chore: suppress mongoose warnings in tests

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -2,6 +2,8 @@ reporter: spec # better to identify failing / slow tests than "dot"
 ui: bdd # explicitly setting, even though it is mocha default
 require:
   - test/mocha-fixtures.js
+node-option:
+  - disable-warning=MONGOOSE
 extension:
   - test.js
 watch-files:

--- a/test/common.js
+++ b/test/common.js
@@ -7,19 +7,6 @@
 const mongoose = require('../index');
 const Collection = mongoose.Collection;
 const assert = require('assert');
-// Suppress MONGOOSE warnings in tests to avoid polluting test output.
-// Tests that need to assert on warnings use sinon.stub(utils, 'warn') or
-// sinon.stub(process, 'emitWarning') which intercept before this handler.
-const _originalEmitWarning = process.emitWarning;
-process.emitWarning = function suppressedEmitWarning(message, options) {
-  if (options?.code === 'MONGOOSE') {
-    if (typeof message !== 'string') {
-      throw new Error('`utils.warn` should be called with a string, got: ' + typeof message);
-    }
-    return;
-  }
-  return _originalEmitWarning.apply(this, arguments);
-};
 
 const collectionNames = new Map();
 


### PR DESCRIPTION
re https://github.com/Automattic/mongoose/pull/16008#:~:text=I%20noticed%20that%20this%20addition%20polluted%20the%20tests%20with%20a%20bunch%20of%20unnecessary%20warnings%2C%20I%27ll%20try%20to%20figure%20out%20a%20way%20in%20a%20future%20PR%20to%20make%20warnings%20not%20appear%20at%20all%20in%20test%20logs https://github.com/Automattic/mongoose/pull/15911

This PR:
* Suppresses logs in tests to avoid polluting test outputs with unnecessary logs, `utils.warn` can still be asserted against, and we still validate that any invalid calls to `utils.warn` error out.
* Sets `GEN_TYPE_TEST` to `false` in `test/model.middleware.preposttypes.test.js` to avoid logging auto-generated TS file in all the CI runs, same argument as #15911. I suspect this was left as `true` accidentally.