### PR TITLE
Fix wrong this context in QueryCursor._read cursor close callback

### DIFF
--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -132,7 +132,7 @@ QueryCursor.prototype._read = function() {
     }
     if (!doc) {
       this.push(null);
-      this.cursor.close(function(error) {
+      this.cursor.close((error) => {
         if (error) {
           return this.emit('error', error);
         }


### PR DESCRIPTION
## Fix wrong `this` context in `QueryCursor._read` cursor close callback

**Problem:**
In `QueryCursor.prototype._read`, the `cursor.close()` callback used a regular `function`, causing `this` to be `undefined`. This meant any error during cursor close would fail silently instead of being emitted on the QueryCursor instance.

**Fix:**
Changed the regular `function` to an arrow function so `this` correctly refers to the QueryCursor instance - consistent with how `AggregationCursor._read` already handles it.

```js
// Before
this.cursor.close(function(error) {
  if (error) {
    return this.emit('error', error); // `this` is wrong here
  }
});

// After
this.cursor.close((error) => {
  if (error) {
    return this.emit('error', error); // `this` correctly refers to QueryCursor
  }
});
```

**Note:** `AggregationCursor._read` already handles this correctly using `_this`. This PR makes `QueryCursor` consistent with that pattern.