### PR TITLE
Fix strict-mode dropping nested discriminator update paths when using arrayFilters

### DIFF
--- a/lib/helpers/query/getEmbeddedDiscriminatorPath.js
+++ b/lib/helpers/query/getEmbeddedDiscriminatorPath.js
@@ -89,7 +89,7 @@ module.exports = function getEmbeddedDiscriminatorPath(schema, update, filter, p
       }
 
       const rest = parts.slice(i + 1).join('.');
-      schematype = discriminatorSchema.path(rest);
+      schematype = discriminatorSchema._getSchema(rest);
       schema = discriminatorSchema;
       startIndex = i + 1;
       if (schematype != null) {

--- a/test/model.discriminator.querying.test.js
+++ b/test/model.discriminator.querying.test.js
@@ -564,6 +564,66 @@ describe('model', function() {
         expected.name = 'Conversion event - updated';
         assert.deepEqual(document.toJSON(), expected);
       });
+
+      it('handles deeply nested paths with discriminators and arrayFilters (gh-15338)', async function() {
+        const eventSchema = new Schema(
+          { message: String },
+          { discriminatorKey: 'kind', _id: false }
+        );
+
+        const batchSchema = new Schema(
+          { events: [eventSchema] },
+          { timestamps: true }
+        );
+
+        const docArray = batchSchema.path('events');
+
+        docArray.discriminator(
+          'Clicked',
+          new Schema({ element: { type: String, required: true } }, { _id: false })
+        );
+
+        docArray.discriminator(
+          'Purchased',
+          new Schema({
+            products: {
+              type: new Schema({ map: { type: Schema.Types.Map, of: String } }, { _id: false })
+            }
+          })
+        );
+
+        const Batch = db.model('gh15338', batchSchema);
+
+        const purchasedId = new mongoose.Types.ObjectId();
+
+        const doc = await Batch.create({
+          events: [
+            { kind: 'Clicked', element: '#hero', message: 'hello' },
+            {
+              kind: 'Purchased',
+              _id: purchasedId,
+              products: { map: { key: 'value' } },
+              message: 'world'
+            }
+          ]
+        });
+
+        const updatedBatch = await Batch.findByIdAndUpdate(
+          doc._id,
+          { 'events.$[event].products.map.key': 'newValue' },
+          {
+            arrayFilters: [
+              {
+                'event._id': purchasedId,
+                'event.kind': 'Purchased'
+              }
+            ],
+            new: true
+          }
+        ).exec();
+
+        assert.equal(updatedBatch.events[1].products.map.get('key'), 'newValue');
+      });
     });
 
     describe('population/reference mapping', function() {


### PR DESCRIPTION


Fixes #15338.

This PR fixes a problem where Mongoose’s strict-mode validation would silently remove `$set` update paths in `findByIdAndUpdate` when `arrayFilters` were used and the path passed through a discriminator and targeted a deeply nested field (for example, a key inside a `Map`).

### Root Cause

The issue came from `lib/helpers/query/getEmbeddedDiscriminatorPath.js`. After identifying the correct discriminator schema, the code used the `path()` method to resolve subpaths.

However, `path()` only checks top-level schema paths and cannot resolve deeply nested fields or dynamic Map keys. Because of this, update paths like:

events.$[event].products.map.key

could not be resolved through the discriminator schema, so strict-mode validation would silently strip the path from the update.

Since the update path was removed, MongoDB received the `arrayFilters` but no update referencing them, which resulted in the error:

MongoServerError: The array filter for identifier 'event' was not used in the update

### Fix

This PR replaces the use of `path()` with `_getSchema()`, which can properly traverse nested sub-schemas and Map structures.

With this change, Mongoose is able to correctly resolve deeply nested paths inside discriminator schemas, so the update path is preserved and sent to MongoDB as expected.

### Tests

A new test has been added in:

test/model.discriminator.querying.test.js

titled:

handles deeply nested paths with discriminators and arrayFilters (gh-15338)

This test reproduces the issue where an update like:

events.$[event].products.map.key

would previously be stripped during strict validation.

With the fix applied, the path is now correctly preserved and the update succeeds.