### PR TITLE
chore(deps): add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  cooldown:
+    default-days: 2
   open-pull-requests-limit: 100
   target-branch: master
 - package-ecosystem: github-actions


### PR DESCRIPTION
This PR adds a 2-day cooldown for dependabot updates, matching the `.npmrc` `min-release-age=2` policy.

Node 24 CI uses npm 11, which enforces `min-release-age`. A freshly published package can be selected by Dependabot before npm will install it, causing dependency update PRs like #16262 to fail until the cooldown expires.