### PR TITLE
fix(query): avoid cloning update until absolutely necessary to better support updates with __proto__ re: #16202

### DIFF
--- a/benchmarks/findOneAndUpdateSimple.js
+++ b/benchmarks/findOneAndUpdateSimple.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const mongoose = require('../');
+const { MongoClient } = require('mongodb');
+
+run().catch(err => {
+  console.error(err);
+  process.exit(-1);
+});
+
+async function run() {
+  const uri = 'mongodb://127.0.0.1:27017/mongoose_benchmark';
+
+  await mongoose.connect(uri);
+  const FooSchema = new mongoose.Schema({
+    prop1: String,
+    prop2: String,
+    prop3: String,
+    prop4: String,
+    prop5: String,
+    prop6: String,
+    prop7: String,
+    prop8: String,
+    prop9: String,
+    prop10: String
+  });
+  const FooModel = mongoose.model('FindOneAndUpdateSimpleFoo', FooSchema, 'findOneAndUpdateSimpleFoos');
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db();
+  const fooCollection = db.collection('findOneAndUpdateSimpleFoos');
+
+  if (!process.env.MONGOOSE_BENCHMARK_SKIP_SETUP) {
+    await FooModel.deleteMany({});
+    await fooCollection.deleteMany({});
+  }
+
+  const driverId = new mongoose.Types.ObjectId();
+  const mongooseId = new mongoose.Types.ObjectId();
+
+  await fooCollection.replaceOne(
+    { _id: driverId },
+    { _id: driverId, ...buildProps('driver setup') },
+    { upsert: true }
+  );
+  await fooCollection.replaceOne(
+    { _id: mongooseId },
+    { _id: mongooseId, ...buildProps('mongoose setup') },
+    { upsert: true }
+  );
+
+  const numIterations = 500;
+  for (let i = 0; i < 15000; ++i) {
+    // Warm up
+    await fooCollection.findOneAndUpdate(
+      { _id: driverId },
+      { $set: buildProps(`driver warmup ${i}`) }
+    );
+    await FooModel.findOneAndUpdate(
+      { _id: mongooseId },
+      { $set: buildProps(`mongoose warmup ${i}`) }
+    );
+  }
+
+  const driverFindOneAndUpdateStart = Date.now();
+  for (let i = 0; i < numIterations; ++i) {
+    for (let j = 0; j < 10; ++j) {
+      await fooCollection.findOneAndUpdate(
+        { _id: driverId },
+        { $set: buildProps(`driver ${i}-${j}`) }
+      );
+    }
+  }
+  const driverFindOneAndUpdateEnd = Date.now();
+
+  const mongooseFindOneAndUpdateStart = Date.now();
+  for (let i = 0; i < numIterations; ++i) {
+    for (let j = 0; j < 10; ++j) {
+      await FooModel.findOneAndUpdate(
+        { _id: mongooseId },
+        { $set: buildProps(`mongoose ${i}-${j}`) }
+      );
+    }
+  }
+  const mongooseFindOneAndUpdateEnd = Date.now();
+
+  const results = {
+    'Average mongoose findOneAndUpdate time ms': +((mongooseFindOneAndUpdateEnd - mongooseFindOneAndUpdateStart) / numIterations).toFixed(2),
+    'Average driver findOneAndUpdate time ms': +((driverFindOneAndUpdateEnd - driverFindOneAndUpdateStart) / numIterations).toFixed(2)
+  };
+
+  await mongoose.disconnect();
+  await client.close();
+
+  console.log(JSON.stringify(results, null, '  '));
+  process.exit(0);
+}
+
+function buildProps(prefix) {
+  return {
+    prop1: `${prefix} 1`,
+    prop2: `${prefix} 2`,
+    prop3: `${prefix} 3`,
+    prop4: `${prefix} 4`,
+    prop5: `${prefix} 5`,
+    prop6: `${prefix} 6`,
+    prop7: `${prefix} 7`,
+    prop8: `${prefix} 8`,
+    prop9: `${prefix} 9`,
+    prop10: `${prefix} 10`
+  };
+}

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -98,7 +98,7 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     moveImmutableProperties(schema, obj, context);
   }
 
-  if (obj?.$__) {
+  if (obj?.$__ && typeof obj.toObject === 'function') {
     obj = obj.toObject(internalToObjectOptions);
   }
 

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -98,6 +98,10 @@ module.exports = function castUpdate(schema, obj, options, context, filter) {
     moveImmutableProperties(schema, obj, context);
   }
 
+  if (obj?.$__) {
+    obj = obj.toObject(internalToObjectOptions);
+  }
+
   const ops = Object.keys(obj);
   let i = ops.length;
   const ret = {};

--- a/lib/model.js
+++ b/lib/model.js
@@ -2418,11 +2418,6 @@ Model.findOneAndUpdate = function(conditions, update, options) {
     fields = options.fields || options.projection;
   }
 
-  update = clone(update, {
-    depopulate: true,
-    _isNested: true
-  });
-
   decorateUpdateWithVersionKey(update, options, this.schema.options.versionKey);
 
   const mq = new this.Query({}, {}, this, this.$__collection);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2418,8 +2418,6 @@ Model.findOneAndUpdate = function(conditions, update, options) {
     fields = options.fields || options.projection;
   }
 
-  decorateUpdateWithVersionKey(update, options, this.schema.options.versionKey);
-
   const mq = new this.Query({}, {}, this, this.$__collection);
   mq.select(fields);
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -20,6 +20,7 @@ const castArrayFilters = require('./helpers/update/castArrayFilters');
 const castNumber = require('./cast/number');
 const castUpdate = require('./helpers/query/castUpdate');
 const clone = require('./helpers/clone');
+const decorateUpdateWithVersionKey = require('./helpers/update/decorateUpdateWithVersionKey');
 const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminatorByValue');
 const helpers = require('./queryHelpers');
 const internalToObjectOptions = require('./options').internalToObjectOptions;
@@ -1971,6 +1972,7 @@ Query.prototype.setQuery = function(val) {
  */
 
 Query.prototype.getUpdate = function() {
+  _cloneUpdateIfShared(this);
   return this._update;
 };
 
@@ -1991,6 +1993,7 @@ Query.prototype.getUpdate = function() {
 
 Query.prototype.setUpdate = function(val) {
   this._update = clone(val);
+  this._updateIsShared = false;
 };
 
 /**
@@ -2217,6 +2220,8 @@ Query.prototype.lean = function(v) {
  */
 
 Query.prototype.set = function(path, val) {
+  _cloneUpdateIfShared(this);
+
   if (typeof path === 'object') {
     const keys = Object.keys(path);
     for (const key of keys) {
@@ -2561,6 +2566,7 @@ Query.prototype.merge = function(source) {
     }
 
     if (source._update) {
+      _cloneUpdateIfShared(this);
       this._update || (this._update = {});
       utils.mergeClone(this._update, source._update);
     }
@@ -2856,6 +2862,7 @@ Query.prototype._applyTranslateAliases = function _applyTranslateAliases() {
   }
 
   if (this.model?.schema?.aliases && utils.hasOwnKeys(this.model.schema.aliases)) {
+    _cloneUpdateIfShared(this);
     this.model.translateAliases(this._conditions, true);
     this.model.translateAliases(this._fields, true);
     this.model.translateAliases(this._update, true);
@@ -3488,11 +3495,20 @@ Query.prototype.findOneAndUpdate = function(filter, update, options) {
     options.updatePipeline = updatePipeline;
   }
 
+  if (!options.updatePipeline && Array.isArray(update)) {
+    throw new MongooseError('Cannot pass an array to query updates unless the `updatePipeline` option is set.');
+  }
+
   this.setOptions(options);
 
   // apply doc
   if (update) {
-    this._mergeUpdate(update);
+    if (this._update == null || utils.isEmptyObject(this._update)) {
+      this._update = update;
+      this._updateIsShared = true;
+    } else {
+      this._mergeUpdate(update);
+    }
   }
 
   return this;
@@ -3531,6 +3547,8 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   convertNewToReturnDocument(options);
 
   this._update = this._castUpdate(this._update);
+  this._updateIsShared = false;
+  decorateUpdateWithVersionKey(this._update, options, this.schema.options.versionKey);
 
   this._update = setDefaultsOnInsert(
     this._conditions,
@@ -4056,6 +4074,8 @@ function _completeManyLean(schema, docs, path, opts) {
  */
 
 Query.prototype._mergeUpdate = function(update) {
+  _cloneUpdateIfShared(this);
+
   const updatePipeline = this._mongooseOptions.updatePipeline;
   if (!updatePipeline && Array.isArray(update)) {
     throw new MongooseError('Cannot pass an array to query updates unless the `updatePipeline` option is set.');
@@ -4164,6 +4184,7 @@ Query.prototype._updateMany = async function _updateMany() {
   }
 
   const options = this._optionsForExec(this.model);
+  _cloneUpdateIfShared(this);
   this._update = this._castUpdate(this._update);
   if (this._update == null || utils.hasOwnKeys(this._update) === false) {
     return { acknowledged: false };
@@ -4209,6 +4230,7 @@ Query.prototype._updateOne = async function _updateOne() {
   }
 
   const options = this._optionsForExec(this.model);
+  _cloneUpdateIfShared(this);
   this._update = this._castUpdate(this._update);
   if (this._update == null || utils.hasOwnKeys(this._update) === false) {
     return { acknowledged: false };
@@ -4517,11 +4539,20 @@ function _update(query, op, filter, doc, options, callback) {
     options.updatePipeline = updatePipeline;
   }
 
+  if (!options?.updatePipeline && Array.isArray(doc)) {
+    throw new MongooseError('Cannot pass an array to query updates unless the `updatePipeline` option is set.');
+  }
+
   if (utils.isObject(options)) {
     query.setOptions(options);
   }
 
-  query._mergeUpdate(doc);
+  if (query._update == null || utils.isEmptyObject(query._update)) {
+    query._update = doc;
+    query._updateIsShared = true;
+  } else {
+    query._mergeUpdate(doc);
+  }
 
   // Hooks
   if (callback) {
@@ -4794,6 +4825,17 @@ function _executePreHooks(query, op) {
     [],
     { filter }
   );
+}
+
+function _cloneUpdateIfShared(query) {
+  if (!query._updateIsShared) {
+    return;
+  }
+
+  query._update = clone(query._update, {
+    flattenDecimals: false
+  });
+  query._updateIsShared = false;
 }
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -2013,7 +2013,7 @@ Query.prototype.getUpdate = function() {
 Query.prototype.setUpdate = function(val, cloneUpdate) {
   this[queryUpdateSymbol] = cloneUpdate === false ? val : clone(val);
   if (cloneUpdate != null) {
-    this.mongooseOptions.cloneUpdate = cloneUpdate;
+    this._mongooseOptions.cloneUpdate = cloneUpdate;
   }
   this._updateIsShared = false;
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -86,7 +86,7 @@ const opToThunk = new Map([
   ['findOneAndDelete', '_findOneAndDelete']
 ]);
 
-const queryUpdateSymbol = Symbol('mongoose#update');
+const queryUpdateSymbol = Symbol('mongoose#Query#update');
 
 /**
  * Query constructor used for building queries. You do not need
@@ -1684,6 +1684,7 @@ Query.prototype.getOptions = function() {
  * - [upsert](https://www.mongodb.com/docs/manual/reference/method/db.collection.update/)
  * - [writeConcern](https://www.mongodb.com/docs/manual/reference/method/db.collection.update/)
  * - [timestamps](https://mongoosejs.com/docs/guide.html#timestamps): If `timestamps` is set in the schema, set this option to `false` to skip timestamps for that particular update. Has no effect if `timestamps` is not enabled in the schema options.
+ * - cloneUpdate: set to `false` to skip cloning the update before executing the query.
  * - overwriteDiscriminatorKey: allow setting the discriminator key in the update. Will use the correct discriminator schema if the update changes the discriminator key.
  * - overwriteImmutable: allow overwriting properties that are set to `immutable` in the schema. Defaults to false.
  *
@@ -1766,6 +1767,10 @@ Query.prototype.setOptions = function(options, overwrite) {
   if ('updatePipeline' in options) {
     this._mongooseOptions.updatePipeline = options.updatePipeline;
     delete options.updatePipeline;
+  }
+  if ('cloneUpdate' in options) {
+    this._mongooseOptions.cloneUpdate = options.cloneUpdate;
+    delete options.cloneUpdate;
   }
   if ('sanitizeProjection' in options) {
     if (options.sanitizeProjection && !this._mongooseOptions.sanitizeProjection) {
@@ -2000,12 +2005,16 @@ Query.prototype.getUpdate = function() {
  *     query.getUpdate(); // { $set: { b: 6 } }
  *
  * @param {object} new update operation
+ * @param {boolean} [cloneUpdate=true] if `false`, Mongoose will not clone the update
  * @return {undefined}
  * @api public
  */
 
-Query.prototype.setUpdate = function(val) {
-  this[queryUpdateSymbol] = clone(val);
+Query.prototype.setUpdate = function(val, cloneUpdate) {
+  this[queryUpdateSymbol] = cloneUpdate === false ? val : clone(val);
+  if (cloneUpdate != null) {
+    this.mongooseOptions.cloneUpdate = cloneUpdate;
+  }
   this._updateIsShared = false;
 };
 
@@ -2356,6 +2365,7 @@ Query.prototype._unsetCastError = function _unsetCastError() {
  * - `strictQuery`: controls how Mongoose handles keys that aren't in the schema for the query `filter`. This option is `false` by default, which means Mongoose will allow `Model.find({ foo: 'bar' })` even if `foo` is not in the schema. See the [`strictQuery` docs](https://mongoosejs.com/docs/guide.html#strictQuery) for more information.
  * - `nearSphere`: use `$nearSphere` instead of `near()`. See the [`Query.prototype.nearSphere()` docs](https://mongoosejs.com/docs/api/query.html#Query.prototype.nearSphere())
  * - `schemaLevelProjections`: if `false`, Mongoose will not apply schema-level `select: false` or `select: true` for this query
+ * - `cloneUpdate`: if `false`, Mongoose will not clone updates before executing the query
  *
  * Mongoose maintains a separate object for internal options because
  * Mongoose sends `Query.prototype.options` to the MongoDB server, and the
@@ -3436,6 +3446,7 @@ function prepareDiscriminatorCriteria(query) {
  * @param {object|Query} [filter]
  * @param {object} [update]
  * @param {object} [options]
+ * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.includeResultMetadata] if true, returns the full [ModifyResult from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/7.0/interfaces/ModifyResult.html) rather than just the document
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
@@ -3743,6 +3754,7 @@ Query.prototype._findOneAndDelete = async function _findOneAndDelete() {
  * @param {object} [filter]
  * @param {object} [replacement]
  * @param {object} [options]
+ * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.includeResultMetadata] if true, returns the full [ModifyResult from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/7.0/interfaces/ModifyResult.html) rather than just the document
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
@@ -3916,6 +3928,7 @@ Query.prototype.findById = function(id, projection, options) {
  * @param {any} id value of `_id` to query by
  * @param {object} [doc]
  * @param {object} [options]
+ * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.includeResultMetadata] if true, returns the full [ModifyResult from the MongoDB driver](https://mongodb.github.io/node-mongodb-native/7.0/interfaces/ModifyResult.html) rather than just the document
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {ClientSession} [options.session=null] The session associated with this query. See [transactions docs](https://mongoosejs.com/docs/transactions.html).
@@ -4331,6 +4344,7 @@ Query.prototype._replaceOne = async function _replaceOne() {
  * @param {object} [filter]
  * @param {object|Array} [update] the update command. If array, this update will be treated as an update pipeline and not casted.
  * @param {object} [options]
+ * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {boolean} [options.upsert=false] if true, and no documents found, insert a new document
@@ -4406,6 +4420,7 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @param {object} [filter]
  * @param {object|Array} [update] the update command. If array, this update will be treated as an update pipeline and not casted.
  * @param {object} [options]
+ * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {boolean} [options.upsert=false] if true, and no documents found, insert a new document
@@ -4475,6 +4490,7 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * @param {object} [filter]
  * @param {object} [doc] the update command
  * @param {object} [options]
+ * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {boolean} [options.upsert=false] if true, and no documents found, insert a new document
@@ -4846,6 +4862,9 @@ function _executePreHooks(query, op) {
 
 function _cloneUpdateIfShared(query) {
   if (!query._updateIsShared) {
+    return;
+  }
+  if (query.mongooseOptions().cloneUpdate === false) {
     return;
   }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -86,6 +86,8 @@ const opToThunk = new Map([
   ['findOneAndDelete', '_findOneAndDelete']
 ]);
 
+const queryUpdateSymbol = Symbol('mongoose#update');
+
 /**
  * Query constructor used for building queries. You do not need
  * to instantiate a `Query` directly. Instead use Model functions like
@@ -197,6 +199,18 @@ function checkRequireFilter(filter, options) {
 Query.prototype = new mquery();
 Query.prototype.constructor = Query;
 
+Object.defineProperty(Query.prototype, '_update', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    _cloneUpdateIfShared(this);
+    return this[queryUpdateSymbol];
+  },
+  set: function(v) {
+    this[queryUpdateSymbol] = v;
+  }
+});
+
 // Remove some legacy methods that we removed in Mongoose 8, but
 // are still in mquery 5.
 Query.prototype.count = undefined;
@@ -301,7 +315,7 @@ Query.prototype.toConstructor = function toConstructor() {
   p.op = this.op;
   p._conditions = clone(this._conditions);
   p._fields = clone(this._fields);
-  p._update = clone(this._update, {
+  p[queryUpdateSymbol] = clone(this[queryUpdateSymbol], {
     flattenDecimals: false
   });
   p._path = this._path;
@@ -349,7 +363,7 @@ Query.prototype.clone = function() {
   q.op = this.op;
   q._conditions = clone(this._conditions);
   q._fields = clone(this._fields);
-  q._update = clone(this._update, {
+  q[queryUpdateSymbol] = clone(this[queryUpdateSymbol], {
     flattenDecimals: false
   });
   q._path = this._path;
@@ -1366,7 +1380,7 @@ Query.prototype.toString = function toString() {
       this.op === 'update' ||
       this.op === 'updateMany' ||
       this.op === 'updateOne') {
-    return `${this.model.modelName}.${this.op}(${util.inspect(this._conditions)}, ${util.inspect(this._update)})`;
+    return `${this.model.modelName}.${this.op}(${util.inspect(this._conditions)}, ${util.inspect(this[queryUpdateSymbol])})`;
   }
 
   // 'estimatedDocumentCount' or any others
@@ -1972,7 +1986,6 @@ Query.prototype.setQuery = function(val) {
  */
 
 Query.prototype.getUpdate = function() {
-  _cloneUpdateIfShared(this);
   return this._update;
 };
 
@@ -1992,7 +2005,7 @@ Query.prototype.getUpdate = function() {
  */
 
 Query.prototype.setUpdate = function(val) {
-  this._update = clone(val);
+  this[queryUpdateSymbol] = clone(val);
   this._updateIsShared = false;
 };
 
@@ -2026,7 +2039,7 @@ Query.prototype._fieldsForExec = function() {
  */
 
 Query.prototype._updateForExec = function() {
-  const update = clone(this._update, {
+  const update = clone(this[queryUpdateSymbol], {
     transform: false,
     depopulate: true
   });
@@ -2230,12 +2243,16 @@ Query.prototype.set = function(path, val) {
     return this;
   }
 
-  this._update = this._update || {};
-  if (path in this._update) {
-    delete this._update[path];
+  let update = this[queryUpdateSymbol];
+  if (update == null) {
+    update = {};
+    this[queryUpdateSymbol] = update;
   }
-  this._update.$set = this._update.$set || {};
-  this._update.$set[path] = val;
+  if (path in update) {
+    delete update[path];
+  }
+  update.$set = update.$set || {};
+  update.$set[path] = val;
   return this;
 };
 
@@ -2255,7 +2272,7 @@ Query.prototype.set = function(path, val) {
  */
 
 Query.prototype.get = function get(path) {
-  const update = this._update;
+  const update = this[queryUpdateSymbol];
   if (update == null) {
     return void 0;
   }
@@ -2565,10 +2582,10 @@ Query.prototype.merge = function(source) {
       utils.merge(this.options, source.options, opts);
     }
 
-    if (source._update) {
+    if (source[queryUpdateSymbol] != null) {
       _cloneUpdateIfShared(this);
-      this._update || (this._update = {});
-      utils.mergeClone(this._update, source._update);
+      this[queryUpdateSymbol] || (this[queryUpdateSymbol] = {});
+      utils.mergeClone(this[queryUpdateSymbol], source[queryUpdateSymbol]);
     }
 
     if (source._distinct) {
@@ -2865,7 +2882,7 @@ Query.prototype._applyTranslateAliases = function _applyTranslateAliases() {
     _cloneUpdateIfShared(this);
     this.model.translateAliases(this._conditions, true);
     this.model.translateAliases(this._fields, true);
-    this.model.translateAliases(this._update, true);
+    this.model.translateAliases(this[queryUpdateSymbol], true);
     if (this._distinct != null && this.model.schema.aliases[this._distinct] != null) {
       this._distinct = this.model.schema.aliases[this._distinct];
     }
@@ -3503,8 +3520,8 @@ Query.prototype.findOneAndUpdate = function(filter, update, options) {
 
   // apply doc
   if (update) {
-    if (this._update == null || utils.isEmptyObject(this._update)) {
-      this._update = update;
+    if (this[queryUpdateSymbol] == null || utils.isEmptyObject(this[queryUpdateSymbol])) {
+      this[queryUpdateSymbol] = update;
       this._updateIsShared = true;
     } else {
       this._mergeUpdate(update);
@@ -3546,51 +3563,51 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   const options = this._optionsForExec(this.model);
   convertNewToReturnDocument(options);
 
-  this._update = this._castUpdate(this._update);
+  this[queryUpdateSymbol] = this._castUpdate(this[queryUpdateSymbol]);
   this._updateIsShared = false;
-  decorateUpdateWithVersionKey(this._update, options, this.schema.options.versionKey);
+  decorateUpdateWithVersionKey(this[queryUpdateSymbol], options, this.schema.options.versionKey);
 
-  this._update = setDefaultsOnInsert(
+  this[queryUpdateSymbol] = setDefaultsOnInsert(
     this._conditions,
     this.model.schema,
-    this._update,
+    this[queryUpdateSymbol],
     options,
     this._mongooseOptions,
     this
   );
 
-  if (!this._update || utils.hasOwnKeys(this._update) === false) {
+  if (!this[queryUpdateSymbol] || utils.hasOwnKeys(this[queryUpdateSymbol]) === false) {
     if (options.upsert) {
       // still need to do the upsert to empty doc
-      const $set = clone(this._update);
+      const $set = clone(this[queryUpdateSymbol]);
       delete $set._id;
-      this._update = { $set };
+      this[queryUpdateSymbol] = { $set };
     } else {
       this._execCount = 0;
       const res = await this._findOne();
       return res;
     }
-  } else if (this._update instanceof Error) {
-    throw this._update;
+  } else if (this[queryUpdateSymbol] instanceof Error) {
+    throw this[queryUpdateSymbol];
   } else {
     // In order to make MongoDB 2.6 happy (see
     // https://jira.mongodb.org/browse/SERVER-12266 and related issues)
     // if we have an actual update document but $set is empty, junk the $set.
-    if (this._update.$set && utils.hasOwnKeys(this._update.$set) === false) {
-      delete this._update.$set;
+    if (this[queryUpdateSymbol].$set && utils.hasOwnKeys(this[queryUpdateSymbol].$set) === false) {
+      delete this[queryUpdateSymbol].$set;
     }
   }
 
   const runValidators = _getOption(this, 'runValidators', false);
   if (runValidators) {
-    await this.validate(this._update, options, false);
+    await this.validate(this[queryUpdateSymbol], options, false);
   }
 
-  if (typeof this._update.toBSON === 'function') {
-    this._update = this._update.toBSON();
+  if (typeof this[queryUpdateSymbol].toBSON === 'function') {
+    this[queryUpdateSymbol] = this[queryUpdateSymbol].toBSON();
   }
 
-  let res = await this.mongooseCollection.findOneAndUpdate(this._conditions, this._update, options);
+  let res = await this.mongooseCollection.findOneAndUpdate(this._conditions, this[queryUpdateSymbol], options);
   for (const fn of this._transforms) {
     res = fn(res);
   }
@@ -3821,13 +3838,13 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
   const runValidators = _getOption(this, 'runValidators', false);
 
   try {
-    const update = new this.model(this._update, null, modelOpts);
+    const update = new this.model(this[queryUpdateSymbol], null, modelOpts);
     if (runValidators) {
       await update.validate();
     } else if (update.$__.validationError) {
       throw update.$__.validationError;
     }
-    this._update = update.toBSON();
+    this[queryUpdateSymbol] = update.toBSON();
   } catch (err) {
     if (err instanceof ValidationError) {
       throw err;
@@ -3837,7 +3854,7 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
     throw validationError;
   }
 
-  let res = await this.mongooseCollection.findOneAndReplace(filter, this._update, options);
+  let res = await this.mongooseCollection.findOneAndReplace(filter, this[queryUpdateSymbol], options);
 
   for (const fn of this._transforms) {
     res = fn(res);
@@ -4080,8 +4097,8 @@ Query.prototype._mergeUpdate = function(update) {
   if (!updatePipeline && Array.isArray(update)) {
     throw new MongooseError('Cannot pass an array to query updates unless the `updatePipeline` option is set.');
   }
-  if (!this._update) {
-    this._update = Array.isArray(update) ? [] : {};
+  if (!this[queryUpdateSymbol]) {
+    this[queryUpdateSymbol] = Array.isArray(update) ? [] : {};
   }
 
   if (update == null || (typeof update === 'object' && utils.hasOwnKeys(update) === false)) {
@@ -4089,28 +4106,28 @@ Query.prototype._mergeUpdate = function(update) {
   }
 
   if (update instanceof Query) {
-    if (Array.isArray(this._update)) {
-      throw new MongooseError(`Cannot mix array and object updates (current: ${_previewUpdate(this._update)}, incoming: ${_previewUpdate(update._update)})`);
+    if (Array.isArray(this[queryUpdateSymbol])) {
+      throw new MongooseError(`Cannot mix array and object updates (current: ${_previewUpdate(this[queryUpdateSymbol])}, incoming: ${_previewUpdate(update[queryUpdateSymbol])})`);
     }
-    if (update._update) {
-      utils.mergeClone(this._update, update._update);
+    if (update[queryUpdateSymbol]) {
+      utils.mergeClone(this[queryUpdateSymbol], update[queryUpdateSymbol]);
     }
   } else if (Array.isArray(update)) {
-    if (!Array.isArray(this._update)) {
+    if (!Array.isArray(this[queryUpdateSymbol])) {
       // `_update` may be empty object by default, like in `doc.updateOne()`
       // because we create the query first, then run hooks, then apply the update.
-      if (this._update == null || utils.isEmptyObject(this._update)) {
-        this._update = [];
+      if (this[queryUpdateSymbol] == null || utils.isEmptyObject(this[queryUpdateSymbol])) {
+        this[queryUpdateSymbol] = [];
       } else {
-        throw new MongooseError(`Cannot mix array and object updates (current: ${_previewUpdate(this._update)}, incoming: ${_previewUpdate(update)})`);
+        throw new MongooseError(`Cannot mix array and object updates (current: ${_previewUpdate(this[queryUpdateSymbol])}, incoming: ${_previewUpdate(update)})`);
       }
     }
-    this._update = this._update.concat(update);
+    this[queryUpdateSymbol] = this[queryUpdateSymbol].concat(update);
   } else {
-    if (Array.isArray(this._update)) {
-      throw new MongooseError(`Cannot mix array and object updates (current: ${_previewUpdate(this._update)}, incoming: ${_previewUpdate(update)})`);
+    if (Array.isArray(this[queryUpdateSymbol])) {
+      throw new MongooseError(`Cannot mix array and object updates (current: ${_previewUpdate(this[queryUpdateSymbol])}, incoming: ${_previewUpdate(update)})`);
     }
-    utils.mergeClone(this._update, update);
+    utils.mergeClone(this[queryUpdateSymbol], update);
   }
 };
 
@@ -4185,30 +4202,30 @@ Query.prototype._updateMany = async function _updateMany() {
 
   const options = this._optionsForExec(this.model);
   _cloneUpdateIfShared(this);
-  this._update = this._castUpdate(this._update);
-  if (this._update == null || utils.hasOwnKeys(this._update) === false) {
+  this[queryUpdateSymbol] = this._castUpdate(this[queryUpdateSymbol]);
+  if (this[queryUpdateSymbol] == null || utils.hasOwnKeys(this[queryUpdateSymbol]) === false) {
     return { acknowledged: false };
   }
-  removeUnusedArrayFilters(this._update, options);
+  removeUnusedArrayFilters(this[queryUpdateSymbol], options);
 
-  this._update = setDefaultsOnInsert(
+  this[queryUpdateSymbol] = setDefaultsOnInsert(
     this._conditions,
     this.model.schema,
-    this._update,
+    this[queryUpdateSymbol],
     options,
     this._mongooseOptions,
     this
   );
 
   if (_getOption(this, 'runValidators', false)) {
-    await this.validate(this._update, options, false);
+    await this.validate(this[queryUpdateSymbol], options, false);
   }
 
-  if (typeof this._update.toBSON === 'function') {
-    this._update = this._update.toBSON();
+  if (typeof this[queryUpdateSymbol].toBSON === 'function') {
+    this[queryUpdateSymbol] = this[queryUpdateSymbol].toBSON();
   }
 
-  return this.mongooseCollection.updateMany(this._conditions, this._update, options);
+  return this.mongooseCollection.updateMany(this._conditions, this[queryUpdateSymbol], options);
 };
 
 /**
@@ -4231,30 +4248,30 @@ Query.prototype._updateOne = async function _updateOne() {
 
   const options = this._optionsForExec(this.model);
   _cloneUpdateIfShared(this);
-  this._update = this._castUpdate(this._update);
-  if (this._update == null || utils.hasOwnKeys(this._update) === false) {
+  this[queryUpdateSymbol] = this._castUpdate(this[queryUpdateSymbol]);
+  if (this[queryUpdateSymbol] == null || utils.hasOwnKeys(this[queryUpdateSymbol]) === false) {
     return { acknowledged: false };
   }
-  removeUnusedArrayFilters(this._update, options);
+  removeUnusedArrayFilters(this[queryUpdateSymbol], options);
 
-  this._update = setDefaultsOnInsert(
+  this[queryUpdateSymbol] = setDefaultsOnInsert(
     this._conditions,
     this.model.schema,
-    this._update,
+    this[queryUpdateSymbol],
     options,
     this._mongooseOptions,
     this
   );
 
   if (_getOption(this, 'runValidators', false)) {
-    await this.validate(this._update, options, false);
+    await this.validate(this[queryUpdateSymbol], options, false);
   }
 
-  if (typeof this._update.toBSON === 'function') {
-    this._update = this._update.toBSON();
+  if (typeof this[queryUpdateSymbol].toBSON === 'function') {
+    this[queryUpdateSymbol] = this[queryUpdateSymbol].toBSON();
   }
 
-  return this.mongooseCollection.updateOne(this._conditions, this._update, options);
+  return this.mongooseCollection.updateOne(this._conditions, this[queryUpdateSymbol], options);
 };
 
 /**
@@ -4276,18 +4293,18 @@ Query.prototype._replaceOne = async function _replaceOne() {
   }
 
   const options = this._optionsForExec(this.model);
-  this._update = new this.model(this._update, null, { skipId: true });
-  removeUnusedArrayFilters(this._update, options);
+  this[queryUpdateSymbol] = new this.model(this[queryUpdateSymbol], null, { skipId: true });
+  removeUnusedArrayFilters(this[queryUpdateSymbol], options);
 
   if (_getOption(this, 'runValidators', false)) {
-    await this.validate(this._update, options, true);
+    await this.validate(this[queryUpdateSymbol], options, true);
   }
 
-  if (typeof this._update.toBSON === 'function') {
-    this._update = this._update.toBSON();
+  if (typeof this[queryUpdateSymbol].toBSON === 'function') {
+    this[queryUpdateSymbol] = this[queryUpdateSymbol].toBSON();
   }
 
-  return this.mongooseCollection.replaceOne(this._conditions, this._update, options);
+  return this.mongooseCollection.replaceOne(this._conditions, this[queryUpdateSymbol], options);
 };
 
 /**
@@ -4547,8 +4564,8 @@ function _update(query, op, filter, doc, options, callback) {
     query.setOptions(options);
   }
 
-  if (query._update == null || utils.isEmptyObject(query._update)) {
-    query._update = doc;
+  if (query[queryUpdateSymbol] == null || utils.isEmptyObject(query[queryUpdateSymbol])) {
+    query[queryUpdateSymbol] = doc;
     query._updateIsShared = true;
   } else {
     query._mergeUpdate(doc);
@@ -4832,7 +4849,7 @@ function _cloneUpdateIfShared(query) {
     return;
   }
 
-  query._update = clone(query._update, {
+  query[queryUpdateSymbol] = clone(query[queryUpdateSymbol], {
     flattenDecimals: false
   });
   query._updateIsShared = false;

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -168,7 +168,7 @@ describe('model: findOneAndUpdate:', function() {
     const res = await Test.findOneAndUpdate(
       { _id: doc._id },
       update,
-      { returnDocument: 'after' }
+      { returnDocument: 'after', cloneUpdate: false }
     ).lean();
 
     assert.equal(Object.prototype.hasOwnProperty.call(update.$set.path1, '__proto__'), true);

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -157,6 +157,66 @@ describe('model: findOneAndUpdate:', function() {
     assert.ok(up.comments[1]._id instanceof DocumentObjectId);
   });
 
+  it('preserves own __proto__ keys in update payloads without mutating the caller update (gh-16202)', async function() {
+    const Test = db.model('Test', new Schema({
+      path1: Schema.Types.Mixed
+    }));
+
+    const doc = await Test.create({ path1: {} });
+    const update = { $set: { path1: { ['__proto__']: 'abcd' } } };
+
+    const res = await Test.findOneAndUpdate(
+      { _id: doc._id },
+      update,
+      { returnDocument: 'after' }
+    ).lean();
+
+    assert.equal(Object.prototype.hasOwnProperty.call(update.$set.path1, '__proto__'), true);
+    assert.equal(update.$set.path1.__proto__, 'abcd');
+    assert.equal(Object.prototype.hasOwnProperty.call(res.path1, '__proto__'), true);
+    assert.equal(res.path1.__proto__, 'abcd');
+  });
+
+  it('does not mutate the caller update when chaining set() after findOneAndUpdate()', async function() {
+    const Test = db.model('Test', new Schema({
+      title: String,
+      status: String
+    }));
+
+    const doc = await Test.create({ title: 'before', status: 'before' });
+    const update = { title: 'after' };
+
+    const query = Test.findOneAndUpdate(
+      { _id: doc._id },
+      update,
+      { returnDocument: 'after' }
+    );
+
+    query.set('status', 'changed');
+    const res = await query;
+
+    assert.deepStrictEqual(update, { title: 'after' });
+    assert.equal(res.title, 'after');
+    assert.equal(res.status, 'changed');
+  });
+
+  it('does not mutate the caller update when built-in timestamp middleware runs', async function() {
+    const Test = db.model('Test', new Schema({
+      title: String
+    }, { timestamps: true }));
+
+    const doc = await Test.create({ title: 'before' });
+    const update = { $set: { title: 'after' } };
+
+    await Test.findOneAndUpdate(
+      { _id: doc._id },
+      update,
+      { returnDocument: 'after' }
+    );
+
+    assert.deepStrictEqual(update, { $set: { title: 'after' } });
+  });
+
   describe('will correctly', function() {
     let ItemParentModel, ItemChildModel;
 

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -394,6 +394,29 @@ describe('model: updateOne:', function() {
     assert.equal(doc.get('meta.visitors'), 9);
   });
 
+  it('updateOne() preserves existing update state on the query', async function() {
+    const q = BlogPost.find({ _id: post._id });
+    q.set('slug', 'test-slug');
+
+    await q.updateOne({ title: 'newtitle' });
+
+    const doc = await BlogPost.findById(post._id);
+    assert.equal(doc.title, 'newtitle');
+    assert.equal(doc.slug, 'test-slug');
+  });
+
+  it('updateMany() preserves existing update state on the query', async function() {
+    const q = BlogPost.find({});
+    q.set('slug', 'test-slug');
+
+    await q.updateMany({ title: 'newtitle' });
+
+    const docs = await BlogPost.find({});
+    assert.equal(docs.length, 1);
+    assert.equal(docs[0].title, 'newtitle');
+    assert.equal(docs[0].slug, 'test-slug');
+  });
+
   it('passes number of affected docs', async function() {
     await BlogPost.deleteMany({});
     await BlogPost.create({ title: 'one' }, { title: 'two' }, { title: 'three' });

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3386,6 +3386,7 @@ describe('Query', function() {
         versionKey: false,
         writeConcern: {
           w: 'majority',
+          j: true,
           wtimeout: 15000
         }
       }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2571,6 +2571,17 @@ describe('Query', function() {
       assert.strictEqual(q._update.$set.testing, undefined);
       assert.strictEqual(q._update.$set.newPath, 'newValue');
     });
+
+    it('clones shared update when mutating `_update` directly', function() {
+      const q = new Query({});
+      const update = { $set: { newPath: 'newValue' } };
+
+      q.updateOne({}, update);
+      q._update.$set.otherPath = 'otherValue';
+
+      assert.deepStrictEqual(update, { $set: { newPath: 'newValue' } });
+      assert.strictEqual(q.getUpdate().$set.otherPath, 'otherValue');
+    });
   });
 
   describe('get() (gh-7312)', function() {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2572,6 +2572,16 @@ describe('Query', function() {
       assert.strictEqual(q._update.$set.newPath, 'newValue');
     });
 
+    it('stores cloneUpdate option when setting update', function() {
+      const q = new Query({});
+      const update = { $set: { newPath: 'newValue' } };
+
+      q.setUpdate(update, false);
+
+      assert.strictEqual(q.mongooseOptions().cloneUpdate, false);
+      assert.strictEqual(q.getUpdate(), update);
+    });
+
     it('clones shared update when mutating `_update` directly', function() {
       const q = new Query({});
       const update = { $set: { newPath: 'newValue' } };

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3375,7 +3375,6 @@ describe('Query', function() {
         versionKey: false,
         writeConcern: {
           w: 'majority',
-          j: true,
           wtimeout: 15000
         }
       }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -122,6 +122,7 @@ Test.findOneAndUpdate({ name: 'test' }, { name: 'test3' }, { includeResultMetada
 Test.findOneAndUpdate({ name: 'test' }, { name: 'test3' }, { new: true, upsert: true, includeResultMetadata: true }).then((res: any) => {
   console.log(res.ok);
 });
+Test.findOneAndUpdate({ name: 'test' }, { name: 'test3' }, { cloneUpdate: false });
 
 Test.findOneAndReplace({ name: 'test' }, { _id: new Types.ObjectId(), name: 'test2' }).exec().then((res: ITest | null) => console.log(res));
 
@@ -136,6 +137,7 @@ Test.findOneAndUpdate({ name: 'test' }, update);
 
 Test.findOneAndUpdate({ name: 'test' }, { $currentDate: { endDate: true } });
 Test.findOneAndUpdate({ name: 'test' }, [{ $set: { endDate: true } }]);
+Test.findOneAndUpdate().setUpdate({ $set: { name: 'test' } }, false);
 
 Test.findByIdAndUpdate({ name: 'test' }, { name: 'test2' }, (err: any, doc: any) => console.log(doc));
 
@@ -398,7 +400,8 @@ function gh12142() {
     { _id: new Types.ObjectId() },
     {
       $pull: { comments: new Types.ObjectId() }
-    }
+    },
+    { cloneUpdate: false }
   );
 }
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -51,6 +51,7 @@ declare module 'mongoose' {
   type QueryFilter<T> = IsItRecordAndNotAny<T> extends true ? _QueryFilter<WithLevel1NestedPaths<T>> : _QueryFilterLooseId<Record<string, any>>;
 
   type MongooseBaseQueryOptionKeys =
+    | 'cloneUpdate'
     | 'context'
     | 'middleware'
     | 'multipleCastError'
@@ -108,6 +109,10 @@ declare module 'mongoose' {
     collation?: mongodb.CollationOptions;
     comment?: any;
     context?: string;
+    /**
+     * If `false`, Mongoose will not clone the update before executing the query.
+     */
+    cloneUpdate?: boolean;
     explain?: mongodb.ExplainVerbosityLike;
     fields?: any | string;
     hint?: mongodb.Hint;
@@ -889,7 +894,7 @@ declare module 'mongoose' {
     setQuery(val: QueryFilter<RawDocType> | null): void;
     setQuery(val: Query<any, any> | null): void;
 
-    setUpdate(update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline): void;
+    setUpdate(update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline, cloneUpdate?: boolean): void;
 
     /** Specifies an `$size` query condition. When called with one argument, the most recent path passed to `where()` is used. */
     size(path: string, val: number): this;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

An alternative fix for #16202 which also has some small performance benefits: Mongoose loses the `__proto__` property because Mongoose deep clones the `update` every time. But in many cases, Mongoose does not have to deep clone `update` - if the user is simply calling `await Model.findOneAndUpdate(filter, update)` then deep cloning is a waste.

Furthermore, currently Mongoose `findOneAndUpdate` does multiple clone operations:

1. `Model.findOneAndUpdate()` deep clones first
2. Then `Query.mergeUpdate()` does `mergeClone()`, which also deep clones
3. Finally, before running, `castUpdate()` does a shallow clone

That's a lot of cloning that is not always necessary. In this PR, I got rid of the `Model.findOneAndUpdate()` deep clone, and made `mergeUpdate()` use assignment instead of `mergeClone()` if there is no existing update. `castUpdate()` still does a shallow clone though before sending the update.

To be backwards compatible, I moved the core `update` property into a symbol, and made `_update` a computed property on `Query` that clones if necessary on access.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
