### PR TITLE
fix(docs): keep copy button fixed in horizontally scrollable code blocks

### DIFF
--- a/docs/css/copy-code.css
+++ b/docs/css/copy-code.css
@@ -1,3 +1,7 @@
+.code-block-wrapper {
+  position: relative;
+}
+
 /* Base button placement & visibility */
 .copy-btn {
   position: absolute;
@@ -16,11 +20,12 @@
   align-items: center;
   justify-content: center;
 
-  color: #666; /* default icon color */
+  color: #666;
+  /* default icon color */
 }
 
 /* Show button only when the code block is hovered */
-pre:hover .copy-btn {
+.code-block-wrapper:hover .copy-btn {
   opacity: 1;
   transform: translateY(0);
 }

--- a/docs/js/copy-code.js
+++ b/docs/js/copy-code.js
@@ -18,8 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Inject a copy button into each <pre><code> block used in docs
   document.querySelectorAll('pre code').forEach(block => {
-    const wrapper = block.parentElement;
-    wrapper.style.position = 'relative'; // ensures button can be positioned correctly
+    const pre = block.parentElement;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'code-block-wrapper';
+
+    pre.parentNode.insertBefore(wrapper, pre);
+    wrapper.appendChild(pre);
 
     const btn = document.createElement('button');
     btn.className = 'copy-btn';
@@ -27,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.innerHTML = copyIcon; // initial icon state
 
     // Handle the copy-to-clipboard action
-    btn.onclick = async() => {
+    btn.onclick = async () => {
       if (btn.dataset.locked) return; // prevents multiple fast clicks
       btn.dataset.locked = '1';
 


### PR DESCRIPTION
Fixes #16293

Summary:
- Wrap each pre element in a .code-block-wrapper container
- Move copy button positioning to the wrapper instead of the scrollable pre element
- Update hover selector to target the wrapper

Result:
The copy button now remains fixed in the top-right corner while horizontally scrolling code blocks.

Tested:
- Copy button appears on hover
- Copy functionality still works
- Button remains fixed during horizontal scrolling
- Verified on actual Mongoose docs pages using browser overrides