### PR TITLE
style(docs): fix lint errors in copy-code.js

### DIFF
--- a/docs/js/copy-code.js
+++ b/docs/js/copy-code.js
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.innerHTML = copyIcon; // initial icon state
 
     // Handle the copy-to-clipboard action
-    btn.onclick = async () => {
+    btn.onclick = async() => {
       if (btn.dataset.locked) return; // prevents multiple fast clicks
       btn.dataset.locked = '1';
 


### PR DESCRIPTION
Fixes CI failure on master and a lint warning.
I see @vkarpov15 already made these changes in https://github.com/Automattic/mongoose/pull/16289 so I'll treat it as an implicit approval so that we avoid having CI being red on master, not a good look.