### PR TITLE
chore: make the TSConfig stricter

### DIFF
--- a/test/types/expressions.test.ts
+++ b/test/types/expressions.test.ts
@@ -164,26 +164,31 @@ const dateFromParts: Expression = {
   }
 };
 
+interface State {
+  count: number;
+  sum: number;
+}
+
 const accumulator: Expression = {
   $accumulator:
   {
-    init: function() { // Set the initial state
+    init: function(): State { // Set the initial state
       return { count: 0, sum: 0 };
     },
-    accumulate: function(state, numCopies) { // Define how to update the state
+    accumulate: function(state: State, numCopies: number) { // Define how to update the state
       return {
         count: state.count + 1,
         sum: state.sum + numCopies
       };
     },
     accumulateArgs: ['$copies'], // Argument required by the accumulate function
-    merge: function(state1, state2) { // When the operator performs a merge,
+    merge: function(state1: State, state2: State) { // When the operator performs a merge,
       return { // add the fields from the two states
         count: state1.count + state2.count,
         sum: state1.sum + state2.sum
       };
     },
-    finalize: function(state) { // After collecting the results from all documents,
+    finalize: function(state: State) { // After collecting the results from all documents,
       return (state.sum / state.count); // calculate the average
     },
     lang: 'js'
@@ -201,7 +206,7 @@ const bsonSize: Expression = { $bsonSize: '$current_task' };
 const functionExpr: Expression = {
   $function:
   {
-    body: function(name) {
+    body: function(name: string) {
       return name == 'Detlef';
     },
     args: ['$name'],

--- a/test/types/generics.test.ts
+++ b/test/types/generics.test.ts
@@ -13,7 +13,7 @@ class Repository<T> {
 }
 
 class Foo {
-  name: string;
+  name!: string;
 }
 
 type Test = Repository<Foo>;

--- a/test/types/loadclass.test.ts
+++ b/test/types/loadclass.test.ts
@@ -159,7 +159,7 @@ function getterLimitationTest() {
   }
 
   class TestGetter {
-    name: string;
+    name!: string;
 
     // TS errors if you try `this` in getter
     // @ts-expect-error  'get' and 'set' accessors cannot declare 'this' parameters.

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -139,7 +139,7 @@ Test.findOneAndUpdate({ name: 'test' }, update);
 Test.findOneAndUpdate({ name: 'test' }, { $currentDate: { endDate: true } });
 Test.findOneAndUpdate({ name: 'test' }, [{ $set: { endDate: true } }]);
 
-Test.findByIdAndUpdate({ name: 'test' }, { name: 'test2' }, (err: any, doc) => console.log(doc));
+Test.findByIdAndUpdate({ name: 'test' }, { name: 'test2' }, (err: any, doc: any) => console.log(doc));
 
 Test.findOneAndUpdate({ name: 'test' }, { 'docs.0.myId': '0'.repeat(24) });
 

--- a/test/types/schema.create.test.ts
+++ b/test/types/schema.create.test.ts
@@ -376,10 +376,10 @@ export function autoTypedSchema() {
   // Test auto schema type obtaining with all possible path types.
 
   class Int8 extends SchemaType {
-    constructor(key, options) {
+    constructor(key: string, options: Record<string, any>) {
       super(key, options, 'Int8');
     }
-    cast(val) {
+    cast(val: unknown) {
       let _val = Number(val);
       if (isNaN(_val)) {
         throw new Error('Int8: ' + val + ' is not a number');
@@ -1849,8 +1849,7 @@ function gh15301() {
     }
   });
 
-  const timeStringToObject = (time) => {
-    if (typeof time !== 'string') return time;
+  const timeStringToObject = (time: string) => {
     const [hours, minutes] = time.split(':');
     return { hours: parseInt(hours), minutes: parseInt(minutes) };
   };

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -378,10 +378,10 @@ export function autoTypedSchema() {
   // Test auto schema type obtaining with all possible path types.
 
   class Int8 extends SchemaType {
-    constructor(key, options) {
+    constructor(key: string, options: Record<string, any>) {
       super(key, options, 'Int8');
     }
-    cast(val) {
+    cast(val: unknown) {
       let _val = Number(val);
       if (isNaN(_val)) {
         throw new Error('Int8: ' + val + ' is not a number');
@@ -1887,8 +1887,7 @@ function gh15301() {
     }
   });
 
-  const timeStringToObject = (time) => {
-    if (typeof time !== 'string') return time;
+  const timeStringToObject = (time: string) => {
     const [hours, minutes] = time.split(':');
     return { hours: parseInt(hours), minutes: parseInt(minutes) };
   };

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -4,15 +4,11 @@
     "esModuleInterop": false,
     "strict": true,
     "allowSyntheticDefaultImports": true,
-    "strictPropertyInitialization": false,
-    "noImplicitAny": false,
-    "strictNullChecks": true,
     "module": "commonjs",
     "target": "ES2022",
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
-  "include": [
-    "*.test.ts"
-  ]
+  "include": ["**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "strictNullChecks": true,
+    "types": ["node"],
     "paths": {
       "mongoose" : ["./types/index.d.ts"]
     }


### PR DESCRIPTION
**Summary**

This PR makes the TSConfig stricter, by removing `strictPropertyInitialization: false` and `noImplicitAny: false`. Only few minor changes had to be included in the type test files.

TSTyche is using this `tsconfig.json` file and it checks `.d.ts` declarations based on it (as an example, #16029 was detected). So I think it is better to avoid settings like `noImplicitAny: false`.