### PR TITLE
fix(utils): implement proper deepEqual comparison for Set objects

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -119,6 +119,16 @@ exports.deepEqual = function deepEqual(a, b) {
       deepEqual(Array.from(a.values()), Array.from(b.values()));
   }
 
+  if (a instanceof Set || b instanceof Set) {
+    if (!(a instanceof Set) || !(b instanceof Set)) {
+      return false;
+    }
+    if (a.size !== b.size) {
+      return false;
+    }
+    return deepEqual(Array.from(a.values()), Array.from(b.values()));
+  }
+
   // Handle MongooseNumbers
   if (a instanceof Number && b instanceof Number) {
     return a.valueOf() === b.valueOf();

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -145,6 +145,22 @@ describe('utils', function() {
     assert.ok(!utils.deepEqual(a, b));
   });
 
+  it('deepEquals on sets', function() {
+    const a = new Set([1, 2, 3]);
+    let b = new Set([1, 2, 3]);
+
+    assert.ok(utils.deepEqual(a, b));
+
+    b = new Set([1, 2, 4]);
+    assert.ok(!utils.deepEqual(a, b));
+
+    b = new Set([1, 2]);
+    assert.ok(!utils.deepEqual(a, b));
+
+    b = new Set([1, 2, 3, 4]);
+    assert.ok(!utils.deepEqual(a, b));
+  });
+
   it('deepEquals on MongooseDocumentArray works', function() {
     const A = new Schema({ a: String });
     mongoose.deleteModel(/Test/);


### PR DESCRIPTION
**Summary**

This PR fixes a silent bug in `utils.deepEqual` where `Set` objects were incorrectly evaluated as equal even if their contents were completely different. 

This occurred because `Set` objects do not have enumerable keys, causing `deepEqual` to fall through to the default object comparison logic and return `true` prematurely. I have added specific handling for `Set` objects in `lib/utils.js` that first compares `.size` (for an early exit) and then recursively compares the set values to ensure strict equality.

**Examples**

**Before this change:**
```javascript
const utils = require('./lib/utils');

const setA = new Set([1, 2, 3]);
const setB = new Set([4, 5, 6]);

console.log(utils.deepEqual(setA, setB)); 
// Output: true (Incorrect - contents are different)
```

**After this change:**
```javascript
const utils = require('./lib/utils');

const setA = new Set([1, 2, 3]);
const setB = new Set([4, 5, 6]);

console.log(utils.deepEqual(setA, setB)); 
// Output: false (Correct)
```

*Note: I have also added comprehensive regression tests to `test/utils.test.js` covering `Set` equality, inequality with different values, and inequality with different sizes. All tests (`npm run test -- --grep "deepEqual"`) are passing locally.*

