### PR TITLE
fix(update): preserve $setOnInsert.createdAt with overwriteImmutable: true

### DIFF
--- a/lib/helpers/update/applyTimestampsToUpdate.js
+++ b/lib/helpers/update/applyTimestampsToUpdate.js
@@ -82,7 +82,9 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
 
   if (!skipCreatedAt && createdAt) {
     const overwriteImmutable = get(options, 'overwriteImmutable', false);
-    const hasUserCreatedAt = currentUpdate[createdAt] != null || currentUpdate.$set?.[createdAt] != null;
+    const hasUserCreatedAt = currentUpdate[createdAt] != null
+      || currentUpdate.$set?.[createdAt] != null
+      || currentUpdate.$setOnInsert?.[createdAt] != null;
 
     // If overwriteImmutable is true and user provided createdAt, keep their value
     if (overwriteImmutable && hasUserCreatedAt) {
@@ -91,7 +93,7 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
         updates.$set[createdAt] = currentUpdate[createdAt];
         delete currentUpdate[createdAt];
       }
-      // User's value is already in $set, nothing more to do
+      // User's value is already in $set or $setOnInsert, nothing more to do
     } else {
       if (currentUpdate[createdAt]) {
         delete currentUpdate[createdAt];

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -2798,6 +2798,14 @@ describe('model: updateOne: ', function() {
         const doc1 = await Model.create({ name: 'gh-15781-1' });
         const doc2 = await Model.create({ name: 'gh-15781-2' });
 
+        // Seed a known past `updatedAt` via the raw collection (bypasses immutable casting)
+        // so we can observe whether the bulkWrite advances `updatedAt`.
+        const initialUpdatedAt = new Date('2020-06-15');
+        await Model.collection.updateMany(
+          { _id: { $in: [doc1._id, doc2._id] } },
+          { $set: { updatedAt: initialUpdatedAt } }
+        );
+
         // Act
         const createdAt = new Date('2011-06-01');
 
@@ -2825,6 +2833,15 @@ describe('model: updateOne: ', function() {
 
         assert.equal(updatesDocs[0].createdAt.valueOf(), createdAt.valueOf());
         assert.equal(updatesDocs[1].createdAt.valueOf(), createdAt.valueOf());
+
+        // Per-op `timestamps` should be honored: `updatedAt` only advances when not `false`.
+        if (timestamps === false) {
+          assert.strictEqual(updatesDocs[0].updatedAt.valueOf(), initialUpdatedAt.valueOf());
+          assert.strictEqual(updatesDocs[1].updatedAt.valueOf(), initialUpdatedAt.valueOf());
+        } else {
+          assert.ok(updatesDocs[0].updatedAt > initialUpdatedAt);
+          assert.ok(updatesDocs[1].updatedAt > initialUpdatedAt);
+        }
       });
 
       it(`can not update immutable fields without overwriteImmutable: true and timestamps: ${timestamps}`, async function() {
@@ -2835,6 +2852,14 @@ describe('model: updateOne: ', function() {
           { name: 'Eve', ssn: '333-33-3333' }
         ]);
         const newCreatedAt = new Date('2020-01-01');
+
+        // Seed a known past `updatedAt` via the raw collection (bypasses immutable casting)
+        // so we can observe whether the bulkWrite advances `updatedAt`.
+        const initialUpdatedAt = new Date('2020-06-15');
+        await User.collection.updateMany(
+          { _id: { $in: users.map(u => u._id) } },
+          { $set: { updatedAt: initialUpdatedAt } }
+        );
 
         // Act
         // `name` keeps the update non-empty when `timestamps: false`, since `ssn` and `createdAt` are immutable and get stripped.
@@ -2868,6 +2893,15 @@ describe('model: updateOne: ', function() {
         assert.strictEqual(updatedUser2.name, 'Updated Eve');
         assert.strictEqual(updatedUser2.ssn, '333-33-3333');
         assert.notStrictEqual(updatedUser2.createdAt.valueOf(), newCreatedAt.valueOf());
+
+        // Per-op `timestamps` should be honored: `updatedAt` only advances when not `false`.
+        if (timestamps === false) {
+          assert.strictEqual(updatedUser1.updatedAt.valueOf(), initialUpdatedAt.valueOf());
+          assert.strictEqual(updatedUser2.updatedAt.valueOf(), initialUpdatedAt.valueOf());
+        } else {
+          assert.ok(updatedUser1.updatedAt > initialUpdatedAt);
+          assert.ok(updatedUser2.updatedAt > initialUpdatedAt);
+        }
       });
     }
 

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -2845,7 +2845,7 @@ describe('model: updateOne: ', function() {
       });
 
       it(`can not update immutable fields without overwriteImmutable: true and timestamps: ${timestamps}`, async function() {
-      // Arrange
+        // Arrange
         const { User } = createTestContext();
         const users = await User.create([
           { name: 'Bob', ssn: '222-22-2222' },

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -2841,16 +2841,16 @@ describe('model: updateOne: ', function() {
           {
             updateOne: {
               filter: { _id: users[0]._id },
-              update: { ssn: '888-88-8888', createdAt: newCreatedAt }
-            },
-            timestamps
+              update: { name: 'Updated Bob', ssn: '888-88-8888', createdAt: newCreatedAt },
+              timestamps
+            }
           },
           {
             updateMany: {
               filter: { _id: users[1]._id },
-              update: { ssn: '777-77-7777', createdAt: newCreatedAt }
-            },
-            timestamps
+              update: { name: 'Updated Eve', ssn: '777-77-7777', createdAt: newCreatedAt },
+              timestamps
+            }
           }
         ]);
 
@@ -2860,142 +2860,11 @@ describe('model: updateOne: ', function() {
           User.findById(users[0]._id),
           User.findById(users[1]._id)
         ]);
+        assert.strictEqual(updatedUser1.name, 'Updated Bob');
         assert.strictEqual(updatedUser1.ssn, '222-22-2222');
         assert.notStrictEqual(updatedUser1.createdAt.valueOf(), newCreatedAt.valueOf());
 
-        assert.strictEqual(updatedUser2.ssn, '333-33-3333');
-        assert.notStrictEqual(updatedUser2.createdAt.valueOf(), newCreatedAt.valueOf());
-      });
-    }
-
-    function createTestContext() {
-      const userSchema = new Schema({
-        name: String,
-        ssn: { type: String, immutable: true }
-      }, { timestamps: true });
-      const User = db.model('User', userSchema);
-      return { User };
-    }
-  });
-
-  describe('bulkWrite overwriteImmutable option (gh-15781)', function() {
-    it('updateOne can update immutable field with overwriteImmutable: true', async function() {
-      // Arrange
-      const { User } = createTestContext();
-      const user = await User.create({ name: 'John', ssn: '123-45-6789' });
-      const customCreatedAt = new Date('2020-01-01');
-
-      // Act
-      await User.bulkWrite([{
-        updateOne: {
-          filter: { _id: user._id },
-          update: { createdAt: customCreatedAt, ssn: '999-99-9999' },
-          overwriteImmutable: true
-        }
-      }]);
-
-      // Assert
-      const updatedUser = await User.findById(user._id);
-      assert.strictEqual(updatedUser.ssn, '999-99-9999');
-      assert.strictEqual(updatedUser.createdAt.valueOf(), customCreatedAt.valueOf());
-    });
-
-    it('updateMany can update immutable field with overwriteImmutable: true', async function() {
-      // Arrange
-      const { User } = createTestContext();
-      const user = await User.create({ name: 'Alice', ssn: '111-11-1111' });
-      const customCreatedAt = new Date('2020-01-01');
-
-      // Act
-      await User.bulkWrite([{
-        updateMany: {
-          filter: { _id: user._id },
-          update: { createdAt: customCreatedAt, ssn: '000-00-0000' },
-          overwriteImmutable: true
-        }
-      }]);
-
-      // Assert
-      const updatedUser = await User.findById(user._id);
-      assert.strictEqual(updatedUser.ssn, '000-00-0000');
-      assert.strictEqual(updatedUser.createdAt.valueOf(), customCreatedAt.valueOf());
-    });
-
-    for (const timestamps of [true, false, null, undefined]) {
-      it(`overwriting immutable createdAt with bulkWrite (gh-15781) when \`timestamps\` is \`${timestamps}\``, async function() {
-        // Arrange
-        const schema = Schema({ name: String }, { timestamps: true });
-
-        const Model = db.model('Test', schema);
-
-        const doc1 = await Model.create({ name: 'gh-15781-1' });
-        const doc2 = await Model.create({ name: 'gh-15781-2' });
-
-        // Act
-        const createdAt = new Date('2011-06-01');
-
-        await Model.bulkWrite([
-          {
-            updateOne: {
-              filter: { _id: doc1._id },
-              update: { createdAt },
-              overwriteImmutable: true,
-              timestamps
-            }
-          },
-          {
-            updateMany: {
-              filter: { _id: doc2._id },
-              update: { createdAt },
-              overwriteImmutable: true,
-              timestamps
-            }
-          }
-        ]);
-
-        // Assert
-        const updatesDocs = await Model.find({ _id: { $in: [doc1._id, doc2._id] } });
-
-        assert.equal(updatesDocs[0].createdAt.valueOf(), createdAt.valueOf());
-        assert.equal(updatesDocs[1].createdAt.valueOf(), createdAt.valueOf());
-      });
-
-      it(`can not update immutable fields without overwriteImmutable: true and timestamps: ${timestamps}`, async function() {
-      // Arrange
-        const { User } = createTestContext();
-        const users = await User.create([
-          { name: 'Bob', ssn: '222-22-2222' },
-          { name: 'Eve', ssn: '333-33-3333' }
-        ]);
-        const newCreatedAt = new Date('2020-01-01');
-
-        // Act
-        await User.bulkWrite([
-          {
-            updateOne: {
-              filter: { _id: users[0]._id },
-              update: { ssn: '888-88-8888', createdAt: newCreatedAt }
-            },
-            timestamps
-          },
-          {
-            updateMany: {
-              filter: { _id: users[1]._id },
-              update: { ssn: '777-77-7777', createdAt: newCreatedAt }
-            },
-            timestamps
-          }
-        ]);
-
-
-        // Assert
-        const [updatedUser1, updatedUser2] = await Promise.all([
-          User.findById(users[0]._id),
-          User.findById(users[1]._id)
-        ]);
-        assert.strictEqual(updatedUser1.ssn, '222-22-2222');
-        assert.notStrictEqual(updatedUser1.createdAt.valueOf(), newCreatedAt.valueOf());
-
+        assert.strictEqual(updatedUser2.name, 'Updated Eve');
         assert.strictEqual(updatedUser2.ssn, '333-33-3333');
         assert.notStrictEqual(updatedUser2.createdAt.valueOf(), newCreatedAt.valueOf());
       });

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -2837,6 +2837,7 @@ describe('model: updateOne: ', function() {
         const newCreatedAt = new Date('2020-01-01');
 
         // Act
+        // `name` keeps the update non-empty when `timestamps: false`, since `ssn` and `createdAt` are immutable and get stripped.
         await User.bulkWrite([
           {
             updateOne: {

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -2788,6 +2788,50 @@ describe('model: updateOne: ', function() {
       assert.strictEqual(updatedUser.createdAt.valueOf(), customCreatedAt.valueOf());
     });
 
+    it('updateOne upsert preserves user-provided `$setOnInsert.createdAt` with overwriteImmutable: true', async function() {
+      // Arrange
+      const schema = Schema({ name: String }, { timestamps: true });
+      const Model = db.model('UpsertSetOnInsertOne', schema);
+      const userCreatedAt = new Date('2020-01-01');
+      const filter = { name: 'gh-setoninsert-createdat-one' };
+
+      // Act
+      await Model.bulkWrite([{
+        updateOne: {
+          filter,
+          update: { $setOnInsert: { createdAt: userCreatedAt, name: filter.name } },
+          upsert: true,
+          overwriteImmutable: true
+        }
+      }]);
+
+      // Assert
+      const doc = await Model.findOne(filter);
+      assert.strictEqual(doc.createdAt.valueOf(), userCreatedAt.valueOf());
+    });
+
+    it('updateMany upsert preserves user-provided `$setOnInsert.createdAt` with overwriteImmutable: true', async function() {
+      // Arrange
+      const schema = Schema({ name: String }, { timestamps: true });
+      const Model = db.model('UpsertSetOnInsertMany', schema);
+      const userCreatedAt = new Date('2020-01-01');
+      const filter = { name: 'gh-setoninsert-createdat-many' };
+
+      // Act
+      await Model.bulkWrite([{
+        updateMany: {
+          filter,
+          update: { $setOnInsert: { createdAt: userCreatedAt, name: filter.name } },
+          upsert: true,
+          overwriteImmutable: true
+        }
+      }]);
+
+      // Assert
+      const doc = await Model.findOne(filter);
+      assert.strictEqual(doc.createdAt.valueOf(), userCreatedAt.valueOf());
+    });
+
     for (const timestamps of [true, false, null, undefined]) {
       it(`overwriting immutable createdAt with bulkWrite (gh-15781) when \`timestamps\` is \`${timestamps}\``, async function() {
         // Arrange


### PR DESCRIPTION
`applyTimestampsToUpdate` only checked top-level and `$set` for a user-provided `createdAt`, so bulkWrite upserts with `$setOnInsert: { createdAt }` and `overwriteImmutable: true` silently overwrote the value with `now`. Including `$setOnInsert` in the check preserves it.

Also cleans up #15781 tests added in #15819:
- `timestamps` was placed outside the op descriptor in the loop tests, so all four `[true, false, null, undefined]` iterations ran with the default. Moved inside.
- Loop tests now assert `updatedAt` actually varies with `timestamps`. Previously assertions were invariant, so a regression would still pass.
- Removes a duplicate of the describe block.