### PR TITLE
fix(document): fix pathToSave crashing with no updates, and ignoring non-`$set` operators

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -407,11 +407,14 @@ Model.prototype.$__save = async function $__save(options) {
       this.$__.inserting = false;
       const delta = this.$__delta();
 
-      if (options.pathsToSave && delta) {
+      if (options.pathsToSave && delta?.[1]) {
         const update = delta[1];
+        const versionKey = this.$__schema.options.versionKey;
         for (const op of Object.keys(update)) {
           for (const key in update[op]) {
-            if (options.pathsToSave.includes(key)) {
+            if (key === versionKey) {
+              continue;
+            } else if (options.pathsToSave.includes(key)) {
               continue;
             } else if (options.pathsToSave.some(pathToSave => key.slice(0, pathToSave.length) === pathToSave && key.charAt(pathToSave.length) === '.')) {
               continue;

--- a/lib/model.js
+++ b/lib/model.js
@@ -451,6 +451,12 @@ Model.prototype.$__save = async function $__save(options) {
           }
         }
 
+        for (const op of Object.keys(update)) {
+          if (utils.hasOwnKeys(update[op]) === false) {
+            delete update[op];
+          }
+        }
+
         // store the modified paths before the document is reset
         this.$__.modifiedPaths = this.modifiedPaths();
         this.$__reset();

--- a/lib/model.js
+++ b/lib/model.js
@@ -407,14 +407,17 @@ Model.prototype.$__save = async function $__save(options) {
       this.$__.inserting = false;
       const delta = this.$__delta();
 
-      if (options.pathsToSave) {
-        for (const key in delta[1]['$set']) {
-          if (options.pathsToSave.includes(key)) {
-            continue;
-          } else if (options.pathsToSave.some(pathToSave => key.slice(0, pathToSave.length) === pathToSave && key.charAt(pathToSave.length) === '.')) {
-            continue;
-          } else {
-            delete delta[1]['$set'][key];
+      if (options.pathsToSave && delta) {
+        const update = delta[1];
+        for (const op of Object.keys(update)) {
+          for (const key in update[op]) {
+            if (options.pathsToSave.includes(key)) {
+              continue;
+            } else if (options.pathsToSave.some(pathToSave => key.slice(0, pathToSave.length) === pathToSave && key.charAt(pathToSave.length) === '.')) {
+              continue;
+            } else {
+              delete update[op][key];
+            }
           }
         }
       }


### PR DESCRIPTION
re https://github.com/Automattic/mongoose/pull/15850 https://github.com/Automattic/mongoose/pull/15896
This PR fixes two issues:
* When calling `Document#save`  with `pathsToSave` on a document with no changes, mongoose crashes with `TypeError: Cannot read properties of null`.
* Updates that would use `$push` or any other non-`$set` operator would silently be ignored.