### PR TITLE
types: handle compiling with exactOptionalPropertyTypes

### DIFF
--- a/test/types/exactOptionalPropertyTypes/exactOptionalPropertyTypes.test.ts
+++ b/test/types/exactOptionalPropertyTypes/exactOptionalPropertyTypes.test.ts
@@ -1,0 +1,23 @@
+// Pinned to a stricter tsconfig (`exactOptionalPropertyTypes: true`,
+// `skipLibCheck: false`) via the tsconfig.json in this directory. tstyche
+// uses tsserver's project service to pick up the nearest tsconfig per file,
+// so this test ensures mongoose's own .d.ts files type-check cleanly under
+// these settings.
+import mongoose, { InferSchemaType } from 'mongoose';
+import { expect } from 'tstyche';
+
+interface IUser {
+  name: string;
+  email: string;
+  createdAt: Date;
+}
+
+const userSchema = new mongoose.Schema<IUser>({
+  name: { type: String, required: true },
+  email: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+mongoose.model<IUser>('User', userSchema);
+
+expect<InferSchemaType<typeof userSchema>>().type.toBe<IUser>();

--- a/test/types/exactOptionalPropertyTypes/tsconfig.json
+++ b/test/types/exactOptionalPropertyTypes/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": false,
+    "lib": ["ES2022", "ESNext.Disposable"]
+  },
+  "include": ["**/*"]
+}

--- a/tstyche.json
+++ b/tstyche.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "testFileMatch": [
-    "test/types/*.test.*"
+    "test/types/*.test.*",
+    "test/types/**/*.test.*"
   ]
 }

--- a/types/inferhydrateddoctype.d.ts
+++ b/types/inferhydrateddoctype.d.ts
@@ -104,7 +104,7 @@ declare module 'mongoose' {
                   Types.Subdocument<InferHydratedDocType<Item>['_id'], unknown, InferHydratedDocType<Item>> & InferHydratedDocType<Item>
                 >:
               IsSchemaTypeFromBuiltinClass<Item> extends true ?
-                Types.Array<ResolveHydratedPathType<Item, { enum: Options['enum'] }, TypeKey>> :
+                Types.Array<ResolveHydratedPathType<Item, { enum: Exclude<Options['enum'], undefined> }, TypeKey>> :
                 IsItRecordAndNotAny<Item> extends true ?
                   Item extends Record<string, never> ?
                     Types.Array<ObtainHydratedDocumentPathType<Item, TypeKey>> :

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -144,7 +144,7 @@ declare module 'mongoose' {
            : // If the type key isn't callable, then this is an array of objects, in which case
              // we need to call InferRawDocType to correctly infer its type.
              Array<InferRawDocType<Item, DefaultSchemaOptions, TTransformOptions>>
-         : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolveRawPathType<Item, { enum: Options['enum'] }, TypeKey, TTransformOptions>[]
+         : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolveRawPathType<Item, { enum: Exclude<Options['enum'], undefined> }, TypeKey, TTransformOptions>[]
          : IsItRecordAndNotAny<Item> extends true ?
            Item extends Record<string, never> ?
              ObtainRawDocumentPathType<Item, TypeKey, TTransformOptions>[]

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -345,7 +345,7 @@ type ResolvePathType<
         : // If the type key isn't callable, then this is an array of objects, in which case
           // we need to call ObtainDocumentType to correctly infer its type.
           Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>>
-      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolvePathType<Item, { enum: Options['enum'] }, TypeKey>[]
+      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolvePathType<Item, { enum: Exclude<Options['enum'], undefined> }, TypeKey>[]
       : IsItRecordAndNotAny<Item> extends true ?
         Item extends Record<string, never> ?
           ObtainDocumentPathType<Item, TypeKey>[]


### PR DESCRIPTION
Fix #16273

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Fix compiling with TypeScript's `exactOptionalPropertyTypes` flag. I also added a separate test folder with a separate `tsconfig.json` for testing compiling with that flag set.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
