### PR TITLE
feat(types): export Projector, ArrayOperators, QueryResultType, and P…

### DIFF
--- a/test/types/exportedTypes.test.ts
+++ b/test/types/exportedTypes.test.ts
@@ -1,0 +1,18 @@
+import { Projector, ArrayOperators, QueryResultType, PluginFunction, Query, Schema } from 'mongoose';
+import { expect } from 'tstyche';
+
+// Test Projector is exported and works correctly
+type TestProjection = Projector<{ name: string; age: number }, true>;
+expect<TestProjection['name']>().type.toBe<true | undefined>();
+expect<TestProjection['age']>().type.toBe<true | undefined>();
+
+// Test ArrayOperators is exported
+expect<ArrayOperators['$slice']>().type.toBe<number | [number, number] | undefined>();
+
+// Test QueryResultType is exported
+type TestQuery = Query<string[], string>;
+expect<QueryResultType<TestQuery>>().type.toBe<string[]>();
+
+// Test PluginFunction is exported
+type TestPlugin = PluginFunction<{ name: string }, any, any, any, any, any>;
+expect<ReturnType<TestPlugin>>().type.toBe<void>();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -288,9 +288,9 @@ declare module 'mongoose' {
       ? Schema<MergeType<DocType, DisSchemaEDocType>, DiscriminatorModel<DisSchemaM, M>, DisSchemaInstanceMethods | TInstanceMethods, DisSchemaQueryhelpers | TQueryHelpers, DisSchemaVirtuals | TVirtuals, DisSchemaStatics & TStaticMethods>
       : Schema<DocType, M, TInstanceMethods, TQueryHelpers, TVirtuals, TStaticMethods>;
 
-  type QueryResultType<T> = T extends Query<infer ResultType, any> ? ResultType : never;
+  export type QueryResultType<T> = T extends Query<infer ResultType, any> ? ResultType : never;
 
-  type PluginFunction<
+  export type PluginFunction<
     DocType,
     M,
     TInstanceMethods,
@@ -819,7 +819,7 @@ declare module 'mongoose' {
 
   export type ReturnsNewDoc = { new: true } | { returnOriginal: false } | { returnDocument: 'after' };
 
-  type ArrayOperators = { $slice: number | [number, number]; $elemMatch?: never } | { $elemMatch: Record<string, any>; $slice?: never };
+  export type ArrayOperators = { $slice: number | [number, number]; $elemMatch?: never } | { $elemMatch: Record<string, any>; $slice?: never };
   /**
    * This Type Assigns `Element | undefined` recursively to the `T` type.
    * if it is an array it will do this to the element of the array, if it is an object it will do this for the properties of the object.
@@ -836,7 +836,7 @@ declare module 'mongoose' {
         d?: true | ArrayOperators | undefined;
     }
   */
-  type Projector<T, Element> = T extends Array<infer U>
+  export type Projector<T, Element> = T extends Array<infer U>
     ? Projector<U, Element> | ArrayOperators
     : T extends TreatAsPrimitives
       ? Element


### PR DESCRIPTION
Fixes #16235

## What this PR does
Exports previously internal TypeScript helper types so library 
authors can use them directly.

## Changes
- `types/index.d.ts`: added `export` to `Projector`, 
  `ArrayOperators`, `QueryResultType`, and `PluginFunction`
- `test/types/exportedTypes.test.ts`: added type tests to verify 
  the exports work correctly

## Testing
All 39 type test files pass (958 assertions)