### PR TITLE
fix(setDefaultsOnInsert): run setters on default values during upsert

### DIFF
--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -84,7 +84,7 @@ module.exports = function(filter, schema, castedDoc, options, queryMongooseOptio
     if (schemaType.path === '_id' && schemaType.options.auto) {
       return;
     }
-    const def = schemaType.getDefault(null, true, { context });
+    const def = schemaType.getDefault(null, false, { context });
     if (typeof def === 'undefined') {
       return;
     }

--- a/test/helpers/setDefaultsOnInsert.test.js
+++ b/test/helpers/setDefaultsOnInsert.test.js
@@ -107,6 +107,25 @@ describe('setDefaultsOnInsert', function() {
     assert.equal(update.$setOnInsert['referralConversion'], 'bar');
   });
 
+  it('runs setters on default values (gh-16051)', function() {
+    const schema = new Schema({
+      name: String,
+      slug: {
+        type: String,
+        default: 'Hello World!',
+        set: function(v) {
+          return v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+        }
+      }
+    });
+
+    const opts = { upsert: true, setDefaultsOnInsert: true };
+    let update = { $set: { name: 'test' } };
+    update = setDefaultsOnInsert({}, schema, update, opts);
+
+    assert.equal(update.$setOnInsert['slug'], 'hello-world');
+  });
+
   it('skips default if parent is $set (gh-12279)', function() {
     const SubscriptionsConfigSchema = Schema({
       hasPaidSubscription: { type: Boolean, required: true },

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -624,18 +624,14 @@ describe('model: updateOne:', function() {
 
     });
 
-    it('setDefaultsOnInsert does not run setters on default values (gh-16025)', async function() {
-      const setterContexts = [];
+    it('setDefaultsOnInsert runs setters on default values (gh-16051)', async function() {
       const schema = new Schema({
         name: String,
         slug: {
           type: String,
-          default: function() {
-            return this.get('name');
-          },
+          default: 'Hello World!',
           set: function(v) {
-            setterContexts.push(this);
-            return v;
+            return v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
           }
         }
       });
@@ -647,10 +643,8 @@ describe('model: updateOne:', function() {
         { upsert: true, setDefaultsOnInsert: true }
       );
 
-      assert.equal(setterContexts.length, 0);
-
       const doc = await Test.findOne({ name: 'foo' });
-      assert.equal(doc.slug, 'foo');
+      assert.equal(doc.slug, 'hello-world');
     });
 
     it('avoids nested paths if setting parent path (gh-4911)', function(done) {


### PR DESCRIPTION
## Problem

When using `setDefaultsOnInsert` with upsert operations, default values are not passed through setters. This means a schema like:

```js
const schema = new Schema({
  name: String,
  slug: {
    type: String,
    default: 'Hello World!',
    set: function(v) {
      return v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
    }
  }
});
```

will store `slug` as `'Hello World!'` when upserted, instead of `'hello-world'` (what you get with normal document creation).

## Root Cause

In `lib/helpers/setDefaultsOnInsert.js`, `schemaType.getDefault()` was called with `init = true`. This causes `_applySetters` to skip all setters, since `init` is meant to signal that the value is being initialized and shouldn't go through setter transformations.

## Solution

Changed `init` from `true` to `false` in the `getDefault()` call so setters run on default values, matching the behavior of normal document creation via `new Model()`.

Also updated the existing test from gh-16025 which was asserting the old (buggy) behavior, and added a unit test in `test/helpers/setDefaultsOnInsert.test.js`.

## How to Test

```js
const schema = new Schema({
  name: String,
  slug: {
    type: String,
    default: 'Hello World!',
    set: v => v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
  }
});
const Test = mongoose.model('Test', schema);

await Test.updateOne(
  { name: 'test' },
  { $set: { name: 'test' } },
  { upsert: true, setDefaultsOnInsert: true }
);

const doc = await Test.findOne({ name: 'test' });
assert.equal(doc.slug, 'hello-world'); // was 'Hello World!' before this fix
```

Fixes #16051