### PR TITLE
fix(schema): always pass raw string value to error validators, only trim to 30 chars for maxlength validator

### DIFF
--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -736,7 +736,11 @@ module.exports = SchemaString;
 
 function formatMaxLengthValidatorMessage(msg) {
   return function(props, doc) {
-    if (typeof props.value === 'string' && props.value.length > 30) {
+    if (typeof msg === 'function') {
+      return MongooseError.ValidatorError.prototype.formatMessage(msg, props, doc);
+    }
+
+    if (typeof msg === 'string' && typeof props.value === 'string' && props.value.length > 30) {
       props = Object.assign({}, props, {
         value: props.value.slice(0, 30) + '...'
       });

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -474,12 +474,14 @@ SchemaString.prototype.maxlength = function(value, message) {
 
   if (value !== null && value !== undefined) {
     let msg = message || MongooseError.messages.String.maxlength;
-    msg = msg.replace(/{MAXLENGTH}/, value);
+    if (typeof msg !== 'function') {
+      msg = msg.replace(/{MAXLENGTH}/, value);
+    }
     this.validators.push({
       validator: this.maxlengthValidator = function(v) {
         return v === null || v.length <= value;
       },
-      message: msg,
+      message: formatMaxLengthValidatorMessage(msg),
       type: 'maxlength',
       maxlength: value
     });
@@ -731,3 +733,14 @@ SchemaString.prototype.autoEncryptionType = function autoEncryptionType() {
  */
 
 module.exports = SchemaString;
+
+function formatMaxLengthValidatorMessage(msg) {
+  return function(props, doc) {
+    if (typeof props.value === 'string' && props.value.length > 30) {
+      props = Object.assign({}, props, {
+        value: props.value.slice(0, 30) + '...'
+      });
+    }
+    return MongooseError.ValidatorError.prototype.formatMessage(msg, props, doc);
+  };
+}

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1381,9 +1381,6 @@ SchemaType.prototype.doValidate = function(value, fn, scope, options) {
     validatorProperties.value = value;
     if (typeof value === 'string') {
       validatorProperties.length = value.length;
-      if (validatorProperties.value.length > 30) {
-        validatorProperties.value = validatorProperties.value.slice(0, 30) + '...';
-      }
     }
 
     if (validator instanceof RegExp) {
@@ -1508,9 +1505,6 @@ SchemaType.prototype.doValidateSync = function(value, scope, options) {
     validatorProperties.value = value;
     if (typeof value === 'string') {
       validatorProperties.length = value.length;
-      if (validatorProperties.value.length > 30) {
-        validatorProperties.value = validatorProperties.value.slice(0, 30) + '...';
-      }
     }
     let ok = false;
 

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -210,6 +210,8 @@ describe('ValidationError', function() {
       const err = await model.validate().then(() => null, err => err);
 
       assert.notEqual(err, null, 'String maxLength validation failed.');
+      assert.equal(err.errors.name.value, 'John Jacob Jingleheimer Schmidt');
+      assert.equal(err.errors.name.properties.value, 'John Jacob Jingleheimer Schmidt');
       assert.ok(
         err.message.endsWith('Path `name` (`John Jacob Jingleheimer Schmid...`, length 31) is longer than the maximum allowed length (10).'),
         err.message

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -735,6 +735,52 @@ describe('schema', function() {
           const err = await m.validate().then(() => null, err => err);
           assert.equal(err.errors.x.toString(), 'Custom message');
         });
+
+        it('passes full string value to custom validator message functions', async function() {
+          const value = 'long-long-long.short-enough.com';
+          const schema = new Schema({
+            url: {
+              type: String,
+              validate: {
+                validator: function() {
+                  return false;
+                },
+                message: props => `${props.value} is not a valid url`
+              }
+            }
+          });
+
+          const M = mongoose.model('gh-15571', schema);
+          const m = new M({ url: value });
+
+          const err = await m.validate().then(() => null, err => err);
+          assert.equal(err.errors.url.message, `${value} is not a valid url`);
+          assert.equal(err.errors.url.value, value);
+          assert.equal(err.errors.url.properties.value, value);
+        });
+
+        it('passes full string value to custom validator message functions on validateSync()', function() {
+          const value = 'long-long-long.short-enough.com';
+          const schema = new Schema({
+            url: {
+              type: String,
+              validate: {
+                validator: function() {
+                  return false;
+                },
+                message: props => `${props.value} is not a valid url`
+              }
+            }
+          });
+
+          const M = mongoose.model('gh-15571-sync', schema);
+          const m = new M({ url: value });
+
+          const err = m.validateSync();
+          assert.equal(err.errors.url.message, `${value} is not a valid url`);
+          assert.equal(err.errors.url.value, value);
+          assert.equal(err.errors.url.properties.value, value);
+        });
       });
     });
 


### PR DESCRIPTION
Fix #16236
Re: #15550
Re: #15571

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Original bug report was about trimming long strings in the `maxlength` validator, but the fix in #15571 also leaks the 30 character max limit to user-specified validators, which is incorrect. With this PR, the validator props will always have the raw untrimmed value, and we will just apply the 30 character limit to the error message for the `maxlength` validator.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
