### PR TITLE
perf(projection): split by space instead of regex in parseProjection

### DIFF
--- a/lib/helpers/projection/parseProjection.js
+++ b/lib/helpers/projection/parseProjection.js
@@ -9,7 +9,7 @@ module.exports = function parseProjection(v, retainMinusPaths) {
   const type = typeof v;
 
   if (type === 'string') {
-    v = v.split(/\s+/);
+    v = v.split(' ');
   }
   if (!Array.isArray(v) && Object.prototype.toString.call(v) !== '[object Arguments]') {
     return v;


### PR DESCRIPTION
## Problem

`parseProjection` currently uses `v.split(/\s+/)` to split string projections. Splitting by regex is significantly slower than splitting by a plain string.

As noted in #16087, splitting by `' '` is ~5x faster than splitting by `/\s+/`.

## Solution

Changed `v.split(/\s+/)` to `v.split(' ')` in `parseProjection`.

This is a safe change because the existing `if (!field) continue` guard on line 22 already handles empty strings that may result from consecutive spaces. In practice, projection strings use regular spaces as delimiters, so there's no need to match tabs or other whitespace characters.

## Testing

All existing tests pass. Verified the following cases manually:

```js
parseProjection('name age email')       // { name: 1, age: 1, email: 1 }
parseProjection('name  age   email')    // { name: 1, age: 1, email: 1 } (consecutive spaces)
parseProjection(' name age ')           // { name: 1, age: 1 } (leading/trailing spaces)
parseProjection('-name age')            // { name: 0, age: 1 } (exclusion)
parseProjection('-name age', true)      // { '-name': 0, age: 1 } (retainMinusPaths)
```

Fixes #16087