### PR TITLE
replace ms with ms-tiny

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@
  */
 
 const UUID = require('mongodb/lib/bson').UUID;
-const ms = require('ms');
+const ms = require('ms-tiny');
 const mpath = require('mpath');
 const ObjectId = require('./types/objectid');
 const PopulateOptions = require('./options/populateOptions');
@@ -533,9 +533,17 @@ exports.expires = function expires(object) {
     return;
   }
 
-  object.expireAfterSeconds = (typeof object.expires !== 'string')
-    ? object.expires
-    : Math.round(ms(object.expires) / 1000);
+  let expireAfterSeconds;
+  if (typeof object.expires !== 'string') {
+    expireAfterSeconds = object.expires;
+  } else {
+    try {
+      expireAfterSeconds = Math.round(ms(object.expires) / 1000);
+    } catch {
+      expireAfterSeconds = NaN;
+    }
+  }
+  object.expireAfterSeconds = expireAfterSeconds;
   delete object.expires;
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mongodb": "~7.1",
     "mpath": "0.9.0",
     "mquery": "6.0.0",
-    "ms": "2.1.3",
+    "ms-tiny": "^1.1.0",
     "sift": "17.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
ms has no TypeScript types and no ESM exports.

ms-tiny has the same API, ships ESM + CJS with built-in types. 833 bytes gzipped, zero deps.

One behavioral difference: ms-tiny throws on invalid input instead of returning undefined. Added try-catch where needed to preserve existing behavior.

https://npmgraph.js.org/?q=ms-tiny