### PR TITLE
Make typescript fail when providing unknown query operator

### DIFF
--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -473,7 +473,7 @@ SchemaNumber.prototype.castForQuery = function($conditional, val, context) {
   if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
-      throw new CastError('number', val, this.path, null, this);
+      throw new Error('Can\'t use ' + $conditional + ' with Number.');
     }
     return handler.call(this, val, context);
   }

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -473,7 +473,7 @@ SchemaNumber.prototype.castForQuery = function($conditional, val, context) {
   if ($conditional != null) {
     handler = this.$conditionalHandlers[$conditional];
     if (!handler) {
-      throw new Error('Can\'t use ' + $conditional + ' with Number.');
+      throw new MongooseError('Can\'t use ' + $conditional + ' with Number.');
     }
     return handler.call(this, val, context);
   }

--- a/test/types.number.test.js
+++ b/test/types.number.test.js
@@ -100,6 +100,18 @@ describe('types.number', function() {
     done();
   });
 
+  it('throws an error when using an unsupported query operator (gh-16062)', function() {
+    const n = new SchemaNumber();
+    let err;
+    try {
+      n.castForQuery('$wrong', 100);
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err);
+    assert.ok(err.message.includes('Can\'t use $wrong with Number'));
+  });
+
   it('throws a CastError with a bad conditional (gh-6927)', function() {
     const n = new SchemaNumber();
     let err;

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -914,5 +914,7 @@ async function gh15779_2() {
 async function gh16062() {
   const Test = model('Test', new Schema({ runtime: Number }));
   // @ts-expect-error  No overload matches this call.
-  Test.findOne({ runtime: { $wrong: 100 } });
+  await Test.findOne({ runtime: { $wrong: 100 } });
+  // @ts-expect-error  No overload matches this call.
+  await Test.findOne({ $and: [{ runtime: { $wrong: 100 } }] });
 }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -873,7 +873,7 @@ async function gh15779() {
 
   type AgeType = typeof v8Filter.age;
   ExpectAssignable<typeof v8Filter.age>()(42);
-  // @ts-expect-error  Type '"taco"' is not assignable to type 'Condition<ApplyBasicQueryCasting<number>> | undefined'.
+  // @ts-expect-error  Type '"taco"' is not assignable to type 'StrictCondition<ApplyBasicQueryCasting<number>> | undefined'.
   const a1: AgeType = 'taco';
 
   const TestModel = model('Test', new Schema({ age: Number, name: String }));
@@ -909,4 +909,10 @@ async function gh15779_2() {
   const jobs = await JobModel.aggregate<Job>([
     { $match: {} as QueryFilter<Job> }
   ]);
+}
+
+async function gh16062() {
+  const Test = model('Test', new Schema({ runtime: Number }));
+  // @ts-expect-error  No overload matches this call.
+  Test.findOne({ runtime: { $wrong: 100 } });
 }

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -18,14 +18,22 @@ declare module 'mongoose' {
             ? DateQueryTypeCasting
             : T;
 
-  export type ApplyBasicQueryCasting<T> = QueryTypeCasting<T> | QueryTypeCasting<T[]> | (T extends (infer U)[] ? QueryTypeCasting<U> : T) | null;
+  export type ApplyBasicQueryCasting<T> = QueryTypeCasting<T> | QueryTypeCasting<T>[] | (T extends (infer U)[] ? QueryTypeCasting<U> : T) | null;
+
+  type RemoveIndexSignature<T> = {
+    [K in keyof T as string extends K ? never : number extends K ? never : symbol extends K ? never : K]: T[K];
+  };
+
+  type StrictFilterOperators<TValue> = RemoveIndexSignature<mongodb.FilterOperators<TValue>>;
+
+  type StrictCondition<T> = mongodb.AlternativeType<T> | StrictFilterOperators<mongodb.AlternativeType<T>>;
 
   type _QueryFilter<T> = (
-    { [P in keyof T]?: mongodb.Condition<ApplyBasicQueryCasting<T[P]>>; } &
+    { [P in keyof T]?: StrictCondition<ApplyBasicQueryCasting<T[P]>>; } &
     mongodb.RootFilterOperators<{ [P in keyof mongodb.WithId<T>]?: ApplyBasicQueryCasting<mongodb.WithId<T>[P]>; }>
   );
   type _QueryFilterLooseId<T> = (
-    { [P in keyof T]?: mongodb.Condition<ApplyBasicQueryCasting<T[P]>>; } &
+    { [P in keyof T]?: StrictCondition<ApplyBasicQueryCasting<T[P]>>; } &
     mongodb.RootFilterOperators<
       { [P in keyof T]?: ApplyBasicQueryCasting<T[P]>; } &
       { _id?: any; }

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -28,15 +28,24 @@ declare module 'mongoose' {
 
   type StrictCondition<T> = mongodb.AlternativeType<T> | StrictFilterOperators<mongodb.AlternativeType<T>>;
 
+  type _StrictFilter<TSchema> = {
+    [P in keyof TSchema]?: StrictCondition<ApplyBasicQueryCasting<TSchema[P]>>;
+  } & StrictRootFilterOperators<TSchema>;
+
+  type StrictRootFilterOperators<TSchema> = Omit<mongodb.RootFilterOperators<TSchema>, '$and' | '$or' | '$nor'> & {
+    $and?: _StrictFilter<TSchema>[];
+    $or?: _StrictFilter<TSchema>[];
+    $nor?: _StrictFilter<TSchema>[];
+  };
+
   type _QueryFilter<T> = (
     { [P in keyof T]?: StrictCondition<ApplyBasicQueryCasting<T[P]>>; } &
-    mongodb.RootFilterOperators<{ [P in keyof mongodb.WithId<T>]?: ApplyBasicQueryCasting<mongodb.WithId<T>[P]>; }>
+    StrictRootFilterOperators<{ [P in keyof mongodb.WithId<T>]?: ApplyBasicQueryCasting<mongodb.WithId<T>[P]>; }>
   );
   type _QueryFilterLooseId<T> = (
     { [P in keyof T]?: StrictCondition<ApplyBasicQueryCasting<T[P]>>; } &
-    mongodb.RootFilterOperators<
-      { [P in keyof T]?: ApplyBasicQueryCasting<T[P]>; } &
-      { _id?: any; }
+    StrictRootFilterOperators<
+      { [P in keyof T]?: ApplyBasicQueryCasting<T[P]>; }
     >
   );
   type QueryFilter<T> = IsItRecordAndNotAny<T> extends true ? _QueryFilter<WithLevel1NestedPaths<T>> : _QueryFilterLooseId<Record<string, any>>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now providing an unknown query operator like `$wrong` passes in TypeScript, but throws a runtime error. 937eeb1 fixes a related issue where the error message is inconsistent for numbers vs other schematypes.

269afd9 updates it so Mongoose doesn't use MongoDB Node driver's `Condition` type, which intentionally allows string signature. Instead, we strip out the string signature so only known query operators are allowed. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
