### PR TITLE
chore(aggregate): use MongooseError instead of Error

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -170,7 +170,7 @@ Aggregate.prototype.append = function() {
     : [...arguments];
 
   if (!args.every(isOperator)) {
-    throw new Error('Arguments must be aggregate pipeline operators');
+    throw new MongooseError('Arguments must be aggregate pipeline operators');
   }
 
   this._pipeline = this._pipeline.concat(args);
@@ -203,7 +203,7 @@ Aggregate.prototype.append = function() {
  */
 Aggregate.prototype.addFields = function(arg) {
   if (typeof arg !== 'object' || arg === null || Array.isArray(arg)) {
-    throw new Error('Invalid addFields() argument. Must be an object');
+    throw new MongooseError('Invalid addFields() argument. Must be an object');
   }
   return this.append({ $addFields: Object.assign({}, arg) });
 };
@@ -259,7 +259,7 @@ Aggregate.prototype.project = function(arg) {
       fields[field] = include;
     });
   } else {
-    throw new Error('Invalid project() argument. Must be string or object');
+    throw new MongooseError('Invalid project() argument. Must be string or object');
   }
 
   return this.append({ $project: fields });
@@ -462,7 +462,7 @@ Aggregate.prototype.unwind = function() {
         $unwind: (arg[0] === '$') ? arg : '$' + arg
       });
     } else {
-      throw new Error('Invalid arg "' + arg + '" to unwind(), ' +
+      throw new MongooseError('Invalid arg "' + arg + '" to unwind(), ' +
         'must be string or object');
     }
   }
@@ -761,7 +761,7 @@ Aggregate.prototype.redact = function(expression, thenExpr, elseExpr) {
   if (arguments.length === 3) {
     if ((typeof thenExpr === 'string' && !validRedactStringValues.has(thenExpr)) ||
       (typeof elseExpr === 'string' && !validRedactStringValues.has(elseExpr))) {
-      throw new Error('If thenExpr or elseExpr is string, it must be either $$DESCEND, $$PRUNE or $$KEEP');
+      throw new MongooseError('If thenExpr or elseExpr is string, it must be either $$DESCEND, $$PRUNE or $$KEEP');
     }
 
     expression = {
@@ -796,7 +796,7 @@ Aggregate.prototype.explain = async function explain(verbosity) {
   const model = this._model;
 
   if (!this._pipeline.length) {
-    throw new Error('Aggregate has empty pipeline');
+    throw new MongooseError('Aggregate has empty pipeline');
   }
 
   prepareDiscriminatorPipeline(this._pipeline, this._model.schema);
@@ -1058,7 +1058,7 @@ Aggregate.prototype.pipelineForUnionWith = function pipelineForUnionWith() {
 
 Aggregate.prototype.exec = async function exec() {
   if (!this._model && !this._connection) {
-    throw new Error('Aggregate not bound to any Model');
+    throw new MongooseError('Aggregate not bound to any Model');
   }
   if (typeof arguments[0] === 'function') {
     throw new MongooseError('Aggregate.prototype.exec() no longer accepts a callback');


### PR DESCRIPTION
## Summary

Replaces 7 instances of `throw new Error(...)` with `throw new MongooseError(...)` in `lib/aggregate.js` as part of the effort to standardize error types across the codebase.

`MongooseError` extends `Error`, so this is backward-compatible for any code catching generic `Error` instances.

### Changed methods:
- `append()` — invalid pipeline operator
- `addFields()` — invalid argument type
- `project()` — invalid argument type
- `unwind()` — invalid argument type
- `redact()` — invalid thenExpr/elseExpr value
- `explain()` — empty pipeline
- `exec()` — aggregate not bound to model

## Testing

All 118 aggregate-related tests pass. Verified that thrown errors are `instanceof MongooseError` and still `instanceof Error`.

Re: #15995