### PR TITLE
types(model): make bulkSave() correctly take array of THydratedDocumentType

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1020,6 +1020,31 @@ async function gh15369() {
   }
 }
 
+async function gh16032() {
+  interface IEmail {
+    _id: string;
+    to: string;
+    subject: string;
+  }
+
+  type EmailInstance = HydratedDocument<IEmail>;
+  type EmailModelType = Model<IEmail, {}, {}, {}, EmailInstance>;
+
+  const emailSchema = new Schema<IEmail, EmailModelType>({
+    _id: { type: Schema.Types.String, required: true },
+    to: { type: Schema.Types.String, required: true },
+    subject: { type: Schema.Types.String, required: true }
+  }, { _id: false });
+
+  const Email = model<IEmail, EmailModelType>('Email', emailSchema);
+  const emails: EmailInstance[] = [
+    new Email({ _id: 'msg-001', to: 'a@example.com', subject: 'Hello' }),
+    new Email({ _id: 'msg-002', to: 'b@example.com', subject: 'World' })
+  ];
+
+  await Email.bulkSave(emails);
+}
+
 async function gh15437() {
   interface Person {
     name: string;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -273,7 +273,7 @@ declare module 'mongoose' {
      * sending multiple `save()` calls because with `bulkSave()` there is only one
      * network round trip to the MongoDB server.
      */
-    bulkSave(documents: Array<Document>, options?: MongooseBulkSaveOptions): Promise<MongooseBulkWriteResult>;
+    bulkSave(documents: Array<THydratedDocumentType>, options?: MongooseBulkSaveOptions): Promise<MongooseBulkWriteResult>;
 
     /** Collection the model uses. */
     collection: Collection;


### PR DESCRIPTION
Fix #16032

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`bulkSave()` is intended to take in an array of document instances of the given model, so these types are more correct IMO.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
