### PR TITLE
Extend `defaults` query option to `find`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1679,6 +1679,7 @@ Query.prototype.getOptions = function() {
  * - [projection](https://mongoosejs.com/docs/api/query.html#Query.prototype.projection())
  * - sanitizeProjection
  * - useBigInt64
+ * - defaults: if `false`, skip applying default values to the returned document(s). Defaults to true.
  *
  * The following options are only for all operations **except** `updateOne()`, `updateMany()`, `deleteOne()`, and `deleteMany()`:
  *
@@ -2421,6 +2422,12 @@ Query.prototype._find = async function _find() {
     lean: mongooseOptions.lean || null
   };
 
+  // Intentionally using `in` check: omit the key entirely when unset so
+  // `createModel` doesn't see `defaults: null` and treat it as falsy.
+  if ('defaults' in mongooseOptions) {
+    completeManyOptions.defaults = mongooseOptions.defaults;
+  }
+
   const options = this._optionsForExec();
 
   const filter = this._conditions;
@@ -2691,7 +2698,7 @@ Query.prototype._completeMany = async function _completeMany(docs, fields, userP
   const model = this.model;
   return Promise.all(docs.map(doc => new Promise((resolve, reject) => {
     const rawDoc = doc;
-    doc = helpers.createModel(model, doc, fields, userProvidedFields);
+    doc = helpers.createModel(model, doc, fields, userProvidedFields, opts);
     if (opts.session != null) {
       doc.$session(opts.session);
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -2424,7 +2424,7 @@ Query.prototype._find = async function _find() {
 
   // Intentionally using `in` check: omit the key entirely when unset so
   // `createModel` doesn't see `defaults: null` and treat it as falsy.
-  if ('defaults' in mongooseOptions) {
+  if (mongooseOptions.defaults != null) {
     completeManyOptions.defaults = mongooseOptions.defaults;
   }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -2422,8 +2422,7 @@ Query.prototype._find = async function _find() {
     lean: mongooseOptions.lean || null
   };
 
-  // Intentionally using `in` check: omit the key entirely when unset so
-  // `createModel` doesn't see `defaults: null` and treat it as falsy.
+  // Omit the key entirely when nullish so `createModel` doesn't see `defaults: null` and treat it as falsy.
   if (mongooseOptions.defaults != null) {
     completeManyOptions.defaults = mongooseOptions.defaults;
   }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -8359,21 +8359,6 @@ describe('Model', function() {
 
   });
 
-  it('supports skipping defaults on a find operation gh-7287', async function() {
-    const betaSchema = new Schema({
-      name: { type: String, default: 'foo' },
-      age: { type: Number },
-      _id: { type: Number }
-    });
-
-    const Beta = db.model('Beta', betaSchema);
-
-    await Beta.collection.insertOne({ age: 21, _id: 1 });
-    const test = await Beta.findOne({ _id: 1 }).setOptions({ defaults: false });
-    assert.ok(!test.name);
-
-  });
-
   it('casts ObjectIds with `ref` in schema when calling `hydrate()` (gh-11052)', async function() {
     const authorSchema = new Schema({
       name: String

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4161,6 +4161,107 @@ describe('Query', function() {
     assert.ok(doc);
     assert.equal(doc.title, 'test-defaults-disabled');
   });
+  describe('defaults option skips applying defaults on query results (gh-7287)', function() {
+    const schema = mongoose.Schema({
+      name: { type: String, default: 'foo' },
+      age: { type: Number },
+      _id: { type: Number }
+    });
+    let Test;
+
+    beforeEach(async function() {
+      Test = db.model('Test', schema);
+      await Test.collection.insertMany([{ age: 21, _id: 1 }, { age: 25, _id: 2 }]);
+    });
+
+    it('find()', async function() {
+      const docs = await Test.find().setOptions({ defaults: false });
+      assert.equal(docs.length, 2);
+      for (const doc of docs) {
+        assert.ok(!doc.name);
+      }
+
+      const docsWithDefaults = await Test.find();
+      for (const doc of docsWithDefaults) {
+        assert.equal(doc.name, 'foo');
+      }
+    });
+
+    it('findOne()', async function() {
+      const doc = await Test.findOne({ _id: 1 }).setOptions({ defaults: false });
+      assert.ok(!doc.name);
+
+      const docWithDefaults = await Test.findOne({ _id: 1 });
+      assert.equal(docWithDefaults.name, 'foo');
+    });
+
+    it('findById()', async function() {
+      const doc = await Test.findById(1).setOptions({ defaults: false });
+      assert.ok(!doc.name);
+
+      const docWithDefaults = await Test.findById(1);
+      assert.equal(docWithDefaults.name, 'foo');
+    });
+
+    it('findOneAndUpdate()', async function() {
+      const doc = await Test.findOneAndUpdate(
+        { _id: 1 },
+        { age: 22 },
+        { defaults: false }
+      );
+      assert.ok(!doc.name);
+
+      const docWithDefaults = await Test.findOneAndUpdate(
+        { _id: 1 },
+        { age: 23 }
+      );
+      assert.equal(docWithDefaults.name, 'foo');
+    });
+
+    it('findByIdAndUpdate()', async function() {
+      const doc = await Test.findByIdAndUpdate(
+        1,
+        { age: 22 },
+        { defaults: false }
+      );
+      assert.ok(!doc.name);
+
+      const docWithDefaults = await Test.findByIdAndUpdate(
+        1,
+        { age: 23 }
+      );
+      assert.equal(docWithDefaults.name, 'foo');
+    });
+
+    it('findOneAndReplace()', async function() {
+      const doc = await Test.findOneAndReplace(
+        { _id: 1 },
+        { age: 30, _id: 1 },
+        { defaults: false }
+      );
+      assert.ok(!doc.name);
+      assert.equal(doc.age, 21);
+
+      const docWithDefaults = await Test.findOneAndReplace(
+        { _id: 2 },
+        { age: 31, _id: 2 }
+      );
+      assert.equal(docWithDefaults.name, 'foo');
+    });
+
+    it('findOneAndDelete()', async function() {
+      const doc = await Test.findOneAndDelete(
+        { _id: 2 },
+        { defaults: false }
+      );
+      assert.ok(!doc.name);
+      assert.equal(doc.age, 25);
+
+      const docWithDefaults = await Test.findOneAndDelete({ _id: 1 });
+      assert.equal(docWithDefaults.name, 'foo');
+    });
+  });
+
   it('throws a readable error when executing Query instance without a model (gh-13570)', async function() {
     const schema = new Schema({ name: String });
     const M = db.model('Test', schema, 'Test');

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -129,6 +129,11 @@ declare module 'mongoose' {
      */
     new?: boolean;
 
+    /**
+     * If `false`, skip applying default schema values to the returned document(s).
+     * @default true
+     */
+    defaults?: boolean;
     overwriteDiscriminatorKey?: boolean;
     /**
      * Mongoose removes updated immutable properties from `update` by default (excluding $setOnInsert).


### PR DESCRIPTION
**Summary**

The `defaults` query option (e.g., `{ defaults: false }`) is not currently respected by `find()`. It works for `findOne()` and the `findOneAnd*()` family because those go through `_completeOne`, which passes `this.options` (including `defaults`) down to `createModelAndInit` → `createModel`. But `find()` goes through `_completeMany`, which:

1. Builds `completeManyOptions` with only `session` and `lean`, dropping `defaults`
2. Calls `helpers.createModel(model, doc, fields, userProvidedFields)` without the options argument, so `createModel` never sees `defaults: false`

This also adds `defaults` to the JSDoc for `setOptions()` and to the TypeScript declarations in `QueryOptions`.

I'm also wondering if this is why [some folks still reported issues](https://github.com/Automattic/mongoose/issues/7287#issuecomment-1069383032) with this `defaults` query option not working?

**Reproducible example**

```ts
import mongoose from "mongoose";

async function main() {
  await mongoose.connect("mongodb://localhost:27017/test");

  const schema = new mongoose.Schema({
    name: { type: String, default: "foo" },
    age: Number,
  });
  const Test = mongoose.model("Test", schema);

  await Test.deleteMany({});
  await Test.collection.insertMany([{ age: 21 }, { age: 25 }]);

  // findOne works — defaults are skipped
  const one = await Test.findOne().setOptions({ defaults: false });
  console.log("findOne name:", one?.name); // undefined ✓

  // find is broken — defaults are still applied
  const docs = await Test.find().setOptions({ defaults: false });
  console.log(
    "find names:",
    docs.map((d) => d.name),
  ); // ['foo', 'foo'] ✗ (should be [undefined, undefined])

  await mongoose.disconnect();
}

void main();
```