### PR TITLE
refactor: remove duplicate definition of the `UUIDToJSON` type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -945,29 +945,6 @@ declare module 'mongoose' {
                     : BufferToBinary<T[K]>;
           } : T;
 
-    /**
-    * Converts any UUID properties into strings for JSON serialization
-    */
-    export type UUIDToJSON<T> = T extends Types.UUID
-      ? string
-      : T extends mongodb.UUID
-        ? string
-        : T extends Document
-          ? T
-          : T extends TreatAsPrimitives
-            ? T
-            : T extends Record<string, any> ? {
-              [K in keyof T]: T[K] extends Types.UUID
-                ? string
-                : T[K] extends mongodb.UUID
-                  ? string
-                  : T[K] extends Types.DocumentArray<infer ItemType>
-                      ? Types.DocumentArray<UUIDToJSON<ItemType>>
-                      : T[K] extends Types.Subdocument<unknown, unknown, infer SubdocType>
-                        ? HydratedSingleSubdocument<UUIDToJSON<SubdocType>>
-                        : UUIDToJSON<T[K]>;
-            } : T;
-
   /**
    * Converts any UUID properties into strings for JSON serialization
    */


### PR DESCRIPTION
**Summary**

Is PR removes duplicate remove duplicate definition of the `UUIDToJSON` type. Seem like the type is rename to `UUIDToString`.

`UUIDToJSON` is also exported here as an alias of `UUIDToString`:

https://github.com/Automattic/mongoose/blob/7a73025db14ccdbd2691cb36ceede4776d27fadb/types/index.d.ts#L971-L975

---

By the way, TSTyche detected this duplication while I was putting together #16024.