### PR TITLE
types(objectid): fix _id getter helper on ObjectId

### DIFF
--- a/test/types/mongo.test.ts
+++ b/test/types/mongo.test.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import * as bson from 'bson';
+import * as mongodb from 'mongodb';
 import { expect } from 'tstyche';
 
 function gh12537() {
@@ -8,10 +8,10 @@ function gh12537() {
 
   const doc = new model({});
 
-  const v = new bson.ObjectId('somehex');
+  const v = new mongodb.ObjectId('somehex');
   expect(v._id.toHexString()).type.toBe<string>();
 
-  doc._id = new bson.ObjectId('somehex');
+  doc._id = new mongodb.ObjectId('somehex');
 }
 
 gh12537();

--- a/types/augmentations.d.ts
+++ b/types/augmentations.d.ts
@@ -1,7 +1,7 @@
 // this import is required so that types get merged instead of completely overwritten
-import 'bson';
+import 'mongodb';
 
-declare module 'bson' {
+declare module 'mongodb' {
   interface ObjectId {
     /** Mongoose automatically adds a conveniency "_id" getter on the base ObjectId class */
     _id: this;


### PR DESCRIPTION
**Summary**

When we removed the dependency on `bson` in
https://github.com/Automattic/mongoose/pull/15576, we inadvertently broke the augmentation added in
https://github.com/Automattic/mongoose/pull/13515 to capture the default option that adds a helper `_id` property on `ObjectId` values.

Updating the augmentation to reference the `ObjectId` type exported from `mongodb` instead of `bson` fixes the augmentation.