### PR TITLE
feat: Add tracing channel support

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -15,6 +15,7 @@ const { buildMiddlewareFilter } = require('./helpers/buildMiddlewareFilter');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
 const { modelSymbol } = require('./helpers/symbols');
+const { traceAggregate } = require('./tracing');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -1090,32 +1091,42 @@ Aggregate.prototype.exec = async function exec() {
   prepareDiscriminatorPipeline(this._pipeline, this._model.schema);
   stringifyFunctionOperators(this._pipeline);
 
-  const preFilter = buildMiddlewareFilter(this.options, 'pre');
-  const postFilter = buildMiddlewareFilter(this.options, 'post');
+  const _this = this;
+  return traceAggregate(async function() {
+    const preFilter = buildMiddlewareFilter(_this.options, 'pre');
+    const postFilter = buildMiddlewareFilter(_this.options, 'post');
 
-  try {
-    await model.hooks.execPre('aggregate', this, [], { filter: preFilter });
-  } catch (error) {
-    return await model.hooks.execPost('aggregate', this, [null], { error, filter: postFilter });
-  }
+    try {
+      await model.hooks.execPre('aggregate', _this, [], { filter: preFilter });
+    } catch (error) {
+      return await model.hooks.execPost('aggregate', _this, [null], { error, filter: postFilter });
+    }
 
-  if (!this._pipeline.length) {
-    throw new MongooseError('Aggregate has empty pipeline');
-  }
+    if (!_this._pipeline.length) {
+      throw new MongooseError('Aggregate has empty pipeline');
+    }
 
-  const options = clone(this.options || {});
-  delete options.middleware;
+    const options = clone(_this.options || {});
+    delete options.middleware;
 
-  let result;
-  try {
-    const cursor = await collection.aggregate(this._pipeline, options);
-    result = await cursor.toArray();
-  } catch (error) {
-    return await model.hooks.execPost('aggregate', this, [null], { error, filter: postFilter });
-  }
+    let result;
+    try {
+      const cursor = await collection.aggregate(_this._pipeline, options);
+      result = await cursor.toArray();
+    } catch (error) {
+      return await model.hooks.execPost('aggregate', _this, [null], { error, filter: postFilter });
+    }
 
-  await model.hooks.execPost('aggregate', this, [result], { error: null, filter: postFilter });
-  return result;
+    await model.hooks.execPost('aggregate', _this, [result], { error: null, filter: postFilter });
+    return result;
+  }, () => ({
+    pipeline: _this._pipeline,
+    collection: collection.name,
+    options: _this.options,
+    database: model.db?.name,
+    serverAddress: model.db?.host,
+    serverPort: model.db?.port
+  }));
 };
 
 /**

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -15,7 +15,8 @@ const { buildMiddlewareFilter } = require('./helpers/buildMiddlewareFilter');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
 const { modelSymbol } = require('./helpers/symbols');
-const { aggregateChannel } = require('./tracing');
+const { createTracedChannel } = require('./tracing');
+const { trace: traceAggregate } = createTracedChannel('mongoose:aggregate');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -1073,7 +1074,7 @@ Aggregate.prototype.exec = async function exec() {
     this._optionsForExec();
 
     const _this = this;
-    return aggregateChannel.trace(async function maybeTracedConnectionAggregate() {
+    return traceAggregate(async function maybeTracedConnectionAggregate() {
       const cursor = await _this._connection.client.db().aggregate(_this._pipeline, _this.options);
       return await cursor.toArray();
     }, () => ({
@@ -1104,7 +1105,7 @@ Aggregate.prototype.exec = async function exec() {
   stringifyFunctionOperators(this._pipeline);
 
   const _this = this;
-  return aggregateChannel.trace(async function maybeTracedAggregateExec() {
+  return traceAggregate(async function maybeTracedAggregateExec() {
     const preFilter = buildMiddlewareFilter(_this.options, 'pre');
     const postFilter = buildMiddlewareFilter(_this.options, 'post');
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1092,7 +1092,7 @@ Aggregate.prototype.exec = async function exec() {
   stringifyFunctionOperators(this._pipeline);
 
   const _this = this;
-  return trace(async function() {
+  return trace(async function maybeTracedAggregateExec() {
     const preFilter = buildMiddlewareFilter(_this.options, 'pre');
     const postFilter = buildMiddlewareFilter(_this.options, 'post');
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -1072,8 +1072,20 @@ Aggregate.prototype.exec = async function exec() {
 
     this._optionsForExec();
 
-    const cursor = await this._connection.client.db().aggregate(this._pipeline, this.options);
-    return await cursor.toArray();
+    const _this = this;
+    return trace(async function maybeTracedConnectionAggregate() {
+      const cursor = await _this._connection.client.db().aggregate(_this._pipeline, _this.options);
+      return await cursor.toArray();
+    }, () => ({
+      operation: 'aggregate',
+      database: _this._connection.name,
+      serverAddress: _this._connection.host,
+      serverPort: _this._connection.port,
+      args: {
+        pipeline: _this._pipeline,
+        options: _this.options
+      }
+    }));
   }
 
   const model = this._model;

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -15,7 +15,7 @@ const { buildMiddlewareFilter } = require('./helpers/buildMiddlewareFilter');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
 const { modelSymbol } = require('./helpers/symbols');
-const { traceAggregate } = require('./tracing');
+const { trace } = require('./tracing');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -1092,7 +1092,7 @@ Aggregate.prototype.exec = async function exec() {
   stringifyFunctionOperators(this._pipeline);
 
   const _this = this;
-  return traceAggregate(async function() {
+  return trace(async function() {
     const preFilter = buildMiddlewareFilter(_this.options, 'pre');
     const postFilter = buildMiddlewareFilter(_this.options, 'post');
 
@@ -1120,12 +1120,15 @@ Aggregate.prototype.exec = async function exec() {
     await model.hooks.execPost('aggregate', _this, [result], { error: null, filter: postFilter });
     return result;
   }, () => ({
-    pipeline: _this._pipeline,
+    operation: 'aggregate',
     collection: collection.name,
-    options: _this.options,
     database: model.db?.name,
     serverAddress: model.db?.host,
-    serverPort: model.db?.port
+    serverPort: model.db?.port,
+    args: {
+      pipeline: _this._pipeline,
+      options: _this.options
+    }
   }));
 };
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -15,7 +15,7 @@ const { buildMiddlewareFilter } = require('./helpers/buildMiddlewareFilter');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
 const { modelSymbol } = require('./helpers/symbols');
-const { queryChannel } = require('./tracing');
+const { aggregateChannel } = require('./tracing');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -1073,7 +1073,7 @@ Aggregate.prototype.exec = async function exec() {
     this._optionsForExec();
 
     const _this = this;
-    return queryChannel.trace(async function maybeTracedConnectionAggregate() {
+    return aggregateChannel.trace(async function maybeTracedConnectionAggregate() {
       const cursor = await _this._connection.client.db().aggregate(_this._pipeline, _this.options);
       return await cursor.toArray();
     }, () => ({
@@ -1104,7 +1104,7 @@ Aggregate.prototype.exec = async function exec() {
   stringifyFunctionOperators(this._pipeline);
 
   const _this = this;
-  return queryChannel.trace(async function maybeTracedAggregateExec() {
+  return aggregateChannel.trace(async function maybeTracedAggregateExec() {
     const preFilter = buildMiddlewareFilter(_this.options, 'pre');
     const postFilter = buildMiddlewareFilter(_this.options, 'post');
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -15,7 +15,7 @@ const { buildMiddlewareFilter } = require('./helpers/buildMiddlewareFilter');
 const stringifyFunctionOperators = require('./helpers/aggregate/stringifyFunctionOperators');
 const utils = require('./utils');
 const { modelSymbol } = require('./helpers/symbols');
-const { trace } = require('./tracing');
+const { queryChannel } = require('./tracing');
 const read = Query.prototype.read;
 const readConcern = Query.prototype.readConcern;
 
@@ -1073,7 +1073,7 @@ Aggregate.prototype.exec = async function exec() {
     this._optionsForExec();
 
     const _this = this;
-    return trace(async function maybeTracedConnectionAggregate() {
+    return queryChannel.trace(async function maybeTracedConnectionAggregate() {
       const cursor = await _this._connection.client.db().aggregate(_this._pipeline, _this.options);
       return await cursor.toArray();
     }, () => ({
@@ -1104,7 +1104,7 @@ Aggregate.prototype.exec = async function exec() {
   stringifyFunctionOperators(this._pipeline);
 
   const _this = this;
-  return trace(async function maybeTracedAggregateExec() {
+  return queryChannel.trace(async function maybeTracedAggregateExec() {
     const preFilter = buildMiddlewareFilter(_this.options, 'pre');
     const postFilter = buildMiddlewareFilter(_this.options, 'post');
 

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -10,6 +10,7 @@ const eachAsync = require('../helpers/cursor/eachAsync');
 const immediate = require('../helpers/immediate');
 const kareem = require('kareem');
 const util = require('util');
+const { traceCursorNext } = require('../tracing');
 
 /**
  * An AggregationCursor is a concurrency primitive for processing aggregation
@@ -277,14 +278,28 @@ AggregationCursor.prototype.next = async function next() {
   if (typeof arguments[0] === 'function') {
     throw new MongooseError('AggregationCursor.prototype.next() no longer accepts a callback');
   }
-  return new Promise((resolve, reject) => {
-    _next(this, (err, res) => {
-      if (err != null) {
-        return reject(err);
-      }
-      resolve(res);
+  const _this = this;
+  const model = this.agg._model;
+  return traceCursorNext(function maybeTracedAggCursorNext() {
+    return new Promise((resolve, reject) => {
+      _next(_this, (err, res) => {
+        if (err != null) {
+          return reject(err);
+        }
+        resolve(res);
+      });
     });
-  });
+  }, () => ({
+    operation: 'aggregate',
+    collection: model?.collection?.name,
+    database: model?.db?.name,
+    serverAddress: model?.db?.host,
+    serverPort: model?.db?.port,
+    args: {
+      pipeline: _this.agg._pipeline,
+      options: _this.agg.options
+    }
+  }));
 };
 
 /**

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -295,6 +295,8 @@ AggregationCursor.prototype.next = async function next() {
     database: model?.db?.name,
     serverAddress: model?.db?.host,
     serverPort: model?.db?.port,
+    batchSize: _this.agg.options?.cursor?.batchSize,
+    tailable: false,
     args: {
       pipeline: _this.agg._pipeline,
       options: _this.agg.options

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -10,7 +10,7 @@ const eachAsync = require('../helpers/cursor/eachAsync');
 const immediate = require('../helpers/immediate');
 const kareem = require('kareem');
 const util = require('util');
-const { traceCursorNext } = require('../tracing');
+const { cursorNextChannel } = require('../tracing');
 
 /**
  * An AggregationCursor is a concurrency primitive for processing aggregation
@@ -280,7 +280,7 @@ AggregationCursor.prototype.next = async function next() {
   }
   const _this = this;
   const model = this.agg._model;
-  return traceCursorNext(function maybeTracedAggCursorNext() {
+  return cursorNextChannel.trace(function maybeTracedAggCursorNext() {
     return new Promise((resolve, reject) => {
       _next(_this, (err, res) => {
         if (err != null) {

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -12,6 +12,7 @@ const kareem = require('kareem');
 const immediate = require('../helpers/immediate');
 const { once } = require('events');
 const util = require('util');
+const { traceCursorNext } = require('../tracing');
 
 /**
  * A QueryCursor is a concurrency primitive for processing query results
@@ -310,14 +311,27 @@ QueryCursor.prototype.next = async function next() {
   if (this._closed) {
     throw new MongooseError('Cannot call `next()` on a closed cursor');
   }
-  return new Promise((resolve, reject) => {
-    _next(this, function(error, doc) {
-      if (error) {
-        return reject(error);
-      }
-      resolve(doc);
+  const _this = this;
+  return traceCursorNext(function maybeTracedQueryCursorNext() {
+    return new Promise((resolve, reject) => {
+      _next(_this, function(error, doc) {
+        if (error) {
+          return reject(error);
+        }
+        resolve(doc);
+      });
     });
-  });
+  }, () => ({
+    operation: _this.query.op || 'find',
+    collection: _this.query.mongooseCollection.name,
+    database: _this.model.db?.name,
+    serverAddress: _this.model.db?.host,
+    serverPort: _this.model.db?.port,
+    args: {
+      filter: _this.query.getFilter(),
+      options: _this.query._mongooseOptions
+    }
+  }));
 };
 
 /**

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -327,6 +327,8 @@ QueryCursor.prototype.next = async function next() {
     database: _this.model.db?.name,
     serverAddress: _this.model.db?.host,
     serverPort: _this.model.db?.port,
+    batchSize: _this.options.batchSize || _this.query.options?.batchSize,
+    tailable: _this.options.tailable || _this.query.options?.tailable || false,
     args: {
       filter: _this.query.getFilter(),
       options: _this.query._mongooseOptions

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -12,7 +12,7 @@ const kareem = require('kareem');
 const immediate = require('../helpers/immediate');
 const { once } = require('events');
 const util = require('util');
-const { traceCursorNext } = require('../tracing');
+const { cursorNextChannel } = require('../tracing');
 
 /**
  * A QueryCursor is a concurrency primitive for processing query results
@@ -312,7 +312,7 @@ QueryCursor.prototype.next = async function next() {
     throw new MongooseError('Cannot call `next()` on a closed cursor');
   }
   const _this = this;
-  return traceCursorNext(function maybeTracedQueryCursorNext() {
+  return cursorNextChannel.trace(function maybeTracedQueryCursorNext() {
     return new Promise((resolve, reject) => {
       _next(_this, function(error, doc) {
         if (error) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -7,7 +7,7 @@
 const Aggregate = require('./aggregate');
 const ChangeStream = require('./cursor/changeStream');
 const Document = require('./document');
-const { trace } = require('./tracing');
+const { queryChannel } = require('./tracing');
 const DocumentNotFoundError = require('./error/notFound');
 const EventEmitter = require('events').EventEmitter;
 const Kareem = require('kareem');
@@ -665,7 +665,7 @@ Model.prototype.save = async function save(options) {
   this.$__.saveOptions = options;
 
   const _this = this;
-  return trace(async function maybeTracedSave() {
+  return queryChannel.trace(async function maybeTracedSave() {
     try {
       await _this.$__save(options);
     } catch (error) {
@@ -3027,7 +3027,7 @@ Model.insertMany = function insertMany(arr, options) {
   }
 
   const ThisModel = this;
-  return trace(function maybeTracedInsertMany() { return _insertMany.call(ThisModel, arr, options); }, () => ({
+  return queryChannel.trace(function maybeTracedInsertMany() { return _insertMany.call(ThisModel, arr, options); }, () => ({
     operation: 'insertMany',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,
@@ -3403,7 +3403,7 @@ Model.bulkWrite = function bulkWrite(ops, options) {
   }
 
   const ThisModel = this;
-  return trace(function maybeTracedBulkWrite() { return _bulkWrite.call(ThisModel, ops, options); }, () => ({
+  return queryChannel.trace(function maybeTracedBulkWrite() { return _bulkWrite.call(ThisModel, ops, options); }, () => ({
     operation: 'bulkWrite',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,

--- a/lib/model.js
+++ b/lib/model.js
@@ -3019,7 +3019,7 @@ Model.startSession = function() {
  * @api public
  */
 
-Model.insertMany = function insertMany(arr, options) {
+Model.insertMany = async function insertMany(arr, options) {
   _checkContext(this, 'insertMany');
   if (typeof options === 'function' ||
     typeof arguments[2] === 'function') {
@@ -3394,7 +3394,7 @@ function _setIsNew(doc, val) {
  * @api public
  */
 
-Model.bulkWrite = function bulkWrite(ops, options) {
+Model.bulkWrite = async function bulkWrite(ops, options) {
   _checkContext(this, 'bulkWrite');
 
   if (typeof options === 'function' ||

--- a/lib/model.js
+++ b/lib/model.js
@@ -665,7 +665,7 @@ Model.prototype.save = async function save(options) {
   this.$__.saveOptions = options;
 
   const _this = this;
-  return trace(async function() {
+  return trace(async function maybeTracedSave() {
     try {
       await _this.$__save(options);
     } catch (error) {
@@ -3027,7 +3027,7 @@ Model.insertMany = function insertMany(arr, options) {
   }
 
   const ThisModel = this;
-  return trace(() => _insertMany.call(ThisModel, arr, options), () => ({
+  return trace(function maybeTracedInsertMany() { return _insertMany.call(ThisModel, arr, options); }, () => ({
     operation: 'insertMany',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,
@@ -3403,7 +3403,7 @@ Model.bulkWrite = function bulkWrite(ops, options) {
   }
 
   const ThisModel = this;
-  return trace(() => _bulkWrite.call(ThisModel, ops, options), () => ({
+  return trace(function maybeTracedBulkWrite() { return _bulkWrite.call(ThisModel, ops, options); }, () => ({
     operation: 'bulkWrite',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,

--- a/lib/model.js
+++ b/lib/model.js
@@ -7,7 +7,10 @@
 const Aggregate = require('./aggregate');
 const ChangeStream = require('./cursor/changeStream');
 const Document = require('./document');
-const { queryChannel } = require('./tracing');
+const { createTracedChannel } = require('./tracing');
+const { trace: traceSave } = createTracedChannel('mongoose:model:save');
+const { trace: traceInsertMany } = createTracedChannel('mongoose:model:insertMany');
+const { trace: traceBulkWrite } = createTracedChannel('mongoose:model:bulkWrite');
 const DocumentNotFoundError = require('./error/notFound');
 const EventEmitter = require('events').EventEmitter;
 const Kareem = require('kareem');
@@ -665,7 +668,7 @@ Model.prototype.save = async function save(options) {
   this.$__.saveOptions = options;
 
   const _this = this;
-  return queryChannel.trace(async function maybeTracedSave() {
+  return traceSave(async function maybeTracedSave() {
     try {
       await _this.$__save(options);
     } catch (error) {
@@ -3027,7 +3030,7 @@ Model.insertMany = async function insertMany(arr, options) {
   }
 
   const ThisModel = this;
-  return queryChannel.trace(function maybeTracedInsertMany() { return _insertMany.call(ThisModel, arr, options); }, () => ({
+  return traceInsertMany(function maybeTracedInsertMany() { return _insertMany.call(ThisModel, arr, options); }, () => ({
     operation: 'insertMany',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,
@@ -3403,7 +3406,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   }
 
   const ThisModel = this;
-  return queryChannel.trace(function maybeTracedBulkWrite() { return _bulkWrite.call(ThisModel, ops, options); }, () => ({
+  return traceBulkWrite(function maybeTracedBulkWrite() { return _bulkWrite.call(ThisModel, ops, options); }, () => ({
     operation: 'bulkWrite',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,

--- a/lib/model.js
+++ b/lib/model.js
@@ -7,7 +7,7 @@
 const Aggregate = require('./aggregate');
 const ChangeStream = require('./cursor/changeStream');
 const Document = require('./document');
-const { traceSave, traceModel } = require('./tracing');
+const { trace } = require('./tracing');
 const DocumentNotFoundError = require('./error/notFound');
 const EventEmitter = require('events').EventEmitter;
 const Kareem = require('kareem');
@@ -665,7 +665,7 @@ Model.prototype.save = async function save(options) {
   this.$__.saveOptions = options;
 
   const _this = this;
-  return traceSave(async function() {
+  return trace(async function() {
     try {
       await _this.$__save(options);
     } catch (error) {
@@ -684,7 +684,8 @@ Model.prototype.save = async function save(options) {
     collection: _this.constructor.collection.name,
     database: _this.constructor.db?.name,
     serverAddress: _this.constructor.db?.host,
-    serverPort: _this.constructor.db?.port
+    serverPort: _this.constructor.db?.port,
+    args: { options }
   }));
 };
 
@@ -3026,12 +3027,13 @@ Model.insertMany = function insertMany(arr, options) {
   }
 
   const ThisModel = this;
-  return traceModel(() => _insertMany.call(ThisModel, arr, options), () => ({
+  return trace(() => _insertMany.call(ThisModel, arr, options), () => ({
     operation: 'insertMany',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,
     serverAddress: ThisModel.db?.host,
-    serverPort: ThisModel.db?.port
+    serverPort: ThisModel.db?.port,
+    args: { docs: arr, options }
   }));
 };
 
@@ -3401,12 +3403,13 @@ Model.bulkWrite = function bulkWrite(ops, options) {
   }
 
   const ThisModel = this;
-  return traceModel(() => _bulkWrite.call(ThisModel, ops, options), () => ({
+  return trace(() => _bulkWrite.call(ThisModel, ops, options), () => ({
     operation: 'bulkWrite',
     collection: ThisModel.collection.name,
     database: ThisModel.db?.name,
     serverAddress: ThisModel.db?.host,
-    serverPort: ThisModel.db?.port
+    serverPort: ThisModel.db?.port,
+    args: { ops, options }
   }));
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -7,6 +7,7 @@
 const Aggregate = require('./aggregate');
 const ChangeStream = require('./cursor/changeStream');
 const Document = require('./document');
+const { traceSave, traceModel } = require('./tracing');
 const DocumentNotFoundError = require('./error/notFound');
 const EventEmitter = require('events').EventEmitter;
 const Kareem = require('kareem');
@@ -663,19 +664,28 @@ Model.prototype.save = async function save(options) {
 
   this.$__.saveOptions = options;
 
-  try {
-    await this.$__save(options);
-  } catch (error) {
-    this.$__handleReject(error);
-    throw error;
-  } finally {
-    this.$__.saving = null;
-    this.$__.saveOptions = null;
-    this.$__.$versionError = null;
-    this.$op = null;
-  }
+  const _this = this;
+  return traceSave(async function() {
+    try {
+      await _this.$__save(options);
+    } catch (error) {
+      _this.$__handleReject(error);
+      throw error;
+    } finally {
+      _this.$__.saving = null;
+      _this.$__.saveOptions = null;
+      _this.$__.$versionError = null;
+      _this.$op = null;
+    }
 
-  return this;
+    return _this;
+  }, () => ({
+    operation: 'save',
+    collection: _this.constructor.collection.name,
+    database: _this.constructor.db?.name,
+    serverAddress: _this.constructor.db?.host,
+    serverPort: _this.constructor.db?.port
+  }));
 };
 
 Model.prototype.$save = Model.prototype.save;
@@ -3008,13 +3018,24 @@ Model.startSession = function() {
  * @api public
  */
 
-Model.insertMany = async function insertMany(arr, options) {
+Model.insertMany = function insertMany(arr, options) {
   _checkContext(this, 'insertMany');
   if (typeof options === 'function' ||
     typeof arguments[2] === 'function') {
     throw new MongooseError('Model.insertMany() no longer accepts a callback');
   }
 
+  const ThisModel = this;
+  return traceModel(() => _insertMany.call(ThisModel, arr, options), () => ({
+    operation: 'insertMany',
+    collection: ThisModel.collection.name,
+    database: ThisModel.db?.name,
+    serverAddress: ThisModel.db?.host,
+    serverPort: ThisModel.db?.port
+  }));
+};
+
+async function _insertMany(arr, options) {
   options = options || {};
   const preFilter = buildMiddlewareFilter(options, 'pre');
   const postFilter = buildMiddlewareFilter(options, 'post');
@@ -3250,7 +3271,7 @@ Model.insertMany = async function insertMany(arr, options) {
 
   const [result] = await this._middleware.execPost('insertMany', this, [docAttributes], { filter: postFilter });
   return result;
-};
+}
 
 /*!
  * ignore
@@ -3371,13 +3392,25 @@ function _setIsNew(doc, val) {
  * @api public
  */
 
-Model.bulkWrite = async function bulkWrite(ops, options) {
+Model.bulkWrite = function bulkWrite(ops, options) {
   _checkContext(this, 'bulkWrite');
 
   if (typeof options === 'function' ||
       typeof arguments[2] === 'function') {
     throw new MongooseError('Model.bulkWrite() no longer accepts a callback');
   }
+
+  const ThisModel = this;
+  return traceModel(() => _bulkWrite.call(ThisModel, ops, options), () => ({
+    operation: 'bulkWrite',
+    collection: ThisModel.collection.name,
+    database: ThisModel.db?.name,
+    serverAddress: ThisModel.db?.host,
+    serverPort: ThisModel.db?.port
+  }));
+};
+
+async function _bulkWrite(ops, options) {
   options = options || {};
   const preFilter = buildMiddlewareFilter(options, 'pre');
   const postFilter = buildMiddlewareFilter(options, 'post');
@@ -3516,7 +3549,7 @@ Model.bulkWrite = async function bulkWrite(ops, options) {
   await this.hooks.execPost('bulkWrite', this, [res], { filter: postFilter });
 
   return res;
-};
+}
 
 /**
  * Takes an array of documents, gets the changes and inserts/updates documents in the database

--- a/lib/query.js
+++ b/lib/query.js
@@ -42,7 +42,7 @@ const updateValidators = require('./helpers/updateValidators');
 const util = require('util');
 const utils = require('./utils');
 const queryMiddlewareFunctions = require('./constants').queryMiddlewareFunctions;
-const { traceQuery } = require('./tracing');
+const { trace } = require('./tracing');
 
 const queryOptionMethods = new Set([
   'allowDiskUse',
@@ -4780,7 +4780,7 @@ Query.prototype.exec = async function exec(op) {
   this._execCount++;
 
   const _this = this;
-  return traceQuery(async function() {
+  return trace(async function() {
     let skipWrappedFunction = null;
     try {
       await _this._hooks.execPre('exec', _this, []);
@@ -4820,12 +4820,14 @@ Query.prototype.exec = async function exec(op) {
   }, () => ({
     operation: _this.op,
     collection: _this.mongooseCollection.name,
-    query: _this.getFilter(),
-    fields: _this._fields,
-    options: _this._mongooseOptions,
     database: _this.model.db?.name,
     serverAddress: _this.model.db?.host,
-    serverPort: _this.model.db?.port
+    serverPort: _this.model.db?.port,
+    args: {
+      filter: _this.getFilter(),
+      fields: _this._fields,
+      options: _this._mongooseOptions
+    }
   }));
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -42,6 +42,7 @@ const updateValidators = require('./helpers/updateValidators');
 const util = require('util');
 const utils = require('./utils');
 const queryMiddlewareFunctions = require('./constants').queryMiddlewareFunctions;
+const { traceQuery } = require('./tracing');
 
 const queryOptionMethods = new Set([
   'allowDiskUse',
@@ -4778,42 +4779,54 @@ Query.prototype.exec = async function exec(op) {
   }
   this._execCount++;
 
-  let skipWrappedFunction = null;
-  try {
-    await this._hooks.execPre('exec', this, []);
-  } catch (err) {
-    if (err instanceof Kareem.skipWrappedFunction) {
-      skipWrappedFunction = err;
-    } else {
-      throw err;
-    }
-  }
-
-  let res;
-
-  let error = null;
-  try {
-    await _executePreHooks(this);
-    res = skipWrappedFunction ? skipWrappedFunction.args[0] : await this[thunk]();
-
-    for (const fn of this._transforms) {
-      res = fn(res);
-    }
-  } catch (err) {
-    if (err instanceof Kareem.skipWrappedFunction) {
-      res = err.args[0];
-    } else {
-      error = err;
+  const _this = this;
+  return traceQuery(async function() {
+    let skipWrappedFunction = null;
+    try {
+      await _this._hooks.execPre('exec', _this, []);
+    } catch (err) {
+      if (err instanceof Kareem.skipWrappedFunction) {
+        skipWrappedFunction = err;
+      } else {
+        throw err;
+      }
     }
 
-    error = this.model.schema._transformDuplicateKeyError(error);
-  }
+    let res;
 
-  res = await _executePostHooks(this, res, error);
+    let error = null;
+    try {
+      await _executePreHooks(_this);
+      res = skipWrappedFunction ? skipWrappedFunction.args[0] : await _this[thunk]();
 
-  await this._hooks.execPost('exec', this, []);
+      for (const fn of _this._transforms) {
+        res = fn(res);
+      }
+    } catch (err) {
+      if (err instanceof Kareem.skipWrappedFunction) {
+        res = err.args[0];
+      } else {
+        error = err;
+      }
 
-  return res;
+      error = _this.model.schema._transformDuplicateKeyError(error);
+    }
+
+    res = await _executePostHooks(_this, res, error);
+
+    await _this._hooks.execPost('exec', _this, []);
+
+    return res;
+  }, () => ({
+    operation: _this.op,
+    collection: _this.mongooseCollection.name,
+    query: _this.getFilter(),
+    fields: _this._fields,
+    options: _this._mongooseOptions,
+    database: _this.model.db?.name,
+    serverAddress: _this.model.db?.host,
+    serverPort: _this.model.db?.port
+  }));
 };
 
 /*!

--- a/lib/query.js
+++ b/lib/query.js
@@ -42,7 +42,7 @@ const updateValidators = require('./helpers/updateValidators');
 const util = require('util');
 const utils = require('./utils');
 const queryMiddlewareFunctions = require('./constants').queryMiddlewareFunctions;
-const { trace } = require('./tracing');
+const { queryChannel } = require('./tracing');
 
 const queryOptionMethods = new Set([
   'allowDiskUse',
@@ -4780,7 +4780,7 @@ Query.prototype.exec = async function exec(op) {
   this._execCount++;
 
   const _this = this;
-  return trace(async function maybeTracedQueryExec() {
+  return queryChannel.trace(async function maybeTracedQueryExec() {
     let skipWrappedFunction = null;
     try {
       await _this._hooks.execPre('exec', _this, []);

--- a/lib/query.js
+++ b/lib/query.js
@@ -42,7 +42,8 @@ const updateValidators = require('./helpers/updateValidators');
 const util = require('util');
 const utils = require('./utils');
 const queryMiddlewareFunctions = require('./constants').queryMiddlewareFunctions;
-const { queryChannel } = require('./tracing');
+const { createTracedChannel } = require('./tracing');
+const { trace: traceQuery } = createTracedChannel('mongoose:query');
 
 const queryOptionMethods = new Set([
   'allowDiskUse',
@@ -4780,7 +4781,7 @@ Query.prototype.exec = async function exec(op) {
   this._execCount++;
 
   const _this = this;
-  return queryChannel.trace(async function maybeTracedQueryExec() {
+  return traceQuery(async function maybeTracedQueryExec() {
     let skipWrappedFunction = null;
     try {
       await _this._hooks.execPre('exec', _this, []);

--- a/lib/query.js
+++ b/lib/query.js
@@ -4780,7 +4780,7 @@ Query.prototype.exec = async function exec(op) {
   this._execCount++;
 
   const _this = this;
-  return trace(async function() {
+  return trace(async function maybeTracedQueryExec() {
     let skipWrappedFunction = null;
     try {
       await _this._hooks.execPre('exec', _this, []);

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const dc = process.getBuiltinModule('node:diagnostics_channel');
+
+const hasTracingChannel = typeof dc.tracingChannel === 'function';
+
+// @types/node is missing hasSubscribers on TracingChannel and types
+// tracePromise as returning void. Both exist at runtime.
+// Check explicitly for `false` rather than truthiness because `hasSubscribers`
+// is not available on all Node.js versions that support TracingChannel.
+// When `hasSubscribers` is `undefined` (older Node), we assume there are
+// subscribers and trace unconditionally, keeping the zero-cost optimization
+// only for versions where we can reliably check.
+function shouldTrace(channel) {
+  return !!channel && channel.hasSubscribers !== false;
+}
+
+const noop = () => {};
+
+const queryChannel = hasTracingChannel
+  ? dc.tracingChannel('mongoose:query')
+  : undefined;
+
+const aggregateChannel = hasTracingChannel
+  ? dc.tracingChannel('mongoose:aggregate')
+  : undefined;
+
+const saveChannel = hasTracingChannel
+  ? dc.tracingChannel('mongoose:save')
+  : undefined;
+
+const modelChannel = hasTracingChannel
+  ? dc.tracingChannel('mongoose:model')
+  : undefined;
+
+function traceQuery(fn, contextFactory) {
+  if (shouldTrace(queryChannel)) {
+    const traced = queryChannel.tracePromise(fn, contextFactory());
+    traced.catch(noop);
+    return traced;
+  }
+  return fn();
+}
+
+function traceAggregate(fn, contextFactory) {
+  if (shouldTrace(aggregateChannel)) {
+    const traced = aggregateChannel.tracePromise(fn, contextFactory());
+    traced.catch(noop);
+    return traced;
+  }
+  return fn();
+}
+
+function traceSave(fn, contextFactory) {
+  if (shouldTrace(saveChannel)) {
+    const traced = saveChannel.tracePromise(fn, contextFactory());
+    traced.catch(noop);
+    return traced;
+  }
+  return fn();
+}
+
+function traceModel(fn, contextFactory) {
+  if (shouldTrace(modelChannel)) {
+    const traced = modelChannel.tracePromise(fn, contextFactory());
+    traced.catch(noop);
+    return traced;
+  }
+  return fn();
+}
+
+module.exports = {
+  queryChannel,
+  aggregateChannel,
+  saveChannel,
+  modelChannel,
+  traceQuery,
+  traceAggregate,
+  traceSave,
+  traceModel,
+  shouldTrace
+};

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -4,65 +4,19 @@ const dc = process.getBuiltinModule('node:diagnostics_channel');
 
 const hasTracingChannel = typeof dc.tracingChannel === 'function';
 
-// @types/node is missing hasSubscribers on TracingChannel and types
-// tracePromise as returning void. Both exist at runtime.
-// Check explicitly for `false` rather than truthiness because `hasSubscribers`
-// is not available on all Node.js versions that support TracingChannel.
-// When `hasSubscribers` is `undefined` (older Node), we assume there are
-// subscribers and trace unconditionally, keeping the zero-cost optimization
-// only for versions where we can reliably check.
 function shouldTrace(channel) {
   return !!channel && channel.hasSubscribers !== false;
 }
 
 const noop = () => {};
 
-const queryChannel = hasTracingChannel
+const channel = hasTracingChannel
   ? dc.tracingChannel('mongoose:query')
   : undefined;
 
-const aggregateChannel = hasTracingChannel
-  ? dc.tracingChannel('mongoose:aggregate')
-  : undefined;
-
-const saveChannel = hasTracingChannel
-  ? dc.tracingChannel('mongoose:save')
-  : undefined;
-
-const modelChannel = hasTracingChannel
-  ? dc.tracingChannel('mongoose:model')
-  : undefined;
-
-function traceQuery(fn, contextFactory) {
-  if (shouldTrace(queryChannel)) {
-    const traced = queryChannel.tracePromise(fn, contextFactory());
-    traced.catch(noop);
-    return traced;
-  }
-  return fn();
-}
-
-function traceAggregate(fn, contextFactory) {
-  if (shouldTrace(aggregateChannel)) {
-    const traced = aggregateChannel.tracePromise(fn, contextFactory());
-    traced.catch(noop);
-    return traced;
-  }
-  return fn();
-}
-
-function traceSave(fn, contextFactory) {
-  if (shouldTrace(saveChannel)) {
-    const traced = saveChannel.tracePromise(fn, contextFactory());
-    traced.catch(noop);
-    return traced;
-  }
-  return fn();
-}
-
-function traceModel(fn, contextFactory) {
-  if (shouldTrace(modelChannel)) {
-    const traced = modelChannel.tracePromise(fn, contextFactory());
+function trace(fn, contextFactory) {
+  if (shouldTrace(channel)) {
+    const traced = channel.tracePromise(fn, contextFactory());
     traced.catch(noop);
     return traced;
   }
@@ -70,13 +24,7 @@ function traceModel(fn, contextFactory) {
 }
 
 module.exports = {
-  queryChannel,
-  aggregateChannel,
-  saveChannel,
-  modelChannel,
-  traceQuery,
-  traceAggregate,
-  traceSave,
-  traceModel,
+  channel,
+  trace,
   shouldTrace
 };

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -35,13 +35,7 @@ function createTracedChannel(name) {
   return { channel: ch, trace };
 }
 
-const query = createTracedChannel('mongoose:query');
-const cursorNext = createTracedChannel('mongoose:cursor:next');
-
 module.exports = {
-  channel: query.channel,
-  cursorNextChannel: cursorNext.channel,
-  trace: query.trace,
-  traceCursorNext: cursorNext.trace,
-  shouldTrace
+  queryChannel: createTracedChannel('mongoose:query'),
+  cursorNextChannel: createTracedChannel('mongoose:cursor:next')
 };

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -28,7 +28,6 @@ function createTracedChannel(name) {
     }
 
     const traced = ch.tracePromise(fn, contextFactory());
-    traced.catch(noop);
     return traced;
   }
 

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -1,8 +1,15 @@
 'use strict';
 
-const dc = process.getBuiltinModule('node:diagnostics_channel');
+let dc;
+try {
+  dc = (typeof process !== 'undefined' && 'getBuiltinModule' in process)
+    ? process.getBuiltinModule('node:diagnostics_channel')
+    : require('node:diagnostics_channel');
+} catch {
+  // diagnostics_channel not available
+}
 
-const hasTracingChannel = typeof dc.tracingChannel === 'function';
+const hasTracingChannel = !!dc && typeof dc.tracingChannel === 'function';
 
 function shouldTrace(channel) {
   // Node 18 and Bun don't expose hasSubscribers on TracingChannel
@@ -12,21 +19,29 @@ function shouldTrace(channel) {
 
 const noop = () => {};
 
-const channel = hasTracingChannel
-  ? dc.tracingChannel('mongoose:query')
-  : undefined;
+function createTracedChannel(name) {
+  const ch = hasTracingChannel ? dc.tracingChannel(name) : undefined;
 
-function trace(fn, contextFactory) {
-  if (shouldTrace(channel)) {
-    const traced = channel.tracePromise(fn, contextFactory());
+  function trace(fn, contextFactory) {
+    if (!shouldTrace(ch)) {
+      return fn();
+    }
+
+    const traced = ch.tracePromise(fn, contextFactory());
     traced.catch(noop);
     return traced;
   }
-  return fn();
+
+  return { channel: ch, trace };
 }
 
+const query = createTracedChannel('mongoose:query');
+const cursorNext = createTracedChannel('mongoose:cursor:next');
+
 module.exports = {
-  channel,
-  trace,
+  channel: query.channel,
+  cursorNextChannel: cursorNext.channel,
+  trace: query.trace,
+  traceCursorNext: cursorNext.trace,
   shouldTrace
 };

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -37,5 +37,6 @@ function createTracedChannel(name) {
 
 module.exports = {
   queryChannel: createTracedChannel('mongoose:query'),
+  aggregateChannel: createTracedChannel('mongoose:aggregate'),
   cursorNextChannel: createTracedChannel('mongoose:cursor:next')
 };

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -36,7 +36,6 @@ function createTracedChannel(name) {
 }
 
 module.exports = {
-  queryChannel: createTracedChannel('mongoose:query'),
-  aggregateChannel: createTracedChannel('mongoose:aggregate'),
+  createTracedChannel,
   cursorNextChannel: createTracedChannel('mongoose:cursor:next')
 };

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -5,6 +5,8 @@ const dc = process.getBuiltinModule('node:diagnostics_channel');
 const hasTracingChannel = typeof dc.tracingChannel === 'function';
 
 function shouldTrace(channel) {
+  // Node 18 and Bun don't expose hasSubscribers on TracingChannel
+  // so undefined means it may or may not have subscribers, so we'll trace anyway
   return !!channel && channel.hasSubscribers !== false;
 }
 

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -17,8 +17,6 @@ function shouldTrace(channel) {
   return !!channel && channel.hasSubscribers !== false;
 }
 
-const noop = () => {};
-
 function createTracedChannel(name) {
   const ch = hasTracingChannel ? dc.tracingChannel(name) : undefined;
 

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -205,6 +205,36 @@ describe('TracingChannel', function() {
         channel.unsubscribe(handlers);
       }
     });
+
+    it('fires start and asyncEnd for connection-level aggregate', async function() {
+      await Test.create([{ name: 'conn-agg1', age: 10 }, { name: 'conn-agg2', age: 20 }]);
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd(ctx) { events.push({ event: 'asyncEnd', result: ctx.result }); },
+        error() {}
+      };
+
+      channel.subscribe(handlers);
+      try {
+        await conn.aggregate([{ $documents: [{ x: 1 }] }]);
+
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start, 'start event should fire');
+        assert.strictEqual(start.operation, 'aggregate');
+        assert.ok(start.database);
+        assert.ok(Array.isArray(start.args.pipeline));
+
+        const asyncEnd = events.find(e => e.event === 'asyncEnd');
+        assert.ok(asyncEnd, 'asyncEnd should fire');
+        assert.ok(Array.isArray(asyncEnd.result));
+      } finally {
+        channel.unsubscribe(handlers);
+      }
+    });
   });
 
   describe('save operations', function() {

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -2,8 +2,13 @@
 
 const assert = require('assert');
 const mongoose = require('../index');
+const dc = require('node:diagnostics_channel');
 
-const { queryChannel, aggregateChannel, cursorNextChannel } = require('../lib/tracing');
+function subscribe(channelName, handlers) {
+  const ch = dc.tracingChannel(channelName);
+  ch.subscribe(handlers);
+  return () => ch.unsubscribe(handlers);
+}
 
 describe('TracingChannel', function() {
   let conn;
@@ -41,7 +46,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:query', handlers);
       try {
         await Test.find({ name: 'test' });
 
@@ -57,7 +62,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd, 'asyncEnd should fire');
         assert.ok(Array.isArray(asyncEnd.result), 'asyncEnd should include the result');
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -71,7 +76,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:query', handlers);
       try {
         await Test.findOne({ name: 'test' });
 
@@ -80,7 +85,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.operation, 'findOne');
         assert.strictEqual(start.collection, collectionName);
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -96,7 +101,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:query', handlers);
       try {
         await Test.updateOne({ name: 'update-test' }, { age: 20 });
 
@@ -105,7 +110,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.operation, 'updateOne');
         assert.strictEqual(start.collection, collectionName);
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -121,7 +126,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:query', handlers);
       try {
         await Test.deleteOne({ name: 'delete-test' });
 
@@ -129,7 +134,7 @@ describe('TracingChannel', function() {
         assert.ok(start);
         assert.strictEqual(start.operation, 'deleteOne');
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -143,14 +148,14 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:query', handlers);
       try {
         await Test.find({ $invalidOperator: true }).catch(() => {});
 
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -164,14 +169,14 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:query', handlers);
       try {
         await Test.find({});
         const ctx = events[0];
         assert.ok(ctx.database);
         assert.ok(ctx.serverAddress);
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
   });
@@ -189,7 +194,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      aggregateChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:aggregate', handlers);
       try {
         await Test.aggregate([{ $match: { age: { $gte: 10 } } }]);
 
@@ -202,7 +207,7 @@ describe('TracingChannel', function() {
         assert.deepStrictEqual(start.args.pipeline[0], { $match: { age: { $gte: 10 } } });
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        aggregateChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -218,7 +223,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      aggregateChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:aggregate', handlers);
       try {
         await conn.aggregate([{ $documents: [{ x: 1 }] }]);
 
@@ -232,7 +237,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd, 'asyncEnd should fire');
         assert.ok(Array.isArray(asyncEnd.result));
       } finally {
-        aggregateChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
   });
@@ -248,7 +253,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:model:save', handlers);
       try {
         const doc = new Test({ name: 'save-test', age: 25 });
         await doc.save();
@@ -264,7 +269,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd.result, 'asyncEnd should include the result');
         assert.strictEqual(asyncEnd.result.name, 'save-test');
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -280,7 +285,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:model:save', handlers);
       try {
         doc.age = 20;
         await doc.save();
@@ -291,7 +296,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.collection, collectionName);
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -310,7 +315,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:model:save', handlers);
       try {
         const doc = new StrictModel({});
         await doc.save().catch(() => {});
@@ -318,7 +323,7 @@ describe('TracingChannel', function() {
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
         await StrictModel.deleteMany({});
       }
     });
@@ -335,7 +340,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:model:insertMany', handlers);
       try {
         await Test.insertMany([
           { name: 'insert1', age: 10 },
@@ -350,7 +355,7 @@ describe('TracingChannel', function() {
         assert.ok(Array.isArray(start.args.docs));
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -364,7 +369,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:model:bulkWrite', handlers);
       try {
         await Test.bulkWrite([
           { insertOne: { document: { name: 'bulk1', age: 30 } } }
@@ -378,7 +383,7 @@ describe('TracingChannel', function() {
         assert.ok(Array.isArray(start.args.ops));
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
   });
@@ -399,7 +404,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      cursorNextChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:cursor:next', handlers);
       try {
         const cursor = Test.find({ name: /^cursor/ }).sort({ name: 1 }).cursor();
         const doc1 = await cursor.next();
@@ -420,7 +425,7 @@ describe('TracingChannel', function() {
         const asyncEnds = events.filter(e => e.event === 'asyncEnd');
         assert.strictEqual(asyncEnds.length, 3, 'should fire asyncEnd for each next() call');
       } finally {
-        cursorNextChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -439,7 +444,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      cursorNextChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:cursor:next', handlers);
       try {
         const cursor = Test.find({ name: /^batch/ }).cursor({ batchSize: 10 });
         await cursor.next();
@@ -448,7 +453,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.batchSize, 10);
         assert.strictEqual(start.tailable, false);
       } finally {
-        cursorNextChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -467,7 +472,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      cursorNextChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:cursor:next', handlers);
       try {
         const cursor = Test.aggregate([
           { $match: { name: /^agg-cursor/ } },
@@ -489,7 +494,7 @@ describe('TracingChannel', function() {
         assert.ok(starts[0].database);
         assert.ok(Array.isArray(starts[0].args.pipeline));
       } finally {
-        cursorNextChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -503,7 +508,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      cursorNextChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:cursor:next', handlers);
       try {
         const cursor = Test.find({ $invalidOperator: true }).cursor();
         await cursor.next().catch(() => {});
@@ -511,7 +516,7 @@ describe('TracingChannel', function() {
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        cursorNextChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
 
@@ -527,12 +532,12 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      cursorNextChannel.channel.subscribe(handlers);
+      const unsubscribe = subscribe('mongoose:cursor:next', handlers);
       try {
         await Test.find({ name: 'no-cursor' });
         assert.strictEqual(events.length, 0, 'cursor:next should not fire for regular find()');
       } finally {
-        cursorNextChannel.channel.unsubscribe(handlers);
+        unsubscribe();
       }
     });
   });

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const mongoose = require('../index');
 
-const { queryChannel, cursorNextChannel } = require('../lib/tracing');
+const { queryChannel, aggregateChannel, cursorNextChannel } = require('../lib/tracing');
 
 describe('TracingChannel', function() {
   let conn;
@@ -189,7 +189,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      aggregateChannel.channel.subscribe(handlers);
       try {
         await Test.aggregate([{ $match: { age: { $gte: 10 } } }]);
 
@@ -202,7 +202,7 @@ describe('TracingChannel', function() {
         assert.deepStrictEqual(start.args.pipeline[0], { $match: { age: { $gte: 10 } } });
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        aggregateChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -218,7 +218,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.channel.subscribe(handlers);
+      aggregateChannel.channel.subscribe(handlers);
       try {
         await conn.aggregate([{ $documents: [{ x: 1 }] }]);
 
@@ -232,7 +232,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd, 'asyncEnd should fire');
         assert.ok(Array.isArray(asyncEnd.result));
       } finally {
-        queryChannel.channel.unsubscribe(handlers);
+        aggregateChannel.channel.unsubscribe(handlers);
       }
     });
   });

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const mongoose = require('../index');
 
-const { queryChannel, aggregateChannel, saveChannel, modelChannel } = require('../lib/tracing');
+const { channel } = require('../lib/tracing');
 
 describe('TracingChannel', function() {
   let conn;
@@ -30,7 +30,7 @@ describe('TracingChannel', function() {
     await Test.deleteMany({});
   });
 
-  describe('mongoose:query', function() {
+  describe('query operations', function() {
     it('fires start and asyncEnd for find', async function() {
       const events = [];
       const handlers = {
@@ -41,20 +41,20 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      queryChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.find({ name: 'test' });
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent, 'start event should fire');
-        assert.strictEqual(startEvent.operation, 'find');
-        assert.strictEqual(startEvent.collection, collectionName);
-        assert.deepStrictEqual(startEvent.query, { name: 'test' });
-        assert.ok(startEvent.database);
-        assert.ok(startEvent.serverAddress);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start, 'start event should fire');
+        assert.strictEqual(start.operation, 'find');
+        assert.strictEqual(start.collection, collectionName);
+        assert.ok(start.database);
+        assert.ok(start.serverAddress);
+        assert.deepStrictEqual(start.args.filter, { name: 'test' });
         assert.ok(events.some(e => e.event === 'asyncEnd'), 'asyncEnd should fire');
       } finally {
-        queryChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -68,16 +68,16 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.findOne({ name: 'test' });
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent);
-        assert.strictEqual(startEvent.operation, 'findOne');
-        assert.strictEqual(startEvent.collection, collectionName);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start);
+        assert.strictEqual(start.operation, 'findOne');
+        assert.strictEqual(start.collection, collectionName);
       } finally {
-        queryChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -93,16 +93,16 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.updateOne({ name: 'update-test' }, { age: 20 });
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent);
-        assert.strictEqual(startEvent.operation, 'updateOne');
-        assert.strictEqual(startEvent.collection, collectionName);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start);
+        assert.strictEqual(start.operation, 'updateOne');
+        assert.strictEqual(start.collection, collectionName);
       } finally {
-        queryChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -118,15 +118,15 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.deleteOne({ name: 'delete-test' });
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent);
-        assert.strictEqual(startEvent.operation, 'deleteOne');
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start);
+        assert.strictEqual(start.operation, 'deleteOne');
       } finally {
-        queryChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -140,14 +140,14 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      queryChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.find({ $invalidOperator: true }).catch(() => {});
 
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        queryChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -161,19 +161,19 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      queryChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.find({});
         const ctx = events[0];
         assert.ok(ctx.database);
         assert.ok(ctx.serverAddress);
       } finally {
-        queryChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
   });
 
-  describe('mongoose:aggregate', function() {
+  describe('aggregate operations', function() {
     it('fires start and asyncEnd for aggregate', async function() {
       await Test.create([{ name: 'agg1', age: 10 }, { name: 'agg2', age: 20 }]);
 
@@ -186,24 +186,25 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      aggregateChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.aggregate([{ $match: { age: { $gte: 10 } } }]);
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent, 'start event should fire');
-        assert.ok(Array.isArray(startEvent.pipeline));
-        assert.deepStrictEqual(startEvent.pipeline[0], { $match: { age: { $gte: 10 } } });
-        assert.strictEqual(startEvent.collection, collectionName);
-        assert.ok(startEvent.database);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start, 'start event should fire');
+        assert.strictEqual(start.operation, 'aggregate');
+        assert.strictEqual(start.collection, collectionName);
+        assert.ok(start.database);
+        assert.ok(Array.isArray(start.args.pipeline));
+        assert.deepStrictEqual(start.args.pipeline[0], { $match: { age: { $gte: 10 } } });
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        aggregateChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
   });
 
-  describe('mongoose:save', function() {
+  describe('save operations', function() {
     it('fires start and asyncEnd for save (insert)', async function() {
       const events = [];
       const handlers = {
@@ -214,19 +215,19 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      saveChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         const doc = new Test({ name: 'save-test', age: 25 });
         await doc.save();
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent, 'start event should fire');
-        assert.strictEqual(startEvent.operation, 'save');
-        assert.strictEqual(startEvent.collection, collectionName);
-        assert.ok(startEvent.database);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start, 'start event should fire');
+        assert.strictEqual(start.operation, 'save');
+        assert.strictEqual(start.collection, collectionName);
+        assert.ok(start.database);
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        saveChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -242,18 +243,18 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      saveChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         doc.age = 20;
         await doc.save();
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent);
-        assert.strictEqual(startEvent.operation, 'save');
-        assert.strictEqual(startEvent.collection, collectionName);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start);
+        assert.strictEqual(start.operation, 'save');
+        assert.strictEqual(start.collection, collectionName);
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        saveChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -272,7 +273,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      saveChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         const doc = new StrictModel({});
         await doc.save().catch(() => {});
@@ -280,13 +281,13 @@ describe('TracingChannel', function() {
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        saveChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
         await StrictModel.deleteMany({});
       }
     });
   });
 
-  describe('mongoose:model', function() {
+  describe('model operations', function() {
     it('fires start and asyncEnd for insertMany', async function() {
       const events = [];
       const handlers = {
@@ -297,21 +298,22 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      modelChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.insertMany([
           { name: 'insert1', age: 10 },
           { name: 'insert2', age: 20 }
         ]);
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent, 'start event should fire');
-        assert.strictEqual(startEvent.operation, 'insertMany');
-        assert.strictEqual(startEvent.collection, collectionName);
-        assert.ok(startEvent.database);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start, 'start event should fire');
+        assert.strictEqual(start.operation, 'insertMany');
+        assert.strictEqual(start.collection, collectionName);
+        assert.ok(start.database);
+        assert.ok(Array.isArray(start.args.docs));
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        modelChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
 
@@ -325,20 +327,21 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      modelChannel.subscribe(handlers);
+      channel.subscribe(handlers);
       try {
         await Test.bulkWrite([
           { insertOne: { document: { name: 'bulk1', age: 30 } } }
         ]);
 
-        const startEvent = events.find(e => e.event === 'start');
-        assert.ok(startEvent, 'start event should fire');
-        assert.strictEqual(startEvent.operation, 'bulkWrite');
-        assert.strictEqual(startEvent.collection, collectionName);
-        assert.ok(startEvent.database);
+        const start = events.find(e => e.event === 'start');
+        assert.ok(start, 'start event should fire');
+        assert.strictEqual(start.operation, 'bulkWrite');
+        assert.strictEqual(start.collection, collectionName);
+        assert.ok(start.database);
+        assert.ok(Array.isArray(start.args.ops));
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        modelChannel.unsubscribe(handlers);
+        channel.unsubscribe(handlers);
       }
     });
   });

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const mongoose = require('../index');
 
-const { channel, cursorNextChannel } = require('../lib/tracing');
+const { queryChannel, cursorNextChannel } = require('../lib/tracing');
 
 describe('TracingChannel', function() {
   let conn;
@@ -41,7 +41,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.find({ name: 'test' });
 
@@ -57,7 +57,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd, 'asyncEnd should fire');
         assert.ok(Array.isArray(asyncEnd.result), 'asyncEnd should include the result');
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -71,7 +71,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.findOne({ name: 'test' });
 
@@ -80,7 +80,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.operation, 'findOne');
         assert.strictEqual(start.collection, collectionName);
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -96,7 +96,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.updateOne({ name: 'update-test' }, { age: 20 });
 
@@ -105,7 +105,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.operation, 'updateOne');
         assert.strictEqual(start.collection, collectionName);
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -121,7 +121,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.deleteOne({ name: 'delete-test' });
 
@@ -129,7 +129,7 @@ describe('TracingChannel', function() {
         assert.ok(start);
         assert.strictEqual(start.operation, 'deleteOne');
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -143,14 +143,14 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.find({ $invalidOperator: true }).catch(() => {});
 
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -164,14 +164,14 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.find({});
         const ctx = events[0];
         assert.ok(ctx.database);
         assert.ok(ctx.serverAddress);
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
   });
@@ -189,7 +189,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.aggregate([{ $match: { age: { $gte: 10 } } }]);
 
@@ -202,7 +202,7 @@ describe('TracingChannel', function() {
         assert.deepStrictEqual(start.args.pipeline[0], { $match: { age: { $gte: 10 } } });
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -218,7 +218,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await conn.aggregate([{ $documents: [{ x: 1 }] }]);
 
@@ -232,7 +232,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd, 'asyncEnd should fire');
         assert.ok(Array.isArray(asyncEnd.result));
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
   });
@@ -248,7 +248,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         const doc = new Test({ name: 'save-test', age: 25 });
         await doc.save();
@@ -264,7 +264,7 @@ describe('TracingChannel', function() {
         assert.ok(asyncEnd.result, 'asyncEnd should include the result');
         assert.strictEqual(asyncEnd.result.name, 'save-test');
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -280,7 +280,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         doc.age = 20;
         await doc.save();
@@ -291,7 +291,7 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.collection, collectionName);
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -310,7 +310,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         const doc = new StrictModel({});
         await doc.save().catch(() => {});
@@ -318,7 +318,7 @@ describe('TracingChannel', function() {
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
         await StrictModel.deleteMany({});
       }
     });
@@ -335,7 +335,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.insertMany([
           { name: 'insert1', age: 10 },
@@ -350,7 +350,7 @@ describe('TracingChannel', function() {
         assert.ok(Array.isArray(start.args.docs));
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -364,7 +364,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      channel.subscribe(handlers);
+      queryChannel.channel.subscribe(handlers);
       try {
         await Test.bulkWrite([
           { insertOne: { document: { name: 'bulk1', age: 30 } } }
@@ -378,7 +378,7 @@ describe('TracingChannel', function() {
         assert.ok(Array.isArray(start.args.ops));
         assert.ok(events.some(e => e.event === 'asyncEnd'));
       } finally {
-        channel.unsubscribe(handlers);
+        queryChannel.channel.unsubscribe(handlers);
       }
     });
   });
@@ -399,7 +399,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      cursorNextChannel.subscribe(handlers);
+      cursorNextChannel.channel.subscribe(handlers);
       try {
         const cursor = Test.find({ name: /^cursor/ }).sort({ name: 1 }).cursor();
         const doc1 = await cursor.next();
@@ -419,7 +419,7 @@ describe('TracingChannel', function() {
         const asyncEnds = events.filter(e => e.event === 'asyncEnd');
         assert.strictEqual(asyncEnds.length, 3, 'should fire asyncEnd for each next() call');
       } finally {
-        cursorNextChannel.unsubscribe(handlers);
+        cursorNextChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -438,7 +438,7 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      cursorNextChannel.subscribe(handlers);
+      cursorNextChannel.channel.subscribe(handlers);
       try {
         const cursor = Test.aggregate([
           { $match: { name: /^agg-cursor/ } },
@@ -460,7 +460,7 @@ describe('TracingChannel', function() {
         assert.ok(starts[0].database);
         assert.ok(Array.isArray(starts[0].args.pipeline));
       } finally {
-        cursorNextChannel.unsubscribe(handlers);
+        cursorNextChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -474,7 +474,7 @@ describe('TracingChannel', function() {
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
-      cursorNextChannel.subscribe(handlers);
+      cursorNextChannel.channel.subscribe(handlers);
       try {
         const cursor = Test.find({ $invalidOperator: true }).cursor();
         await cursor.next().catch(() => {});
@@ -482,7 +482,7 @@ describe('TracingChannel', function() {
         assert.ok(events.some(e => e.event === 'start'), 'start should fire');
         assert.ok(events.some(e => e.event === 'error'), 'error should fire');
       } finally {
-        cursorNextChannel.unsubscribe(handlers);
+        cursorNextChannel.channel.unsubscribe(handlers);
       }
     });
 
@@ -498,12 +498,12 @@ describe('TracingChannel', function() {
         error() {}
       };
 
-      cursorNextChannel.subscribe(handlers);
+      cursorNextChannel.channel.subscribe(handlers);
       try {
         await Test.find({ name: 'no-cursor' });
         assert.strictEqual(events.length, 0, 'cursor:next should not fire for regular find()');
       } finally {
-        cursorNextChannel.unsubscribe(handlers);
+        cursorNextChannel.channel.unsubscribe(handlers);
       }
     });
   });

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -1,0 +1,365 @@
+'use strict';
+
+const assert = require('assert');
+const mongoose = require('../index');
+
+const { queryChannel, aggregateChannel, saveChannel, modelChannel } = require('../lib/tracing');
+
+describe('TracingChannel', function() {
+  let conn;
+  let Test;
+  let collectionName;
+
+  before(async function() {
+    conn = mongoose.createConnection(require('./common').uri);
+    await conn.asPromise();
+    const schema = new mongoose.Schema({
+      name: String,
+      age: Number
+    });
+    Test = conn.model('TracingTest', schema);
+    collectionName = Test.collection.collectionName;
+  });
+
+  after(async function() {
+    await Test.deleteMany({});
+    await conn.close();
+  });
+
+  afterEach(async function() {
+    await Test.deleteMany({});
+  });
+
+  describe('mongoose:query', function() {
+    it('fires start and asyncEnd for find', async function() {
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() { events.push({ event: 'end' }); },
+        asyncStart() { events.push({ event: 'asyncStart' }); },
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error(ctx) { events.push({ event: 'error', error: ctx.error }); }
+      };
+
+      queryChannel.subscribe(handlers);
+      try {
+        await Test.find({ name: 'test' });
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent, 'start event should fire');
+        assert.strictEqual(startEvent.operation, 'find');
+        assert.strictEqual(startEvent.collection, collectionName);
+        assert.deepStrictEqual(startEvent.query, { name: 'test' });
+        assert.ok(startEvent.database);
+        assert.ok(startEvent.serverAddress);
+        assert.ok(events.some(e => e.event === 'asyncEnd'), 'asyncEnd should fire');
+      } finally {
+        queryChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires start and asyncEnd for findOne', async function() {
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      queryChannel.subscribe(handlers);
+      try {
+        await Test.findOne({ name: 'test' });
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent);
+        assert.strictEqual(startEvent.operation, 'findOne');
+        assert.strictEqual(startEvent.collection, collectionName);
+      } finally {
+        queryChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires start and asyncEnd for updateOne', async function() {
+      await Test.create({ name: 'update-test', age: 10 });
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      queryChannel.subscribe(handlers);
+      try {
+        await Test.updateOne({ name: 'update-test' }, { age: 20 });
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent);
+        assert.strictEqual(startEvent.operation, 'updateOne');
+        assert.strictEqual(startEvent.collection, collectionName);
+      } finally {
+        queryChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires start and asyncEnd for deleteOne', async function() {
+      await Test.create({ name: 'delete-test' });
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      queryChannel.subscribe(handlers);
+      try {
+        await Test.deleteOne({ name: 'delete-test' });
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent);
+        assert.strictEqual(startEvent.operation, 'deleteOne');
+      } finally {
+        queryChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires error event on query failure', async function() {
+      const events = [];
+      const handlers = {
+        start() { events.push({ event: 'start' }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error(ctx) { events.push({ event: 'error', error: ctx.error }); }
+      };
+
+      queryChannel.subscribe(handlers);
+      try {
+        await Test.find({ $invalidOperator: true }).catch(() => {});
+
+        assert.ok(events.some(e => e.event === 'start'), 'start should fire');
+        assert.ok(events.some(e => e.event === 'error'), 'error should fire');
+      } finally {
+        queryChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('includes connection info in context', async function() {
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push(ctx); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {}
+      };
+
+      queryChannel.subscribe(handlers);
+      try {
+        await Test.find({});
+        const ctx = events[0];
+        assert.ok(ctx.database);
+        assert.ok(ctx.serverAddress);
+      } finally {
+        queryChannel.unsubscribe(handlers);
+      }
+    });
+  });
+
+  describe('mongoose:aggregate', function() {
+    it('fires start and asyncEnd for aggregate', async function() {
+      await Test.create([{ name: 'agg1', age: 10 }, { name: 'agg2', age: 20 }]);
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      aggregateChannel.subscribe(handlers);
+      try {
+        await Test.aggregate([{ $match: { age: { $gte: 10 } } }]);
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent, 'start event should fire');
+        assert.ok(Array.isArray(startEvent.pipeline));
+        assert.deepStrictEqual(startEvent.pipeline[0], { $match: { age: { $gte: 10 } } });
+        assert.strictEqual(startEvent.collection, collectionName);
+        assert.ok(startEvent.database);
+        assert.ok(events.some(e => e.event === 'asyncEnd'));
+      } finally {
+        aggregateChannel.unsubscribe(handlers);
+      }
+    });
+  });
+
+  describe('mongoose:save', function() {
+    it('fires start and asyncEnd for save (insert)', async function() {
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      saveChannel.subscribe(handlers);
+      try {
+        const doc = new Test({ name: 'save-test', age: 25 });
+        await doc.save();
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent, 'start event should fire');
+        assert.strictEqual(startEvent.operation, 'save');
+        assert.strictEqual(startEvent.collection, collectionName);
+        assert.ok(startEvent.database);
+        assert.ok(events.some(e => e.event === 'asyncEnd'));
+      } finally {
+        saveChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires start and asyncEnd for save (update)', async function() {
+      const doc = await Test.create({ name: 'save-update', age: 10 });
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      saveChannel.subscribe(handlers);
+      try {
+        doc.age = 20;
+        await doc.save();
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent);
+        assert.strictEqual(startEvent.operation, 'save');
+        assert.strictEqual(startEvent.collection, collectionName);
+        assert.ok(events.some(e => e.event === 'asyncEnd'));
+      } finally {
+        saveChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires error event on save validation failure', async function() {
+      const schema = new mongoose.Schema({
+        email: { type: String, required: true }
+      });
+      const StrictModel = conn.model('TracingStrictTest', schema);
+
+      const events = [];
+      const handlers = {
+        start() { events.push({ event: 'start' }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error(ctx) { events.push({ event: 'error', error: ctx.error }); }
+      };
+
+      saveChannel.subscribe(handlers);
+      try {
+        const doc = new StrictModel({});
+        await doc.save().catch(() => {});
+
+        assert.ok(events.some(e => e.event === 'start'), 'start should fire');
+        assert.ok(events.some(e => e.event === 'error'), 'error should fire');
+      } finally {
+        saveChannel.unsubscribe(handlers);
+        await StrictModel.deleteMany({});
+      }
+    });
+  });
+
+  describe('mongoose:model', function() {
+    it('fires start and asyncEnd for insertMany', async function() {
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      modelChannel.subscribe(handlers);
+      try {
+        await Test.insertMany([
+          { name: 'insert1', age: 10 },
+          { name: 'insert2', age: 20 }
+        ]);
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent, 'start event should fire');
+        assert.strictEqual(startEvent.operation, 'insertMany');
+        assert.strictEqual(startEvent.collection, collectionName);
+        assert.ok(startEvent.database);
+        assert.ok(events.some(e => e.event === 'asyncEnd'));
+      } finally {
+        modelChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires start and asyncEnd for bulkWrite', async function() {
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        error() {}
+      };
+
+      modelChannel.subscribe(handlers);
+      try {
+        await Test.bulkWrite([
+          { insertOne: { document: { name: 'bulk1', age: 30 } } }
+        ]);
+
+        const startEvent = events.find(e => e.event === 'start');
+        assert.ok(startEvent, 'start event should fire');
+        assert.strictEqual(startEvent.operation, 'bulkWrite');
+        assert.strictEqual(startEvent.collection, collectionName);
+        assert.ok(startEvent.database);
+        assert.ok(events.some(e => e.event === 'asyncEnd'));
+      } finally {
+        modelChannel.unsubscribe(handlers);
+      }
+    });
+  });
+
+  describe('zero-cost when no subscribers', function() {
+    it('operations work without any subscribers', async function() {
+      const doc = new Test({ name: 'no-sub', age: 5 });
+      await doc.save();
+
+      const found = await Test.find({ name: 'no-sub' });
+      assert.strictEqual(found.length, 1);
+
+      await Test.aggregate([{ $match: { name: 'no-sub' } }]);
+
+      await Test.insertMany([{ name: 'no-sub-insert', age: 6 }]);
+
+      await Test.bulkWrite([
+        { insertOne: { document: { name: 'no-sub-bulk', age: 7 } } }
+      ]);
+
+      await Test.deleteMany({ name: /^no-sub/ });
+    });
+  });
+});

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -36,8 +36,8 @@ describe('TracingChannel', function() {
       const handlers = {
         start(ctx) { events.push({ event: 'start', ...ctx }); },
         end() { events.push({ event: 'end' }); },
-        asyncStart() { events.push({ event: 'asyncStart' }); },
-        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        asyncStart(ctx) { events.push({ event: 'asyncStart', result: ctx.result }); },
+        asyncEnd(ctx) { events.push({ event: 'asyncEnd', result: ctx.result }); },
         error(ctx) { events.push({ event: 'error', error: ctx.error }); }
       };
 
@@ -52,7 +52,10 @@ describe('TracingChannel', function() {
         assert.ok(start.database);
         assert.ok(start.serverAddress);
         assert.deepStrictEqual(start.args.filter, { name: 'test' });
-        assert.ok(events.some(e => e.event === 'asyncEnd'), 'asyncEnd should fire');
+
+        const asyncEnd = events.find(e => e.event === 'asyncEnd');
+        assert.ok(asyncEnd, 'asyncEnd should fire');
+        assert.ok(Array.isArray(asyncEnd.result), 'asyncEnd should include the result');
       } finally {
         channel.unsubscribe(handlers);
       }
@@ -211,7 +214,7 @@ describe('TracingChannel', function() {
         start(ctx) { events.push({ event: 'start', ...ctx }); },
         end() {},
         asyncStart() {},
-        asyncEnd() { events.push({ event: 'asyncEnd' }); },
+        asyncEnd(ctx) { events.push({ event: 'asyncEnd', result: ctx.result }); },
         error() {}
       };
 
@@ -225,7 +228,11 @@ describe('TracingChannel', function() {
         assert.strictEqual(start.operation, 'save');
         assert.strictEqual(start.collection, collectionName);
         assert.ok(start.database);
-        assert.ok(events.some(e => e.event === 'asyncEnd'));
+
+        const asyncEnd = events.find(e => e.event === 'asyncEnd');
+        assert.ok(asyncEnd, 'asyncEnd should fire');
+        assert.ok(asyncEnd.result, 'asyncEnd should include the result');
+        assert.strictEqual(asyncEnd.result.name, 'save-test');
       } finally {
         channel.unsubscribe(handlers);
       }

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const mongoose = require('../index');
 
-const { channel } = require('../lib/tracing');
+const { channel, cursorNextChannel } = require('../lib/tracing');
 
 describe('TracingChannel', function() {
   let conn;
@@ -383,6 +383,131 @@ describe('TracingChannel', function() {
     });
   });
 
+  describe('cursor:next operations', function() {
+    it('fires start and asyncEnd for query cursor next()', async function() {
+      await Test.create([
+        { name: 'cursor1', age: 10 },
+        { name: 'cursor2', age: 20 }
+      ]);
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() { events.push({ event: 'end' }); },
+        asyncStart(ctx) { events.push({ event: 'asyncStart', result: ctx.result }); },
+        asyncEnd(ctx) { events.push({ event: 'asyncEnd', result: ctx.result }); },
+        error(ctx) { events.push({ event: 'error', error: ctx.error }); }
+      };
+
+      cursorNextChannel.subscribe(handlers);
+      try {
+        const cursor = Test.find({ name: /^cursor/ }).sort({ name: 1 }).cursor();
+        const doc1 = await cursor.next();
+        const doc2 = await cursor.next();
+        const doc3 = await cursor.next();
+
+        assert.strictEqual(doc1.name, 'cursor1');
+        assert.strictEqual(doc2.name, 'cursor2');
+        assert.strictEqual(doc3, null);
+
+        const starts = events.filter(e => e.event === 'start');
+        assert.strictEqual(starts.length, 3, 'should fire start for each next() call');
+        assert.strictEqual(starts[0].operation, 'find');
+        assert.strictEqual(starts[0].collection, collectionName);
+        assert.ok(starts[0].database);
+
+        const asyncEnds = events.filter(e => e.event === 'asyncEnd');
+        assert.strictEqual(asyncEnds.length, 3, 'should fire asyncEnd for each next() call');
+      } finally {
+        cursorNextChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires start and asyncEnd for aggregate cursor next()', async function() {
+      await Test.create([
+        { name: 'agg-cursor1', age: 10 },
+        { name: 'agg-cursor2', age: 20 }
+      ]);
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() { events.push({ event: 'end' }); },
+        asyncStart() {},
+        asyncEnd(ctx) { events.push({ event: 'asyncEnd', result: ctx.result }); },
+        error() {}
+      };
+
+      cursorNextChannel.subscribe(handlers);
+      try {
+        const cursor = Test.aggregate([
+          { $match: { name: /^agg-cursor/ } },
+          { $sort: { name: 1 } }
+        ]).cursor();
+
+        const doc1 = await cursor.next();
+        const doc2 = await cursor.next();
+        const doc3 = await cursor.next();
+
+        assert.strictEqual(doc1.name, 'agg-cursor1');
+        assert.strictEqual(doc2.name, 'agg-cursor2');
+        assert.strictEqual(doc3, null);
+
+        const starts = events.filter(e => e.event === 'start');
+        assert.strictEqual(starts.length, 3, 'should fire start for each next() call');
+        assert.strictEqual(starts[0].operation, 'aggregate');
+        assert.strictEqual(starts[0].collection, collectionName);
+        assert.ok(starts[0].database);
+        assert.ok(Array.isArray(starts[0].args.pipeline));
+      } finally {
+        cursorNextChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('fires error event on cursor next() failure', async function() {
+      const events = [];
+      const handlers = {
+        start() { events.push({ event: 'start' }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error(ctx) { events.push({ event: 'error', error: ctx.error }); }
+      };
+
+      cursorNextChannel.subscribe(handlers);
+      try {
+        const cursor = Test.find({ $invalidOperator: true }).cursor();
+        await cursor.next().catch(() => {});
+
+        assert.ok(events.some(e => e.event === 'start'), 'start should fire');
+        assert.ok(events.some(e => e.event === 'error'), 'error should fire');
+      } finally {
+        cursorNextChannel.unsubscribe(handlers);
+      }
+    });
+
+    it('does not fire cursor:next events when using regular find()', async function() {
+      await Test.create({ name: 'no-cursor', age: 5 });
+
+      const events = [];
+      const handlers = {
+        start() { events.push({ event: 'start' }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {}
+      };
+
+      cursorNextChannel.subscribe(handlers);
+      try {
+        await Test.find({ name: 'no-cursor' });
+        assert.strictEqual(events.length, 0, 'cursor:next should not fire for regular find()');
+      } finally {
+        cursorNextChannel.unsubscribe(handlers);
+      }
+    });
+  });
+
   describe('zero-cost when no subscribers', function() {
     it('operations work without any subscribers', async function() {
       const doc = new Test({ name: 'no-sub', age: 5 });
@@ -400,6 +525,17 @@ describe('TracingChannel', function() {
       ]);
 
       await Test.deleteMany({ name: /^no-sub/ });
+    });
+
+    it('cursor next() works without any subscribers', async function() {
+      await Test.create({ name: 'no-sub-cursor', age: 5 });
+
+      const cursor = Test.find({ name: 'no-sub-cursor' }).cursor();
+      const doc = await cursor.next();
+      assert.strictEqual(doc.name, 'no-sub-cursor');
+
+      const done = await cursor.next();
+      assert.strictEqual(done, null);
     });
   });
 });

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -415,9 +415,38 @@ describe('TracingChannel', function() {
         assert.strictEqual(starts[0].operation, 'find');
         assert.strictEqual(starts[0].collection, collectionName);
         assert.ok(starts[0].database);
+        assert.strictEqual(starts[0].tailable, false);
 
         const asyncEnds = events.filter(e => e.event === 'asyncEnd');
         assert.strictEqual(asyncEnds.length, 3, 'should fire asyncEnd for each next() call');
+      } finally {
+        cursorNextChannel.channel.unsubscribe(handlers);
+      }
+    });
+
+    it('includes batchSize in query cursor context', async function() {
+      await Test.create([
+        { name: 'batch1', age: 10 },
+        { name: 'batch2', age: 20 }
+      ]);
+
+      const events = [];
+      const handlers = {
+        start(ctx) { events.push({ event: 'start', ...ctx }); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {}
+      };
+
+      cursorNextChannel.channel.subscribe(handlers);
+      try {
+        const cursor = Test.find({ name: /^batch/ }).cursor({ batchSize: 10 });
+        await cursor.next();
+
+        const start = events.find(e => e.event === 'start');
+        assert.strictEqual(start.batchSize, 10);
+        assert.strictEqual(start.tailable, false);
       } finally {
         cursorNextChannel.channel.unsubscribe(handlers);
       }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,7 @@
 /// <reference path="./inferrawdoctype.d.ts" />
 /// <reference path="./inferschematype.d.ts" />
 /// <reference path="./virtuals.d.ts" />
+/// <reference path="./tracing.d.ts" />
 /// <reference path="./augmentations.d.ts" />
 
 declare class NativeDate extends globalThis.Date { }

--- a/types/tracing.d.ts
+++ b/types/tracing.d.ts
@@ -1,0 +1,10 @@
+declare module 'mongoose' {
+  interface TracingContext {
+    operation: string;
+    collection: string;
+    database: string;
+    serverAddress: string;
+    serverPort: number;
+    args: Record<string, any>;
+  }
+}


### PR DESCRIPTION
This PR explores adding tracing channels to enable agnostic observability for users and APMs alike without having to resort to monkey patching or module patchers.

Each operation type has its own dedicated `TracingChannel`, so subscribers only pay overhead for the operations they care about. The channels are:

| Channel | Operations |
|---|---|
| `mongoose:query` | `find`, `findOne`, `updateOne`, `deleteOne`, `deleteMany`, `count`, `distinct`, etc. |
| `mongoose:aggregate` | `aggregate` |
| `mongoose:model:save` | `save` |
| `mongoose:model:insertMany` | `insertMany` |
| `mongoose:model:bulkWrite` | `bulkWrite` |
| `mongoose:cursor:next` | Cursor iteration (both query and aggregation cursors) |

### Payload

All channels emit the following context:

| Field | Type | Description |
|---|---|---|
| `operation` | `string` | The operation name (e.g. `find`, `updateOne`, `aggregate`) |
| `collection` | `string` | MongoDB collection name |
| `database` | `string` | Database name |
| `serverAddress` | `string` | DB host |
| `serverPort` | `number` | DB port |
| `args` | `Record<string, any>` | Operation-specific arguments |

I also exported the types for use by consumers.

### Example Consumer

```ts
const dc = require('node:diagnostics_channel');

// Subscribe to query operations only
const queryChannel = dc.tracingChannel('mongoose:query');

queryChannel.subscribe({
  start({ operation, collection, database, serverAddress, serverPort, args }) {
    console.log('[query:start]', operation, collection, args);
  },
  asyncEnd({ operation, collection, result }) {
    console.log('[query:end]', operation, collection);
  },
  error({ operation, collection, error }) {
    console.error('[query:error]', operation, collection, error);
  }
});
```

this is what it looks like after consuming the events in an APM, which is inline with current instrumentations today.

<img width="1784" height="1510" alt="CleanShot 2026-05-07 at 13 08 23@2x" src="https://github.com/user-attachments/assets/44d3661b-d21f-42e3-bb36-0e771b77b7ae" />

closes #16105