### PR TITLE
fix(document): deprecate validateSync re #16291

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,3 +1,8 @@
 # Deprecation Warnings
 
-There are no current deprecation warnings for Mongoose 9.x.
+## `Document.prototype.validateSync()`
+
+`Document.prototype.validateSync()` is deprecated and will be removed in Mongoose 10.
+Use `Document.prototype.validate()` instead.
+
+`validateSync()` does not run validate middleware, and it skips asynchronous validators.

--- a/lib/document.js
+++ b/lib/document.js
@@ -3264,6 +3264,9 @@ function _handlePathsToSkip(paths, pathsToSkip) {
 /**
  * Executes registered validation rules (skipping asynchronous validators) for this document.
  *
+ * **Deprecated.** Use [`validate()`](https://mongoosejs.com/docs/api/document.html#Document.prototype.validate()) instead.
+ * `validateSync()` does not run validation middleware and will be removed in Mongoose 10.
+ *
  * #### Note:
  *
  * This method is useful if you need synchronous validation.
@@ -3281,14 +3284,21 @@ function _handlePathsToSkip(paths, pathsToSkip) {
  * @param {object} [options] options for validation
  * @param {boolean} [options.validateModifiedOnly=false] If `true`, Mongoose will only validate modified paths, as opposed to modified paths and `required` paths.
  * @param {Array|string} [options.pathsToSkip] list of paths to skip. If set, Mongoose will validate every modified path that is not in this list.
- * @param {boolean|object} [options.middleware=true] set to `false` to skip all user-defined middleware
- * @param {boolean} [options.middleware.pre=true] set to `false` to skip only pre hooks
- * @param {boolean} [options.middleware.post=true] set to `false` to skip only post hooks
  * @return {ValidationError|undefined} ValidationError if there are errors during validation, or undefined if there is no error.
+ * @deprecated Use `validate()` instead. `validateSync()` does not run middleware and will be removed in Mongoose 10.
  * @api public
  */
 
-Document.prototype.validateSync = function(pathsToValidate, options) {
+Document.prototype.validateSync = function() {
+  utils.warn('Mongoose: `Document.prototype.validateSync()` is deprecated and will be removed in Mongoose 10. Use `Document.prototype.validate()` instead.');
+  return this.$__validateSync.apply(this, arguments);
+};
+
+/*!
+ * ignore
+ */
+
+Document.prototype.$__validateSync = function(pathsToValidate, options) {
   const _this = this;
 
   if (arguments.length === 1 && typeof arguments[0] === 'object' && !Array.isArray(arguments[0])) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3861,7 +3861,7 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
         throw new MongooseError(`documents.${i} was not a mongoose document, documents must be an array of mongoose documents (instanceof mongoose.Document).`);
       }
       if (options.validateBeforeSave == null || options.validateBeforeSave) {
-        const err = document.validateSync();
+        const err = document.$__validateSync();
         if (err != null) {
           throw err;
         }

--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -314,7 +314,7 @@ SchemaDocumentArray.prototype.doValidateSync = function(array, scope, options) {
       continue;
     }
 
-    const subdocValidateError = doc.validateSync(options);
+    const subdocValidateError = doc.$__validateSync(options);
 
     if (subdocValidateError && resultError == null) {
       resultError = subdocValidateError;

--- a/lib/schema/subdocument.js
+++ b/lib/schema/subdocument.js
@@ -310,7 +310,7 @@ SchemaSubdocument.prototype.doValidateSync = function(value, scope, options) {
   if (!value) {
     return;
   }
-  return value.validateSync();
+  return value.$__validateSync();
 };
 
 /**

--- a/lib/schema/union.js
+++ b/lib/schema/union.js
@@ -112,6 +112,9 @@ class Union extends SchemaType {
         return schemaTypeError;
       }
     }
+    if (value != null && typeof value.$__validateSync === 'function') {
+      return value.$__validateSync();
+    }
     if (value != null && typeof value.validateSync === 'function') {
       return value.validateSync();
     }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11269,25 +11269,21 @@ describe('document', function() {
 
     it('emits a deprecation warning', () => {
       // Arrange
-      sinon.stub(utils, 'warn');
-      const User = db.model('UserWarning', Schema({ name: String }));
+      const { User, getWarningCalls } = createTestContext();
       const user = new User({ name: 'Sam' });
 
       // Act
       user.validateSync();
 
       // Assert
-      const calls = utils.warn.getCalls();
+      const calls = getWarningCalls();
       assert.strictEqual(calls.length, 1);
       assert.ok(calls[0].args[0].includes('`Document.prototype.validateSync()` is deprecated'));
     });
 
     it('does not emit a deprecation warning for internal bulkSave() validation', async() => {
       // Arrange
-      sinon.stub(utils, 'warn');
-      const User = db.model('BulkSaveWarning', Schema({
-        name: { type: String, required: true }
-      }));
+      const { User, getWarningCalls } = createTestContext();
       const user = new User();
 
       // Act
@@ -11296,24 +11292,18 @@ describe('document', function() {
       // Assert
       assert.ok(err);
       assert.strictEqual(err.name, 'ValidationError');
-      assert.strictEqual(utils.warn.getCalls().length, 0);
+      assert.strictEqual(getWarningCalls().length, 0);
     });
 
     it('emits one deprecation warning when validating subdocuments and unions', () => {
       // Arrange
-      sinon.stub(utils, 'warn');
-      const addressSchema = Schema({ city: { type: String, required: true } });
-      const officeSchema = Schema({ city: { type: String, required: true } });
-      const preferenceSchema = Schema({ score: { type: Number, required: true } });
-      const User = db.model('SubdocWarning', Schema({
-        address: addressSchema,
-        offices: [officeSchema],
-        preference: {
-          type: 'Union',
-          of: [preferenceSchema, Number]
-        }
-      }));
-      const user = new User({ address: {}, offices: [{}, {}], preference: {} });
+      const { User, getWarningCalls } = createTestContext();
+      const user = new User({
+        name: 'Sam',
+        address: {},
+        offices: [{}, {}],
+        preference: {}
+      });
 
       // Act
       const err = user.validateSync();
@@ -11324,8 +11314,29 @@ describe('document', function() {
       assert.ok(err.errors['offices.0.city']);
       assert.ok(err.errors['offices.1.city']);
       assert.ok(err.errors['preference.score']);
-      assert.strictEqual(utils.warn.getCalls().length, 1);
+      assert.strictEqual(getWarningCalls().length, 1);
     });
+
+    function createTestContext() {
+      sinon.stub(utils, 'warn');
+      const addressSchema = Schema({ city: { type: String, required: true } });
+      const officeSchema = Schema({ city: { type: String, required: true } });
+      const preferenceSchema = Schema({ score: { type: Number, required: true } });
+      const User = db.model('ValidateSyncWarning', Schema({
+        name: { type: String, required: true },
+        address: addressSchema,
+        offices: [officeSchema],
+        preference: {
+          type: 'Union',
+          of: [preferenceSchema, Number]
+        }
+      }));
+
+      return {
+        User,
+        getWarningCalls: () => utils.warn.getCalls()
+      };
+    }
   });
 
   it('skips recursive merging (gh-9121)', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11261,6 +11261,71 @@ describe('document', function() {
       const User = db.model('User', userSchema);
       return User;
     }
+
+  });
+
+  describe('validateSync()', () => {
+    afterEach(() => sinon.restore());
+
+    it('emits a deprecation warning', () => {
+      // Arrange
+      sinon.stub(utils, 'warn');
+      const User = db.model('UserWarning', Schema({ name: String }));
+      const user = new User({ name: 'Sam' });
+
+      // Act
+      user.validateSync();
+
+      // Assert
+      const calls = utils.warn.getCalls();
+      assert.strictEqual(calls.length, 1);
+      assert.ok(calls[0].args[0].includes('`Document.prototype.validateSync()` is deprecated'));
+    });
+
+    it('does not emit a deprecation warning for internal bulkSave() validation', async() => {
+      // Arrange
+      sinon.stub(utils, 'warn');
+      const User = db.model('BulkSaveWarning', Schema({
+        name: { type: String, required: true }
+      }));
+      const user = new User();
+
+      // Act
+      const err = await User.bulkSave([user]).then(() => null, err => err);
+
+      // Assert
+      assert.ok(err);
+      assert.strictEqual(err.name, 'ValidationError');
+      assert.strictEqual(utils.warn.getCalls().length, 0);
+    });
+
+    it('emits one deprecation warning when validating subdocuments and unions', () => {
+      // Arrange
+      sinon.stub(utils, 'warn');
+      const addressSchema = Schema({ city: { type: String, required: true } });
+      const officeSchema = Schema({ city: { type: String, required: true } });
+      const preferenceSchema = Schema({ score: { type: Number, required: true } });
+      const User = db.model('SubdocWarning', Schema({
+        address: addressSchema,
+        offices: [officeSchema],
+        preference: {
+          type: 'Union',
+          of: [preferenceSchema, Number]
+        }
+      }));
+      const user = new User({ address: {}, offices: [{}, {}], preference: {} });
+
+      // Act
+      const err = user.validateSync();
+
+      // Assert
+      assert.ok(err);
+      assert.ok(err.errors['address.city']);
+      assert.ok(err.errors['offices.0.city']);
+      assert.ok(err.errors['offices.1.city']);
+      assert.ok(err.errors['preference.score']);
+      assert.strictEqual(utils.warn.getCalls().length, 1);
+    });
   });
 
   it('skips recursive merging (gh-9121)', function() {

--- a/test/types/model.skip.middleware.test.ts
+++ b/test/types/model.skip.middleware.test.ts
@@ -101,11 +101,13 @@ async function gh8768() {
   await user.validate({ middleware: { pre: false } });
   await user.validate({ middleware: { post: false } });
 
-  // ValidateOptions - doc.validateSync()
-  user.validateSync({ middleware: false });
-  user.validateSync({ middleware: { pre: false } });
-  user.validateSync({ middleware: { post: false } });
-  user.validateSync({ middleware: false, pathsToSkip: ['name'] });
+  user.validateSync({ pathsToSkip: ['name'] });
+
+  // validateSync() does not run middleware, so it does not support middleware options
+  expect(user.validateSync).type.not.toBeCallableWith({ middleware: false });
+  expect(user.validateSync).type.not.toBeCallableWith({ middleware: { pre: false } });
+  expect(user.validateSync).type.not.toBeCallableWith({ middleware: { post: false } });
+  expect(user.validateSync).type.not.toBeCallableWith({ middleware: false, pathsToSkip: ['name'] });
 
   // MongooseBulkSaveOptions
   await User.bulkSave([user], { middleware: false });

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -11,6 +11,12 @@ declare module 'mongoose' {
     middleware?: boolean | SkipMiddlewareOptions;
   }
 
+  interface ValidateSyncOptions extends Omit<ValidateOptions, 'middleware'> {
+    /** `validateSync()` does not run middleware. Use `validate()` if you need middleware. */
+    middleware?: never;
+    [k: string]: any;
+  }
+
   interface DocumentSetOptions {
     merge?: boolean;
 
@@ -320,9 +326,20 @@ declare module 'mongoose' {
     validate(pathsToValidate?: pathsToValidate, options?: Omit<ValidateOptions, 'pathsToSkip'> & AnyObject): Promise<void>;
     validate(options: ValidateOptions): Promise<void>;
 
-    /** Executes registered validation rules (skipping asynchronous validators) for this document. */
-    validateSync(options: ValidateOptions & { [k: string]: any }): Error.ValidationError | null;
-    validateSync<T extends keyof DocType>(pathsToValidate?: T | T[], options?: Omit<ValidateOptions, 'pathsToSkip'> & AnyObject): Error.ValidationError | null;
-    validateSync(pathsToValidate?: pathsToValidate, options?: Omit<ValidateOptions, 'pathsToSkip'> & AnyObject): Error.ValidationError | null;
+    /**
+     * Executes registered validation rules (skipping asynchronous validators) for this document.
+     * @deprecated Use `validate()` instead. `validateSync()` does not run middleware and will be removed in Mongoose 10.
+     */
+    validateSync(options: ValidateSyncOptions): Error.ValidationError | null;
+    /**
+     * Executes registered validation rules (skipping asynchronous validators) for this document.
+     * @deprecated Use `validate()` instead. `validateSync()` does not run middleware and will be removed in Mongoose 10.
+     */
+    validateSync<T extends keyof DocType>(pathsToValidate?: T | T[], options?: Omit<ValidateSyncOptions, 'pathsToSkip'>): Error.ValidationError | null;
+    /**
+     * Executes registered validation rules (skipping asynchronous validators) for this document.
+     * @deprecated Use `validate()` instead. `validateSync()` does not run middleware and will be removed in Mongoose 10.
+     */
+    validateSync(pathsToValidate?: pathsToValidate, options?: Omit<ValidateSyncOptions, 'pathsToSkip'>): Error.ValidationError | null;
   }
 }


### PR DESCRIPTION
re #16291
This PR:
- removes `middleware` support from the `validateSync()` TypeScript surface, because `validateSync()` does not run validate middleware
- marks `Document.prototype.validateSync()` as deprecated in the runtime JSDoc and TypeScript declarations
- emits a deprecation warning when `validateSync()` is called
- updates the deprecation docs and focused type/runtime coverage

Runtime validation behavior is otherwise unchanged.