### PR TITLE
docs: remove broken link to deleted examples/schema/schema.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,6 @@ Comment.pre('save', function(next) {
 });
 ```
 
-Take a look at the example in [`examples/schema/schema.js`](https://github.com/Automattic/mongoose/blob/master/examples/schema/schema.js) for an end-to-end example of a typical setup.
-
 ### Accessing a Model
 
 Once we define a model through `mongoose.model('ModelName', mySchema)`, we can access it through the same function


### PR DESCRIPTION
The `examples/` directory was removed in #15597, but the link in README.md was not updated.
Removes the dangling reference to `examples/schema/schema.js`.