### PR TITLE
fix(utils): wrap discriminator merge check in parentheses to fix precedence

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -313,8 +313,8 @@ exports.merge = function merge(to, from, options, path) {
         // base schema has a given path as a single nested but discriminator schema
         // has the path as a document array, or vice versa (gh-9534)
         if (options.isDiscriminatorSchemaMerge &&
-            (from[key].$isSingleNested && to[key].$isMongooseDocumentArray) ||
-            (from[key].$isMongooseDocumentArray && to[key].$isSingleNested)) {
+            ((from[key].$isSingleNested && to[key].$isMongooseDocumentArray) ||
+            (from[key].$isMongooseDocumentArray && to[key].$isSingleNested))) {
           continue;
         } else if (from[key].instanceOfSchema) {
           if (to[key].instanceOfSchema) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -254,6 +254,36 @@ describe('utils', function() {
       assert.ok(to.toMethod === To.prototype.toMethod);
       assert.equal(to.fomMethod, From.prototype.fomMethod);
     });
+
+    it('should skip schema merge when isDiscriminatorSchemaMerge is true (gh-9534)', function() {
+      const to = {
+        key: { $isSingleNested: true, existingProp: 1 }
+      };
+      const from = {
+        key: { $isMongooseDocumentArray: true, newProp: 2 }
+      };
+
+      // When isDiscriminatorSchemaMerge is true, merge SHOULD skip
+      // conflicting single-nested vs document-array paths
+      utils.merge(to, from, { isDiscriminatorSchemaMerge: true });
+
+      assert.strictEqual(to.key.newProp, undefined);
+    });
+
+    it('should not skip schema merge when isDiscriminatorSchemaMerge is false (gh-9534)', function() {
+      const to = {
+        key: { $isSingleNested: true, existingProp: 1 }
+      };
+      const from = {
+        key: { $isMongooseDocumentArray: true, newProp: 2 }
+      };
+
+      // When isDiscriminatorSchemaMerge is false, merge should NOT skip
+      // the key even if from/to have $isMongooseDocumentArray/$isSingleNested
+      utils.merge(to, from, { isDiscriminatorSchemaMerge: false });
+
+      assert.strictEqual(to.key.newProp, 2);
+    });
   });
 
   describe('mergeClone', function() {


### PR DESCRIPTION

**Summary**:-

While going through `lib/utils.js`, I noticed a regression in `merge()` that seems to have been introduced with the changes from gh-9534. The issue comes down to JavaScript operator precedence — the `isDiscriminatorSchemaMerge` check was only affecting part of the condition, not the whole thing.

**The issue**:-

Right now the condition is effectively evaluated as:

`(options.isDiscriminatorSchemaMerge && A) || B`

Because of that, whenever Condition B is true (the array vs. single nested mismatch case), the merge gets skipped even if `isDiscriminatorSchemaMerge` is false. That doesn’t seem intentional, and in practice it can cause merges to silently drop data in normal (non-discriminator) scenarios that happen to hit this edge case.

**The fix**:-

I added parentheses to group the branches, ensuring the guard covers the entire mismatch logic.

`options.isDiscriminatorSchemaMerge && (ConditionA || ConditionB)`

This keeps the behavior introduced in gh-9534, but limits it to actual discriminator merges, which seems to be the original intent.
While I was here, I also checked `hasKey` and `mergeClone` for similar patterns, but didn’t see the same issue there.

**Tests**:-

Added a couple of regression tests in `test/utils.test.js` to make sure this only triggers when `isDiscriminatorSchemaMerge` is true, and to prevent this from slipping back in later.