### PR TITLE
chore: use typescript 6, remove esmoduleInteropFlag

### DIFF
--- a/benchmarks/typescript/simple/package.json
+++ b/benchmarks/typescript/simple/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "mongoose": "file:../../../mongoose.tgz",
-    "typescript": "5.8.x"
+    "typescript": "6.0.3"
   },
   "scripts": {
     "benchmark": "tsc --extendedDiagnostics"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pug": "3.0.4",
     "sinon": "21.1.2",
     "tstyche": "^7.0.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "^8.31.1",
     "uuid": "14.0.0"
   },

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "esModuleInterop": false,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "module": "commonjs",

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "strict": true,
-    "allowSyntheticDefaultImports": true,
     "module": "commonjs",
     "target": "ES2022",
     "noEmit": true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Replaces #16255: turns out we also need to remove esModuleInterop option. Removing `esModuleInterop` shouldn't affect anything since `esModuleInterop: false` is the default anyway.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
