### PR TITLE
types: add $percentile to TypeScript types

### DIFF
--- a/types/expressions.d.ts
+++ b/types/expressions.d.ts
@@ -2313,6 +2313,19 @@ declare module 'mongoose' {
       }
     }
 
+    export interface Percentile {
+      /**
+       * Returns an array of scalar values that correspond to specified percentile values.
+       *
+       * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/
+       */
+      $percentile: {
+        input: number | Expression,
+        p: (number | Expression)[],
+        method: 'approximate'
+      }
+    }
+
     export interface StdDevPop {
       /**
        * Calculates the population standard deviation of the input values. Use if the values encompass the entire
@@ -2874,6 +2887,7 @@ declare module 'mongoose' {
     Expression.Median |
     Expression.Min |
     Expression.MinN |
+    Expression.Percentile |
     Expression.Push |
     Expression.Rank |
     Expression.Shift |
@@ -2906,6 +2920,7 @@ declare module 'mongoose' {
     Expression.Max |
     Expression.Median |
     Expression.Min |
+    Expression.Percentile |
     Expression.StdDevPop |
     Expression.StdDevSamp |
     Expression.Sum;
@@ -2981,6 +2996,7 @@ declare module 'mongoose' {
     Expression.MergeObjects |
     Expression.Min |
     Expression.MinN |
+    Expression.Percentile |
     Expression.Push |
     Expression.StdDevPop |
     Expression.StdDevSamp |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Quick fix for missing types, here's the docs: https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
