### PR TITLE
fix: validate connection instance in Model.useConnection() (#16098)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -6,6 +6,7 @@
 
 const Aggregate = require('./aggregate');
 const ChangeStream = require('./cursor/changeStream');
+const Connection = require('./connection');
 const Document = require('./document');
 const DocumentNotFoundError = require('./error/notFound');
 const EventEmitter = require('events').EventEmitter;
@@ -191,6 +192,9 @@ Model.prototype.db;
 Model.useConnection = function useConnection(connection) {
   if (!connection) {
     throw new MongooseError('Please provide a connection.');
+  }
+  if (!(connection instanceof Connection)) {
+    throw new MongooseError('`connection` must be an instance of mongoose.Connection, got "' + typeof connection + '" with value "' + connection + '"');
   }
   if (this.db) {
     delete this.db.models[this.modelName];

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9177,8 +9177,29 @@ describe('Model', function() {
         Model.useConnection();
       }, { message: 'Please provide a connection.' });
     });
-  });
+    it('should throw if passed a non-Connection value (gh-16098)', function() {
+      const schema = new mongoose.Schema({ name: String });
+      const Model = db.model('TestUseConnectionValidation', schema);
 
+      assert.throws(
+        () => Model.useConnection({ not: 'a connection' }),
+        /must be an instance of mongoose\.Connection/
+      );
+      assert.throws(
+        () => Model.useConnection('not a connection'),
+        /must be an instance of mongoose\.Connection/
+      );
+      assert.throws(
+        () => Model.useConnection(42),
+        /must be an instance of mongoose\.Connection/
+      );
+      assert.throws(
+        () => Model.useConnection(null),
+        /Please provide a connection/
+      );
+    });
+  });
+  
   it('insertMany should throw an error if there were operations that failed validation, ' +
       'but all operations that passed validation succeeded (gh-13256)', async function() {
     const userSchema = new Schema({


### PR DESCRIPTION
## Problem

`Model.useConnection()` only validated that the `connection` argument was 
not `null` or `undefined`, but accepted any non-nullish value (plain objects, 
strings, numbers, etc.) without throwing an error. This led to confusing 
failures later in the code rather than a clear error at the call site.

## Solution

Added an `instanceof Connection` check immediately after the existing null 
check in `lib/model.js`. If a non-Connection value is passed, a descriptive 
`MongooseError` is thrown with the type and value of the invalid argument.

## Changes

- `lib/model.js` — added `instanceof Connection` validation in 
  `Model.useConnection()` with a clear error message
- `test/model.test.js` — added test case inside the existing 
  `describe('Model.useConnection()')` block covering objects, 
  strings, numbers, and null

## Test
```js
assert.throws(
  () => Model.useConnection({ not: 'a connection' }),
  /must be an instance of mongoose\.Connection/
);
```

Fixes #16098