### PR TITLE
fix(model): use duck-typing with version check to validate the argument to useConnection() is actually a connection

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -193,7 +193,7 @@ Model.useConnection = function useConnection(connection) {
     throw new MongooseError('`useConnection()` requires a Mongoose connection.');
   }
   if (this.db.base?.version && this.db.base?.version !== connection.base?.version) {
-    throw new MongooseError('The connection passed to `useConnection()` has a different version of Mongoose than the model you are using.');
+    throw new MongooseError(`The connection passed to \`useConnection()\` has a different version of Mongoose (${connection.base?.version}) than the model you are using (${this.db.base?.version}).`);
   }
   if (this.db) {
     delete this.db.models[this.modelName];

--- a/lib/model.js
+++ b/lib/model.js
@@ -189,7 +189,7 @@ Model.prototype.db;
  */
 
 Model.useConnection = function useConnection(connection) {
-  if (!connection || typeof connection.model !== 'function' || typeof connection.collection !== 'function') {
+  if (typeof connection?.model !== 'function' || typeof connection.collection !== 'function') {
     throw new MongooseError('`useConnection()` requires a Mongoose connection.');
   }
   if (this.db.base?.version && this.db.base?.version !== connection.base?.version) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -189,7 +189,7 @@ Model.prototype.db;
  */
 
 Model.useConnection = function useConnection(connection) {
-  if (typeof connection?.model !== 'function' || typeof connection.collection !== 'function') {
+  if (typeof connection?.model !== 'function' || typeof connection.collection !== 'function' || typeof connection.base?.version !== 'string') {
     throw new MongooseError('`useConnection()` requires a Mongoose connection.');
   }
   if (this.db.base?.version && this.db.base?.version !== connection.base?.version) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -189,8 +189,11 @@ Model.prototype.db;
  */
 
 Model.useConnection = function useConnection(connection) {
-  if (!connection) {
-    throw new MongooseError('Please provide a connection.');
+  if (!connection || typeof connection.model !== 'function' || typeof connection.collection !== 'function') {
+    throw new MongooseError('`useConnection()` requires a Mongoose connection.');
+  }
+  if (this.db.base?.version && this.db.base?.version !== connection.base?.version) {
+    throw new MongooseError('The connection passed to `useConnection()` has a different version of Mongoose than the model you are using.');
   }
   if (this.db) {
     delete this.db.models[this.modelName];

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9197,7 +9197,7 @@ describe('Model', function() {
       );
     });
 
-    it('should throw a MongooseError if mismatched Mongoose version (gh-16098)', async function() {
+    it('should throw a MongooseError if mismatched Mongoose version (gh-16098)', function() {
       const schema = new mongoose.Schema({ name: String });
       const m = new mongoose.Mongoose();
       m.version = 'not a valid version';

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9188,7 +9188,7 @@ describe('Model', function() {
       );
     });
 
-    it('should throw a MongooseError if null is passed (gh-16098)', async function() {
+    it('should throw a MongooseError if null is passed (gh-16098)', function() {
       const schema = new mongoose.Schema({ name: String });
       const Model = db.model('Test', schema);
       assert.throws(

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9173,9 +9173,42 @@ describe('Model', function() {
         name: String
       });
       const Model = db.model('Test', schema);
-      assert.throws(() => {
-        Model.useConnection();
-      }, { message: 'Please provide a connection.' });
+      assert.throws(
+        () => Model.useConnection(),
+        { name: 'MongooseError', message: '`useConnection()` requires a Mongoose connection.' }
+      );
+    });
+
+    it('should throw a MongooseError if a non-connection object is passed (gh-16098)', async function() {
+      const schema = new mongoose.Schema({ name: String });
+      const Model = db.model('Test', schema);
+      assert.throws(
+        () => Model.useConnection({}),
+        { name: 'MongooseError', message: '`useConnection()` requires a Mongoose connection.' }
+      );
+    });
+
+    it('should throw a MongooseError if null is passed (gh-16098)', async function() {
+      const schema = new mongoose.Schema({ name: String });
+      const Model = db.model('Test', schema);
+      assert.throws(
+        () => Model.useConnection(null),
+        { name: 'MongooseError', message: '`useConnection()` requires a Mongoose connection.' }
+      );
+    });
+
+    it('should throw a MongooseError if mismatched Mongoose version (gh-16098)', async function() {
+      const schema = new mongoose.Schema({ name: String });
+      const m = new mongoose.Mongoose();
+      m.version = 'not a valid version';
+      const Model = db.model('Test', schema);
+      assert.throws(
+        () => Model.useConnection(m.connection),
+        {
+          name: 'MongooseError',
+          message: 'The connection passed to `useConnection()` has a different version of Mongoose than the model you are using.'
+        }
+      );
     });
   });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9200,13 +9200,13 @@ describe('Model', function() {
     it('should throw a MongooseError if mismatched Mongoose version (gh-16098)', function() {
       const schema = new mongoose.Schema({ name: String });
       const m = new mongoose.Mongoose();
-      m.version = 'not a valid version';
+      m.version = '0.0.7';
       const Model = db.model('Test', schema);
       assert.throws(
         () => Model.useConnection(m.connection),
         {
           name: 'MongooseError',
-          message: 'The connection passed to `useConnection()` has a different version of Mongoose than the model you are using.'
+          message: `The connection passed to \`useConnection()\` has a different version of Mongoose (0.0.7) than the model you are using (${mongoose.version}).`
         }
       );
     });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -9179,7 +9179,7 @@ describe('Model', function() {
       );
     });
 
-    it('should throw a MongooseError if a non-connection object is passed (gh-16098)', async function() {
+    it('should throw a MongooseError if a non-connection object is passed (gh-16098)', function() {
       const schema = new mongoose.Schema({ name: String });
       const Model = db.model('Test', schema);
       assert.throws(


### PR DESCRIPTION
Fix #16098

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Throw an error if the argument to `useConnection()` doesn't have `model()` and `collection()` functions - sufficient to avoid many common potentially incorrect arguments. Also check that the version is an exact match. This avoids erroring out in the case of multiple Mongoose modules presuming the versions line up exactly. We do not want to support mixed versions - using a connection from version 8.1.4 with a model from version 8.2.1 is not something we can reasonably write tests for.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
