### PR TITLE
docs: scroll active sidebar link into view

### DIFF
--- a/docs/js/sidebar-collapse.js
+++ b/docs/js/sidebar-collapse.js
@@ -1,6 +1,24 @@
 'use strict';
 
 (function() {
+  function scrollActiveSidebarLinkIntoView() {
+    const sidebar = document.querySelector('.left-sidebar');
+    const activeLink = sidebar == null ? null : sidebar.querySelector('.sidebar-link.active');
+
+    if (sidebar == null || activeLink == null) {
+      return;
+    }
+
+    const sidebarRect = sidebar.getBoundingClientRect();
+    const activeLinkRect = activeLink.getBoundingClientRect();
+
+    if (activeLinkRect.top < sidebarRect.top) {
+      sidebar.scrollTop -= sidebarRect.top - activeLinkRect.top;
+    } else if (activeLinkRect.bottom > sidebarRect.bottom) {
+      sidebar.scrollTop += activeLinkRect.bottom - sidebarRect.bottom + 100;
+    }
+  }
+
   document.querySelectorAll('.sidebar-section-collapsible').forEach(function(section) {
     const toggle = section.querySelector('.sidebar-section-toggle');
     if (!toggle) return;
@@ -21,4 +39,6 @@
       }
     });
   });
+
+  scrollActiveSidebarLinkIntoView();
 })();


### PR DESCRIPTION
Re: #16232

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix to ensure the currently active element on the sidebar scrolls into view when loading a new page to ensure it is easy to browse the docs

cc @snehil200 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
