### PR TITLE
Improve CSFLE docs: highlight defining models before connecting, add example using csfle not queryable encryption

### DIFF
--- a/docs/field-level-encryption.md
+++ b/docs/field-level-encryption.md
@@ -63,7 +63,7 @@ const encryptedUserSchema = new Schema({
     // 1
     encrypt: { 
       keyId: ['<uuid string of key id>'], // Make sure this is an array
-      queries: { queryType: 'equality' }
+      algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
     }
   }
   // 2


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I made a couple of minor improvements to the CSFLE docs based on some issues I ran into troubleshooting #16015:

1. Add additional clarification that models must be added to the connection _before_ connecting for automatic `schemaMap` generation, which is a meaningful gotcha.
2. Current examples only demo queryable encryption but not CSFLE, which is unfortunate because CSFLE definition has slightly different syntax.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
