### PR TITLE
types(schema): infer schema options correctly for model context in statics

### DIFF
--- a/test/types/schema.create.test.ts
+++ b/test/types/schema.create.test.ts
@@ -2017,3 +2017,21 @@ function gh16046() {
   (new IssueTwo()).myMethod();
   IssueTwo.myStaticMethod();
 }
+
+function gh16046VersionKeyFalse() {
+  const mySchema = Schema.create(
+    { name: { type: String, required: true } },
+    {
+      versionKey: false,
+      statics: {
+        testMe: function() {
+          ExpectType<string>(this.modelName);
+        }
+      }
+    }
+  );
+
+  const MyModel = model('TestCreate', mySchema);
+
+  MyModel.testMe();
+}

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -2238,6 +2238,24 @@ function gh16046() {
   IssueTwo.myStaticMethod();
 }
 
+function gh16046VersionKeyFalse() {
+  const mySchema = new Schema(
+    { name: { type: String, required: true } },
+    {
+      versionKey: false,
+      statics: {
+        testMe: function() {
+          ExpectType<string>(this.modelName);
+        }
+      }
+    }
+  );
+
+  const MyModel = model('Test', mySchema);
+
+  MyModel.testMe();
+}
+
 function gh16045() {
   const circleSchema = new Schema({
     kind: { type: String, enum: ['Circle'] },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -379,7 +379,12 @@ declare module 'mongoose' {
       >,
       TMethods = TSchemaOptions extends { methods: infer M } ? { [K in keyof M]: OmitThisParameter<M[K]> } : {},
       TStatics = TSchemaOptions extends { statics: infer S } ? { [K in keyof S]: OmitThisParameter<S[K]> } : {}
-    >(def: TSchemaDefinition, options: TSchemaOptions): Schema<
+    >(def: TSchemaDefinition, options: TSchemaOptions & {
+      statics?: SchemaOptionsStaticsPropertyType<
+        TStatics,
+        Model<RawDocType>
+      >
+    }): Schema<
       RawDocType,
       Model<RawDocType, any, any, any>,
       TMethods,

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -7,6 +7,13 @@ declare module 'mongoose' {
     currentTime?: () => (NativeDate | number);
   }
 
+  type SchemaOptionsStaticsPropertyType<TStaticMethods, TModelType> = IfEquals<
+    TStaticMethods,
+    {},
+    Record<string, (...args: any[]) => unknown> & ThisType<TModelType>,
+    { [K in keyof TStaticMethods]: OmitThisParameter<TStaticMethods[K]> } & ThisType<TModelType>
+  >;
+
   type TypeKeyBaseType = string;
 
   type DefaultTypeKey = 'type';
@@ -222,12 +229,7 @@ declare module 'mongoose' {
     /**
      * Model Statics methods.
      */
-    statics?: IfEquals<
-      TStaticMethods,
-      {},
-      { [name: string]: (this: TModelType, ...args: any[]) => unknown },
-      AddThisParameter<TStaticMethods, TModelType>
-    >
+    statics?: SchemaOptionsStaticsPropertyType<TStaticMethods, TModelType>
 
     /**
      * Document instance methods.


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix #16046 

This PR fixes a lingering error where statics would fail to compile if `versionKey: false` was set due to the static having incorrect Model without `versionKey: false` as `this`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
