### PR TITLE
fix(schema): correct template literal in encryptionType error message

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -750,7 +750,7 @@ Schema.prototype.encryptionType = function encryptionType(encryptionType) {
     return this.options.encryptionType;
   }
   if (!(typeof encryptionType === 'string' || encryptionType === null)) {
-    throw new MongooseError('invalid `encryptionType`: ${encryptionType}');
+    throw new MongooseError(`invalid \`encryptionType\`: ${encryptionType}`);
   }
   this.options.encryptionType = encryptionType;
 };


### PR DESCRIPTION
Fixes an issue where the error message for invalid `encryptionType` does not interpolate the provided value.

The string was defined using single quotes, so `${encryptionType}` was not evaluated and appeared literally in the error message.

This PR replaces the string with a template literal so the actual value is displayed.

This is a minimal change and does not affect behavior.