### PR TITLE
feat(schematype): support `allowNull` option to disallow null values even if not `required`

### DIFF
--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -30,6 +30,7 @@ msg.DocumentNotFoundError = null;
 msg.general = {};
 msg.general.default = 'Validator failed for path `{PATH}` with value `{VALUE}`';
 msg.general.required = 'Path `{PATH}` is required.';
+msg.general.allowNull = 'Path `{PATH}` does not allow null values.';
 
 msg.Number = {};
 msg.Number.min = 'Path `{PATH}` ({VALUE}) is less than minimum allowed value ({MIN}).';

--- a/lib/options/schemaTypeOptions.js
+++ b/lib/options/schemaTypeOptions.js
@@ -95,6 +95,20 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'cast', opts);
 Object.defineProperty(SchemaTypeOptions.prototype, 'required', opts);
 
 /**
+ * Controls whether this path may be set to `null`. By default, Mongoose allows
+ * `null` for non-required paths. Set `allowNull: false` to allow `undefined`
+ * but disallow `null`.
+ *
+ * @api public
+ * @property allowNull
+ * @memberOf SchemaTypeOptions
+ * @type {boolean}
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'allowNull', opts);
+
+/**
  * The default value for this path. If a function, Mongoose executes the function
  * and uses the return value as the default.
  *

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -200,15 +200,16 @@ SchemaType.prototype._createJSONSchemaTypeDefinition = function _createJSONSchem
     (this.options.required == null ?
       (options?._defaultRequired === true || this.path === '_id') :
       this.options.required && typeof this.options.required !== 'function');
+  const allowNull = this.options.allowNull !== false;
 
   if (useBsonType) {
-    if (isRequired) {
+    if (isRequired || !allowNull) {
       return { bsonType };
     }
     return { bsonType: [bsonType, 'null'] };
   }
 
-  if (isRequired) {
+  if (isRequired || !allowNull) {
     return { type };
   }
   return { type: [type, 'null'] };
@@ -1142,6 +1143,12 @@ SchemaType.prototype.required = function(required, message) {
 
   const _this = this;
   this.isRequired = true;
+  this.originalRequiredValue = required;
+
+  if (typeof this.originalRequiredValue !== 'function' &&
+      (utils.hasUserDefinedProperty(this.options, 'allowNull') || this.allowNullValidator != null)) {
+    throw new MongooseError('Path "' + this.path + '" may not have `allowNull` specified when `required` is true');
+  }
 
   this.requiredValidator = function(v) {
     const cachedRequired = this?.$__?.cachedRequired;
@@ -1166,8 +1173,6 @@ SchemaType.prototype.required = function(required, message) {
 
     return _this.checkRequired(v, this);
   };
-  this.originalRequiredValue = required;
-
   if (typeof required === 'string') {
     message = required;
     required = undefined;
@@ -1179,6 +1184,51 @@ SchemaType.prototype.required = function(required, message) {
     message: msg,
     type: 'required'
   }));
+
+  return this;
+};
+
+/**
+ * Adds a validator that disallows `null` for this path without making the path
+ * required. `undefined` values still pass validation.
+ *
+ * #### Example:
+ *
+ *     const schema = new Schema({
+ *       name: { type: String, allowNull: false }
+ *     });
+ *
+ *     new Model({ name: undefined }).validateSync(); // OK
+ *     new Model({ name: null }).validateSync(); // ValidationError
+ *
+ * @param {boolean} allowNull
+ * @return {SchemaType} this
+ * @api public
+ */
+
+SchemaType.prototype.allowNull = function(allowNull) {
+  if (arguments.length > 0 && this.isRequired && typeof this.originalRequiredValue !== 'function') {
+    throw new MongooseError('Path "' + this.path + '" may not have `allowNull` specified when `required` is true');
+  }
+
+  this.validators = this.validators.filter(function(v) {
+    return v.validator !== this.allowNullValidator;
+  }, this);
+
+  if (allowNull !== false) {
+    delete this.allowNullValidator;
+    return this;
+  }
+
+  this.allowNullValidator = function(v) {
+    return v !== null;
+  };
+
+  this.validators.push({
+    validator: this.allowNullValidator,
+    message: MongooseError.messages.general.allowNull,
+    type: 'allowNull'
+  });
 
   return this;
 };
@@ -1802,6 +1852,7 @@ SchemaType.prototype.clone = function() {
   const schematype = new this.constructor(this.path, options, this.instance, this.parentSchema);
   schematype.validators = this.validators.slice();
   if (this.requiredValidator !== undefined) schematype.requiredValidator = this.requiredValidator;
+  if (this.allowNullValidator !== undefined) schematype.allowNullValidator = this.allowNullValidator;
   if (this.defaultValue !== undefined) schematype.defaultValue = this.defaultValue;
   if (this.$immutable !== undefined && this.options.immutable === undefined) {
     schematype.$immutable = this.$immutable;

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1216,10 +1216,12 @@ SchemaType.prototype.allowNull = function(allowNull) {
   }, this);
 
   if (allowNull !== false) {
+    delete this.options.allowNull;
     delete this.allowNullValidator;
     return this;
   }
 
+  this.options.allowNull = false;
   this.allowNullValidator = function(v) {
     return v !== null;
   };

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -340,6 +340,44 @@ describe('model', function() {
         assert.equal(gender.options.default, 'F');
       });
 
+      it('allows discriminator schema to override required true with required false and allowNull false', function() {
+        const baseSchema = new Schema({
+          name: { type: String, required: true }
+        });
+        const Base = db.model('Test1', baseSchema);
+        const Child = Base.discriminator('Child', new Schema({
+          name: { type: String, required: false, allowNull: false }
+        }));
+
+        assert.equal(Base.schema.path('name').isRequired, true);
+        assert.equal(Child.schema.path('name').isRequired, false);
+        assert.equal(Child.schema.path('name').validators.length, 1);
+        assert.equal(Child.schema.path('name').validators[0].type, 'allowNull');
+
+        assert.ifError(new Child({}).validateSync());
+
+        const err = new Child({ name: null }).validateSync();
+        assert.ok(err);
+        assert.ok(err.errors['name']);
+        assert.equal(err.errors['name'].kind, 'allowNull');
+      });
+
+      it('allows discriminator schema to override allowNull false with allowNull true', function() {
+        const baseSchema = new Schema({
+          name: { type: String, allowNull: false }
+        });
+        const Base = db.model('Test2', baseSchema);
+        const Child = Base.discriminator('Child', new Schema({
+          name: { type: String, allowNull: true }
+        }));
+
+        assert.equal(Base.schema.path('name').validators.length, 1);
+        assert.equal(Base.schema.path('name').validators[0].type, 'allowNull');
+        assert.equal(Child.schema.path('name').validators.length, 0);
+
+        assert.ifError(new Child({ name: null }).validateSync());
+      });
+
       it('inherits methods', function() {
         const employee = new Employee();
         assert.strictEqual(employee.getFullName, PersonSchema.methods.getFullName);

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -1110,6 +1110,32 @@ describe('model: findOneAndUpdate:', function() {
       assert.equal(error.errors.topping.message, 'Validator failed for path `topping` with value `bacon`');
     });
 
+    it('applies allowNull validators with runValidators', async function() {
+      const schema = new Schema({
+        name: { type: String, allowNull: false }
+      });
+      const Model = db.model('Test', schema);
+      const doc = await Model.create({ name: 'test' });
+      const updateOptions = { runValidators: true, new: true };
+
+      let err = await Model.findOneAndUpdate(
+        { _id: doc._id },
+        { $set: { name: null } },
+        updateOptions
+      ).then(() => null, err => err);
+
+      assert.ok(err);
+      assert.ok(err.errors['name']);
+      assert.equal(err.errors['name'].kind, 'allowNull');
+
+      err = await Model.findOneAndUpdate(
+        { _id: doc._id },
+        { $set: { name: undefined } },
+        updateOptions
+      ).then(() => null, err => err);
+      assert.equal(err, null);
+    });
+
     it('validators handle $unset and $setOnInsert', async function() {
       const s = new Schema({
         steak: { type: String, required: true },

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3547,6 +3547,31 @@ describe('model: updateOne: ', function() {
     assert.equal(validateNameCalls, 1);
   });
 
+  it('applies allowNull validators with updateOne and runValidators', async function() {
+    const schema = new Schema({
+      name: { type: String, allowNull: false }
+    });
+    const Model = db.model('Test', schema);
+    const doc = await Model.create({ name: 'test' });
+
+    let err = await Model.updateOne(
+      { _id: doc._id },
+      { $set: { name: null } },
+      { runValidators: true }
+    ).then(() => null, err => err);
+
+    assert.ok(err);
+    assert.ok(err.errors['name']);
+    assert.equal(err.errors['name'].kind, 'allowNull');
+
+    err = await Model.updateOne(
+      { _id: doc._id },
+      { $set: { name: undefined } },
+      { runValidators: true }
+    ).then(() => null, err => err);
+    assert.equal(err, null);
+  });
+
   it('casts top level $each (gh-15642)', async function() {
     const schema = new Schema({ tags: [String] });
     const Model = db.model('Test', schema);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1956,6 +1956,33 @@ describe('schema', function() {
         assert.equal(schema.path('name').validators.length, 0);
       });
 
+      it('clones allowNull validators', function() {
+        const schema = new Schema({ name: { type: String, allowNull: false } });
+        const otherSchema = schema.clone();
+        const Model = db.model('Test', otherSchema);
+
+        assert.equal(otherSchema.path('name').validators.length, 1);
+        assert.equal(otherSchema.path('name').validators[0].type, 'allowNull');
+
+        const doc = new Model({ name: null });
+        const err = doc.validateSync();
+
+        assert.ok(err);
+        assert.ok(err.errors['name']);
+        assert.equal(err.errors['name'].kind, 'allowNull');
+      });
+
+      it('clones allowNull validators so they can be removed independently', function() {
+        const schema = new Schema({ name: { type: String, allowNull: false } });
+        const otherSchema = schema.clone();
+
+        otherSchema.path('name').allowNull(true);
+
+        assert.equal(otherSchema.path('name').validators.length, 0);
+        assert.equal(schema.path('name').validators.length, 1);
+        assert.equal(schema.path('name').validators[0].type, 'allowNull');
+      });
+
       it('correctly copies all child schemas (gh-7537)', function() {
         const l3Schema = new Schema({ name: String });
         const l2Schema = new Schema({ l3: l3Schema });
@@ -3511,6 +3538,44 @@ describe('schema', function() {
       assert.ok(validate({ _id: 'test', name: 'John', age: 30, ageSource: 'document' }));
       assert.ok(!validate({ _id: 'test', name: 'Foobar', age: null, ageSource: 'something else' }));
       assert.ok(!validate({}));
+    });
+
+    it('omits null from optional allowNull false paths', function() {
+      const schema = new Schema({
+        name: { type: String, allowNull: false },
+        age: Number
+      }, { autoCreate: false, autoIndex: false });
+
+      assert.deepStrictEqual(schema.toJSONSchema({ useBsonType: true }), {
+        required: ['_id'],
+        properties: {
+          _id: {
+            bsonType: 'objectId'
+          },
+          name: {
+            bsonType: 'string'
+          },
+          age: {
+            bsonType: ['number', 'null']
+          }
+        }
+      });
+
+      assert.deepStrictEqual(schema.toJSONSchema(), {
+        type: 'object',
+        required: ['_id'],
+        properties: {
+          _id: {
+            type: 'string'
+          },
+          name: {
+            type: 'string'
+          },
+          age: {
+            type: ['number', 'null']
+          }
+        }
+      });
     });
 
     it('handles all primitive data types', async function() {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1983,6 +1983,45 @@ describe('schema', function() {
         assert.equal(schema.path('name').validators[0].type, 'allowNull');
       });
 
+      it('keeps allowNull options in sync when changed at runtime', function() {
+        const schema = new Schema({ name: String });
+        const schemaType = schema.path('name');
+
+        schemaType.allowNull(false);
+        assert.equal(schemaType.options.allowNull, false);
+        assert.deepStrictEqual(schema.toJSONSchema(), {
+          type: 'object',
+          required: ['_id'],
+          properties: {
+            _id: {
+              type: 'string'
+            },
+            name: {
+              type: 'string'
+            }
+          }
+        });
+
+        const otherSchema = schema.clone();
+        assert.equal(otherSchema.path('name').options.allowNull, false);
+        assert.deepStrictEqual(otherSchema.toJSONSchema(), schema.toJSONSchema());
+
+        schemaType.allowNull(true);
+        assert.ok(!Object.hasOwn(schemaType.options, 'allowNull'));
+        assert.deepStrictEqual(schema.toJSONSchema(), {
+          type: 'object',
+          required: ['_id'],
+          properties: {
+            _id: {
+              type: 'string'
+            },
+            name: {
+              type: ['string', 'null']
+            }
+          }
+        });
+      });
+
       it('correctly copies all child schemas (gh-7537)', function() {
         const l3Schema = new Schema({ name: String });
         const l2Schema = new Schema({ l3: l3Schema });

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -762,6 +762,70 @@ describe('schema', function() {
       assert.equal(err, null);
     });
 
+    it('disallows null with allowNull false without making the path required', async function() {
+      const schema = new Schema({
+        name: { type: String, allowNull: false }
+      });
+      const Test = mongoose.model('allowNullFalse' + random(), schema);
+
+      await new Test({ name: undefined }).validate();
+
+      const err = await new Test({ name: null }).validate().then(() => null, err => err);
+      assert.ok(err);
+      assert.ok(err.errors['name']);
+      assert.equal(err.errors['name'].name, 'ValidatorError');
+      assert.equal(err.errors['name'].kind, 'allowNull');
+      assert.equal(err.errors['name'].message, 'Path `name` does not allow null values.');
+    });
+
+    it('throws if allowNull is specified with required true', function() {
+      assert.throws(function() {
+        new Schema({
+          name: { type: String, required: true, allowNull: false }
+        });
+      }, /Path "name" may not have `allowNull` specified when `required` is true/);
+
+      assert.throws(function() {
+        new Schema({
+          name: { type: String, required: true, allowNull: true }
+        });
+      }, /Path "name" may not have `allowNull` specified when `required` is true/);
+
+      assert.throws(function() {
+        const schema = new Schema({ name: String });
+        schema.path('name').allowNull(false).required(true);
+      }, /Path "name" may not have `allowNull` specified when `required` is true/);
+
+      assert.throws(function() {
+        const schema = new Schema({ name: { type: String, required: true } });
+        schema.path('name').allowNull(false);
+      }, /Path "name" may not have `allowNull` specified when `required` is true/);
+    });
+
+    it('disallows null with allowNull false when required function returns false', async function() {
+      const schema = new Schema({
+        status: String,
+        endDate: {
+          type: Date,
+          required: function() { return this.status === 'completed'; },
+          allowNull: false
+        }
+      });
+      const Test = mongoose.model('allowNullRequiredFunction' + random(), schema);
+
+      await new Test({ status: 'pending', endDate: undefined }).validate();
+
+      const err = await new Test({ status: 'pending', endDate: null }).validate().then(() => null, err => err);
+      assert.ok(err);
+      assert.ok(err.errors['endDate']);
+      assert.equal(err.errors['endDate'].kind, 'allowNull');
+
+      const requiredErr = await new Test({ status: 'completed', endDate: null }).validate().then(() => null, err => err);
+      assert.ok(requiredErr);
+      assert.ok(requiredErr.errors['endDate']);
+      assert.equal(requiredErr.errors['endDate'].kind, 'required');
+    });
+
     it('should allow an array of subdocuments with enums (gh-3521)', async function() {
       const coolSchema = new Schema({
         votes: [{

--- a/test/types/schema.create.test.ts
+++ b/test/types/schema.create.test.ts
@@ -2035,3 +2035,42 @@ function gh16046VersionKeyFalse() {
 
   MyModel.testMe();
 }
+
+function allowNullFalseInferredTypes() {
+  const schema = Schema.create({
+    name: { type: String, allowNull: false },
+    age: Number,
+    status: String,
+    endDate: {
+      type: Date,
+      required: function() { return this.status === 'completed'; },
+      allowNull: false
+    }
+  });
+
+  type InferredDocType = InferSchemaType<typeof schema>;
+  ExpectType<{ name?: string, age?: number | null, status?: string | null, endDate?: Date }>({} as InferredDocType);
+  ExpectType<string | undefined>({} as InferredDocType['name']);
+  ExpectType<Date | undefined>({} as InferredDocType['endDate']);
+  ExpectType<number | null | undefined>({} as InferredDocType['age']);
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
+  ExpectType<InferredDocType['name']>(null);
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'NativeDate | undefined'.
+  ExpectType<InferredDocType['endDate']>(null);
+
+  const defaultSchema = Schema.create({
+    title: String
+  });
+  type DefaultInferredDocType = InferSchemaType<typeof defaultSchema>;
+  ExpectType<string | null | undefined>({} as DefaultInferredDocType['title']);
+
+  const schemaDefinition = {
+    name: { type: String, allowNull: false },
+    title: String
+  } as const;
+  type RawDocType = InferRawDocType<typeof schemaDefinition>;
+  ExpectType<string | undefined>({} as RawDocType['name']);
+  ExpectType<string | null | undefined>({} as RawDocType['title']);
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
+  ExpectType<RawDocType['name']>(null);
+}

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -2368,3 +2368,42 @@ function gh16045DocumentArray() {
     }
   }
 }
+
+function allowNullFalseInferredTypes() {
+  const schema = new Schema({
+    name: { type: String, allowNull: false },
+    age: Number,
+    status: String,
+    endDate: {
+      type: Date,
+      required: function() { return this.status === 'completed'; },
+      allowNull: false
+    }
+  });
+
+  type InferredDocType = InferSchemaType<typeof schema>;
+  ExpectType<{ name?: string, age?: number | null, status?: string | null, endDate?: Date }>({} as InferredDocType);
+  ExpectType<string | undefined>({} as InferredDocType['name']);
+  ExpectType<Date | undefined>({} as InferredDocType['endDate']);
+  ExpectType<number | null | undefined>({} as InferredDocType['age']);
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
+  ExpectType<InferredDocType['name']>(null);
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'NativeDate | undefined'.
+  ExpectType<InferredDocType['endDate']>(null);
+
+  const defaultSchema = new Schema({
+    title: String
+  });
+  type DefaultInferredDocType = InferSchemaType<typeof defaultSchema>;
+  ExpectType<string | null | undefined>({} as DefaultInferredDocType['title']);
+
+  const schemaDefinition = {
+    name: { type: String, allowNull: false },
+    title: String
+  } as const;
+  type RawDocType = InferRawDocType<typeof schemaDefinition>;
+  ExpectType<string | undefined>({} as RawDocType['name']);
+  ExpectType<string | null | undefined>({} as RawDocType['title']);
+  // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
+  ExpectType<RawDocType['name']>(null);
+}

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -3,7 +3,8 @@ import {
   PathEnumOrString,
   OptionalPaths,
   RequiredPaths,
-  IsPathRequired
+  IsPathRequired,
+  PathAllowsNull
 } from './inferschematype';
 import { Binary, UUID } from 'mongodb';
 
@@ -24,7 +25,9 @@ declare module 'mongoose' {
     OptionalPaths<SchemaDefinition, TSchemaOptions['typeKey']>)
     ]: IsPathRequired<SchemaDefinition[K], TSchemaOptions['typeKey']> extends true
       ? ObtainRawDocumentPathType<SchemaDefinition[K], TSchemaOptions['typeKey'], TTransformOptions>
-      : ObtainRawDocumentPathType<SchemaDefinition[K], TSchemaOptions['typeKey'], TTransformOptions> | null;
+      : PathAllowsNull<SchemaDefinition[K]> extends true
+        ? ObtainRawDocumentPathType<SchemaDefinition[K], TSchemaOptions['typeKey'], TTransformOptions> | null
+        : ObtainRawDocumentPathType<SchemaDefinition[K], TSchemaOptions['typeKey'], TTransformOptions>;
   }, TSchemaOptions>;
 
   export type InferRawDocType<

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -47,7 +47,9 @@ declare module 'mongoose' {
           TSchemaOptions['typeKey']
         > extends true ?
           ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>
-        : ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']> | null;
+        : PathAllowsNull<DocDefinition[K]> extends true ?
+          ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']> | null
+        : ObtainDocumentPathType<DocDefinition[K], TSchemaOptions['typeKey']>;
       };
 
   /**
@@ -221,6 +223,12 @@ type OptionalPaths<T, TypeKey extends string = DefaultTypeKey> = Pick<
   { -readonly [K in keyof T]?: T[K] },
   OptionalPathKeys<T, TypeKey>
 >;
+
+/**
+ * @summary Checks if a document path allows `null` values.
+ * @param {P} P Document path.
+ */
+export type PathAllowsNull<P> = P extends { allowNull: false } ? false : true;
 
 /**
  * @summary Allows users to optionally choose their own type for a schema field for stronger typing.

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -105,6 +105,13 @@ declare module 'mongoose' {
       | [(this: THydratedDocumentType) => boolean, string];
 
     /**
+     * Controls whether this path may be set to `null`. By default, Mongoose allows
+     * `null` for non-required paths. Set `allowNull: false` to allow `undefined`
+     * but disallow `null`.
+     */
+    allowNull?: boolean;
+
+    /**
      * The default value for this path. If a function, Mongoose executes the function
      * and uses the return value as the default.
      */
@@ -354,6 +361,9 @@ declare module 'mongoose' {
      * to the front of this SchemaType's validators array using unshift().
      */
     required(required: boolean, message?: string): this;
+
+    /** Adds or removes a validator that disallows `null` without making this path required. */
+    allowNull(allowNull: boolean): this;
 
     /** If the SchemaType is a subdocument or document array, this is the schema of that subdocument */
     schema?: Schema<any>;


### PR DESCRIPTION
Fix #15905

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Mongoose has historically used `null` and `undefined` interchangeably, but TypeScript sometimes makes working with potentially `null` values cumbersome, leading to a lot of `?? undefined`. This PR adds a `allowNull: false` option which allows a value to be `undefined`, but does not allow said value to be set to `null`, including automatic type inference in TypeScript.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
