### PR TITLE
chore(model): use MongooseError instead of Error

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -189,7 +189,7 @@ Model.prototype.db;
 
 Model.useConnection = function useConnection(connection) {
   if (!connection) {
-    throw new Error('Please provide a connection.');
+    throw new MongooseError('Please provide a connection.');
   }
   if (this.db) {
     delete this.db.models[this.modelName];
@@ -824,7 +824,7 @@ Model.prototype.deleteOne = function deleteOne(options) {
     // `self` is passed to pre hooks as argument for backwards compatibility, but that
     // isn't the actual arguments passed to the wrapped function.
     if (res[0] !== self || res[1] !== options) {
-      throw new Error('Document deleteOne pre hooks cannot overwrite arguments');
+      throw new MongooseError('Document deleteOne pre hooks cannot overwrite arguments');
     }
     query.deleteOne(where, options);
     // Apply custom where conditions _after_ document deleteOne middleware for
@@ -3609,7 +3609,7 @@ async function buildPreSavePromise(document, options) {
   const preFilter = buildMiddlewareFilter(options, 'pre');
   const [newOptions] = await document.schema.s.hooks.execPre('save', document, [options], { filter: preFilter });
   if (newOptions !== options) {
-    throw new Error('Cannot overwrite options in pre("save") hook on bulkSave()');
+    throw new MongooseError('Cannot overwrite options in pre("save") hook on bulkSave()');
   }
 }
 
@@ -3849,7 +3849,7 @@ Model.castObject = function castObject(obj, options) {
 
 Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, options) {
   if (!Array.isArray(documents)) {
-    throw new Error(`bulkSave expects an array of documents to be passed, received \`${documents}\` instead`);
+    throw new MongooseError(`bulkSave expects an array of documents to be passed, received \`${documents}\` instead`);
   }
 
   setDefaultOptions();
@@ -3857,7 +3857,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
   const writeOperations = documents.map((document, i) => {
     if (!options.skipValidation) {
       if (!(document instanceof Document)) {
-        throw new Error(`documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`);
+        throw new MongooseError(`documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`);
       }
       if (options.validateBeforeSave == null || options.validateBeforeSave) {
         const err = document.validateSync();
@@ -4947,7 +4947,7 @@ Model.compile = function compile(name, schema, collectionName, connection, base)
 Model.clientEncryption = function clientEncryption() {
   const ClientEncryption = this.base.driver.get().ClientEncryption;
   if (!ClientEncryption) {
-    throw new Error('The mongodb driver must be used to obtain a ClientEncryption object.');
+    throw new MongooseError('The mongodb driver must be used to obtain a ClientEncryption object.');
   }
 
   const client = this.collection?.conn?.client;


### PR DESCRIPTION
## Summary

Replaces 6 instances of `throw new Error(...)` with `throw new MongooseError(...)` in `lib/model.js` as part of the effort to standardize error types across the codebase.

### Changed locations:
- `useConnection()` — missing connection argument
- `deleteOne()` — pre hook argument overwrite
- `buildPreSavePromise()` — pre save hook option overwrite in bulkSave
- `buildBulkWriteOperations()` — invalid documents argument (2 instances)
- `clientEncryption()` — missing ClientEncryption in driver

`MongooseError` extends `Error`, so this is fully backward-compatible.

## Testing

All 777 model-related tests pass.

Re: #15995