### PR TITLE
chore(deps): remove manual Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
-  cooldown:
-    default-days: 2
   open-pull-requests-limit: 100
   target-branch: master
 - package-ecosystem: github-actions


### PR DESCRIPTION
re #16263

This removes the explicit Dependabot `cooldown` config that we added to keep Dependabot in sync with `.npmrc` `min-release-age=2`.

Context: https://github.com/dependabot/dependabot-core/pull/15132 now makes Dependabot read `min-release-age` from `.npmrc` and apply it as a cooldown floor for npm version updates. That change was merged and the Dependabot maintainer confirmed it has been deployed, so keeping the same value in both `.npmrc` and `dependabot.yml` is just an extra thing to keep in sync.

I also checked whether we need to manually bump any Dependabot version here. We don't, `version: 2` in `dependabot.yml` is the config schema, not a pinned Dependabot runtime version.