### PR TITLE
feat(aggregate): add pipelineForUnionWith() helper to allow reusing pipelines with $unionWith in TypeScript

### DIFF
--- a/.github/workflows/encryption-tests.yml
+++ b/.github/workflows/encryption-tests.yml
@@ -1,4 +1,4 @@
-name: Encryption Tests 
+name: Encryption Tests
 
 on:
   pull_request:
@@ -44,7 +44,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Install mongodb-client-encryption
-        run: npm install mongodb-client-encryption
+        run: npm install mongodb-client-encryption@6.x
       - name: Setup Tests
         run: npm run setup-test-encryption
       - name: Run Tests

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1044,7 +1044,7 @@ Aggregate.prototype.pipeline = function() {
  *     const base = MyModel.aggregate().match({ test: 1 });
  *     base.pipelineForUnionWith(); // [{ $match: { test: 1 } }]
  *
- * @return {Array} The current pipeline with `$unionWith` stage restrictions
+ * @return {PipelineStage[]} The current pipeline with `$unionWith` stage restrictions
  * @api public
  */
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1027,11 +1027,34 @@ Aggregate.prototype.search = function(options) {
  *
  *     MyModel.aggregate().match({ test: 1 }).pipeline(); // [{ $match: { test: 1 } }]
  *
- * @return {Array} The current pipeline similar to the operation that will be executed
+ * @return {PipelineStage[]} The current pipeline similar to the operation that will be executed
  * @api public
  */
 
 Aggregate.prototype.pipeline = function() {
+  return this._pipeline;
+};
+
+/**
+ * Returns the current pipeline as a `$unionWith`-safe pipeline.
+ * Throws if this pipeline contains `$out` or `$merge`.
+ *
+ * #### Example:
+ *
+ *     const base = MyModel.aggregate().match({ test: 1 });
+ *     base.pipelineForUnionWith(); // [{ $match: { test: 1 } }]
+ *
+ * @return {Array} The current pipeline with `$unionWith` stage restrictions
+ * @api public
+ */
+
+Aggregate.prototype.pipelineForUnionWith = function pipelineForUnionWith() {
+  for (const stage of this._pipeline) {
+    if (stage?.$out != null || stage?.$merge != null) {
+      throw new MongooseError('Aggregate pipeline for $unionWith cannot include `$out` or `$merge` stages');
+    }
+  }
+
   return this._pipeline;
 };
 

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -815,6 +815,24 @@ describe('aggregate: ', function() {
       assert.deepEqual(pipeline, [{ $match: { sal: { $lt: 16000 } } }]);
     });
 
+    it('pipelineForUnionWith() returns pipeline for valid unionWith subpipeline', function() {
+      const aggregate = new Aggregate();
+
+      const pipeline = aggregate.
+        match({ sal: { $lt: 16000 } }).
+        pipelineForUnionWith();
+
+      assert.deepEqual(pipeline, [{ $match: { sal: { $lt: 16000 } } }]);
+    });
+
+    it('pipelineForUnionWith() throws if pipeline contains $out or $merge', function() {
+      const aggregateWithOut = new Aggregate().append({ $match: { sal: { $lt: 16000 } } }, { $out: 'test' });
+      assert.throws(() => aggregateWithOut.pipelineForUnionWith(), /cannot include `\$out` or `\$merge`/);
+
+      const aggregateWithMerge = new Aggregate().append({ $match: { sal: { $lt: 16000 } } }, { $merge: { into: 'test' } });
+      assert.throws(() => aggregateWithMerge.pipelineForUnionWith(), /cannot include `\$out` or `\$merge`/);
+    });
+
     it('explain()', async function() {
       const aggregate = new Aggregate([], db.model('Employee'));
 

--- a/test/types/aggregate.test.ts
+++ b/test/types/aggregate.test.ts
@@ -159,3 +159,25 @@ async function gh15300() {
 
   await TestModel.aggregate().project('a b -_id');
 }
+
+function gh16033() {
+  const schema = new Schema({ text: String, published: Boolean });
+  const Item = model('ItemGh16033', schema);
+
+  const basePipeline = Item.aggregate().match({ published: true });
+
+  Item.aggregate()
+    .match({ text: 'example' })
+    .unionWith({
+      coll: 'other_items',
+      pipeline: basePipeline.pipelineForUnionWith()
+    });
+
+  Item.aggregate()
+    .match({ text: 'example' })
+    .unionWith({
+      coll: 'other_items',
+      // @ts-expect-error  Type 'PipelineStage[]' is not assignable to type 'UnionWithPipelineStage[]'.
+      pipeline: basePipeline.pipeline()
+    });
+}

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -123,6 +123,9 @@ declare module 'mongoose' {
     /** Returns the current pipeline */
     pipeline(): PipelineStage[];
 
+    /** Returns the current pipeline typed for use in `$unionWith` */
+    pipelineForUnionWith(): PipelineStage.UnionWithPipelineStage[];
+
     /** Appends a new $project operator to this aggregate pipeline. */
     project(arg: PipelineStage.Project['$project'] | string): this;
 

--- a/types/pipelinestage.d.ts
+++ b/types/pipelinestage.d.ts
@@ -115,6 +115,7 @@ declare module 'mongoose' {
     }
 
     export type FacetPipelineStage = Exclude<PipelineStage, PipelineStage.CollStats | PipelineStage.Facet | PipelineStage.GeoNear | PipelineStage.IndexStats | PipelineStage.Out | PipelineStage.Merge | PipelineStage.PlanCacheStats>;
+    export type UnionWithPipelineStage = Exclude<PipelineStage, PipelineStage.Out | PipelineStage.Merge>;
 
     export interface GeoNear {
       /** [`$geoNear` reference](https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/) */
@@ -303,8 +304,8 @@ declare module 'mongoose' {
       /** [`$unionWith` reference](https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/) */
       $unionWith:
       | string
-      | { coll: string; pipeline?: Exclude<PipelineStage, PipelineStage.Out | PipelineStage.Merge>[] }
-      | { coll?: string; pipeline: Exclude<PipelineStage, PipelineStage.Out | PipelineStage.Merge>[] }
+      | { coll: string; pipeline?: UnionWithPipelineStage[] }
+      | { coll?: string; pipeline: UnionWithPipelineStage[] }
     }
 
     export interface Unset {


### PR DESCRIPTION
Backport #16041 to 8.x
Fix #16033

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
