### PR TITLE
feat(document): add $getChanges() alias, deprecate getChanges()

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4908,22 +4908,42 @@ Document.prototype.$__fullPath = function(path) {
  *     });
  *
  *     // returns an empty object, no changes happened yet
- *     user.getChanges(); // { }
+ *     user.$getChanges(); // { }
  *
  *     user.country = undefined;
  *     user.age = 26;
  *
- *     user.getChanges(); // { $set: { age: 26 }, { $unset: { country: 1 } } }
+ *     user.$getChanges(); // { $set: { age: 26 }, { $unset: { country: 1 } } }
  *
  *     await user.save();
  *
- *     user.getChanges(); // { }
+ *     user.$getChanges(); // { }
  *
- * Modifying the object that `getChanges()` returns does not affect the document's
- * change tracking state. Even if you `delete user.getChanges().$set`, Mongoose
+ * Modifying the object that `$getChanges()` returns does not affect the document's
+ * change tracking state. Even if you `delete user.$getChanges().$set`, Mongoose
  * will still send a `$set` to the server.
  *
  * @return {Object}
+ * @api public
+ * @method $getChanges
+ * @memberOf Document
+ * @instance
+ */
+
+Document.prototype.$getChanges = function() {
+  const delta = this.$__delta();
+  const changes = delta ? delta[1] : {};
+  return changes;
+};
+
+/**
+ * **Deprecated.** Use `$getChanges()` instead.
+ *
+ * Returns the changes that happened to the document
+ * in the format that will be sent to MongoDB.
+ *
+ * @return {Object}
+ * @deprecated Use `$getChanges()` instead. `getChanges` does not use the `$` prefix convention and may conflict with user-defined schema methods/properties.
  * @api public
  * @method getChanges
  * @memberOf Document
@@ -4931,9 +4951,8 @@ Document.prototype.$__fullPath = function(path) {
  */
 
 Document.prototype.getChanges = function() {
-  const delta = this.$__delta();
-  const changes = delta ? delta[1] : {};
-  return changes;
+  utils.warn('`getChanges()` is deprecated, use `$getChanges()` instead.');
+  return this.$getChanges();
 };
 
 /**

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -164,6 +164,13 @@ declare module 'mongoose' {
      * Returns the changes that happened to the document
      * in the format that will be sent to MongoDB.
      */
+    $getChanges(): UpdateQuery<this>;
+
+    /**
+     * Returns the changes that happened to the document
+     * in the format that will be sent to MongoDB.
+     * @deprecated Use `$getChanges()` instead.
+     */
     getChanges(): UpdateQuery<this>;
 
     /** Signal that we desire an increment of this documents version. */


### PR DESCRIPTION
Closes #15959

Hey! This PR adds `$getChanges()` as the preferred way to get pending document changes, and deprecates the old `getChanges()` with a `process.emitWarning`.

**Why?**

Right now `getChanges` sits on the document prototype without the `$` prefix, which means if someone defines a schema method or virtual called `getChanges`, it just gets silently overridden. That's confusing and hard to debug. The `$` prefix convention exists exactly to avoid this kind of collision.

**What changed:**

- `$getChanges()` — new primary method, same logic that `getChanges()` had before
- `getChanges()` — still works, but now delegates to `$getChanges()` and fires a deprecation warning via `utils.warn()` (which uses `process.emitWarning`)
- Updated TypeScript types — added `$getChanges()` and marked `getChanges()` with `@deprecated`

**Backward compat:**

Nothing breaks. `getChanges()` still works the same way, it just warns you to switch over. The warning only fires once per process thanks to how Node handles `emitWarning` with the same message.

As mentioned in the issue, this could be a first step before a full rename or removal of other non-prefixed internal methods in a future major version.