### PR TITLE
types: handle compiling with exactOptionalPropertyTypes

### DIFF
--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -72,7 +72,7 @@ declare module 'mongoose' {
         : // If the type key isn't callable, then this is an array of objects, in which case
           // we need to call InferRawDocType to correctly infer its type.
           Array<InferRawDocType<Item>>
-      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolveRawPathType<Item, { enum: Options['enum'] }, TypeKey>[]
+      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolveRawPathType<Item, { enum: Exclude<Options['enum'], undefined> }, TypeKey>[]
       : IsItRecordAndNotAny<Item> extends true ?
         Item extends Record<string, never> ?
           ObtainRawDocumentPathType<Item, TypeKey>[]

--- a/types/inferschematype.d.ts
+++ b/types/inferschematype.d.ts
@@ -287,7 +287,7 @@ type ResolvePathType<
         : // If the type key isn't callable, then this is an array of objects, in which case
           // we need to call ObtainDocumentType to correctly infer its type.
           Types.DocumentArray<ObtainDocumentType<Item, any, { typeKey: TypeKey }>>
-      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolvePathType<Item, { enum: Options['enum'] }, TypeKey>[]
+      : IsSchemaTypeFromBuiltinClass<Item> extends true ? ResolvePathType<Item, { enum: Exclude<Options['enum'], undefined> }, TypeKey>[]
       : IsItRecordAndNotAny<Item> extends true ?
         Item extends Record<string, never> ?
           ObtainDocumentPathType<Item, TypeKey>[]

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -110,7 +110,7 @@ declare module 'mongoose' {
      * The default value for this path. If a function, Mongoose executes the function
      * and uses the return value as the default.
      */
-    default?: DefaultType<T> | ((this: EnforcedDocType, doc: any) => DefaultType<T> | null | undefined) | null;
+    default?: DefaultType<T> | ((this: EnforcedDocType, doc: any) => DefaultType<T> | null | undefined) | null | undefined;
 
     /**
      * The model that `populate()` should use if populating this path.


### PR DESCRIPTION
Fix #16273
Backport #16277 to 8.x

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I'm unable to write tests for this with tsd because I don't think there's a way I can run one tsd command with multiple tsconfigs. After this PR I'll be working on a more thorough task to use `exactOptionalPropertyTypes` in our tests, but there's a few tests to fix for that.

I did fix one thing additional issue that popped up while I was running out test suite with `exactOptionalPropertyTypes`: `default: undefined` currently fails with `exactOptionalPropertyTypes`, so I added `| undefined` to account for that.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
