### PR TITLE
fix(setDefaultsOnInsert): check child filter paths before applying defaults (backport #16031 to 8.x)

### DIFF
--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -25,7 +25,7 @@ module.exports = function(filter, schema, castedDoc, options) {
   }
 
   const keys = Object.keys(castedDoc || {});
-  const updatedKeys = {};
+  const updatedKeys = Object.create(null);
   const updatedValues = {};
   const numKeys = keys.length;
 
@@ -58,6 +58,20 @@ module.exports = function(filter, schema, castedDoc, options) {
       }
     }
     updatedKeys[path] = true;
+    if (path.indexOf('.') === -1) {
+      continue;
+    }
+    // Also mark all parent prefixes so child-path lookups are O(1).
+    // e.g. 'extraProps.location' also marks 'extraProps'
+    const pieces = schema.paths[path] ?
+        // If the SchemaType already split for us, use that to avoid the extra overhead
+        schema.paths[path].splitPath() :
+        path.split('.');
+    let cur = pieces[0];
+    for (let j = 1; j < pieces.length; ++j) {
+      updatedKeys[cur] = true;
+      cur += '.' + pieces[j];
+    }
   }
 
   if (options && options.overwrite && !hasDollarUpdate) {

--- a/lib/helpers/setDefaultsOnInsert.js
+++ b/lib/helpers/setDefaultsOnInsert.js
@@ -64,9 +64,9 @@ module.exports = function(filter, schema, castedDoc, options) {
     // Also mark all parent prefixes so child-path lookups are O(1).
     // e.g. 'extraProps.location' also marks 'extraProps'
     const pieces = schema.paths[path] ?
-        // If the SchemaType already split for us, use that to avoid the extra overhead
-        schema.paths[path].splitPath() :
-        path.split('.');
+    // If the SchemaType already split for us, use that to avoid the extra overhead
+      schema.paths[path].splitPath() :
+      path.split('.');
     let cur = pieces[0];
     for (let j = 1; j < pieces.length; ++j) {
       updatedKeys[cur] = true;

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -955,6 +955,44 @@ describe('model: findOneAndUpdate:', function() {
       assert.equal(1, count);
     });
 
+    it('includes dot-notation filter paths in upserted document with sub-schema default (gh-16030)', async function() {
+      const addressSchema = new Schema({ city: String });
+      const userSchema = new Schema({
+        firstName: String,
+        lastName: String,
+        address: { type: addressSchema, default: {} }
+      });
+      const User = db.model('User', userSchema);
+
+      const foundUser = await User.findOneAndUpdate(
+          { 'address.city': 'New York' },
+          { $setOnInsert: { firstName: 'John' }, $set: { lastName: 'Smith' } },
+          { upsert: true, new: true, setDefaultsOnInsert: true });
+
+      assert.equal(foundUser.lastName, 'Smith');
+      assert.equal(foundUser.firstName, 'John');
+      assert.equal(foundUser.address.city, 'New York');
+    });
+
+    it('applies sub-schema default on upsert when filter has no dot-notation path (gh-16030)', async function() {
+      const addressSchema = new Schema({ city: String });
+      const userSchema = new Schema({
+        firstName: String,
+        lastName: String,
+        address: { type: addressSchema, default: { city: 'Chicago' } }
+      });
+      const User = db.model('User', userSchema);
+
+      const foundUser = await User.findOneAndUpdate(
+          { firstName: 'John' },
+          { $set: { lastName: 'Smith' } },
+          { upsert: true, new: true, setDefaultsOnInsert: true });
+
+      assert.equal(foundUser.lastName, 'Smith');
+      assert.equal(foundUser.firstName, 'John');
+      assert.equal(foundUser.address.city, 'Chicago');
+    });
+
     it('skips setting defaults within maps (gh-7909)', async function() {
       const socialMediaHandleSchema = Schema({ links: [String] });
       const profileSchema = Schema({

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -965,9 +965,9 @@ describe('model: findOneAndUpdate:', function() {
       const User = db.model('User', userSchema);
 
       const foundUser = await User.findOneAndUpdate(
-          { 'address.city': 'New York' },
-          { $setOnInsert: { firstName: 'John' }, $set: { lastName: 'Smith' } },
-          { upsert: true, new: true, setDefaultsOnInsert: true });
+        { 'address.city': 'New York' },
+        { $setOnInsert: { firstName: 'John' }, $set: { lastName: 'Smith' } },
+        { upsert: true, new: true, setDefaultsOnInsert: true });
 
       assert.equal(foundUser.lastName, 'Smith');
       assert.equal(foundUser.firstName, 'John');
@@ -984,9 +984,9 @@ describe('model: findOneAndUpdate:', function() {
       const User = db.model('User', userSchema);
 
       const foundUser = await User.findOneAndUpdate(
-          { firstName: 'John' },
-          { $set: { lastName: 'Smith' } },
-          { upsert: true, new: true, setDefaultsOnInsert: true });
+        { firstName: 'John' },
+        { $set: { lastName: 'Smith' } },
+        { upsert: true, new: true, setDefaultsOnInsert: true });
 
       assert.equal(foundUser.lastName, 'Smith');
       assert.equal(foundUser.firstName, 'John');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Backport https://github.com/Automattic/mongoose/pull/16031 to v8

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
