### PR TITLE
types(query): allow assigning QueryFilter<DocType> to QueryFilter<any>

### DIFF
--- a/test/types/PipelineStage.test.ts
+++ b/test/types/PipelineStage.test.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import type { PipelineStage } from 'mongoose';
+import type { PipelineStage, QueryFilter } from 'mongoose';
 
 /**
  * $addFields:
@@ -574,3 +574,21 @@ const vectorSearchStages: PipelineStage[] = [
     }
   }
 ];
+
+function gh16006() {
+  interface MyDoc {
+    _id: string;
+    name: string;
+  }
+
+  const matchCriteria: QueryFilter<MyDoc> = {
+    _id: 'foobar',
+    name: 'test'
+  };
+
+  const pipeline: PipelineStage[] = [
+    {
+      $match: matchCriteria
+    }
+  ];
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -945,29 +945,6 @@ declare module 'mongoose' {
                     : BufferToBinary<T[K]>;
           } : T;
 
-    /**
-    * Converts any UUID properties into strings for JSON serialization
-    */
-    export type UUIDToJSON<T> = T extends Types.UUID
-      ? string
-      : T extends mongodb.UUID
-        ? string
-        : T extends Document
-          ? T
-          : T extends TreatAsPrimitives
-            ? T
-            : T extends Record<string, any> ? {
-              [K in keyof T]: T[K] extends Types.UUID
-                ? string
-                : T[K] extends mongodb.UUID
-                  ? string
-                  : T[K] extends Types.DocumentArray<infer ItemType>
-                      ? Types.DocumentArray<UUIDToJSON<ItemType>>
-                      : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
-                        ? HydratedSingleSubdocument<UUIDToJSON<SubdocType>>
-                        : UUIDToJSON<T[K]>;
-            } : T;
-
   /**
    * Converts any UUID properties into strings for JSON serialization
    */

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -20,8 +20,18 @@ declare module 'mongoose' {
 
   export type ApplyBasicQueryCasting<T> = QueryTypeCasting<T> | QueryTypeCasting<T[]> | (T extends (infer U)[] ? QueryTypeCasting<U> : T) | null;
 
-  type _QueryFilter<T> = ({ [P in keyof T]?: mongodb.Condition<ApplyBasicQueryCasting<T[P]>>; } & mongodb.RootFilterOperators<{ [P in keyof mongodb.WithId<T>]?: ApplyBasicQueryCasting<mongodb.WithId<T>[P]>; }>);
-  type QueryFilter<T> = IsItRecordAndNotAny<T> extends true ? _QueryFilter<WithLevel1NestedPaths<T>> : _QueryFilter<Record<string, any>>;
+  type _QueryFilter<T> = (
+    { [P in keyof T]?: mongodb.Condition<ApplyBasicQueryCasting<T[P]>>; } &
+    mongodb.RootFilterOperators<{ [P in keyof mongodb.WithId<T>]?: ApplyBasicQueryCasting<mongodb.WithId<T>[P]>; }>
+  );
+  type _QueryFilterLooseId<T> = (
+    { [P in keyof T]?: mongodb.Condition<ApplyBasicQueryCasting<T[P]>>; } &
+    mongodb.RootFilterOperators<
+      { [P in keyof T]?: ApplyBasicQueryCasting<T[P]>; } &
+      { _id?: any; }
+    >
+  );
+  type QueryFilter<T> = IsItRecordAndNotAny<T> extends true ? _QueryFilter<WithLevel1NestedPaths<T>> : _QueryFilterLooseId<Record<string, any>>;
 
   type MongooseBaseQueryOptionKeys =
     | 'context'


### PR DESCRIPTION
Fix #16006

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The problem in #16006 is that `WithId<>` in `QueryFilter<any>` makes `QueryFilter<any>` act like a query filter with `_id: ObjectId`, which is potentially problematic because you would intuitively assume that `QueryFilter<{ _id: string }>` is assignable to `QueryFilter<any>`. 

I also removed a duplicate `UUIDToJSON` definition

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
