### PR TITLE
chore: align Node version docs and types

### DIFF
--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -270,7 +270,7 @@ In Mongoose 9, this option is no longer necessary because Mongoose no longer sto
 
 ## Node.js version support
 
-Mongoose 9 requires Node.js 18 or higher.
+Mongoose 9 requires Node.js 20.19.0 or higher.
 
 ## UUID's are now MongoDB UUID objects
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@ark/attest": "0.56.0",
     "@eslint/js": "^9.39.3",
     "@mongodb-js/mongodb-downloader": "^1.0.0",
-    "@types/node": "^18.16.0",
+    "@types/node": "^20.19.0",
     "acquit": "1.4.0",
     "acquit-ignore": "0.2.2",
     "acquit-require": "0.1.1",


### PR DESCRIPTION
re #16267

This PR aligns the remaining Node.js version references with the existing `engines.node` minimum:

- updates the Mongoose 9 migration docs from Node.js 18 to Node.js 20.19.0
- bumps `@types/node` from `^18.16.0` to `^20.19.0`