### PR TITLE
fix(clone): isolate cloned arrays from source documents

### DIFF
--- a/lib/helpers/clone.js
+++ b/lib/helpers/clone.js
@@ -202,10 +202,15 @@ function cloneArray(arr, options) {
 
   let ret = null;
   if (options?.retainDocuments) {
+    // Use the cloned parent doc (options.parentDoc) when available so the new
+    // array is wired up to the clone, not the source. Falling back to the
+    // source's parent preserves the previous behavior for callers that don't
+    // pass parentDoc.
+    const newParent = options.parentDoc ?? (arr.isMongooseArray ? arr.$parent() : undefined);
     if (arr.isMongooseDocumentArray) {
-      ret = new (arr.$schemaType().schema.base.Types.DocumentArray)([], arr.$path(), arr.$parent(), arr.$schemaType());
+      ret = new (arr.$schemaType().schema.base.Types.DocumentArray)([], arr.$path(), newParent, arr.$schemaType());
     } else if (arr.isMongooseArray) {
-      ret = new (arr.$parent().schema.base.Types.Array)([], arr.$path(), arr.$parent(), arr.$schemaType());
+      ret = new (arr.$parent().schema.base.Types.Array)([], arr.$path(), newParent, arr.$schemaType());
     } else {
       ret = new Array(len);
     }
@@ -218,9 +223,21 @@ function cloneArray(arr, options) {
     // Create new options object to avoid mutating the shared options.
     // Subdocs need parentArray to point to their own cloned array.
     options = { ...options, parentArray: ret };
-  }
-  for (i = 0; i < len; ++i) {
-    ret[i] = clone(arr[i], options, true);
+    // Skip change-tracking while populating the freshly cloned array: every
+    // index assignment would otherwise call markModified on the cloned parent
+    // doc and (before this guard) on the source parent doc.
+    for (i = 0; i < len; ++i) {
+      const doc = clone(arr[i], options, true);
+      // Document arrays can contain null entries, so only restamp actual subdocs.
+      if (typeof doc?.$setIndex === 'function') {
+        doc.$setIndex(i);
+      }
+      ret.set(i, doc, true);
+    }
+  } else {
+    for (i = 0; i < len; ++i) {
+      ret[i] = clone(arr[i], options, true);
+    }
   }
 
   return ret;

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -13034,6 +13034,193 @@ describe('document', function() {
     }
   });
 
+  describe('$clone() does not leak state to the original document', function() {
+    it('cloned document array $parent() returns the cloned root document', function() {
+      // Arrange
+      const { user } = createTestContext();
+
+      // Act
+      const clonedUser = user.$clone();
+
+      // Assert
+      assert.strictEqual(
+        clonedUser.addresses.$parent(),
+        clonedUser,
+        'cloned document array $parent() should return cloned document'
+      );
+      assert.strictEqual(
+        user.addresses.$parent(),
+        user,
+        'original document array $parent() should still return original document'
+      );
+    });
+
+    it('cloning a freshly-constructed document does not mutate the original document\'s modifiedPaths', function() {
+      // Arrange
+      const { user } = createTestContext();
+      const before = user.modifiedPaths().slice().sort();
+
+      // Act
+      user.$clone();
+
+      // Assert
+      const after = user.modifiedPaths().slice().sort();
+      assert.deepStrictEqual(
+        after,
+        before,
+        'cloning should not add paths to the original document\'s modifiedPaths'
+      );
+    });
+
+    it('modifying a subdoc field on the cloned document does not mark the original as modified', async function() {
+      // Arrange
+      const { User, user } = createTestContext();
+      await user.save();
+      const fetched = await User.findById(user._id);
+      assert.strictEqual(fetched.isModified(), false, 'sanity: fetched doc starts clean');
+
+      // Act
+      const clonedFetched = fetched.$clone();
+      clonedFetched.addresses[0].city = 'New York';
+
+      // Assert
+      assert.strictEqual(
+        fetched.isModified(),
+        false,
+        'original fetched document should remain clean after mutating clone'
+      );
+      assert.deepStrictEqual(
+        fetched.modifiedPaths(),
+        [],
+        'original fetched document modifiedPaths should remain empty'
+      );
+      assert.strictEqual(
+        clonedFetched.isModified('addresses.0.city'),
+        true,
+        'cloned document should track the mutation on its own subdoc'
+      );
+    });
+
+    it('refreshes cloned document array subdoc indexes after source array changes', async function() {
+      // Arrange
+      const { user } = createTestContext({
+        addresses: [
+          { street: '1 Main', city: 'Boston' },
+          { street: '2 Main', city: 'Chicago' },
+          { street: '3 Main', city: 'Denver' }
+        ]
+      });
+      await user.save();
+      user.addresses.pull(user.addresses[0]._id);
+      await user.save();
+      assert.strictEqual(user.isModified(), false, 'sanity: saved doc starts clean');
+
+      // Act
+      const clonedUser = user.$clone();
+      clonedUser.addresses[0].city = 'New York';
+
+      // Assert
+      assert.strictEqual(
+        clonedUser.addresses[0].$__fullPath('city'),
+        'addresses.0.city',
+        'cloned subdoc should use its cloned array index'
+      );
+      assert.strictEqual(
+        clonedUser.isModified('addresses.0.city'),
+        true,
+        'cloned document should track the first subdoc by its cloned index'
+      );
+      assert.strictEqual(
+        clonedUser.isModified('addresses.1.city'),
+        false,
+        'cloned document should not track the first subdoc by its stale source index'
+      );
+    });
+
+    it('clones document arrays with null entries', function() {
+      // Arrange
+      const { user } = createTestContext({
+        addresses: [
+          null,
+          { street: '1 Main', city: 'Boston' }
+        ]
+      });
+
+      // Act
+      const clonedUser = user.$clone();
+
+      // Assert
+      assert.strictEqual(clonedUser.addresses[0], null);
+      assert.strictEqual(
+        clonedUser.addresses[1].$__fullPath('city'),
+        'addresses.1.city',
+        'non-null cloned subdoc should keep the correct array index'
+      );
+    });
+
+    it('cloning a document with a primitive array does not mutate the original document\'s modifiedPaths', function() {
+      // Arrange
+      const { user } = createTestContext({ tags: ['admin'] });
+      const before = user.modifiedPaths().slice().sort();
+
+      // Act
+      user.$clone();
+
+      // Assert
+      const after = user.modifiedPaths().slice().sort();
+      assert.deepStrictEqual(
+        after,
+        before,
+        'cloning should not add primitive array paths to the original document\'s modifiedPaths'
+      );
+    });
+
+    it('modifying a primitive array on the cloned document does not mark the original as modified', async function() {
+      // Arrange
+      const { User, user } = createTestContext({ tags: ['admin'] });
+      await user.save();
+      const fetched = await User.findById(user._id);
+      assert.strictEqual(fetched.isModified(), false, 'sanity: fetched doc starts clean');
+
+      // Act
+      const clonedFetched = fetched.$clone();
+      clonedFetched.tags[0] = 'member';
+
+      // Assert
+      assert.strictEqual(
+        fetched.isModified(),
+        false,
+        'original fetched document should remain clean after mutating cloned primitive array'
+      );
+      assert.deepStrictEqual(
+        fetched.modifiedPaths(),
+        [],
+        'original fetched document modifiedPaths should remain empty'
+      );
+      assert.strictEqual(
+        clonedFetched.isModified('tags.0'),
+        true,
+        'cloned document should track the primitive array mutation'
+      );
+    });
+
+    function createTestContext({ addresses, tags } = {}) {
+      const addressSchema = new Schema({ street: String, city: String });
+      const userSchema = new Schema({
+        name: String,
+        addresses: [addressSchema],
+        tags: [String]
+      });
+      const User = db.model('UserCloneIsolation', userSchema);
+      const user = new User({
+        name: 'John',
+        addresses: addresses ?? [{ street: '1 Main', city: 'Boston' }],
+        tags: tags ?? []
+      });
+      return { User, user };
+    }
+  });
+
   it('can create document with document array and top-level key named `schema` (gh-12480)', async function() {
     const AuthorSchema = new Schema({
       fullName: { type: 'String', required: true }


### PR DESCRIPTION
re #15958

`$clone()` was still leaving one parent pointer connected to the source document. We fixed the parent pointers on cloned subdocs, but retained Mongoose arrays were still constructed with the source document as their internal array parent. That meant cloning could mark the original document modified while populating the clone, and later writes to a cloned array could bubble `markModified()` back to the original.

This PR:
- uses the cloned parent doc when constructing retained Mongoose arrays
- populates cloned document arrays without marking either document modified
- restamps cloned array subdoc indexes while doing that, so stale indexes from prior array edits don't leak into the clone
- adds regression coverage for document arrays and primitive arrays