### PR TITLE
docs(contributing): fix outdated issue tracker links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,13 @@ If you have a question about Mongoose (not a bug report) please post it to eithe
 
 ## Requesting new features
 
-* Before opening a new issue, look for existing [issues](https://github.com/learnboost/mongoose/issues) to avoid duplication. If the issue does not yet exist, [create one](https://github.com/learnboost/mongoose/issues/new).
+* Before opening a new issue, look for existing [issues](https://github.com/Automattic/mongoose/issues) to avoid duplication. If the issue does not yet exist, [create one](https://github.com/Automattic/mongoose/issues/new).
 * Please describe a use case for it
 * Please include test cases if possible
 
 ## Fixing bugs / Adding features
 
-* Before starting to write code, look for existing [issues](https://github.com/learnboost/mongoose/issues). That way you avoid working on something that might not be of interest or that has been addressed already in a different branch. [You can create a new issue on GitHub](https://github.com/learnboost/mongoose/issues/new).
+* Before starting to write code, look for existing [issues](https://github.com/Automattic/mongoose/issues). That way you avoid working on something that might not be of interest or that has been addressed already in a different branch. [You can create a new issue on GitHub](https://github.com/Automattic/mongoose/issues/new).
   * *The source of this project is written in JavaScript, not CoffeeScript or TypeScript. Please write your bug reports in JavaScript that can run in vanilla Node.js*.
 * Fork the [repo](https://github.com/Automattic/mongoose) *or* for small documentation changes, navigate to the source on github and click the [Edit](https://github.com/blog/844-forking-with-the-edit-button) button.
 * Follow the general coding style of the rest of the project:


### PR DESCRIPTION
## Summary of the problem
The `CONTRIBUTING.md` guide still references the legacy `learnboost/mongoose` GitHub repository in the "Requesting new features" and "Fixing bugs / Adding features" sections. These outdated links can send contributors to the wrong issue tracker, making it harder to report bugs or request features in the active `Automattic/mongoose` repository.

## Explanation of the solution
- Updated all remaining `https://github.com/learnboost/mongoose/...` links in `CONTRIBUTING.md` to point to `https://github.com/Automattic/mongoose/...`.
- Kept the existing wording and structure of the contribution guide intact, only changing the repository owner in the URLs.
- Ensured the bug-reporting section, feature-request section, and fixing-bugs section now consistently reference the same, current issue tracker.

## Before vs After behavior
- **Before**
  - "Requesting new features" linked to `https://github.com/learnboost/mongoose/issues` and `https://github.com/learnboost/mongoose/issues/new`.
  - "Fixing bugs / Adding features" linked to the same `learnboost/mongoose` issue URLs.
  - Contributors could be redirected to an outdated repository when filing or browsing issues.

- **After**
  - All issue tracker links in `CONTRIBUTING.md` now consistently use `https://github.com/Automattic/mongoose/issues` and `https://github.com/Automattic/mongoose/issues/new`.
  - New contributors are guided to the active `Automattic/mongoose` issue tracker when reporting bugs or requesting features.

## Testing performed
- Documentation-only change; no runtime code affected.
- Manually verified that all updated URLs resolve to the correct pages in the `Automattic/mongoose` repository and that there are no remaining `learnboost/mongoose` issue links in `CONTRIBUTING.md`.
