### PR TITLE
fix(document): correctly handle modified subpaths when parent path is  unset after modifying

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3750,15 +3750,17 @@ Document.prototype.$__dirty = function() {
     }
 
     let top = null;
+    let foundParent = false;
 
     const array = parentPaths(item.path);
     for (let i = 0; i < array.length - 1; i++) {
       if (allPaths.has(array[i])) {
         top = allPaths.get(array[i]);
+        foundParent = true;
         break;
       }
     }
-    if (top == null) {
+    if (!foundParent) {
       minimal.push(item);
     } else if (top != null &&
         top[arrayAtomicsSymbol] != null &&

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -15705,6 +15705,31 @@ describe('document', function() {
       { updatePipeline: true }
     );
   });
+
+  it('clears child modified paths when parent mixed path is unset (gh-16252)', async function() {
+    const schema = new Schema({
+      mail: Schema.Types.Mixed
+    }, { versionKey: false });
+    const Test = db.model('Test', schema);
+
+    const created = await Test.create({
+      mail: { 207: { emId: 207, readStatus: 0, getAttach: 0 } }
+    });
+
+    const doc = await Test.findById(created._id).orFail();
+    doc.mail[207].readStatus = 1;
+    doc.markModified('mail.207.readStatus');
+
+    delete doc.mail[207];
+    doc.markModified('mail.207');
+
+    const delta = doc.$__delta()[1];
+    assert.deepStrictEqual(delta, { $unset: { 'mail.207': 1 } });
+
+    await doc.save();
+    const reloaded = await Test.findById(created._id).orFail();
+    assert.strictEqual(reloaded.mail[207], undefined);
+  });
 });
 
 describe('Check if instance function that is supplied in schema option is available', function() {


### PR DESCRIPTION
Fix #16252

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#16252 highlighted that, when building the document delta in `$__dirty()`, use `top != null` to check whether we should add the path to the delta, which breaks down if the parent path is unset. For example, if `allPaths.has(array[i])` is true but the value of `array[i]` is undefined (like if unset using `delete`) Mongoose will keep the subpath in the delta.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
