### PR TITLE
perf(document): speed up $__reset() in saveSimple insert case

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3603,7 +3603,7 @@ Document.prototype.$isValid = function(path) {
  * @instance
  */
 
-Document.prototype.$__reset = function reset() {
+Document.prototype.$__reset = function reset(options) {
   let _this = this;
 
   const onlyPrimitiveValues = this.$__hasOnlyPrimitiveValues();
@@ -3620,25 +3620,29 @@ Document.prototype.$__reset = function reset() {
   // Clear atomics on dirty paths. Walk the modified and default paths
   // directly instead of calling $__dirty(), which builds intermediate
   // arrays, a Map, and does parent-path deduplication we don't need here.
-  this.$__resetAtomics();
+  if (!onlyPrimitiveValues) {
+    this.$__resetAtomics();
+  }
 
-  this.$__.backup = {};
-  this.$__.backup.activePaths = {
-    modify: Object.assign({}, this.$__.activePaths.getStatePaths('modify')),
-    default: Object.assign({}, this.$__.activePaths.getStatePaths('default'))
-  };
-  this.$__.backup.validationError = this.$__.validationError;
-  this.$__.backup.errors = this.$errors;
+  if (!options || !options.skipBackup) {
+    this.$__.backup = {};
+    this.$__.backup.activePaths = {
+      modify: Object.assign({}, this.$__.activePaths.getStatePaths('modify')),
+      default: Object.assign({}, this.$__.activePaths.getStatePaths('default'))
+    };
+    this.$__.backup.validationError = this.$__.validationError;
+    this.$__.backup.errors = this.$errors;
+  }
 
   // Clear 'dirty' cache
   this.$__.activePaths.clear('modify');
   this.$__.activePaths.clear('default');
   this.$__.validationError = undefined;
   this.$errors = undefined;
-  _this = this;
-  this.$__schema.requiredPaths().forEach(function(path) {
-    _this.$__.activePaths.require(path);
-  });
+  const requiredPaths = this.$__schema.requiredPaths();
+  for (let i = 0; i < requiredPaths.length; ++i) {
+    this.$__.activePaths.require(requiredPaths[i]);
+  }
 
   return this;
 };

--- a/lib/document.js
+++ b/lib/document.js
@@ -3604,8 +3604,6 @@ Document.prototype.$isValid = function(path) {
  */
 
 Document.prototype.$__reset = function reset(options) {
-  let _this = this;
-
   const onlyPrimitiveValues = this.$__hasOnlyPrimitiveValues();
 
   // Skip for subdocuments. Also skip if doc only has primitive values,

--- a/lib/model.js
+++ b/lib/model.js
@@ -421,7 +421,7 @@ Model.prototype.$__save = async function $__save(options) {
       }
 
       this.$__version(true, obj);
-      this.$__reset();
+      this.$__reset({ skipBackup: true });
       _setIsNew(this, false);
       // Make it possible to retry the insert
       this.$__.inserting = true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Creating `$__.backup` and running `$__resetAtomics()` add a non-trivial amount of overhead that can be avoided:

1. `$__resetAtomics()` is not necessary on schemas that only have primitives
2. `$__.backup` isn't necessary in the case where we're inserting the new document, because we don't use change tracking to determine which fields to save when inserting a new document in `save()`. Because `save()` currently doesn't call `undoReset()` if inserting a new document fails, `$__.backup` isn't used.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
