### PR TITLE
types: add Percentile as AccumulatorOperator

### DIFF
--- a/test/types/aggregate.test.ts
+++ b/test/types/aggregate.test.ts
@@ -181,3 +181,31 @@ function gh16033() {
       pipeline: basePipeline.pipeline()
     });
 }
+
+function gh16288() {
+  // `$percentile` should be a valid accumulator in `$group`, alongside the
+  // already-supported `$median`.
+  const pipeline: PipelineStage[] = [
+    {
+      $group: {
+        _id: null,
+        p95: {
+          $percentile: {
+            input: '$orderTotal',
+            p: [0.95],
+            method: 'approximate'
+          }
+        },
+        median: {
+          $median: {
+            input: '$orderTotal',
+            method: 'approximate'
+          }
+        }
+      }
+    }
+  ];
+
+  const Order = model('OrderGh16288', new Schema({ orderTotal: Number }));
+  Order.aggregate(pipeline);
+}

--- a/types/expressions.d.ts
+++ b/types/expressions.d.ts
@@ -2313,6 +2313,19 @@ declare module 'mongoose' {
       }
     }
 
+    export interface Percentile {
+      /**
+       * Returns an array of scalar values that correspond to specified percentile values.
+       *
+       * @see https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/percentile/
+       */
+      $percentile: {
+        input: number | Expression,
+        p: Array<number | Expression>,
+        method: 'approximate'
+      }
+    }
+
     export interface StdDevPop {
       /**
        * Calculates the population standard deviation of the input values. Use if the values encompass the entire
@@ -2981,6 +2994,7 @@ declare module 'mongoose' {
     Expression.MergeObjects |
     Expression.Min |
     Expression.MinN |
+    Expression.Percentile |
     Expression.Push |
     Expression.StdDevPop |
     Expression.StdDevSamp |


### PR DESCRIPTION
Fix #16288

**Summary**

`$percentile` is a valid MongoDB 7.0+ accumulator operator in the `$group` stage but is missing from Mongoose's `AccumulatorOperator` type. Using it in a typed pipeline currently throws `TS2353: Object literal may only specify known properties, and '$percentile' does not exist in type 'AccumulatorOperator'.`

This mirrors the existing `$median` pattern in `types/expressions.d.ts`:

- Adds a `Percentile` interface alongside `Median`, with the same JSDoc style and a `@see` link to the MongoDB v7.0 docs.
- Adds `Expression.Percentile` to the `AccumulatorOperator` union (immediately before `Expression.Push`, alphabetical).

Scoped narrowly to match the precedent set in [`2de289bd5`](https://github.com/Automattic/mongoose/commit/2de289bd5) (adding `$median` as `AccumulatorOperator`). `$percentile` is also valid in `$setWindowFields` per the MongoDB docs — happy to extend the type to `WindowOperator` / `WindowOperatorReturningArray` in this PR or a follow-up if preferred.

**Examples**

Added a typings test (`gh16288()` in `test/types/aggregate.test.ts`) that reproduces the exact code from the issue and now type-checks cleanly:

```ts
const pipeline: PipelineStage[] = [
  {
    $group: {
      _id: null,
      p95: {
        $percentile: {
          input: '$orderTotal',
          p: [0.95],
          method: 'approximate'
        }
      }
    }
  }
];
```

**Checks run locally**

- `npm run test:types` (tstyche) — 960/960 assertions, 39/39 files pass (including the new `gh16288` test)
- `npm run lint-ts` — clean
- `npm run lint` — clean
