### PR TITLE
chore: use TSTyche assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ncp": "^2.0.0",
     "pug": "3.0.4",
     "sinon": "21.0.3",
-    "tstyche": "^7.0.0-rc.1",
+    "tstyche": "^7.0.0",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.31.1",
     "uuid": "11.1.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ncp": "^2.0.0",
     "pug": "3.0.4",
     "sinon": "21.0.3",
-    "tstyche": "^7.0.0-rc.0",
+    "tstyche": "^7.0.0-rc.1",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.31.1",
     "uuid": "11.1.0"

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -1,5 +1,5 @@
 import mongoose, { InferRawDocType, type InferRawDocTypeWithout_id, type ResolveTimestamps, type Schema, type Types, FlattenMaps } from 'mongoose';
-import { ExpectType } from './util/assertions';
+import { expect } from 'tstyche';
 
 function inferPojoType() {
   const schemaDefinition = {
@@ -20,9 +20,13 @@ function inferPojoType() {
     }
   };
 
-  type UserType = InferRawDocTypeWithout_id<typeof schemaDefinition>;
-  ExpectType<{ email: string, password: string, dateOfBirth: Date }>({} as UserType);
+  expect<InferRawDocTypeWithout_id<typeof schemaDefinition>>().type.toBe<{
+    email: string,
+    password: string,
+    dateOfBirth: Date
+  }>();
 }
+
 function gh14839() {
   const schemaDefinition = {
     email: {
@@ -42,8 +46,11 @@ function gh14839() {
     }
   };
 
-  type UserType = InferRawDocType< typeof schemaDefinition>;
-  ExpectType<{ email: string, password: string, dateOfBirth: Date } & { _id: Types.ObjectId }>({} as UserType);
+  expect<InferRawDocType<typeof schemaDefinition>>().type.toBe<{
+    email: string,
+    password: string,
+    dateOfBirth: Date,
+    _id: Types.ObjectId }>();
 }
 
 function optionality() {
@@ -57,8 +64,11 @@ function optionality() {
     }
   };
 
-  type UserType = InferRawDocType<typeof schemaDefinition>;
-  ExpectType<{ name: string; dateOfBirth?: number | null | undefined } & { _id: Types.ObjectId }>({} as UserType);
+  expect<InferRawDocType<typeof schemaDefinition>>().type.toBe<{
+    name: string;
+    dateOfBirth?: number | null | undefined,
+    _id: Types.ObjectId
+  }>();
 }
 
 type SchemaOptionsWithTimestamps<t> = {
@@ -80,12 +90,12 @@ function Timestamps() {
     }
   };
 
-  type UserType = InferRawDocType<typeof schemaDefinition, SchemaOptionsWithTimestamps<true>>;
-  type ExpectedUserType = {
+  expect<InferRawDocType<typeof schemaDefinition, SchemaOptionsWithTimestamps<true>>>().type.toBe<{
     name: string;
     dateOfBirth?: number | null | undefined;
-  } & { createdAt: NativeDate; updatedAt: NativeDate; } & { _id: Types.ObjectId };
-  ExpectType<ExpectedUserType>({} as UserType);
+    createdAt: NativeDate; updatedAt: NativeDate;
+    _id: Types.ObjectId }
+  >();
 
   type Resolved = ResolveTimestamps<
     { foo: true },
@@ -96,12 +106,7 @@ function Timestamps() {
     }
   >;
 
-  ExpectType<Resolved>(
-    {} as {
-      foo: true;
-      bar: NativeDate;
-    }
-  );
+  expect<Resolved>().type.toBe<{ foo: true; bar: NativeDate }>();
 }
 
 function DefinitionTypes() {
@@ -114,15 +119,15 @@ function DefinitionTypes() {
     schemaInstance: Schema.Types.String;
   }>;
 
-  type ExpectedActualType = {
+  expect<Actual>().type.toBe<{
     lowercaseString?: string | null | undefined;
     uppercaseString?: string | null | undefined;
     stringConstructor?: string | null | undefined;
     schemaConstructor?: string | null | undefined;
     stringInstance?: string | null | undefined;
     schemaInstance?: string | null | undefined;
-  } & { _id: Types.ObjectId };
-  ExpectType<ExpectedActualType>({} as Actual);
+    _id: Types.ObjectId
+  }>();
 }
 
 function MoreDefinitionTypes() {
@@ -135,27 +140,24 @@ function MoreDefinitionTypes() {
     objectIdInstance: Schema.Types.ObjectId;
   }>;
 
-  type ExpectedActualType = {
+  expect<Actual>().type.toBe<{
     numberString?: number | null | undefined;
     // these should not fallback to Boolean, which has no methods
     objectIdConstructor?: Types.ObjectId | null | undefined;
     objectIdInstance?: Types.ObjectId | null | undefined;
-  } & { _id: Types.ObjectId };
-  ExpectType<ExpectedActualType>({} as Actual);
+    _id: Types.ObjectId
+  }>();
 }
 
 function HandlesAny() {
-  type ActualShallow = InferRawDocType<any>;
-  ExpectType<{ [x: PropertyKey]: any } & { _id: unknown }>({} as ActualShallow);
-  type ActualNested = InferRawDocType<Record<string, any>>;
-  ExpectType<{ [x: string]: any } & { _id: unknown }>({} as ActualNested);
+  expect<InferRawDocType<any>>().type.toBe<{ [x: PropertyKey]: any; _id: unknown }>();
+  expect<InferRawDocType<Record<string, any>>>().type.toBe<{ [x: string]: any; _id: unknown }>();
 }
 
 function gh15699() {
   const schema = { unTypedArray: [] } as const;
 
-  type TSchema = InferRawDocType<typeof schema>;
-  ExpectType<any[] | null | undefined>({} as unknown as TSchema['unTypedArray']);
+  expect<InferRawDocType<typeof schema>['unTypedArray']>().type.toBe<any[] | null | undefined>();
 }
 
 function gh13772RawType() {
@@ -166,12 +168,10 @@ function gh13772RawType() {
     child: childSchema
   };
 
-  type RawParentDoc = InferRawDocType<typeof parentSchemaDef>;
-
-  ExpectType<{
+  expect<InferRawDocType<typeof parentSchemaDef>>().type.toBe<{
     children:(FlattenMaps<{ name?: string | null | undefined }> & { _id: Types.ObjectId })[];
     child?: (FlattenMaps<{ name?: string | null | undefined }> & { _id: Types.ObjectId }) | null | undefined;
-      } & { _id: Types.ObjectId }>({} as RawParentDoc);
+    _id: Types.ObjectId }>();
 }
 
 function gh13772WithIdFalse() {
@@ -182,12 +182,10 @@ function gh13772WithIdFalse() {
     child: childSchema
   };
 
-  type RawParentDoc = InferRawDocType<typeof parentSchemaDef>;
-
-  ExpectType<{
+  expect<InferRawDocType<typeof parentSchemaDef>>().type.toBe<{
     children: FlattenMaps<{ name?: string | null | undefined }>[];
     child?: FlattenMaps<{ name?: string | null | undefined }> | null | undefined;
-  } & { _id: Types.ObjectId }>({} as RawParentDoc);
+    _id: Types.ObjectId }>();
 }
 
 function gh13772WithSchemaCreate() {
@@ -198,12 +196,10 @@ function gh13772WithSchemaCreate() {
     child: childSchema
   };
 
-  type RawParentDoc = InferRawDocType<typeof parentSchemaDef>;
-
-  ExpectType<{
-    children:({ name?: string | null | undefined } & { _id: Types.ObjectId })[];
-    child?: ({ name?: string | null | undefined } & { _id: Types.ObjectId }) | null | undefined;
-      } & { _id: Types.ObjectId }>({} as RawParentDoc);
+  expect<InferRawDocType<typeof parentSchemaDef>>().type.toBe<{
+    children:({ name?: string | null | undefined; _id: Types.ObjectId })[];
+    child?: ({ name?: string | null | undefined; _id: Types.ObjectId }) | null | undefined;
+    _id: Types.ObjectId }>();
 }
 
 function gh13772WithSchemaCreateIdFalse() {
@@ -214,13 +210,11 @@ function gh13772WithSchemaCreateIdFalse() {
     child: childSchema
   };
 
-  type RawParentDoc = InferRawDocType<typeof parentSchemaDef>;
-
   // Schema.create with _id: false - child subdocs should not have _id
-  ExpectType<{
+  expect<InferRawDocType<typeof parentSchemaDef>>().type.toBe<{
     children: { name?: string | null | undefined }[];
     child?: { name?: string | null | undefined } | null | undefined;
-  } & { _id: Types.ObjectId }>({} as RawParentDoc);
+    _id: Types.ObjectId }>();
 }
 
 function gh13772WithExplicitDocType() {
@@ -232,13 +226,11 @@ function gh13772WithExplicitDocType() {
     child: childSchema
   };
 
-  type RawParentDoc = InferRawDocType<typeof parentSchemaDef>;
-
   // Explicit DocType is used directly as RawDocType
-  ExpectType<{
+  expect<InferRawDocType<typeof parentSchemaDef>>().type.toBe<{
     children: ChildDocType[];
     child?: ChildDocType | null | undefined;
-  } & { _id: Types.ObjectId }>({} as RawParentDoc);
+    _id: Types.ObjectId }>();
 }
 
 function gh13772WithExplicitDocTypeIdFalse() {
@@ -250,13 +242,11 @@ function gh13772WithExplicitDocTypeIdFalse() {
     child: childSchema
   };
 
-  type RawParentDoc = InferRawDocType<typeof parentSchemaDef>;
-
   // Explicit DocType is used directly as RawDocType
-  ExpectType<{
+  expect<InferRawDocType<typeof parentSchemaDef>>().type.toBe<{
     children: ChildDocType[];
     child?: ChildDocType | null | undefined;
-  } & { _id: Types.ObjectId }>({} as RawParentDoc);
+    _id: Types.ObjectId }>();
 }
 
 function gh15988() {
@@ -278,13 +268,11 @@ function gh15988() {
     }
   } as const;
 
-  type Location = InferRawDocType<typeof locationSchemaDef>;
-
   // Nested paths should not have _id added
-  ExpectType<{
+  expect<InferRawDocType<typeof locationSchemaDef>>().type.toBe<{
     name: string;
     coordinates?: { latitude: number; longitude: number } | null | undefined;
-  } & { _id: Types.ObjectId }>({} as Location);
+    _id: Types.ObjectId }>();
 
   // Test subdocument (has type key with object value) - should have _id
   const schemaDef2 = {
@@ -300,13 +288,11 @@ function gh15988() {
     }
   } as const;
 
-  type Doc2 = InferRawDocType<typeof schemaDef2>;
-
   // Subdocuments (defined with type: {...}) should have _id added
-  ExpectType<{
+  expect<InferRawDocType<typeof schemaDef2>>().type.toBe<{
     name: string;
-    data: { role?: string | null | undefined } & { _id: Types.ObjectId };
-  } & { _id: Types.ObjectId }>({} as Doc2);
+    data: { role?: string | null | undefined; _id: Types.ObjectId };
+    _id: Types.ObjectId }>();
 
   // Test subdocument with _id: false - should NOT have _id
   const schemaDef3 = {
@@ -330,13 +316,11 @@ function gh15988() {
     }
   } as const;
 
-  type Doc3 = InferRawDocType<typeof schemaDef3>;
-
   // Subdocuments with _id: false should not have _id added
-  ExpectType<{
+  expect<InferRawDocType<typeof schemaDef3>>().type.toBe<{
     name: string;
     coordinates: { latitude: number; longitude: number };
-  } & { _id: Types.ObjectId }>({} as Doc3);
+    _id: Types.ObjectId }>();
 
   // Test subdocument (has type key with object value) with no options - should have _id
   const schemaDef4 = {
@@ -351,13 +335,11 @@ function gh15988() {
     }
   } as const;
 
-  type Doc4 = InferRawDocType<typeof schemaDef4>;
-
   // Subdocuments (defined with type: {...}) should have _id added, but optional since no `required` or `default`
-  ExpectType<{
+  expect<InferRawDocType<typeof schemaDef4>>().type.toBe<{
     name: string;
-    data?:({ role?: string | null | undefined } & { _id: Types.ObjectId }) | null | undefined;
-      } & { _id: Types.ObjectId }>({} as Doc4);
+    data?:({ role?: string | null | undefined; _id: Types.ObjectId }) | null | undefined;
+    _id: Types.ObjectId }>();
 
   // Test 1: Array of subdocuments - should have _id
   const schemaDef5 = {
@@ -367,12 +349,10 @@ function gh15988() {
     }]
   } as const;
 
-  type Doc5 = InferRawDocType<typeof schemaDef5>;
-
   // Arrays of subdocuments should have _id added to each element
-  ExpectType<{
-    users?: Array<{ name: string; email?: string | null | undefined } & { _id: Types.ObjectId }> | null | undefined;
-  } & { _id: Types.ObjectId }>({} as Doc5);
+  expect<InferRawDocType<typeof schemaDef5>>().type.toBe<{
+    users?: Array<{ name: string; email?: string | null | undefined; _id: Types.ObjectId }> | null | undefined;
+    _id: Types.ObjectId }>();
 
   // Test 2: Array of nested paths (no type key in array element) - should have _id (arrays are always subdocs)
   const schemaDef6 = {
@@ -382,12 +362,10 @@ function gh15988() {
     }]
   } as const;
 
-  type Doc6 = InferRawDocType<typeof schemaDef6>;
-
   // Arrays of objects are subdocuments, so they get _id
-  ExpectType<{
-    locations?: Array<{ latitude?: number | null | undefined; longitude?: number | null | undefined } & { _id: Types.ObjectId }> | null | undefined;
-  } & { _id: Types.ObjectId }>({} as Doc6);
+  expect<InferRawDocType<typeof schemaDef6>>().type.toBe<{
+    locations?: Array<{ latitude?: number | null | undefined; longitude?: number | null | undefined; _id: Types.ObjectId }> | null | undefined;
+    _id: Types.ObjectId }>();
 
   // Test 3: Custom typeKey - nested path should not have _id
   const schemaDef7 = {
@@ -407,13 +385,11 @@ function gh15988() {
     }
   } as const;
 
-  type Doc7 = InferRawDocType<typeof schemaDef7, { typeKey: '$type' }>;
-
   // With custom typeKey, nested paths (no $type key) should still not have _id
-  ExpectType<{
+  expect<InferRawDocType<typeof schemaDef7, { typeKey: '$type' }>>().type.toBe<{
     name: string;
     coordinates?: { latitude: number; longitude: number } | null | undefined;
-  } & { _id: Types.ObjectId }>({} as Doc7);
+    _id: Types.ObjectId }>();
 
   // Test 4: Custom typeKey - subdocument should have _id
   const schemaDef8 = {
@@ -429,13 +405,11 @@ function gh15988() {
     }
   } as const;
 
-  type Doc8 = InferRawDocType<typeof schemaDef8, { typeKey: '$type' }>;
-
   // With custom typeKey, subdocuments (with $type key) should have _id
-  ExpectType<{
+  expect<InferRawDocType<typeof schemaDef8, { typeKey: '$type' }>>().type.toBe<{
     name: string;
-    data: { role?: string | null | undefined } & { _id: Types.ObjectId };
-  } & { _id: Types.ObjectId }>({} as Doc8);
+    data: { role?: string | null | undefined; _id: Types.ObjectId };
+    _id: Types.ObjectId }>();
 }
 
 async function gh16053() {
@@ -460,7 +434,7 @@ async function gh16053() {
   async function queryById(id: string) {
     TestModel.findById(id).lean().then(result => {
       if (result) {
-        ExpectType<FlattenMaps<TestType> & { _id: Types.ObjectId }>(result);
+        expect(result).type.toBe<FlattenMaps<TestType> & { _id: Types.ObjectId, __v: number }>();
         console.log(result._id);
       }
     });

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -8,6 +8,7 @@ import mongoose, {
   InferSchemaType,
   InsertManyResult,
   Model,
+  ModifyResult,
   Query,
   Schema,
   Types,
@@ -20,8 +21,8 @@ import mongoose, {
   UpdateManyModel
 } from 'mongoose';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
-import { ModifyResult, UpdateOneModel as MongoUpdateOneModel, ChangeStreamInsertDocument, ObjectId } from 'mongodb';
-import { ExpectAssignable, ExpectType } from './util/assertions';
+import { UpdateOneModel as MongoUpdateOneModel, ChangeStreamInsertDocument, ObjectId } from 'mongodb';
+import { expect } from 'tstyche';
 
 function rawDocSyntax(): void {
   interface ITest {
@@ -40,7 +41,7 @@ function rawDocSyntax(): void {
 
   const Test = connection.model<ITest, TestModel>('Test', TestSchema);
 
-  ExpectType<Model<ITest, {}, ITestMethods, {}>>(Test);
+  expect(Test).type.toBe<Model<ITest, {}, ITestMethods, {}>>();
 
   const doc = new Test({ foo: '42' });
   console.log(doc.foo);
@@ -81,10 +82,10 @@ async function insertManyTest() {
   });
 
   const res = await Test.insertMany([{ foo: 'bar' }], { rawResult: true });
-  ExpectType<Types.ObjectId>(res.insertedIds[0]);
+  expect(res.insertedIds[0]).type.toBe<Types.ObjectId>();
 
   const res2 = await Test.insertMany([{ foo: 'bar' }], { ordered: false, rawResult: true });
-  ExpectAssignable<Error | Object | ReturnType<(typeof Test)['hydrate']>>()(res2.mongoose.results[0]);
+  expect(res2.mongoose.results[0]).type.toBe<Error | Object | ReturnType<(typeof Test)['hydrate']>>();
 }
 
 function gh13930() {
@@ -139,10 +140,10 @@ async function gh10359() {
 
   async function foo(model: Model<User, {}, {}, {}>) {
     const doc = await model.findOne({ groupId: 'test' }).orFail().lean().exec();
-    ExpectType<string>(doc.firstName);
-    ExpectType<string>(doc.lastName);
-    ExpectType<Types.ObjectId>(doc._id);
-    ExpectType<string>(doc.groupId);
+    expect(doc.firstName).type.toBe<string>();
+    expect(doc.lastName).type.toBe<string>();
+    expect(doc._id).type.toBe<Types.ObjectId>();
+    expect(doc.groupId).type.toBe<string>();
     return doc;
   }
 
@@ -251,8 +252,7 @@ function inheritance() {
 
 Project.createCollection({ expires: '5 seconds' });
 Project.createCollection({ expireAfterSeconds: 5 });
-// @ts-expect-error  Type 'string' is not assignable to type 'number'.
-Project.createCollection({ expireAfterSeconds: '5 seconds' });
+expect(Project.createCollection).type.not.toBeCallableWith({ expireAfterSeconds: '5 seconds' });
 
 function bulkWrite() {
 
@@ -342,11 +342,10 @@ async function overwriteBulkWriteContents() {
 
   const BaseModel = model<BaseModelClassDoc>('test', baseModelClassSchema);
 
-  BaseModel.bulkWrite<{ testy: string }>([
+  expect(BaseModel.bulkWrite<{ testy: string }>).type.not.toBeCallableWith([
     {
       insertOne: {
         document: {
-          // @ts-expect-error  'test' does not exist in type 'OptionalId<{ testy: string; }>'.
           test: 'hello'
         }
       }
@@ -382,22 +381,22 @@ export function autoTypedModel() {
   // Model-functions-test
   // Create should works with arbitrary objects.
     const randomObject = await AutoTypedModel.create({ unExistKey: 'unExistKey', description: 'st' } as Partial<InferSchemaType<typeof AutoTypedSchema>>);
-    ExpectType<AutoTypedSchemaType['schema']['userName']>(randomObject.userName);
+    expect(randomObject.userName).type.toBe<AutoTypedSchemaType['schema']['userName']>();
 
     const testDoc1 = await AutoTypedModel.create({ userName: 'M0_0a' });
-    ExpectType<AutoTypedSchemaType['schema']['userName']>(testDoc1.userName);
-    ExpectType<AutoTypedSchemaType['schema']['description']>(testDoc1.description);
+    expect(testDoc1.userName).type.toBe<AutoTypedSchemaType['schema']['userName']>();
+    expect(testDoc1.description).type.toBe<AutoTypedSchemaType['schema']['description']>();
 
     const testDoc2 = await AutoTypedModel.insertMany([{ userName: 'M0_0a' }]);
-    ExpectType<AutoTypedSchemaType['schema']['userName']>(testDoc2[0].userName);
-    ExpectType<AutoTypedSchemaType['schema']['description'] | undefined>(testDoc2[0]?.description);
+    expect(testDoc2[0].userName).type.toBe<AutoTypedSchemaType['schema']['userName']>();
+    expect(testDoc2[0].description).type.toBe<AutoTypedSchemaType['schema']['description'] | undefined>();
 
     const testDoc3 = await AutoTypedModel.findOne({ userName: 'M0_0a' });
-    ExpectType<AutoTypedSchemaType['schema']['userName'] | undefined>(testDoc3?.userName);
-    ExpectType<AutoTypedSchemaType['schema']['description'] | undefined>(testDoc3?.description);
+    expect(testDoc3?.userName).type.toBe<AutoTypedSchemaType['schema']['userName'] | undefined>();
+    expect(testDoc3?.description).type.toBe<AutoTypedSchemaType['schema']['description'] | undefined>();
 
     // Model-statics-functions-test
-    ExpectType<ReturnType<AutoTypedSchemaType['statics']['staticFn']>>(AutoTypedModel.staticFn());
+    expect(AutoTypedModel.staticFn()).type.toBe<ReturnType<AutoTypedSchemaType['statics']['staticFn']>>();
 
   })();
   return AutoTypedModel;
@@ -415,10 +414,10 @@ function gh11911() {
   const Animal = model<IAnimal>('Animal', animalSchema);
 
   const changes: UpdateQuery<IAnimal> = {};
-  ExpectAssignable<MongoUpdateOneModel>()({
+  expect({
     filter: {},
     update: changes
-  });
+  }).type.toBeAssignableTo<MongoUpdateOneModel>();
 }
 
 
@@ -492,7 +491,7 @@ function gh12100() {
   const TestModel = model('test', schema_with_string_id);
   const obj = new TestModel();
 
-  ExpectType<string | null>(obj._id);
+  expect(obj._id).type.toBe<string | null>();
 })();
 
 (async function gh12094() {
@@ -505,7 +504,7 @@ function gh12100() {
   const User = model('User', userSchema);
 
   const doc = await User.exists({ name: 'Bill' }).orFail();
-  ExpectType<Types.ObjectId>(doc._id);
+  expect(doc._id).type.toBe<Types.ObjectId>();
 })();
 
 
@@ -529,7 +528,7 @@ async function gh12286() {
   if (user == null) {
     return;
   }
-  ExpectType<string>(user.name);
+  expect(user.name).type.toBe<string>();
 }
 
 
@@ -556,7 +555,7 @@ async function gh12347() {
   const User = model<IUser>('User', schema);
 
   const replaceOneResult = await User.replaceOne({}, {});
-  ExpectType<UpdateWriteOpResult>(replaceOneResult);
+  expect(replaceOneResult).type.toBe<UpdateWriteOpResult>();
 }
 
 async function gh12319() {
@@ -583,7 +582,7 @@ async function gh12319() {
     typeof projectSchema
   >;
 
-  ExpectAssignable<ProjectModelHydratedDoc>()(await ProjectModel.findOne().orFail());
+  expect(await ProjectModel.findOne().orFail()).type.toBe<ProjectModelHydratedDoc>();
 }
 
 function findWithId() {
@@ -596,9 +595,9 @@ function findWithId() {
 function gh12573ModelAny() {
   const TestModel = model<any>('Test', new Schema({}));
   const doc = new TestModel();
-  ExpectType<any>(doc);
+  expect(doc).type.toBe<any>();
   const { fieldA } = doc;
-  ExpectType<any>(fieldA);
+  expect(fieldA).type.toBe<any>();
 }
 
 function aggregateOptionsTest() {
@@ -623,9 +622,9 @@ async function gh13151() {
 
   const TestModel = model<ITest>('Test', TestSchema);
   const test = await TestModel.findOne().lean();
-  ExpectType<ITest & { _id: Types.ObjectId } & { __v: number } | null>(test);
+  expect(test).type.toBe<ITest & { _id: Types.ObjectId, __v: number } | null>();
   if (!test) return;
-  ExpectType<ITest & { _id: Types.ObjectId } & { __v: number }>(test);
+  expect(test).type.toBe<ITest & { _id: Types.ObjectId, __v: number }>();
 }
 
 function gh13206() {
@@ -635,7 +634,7 @@ function gh13206() {
   const TestSchema = new Schema({ name: String });
   const TestModel = model<ITest>('Test', TestSchema);
   TestModel.watch<ITest, ChangeStreamInsertDocument<ITest>>([], { fullDocument: 'updateLookup' }).on('change', (change) => {
-    ExpectType<ChangeStreamInsertDocument<ITest>>(change);
+    expect(change).type.toBe<ChangeStreamInsertDocument<ITest>>();
   });
 }
 
@@ -664,31 +663,31 @@ async function gh13705() {
   type ExpectedLeanDoc = (mongoose.FlattenMaps<{ name?: string | null }> & { _id: mongoose.Types.ObjectId } & { __v: number });
 
   const findByIdRes = await TestModel.findById('0'.repeat(24), undefined, { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findByIdRes);
+  expect(findByIdRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findOneRes = await TestModel.findOne({ _id: '0'.repeat(24) }, undefined, { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findOneRes);
+  expect(findOneRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findRes = await TestModel.find({ _id: '0'.repeat(24) }, undefined, { lean: true });
-  ExpectType<ExpectedLeanDoc[]>(findRes);
+  expect(findRes).type.toBe<ExpectedLeanDoc[]>();
 
   const findByIdAndDeleteRes = await TestModel.findByIdAndDelete('0'.repeat(24), { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findByIdAndDeleteRes);
+  expect(findByIdAndDeleteRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findByIdAndUpdateRes = await TestModel.findByIdAndUpdate('0'.repeat(24), {}, { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findByIdAndUpdateRes);
+  expect(findByIdAndUpdateRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findOneAndDeleteRes = await TestModel.findOneAndDelete({ _id: '0'.repeat(24) }, { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findOneAndDeleteRes);
+  expect(findOneAndDeleteRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findOneAndReplaceRes = await TestModel.findOneAndReplace({ _id: '0'.repeat(24) }, {}, { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findOneAndReplaceRes);
+  expect(findOneAndReplaceRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findOneAndUpdateRes = await TestModel.findOneAndUpdate({}, {}, { lean: true });
-  ExpectType<ExpectedLeanDoc | null>(findOneAndUpdateRes);
+  expect(findOneAndUpdateRes).type.toBe<ExpectedLeanDoc | null>();
 
   const findOneAndUpdateResWithMetadata = await TestModel.findOneAndUpdate({}, {}, { lean: true, includeResultMetadata: true });
-  ExpectAssignable<ModifyResult<ExpectedLeanDoc>>()(findOneAndUpdateResWithMetadata);
+  expect(findOneAndUpdateResWithMetadata).type.toBe<ModifyResult<{ name?: string | null | undefined }>>();
 }
 
 async function gh13746() {
@@ -698,29 +697,29 @@ async function gh13746() {
   type OkType = 0 | 1;
 
   const findByIdAndUpdateRes = await TestModel.findByIdAndUpdate('0'.repeat(24), {}, { includeResultMetadata: true });
-  ExpectType<boolean | undefined>(findByIdAndUpdateRes.lastErrorObject?.updatedExisting);
-  ExpectType<ObjectId | undefined>(findByIdAndUpdateRes.lastErrorObject?.upserted);
-  ExpectType<OkType>(findByIdAndUpdateRes.ok);
+  expect(findByIdAndUpdateRes.lastErrorObject?.updatedExisting).type.toBe<boolean | undefined>();
+  expect(findByIdAndUpdateRes.lastErrorObject?.upserted).type.toBe<ObjectId | undefined>();
+  expect(findByIdAndUpdateRes.ok).type.toBe<OkType>();
 
   const findOneAndReplaceRes = await TestModel.findOneAndReplace({ _id: '0'.repeat(24) }, {}, { includeResultMetadata: true });
-  ExpectType<boolean | undefined>(findOneAndReplaceRes.lastErrorObject?.updatedExisting);
-  ExpectType<ObjectId | undefined>(findOneAndReplaceRes.lastErrorObject?.upserted);
-  ExpectType<OkType>(findOneAndReplaceRes.ok);
+  expect(findOneAndReplaceRes.lastErrorObject?.updatedExisting).type.toBe<boolean | undefined>();
+  expect(findOneAndReplaceRes.lastErrorObject?.upserted).type.toBe<ObjectId | undefined>();
+  expect(findOneAndReplaceRes.ok).type.toBe<OkType>();
 
   const findOneAndUpdateRes = await TestModel.findOneAndUpdate({ _id: '0'.repeat(24) }, {}, { includeResultMetadata: true });
-  ExpectType<boolean | undefined>(findOneAndUpdateRes.lastErrorObject?.updatedExisting);
-  ExpectType<ObjectId | undefined>(findOneAndUpdateRes.lastErrorObject?.upserted);
-  ExpectType<OkType>(findOneAndUpdateRes.ok);
+  expect(findOneAndUpdateRes.lastErrorObject?.updatedExisting).type.toBe<boolean | undefined>();
+  expect(findOneAndUpdateRes.lastErrorObject?.upserted).type.toBe<ObjectId | undefined>();
+  expect(findOneAndUpdateRes.ok).type.toBe<OkType>();
 
   const findOneAndDeleteRes = await TestModel.findOneAndDelete({ _id: '0'.repeat(24) }, { includeResultMetadata: true });
-  ExpectType<boolean | undefined>(findOneAndDeleteRes.lastErrorObject?.updatedExisting);
-  ExpectType<ObjectId | undefined>(findOneAndDeleteRes.lastErrorObject?.upserted);
-  ExpectType<OkType>(findOneAndDeleteRes.ok);
+  expect(findOneAndDeleteRes.lastErrorObject?.updatedExisting).type.toBe<boolean | undefined>();
+  expect(findOneAndDeleteRes.lastErrorObject?.upserted).type.toBe<ObjectId | undefined>();
+  expect(findOneAndDeleteRes.ok).type.toBe<OkType>();
 
   const findByIdAndDeleteRes = await TestModel.findByIdAndDelete('0'.repeat(24), { includeResultMetadata: true });
-  ExpectType<boolean | undefined>(findByIdAndDeleteRes.lastErrorObject?.updatedExisting);
-  ExpectType<ObjectId | undefined>(findByIdAndDeleteRes.lastErrorObject?.upserted);
-  ExpectType<OkType>(findByIdAndDeleteRes.ok);
+  expect(findByIdAndDeleteRes.lastErrorObject?.updatedExisting).type.toBe<boolean | undefined>();
+  expect(findByIdAndDeleteRes.lastErrorObject?.upserted).type.toBe<ObjectId | undefined>();
+  expect(findByIdAndDeleteRes.ok).type.toBe<OkType>();
 }
 
 function gh13904() {
@@ -731,13 +730,13 @@ function gh13904() {
   }
   const Test = model<ITest>('Test', schema);
 
-  ExpectAssignable<Promise<InsertManyResult<ITest>>>()(Test.insertMany(
+  expect(Test.insertMany(
     [{ name: 'test' }],
     {
       ordered: false,
       rawResult: true
     }
-  ));
+  )).type.toBeAssignableTo<Promise<InsertManyResult<ITest>>>();
 }
 
 function gh13957() {
@@ -761,7 +760,7 @@ function gh13957() {
   const schema = new Schema({ name: { type: String, required: true } });
   const TestModel = model('Test', schema);
   const repository = new RepositoryBase<ITest>(TestModel);
-  ExpectType<Promise<ITest[]>>(repository.insertMany([{ name: 'test' }]));
+  expect(repository.insertMany([{ name: 'test' }])).type.toBe<Promise<ITest[]>>();
 }
 
 function gh13897() {
@@ -780,11 +779,8 @@ function gh13897() {
 
   const Document = model<IDocument>('Document', documentSchema);
   const doc = new Document({ name: 'foo' });
-  ExpectType<Date>(doc.createdAt);
-  new Document<IDocument>(
-    // @ts-expect-error  Type '{ name: string; }' is missing the following properties from type 'IDocument': createdAt, updatedAt
-    { name: 'foo' }
-  );
+  expect(doc.createdAt).type.toBe<Date>();
+  expect(Document<IDocument>).type.not.toBeConstructableWith({ name: 'foo' });
 }
 
 async function gh14026() {
@@ -795,14 +791,14 @@ async function gh14026() {
   const FooModel = mongoose.model<Foo>('Foo', new mongoose.Schema<Foo>({ bar: [String] }));
 
   const distinctBar = await FooModel.distinct('bar');
-  ExpectType<string[]>(distinctBar);
+  expect(distinctBar).type.toBe<string[]>();
 
   const TestModel = mongoose.model(
     'Test',
     new mongoose.Schema({ bar: [String] })
   );
 
-  ExpectType<string[]>(await TestModel.distinct('bar'));
+  expect(await TestModel.distinct('bar')).type.toBe<string[]>();
 }
 
 async function gh14072() {
@@ -865,7 +861,7 @@ async function gh14114() {
   const Test = mongoose.model('Test', schema);
 
   const doc = await Test.findOneAndDelete({ name: 'foo' });
-  ExpectType<ReturnType<(typeof Test)['hydrate']> | null>(doc);
+  expect(doc).type.toBe<ReturnType<(typeof Test)['hydrate']> | null>();
 }
 
 async function gh13999() {
@@ -932,14 +928,10 @@ async function gh12064() {
 
   const MyRecord = model('MyRecord', MyRecordSchema);
 
-  ExpectType<(string | null)[]>(
-    await MyRecord.distinct('foo.one').exec()
-  );
-  ExpectType<(string | null)[]>(
-    await MyRecord.find().distinct('foo.one').exec()
-  );
-  ExpectType<unknown[]>(await MyRecord.distinct('foo.two').exec());
-  ExpectType<unknown[]>(await MyRecord.distinct('arr.0').exec());
+  expect(await MyRecord.distinct('foo.one').exec()).type.toBe<(string | null)[]>();
+  expect(await MyRecord.find().distinct('foo.one').exec()).type.toBe<(string | null)[]>();
+  expect(await MyRecord.distinct('foo.two').exec()).type.toBe<unknown[]>();
+  expect(await MyRecord.distinct('arr.0').exec()).type.toBe<unknown[]>();
 }
 
 function testWithLevel1NestedPaths() {
@@ -960,7 +952,7 @@ function testWithLevel1NestedPaths() {
     nested2Level: { l2: { l3: boolean } },
     'nested2Level.l2': { l3: boolean }
   };
-  ExpectType<ExpectedTest1Type>({} as Test1);
+  expect<Test1>().type.toBe<ExpectedTest1Type>();
 
   const FooSchema = new Schema({
     one: { type: String }
@@ -979,11 +971,11 @@ function testWithLevel1NestedPaths() {
     foo: { one?: string | null | undefined },
     'foo.one': string | null | undefined
   };
-  ExpectType<ExpectedTest2Type>({} as Test2);
-  ExpectType<string>({} as Test2['_id']);
-  ExpectType<{ one?: string | null | undefined }>({} as Test2['foo']);
-  ExpectType<string | null | undefined>({} as Test2['foo.one']);
-  ExpectType<'_id' | 'foo' | 'foo.one'>({} as keyof Test2);
+  expect<Test2>().type.toBe<ExpectedTest2Type>();
+  expect<Test2['_id']>().type.toBe<string>();
+  expect<Test2['foo']>().type.toBe<{ one?: string | null | undefined }>();
+  expect<Test2['foo.one']>().type.toBe<string | null | undefined>();
+  expect<keyof Test2>().type.toBe<'_id' | 'foo' | 'foo.one'>();
 }
 
 async function gh14802() {
@@ -1003,7 +995,7 @@ async function gh14843() {
   const Model = model('Test', schema);
 
   const doc = await Model.insertOne({ name: 'taco' });
-  ExpectType<ReturnType<(typeof Model)['hydrate']>>(doc);
+  expect(doc).type.toBe<ReturnType<(typeof Model)['hydrate']>>();
 }
 
 async function gh15369() {
@@ -1065,9 +1057,9 @@ async function gh15437() {
 
   // Test hydrating with string projection
   const doc1 = PersonModel.hydrate(data, 'name age');
-  ExpectType<string>(doc1.name);
-  ExpectType<number>(doc1.age);
-  ExpectAssignable<undefined | null | string>()(doc1.address);
+  expect(doc1.name).type.toBe<string>();
+  expect(doc1.age).type.toBe<number>();
+  expect(doc1.address).type.toBe<string>();
 }
 
 async function customModelInstanceWithStatics() {
@@ -1078,7 +1070,7 @@ async function customModelInstanceWithStatics() {
     {
       statics: {
         function() {
-          ExpectType<number>(this.someCustomProp);
+          expect(this.someCustomProp).type.toBe<number>();
         }
       }
     }
@@ -1090,7 +1082,7 @@ async function gh16526() {
   const Tank = model('Tank', schema);
 
   const insertManyResult = await Tank.insertMany([{ name: 'test' }], { lean: true, rawResult: true });
-  ExpectType<number>(insertManyResult.insertedCount);
+  expect(insertManyResult.insertedCount).type.toBe<number>();
 }
 
 async function gh15693() {
@@ -1106,23 +1098,19 @@ async function gh15693() {
 
   const schema = new Schema<IUser, Model<IUser>, UserMethods>({ name: { type: String, required: true } });
   schema.method('printNamePrefixed', function printName(this: IUser, prefix: string) {
-    // @ts-expect-error  Property 'isModified' does not exist on type 'IUser'.
-    this.isModified('name');
-    // @ts-expect-error  Property 'doesNotExist' does not exist on type 'IUser'.
-    this.doesNotExist();
-    ExpectType<string>(this.name);
+    expect(this).type.not.toHaveProperty('isModified');
+    expect(this).type.not.toHaveProperty('doesNotExist');
+    expect(this.name).type.toBe<string>();
     console.log(prefix + this.name);
   });
   schema.method('printName', function printName(this: IUser) {
-    // @ts-expect-error  Property 'isModified' does not exist on type 'IUser'.
-    this.isModified('name');
-    // @ts-expect-error  Property 'doesNotExist' does not exist on type 'IUser'.
-    this.doesNotExist();
-    ExpectType<string>(this.name);
+    expect(this).type.not.toHaveProperty('isModified');
+    expect(this).type.not.toHaveProperty('doesNotExist');
+    expect(this.name).type.toBe<string>();
     console.log(this.name);
   });
   schema.method('getName', function getName() {
-    ExpectType<boolean>(this.isModified('name'));
+    expect(this.isModified('name')).type.toBe<boolean>();
     return this.name;
   });
   const User = model('user', schema);
@@ -1159,10 +1147,10 @@ async function gh15781() {
     }
   ]);
 
-  ExpectType<boolean | undefined>({} as UpdateOneModel['timestamps']);
-  ExpectType<boolean | undefined>({} as UpdateOneModel['overwriteImmutable']);
-  ExpectType<boolean | undefined>({} as UpdateManyModel['timestamps']);
-  ExpectType<boolean | undefined>({} as UpdateManyModel['overwriteImmutable']);
+  expect<UpdateOneModel['timestamps']>().type.toBe<boolean | undefined>();
+  expect<UpdateOneModel['overwriteImmutable']>().type.toBe<boolean | undefined>();
+  expect<UpdateManyModel['timestamps']>().type.toBe<boolean | undefined>();
+  expect<UpdateManyModel['overwriteImmutable']>().type.toBe<boolean | undefined>();
 }
 
 async function gh15910() {
@@ -1248,7 +1236,7 @@ function hydrateWithStrictOption() {
     extraField: 'value'
   }, undefined, { strict: false });
 
-  ExpectType<ReturnType<(typeof TestModel)['hydrate']>>(doc1);
+  expect(doc1).type.toBe<ReturnType<(typeof TestModel)['hydrate']>>();
 
   // Test with strict: true
   const doc2 = TestModel.hydrate({
@@ -1257,7 +1245,7 @@ function hydrateWithStrictOption() {
     age: 25
   }, undefined, { strict: true });
 
-  ExpectType<ReturnType<(typeof TestModel)['hydrate']>>(doc2);
+  expect(doc2).type.toBe<ReturnType<(typeof TestModel)['hydrate']>>();
 
   // Test with strict: 'throw'
   const doc3 = TestModel.hydrate({
@@ -1266,7 +1254,7 @@ function hydrateWithStrictOption() {
     age: 35
   }, undefined, { strict: 'throw' });
 
-  ExpectType<ReturnType<(typeof TestModel)['hydrate']>>(doc3);
+  expect(doc3).type.toBe<ReturnType<(typeof TestModel)['hydrate']>>();
 
   // Test without strict option
   const doc4 = TestModel.hydrate({
@@ -1275,5 +1263,5 @@ function hydrateWithStrictOption() {
     age: 28
   });
 
-  ExpectType<ReturnType<(typeof TestModel)['hydrate']>>(doc4);
+  expect(doc4).type.toBe<ReturnType<(typeof TestModel)['hydrate']>>();
 }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -20,7 +20,7 @@ import mongoose, {
 import mongodb from 'mongodb';
 import { ModifyResult, ObjectId } from 'mongodb';
 import { autoTypedModel } from './models.test';
-import { ExpectAssignable, ExpectType } from './util/assertions';
+import { expect } from 'tstyche';
 
 interface QueryHelpers {
   _byName(this: QueryWithHelpers<any, ITest, QueryHelpers>, name: string): QueryWithHelpers<Array<ITest>, ITest, QueryHelpers>;
@@ -43,8 +43,7 @@ schema.query._byName = function(name: string): QueryWithHelpers<ITest[], ITest, 
 };
 
 schema.query.byName = function(name: string): QueryWithHelpers<ITest[], ITest, QueryHelpers> {
-  // @ts-expect-error  Property 'notAQueryHelper' does not exist on type
-  this.notAQueryHelper();
+  expect(this).type.not.toHaveProperty('notAQueryHelper');
   return this._byName(name);
 };
 
@@ -70,8 +69,7 @@ interface ITest {
   endDate?: Date;
 }
 
-type X = mongoose.WithLevel1NestedPaths<ITest>;
-ExpectType<number | undefined>({} as X['docs.id']);
+expect<mongoose.WithLevel1NestedPaths<ITest>['docs.id']>().type.toBe<number | undefined>();
 
 const Test = model<ITest, Model<ITest, QueryHelpers>>('Test', schema);
 
@@ -157,15 +155,12 @@ const p1: Record<string, number> = Test.find().projection('age docs.id');
 const p2: Record<string, number> | null = Test.find().projection();
 const p3: null = Test.find().projection(null);
 
-
-// @ts-expect-error  No overload matches this call.
-Test.find({ }, { name: 'ss' }); // Only 0 and 1 are allowed
+expect(Test.find).type.not.toBeCallableWith({}, { name: 'ss' }); // Only 0 and 1 are allowed
 Test.find({}, { name: 3 });
 Test.find({}, { name: true, age: false, endDate: true, tags: 1 });
 Test.find({}, { name: true, age: false, endDate: true });
 Test.find({}, { name: false, age: false, tags: false, child: { name: false }, docs: { myId: false, id: true } });
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { tags: { something: 1 } }); // Array of strings or numbers should only be allowed to be a boolean or 1 and 0
+expect(Test.find).type.not.toBeCallableWith({}, { tags: { something: 1 } }); // Array of strings or numbers should only be allowed to be a boolean or 1 and 0
 Test.find({}, { name: true, age: true, endDate: true, tags: 1, child: { name: true }, docs: { myId: true, id: true } }); // This should be allowed
 Test.find({}, { name: 1, age: 1, endDate: 1, tags: 1, child: { name: 1 }, docs: { myId: 1, id: 1 } }); // This should be allowed
 Test.find({}, { _id: 0, name: 1, age: 1, endDate: 1, tags: 1, child: 1, docs: 1 }); // _id is an exception and should be allowed to be excluded
@@ -173,36 +168,27 @@ Test.find({}, { name: 0, age: 0, endDate: 0, tags: 0, child: 0, docs: 0 }); // T
 Test.find({}, { name: 0, age: 0, endDate: 0, tags: 0, child: { name: 0 }, docs: { myId: 0, id: 0 } }); // This should be allowed
 Test.find({}, { name: 1, age: 1, _id: 0 }); // This should be allowed since _id is an exception
 Test.find({}, { someOtherField: 1 }); // This should be allowed since it's not a field in the schema
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { name: { $slice: 1 } }); // $slice should only be allowed on arrays
+expect(Test.find).type.not.toBeCallableWith({}, { name: { $slice: 1 } }); // $slice should only be allowed on arrays
 Test.find({}, { tags: { $slice: 1 } }); // $slice should be allowed on arrays
 Test.find({}, { tags: { $slice: [1, 2] } }); // $slice with the format of [ <number to skip>, <number to return> ] should also be allowed on arrays
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { age: { $elemMatch: {} } }); // $elemMatch should not be allowed on non arrays
+expect(Test.find).type.not.toBeCallableWith({}, { age: { $elemMatch: {} } }); // $elemMatch should not be allowed on non arrays
 Test.find({}, { docs: { $elemMatch: { id: 'aa' } } }); // $elemMatch should be allowed on arrays
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { tags: { $slice: 1, $elemMatch: {} } }); // $elemMatch and $slice should not be allowed together
+expect(Test.find).type.not.toBeCallableWith({}, { tags: { $slice: 1, $elemMatch: {} } }); // $elemMatch and $slice should not be allowed together
 Test.find({}, { age: 1, tags: { $slice: 5 } }); // $slice should be allowed in inclusion projection
 Test.find({}, { age: 0, tags: { $slice: 5 } }); // $slice should be allowed in exclusion projection
 Test.find({}, { age: 1, tags: { $elemMatch: {} } }); // $elemMatch should be allowed in inclusion projection
 Test.find({}, { age: 0, tags: { $elemMatch: {} } }); // $elemMatch should be allowed in exclusion projection
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { 'docs.id': 'taco' }); // Dot notation should be allowed and does not accept any
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { docs: { id: '1' } }); // Dot notation should be able to use a combination with objects
+expect(Test.find).type.not.toBeCallableWith({}, { 'docs.id': 'taco' }); // Dot notation should be allowed and does not accept any
+expect(Test.find).type.not.toBeCallableWith({}, { docs: { id: '1' } }); // Dot notation should be able to use a combination with objects
 Test.find({}, { docs: { id: false } }); // Dot notation should be allowed with valid values - should correctly handle arrays
 Test.find({}, { docs: { id: true } }); // Dot notation should be allowed with valid values - should correctly handle arrays
 Test.find({ docs: { $elemMatch: { id: 1 } } }, { 'docs.$': 1 }); // $ projection should be allowed
 Test.find({}, { child: 1 }); // Dot notation should be able to use a combination with objects
 // Test.find({}, { 'docs.profiles': { name: 1 } }); // 3 levels deep not supported
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { 'docs.profiles': { name: 'aa' } }); // should support a combination of dot notation and objects
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { endDate: { toString: 1 } }); // should not allow projecting inherited methods in nested objects
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { tags: { trim: 1 } }); // should not allow projecting inherited methods in nested objects
-// @ts-expect-error  No overload matches this call.
-Test.find({}, { child: { toJSON: 1 } }); // should not allow projecting inherited methods in nested objects
+expect(Test.find).type.not.toBeCallableWith({}, { 'docs.profiles': { name: 'aa' } }); // should support a combination of dot notation and objects
+expect(Test.find).type.not.toBeCallableWith({}, { endDate: { toString: 1 } }); // should not allow projecting inherited methods in nested objects
+expect(Test.find).type.not.toBeCallableWith({}, { tags: { trim: 1 } }); // should not allow projecting inherited methods in nested objects
+expect(Test.find).type.not.toBeCallableWith({}, { child: { toJSON: 1 } }); // should not allow projecting inherited methods in nested objects
 Test.find({}, { age: 1, _id: 0 });
 Test.find({}, { name: 0, age: 0, _id: 1 });
 
@@ -217,16 +203,11 @@ Test.find().sort(undefined);
 Test.find().sort(null);
 Test.find().sort([['key', 'ascending']]);
 Test.find().sort([['key1', 'ascending'], ['key2', 'descending']]);
-// @ts-expect-error  Argument of type '{ name: 2; }' is not assignable
-Test.find().sort({ name: 2 });
-// @ts-expect-error  Argument of type '{ name: "invalidSortOrder"; }' is not assignable
-Test.find().sort({ name: 'invalidSortOrder' });
-// @ts-expect-error  Type '"invalid"' is not assignable to type 'SortOrder'.
-Test.find().sort([['key', 'invalid']]);
-// @ts-expect-error  Type 'false' is not assignable to type 'SortOrder'.
-Test.find().sort([['key', false]]);
-// @ts-expect-error  Type 'string' is not assignable to type '[string, SortOrder]'.
-Test.find().sort(['invalid']);
+expect(Test.find().sort).type.not.toBeCallableWith({ name: 2 });
+expect(Test.find().sort).type.not.toBeCallableWith({ name: 'invalidSortOrder' });
+expect(Test.find().sort).type.not.toBeCallableWith([['key', 'invalid']]);
+expect(Test.find().sort).type.not.toBeCallableWith([['key', false]]);
+expect(Test.find().sort).type.not.toBeCallableWith(['invalid']);
 
 // Super generic query
 function testGenericQuery(): void {
@@ -242,10 +223,10 @@ function testGenericQuery(): void {
 
 function eachAsync(): void {
   Test.find().cursor().eachAsync((doc) => {
-    ExpectType<HydratedDocument<ITest, {}, QueryHelpers>>(doc);
+    expect(doc).type.toBe<HydratedDocument<ITest, {}, QueryHelpers>>();
   });
   Test.find().cursor().eachAsync((docs) => {
-    ExpectType<HydratedDocument<ITest, {}, QueryHelpers>[]>(docs);
+    expect(docs).type.toBe<HydratedDocument<ITest, {}, QueryHelpers>[]>();
   }, { batchSize: 2 });
 }
 
@@ -315,7 +296,7 @@ async function gh11156(): Promise<void> {
   const User: Model<IUser> = model<IUser>('User', schema);
 
   const doc = await User.findOne<Pick<IUser, 'name'>>({}).orFail();
-  ExpectType<{ name: string }>(doc);
+  expect(doc).type.toBe<{ name: string }>();
 }
 
 async function gh11041(): Promise<void> {
@@ -335,7 +316,7 @@ async function gh11041(): Promise<void> {
   // 3. Create a Model.
   const MyModel = model<User>('User', schema);
 
-  ExpectType<HydratedDocument<User> | null>(await MyModel.findOne({}).populate('someField').exec());
+  expect(await MyModel.findOne({}).populate('someField').exec()).type.toBe<HydratedDocument<User> | null>();
 }
 
 async function gh11306(): Promise<void> {
@@ -355,14 +336,14 @@ async function gh11306(): Promise<void> {
   // 3. Create a Model.
   const MyModel = model<User>('User', schema);
 
-  ExpectType<unknown[]>(await MyModel.distinct('notThereInSchema'));
-  ExpectType<string[]>(await MyModel.distinct('name'));
+  expect(await MyModel.distinct('notThereInSchema')).type.toBe<unknown[]>();
+  expect(await MyModel.distinct('name')).type.toBe<string[]>();
 }
 
 function autoTypedQuery() {
   const AutoTypedModel = autoTypedModel();
   const query = AutoTypedModel.find();
-  ExpectType<typeof query>(AutoTypedModel.find().byUserName(''));
+  expect(AutoTypedModel.find().byUserName('')).type.toBe<typeof query>();
 }
 
 function gh11964() {
@@ -389,11 +370,8 @@ function gh14397() {
 
   const id = 'Test Id';
 
-  let idCondition: Condition<WithId<TestUser>['id']>;
-  let filter: QueryFilter<WithId<TestUser>>;
-
-  ExpectAssignable<typeof idCondition>()(id);
-  ExpectAssignable<typeof filter>()({ id });
+  expect<Condition<WithId<TestUser>['id']>>().type.toBeAssignableFrom(id);
+  expect<QueryFilter<WithId<TestUser>>>().type.toBeAssignableFrom({ id });
 }
 
 function gh12091() {
@@ -459,9 +437,8 @@ async function gh12342_manual() {
   // 2nd param to `model()` is the Model class to return.
   const ProjectModel = model<Project, ProjectModelType>('Project', schema);
 
-  ExpectType<HydratedDocument<Project>[]>(
-    await ProjectModel.findOne().where('stars').gt(1000).byName('mongoose')
-  );
+  expect(await ProjectModel.findOne().where('stars').gt(1000).byName('mongoose')).type.toBe<HydratedDocument<Project>[]>();
+
 }
 
 async function gh12342_auto() {
@@ -483,9 +460,7 @@ async function gh12342_auto() {
 
   const ProjectModel = model('Project', ProjectSchema);
 
-  ExpectAssignable<HydratedDocument<Project>[]>()(
-    await ProjectModel.findOne().where('stars').gt(1000).byName('mongoose')
-  );
+  expect(await ProjectModel.findOne().where('stars').gt(1000).byName('mongoose')).type.toBe<HydratedDocument<Project>[]>();
 }
 
 async function gh11602(): Promise<void> {
@@ -500,17 +475,15 @@ async function gh11602(): Promise<void> {
     includeResultMetadata: true
   });
 
-  // @ts-expect-error  Property 'modifiedCount' does not exist on type
-  updateResult.lastErrorObject?.modifiedCount;
-  ExpectType<boolean | undefined>(updateResult.lastErrorObject?.updatedExisting);
-  ExpectType<ObjectId | undefined>(updateResult.lastErrorObject?.upserted);
+  expect(updateResult.lastErrorObject!).type.not.toHaveProperty('modifiedCount');
+  expect(updateResult.lastErrorObject?.updatedExisting).type.toBe<boolean | undefined>();
+  expect(updateResult.lastErrorObject?.upserted).type.toBe<ObjectId | undefined>();
 
   ModelType.findOneAndUpdate({}, {}, { returnDocument: 'before' });
   ModelType.findOneAndUpdate({}, {}, { returnDocument: 'after' });
   ModelType.findOneAndUpdate({}, {}, { returnDocument: undefined });
   ModelType.findOneAndUpdate({}, {}, {});
-  // @ts-expect-error  No overload matches this call.
-  ModelType.findOneAndUpdate({}, {}, { returnDocument: 'not-before-or-after' }); // returnDocument should be 'before' or 'after'
+  expect(ModelType.findOneAndUpdate).type.not.toBeCallableWith({}, {}, { returnDocument: 'not-before-or-after' }); // returnDocument should be 'before' or 'after'
 }
 
 async function gh13142() {
@@ -549,7 +522,7 @@ async function gh13142() {
     { lean: true }
   );
   if (!blog) return;
-  ExpectType<Pick<Blog, Extract<keyof { content: 1 }, keyof Blog>>>(blog);
+  expect(blog).type.toBe<Pick<Blog, Extract<keyof { content: 1 }, keyof Blog>>>();
 }
 
 async function gh13224() {
@@ -557,25 +530,22 @@ async function gh13224() {
   const UserModel = model('User', userSchema);
 
   const u1 = await UserModel.findOne().select(['name']).orFail();
-  ExpectType<string | undefined | null>(u1.name);
-  ExpectType<number | undefined | null>(u1.age);
-  ExpectAssignable<Function>()(u1.toObject);
+  expect(u1.name).type.toBe<string | undefined | null>();
+  expect(u1.age).type.toBe<number | undefined | null>();
+  expect(u1.toObject).type.toBeAssignableTo<Function>();
 
   const u2 = await UserModel.findOne().select<{ name?: string }>(['name']).orFail();
-  ExpectType<string | undefined>(u2.name);
-  // @ts-expect-error  Property 'age' does not exist on type
-  u2.age;
-  ExpectAssignable<Function>()(u2.toObject);
+  expect(u2.name).type.toBe<string | undefined>();
+  expect(u2).type.not.toHaveProperty('age');
+  expect(u2.toObject).type.toBeAssignableTo<Function>();
 
   const users = await UserModel.find().select<{ name?: string }>(['name']);
   const u3 = users[0];
-  ExpectType<string | undefined>(u3!.name);
-  // @ts-expect-error  Property 'age' does not exist on type
-  u3!.age;
-  ExpectAssignable<Function>()(u3.toObject);
+  expect(u3.name).type.toBe<string | undefined>();
+  expect(u3).type.not.toHaveProperty('age');
+  expect(u3.toObject).type.toBeAssignableTo<Function>();
 
-  // @ts-expect-error  Type '{ notInSchema: string; }' has no properties in common with type '{ name?: any; age?: any; _id?: any; __v?: any; }'.
-  await UserModel.findOne().select<{ notInSchema: string }>(['name']).orFail();
+  expect(UserModel.findOne().select).type.not.toBeInstantiableWith<[{ notInSchema: string }]>();
 }
 
 function gh13630() {
@@ -587,16 +557,13 @@ function gh13630() {
     }
   }
 
-  ExpectAssignable<UpdateQueryKnownOnly<User>>()({ $set: { name: 'John' } });
-  ExpectAssignable<UpdateQueryKnownOnly<User>>()({ $unset: { phone: 'test' } });
-  ExpectAssignable<UpdateQueryKnownOnly<User>>()({ $set: { nested: { test: 'foo' } } });
-  // @ts-expect-error  'namee' does not exist in type 'AnyKeys<User>'.
-  const q1: UpdateQueryKnownOnly<User> = { $set: { namee: 'foo' } };
-  // @ts-expect-error  ''nested.test'' does not exist in type 'AnyKeys<User>'.
-  const q2: UpdateQueryKnownOnly<User> = { $set: { 'nested.test': 'foo' } };
+  expect<UpdateQueryKnownOnly<User>>().type.toBeAssignableFrom({ $set: { name: 'John' } });
+  expect<UpdateQueryKnownOnly<User>>().type.toBeAssignableFrom({ $unset: { phone: 'test' } });
+  expect<UpdateQueryKnownOnly<User>>().type.toBeAssignableFrom({ $set: { nested: { test: 'foo' } } });
+  expect<UpdateQueryKnownOnly<User>>().type.not.toBeAssignableFrom({ $set: { namee: 'foo' } });
+  expect<UpdateQueryKnownOnly<User>>().type.not.toBeAssignableFrom({ $set: { 'nested.test': 'foo' } });
 
-  const x: UpdateQueryKnownOnly<User> = { $set: { name: 'John' } };
-  ExpectAssignable<UpdateQuery<User>>()(x);
+  expect<UpdateQueryKnownOnly<User>>().type.toBeAssignableTo<UpdateQuery<User>>();
 }
 
 async function gh14190() {
@@ -604,23 +571,23 @@ async function gh14190() {
   const UserModel = model('User', userSchema);
 
   const doc = await UserModel.findByIdAndDelete('0'.repeat(24));
-  ExpectType<ReturnType<(typeof UserModel)['hydrate']> | null>(doc);
+  expect(doc).type.toBe<ReturnType<(typeof UserModel)['hydrate']> | null>();
 
   const res = await UserModel.findByIdAndDelete(
     '0'.repeat(24),
     { includeResultMetadata: true }
   );
-  ExpectAssignable<
+  expect(res).type.toBeAssignableTo<
     ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
-      >()(res);
+  >();
 
   const res2 = await UserModel.find().findByIdAndDelete(
     '0'.repeat(24),
     { includeResultMetadata: true }
   );
-  ExpectAssignable<
+  expect(res2).type.toBeAssignableTo<
     ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
-      >()(res2);
+  >();
 }
 
 function mongooseQueryOptions() {
@@ -725,10 +692,8 @@ async function gh14545() {
   const myDocs = await M.find({}).exec();
   const myDoc = await M.findOne({}).exec();
 
-  const myProjections = await M.find({}).select<SlimTest>({ prop: 1 }).exec();
-  ExpectType<SlimTestDocument[]>(myProjections);
-  const myProjection = await M.findOne({}).select<SlimTest>({ prop: 1 }).exec();
-  ExpectType<SlimTestDocument | null>(myProjection);
+  expect(await M.find({}).select<SlimTest>({ prop: 1 }).exec()).type.toBe<SlimTestDocument[]>();
+  expect(await M.findOne({}).select<SlimTest>({ prop: 1 }).exec()).type.toBe<SlimTestDocument | null>();
 }
 
 function gh14841() {
@@ -757,10 +722,8 @@ async function gh15526() {
   const u1 = await UserModel.findOne()
     .select<SelectType>(selection)
     .orFail();
-  ExpectType<string | undefined | null>(u1.name);
-
-  // @ts-expect-error  Property 'age' does not exist on type
-  u1.age;
+  expect(u1.name).type.toBe<string | undefined | null>();
+  expect(u1).type.not.toHaveProperty('age');
 }
 
 async function gh14173() {
@@ -820,12 +783,9 @@ async function gh12064() {
   const TestModel = model('Model', schema);
 
   await TestModel.findOne({ 'subdoc.subdocProp': { $gt: 0 }, 'nested.nestedProp': { $in: ['foo', 'bar'] }, 'documentArray.documentArrayProp': { $ne: true } });
-  // @ts-expect-error  No overload matches this call.
-  TestModel.findOne({ 'subdoc.subdocProp': 'taco tuesday' });
-  // @ts-expect-error  No overload matches this call.
-  TestModel.findOne({ 'nested.nestedProp': true });
-  // @ts-expect-error  No overload matches this call.
-  TestModel.findOne({ 'documentArray.documentArrayProp': 'taco' });
+  expect(TestModel.findOne).type.not.toBeCallableWith({ 'subdoc.subdocProp': 'taco tuesday' });
+  expect(TestModel.findOne).type.not.toBeCallableWith({ 'nested.nestedProp': true });
+  expect(TestModel.findOne).type.not.toBeCallableWith({ 'documentArray.documentArrayProp': 'taco' });
 }
 
 function gh15671() {
@@ -871,10 +831,8 @@ async function gh15779() {
 
   v8Filter.name = 'test';
 
-  type AgeType = typeof v8Filter.age;
-  ExpectAssignable<typeof v8Filter.age>()(42);
-  // @ts-expect-error  Type '"taco"' is not assignable to type 'StrictCondition<ApplyBasicQueryCasting<number>> | undefined'.
-  const a1: AgeType = 'taco';
+  expect(v8Filter.age).type.toBeAssignableFrom(42);
+  expect(v8Filter.age).type.not.toBeAssignableFrom('taco');
 
   const TestModel = model('Test', new Schema({ age: Number, name: String }));
   const query = TestModel.find({ age: { $gt: 18 } });
@@ -913,8 +871,6 @@ async function gh15779_2() {
 
 async function gh16062() {
   const Test = model('Test', new Schema({ runtime: Number }));
-  // @ts-expect-error  No overload matches this call.
-  await Test.findOne({ runtime: { $wrong: 100 } });
-  // @ts-expect-error  No overload matches this call.
-  await Test.findOne({ $and: [{ runtime: { $wrong: 100 } }] });
+  expect(Test.findOne).type.not.toBeCallableWith({ runtime: { $wrong: 100 } });
+  expect(Test.findOne).type.not.toBeCallableWith({ $and: [{ runtime: { $wrong: 100 } }] });
 }

--- a/test/types/querycursor.test.ts
+++ b/test/types/querycursor.test.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Model, Types } from 'mongoose';
-import { ExpectType } from './util/assertions';
+import { expect } from 'tstyche';
 
 const schema = new Schema({ name: { type: 'String' } });
 
@@ -9,19 +9,19 @@ type ITest = ReturnType<(typeof Test)['hydrate']>;
 
 Test.find().cursor().
   eachAsync(async(doc: ITest) => {
-    ExpectType<Types.ObjectId>(doc._id);
-    ExpectType<string | undefined | null>(doc.name);
+    expect(doc._id).type.toBe<Types.ObjectId>();
+    expect(doc.name).type.toBe<string | undefined | null>();
   }).
   then(() => console.log('Done!'));
 
 Test.find().cursor().
   eachAsync(async(doc: ITest, i) => {
-    ExpectType<Types.ObjectId>(doc._id);
-    ExpectType<number>(i);
+    expect(doc._id).type.toBe<Types.ObjectId>();
+    expect(i).type.toBe<number>();
   }).
   then(() => console.log('Done!'));
 
-Test.find().cursor().next().then((doc) => ExpectType<ITest | null>(doc));
+Test.find().cursor().next().then((doc) => expect(doc).type.toBe<ITest | null>());
 
 async function gh14374() {
   // `Parent` represents the object as it is stored in MongoDB
@@ -44,6 +44,6 @@ async function gh14374() {
 
   const cursor = ParentModel.find({}).populate<{ child: Child }>('child').cursor();
   for await (const doc of cursor) {
-    ExpectType<Child>(doc.child);
+    expect(doc.child).type.toBe<Child>();
   }
 }


### PR DESCRIPTION
**Summary**

This PR migrates type tests to TSTyche assertions in the following files:

```
test/types/inferrawdoctype.test.ts
test/types/models.test.ts
test/types/queries.test.ts
test/types/querycursor.test.ts
```

While working on these, I found a bug in TSTyche logic. Index signatures were required to be defined in the same order, but that is not correct behaviour. Fixed that and updated the TSTyche version.

Also, the new `.toBeInstantiableWith()` matcher is used here once.