### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -32,7 +32,7 @@ const MongooseError = require('./mongooseError');
  * - `ValidationError`: error returned from [`validate()`](https://mongoosejs.com/docs/api/document.html#Document.prototype.validate()) or [`validateSync()`](https://mongoosejs.com/docs/api/document.html#Document.prototype.validateSync()). Contains zero or more `ValidatorError` instances in `.errors` property.
  * - `MissingSchemaError`: You called `mongoose.Document()` without a schema
  * - `ObjectExpectedError`: Thrown when you set a nested path to a non-object value with [strict mode set](https://mongoosejs.com/docs/guide.html#strict).
- * - `ObjectParameterError`: Thrown when you pass a non-object value to a function which expects an object as a paramter
+ * - `ObjectParameterError`: Thrown when you pass a non-object value to a function which expects an object as a parameter
  * - `OverwriteModelError`: Thrown when you call [`mongoose.model()`](https://mongoosejs.com/docs/api/mongoose.html#Mongoose.model()) to re-define a model that was already defined.
  * - `ParallelSaveError`: Thrown when you call [`save()`](https://mongoosejs.com/docs/api/model.html#Model.prototype.save()) on a document when the same document instance is already saving.
  * - `StrictModeError`: Thrown when you set a path that isn't the schema and [strict mode](https://mongoosejs.com/docs/guide.html#strict) is set to `throw`.

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -380,10 +380,10 @@ SchemaType.get = function(getter) {
  * #### Example:
  *
  *     // values are cast:
- *     const schema = new Schema({ a number: { type: Number, default: 4.815162342 }})
+ *     const schema = new Schema({ num: { type: Number, default: 4.815162342 }})
  *     const M = db.model('M', schema)
  *     const m = new M;
- *     console.log(m.a number) // 4.815162342
+ *     console.log(m.num) // 4.815162342
  *
  *     // default unique objects for Mixed types:
  *     const schema = new Schema({ mixed: Schema.Types.Mixed });

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -380,10 +380,10 @@ SchemaType.get = function(getter) {
  * #### Example:
  *
  *     // values are cast:
- *     const schema = new Schema({ aNumber: { type: Number, default: 4.815162342 }})
+ *     const schema = new Schema({ a number: { type: Number, default: 4.815162342 }})
  *     const M = db.model('M', schema)
  *     const m = new M;
- *     console.log(m.aNumber) // 4.815162342
+ *     console.log(m.a number) // 4.815162342
  *
  *     // default unique objects for Mixed types:
  *     const schema = new Schema({ mixed: Schema.Types.Mixed });
@@ -786,7 +786,7 @@ SchemaType.prototype.set = function(fn) {
  *     // defining within the schema
  *     const s = new Schema({ born: { type: Date, get: dob })
  *
- *     // or by retreiving its SchemaType
+ *     // or by retrieving its SchemaType
  *     const s = new Schema({ born: Date })
  *     s.path('born').get(dob)
  *
@@ -936,7 +936,7 @@ SchemaType.prototype.validateAll = function(validators) {
  *       }
  *     });
  *
- * You might use asynchronous validators to retreive other documents from the database to validate against or to meet other I/O bound validation needs.
+ * You might use asynchronous validators to retrieve other documents from the database to validate against or to meet other I/O bound validation needs.
  *
  * Validation occurs `pre('save')` or whenever you manually execute [document#validate](https://mongoosejs.com/docs/api/document.html#Document.prototype.validate()).
  *

--- a/lib/types/array/methods/index.js
+++ b/lib/types/array/methods/index.js
@@ -572,7 +572,7 @@ const methods = {
    *
    * #### Note:
    *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwriting any changes that happen between when you retrieved the object and when you save it._
    *
    * @param {...any} [args]
    * @api public
@@ -830,7 +830,7 @@ const methods = {
    *
    * #### Note:
    *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwriting any changes that happen between when you retrieved the object and when you save it._
    *
    * @api public
    * @method shift
@@ -850,7 +850,7 @@ const methods = {
    *
    * #### Note:
    *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwriting any changes that happen between when you retrieved the object and when you save it._
    *
    * @api public
    * @method sort
@@ -870,7 +870,7 @@ const methods = {
    *
    * #### Note:
    *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwriting any changes that happen between when you retrieved the object and when you save it._
    *
    * @api public
    * @method splice


### PR DESCRIPTION
This PR fixes a few minor typographical errors in comments to improve code readability. Found via codespell.