### PR TITLE
fix(connection): snapshot Date in heartbeat handler and flush queue on recovery

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1005,10 +1005,7 @@ Connection.prototype.error = function error(err, callback) {
 Connection.prototype.onOpen = function() {
   this.readyState = STATES.connected;
 
-  for (const d of this._queue) {
-    d.fn.apply(d.ctx, d.args);
-  }
-  this._queue = [];
+  this._flushQueue();
 
   // avoid having the collection subscribe to our event emitter
   // to prevent 0.3 warning
@@ -1019,6 +1016,21 @@ Connection.prototype.onOpen = function() {
   }
 
   this.emit('open');
+};
+
+/**
+ * Flush all buffered operations in `_queue`. Called by `onOpen()` and
+ * by the heartbeat handler when a previously-stale connection recovers.
+ *
+ * @api private
+ */
+
+Connection.prototype._flushQueue = function _flushQueue() {
+  const queue = this._queue;
+  this._queue = [];
+  for (const d of queue) {
+    d.fn.apply(d.ctx, d.args);
+  }
 };
 
 /**

--- a/lib/drivers/node-mongodb-native/connection.js
+++ b/lib/drivers/node-mongodb-native/connection.js
@@ -14,6 +14,10 @@ const setTimeout = require('../../helpers/timers').setTimeout;
 const utils = require('../../utils');
 const Schema = require('../../schema');
 
+// Snapshot the native Date constructor to ensure Date.now()
+// bypasses timer mocks such as those set up by useFakeTimers().
+const Date = globalThis.Date;
+
 /**
  * A [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) connection implementation.
  *
@@ -481,6 +485,15 @@ function _setClient(conn, client, options, dbName) {
     conn._lastHeartbeatAt = Date.now();
     for (const otherDb of conn.otherDbs) {
       otherDb._lastHeartbeatAt = conn._lastHeartbeatAt;
+    }
+    // Flush buffered operations if the connection is no longer stale (gh-16183)
+    if (conn._queue.length > 0 && conn.readyState === STATES.connected) {
+      conn._flushQueue();
+    }
+    for (const otherDb of conn.otherDbs) {
+      if (otherDb._queue.length > 0 && otherDb.readyState === STATES.connected) {
+        otherDb._flushQueue();
+      }
     }
   });
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -880,6 +880,67 @@ describe('connections:', function() {
       assert.ok(db._lastHeartbeatAt >= now);
       assert.ok(db2._lastHeartbeatAt >= now);
     });
+
+    it('heartbeat handler uses snapshotted Date, not affected by faked globalThis.Date (gh-16183)', async function() {
+      const db = await mongoose.createConnection(start.uri).asPromise();
+
+      const OriginalDate = globalThis.Date;
+      try {
+        const FAKE_NOW = 1;
+        globalThis.Date = { now: () => FAKE_NOW };
+
+        db.client.emit('serverHeartbeatSucceeded');
+
+        // If using snapshotted Date, _lastHeartbeatAt should be a real timestamp, not the faked value
+        assert.notStrictEqual(db._lastHeartbeatAt, FAKE_NOW);
+        assert.ok(db._lastHeartbeatAt > Date.now());
+      } finally {
+        globalThis.Date = OriginalDate;
+        await db.close();
+      }
+    });
+
+    it('flushes buffered operations when heartbeat refreshes stale connection (gh-16183)', async function() {
+      const db = await mongoose.createConnection(start.uri).asPromise();
+
+      // Make heartbeat stale so readyState getter returns disconnected
+      db._lastHeartbeatAt = 1;
+      assert.equal(db._readyState, STATES.connected);
+      assert.equal(db.readyState, STATES.disconnected);
+
+      // Simulate a buffered operation
+      let flushed = false;
+      db._queue.push({ fn: () => { flushed = true; } });
+
+      // Heartbeat should update timestamp AND flush queue
+      db.client.emit('serverHeartbeatSucceeded');
+
+      assert.equal(db.readyState, STATES.connected);
+      assert.strictEqual(flushed, true);
+      assert.equal(db._queue.length, 0);
+
+      await db.close();
+    });
+
+    it('flushes buffered operations on child dbs when heartbeat refreshes stale connection (gh-16183)', async function() {
+      const db = await mongoose.createConnection(start.uri).asPromise();
+      const db2 = db.useDb(start.databases[1]);
+
+      // Make both stale
+      db._lastHeartbeatAt = 1;
+      db2._lastHeartbeatAt = 1;
+
+      // Queue operation on child db
+      let childFlushed = false;
+      db2._queue.push({ fn: () => { childFlushed = true; } });
+
+      db.client.emit('serverHeartbeatSucceeded');
+
+      assert.strictEqual(childFlushed, true);
+      assert.equal(db2._queue.length, 0);
+
+      await db.close();
+    });
   });
 
   describe('shouldAuthenticate()', function() {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -889,11 +889,14 @@ describe('connections:', function() {
         const FAKE_NOW = 1;
         globalThis.Date = { now: () => FAKE_NOW };
 
+        const realBefore = OriginalDate.now();
         db.client.emit('serverHeartbeatSucceeded');
+        const realAfter = OriginalDate.now();
 
         // If using snapshotted Date, _lastHeartbeatAt should be a real timestamp, not the faked value
         assert.notStrictEqual(db._lastHeartbeatAt, FAKE_NOW);
-        assert.ok(db._lastHeartbeatAt > Date.now());
+        assert.ok(db._lastHeartbeatAt >= realBefore);
+        assert.ok(db._lastHeartbeatAt <= realAfter);
       } finally {
         globalThis.Date = OriginalDate;
         await db.close();


### PR DESCRIPTION
## Summary

Fixes #16183. Two related bugs in the heartbeat staleness check:

- **Missing Date snapshot**: `drivers/node-mongodb-native/connection.js` used the global `Date.now()` in the `serverHeartbeatSucceeded` handler instead of a snapshotted copy (like `lib/connection.js` already does). When test frameworks fake `globalThis.Date`, `_lastHeartbeatAt` gets a fake timestamp while the `readyState` getter uses the real `Date.now()`, causing false staleness detection.

- **No recovery path for buffered operations**: When a stale heartbeat causes `readyState` to report `disconnected`, operations buffer into `_queue`. When the next heartbeat refreshes `_lastHeartbeatAt`, `readyState` returns `connected` again, but the queue is never flushed because `_readyState` never actually changed — so no state change event fires and `onOpen()` is never called. This extracts `_flushQueue()` from `onOpen()` and calls it from the heartbeat handler when the connection is no longer stale.

## Test plan

- [x] Added test: heartbeat handler uses snapshotted Date, not affected by faked `globalThis.Date`
- [x] Added test: buffered operations flush when heartbeat refreshes stale connection
- [x] Added test: child db (`useDb()`) queues also flush on heartbeat recovery
- [x] Existing `connection pool sharing` tests all pass
- [x] ESLint passes on changed files