### PR TITLE
types(query): make QueryFilter respect string unions and enums

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -466,7 +466,7 @@ async function gh15077() {
     const newFoo = {
       state: 'on'
       // extra props but irrelevant
-    };
+    } as const;
 
     const createdFoo = await fooModel.create(newFoo);
 

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -270,6 +270,36 @@ function gh10857() {
   }
   type MyClassDocument = MyClass & Document;
   const test: QueryFilter<MyClass> = { status: { $in: ['VALUE1', 'VALUE2'] } };
+  expect<QueryFilter<MyClass>>().type.not.toBeAssignableFrom({ status: 'nope' });
+}
+
+function gh16240() {
+  enum Status {
+    ACTIVE = 'active',
+    BANNED = 'banned'
+  }
+
+  interface MyClass {
+    statusUnion: 'active' | 'banned';
+    statusEnum: Status;
+    name: string;
+  }
+
+  expect<QueryFilter<MyClass>>().type.not.toBeAssignableFrom({
+    statusUnion: 'nope'
+  });
+  expect<QueryFilter<MyClass>>().type.not.toBeAssignableFrom({
+    statusEnum: 'nope'
+  });
+  expect<QueryFilter<MyClass>>().type.toBeAssignableFrom({
+    statusUnion: 'active'
+  } as const);
+  expect<QueryFilter<MyClass>>().type.toBeAssignableFrom({
+    statusEnum: Status.ACTIVE
+  });
+  expect<QueryFilter<MyClass>>().type.toBeAssignableFrom({
+    name: /valid/
+  } as const);
 }
 
 function gh10786() {

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -1,13 +1,13 @@
 declare module 'mongoose' {
   import mongodb = require('mongodb');
 
-  type StringQueryTypeCasting = string | RegExp;
+  type StringQueryTypeCasting<T> = string extends T ? string | RegExp : T | RegExp;
   type ObjectIdQueryTypeCasting = Types.ObjectId | string;
   type DateQueryTypeCasting = string | number | NativeDate;
   type UUIDQueryTypeCasting = Types.UUID | string;
   type BufferQueryCasting = Buffer | mongodb.Binary | number[] | string | { $binary: string | mongodb.Binary };
   type QueryTypeCasting<T> = T extends string
-    ? StringQueryTypeCasting
+    ? StringQueryTypeCasting<T>
     : T extends Types.ObjectId
       ? ObjectIdQueryTypeCasting
       : T extends Types.UUID


### PR DESCRIPTION
Fix #16240

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Right now `QueryFilter` does type widening on string unions and enums, converting types like `'on' | 'off'` to `string | RegExp`. We should preserve unions like this where possible.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
