### PR TITLE
perf(document+model): avoid parallel save error instantiation, simplify resetting atomics, streamline validation and collection handling

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2981,7 +2981,37 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
       // Skip $* paths - they represent map schemas, not actual document paths
       return;
     }
+
+    const _pathType = doc.$__schema.path(p);
+
+    // Optimization: if primitive path with no validators, or array of primitives
+    // with no validators, skip validating this path entirely.
+    // Note: paths with no _pathType (e.g. sub-paths under Mixed) must still be
+    // added, as they trigger validation of the parent Mixed path.
+    if (_pathType) {
+      if (!_pathType.schema &&
+        !_pathType.embeddedSchemaType &&
+        _pathType.validators.length === 0 &&
+        !_pathType.$parentSchemaDocArray &&
+        // gh-15957: skip this optimization for SchemaMap as maps can contain subdocuments
+        // that need validation even if the map itself has no validators
+        !_pathType.$isSchemaMap) {
+        return;
+      } else if (_pathType.$isMongooseArray &&
+        !_pathType.$isMongooseDocumentArray && // Skip document arrays...
+        !_pathType.embeddedSchemaType.$isMongooseArray && // and arrays of arrays
+        _pathType.validators.length === 0 && // and arrays with top-level validators
+        _pathType.embeddedSchemaType.validators.length === 0) {
+        return;
+      }
+    }
+
     paths.add(p);
+  }
+
+  const onlyPrimitiveValues = doc.$__hasOnlyPrimitiveValues();
+  if (onlyPrimitiveValues && paths.size === 0) {
+    return [[], doValidateOptions];
   }
 
   if (!isNestedValidate) {
@@ -3048,36 +3078,16 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
     }
   }
 
-  for (const path of paths) {
-    const _pathType = doc.$__schema.path(path);
-    if (!_pathType) {
-      continue;
-    }
-
-    if (_pathType.$isMongooseDocumentArray) {
-      for (const p of paths) {
-        if (p == null || p.startsWith(_pathType.path + '.')) {
-          paths.delete(p);
+  if (!onlyPrimitiveValues) {
+    for (const path of paths) {
+      const _pathType = doc.$__schema.path(path);
+      if (_pathType && _pathType.$isMongooseDocumentArray) {
+        for (const p of paths) {
+          if (p == null || p.startsWith(_pathType.path + '.')) {
+            paths.delete(p);
+          }
         }
       }
-    }
-
-    // Optimization: if primitive path with no validators, or array of primitives
-    // with no validators, skip validating this path entirely.
-    if (!_pathType.schema &&
-      !_pathType.embeddedSchemaType &&
-      _pathType.validators.length === 0 &&
-      !_pathType.$parentSchemaDocArray &&
-      // gh-15957: skip this optimization for SchemaMap as maps can contain subdocuments
-      // that need validation even if the map itself has no validators
-      !_pathType.$isSchemaMap) {
-      paths.delete(path);
-    } else if (_pathType.$isMongooseArray &&
-      !_pathType.$isMongooseDocumentArray && // Skip document arrays...
-      !_pathType.embeddedSchemaType.$isMongooseArray && // and arrays of arrays
-      _pathType.validators.length === 0 && // and arrays with top-level validators
-      _pathType.embeddedSchemaType.validators.length === 0) {
-      paths.delete(path);
     }
   }
 
@@ -3595,25 +3605,21 @@ Document.prototype.$isValid = function(path) {
 Document.prototype.$__reset = function reset() {
   let _this = this;
 
-  // Skip for subdocuments
-  const subdocs = !this.$isSubdocument ? this.$getAllSubdocs({ useCache: true }) : null;
+  const onlyPrimitiveValues = this.$__hasOnlyPrimitiveValues();
+
+  // Skip for subdocuments. Also skip if doc only has primitive values,
+  // because primitives can't be subdocs.
+  const subdocs = !this.$isSubdocument && !onlyPrimitiveValues ? this.$getAllSubdocs({ useCache: true }) : null;
   if (subdocs?.length > 0) {
     for (const subdoc of subdocs) {
       subdoc.$__reset();
     }
   }
 
-  // clear atomics
-  this.$__dirty().forEach(function(dirt) {
-    const type = dirt.value;
-
-    if (type && typeof type.clearAtomics === 'function') {
-      type.clearAtomics();
-    } else if (type && type[arrayAtomicsSymbol]) {
-      type[arrayAtomicsBackupSymbol] = type[arrayAtomicsSymbol];
-      type[arrayAtomicsSymbol] = {};
-    }
-  });
+  // Clear atomics on dirty paths. Walk the modified and default paths
+  // directly instead of calling $__dirty(), which builds intermediate
+  // arrays, a Map, and does parent-path deduplication we don't need here.
+  this.$__resetAtomics();
 
   this.$__.backup = {};
   this.$__.backup.activePaths = {
@@ -3635,6 +3641,40 @@ Document.prototype.$__reset = function reset() {
 
   return this;
 };
+
+/*!
+ * Clear atomics on all dirty (modified + default) paths. This is a lighter
+ * alternative to calling `$__dirty()` when we only need to clear atomics
+ * and don't need the full {path, value, schema} objects or parent-path
+ * deduplication.
+ */
+
+Document.prototype.$__resetAtomics = function $__resetAtomics() {
+  const activePaths = this.$__.activePaths;
+  const modifyPaths = activePaths.getStatePaths('modify');
+  const defaultPaths = activePaths.getStatePaths('default');
+
+  _clearAtomicsOnPaths(this, modifyPaths);
+  _clearAtomicsOnPaths(this, defaultPaths);
+};
+
+function _clearAtomicsOnPaths(doc, paths) {
+  if (paths == null) {
+    return;
+  }
+  const keys = Object.keys(paths);
+  for (let i = 0; i < keys.length; ++i) {
+    const type = doc.$__getValue(keys[i]);
+    if (type != null) {
+      if (typeof type.clearAtomics === 'function') {
+        type.clearAtomics();
+      } else if (type[arrayAtomicsSymbol]) {
+        type[arrayAtomicsBackupSymbol] = type[arrayAtomicsSymbol];
+        type[arrayAtomicsSymbol] = {};
+      }
+    }
+  }
+}
 
 /*!
  * ignore

--- a/lib/drivers/node-mongodb-native/collection.js
+++ b/lib/drivers/node-mongodb-native/collection.js
@@ -89,12 +89,11 @@ NativeCollection.prototype._getCollection = function _getCollection() {
 function iter(i) {
   NativeCollection.prototype[i] = function() {
     const collection = this._getCollection();
-    const args = Array.from(arguments);
+    const args = arguments;
     const _this = this;
     const globalDebug = _this?.conn?.base?.options?.debug;
     const connectionDebug = _this?.conn?.options?.debug;
     const debug = connectionDebug == null ? globalDebug : connectionDebug;
-    const opId = new ObjectId();
 
     // If user force closed, queueing will hang forever. See #5664
     if (this.conn.$wasForceClosed) {
@@ -108,9 +107,21 @@ function iter(i) {
       }
     }
 
+    // Lazily generate opId and argsArray only if necessary because they have
+    // a non-trivial performance cost.
+    let opId = null;
+    let argsArray = null;
+    const hasOperationListeners = this.conn.listenerCount('operation-start') > 0 || this.conn.listenerCount('operation-end') > 0;
+    if (hasOperationListeners || debug) {
+      opId = new ObjectId();
+    }
+
     let timeout = null;
     let waitForBufferPromise = null;
     if (this._shouldBufferCommands() && this.buffer) {
+      if (opId == null) {
+        opId = new ObjectId();
+      }
       this.conn.emit('buffer', {
         _id: opId,
         modelName: _this.modelName,
@@ -145,11 +156,14 @@ function iter(i) {
 
     if (debug) {
       if (typeof debug === 'function') {
+        if (argsArray == null) {
+          argsArray = Array.from(args);
+        }
         let argsToAdd = null;
-        if (typeof args[args.length - 1] == 'function') {
-          argsToAdd = args.slice(0, args.length - 1);
+        if (typeof argsArray[argsArray.length - 1] == 'function') {
+          argsToAdd = argsArray.slice(0, argsArray.length - 1);
         } else {
-          argsToAdd = args;
+          argsToAdd = argsArray;
         }
         debug.apply(_this,
           [_this.name, i].concat(argsToAdd));
@@ -162,7 +176,12 @@ function iter(i) {
       }
     }
 
-    this.conn.emit('operation-start', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, params: args });
+    if (hasOperationListeners) {
+      if (argsArray == null) {
+        argsArray = Array.from(args);
+      }
+      this.conn.emit('operation-start', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, params: argsArray });
+    }
 
     try {
       if (collection == null) {
@@ -179,20 +198,26 @@ function iter(i) {
             if (timeout != null) {
               clearTimeout(timeout);
             }
-            this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result });
+            if (hasOperationListeners) {
+              this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result });
+            }
             return result;
           },
           error => {
             if (timeout != null) {
               clearTimeout(timeout);
             }
-            this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error });
+            if (hasOperationListeners) {
+              this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error });
+            }
             throw error;
           }
         );
       }
 
-      this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result: ret });
+      if (hasOperationListeners) {
+        this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, result: ret });
+      }
       if (timeout != null) {
         clearTimeout(timeout);
       }
@@ -201,7 +226,9 @@ function iter(i) {
       if (timeout != null) {
         clearTimeout(timeout);
       }
-      this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error: error });
+      if (hasOperationListeners) {
+        this.conn.emit('operation-end', { _id: opId, modelName: _this.modelName, collectionName: this.name, method: i, error: error });
+      }
       throw error;
     }
   };

--- a/lib/model.js
+++ b/lib/model.js
@@ -635,7 +635,7 @@ Model.prototype.save = async function save(options) {
   if (this.$__.saving) {
     parallelSave = new ParallelSaveError(this);
   } else {
-    this.$__.saving = new ParallelSaveError(this);
+    this.$__.saving = true;
   }
 
   options = new SaveOptions(options);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Some performance improvements to optimize the `saveSimple` benchmark path

1. Separate `$__resetAtomics()` function to avoid the overhead of `$__dirty()`
2. Avoid instantiating `ParallelSaveError` every time. ParallelSaveError is substantially less useful now that we have async stack traces.
3. Minimize `delete()` on the `paths` set in `_getPathsToValidate()`: avoid adding the paths to begin with.
4. Avoid converting `arguments` -> `Array.from(arguments)` and avoid instantiating `opId` unless the user actually uses them. `Array.from(arguments)` and `opId` have non-trivial performance costs.

Benchmark on master (sample run):

```
{
  "Average mongoose save time ms": 2.37,
  "Average driver insertOne time ms": 0.72
}

```

With this change:

```
{
  "Average mongoose save time ms": 2.1,
  "Average driver insertOne time ms": 0.86
}
```

So we're getting a decent speedup of maybe 10-15% on `saveSimple`, which is helpful

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
