### PR TITLE
perf: use kareem 3.3.0 re: mongoosejs/kareem#45

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 package-lock=false
 ignore-scripts=true
-min-release-age=7
+min-release-age=3

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 package-lock=false
 ignore-scripts=true
-min-release-age=3
+min-release-age=2

--- a/benchmarks/saveSimple.js
+++ b/benchmarks/saveSimple.js
@@ -55,53 +55,57 @@ async function run() {
     });
   }
 
-  const driverInsertStart = Date.now();
-  for (let i = 0; i < numIterations; ++i) {
-    for (let j = 0; j < 10; ++j) {
-      await fooCollection.insertOne({
-        _id: new mongoose.Types.ObjectId(),
-        prop1: `test ${i}`,
-        prop2: `test ${i}`,
-        prop3: `test ${i}`,
-        prop4: `test ${i}`,
-        prop5: `test ${i}`,
-        prop6: `test ${i}`,
-        prop7: `test ${i}`,
-        prop8: `test ${i}`,
-        prop9: `test ${i}`,
-        prop10: `test ${i}`
-      });
+  for (let i = 0; i < 3; ++i) {
+    const driverInsertStart = Date.now();
+    for (let i = 0; i < numIterations; ++i) {
+      for (let j = 0; j < 10; ++j) {
+        await fooCollection.insertOne({
+          _id: new mongoose.Types.ObjectId(),
+          prop1: `test ${i}`,
+          prop2: `test ${i}`,
+          prop3: `test ${i}`,
+          prop4: `test ${i}`,
+          prop5: `test ${i}`,
+          prop6: `test ${i}`,
+          prop7: `test ${i}`,
+          prop8: `test ${i}`,
+          prop9: `test ${i}`,
+          prop10: `test ${i}`
+        });
+      }
     }
-  }
-  const driverInsertEnd = Date.now();
+    const driverInsertEnd = Date.now();
 
-  const mongooseSaveStart = Date.now();
-  for (let i = 0; i < numIterations; ++i) {
-    for (let j = 0; j < 10; ++j) {
-      const doc = new FooModel({
-        prop1: `test ${i}`,
-        prop2: `test ${i}`,
-        prop3: `test ${i}`,
-        prop4: `test ${i}`,
-        prop5: `test ${i}`,
-        prop6: `test ${i}`,
-        prop7: `test ${i}`,
-        prop8: `test ${i}`,
-        prop9: `test ${i}`,
-        prop10: `test ${i}`
-      });
-      await doc.save();
+    const mongooseSaveStart = Date.now();
+    for (let i = 0; i < numIterations; ++i) {
+      for (let j = 0; j < 10; ++j) {
+        const doc = new FooModel({
+          prop1: `test ${i}`,
+          prop2: `test ${i}`,
+          prop3: `test ${i}`,
+          prop4: `test ${i}`,
+          prop5: `test ${i}`,
+          prop6: `test ${i}`,
+          prop7: `test ${i}`,
+          prop8: `test ${i}`,
+          prop9: `test ${i}`,
+          prop10: `test ${i}`
+        });
+        await doc.save();
+      }
     }
-  }
-  const mongooseSaveEnd = Date.now();
+    const mongooseSaveEnd = Date.now();
 
-  const results = {
-    'Average mongoose save time ms': +((mongooseSaveEnd - mongooseSaveStart) / numIterations).toFixed(2),
-    'Average driver insertOne time ms': +((driverInsertEnd - driverInsertStart) / numIterations).toFixed(2)
-  };
+    const results = {
+      'Average mongoose save time ms': +((mongooseSaveEnd - mongooseSaveStart) / numIterations).toFixed(2),
+      'Average driver insertOne time ms': +((driverInsertEnd - driverInsertStart) / numIterations).toFixed(2)
+    };
+
+    console.log(JSON.stringify(results, null, '  '));
+  }
+
 
   await client.close();
 
-  console.log(JSON.stringify(results, null, '  '));
   process.exit(0);
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "commonjs",
   "license": "MIT",
   "dependencies": {
-    "kareem": "3.2.0",
+    "kareem": "3.3.0",
     "mongodb": "~7.1",
     "mpath": "0.9.0",
     "mquery": "6.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Pulling in changes from mongoosejs/kareem#45 - consistently trims 5-10% off of the `saveSimple` benchmark. Not a lot, but we're getting much closer to matching the MongoDB Node driver.

Before: 
```
{
  "Average mongoose save time ms": 1.03,
  "Average driver insertOne time ms": 0.71
}
```

After:

```
{
  "Average mongoose save time ms": 0.98,
  "Average driver insertOne time ms": 0.73
}

```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
