### PR TITLE
feat(setDefaultsOnInsert): pass query as context to default functions

### DIFF
--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -8,11 +8,12 @@ const get = require('./get');
  * @param {Schema} schema
  * @param {Object} castedDoc
  * @param {Object} options
+ * @param {Object} [context] the context to pass to default functions as `this`
  * @method setDefaultsOnInsert
  * @api private
  */
 
-module.exports = function(filter, schema, castedDoc, options) {
+module.exports = function(filter, schema, castedDoc, options, context) {
   options = options || {};
 
   const shouldSetDefaultsOnInsert = options.setDefaultsOnInsert ?? schema.base.options.setDefaultsOnInsert;
@@ -68,7 +69,7 @@ module.exports = function(filter, schema, castedDoc, options) {
     if (schemaType.path === '_id' && schemaType.options.auto) {
       return;
     }
-    const def = schemaType.getDefault(null, true);
+    const def = schemaType.getDefault(context, true);
     if (typeof def === 'undefined') {
       return;
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -3528,8 +3528,13 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   const _opts = Object.assign({}, options, {
     setDefaultsOnInsert: this._mongooseOptions.setDefaultsOnInsert
   });
-  this._update = setDefaultsOnInsert(this._conditions, this.model.schema,
-    this._update, _opts);
+  this._update = setDefaultsOnInsert(
+    this._conditions,
+    this.model.schema,
+    this._update,
+    _opts,
+    this
+  );
 
   if (!this._update || utils.hasOwnKeys(this._update) === false) {
     if (options.upsert) {
@@ -4134,8 +4139,13 @@ async function _updateThunk(op) {
     const _opts = Object.assign({}, options, {
       setDefaultsOnInsert: this._mongooseOptions.setDefaultsOnInsert
     });
-    this._update = setDefaultsOnInsert(this._conditions, this.model.schema,
-      this._update, _opts);
+    this._update = setDefaultsOnInsert(
+      this._conditions,
+      this.model.schema,
+      this._update,
+      _opts,
+      this
+    );
   }
 
   if (Array.isArray(options.arrayFilters)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Validators get query as context, but default functions still get `null` as context, which makes writing default functions that depend on other fields tricky.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
