### PR TITLE
fix(types): make bulkSave accept documents with custom _id types

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1250,3 +1250,30 @@ function hydrateWithStrictOption() {
 
   ExpectType<ReturnType<(typeof TestModel)['hydrate']>>(doc4);
 }
+
+async function gh16032() {
+  interface IEmail {
+    _id: string;
+    to: string;
+    subject: string;
+  }
+
+  type EmailInstance = mongoose.HydratedDocument<IEmail>;
+  type EmailModelType = mongoose.Model<IEmail, {}, {}, {}, EmailInstance>;
+
+  const emailSchema = new Schema<IEmail, EmailModelType>({
+    _id: { type: mongoose.Schema.Types.String, required: true },
+    to: { type: mongoose.Schema.Types.String, required: true },
+    subject: { type: mongoose.Schema.Types.String, required: true }
+  }, { _id: false });
+
+  const Email = model<IEmail, EmailModelType>('Email', emailSchema);
+
+  const emails: EmailInstance[] = [
+    new Email({ _id: 'msg-001', to: 'a@example.com', subject: 'Hello' }),
+    new Email({ _id: 'msg-002', to: 'b@example.com', subject: 'World' })
+  ];
+
+  // This should work without type error - bulkSave should accept documents with custom _id types
+  await Email.bulkSave(emails);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -273,7 +273,7 @@ declare module 'mongoose' {
      * sending multiple `save()` calls because with `bulkSave()` there is only one
      * network round trip to the MongoDB server.
      */
-    bulkSave(documents: Array<Document>, options?: MongooseBulkSaveOptions): Promise<MongooseBulkWriteResult>;
+    bulkSave<T = any>(documents: Array<Document<T>>, options?: MongooseBulkSaveOptions): Promise<MongooseBulkWriteResult>;
 
     /** Collection the model uses. */
     collection: Collection;


### PR DESCRIPTION
After #15688 changed `Document`'s default generic from `unknown` to `Types.ObjectId`, calling `Model.bulkSave()` on models with a custom string `_id` started throwing a type error:

```
TS2345: Argument of type 'Array<HydratedDocument<IEmail, IEmailVirtuals>>'
  is not assignable to parameter of type 'Array<Document>'.
    Types of property '_id' are incompatible.
      Type 'string' is not assignable to type 'ObjectId'.
```

The fix makes `bulkSave` generic over the `_id` type parameter (`bulkSave<T = any>(documents: Array<Document<T>>, ...)`) so it accepts documents with any `_id` type, not just `ObjectId`.

Added a type test with a custom string `_id` model to verify the fix.

Fixes #16032