### PR TITLE
style(schemaType): fix "toJSON" being JSDOC being both "instance" "static" warning

### DIFF
--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -170,7 +170,6 @@ SchemaType.prototype.path;
  *     const schematype = schema.path('name');
  *     console.log(schematype.toJSON());
  *
- * @function toJSON
  * @memberOf SchemaType
  * @instance
  * @api public


### PR DESCRIPTION
**Summary**

This PR contains a fix for `SchemaType.prototoype.toJSON` being both marked `static` and `instance` in the JSDoc.

Re #16037
