### PR TITLE
types(populate): retain populated paths in toObject() and toJSON() unless depopulate: true set

### DIFF
--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -453,6 +453,37 @@ function gh14441() {
       ExpectType<string>(plainObject.children[0].name);
       const depopulatedObject = populatedDoc.toObject({ depopulate: true });
       ExpectType<Types.ObjectId>(depopulatedObject.children![0]);
+
+      const objectWithVirtuals = populatedDoc.toObject({ virtuals: true });
+      ExpectType<string>(objectWithVirtuals.children![0].name);
+
+      const objectWithFlattenObjectIds = populatedDoc.toObject({ flattenObjectIds: true });
+      ExpectType<string>(objectWithFlattenObjectIds.children![0].name);
+
+      const depopulatedAndFlattened = populatedDoc.toObject({ depopulate: true, flattenObjectIds: true });
+      ExpectType<string>(depopulatedAndFlattened.children![0]);
+
+      const jsonObject = populatedDoc.toJSON();
+      ExpectType<string>(jsonObject.children![0].name);
+      const jsonObjectWithVirtuals = populatedDoc.toJSON({ virtuals: true });
+      ExpectType<string>(jsonObjectWithVirtuals.children![0].name);
+      const jsonDepopulated = populatedDoc.toJSON({ depopulate: true });
+      ExpectType<Types.ObjectId>(jsonDepopulated.children![0]);
+
+      // Known limitation: structural wrappers that drop the marker lose the populated toObject() behavior.
+      const strippedMarkerDoc: Omit<typeof populatedDoc, keyof mongoose.PopulatedDocumentMarker<any, any>> =
+        populatedDoc;
+      const strippedMarkerObject = strippedMarkerDoc.toObject();
+      // @ts-expect-error Property 'name' does not exist on type 'ObjectId'
+      ExpectType<string>(strippedMarkerObject.children![0].name);
+
+      // Known limitation: generic helpers that erase the marker only see the base toObject() typing.
+      function toObjectWithBaseTyping<T extends Document<unknown, any, ArrayParent>>(input: T) {
+        return input.toObject();
+      }
+      const genericObject = toObjectWithBaseTyping(populatedDoc);
+      // Generic helper removed the populated behavior so we only get the raw ObjectId back.
+      ExpectType<Types.ObjectId>(genericObject.children![0]);
     });
 
   ArrayParentModel.findOne({})

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -420,6 +420,69 @@ function gh14441() {
       const docObject = docs[0]!.toObject();
       ExpectType<string>(docObject.child.name);
     });
+
+  interface ArrayParent {
+    children?: Types.ObjectId[];
+    title?: string;
+  }
+  const ArrayParentModel = model<ArrayParent>(
+    'ArrayParent',
+    new Schema({
+      title: String,
+      children: [{ type: Schema.Types.ObjectId, ref: 'Child' }]
+    })
+  );
+
+  type PopulatedChildren = {
+    children: mongoose.Types.DocumentArray<mongoose.HydratedDocFromModel<typeof ChildModel>>;
+  };
+
+  ArrayParentModel.findOne({})
+    .orFail()
+    .then(async doc => {
+      const populatedDoc = await doc.populate<PopulatedChildren>('children');
+
+      // Populating changes the path type from ObjectIds to documents, so the result should
+      // not be assignable back to the model's original hydrated type.
+      // @ts-expect-error Type 'PopulateDocumentResult<Document<unknown, {}, ArrayParent, {}, DefaultSchemaOptions> & ArrayParent...'
+      const hydratedDoc: mongoose.HydratedDocFromModel<typeof ArrayParentModel> = populatedDoc;
+      ExpectAssignable<Document<any>>()(populatedDoc);
+      ExpectAssignable<Document<unknown>>()(populatedDoc);
+      ExpectType<string | undefined>(populatedDoc.children[0]?.name);
+      const plainObject = populatedDoc.toObject();
+      ExpectType<string>(plainObject.children[0].name);
+      const depopulatedObject = populatedDoc.toObject({ depopulate: true });
+      ExpectType<Types.ObjectId>(depopulatedObject.children![0]);
+    });
+
+  ArrayParentModel.findOne({})
+    .populate<PopulatedChildren>('children')
+    .orFail()
+    .then(populatedDoc => {
+      ExpectAssignable<Document<any>>()(populatedDoc);
+      ExpectAssignable<Document<unknown>>()(populatedDoc);
+      ExpectType<string | undefined>(populatedDoc.children[0]?.name);
+      const plainObject = populatedDoc.toObject();
+      ExpectType<string>(plainObject.children[0].name);
+      const depopulatedObject = populatedDoc.toObject({ depopulate: true });
+      ExpectType<Types.ObjectId>(depopulatedObject.children![0]);
+    });
+
+  ArrayParentModel.findOne({})
+    .orFail()
+    .then(async doc => {
+      const populatedDoc = await ArrayParentModel.populate<PopulatedChildren>(doc, 'children');
+
+      // @ts-expect-error Type 'PopulateDocumentResult<Document<unknown, {}, ArrayParent, {}, DefaultSchemaOptions> & ArrayParent...'
+      const hydratedDoc: mongoose.HydratedDocFromModel<typeof ArrayParentModel> = populatedDoc;
+      ExpectAssignable<Document<any>>()(populatedDoc);
+      ExpectAssignable<Document<unknown>>()(populatedDoc);
+      ExpectType<string | undefined>(populatedDoc.children[0]?.name);
+      const plainObject = populatedDoc.toObject();
+      ExpectType<string>(plainObject.children[0].name);
+      const depopulatedObject = populatedDoc.toObject({ depopulate: true });
+      ExpectType<Types.ObjectId>(depopulatedObject.children![0]);
+    });
 }
 
 async function gh14574() {

--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -514,6 +514,42 @@ function gh14441() {
       const depopulatedObject = populatedDoc.toObject({ depopulate: true });
       ExpectType<Types.ObjectId>(depopulatedObject.children![0]);
     });
+
+  interface MultiPopulateParent {
+    firstChild?: Types.ObjectId;
+    secondChild?: Types.ObjectId;
+  }
+
+  const MultiPopulateParentModel = model<MultiPopulateParent>(
+    'MultiPopulateParent',
+    new Schema({
+      firstChild: { type: Schema.Types.ObjectId, ref: 'Child' },
+      secondChild: { type: Schema.Types.ObjectId, ref: 'Child' }
+    })
+  );
+
+  type PopulatedFirstChild = {
+    firstChild: mongoose.HydratedDocFromModel<typeof ChildModel>;
+  };
+
+  type PopulatedSecondChild = {
+    secondChild: mongoose.HydratedDocFromModel<typeof ChildModel>;
+  };
+
+  MultiPopulateParentModel.findOne({})
+    .populate<PopulatedFirstChild>('firstChild')
+    .populate<PopulatedSecondChild>('secondChild')
+    .orFail()
+    .then(populatedDoc => {
+      ExpectType<string | undefined>(populatedDoc.firstChild?.name);
+      ExpectType<string | undefined>(populatedDoc.secondChild?.name);
+      const plainObject = populatedDoc.toObject();
+      ExpectType<string>(plainObject.firstChild!.name);
+      ExpectType<string>(plainObject.secondChild!.name);
+      const depopulatedObject = populatedDoc.toObject({ depopulate: true });
+      ExpectType<Types.ObjectId>(depopulatedObject.firstChild!);
+      ExpectType<Types.ObjectId>(depopulatedObject.secondChild!);
+    });
 }
 
 async function gh14574() {

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -32,7 +32,7 @@ declare module 'mongoose' {
     _id: T;
 
     /** Assert that a given path or paths is populated. Throws an error if not populated. */
-    $assertPopulated<Paths = {}>(path: string | string[], values?: Partial<Paths>): PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType, TVirtuals, TSchemaOptions>;
+    $assertPopulated<Paths = {}>(path: string | string[], values?: Partial<Paths>): PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType>;
 
     /** Clear the document's modified paths. */
     $clearModifiedPaths(): this;
@@ -238,8 +238,8 @@ declare module 'mongoose' {
     $parent(): Document | undefined;
 
     /** Populates document references. */
-    populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType, TVirtuals, TSchemaOptions>>;
-    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType, TVirtuals, TSchemaOptions>>;
+    populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType>>;
+    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType>>;
 
     /** Gets _id(s) used during population of the given `path`. If the path was not populated, returns `undefined`. */
     populated(path: string): any;
@@ -262,11 +262,41 @@ declare module 'mongoose' {
     toBSON(): Require_id<DocType>;
 
     /** The return value of this method is used in calls to JSON.stringify(doc). */
+    toJSON<PopulatedRawDocType, DepopulatedRawDocType>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, DepopulatedRawDocType>,
+      options: { depopulate: true }
+    ): Default__v<Require_id<DepopulatedRawDocType>, TSchemaOptions>;
+    toJSON<PopulatedRawDocType, DepopulatedRawDocType, O extends ToObjectOptions & { depopulate: true }>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, DepopulatedRawDocType>,
+      options: O
+    ): ToObjectReturnType<DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+    toJSON<PopulatedRawDocType, O extends ToObjectOptions>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, any>,
+      options: O
+    ): ToObjectReturnType<PopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+    toJSON<PopulatedRawDocType>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, any>
+    ): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
     toJSON<O extends ToObjectOptions>(options: O): ToObjectReturnType<DocType, TVirtuals, O, TSchemaOptions>;
     toJSON(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
     toJSON<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
+    toObject<PopulatedRawDocType, DepopulatedRawDocType>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, DepopulatedRawDocType>,
+      options: { depopulate: true }
+    ): Default__v<Require_id<DepopulatedRawDocType>, TSchemaOptions>;
+    toObject<PopulatedRawDocType, DepopulatedRawDocType, O extends ToObjectOptions & { depopulate: true }>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, DepopulatedRawDocType>,
+      options: O
+    ): ToObjectReturnType<DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+    toObject<PopulatedRawDocType, O extends ToObjectOptions>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, any>,
+      options: O
+    ): ToObjectReturnType<PopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+    toObject<PopulatedRawDocType>(
+      this: PopulatedDocumentMarker<PopulatedRawDocType, any>
+    ): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
     toObject<O extends ToObjectOptions>(options: O): ToObjectReturnType<DocType, TVirtuals, O, TSchemaOptions>;
     toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
     toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -32,7 +32,7 @@ declare module 'mongoose' {
     _id: T;
 
     /** Assert that a given path or paths is populated. Throws an error if not populated. */
-    $assertPopulated<Paths = {}>(path: string | string[], values?: Partial<Paths>): Omit<this, keyof Paths> & Paths;
+    $assertPopulated<Paths = {}>(path: string | string[], values?: Partial<Paths>): PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType, TVirtuals, TSchemaOptions>;
 
     /** Clear the document's modified paths. */
     $clearModifiedPaths(): this;
@@ -238,8 +238,8 @@ declare module 'mongoose' {
     $parent(): Document | undefined;
 
     /** Populates document references. */
-    populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<MergeType<this, Paths>>;
-    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions): Promise<MergeType<this, Paths>>;
+    populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType, TVirtuals, TSchemaOptions>>;
+    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType, TVirtuals, TSchemaOptions>>;
 
     /** Gets _id(s) used during population of the given `path`. If the path was not populated, returns `undefined`. */
     populated(path: string): any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1088,6 +1088,9 @@ declare module 'mongoose' {
     // Handle DocumentArray - recurse into items
     : T extends Types.DocumentArray<infer ItemType>
       ? Types.DocumentArray<ApplyFlattenTransforms<ItemType, O>>
+    // Handle plain arrays - recurse into items
+    : T extends Array<infer ItemType>
+      ? ApplyFlattenTransforms<ItemType, O>[]
     // Handle Subdocument - recurse into subdoc type
     : T extends Types.Subdocument<unknown, unknown, infer SubdocType>
       ? HydratedSingleSubdocument<ApplyFlattenTransforms<SubdocType, O>>

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -628,10 +628,10 @@ declare module 'mongoose' {
     populate<Paths>(
       docs: Array<any>,
       options: PopulateOptions | Array<PopulateOptions> | string
-    ): Promise<Array<MergeType<THydratedDocumentType, Paths>>>;
+    ): Promise<Array<PopulateDocumentResult<THydratedDocumentType, Paths, PopulatedPathsDocumentType<TRawDocType, Paths>, TRawDocType, TVirtuals>>>;
     populate<Paths>(
       doc: any, options: PopulateOptions | Array<PopulateOptions> | string
-    ): Promise<MergeType<THydratedDocumentType, Paths>>;
+    ): Promise<PopulateDocumentResult<THydratedDocumentType, Paths, PopulatedPathsDocumentType<TRawDocType, Paths>, TRawDocType, TVirtuals>>;
 
     /**
      * Update an existing [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -628,10 +628,10 @@ declare module 'mongoose' {
     populate<Paths>(
       docs: Array<any>,
       options: PopulateOptions | Array<PopulateOptions> | string
-    ): Promise<Array<PopulateDocumentResult<THydratedDocumentType, Paths, PopulatedPathsDocumentType<TRawDocType, Paths>, TRawDocType, TVirtuals>>>;
+    ): Promise<Array<PopulateDocumentResult<THydratedDocumentType, Paths, PopulatedPathsDocumentType<TRawDocType, Paths>, TRawDocType>>>;
     populate<Paths>(
       doc: any, options: PopulateOptions | Array<PopulateOptions> | string
-    ): Promise<PopulateDocumentResult<THydratedDocumentType, Paths, PopulatedPathsDocumentType<TRawDocType, Paths>, TRawDocType, TVirtuals>>;
+    ): Promise<PopulateDocumentResult<THydratedDocumentType, Paths, PopulatedPathsDocumentType<TRawDocType, Paths>, TRawDocType>>;
 
     /**
      * Update an existing [Atlas search index](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -8,33 +8,49 @@ declare module 'mongoose' {
     RawId extends RefType = (PopulatedType extends { _id?: RefType; } ? NonNullable<PopulatedType['_id']> : Types.ObjectId) | undefined
   > = PopulatedType | RawId;
 
-  type PopulatedPathsDocumentType<RawDocType, Paths> = UnpackedIntersection<RawDocType, Paths>;
+  const mongoosePopulatedDocumentMarker: unique symbol;
 
-  type PopulatedPathsSerializationReturnType<
+  type ExtractDocumentObjectType<T> = T extends infer ObjectType & Document ? FlatRecord<ObjectType> : T;
+
+  type PopulatePathToRawDocType<T> =
+    T extends Types.DocumentArray<any, infer ItemType>
+      ? PopulatePathToRawDocType<ItemType>[]
+      : T extends Array<infer ItemType>
+        ? PopulatePathToRawDocType<ItemType>[]
+        : T extends Document
+          ? SubdocsToPOJOs<ExtractDocumentObjectType<T>>
+          : T extends Record<string, any>
+            ? { [K in keyof T]: PopulatePathToRawDocType<T[K]> }
+            : T;
+
+  type PopulatedPathsDocumentType<RawDocType, Paths> = UnpackedIntersection<RawDocType, PopulatePathToRawDocType<Paths>>;
+
+  type PopulatedDocumentMarker<
     PopulatedRawDocType,
     DepopulatedRawDocType,
-    TVirtuals,
-    O extends ToObjectOptions,
-    TSchemaOptions = {}
-  > = O extends { depopulate: true }
-    ? ToObjectReturnType<DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>
-    : ToObjectReturnType<PopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+  > = {
+    [mongoosePopulatedDocumentMarker]?: {
+      populated: PopulatedRawDocType,
+      depopulated: DepopulatedRawDocType
+    }
+  };
+
+  type ResolvePopulatedRawDocType<
+    ThisType,
+    FallbackRawDocType,
+    O = never
+  > = ThisType extends PopulatedDocumentMarker<infer PopulatedRawDocType, infer DepopulatedRawDocType>
+    ? O extends { depopulate: true }
+      ? DepopulatedRawDocType
+      : PopulatedRawDocType
+    : FallbackRawDocType;
 
   type PopulateDocumentResult<
     Doc,
     Paths,
     PopulatedRawDocType,
-    DepopulatedRawDocType = PopulatedRawDocType,
-    TVirtuals = {},
-    TSchemaOptions = {}
-  > = Omit<MergeType<Doc, Paths>, 'toJSON' | 'toObject'> & {
-      toJSON<O extends ToObjectOptions>(options: O): PopulatedPathsSerializationReturnType<PopulatedRawDocType, DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
-      toJSON(options?: ToObjectOptions): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
-      toJSON<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
-      toObject<O extends ToObjectOptions>(options: O): PopulatedPathsSerializationReturnType<PopulatedRawDocType, DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
-      toObject(options?: ToObjectOptions): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
-      toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
-    };
+    DepopulatedRawDocType = PopulatedRawDocType
+  > = MergeType<Doc, Paths> & PopulatedDocumentMarker<PopulatedRawDocType, DepopulatedRawDocType>;
 
   interface PopulateOptions {
     /** space delimited path(s) to populate */

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -8,6 +8,34 @@ declare module 'mongoose' {
     RawId extends RefType = (PopulatedType extends { _id?: RefType; } ? NonNullable<PopulatedType['_id']> : Types.ObjectId) | undefined
   > = PopulatedType | RawId;
 
+  type PopulatedPathsDocumentType<RawDocType, Paths> = UnpackedIntersection<RawDocType, Paths>;
+
+  type PopulatedPathsSerializationReturnType<
+    PopulatedRawDocType,
+    DepopulatedRawDocType,
+    TVirtuals,
+    O extends ToObjectOptions,
+    TSchemaOptions = {}
+  > = O extends { depopulate: true }
+    ? ToObjectReturnType<DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>
+    : ToObjectReturnType<PopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+
+  type PopulateDocumentResult<
+    Doc,
+    Paths,
+    PopulatedRawDocType,
+    DepopulatedRawDocType = PopulatedRawDocType,
+    TVirtuals = {},
+    TSchemaOptions = {}
+  > = Omit<MergeType<Doc, Paths>, 'toJSON' | 'toObject'> & {
+      toJSON<O extends ToObjectOptions>(options: O): PopulatedPathsSerializationReturnType<PopulatedRawDocType, DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+      toJSON(options?: ToObjectOptions): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
+      toJSON<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
+      toObject<O extends ToObjectOptions>(options: O): PopulatedPathsSerializationReturnType<PopulatedRawDocType, DepopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
+      toObject(options?: ToObjectOptions): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
+      toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
+    };
+
   interface PopulateOptions {
     /** space delimited path(s) to populate */
     path: string;

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -201,10 +201,22 @@ declare module 'mongoose' {
       ? ResultType
       : ResultType extends (infer U)[]
         ? U extends Document
-          ? HydratedDocument<MergeType<RawDocType, Paths>, TDocOverrides, TQueryHelpers>[]
+          ? PopulateDocumentResult<
+              HydratedDocument<MergeType<RawDocType, Paths>, TDocOverrides, TQueryHelpers>,
+              {},
+              MergeType<RawDocType, Paths>,
+              RawDocType,
+              TDocOverrides
+            >[]
           : (MergeType<U, Paths>)[]
         : ResultType extends Document
-          ? HydratedDocument<MergeType<RawDocType, Paths>, TDocOverrides, TQueryHelpers>
+          ? PopulateDocumentResult<
+              HydratedDocument<MergeType<RawDocType, Paths>, TDocOverrides, TQueryHelpers>,
+              {},
+              MergeType<RawDocType, Paths>,
+              RawDocType,
+              TDocOverrides
+            >
           : MergeType<ResultType, Paths>
     : MergeType<ResultType, Paths>;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -201,22 +201,10 @@ declare module 'mongoose' {
       ? ResultType
       : ResultType extends (infer U)[]
         ? U extends Document
-          ? PopulateDocumentResult<
-              HydratedDocument<MergeType<RawDocType, Paths>, TDocOverrides, TQueryHelpers>,
-              {},
-              MergeType<RawDocType, Paths>,
-              RawDocType,
-              TDocOverrides
-            >[]
+          ? PopulateDocumentResult<U, Paths, MergeType<RawDocType, Paths>, RawDocType>[]
           : (MergeType<U, Paths>)[]
         : ResultType extends Document
-          ? PopulateDocumentResult<
-              HydratedDocument<MergeType<RawDocType, Paths>, TDocOverrides, TQueryHelpers>,
-              {},
-              MergeType<RawDocType, Paths>,
-              RawDocType,
-              TDocOverrides
-            >
+          ? PopulateDocumentResult<ResultType, Paths, MergeType<RawDocType, Paths>, RawDocType>
           : MergeType<ResultType, Paths>
     : MergeType<ResultType, Paths>;
 


### PR DESCRIPTION
Fix #16085

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The populate typing fix now preserves populated path types through `toObject()` / `toJSON()` for document, query, and model `populate()` calls, while still returning the original raw path types for `toObject({ depopulate: true })`. 

The primary change is a new `PopulateDocumentResult` type that returns a document with a `mongoosePopulatedDocumentMarker` marker type that stores the populated type and depopulated type. I switched to using a marker for performance reasons - the previous type approach lead to too many instantiations and made our ts benchmark blow up. `toObject()` and `toJSON()` have overrides that detect `mongoosePopulatedDocumentMarker` on `this` and pull the types from the marker.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
