### PR TITLE
docs(schema): add instanceof/typeof checks to all default getters for populated doc and nullish value handling

### DIFF
--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -69,7 +69,7 @@ SchemaBigInt.setters = [];
  * #### Example:
  *
  *     // Convert bigints to numbers
- *     mongoose.Schema.BigInt.get(v => v == null ? v : Number(v));
+ *     mongoose.Schema.BigInt.get(v => typeof v === 'bigint' ? Number(v) : v);
  *
  * @param {Function} getter
  * @return {this}

--- a/lib/schema/bigint.js
+++ b/lib/schema/bigint.js
@@ -69,7 +69,7 @@ SchemaBigInt.setters = [];
  * #### Example:
  *
  *     // Convert bigints to numbers
- *     mongoose.Schema.BigInt.get(v => typeof v === 'bigint' ? Number(v) : v);
+ *     mongoose.Schema.Types.BigInt.get(v => typeof v === 'bigint' ? Number(v) : v);
  *
  * @param {Function} getter
  * @return {this}

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -78,7 +78,7 @@ SchemaBuffer.setters = [];
  * #### Example:
  *
  *     // Always convert to string when getting an ObjectId
- *     mongoose.Schema.Types.Buffer.get(v => v.toString('hex'));
+ *     mongoose.Schema.Types.Buffer.get(v => Buffer.isBuffer(v) ? v.toString('hex') : v);
  *
  *     const Model = mongoose.model('Test', new Schema({ buf: Buffer } }));
  *     typeof (new Model({ buf: Buffer.fromString('hello') }).buf); // 'string'

--- a/lib/schema/buffer.js
+++ b/lib/schema/buffer.js
@@ -77,11 +77,11 @@ SchemaBuffer.setters = [];
  *
  * #### Example:
  *
- *     // Always convert to string when getting an ObjectId
+ *     // Always convert to string when getting a buffer
  *     mongoose.Schema.Types.Buffer.get(v => Buffer.isBuffer(v) ? v.toString('hex') : v);
  *
- *     const Model = mongoose.model('Test', new Schema({ buf: Buffer } }));
- *     typeof (new Model({ buf: Buffer.fromString('hello') }).buf); // 'string'
+ *     const Model = mongoose.model('Test', new Schema({ buf: Buffer }));
+ *     typeof (new Model({ buf: Buffer.from('hello') }).buf); // 'string'
  *
  * @param {Function} getter
  * @return {this}

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -78,7 +78,7 @@ SchemaDate.setters = [];
  * #### Example:
  *
  *     // Always convert Dates to string
- *     mongoose.Date.get(v => v.toString());
+ *     mongoose.Date.get(v => v instanceof Date ? v.toString() : v);
  *
  *     const Model = mongoose.model('Test', new Schema({ date: { type: Date, default: () => new Date() } }));
  *     typeof (new Model({}).date); // 'string'

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -73,7 +73,7 @@ Decimal128.setters = [];
  * #### Example:
  *
  *     // Automatically convert Decimal128s to Numbers
- *     mongoose.Schema.Decimal128.get(v => v == null ? v : Number(v));
+ *     mongoose.Schema.Decimal128.get(v => v instanceof mongoose.Types.Decimal128 ? Number(v) : v);
  *
  * @param {Function} getter
  * @return {this}

--- a/lib/schema/decimal128.js
+++ b/lib/schema/decimal128.js
@@ -73,7 +73,7 @@ Decimal128.setters = [];
  * #### Example:
  *
  *     // Automatically convert Decimal128s to Numbers
- *     mongoose.Schema.Decimal128.get(v => v instanceof mongoose.Types.Decimal128 ? Number(v) : v);
+ *     mongoose.Schema.Types.Decimal128.get(v => v instanceof mongoose.Types.Decimal128 ? Number(v) : v);
  *
  * @param {Function} getter
  * @return {this}

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -32,7 +32,7 @@ function SchemaNumber(key, options) {
  * #### Example:
  *
  *     // Make all numbers round down
- *     mongoose.Number.get(function(v) { return Math.floor(v); });
+ *     mongoose.Number.get(function(v) { return typeof v === 'number' ? Math.floor(v) : v; });
  *
  *     const Model = mongoose.model('Test', new Schema({ test: Number }));
  *     new Model({ test: 3.14 }).test; // 3

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -58,8 +58,9 @@ ObjectId.prototype.OptionsConstructor = SchemaObjectIdOptions;
  *
  * #### Example:
  *
- *     // Always convert to string when getting an ObjectId
- *     mongoose.ObjectId.get(v => v.toString());
+ *     // Always convert to string when getting an ObjectId. Check for instanceof ObjectId first
+ *     // in case of null/undefined values as well as populated documents.
+ *     mongoose.ObjectId.get(v => v instanceof mongoose.Types.ObjectId ? v.toString() : v);
  *
  *     const Model = mongoose.model('Test', new Schema({}));
  *     typeof (new Model({})._id); // 'string'

--- a/lib/schema/objectid.js
+++ b/lib/schema/objectid.js
@@ -58,8 +58,8 @@ ObjectId.prototype.OptionsConstructor = SchemaObjectIdOptions;
  *
  * #### Example:
  *
- *     // Always convert to string when getting an ObjectId. Check for instanceof ObjectId first
- *     // in case of null/undefined values as well as populated documents.
+ *     // Convert actual ObjectId values to strings when getting an ObjectId. Check for
+ *     // instanceof ObjectId first so null/undefined values and populated documents are left as-is.
  *     mongoose.ObjectId.get(v => v instanceof mongoose.Types.ObjectId ? v.toString() : v);
  *
  *     const Model = mongoose.model('Test', new Schema({}));

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -107,8 +107,9 @@ SchemaString._defaultCaster = v => {
  *
  * #### Example:
  *
- *     // Make all numbers round down
- *     mongoose.Schema.String.get(v => v.toLowerCase());
+ *     // Make all numbers round down. Check for string type before calling `toLowerCase()`
+ *     // to account for null/undefined values as well as populated docs.
+ *     mongoose.Schema.String.get(v => typeof v === 'string' ? v.toLowerCase() : v);
  *
  *     const Model = mongoose.model('Test', new Schema({ test: String }));
  *     new Model({ test: 'FOO' }).test; // 'foo'

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -107,9 +107,9 @@ SchemaString._defaultCaster = v => {
  *
  * #### Example:
  *
- *     // Make all numbers round down. Check for string type before calling `toLowerCase()`
+ *     // Make all strings lowercase. Check for string type before calling `toLowerCase()`
  *     // to account for null/undefined values as well as populated docs.
- *     mongoose.Schema.String.get(v => typeof v === 'string' ? v.toLowerCase() : v);
+ *     mongoose.Schema.Types.String.get(v => typeof v === 'string' ? v.toLowerCase() : v);
  *
  *     const Model = mongoose.model('Test', new Schema({ test: String }));
  *     new Model({ test: 'FOO' }).test; // 'foo'


### PR DESCRIPTION
Fix #16250

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Default getters as described in the docs are currently somewhat brittle - they don't account for populated docs or nullish values. Fix that so these examples are more copy/pastable.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
