### PR TITLE
docs: fix typos around 'retrieve'

### DIFF
--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -786,7 +786,7 @@ SchemaType.prototype.set = function(fn) {
  *     // defining within the schema
  *     const s = new Schema({ born: { type: Date, get: dob })
  *
- *     // or by retreiving its SchemaType
+ *     // or by retrieving its SchemaType
  *     const s = new Schema({ born: Date })
  *     s.path('born').get(dob)
  *
@@ -936,7 +936,7 @@ SchemaType.prototype.validateAll = function(validators) {
  *       }
  *     });
  *
- * You might use asynchronous validators to retreive other documents from the database to validate against or to meet other I/O bound validation needs.
+ * You might use asynchronous validators to retrieve other documents from the database to validate against or to meet other I/O bound validation needs.
  *
  * Validation occurs `pre('save')` or whenever you manually execute [document#validate](https://mongoosejs.com/docs/api/document.html#Document.prototype.validate()).
  *

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3291,7 +3291,7 @@ describe('Model', function() {
 
   });
 
-  it('path is cast to correct value when retreived from db', async function() {
+  it('path is cast to correct value when retrieved from db', async function() {
     const schema = new Schema({ title: { type: 'string', index: true } });
     const T = db.model('Test', schema);
     await T.collection.insertOne({ title: 234 });


### PR DESCRIPTION
Found some typos where 'retrieve' was spelled 'retreive'. Addressed them in lib/schemaType.js and test/model.test.js.