### PR TITLE
types: add `id` to HydratedDocument virtuals by default unless explicitly set

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -315,6 +315,34 @@ function gh13094() {
   expect(doc.name).type.toBe<string>();
 }
 
+async function gh16178() {
+  interface IData {
+    name: string;
+  }
+
+  interface IDataMethods {
+    info(): Promise<string>;
+  }
+
+  type DataModel = Model<IData, {}, IDataMethods>;
+  type DataDocument = HydratedDocument<IData, IDataMethods>;
+
+  const dataSchema = new Schema<IData, DataModel, IDataMethods>({
+    name: { type: String, required: true }
+  });
+
+  dataSchema.methods.info = async function(): Promise<string> {
+    return `Name: ${this.name}`;
+  };
+
+  const Data = model<IData, DataModel>('Data', dataSchema);
+  const data = await Data.create({ name: 'Test' });
+  const dataDoc = null as any as DataDocument;
+
+  expect(data.id).type.toBe<string>();
+  expect(dataDoc.id).type.toBe<string>();
+}
+
 function gh13738() {
   interface IPerson {
     age: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -177,13 +177,25 @@ declare module 'mongoose' {
     HydratedDocPathsType,
     any,
     TOverrides extends Record<string, never> ?
-      Document<unknown, TQueryHelpers, RawDocType, TVirtuals, TSchemaOptions> & Default__v<Require_id<HydratedDocPathsType>, TSchemaOptions> & AddDefaultId<HydratedDocPathsType, {}, TSchemaOptions> :
+      Document<unknown, TQueryHelpers, RawDocType, TVirtuals, TSchemaOptions> &
+      Default__v<Require_id<HydratedDocPathsType>, TSchemaOptions> &
+      IfEquals<
+        TVirtuals,
+        {},
+        AddDefaultId<HydratedDocPathsType, {}, TSchemaOptions>,
+        TVirtuals
+      > :
       IfAny<
         TOverrides,
         Document<unknown, TQueryHelpers, RawDocType, TVirtuals, TSchemaOptions> & Default__v<Require_id<HydratedDocPathsType>, TSchemaOptions>,
         Document<unknown, TQueryHelpers, RawDocType, TVirtuals, TSchemaOptions> & MergeType<
           Default__v<Require_id<HydratedDocPathsType>, TSchemaOptions>,
-          TOverrides
+          IfEquals<
+            TOverrides,
+            {},
+            TOverrides,
+            TOverrides & AddDefaultId<HydratedDocPathsType, TVirtuals, TSchemaOptions>
+          >
         >
       >
   >;


### PR DESCRIPTION
Fix #16178

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

If `TVirtuals` is empty object `{}`, default to adding `id: string` virtual. This way users don't have to specify `id` on virtuals unless they explicitly pass in `TVirtuals` as a generic.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
