### PR TITLE
BREAKING CHANGE: require passing both filter and update to Query.prototype.updateOne(), make Document.prototype.init() fully sync

### DIFF
--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -595,15 +595,15 @@ function _nextDoc(ctx, doc, pop, callback) {
   }
 
   const { model, _fields, _userProvidedFields, options } = ctx.query;
-  helpers.createModelAndInit(model, doc, _fields, _userProvidedFields, options, pop, (err, doc) => {
-    if (err != null) {
-      return callback(err);
-    }
+  try {
+    doc = helpers.createModelAndInit(model, doc, _fields, _userProvidedFields, options, pop);
     if (options.session != null) {
       doc.$session(options.session);
     }
-    ctx.model.hooks.execPost('find', ctx.query, [[doc]]).then(() => callback(null, doc), err => callback(err));
-  });
+  } catch (err) {
+    return callback(err);
+  }
+  ctx.model.hooks.execPost('find', ctx.query, [[doc]]).then(() => callback(null, doc), err => callback(err));
 }
 
 /*!

--- a/lib/document.js
+++ b/lib/document.js
@@ -639,27 +639,17 @@ Document.prototype.toBSON = function() {
  * @param {object} doc raw document returned by mongo
  * @param {object} [opts]
  * @param {boolean} [opts.hydratedPopulatedDocs=false] If true, hydrate and mark as populated any paths that are populated in the raw document
- * @param {Function} [fn]
  * @api public
  * @memberOf Document
  * @instance
  */
 
-Document.prototype.init = function(doc, opts, fn) {
-  if (typeof opts === 'function') {
-    fn = opts;
-    opts = null;
-  }
-
+Document.prototype.init = function(doc, opts) {
   if (doc == null) {
     throw new ObjectParameterError(doc, 'doc', 'init');
   }
 
   this.$__init(doc, opts);
-
-  if (fn) {
-    fn(null, this);
-  }
 
   return this;
 };

--- a/lib/document.js
+++ b/lib/document.js
@@ -648,6 +648,10 @@ Document.prototype.init = function(doc, opts) {
   if (doc == null) {
     throw new ObjectParameterError(doc, 'doc', 'init');
   }
+  if (typeof opts === 'function' ||
+      (arguments.length > 2 && typeof arguments[2] === 'function')) {
+    throw new MongooseError('Document.prototype.init() no longer accepts a callback');
+  }
 
   this.$__init(doc, opts);
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3996,14 +3996,14 @@ Model.hydrate = function hydrate(obj, projection, options) {
  * @api public
  */
 
-Model.updateMany = function updateMany(conditions, update, options) {
+Model.updateMany = function updateMany(filter, update, options) {
   _checkContext(this, 'updateMany');
 
   if (update == null) {
     throw new MongooseError('updateMany `update` parameter cannot be nullish');
   }
 
-  return _update(this, 'updateMany', conditions, update, options);
+  return _update(this, 'updateMany', filter, update, options);
 };
 
 /**
@@ -4044,10 +4044,10 @@ Model.updateMany = function updateMany(conditions, update, options) {
  * @api public
  */
 
-Model.updateOne = function updateOne(conditions, doc, options) {
+Model.updateOne = function updateOne(filter, update, options) {
   _checkContext(this, 'updateOne');
 
-  return _update(this, 'updateOne', conditions, doc, options);
+  return _update(this, 'updateOne', filter, update, options);
 };
 
 /**
@@ -4067,7 +4067,7 @@ Model.updateOne = function updateOne(conditions, doc, options) {
  * - `replaceOne()`
  *
  * @param {object} filter
- * @param {object} doc
+ * @param {object} replacement
  * @param {object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
  * @param {boolean|'throw'} [options.strict] overwrites the schema's [strict mode option](https://mongoosejs.com/docs/guide.html#strict)
  * @param {boolean} [options.upsert=false] if true, and no documents found, insert a new document
@@ -4081,15 +4081,15 @@ Model.updateOne = function updateOne(conditions, doc, options) {
  * @api public
  */
 
-Model.replaceOne = function replaceOne(conditions, doc, options) {
+Model.replaceOne = function replaceOne(filter, replacement, options) {
   _checkContext(this, 'replaceOne');
 
   const versionKey = this?.schema?.options?.versionKey || null;
-  if (versionKey && !doc[versionKey]) {
-    doc[versionKey] = 0;
+  if (versionKey && !replacement[versionKey]) {
+    replacement[versionKey] = 0;
   }
 
-  return _update(this, 'replaceOne', conditions, doc, options);
+  return _update(this, 'replaceOne', filter, replacement, options);
 };
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -4315,7 +4315,7 @@ Query.prototype._replaceOne = async function _replaceOne() {
  */
 
 Query.prototype.updateMany = function updateMany(filter, update, options) {
-  if (typeof filter === 'function' || typeof update === 'function' || typeof options === 'function') {
+  if (typeof filter === 'function' || typeof update === 'function' || typeof options === 'function' || typeof arguments[3] === 'function') {
     throw new MongooseError('Query.prototype.updateMany() no longer accepts a callback');
   }
   if (arguments.length < 2) {
@@ -4374,7 +4374,7 @@ Query.prototype.updateMany = function updateMany(filter, update, options) {
  */
 
 Query.prototype.updateOne = function updateOne(filter, update, options) {
-  if (typeof filter === 'function' || typeof update === 'function' || typeof options === 'function') {
+  if (typeof filter === 'function' || typeof update === 'function' || typeof options === 'function' || typeof arguments[3] === 'function') {
     throw new MongooseError('Query.prototype.updateOne() no longer accepts a callback');
   }
   if (arguments.length < 2) {
@@ -4425,7 +4425,7 @@ Query.prototype.updateOne = function updateOne(filter, update, options) {
  */
 
 Query.prototype.replaceOne = function replaceOne(filter, replacement, options) {
-  if (typeof filter === 'function' || typeof replacement === 'function' || typeof options === 'function') {
+  if (typeof filter === 'function' || typeof replacement === 'function' || typeof options === 'function' || typeof arguments[3] === 'function') {
     throw new MongooseError('Query.prototype.replaceOne() no longer accepts a callback');
   }
   if (arguments.length < 2) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -4404,8 +4404,8 @@ Query.prototype.updateOne = function updateOne(filter, update, options) {
  *
  * - `replaceOne()`
  *
- * @param {object} [filter]
- * @param {object} [replacement] the replacement doc
+ * @param {object} filter
+ * @param {object} replacement the replacement doc
  * @param {object} [options]
  * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.

--- a/lib/query.js
+++ b/lib/query.js
@@ -2662,9 +2662,9 @@ Query.prototype.collation = function(value) {
  * @api private
  */
 
-Query.prototype._completeOne = function(doc, res, projection, callback) {
+Query.prototype._completeOne = function(doc, res, projection) {
   if (!doc && !this.options.includeResultMetadata) {
-    return callback(null, null);
+    return null;
   }
 
   const model = this.model;
@@ -2678,7 +2678,7 @@ Query.prototype._completeOne = function(doc, res, projection, callback) {
   }
 
   if (options.explain) {
-    return callback(null, doc);
+    return doc;
   }
 
   if (!mongooseOptions.populate) {
@@ -2689,29 +2689,18 @@ Query.prototype._completeOne = function(doc, res, projection, callback) {
       }
     }
     return mongooseOptions.lean ?
-      _completeOneLean(model.schema, doc, null, res, options, callback) :
+      _completeOneLean(model.schema, doc, null, res, options) :
       completeOne(model, doc, res, options, projection, userProvidedFields,
-        null, callback);
+        null);
   }
 
   const pop = helpers.preparePopulationOptionsMQ(this, this._mongooseOptions);
   if (mongooseOptions.lean) {
-    return model.populate(doc, pop).then(
-      doc => {
-        _completeOneLean(model.schema, doc, null, res, options, callback);
-      },
-      error => {
-        callback(error);
-      }
-    );
+    return model.populate(doc, pop).then(doc => _completeOneLean(model.schema, doc, null, res, options));
   }
 
-  completeOne(model, doc, res, options, projection, userProvidedFields, [], (err, doc) => {
-    if (err != null) {
-      return callback(err);
-    }
-    model.populate(doc, pop).then(res => { callback(null, res); }, err => { callback(err); });
-  });
+  doc = completeOne(model, doc, res, options, projection, userProvidedFields, []);
+  return model.populate(doc, pop);
 };
 
 /**
@@ -2727,21 +2716,29 @@ Query.prototype._completeOne = function(doc, res, projection, callback) {
  * @api private
  */
 
-Query.prototype._completeMany = async function _completeMany(docs, fields, userProvidedFields, opts) {
+Query.prototype._completeMany = function _completeMany(docs, fields, userProvidedFields, opts) {
   const model = this.model;
-  return Promise.all(docs.map(doc => new Promise((resolve, reject) => {
+  let firstError = null;
+  const result = docs.map(doc => {
     const rawDoc = doc;
     doc = helpers.createModel(model, doc, fields, userProvidedFields, opts);
     if (opts.session != null) {
       doc.$session(opts.session);
     }
-    doc.$init(rawDoc, opts, (err) => {
-      if (err != null) {
-        return reject(err);
+    // Try to init as many docs as possible, don't fail if the first one is invalid
+    try {
+      doc.$init(rawDoc, opts);
+    } catch (err) {
+      if (firstError == null) {
+        firstError = err;
       }
-      resolve(doc);
-    });
-  })));
+    }
+    return doc;
+  });
+  if (firstError != null) {
+    throw firstError;
+  }
+  return result;
 };
 
 /**
@@ -2769,14 +2766,7 @@ Query.prototype._findOne = async function _findOne() {
 
   // don't pass in the conditions because we already merged them in
   const doc = await this.mongooseCollection.findOne(this._conditions, options);
-  return new Promise((resolve, reject) => {
-    this._completeOne(doc, null, options.projection, (err, res) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve(res);
-    });
-  });
+  return this._completeOne(doc, null, options.projection);
 };
 
 /**
@@ -3357,40 +3347,27 @@ Query.prototype._deleteMany = async function _deleteMany() {
  * @param {object} fields
  * @param {Query} self
  * @param {Array} [pop] array of paths used in population
- * @param {Function} callback
  * @api private
  */
 
-function completeOne(model, doc, res, options, fields, userProvidedFields, pop, callback) {
+function completeOne(model, doc, res, options, fields, userProvidedFields, pop) {
   if (options.includeResultMetadata && doc == null) {
-    _init(null);
-    return null;
+    res.value = null;
+    return res;
   }
 
-  helpers.createModelAndInit(model, doc, fields, userProvidedFields, options, pop, _init);
-
-  function _init(err, casted) {
-    if (err) {
-      return callback(err);
-    }
-
-
-    if (options.includeResultMetadata) {
-      if (doc && casted) {
-        if (options.session != null) {
-          casted.$session(options.session);
-        }
-        res.value = casted;
-      } else {
-        res.value = null;
-      }
-      return callback(null, res);
-    }
+  const casted = helpers.createModelAndInit(model, doc, fields, userProvidedFields, options, pop);
+  if (options.includeResultMetadata) {
     if (options.session != null) {
       casted.$session(options.session);
     }
-    callback(null, casted);
+    res.value = casted;
+    return res;
   }
+  if (options.session != null) {
+    casted.$session(options.session);
+  }
+  return casted;
 }
 
 /**
@@ -3624,14 +3601,7 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   }
   const doc = !options.includeResultMetadata ? res : res.value;
 
-  return new Promise((resolve, reject) => {
-    this._completeOne(doc, res, options.projection, (err, res) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve(res);
-    });
-  });
+  return this._completeOne(doc, res, options.projection);
 };
 
 /**
@@ -3717,14 +3687,7 @@ Query.prototype._findOneAndDelete = async function _findOneAndDelete() {
   }
   const doc = !includeResultMetadata ? res : res.value;
 
-  return new Promise((resolve, reject) => {
-    this._completeOne(doc, res, options.projection, (err, res) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve(res);
-    });
-  });
+  return this._completeOne(doc, res, options.projection);
 };
 
 /**
@@ -3873,14 +3836,7 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
   }
 
   const doc = !includeResultMetadata ? res : res.value;
-  return new Promise((resolve, reject) => {
-    this._completeOne(doc, res, options.projection, (err, res) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve(res);
-    });
-  });
+  return this._completeOne(doc, res, options.projection);
 };
 
 /**
@@ -4033,8 +3989,8 @@ function _getOption(query, option, def) {
  * ignore
  */
 
-function _completeOneLean(schema, doc, path, res, opts, callback) {
-  if (opts.lean && typeof opts.lean.transform === 'function') {
+function _completeOneLean(schema, doc, path, res, opts) {
+  if (doc != null && opts.lean && typeof opts.lean.transform === 'function') {
     opts.lean.transform(doc);
 
     for (let i = 0; i < schema.childSchemas.length; i++) {
@@ -4053,16 +4009,11 @@ function _completeOneLean(schema, doc, path, res, opts, callback) {
       }
       _completeOneLean(_schema, obj, childPath, res, opts);
     }
-    if (callback) {
-      return callback(null, doc);
-    } else {
-      return;
-    }
   }
   if (opts.includeResultMetadata) {
-    return callback(null, res);
+    return res;
   }
-  return callback(null, doc);
+  return doc;
 }
 
 /*!
@@ -4341,8 +4292,8 @@ Query.prototype._replaceOne = async function _replaceOne() {
  *
  * - `updateMany()`
  *
- * @param {object} [filter]
- * @param {object|Array} [update] the update command. If array, this update will be treated as an update pipeline and not casted.
+ * @param {object} filter the filter to match documents to update
+ * @param {object|Array} update the update command. If array, this update will be treated as an update pipeline and not casted.
  * @param {object} [options]
  * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
@@ -4363,32 +4314,15 @@ Query.prototype._replaceOne = async function _replaceOne() {
  * @api public
  */
 
-Query.prototype.updateMany = function(conditions, doc, options, callback) {
-  if (typeof options === 'function') {
-    // .update(conditions, doc, callback)
-    callback = options;
-    options = undefined;
-  } else if (typeof doc === 'function') {
-    // .update(doc, callback);
-    callback = doc;
-    doc = conditions;
-    conditions = {};
-    options = undefined;
-  } else if (typeof conditions === 'function') {
-    // .update(callback)
-    callback = conditions;
-    conditions = undefined;
-    doc = undefined;
-    options = undefined;
-  } else if (typeof conditions === 'object' && !doc && !options && !callback) {
-    // .update(doc)
-    doc = conditions;
-    conditions = undefined;
-    options = undefined;
-    callback = undefined;
+Query.prototype.updateMany = function updateMany(conditions, doc, options) {
+  if (typeof conditions === 'function' || typeof doc === 'function' || typeof options === 'function') {
+    throw new MongooseError('Query.prototype.updateMany() no longer accepts a callback');
+  }
+  if (arguments.length < 2) {
+    throw new MongooseError('Query.prototype.updateMany() requires at least 2 arguments');
   }
 
-  return _update(this, 'updateMany', conditions, doc, options, callback);
+  return _update(this, 'updateMany', conditions, doc, options);
 };
 
 /**
@@ -4417,8 +4351,8 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  *
  * - `updateOne()`
  *
- * @param {object} [filter]
- * @param {object|Array} [update] the update command. If array, this update will be treated as an update pipeline and not casted.
+ * @param {object} filter
+ * @param {object|Array} update the update command. If array, this update will be treated as an update pipeline and not casted.
  * @param {object} [options]
  * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
@@ -4439,32 +4373,15 @@ Query.prototype.updateMany = function(conditions, doc, options, callback) {
  * @api public
  */
 
-Query.prototype.updateOne = function(conditions, doc, options, callback) {
-  if (typeof options === 'function') {
-    // .update(conditions, doc, callback)
-    callback = options;
-    options = undefined;
-  } else if (typeof doc === 'function') {
-    // .update(doc, callback);
-    callback = doc;
-    doc = conditions;
-    conditions = {};
-    options = undefined;
-  } else if (typeof conditions === 'function') {
-    // .update(callback)
-    callback = conditions;
-    conditions = undefined;
-    doc = undefined;
-    options = undefined;
-  } else if (typeof conditions === 'object' && !doc && !options && !callback) {
-    // .update(doc)
-    doc = conditions;
-    conditions = undefined;
-    options = undefined;
-    callback = undefined;
+Query.prototype.updateOne = function updateOne(conditions, update, options) {
+  if (typeof conditions === 'function' || typeof update === 'function' || typeof options === 'function') {
+    throw new MongooseError('Query.prototype.updateOne() no longer accepts a callback');
+  }
+  if (arguments.length < 2) {
+    throw new MongooseError('Query.prototype.updateOne() requires at least 2 arguments');
   }
 
-  return _update(this, 'updateOne', conditions, doc, options, callback);
+  return _update(this, 'updateOne', conditions, update, options);
 };
 
 /**
@@ -4507,32 +4424,15 @@ Query.prototype.updateOne = function(conditions, doc, options, callback) {
  * @api public
  */
 
-Query.prototype.replaceOne = function(conditions, doc, options, callback) {
-  if (typeof options === 'function') {
-    // .update(conditions, doc, callback)
-    callback = options;
-    options = undefined;
-  } else if (typeof doc === 'function') {
-    // .update(doc, callback);
-    callback = doc;
-    doc = conditions;
-    conditions = {};
-    options = undefined;
-  } else if (typeof conditions === 'function') {
-    // .update(callback)
-    callback = conditions;
-    conditions = undefined;
-    doc = undefined;
-    options = undefined;
-  } else if (typeof conditions === 'object' && !doc && !options && !callback) {
-    // .update(doc)
-    doc = conditions;
-    conditions = undefined;
-    options = undefined;
-    callback = undefined;
+Query.prototype.replaceOne = function replaceOne(conditions, doc, options) {
+  if (typeof conditions === 'function' || typeof doc === 'function' || typeof options === 'function') {
+    throw new MongooseError('Query.prototype.replaceOne() no longer accepts a callback');
+  }
+  if (arguments.length < 2) {
+    throw new MongooseError('Query.prototype.replaceOne() requires at least 2 arguments');
   }
 
-  return _update(this, 'replaceOne', conditions, doc, options, callback);
+  return _update(this, 'replaceOne', conditions, doc, options);
 };
 
 /**
@@ -4542,11 +4442,10 @@ Query.prototype.replaceOne = function(conditions, doc, options, callback) {
  * @param {object} filter
  * @param {Document} [doc]
  * @param {object} [options]
- * @param {Function} callback
  * @api private
  */
 
-function _update(query, op, filter, doc, options, callback) {
+function _update(query, op, filter, doc, options) {
   // make sure we don't send in the whole Document to merge()
   query.op = op;
   doc = doc || {};
@@ -4585,13 +4484,6 @@ function _update(query, op, filter, doc, options, callback) {
     query._updateIsShared = true;
   } else {
     query._mergeUpdate(doc);
-  }
-
-  // Hooks
-  if (callback) {
-    query.exec(callback);
-
-    return query;
   }
 
   return query;

--- a/lib/query.js
+++ b/lib/query.js
@@ -4314,15 +4314,15 @@ Query.prototype._replaceOne = async function _replaceOne() {
  * @api public
  */
 
-Query.prototype.updateMany = function updateMany(conditions, doc, options) {
-  if (typeof conditions === 'function' || typeof doc === 'function' || typeof options === 'function') {
+Query.prototype.updateMany = function updateMany(filter, update, options) {
+  if (typeof filter === 'function' || typeof update === 'function' || typeof options === 'function') {
     throw new MongooseError('Query.prototype.updateMany() no longer accepts a callback');
   }
   if (arguments.length < 2) {
     throw new MongooseError('Query.prototype.updateMany() requires at least 2 arguments');
   }
 
-  return _update(this, 'updateMany', conditions, doc, options);
+  return _update(this, 'updateMany', filter, update, options);
 };
 
 /**
@@ -4373,15 +4373,15 @@ Query.prototype.updateMany = function updateMany(conditions, doc, options) {
  * @api public
  */
 
-Query.prototype.updateOne = function updateOne(conditions, update, options) {
-  if (typeof conditions === 'function' || typeof update === 'function' || typeof options === 'function') {
+Query.prototype.updateOne = function updateOne(filter, update, options) {
+  if (typeof filter === 'function' || typeof update === 'function' || typeof options === 'function') {
     throw new MongooseError('Query.prototype.updateOne() no longer accepts a callback');
   }
   if (arguments.length < 2) {
     throw new MongooseError('Query.prototype.updateOne() requires at least 2 arguments');
   }
 
-  return _update(this, 'updateOne', conditions, update, options);
+  return _update(this, 'updateOne', filter, update, options);
 };
 
 /**
@@ -4405,7 +4405,7 @@ Query.prototype.updateOne = function updateOne(conditions, update, options) {
  * - `replaceOne()`
  *
  * @param {object} [filter]
- * @param {object} [doc] the update command
+ * @param {object} [replacement] the replacement doc
  * @param {object} [options]
  * @param {boolean} [options.cloneUpdate=true] if `false`, Mongoose will not clone the update before executing the query
  * @param {boolean} [options.multipleCastError] by default, mongoose only returns the first error that occurred in casting the query. Turn on this option to aggregate all the cast errors.
@@ -4424,15 +4424,15 @@ Query.prototype.updateOne = function updateOne(conditions, update, options) {
  * @api public
  */
 
-Query.prototype.replaceOne = function replaceOne(conditions, doc, options) {
-  if (typeof conditions === 'function' || typeof doc === 'function' || typeof options === 'function') {
+Query.prototype.replaceOne = function replaceOne(filter, replacement, options) {
+  if (typeof filter === 'function' || typeof replacement === 'function' || typeof options === 'function') {
     throw new MongooseError('Query.prototype.replaceOne() no longer accepts a callback');
   }
   if (arguments.length < 2) {
     throw new MongooseError('Query.prototype.replaceOne() requires at least 2 arguments');
   }
 
-  return _update(this, 'replaceOne', conditions, doc, options);
+  return _update(this, 'replaceOne', filter, replacement, options);
 };
 
 /**

--- a/lib/queryHelpers.js
+++ b/lib/queryHelpers.js
@@ -114,7 +114,7 @@ exports.createModel = function createModel(model, doc, fields, userProvidedField
  * ignore
  */
 
-exports.createModelAndInit = function createModelAndInit(model, doc, fields, userProvidedFields, options, populatedIds, callback) {
+exports.createModelAndInit = function createModelAndInit(model, doc, fields, userProvidedFields, options, populatedIds) {
   const initOpts = {};
   if (populatedIds) {
     initOpts.populated = populatedIds;
@@ -124,11 +124,8 @@ exports.createModelAndInit = function createModelAndInit(model, doc, fields, use
   }
 
   const casted = exports.createModel(model, doc, fields, userProvidedFields, options);
-  try {
-    casted.$init(doc, initOpts, callback);
-  } catch (error) {
-    callback(error, casted);
-  }
+  casted.$init(doc, initOpts);
+  return casted;
 };
 
 /*!

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -398,7 +398,7 @@ describe('model: updateOne:', function() {
     const q = BlogPost.find({ _id: post._id });
     q.set('slug', 'test-slug');
 
-    await q.updateOne({ title: 'newtitle' });
+    await q.updateOne({}, { title: 'newtitle' });
 
     const doc = await BlogPost.findById(post._id);
     assert.equal(doc.title, 'newtitle');
@@ -409,7 +409,7 @@ describe('model: updateOne:', function() {
     const q = BlogPost.find({});
     q.set('slug', 'test-slug');
 
-    await q.updateMany({ title: 'newtitle' });
+    await q.updateMany({}, { title: 'newtitle' });
 
     const docs = await BlogPost.find({});
     assert.equal(docs.length, 1);
@@ -1285,10 +1285,10 @@ describe('model: updateOne:', function() {
       const Schema = mongoose.Schema({ name: String });
       const Model = db.model('Test', Schema);
 
-      let query = Model.updateOne({ name: 'Val' });
+      let query = Model.updateOne({}, { name: 'Val' });
       assert.equal(query.getUpdate().name, 'Val');
 
-      query = Model.find().updateOne({ name: 'Val' });
+      query = Model.find().updateOne({}, { name: 'Val' });
       assert.equal(query.getUpdate().name, 'Val');
 
       return query.setOptions({ upsert: true }).
@@ -1302,7 +1302,7 @@ describe('model: updateOne:', function() {
       const Schema = mongoose.Schema({ name: String });
 
       Schema.pre('updateOne', function() {
-        this.updateOne({ name: 'Val' });
+        this.updateOne({}, { name: 'Val' });
       });
 
       const Model = db.model('Test', Schema);

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -1278,24 +1278,6 @@ describe('model: updateOne:', function() {
       const Model = db.model('Test', Schema);
 
       await Model.updateOne({}, { myBufferField: Buffer.alloc(1) });
-
-    });
-
-    it('.updateOne(doc) (gh-3221)', function() {
-      const Schema = mongoose.Schema({ name: String });
-      const Model = db.model('Test', Schema);
-
-      let query = Model.updateOne({}, { name: 'Val' });
-      assert.equal(query.getUpdate().name, 'Val');
-
-      query = Model.find().updateOne({}, { name: 'Val' });
-      assert.equal(query.getUpdate().name, 'Val');
-
-      return query.setOptions({ upsert: true }).
-        then(() => Model.findOne()).
-        then(doc => {
-          assert.equal(doc.name, 'Val');
-        });
     });
 
     it('middleware update with exec (gh-3549)', async function() {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1862,8 +1862,8 @@ describe('Query', function() {
       const TestModel = db.model('Test', TestSchema);
 
       for (const op of ops) {
-        const q = TestModel.find({}).updateOne({ name: 'test' });
-        const error = await q[op]().then(() => null, err => err);
+        const q = TestModel.find({}).updateOne({}, { name: 'test' });
+        const error = await q.exec(op).then(() => null, err => err);
         assert.ok(error);
         assert.equal(error.message, op + ' error');
       }


### PR DESCRIPTION
Fix #16269

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Remove some more callback-based internals: `Document.prototype.init()` has no reason to support callbacks it is fully sync. Likewise, logic that uses it, like `completeOne()`, doesn't necessarily need to be async unless there's `populate()` involved.

Also, for consistency with our TypeScript types and Model.updateX(); `Query.prototype.updateOne()`, `updateMany()`, and `replaceOne()` now require both a `filter` and `update`/`replacement` argument. To avoid any confusion with our legacy behavior of `Query.prototype.updateOne(obj)` treating `obj` as a `update` not a `filter`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
