### PR TITLE
types: use exactOptionalPropertyTypes in tests

### DIFF
--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -36,7 +36,7 @@ function optionality() {
   };
 
   type UserType = InferRawDocType<typeof schemaDefinition>;
-  expectType<{ name: string; dateOfBirth?: number | null | undefined }>({} as UserType);
+  expectType<{ name: string; dateOfBirth?: number | null }>({} as UserType);
 }
 
 type SchemaOptionsWithTimestamps<t> = {
@@ -61,7 +61,7 @@ function Timestamps() {
   type UserType = InferRawDocType<typeof schemaDefinition, SchemaOptionsWithTimestamps<true>>;
   expectType<{
     name: string;
-    dateOfBirth?: number | null | undefined;
+    dateOfBirth?: number | null;
     createdAt: NativeDate;
     updatedAt: NativeDate;
   }>({} as UserType);
@@ -94,12 +94,12 @@ function DefinitionTypes() {
   }>;
 
   expectType<{
-    lowercaseString?: string | null | undefined;
-    uppercaseString?: string | null | undefined;
-    stringConstructor?: string | null | undefined;
-    schemaConstructor?: string | null | undefined;
-    stringInstance?: string | null | undefined;
-    schemaInstance?: string | null | undefined;
+    lowercaseString?: string | null;
+    uppercaseString?: string | null;
+    stringConstructor?: string | null;
+    schemaConstructor?: string | null;
+    stringInstance?: string | null;
+    schemaInstance?: string | null;
   }>({} as Actual);
 }
 
@@ -114,10 +114,10 @@ function MoreDefinitionTypes() {
   }>;
 
   expectType<{
-    numberString?: number | null | undefined;
+    numberString?: number | null;
     // these should not fallback to Boolean, which has no methods
-    objectIdConstructor?: Types.ObjectId | null | undefined;
-    objectIdInstance?: Types.ObjectId | null | undefined;
+    objectIdConstructor?: Types.ObjectId | null;
+    objectIdInstance?: Types.ObjectId | null;
   }>({} as Actual);
 }
 

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -486,7 +486,6 @@ async function gh11602(): Promise<void> {
 
   ModelType.findOneAndUpdate({}, {}, { returnDocument: 'before' });
   ModelType.findOneAndUpdate({}, {}, { returnDocument: 'after' });
-  ModelType.findOneAndUpdate({}, {}, { returnDocument: undefined });
   ModelType.findOneAndUpdate({}, {}, {});
   expectError(ModelType.findOneAndUpdate({}, {}, {
     returnDocument: 'not-before-or-after'

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -9,6 +9,7 @@ import {
   IndexOptions,
   InferRawDocType,
   InferSchemaType,
+  FlattenMaps,
   InsertManyOptions,
   JSONSerialized,
   ObtainDocumentType,
@@ -1778,14 +1779,14 @@ async function gh14451() {
 
   type TestJSON = JSONSerialized<InferSchemaType<typeof exampleSchema>>;
   expectType<{
-    myId?: string | undefined | null,
+    myId?: string | null,
     myRequiredId: string,
     myBuf: { type: 'buffer', data: number[] },
     subdoc?: {
       subdocProp?: string | undefined | null
     } | null,
-    docArr: { nums: number[], times: string[] }[],
-    myMap?: Record<string, string> | null | undefined
+    docArr: FlattenMaps<{ nums: number[], times: string[] }>[],
+    myMap?: Record<string, string> | null
   }>({} as TestJSON);
 }
 

--- a/test/types/schemaTypeOptions.test.ts
+++ b/test/types/schemaTypeOptions.test.ts
@@ -88,7 +88,7 @@ function encrypt() {
   // qe + valid queries
   new SchemaTypeOptions<string>()['encrypt'] = { keyId: uuid, queries: 'equality' };
   new SchemaTypeOptions<string>()['encrypt'] = { keyId: uuid, queries: 'range' };
-  new SchemaTypeOptions<string>()['encrypt'] = { keyId: uuid, queries: undefined };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId: uuid };
 
   // empty object
   expectError<SchemaTypeOptions<string>['encrypt']>({});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "strictNullChecks": true,
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "mongoose" : ["./types/index.d.ts"]
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

For 8.x, re: #16273. Changes limited purely to tests - things like `returnDocument: undefined` aren't supported under `exactOptionalPropertyTypes` but that seems reasonable to me. Document property types also don't include `undefined` anymore, which is reasonable since Mongoose does not store `undefined` properties and lines up with how people expect to use exactOptionalPropertyTypes.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
