### PR TITLE
fix(document): throw error if overwriting array selected with $slice

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -5276,6 +5276,12 @@ function checkDivergentArray(doc, path, array) {
     // If any array was selected using an $elemMatch projection, we deny the update.
     // NOTE: MongoDB only supports projected $elemMatch on top level array.
     const top = path.split('.')[0];
+    if (doc.$__.selected[top] && doc.$__.selected[top].$slice != null && utils.isMongooseArray(array)) {
+      const atomics = array[arrayAtomicsSymbol];
+      if (atomics.$set) {
+        return top;
+      }
+    }
     if (doc.$__.selected[top + '.$']) {
       return top;
     }

--- a/lib/error/divergentArray.js
+++ b/lib/error/divergentArray.js
@@ -17,7 +17,7 @@ class DivergentArrayError extends MongooseError {
 
   constructor(paths) {
     const msg = 'For your own good, using `document.save()` to update an array '
-            + 'which was selected using an $elemMatch projection OR '
+            + 'which was selected using an $elemMatch or $slice projection OR '
             + 'populated using skip, limit, query conditions, or exclusion of '
             + 'the _id field when the operation results in a $pop or $set of '
             + 'the entire array is not supported. The following '

--- a/test/model.field.selection.test.js
+++ b/test/model.field.selection.test.js
@@ -12,6 +12,7 @@ const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 const ObjectId = Schema.Types.ObjectId;
 const DocumentObjectId = mongoose.Types.ObjectId;
+const DivergentArrayError = mongoose.Error.DivergentArrayError;
 
 describe('model field selection', function() {
   let Comments;
@@ -264,6 +265,98 @@ describe('model field selection', function() {
       post.tags[0].count = 1;
       const err = await post.save().then(() => null, err => err);
       assert.ok(err);
+    });
+  });
+
+  describe('with $slice projection', function() {
+    it('throws divergent array error when saving with $set atomic', async function() {
+      const postSchema = new Schema({
+        numbers: [Number]
+      });
+
+      const B = db.model('Test', postSchema);
+
+      const doc = await B.create({ numbers: [1, 2, 3] });
+      const found = await B.findById(doc._id).select({ numbers: { $slice: -1 } });
+      assert.deepEqual(found.numbers, [3]);
+
+      found.numbers.unshift(0);
+
+      const err = await found.save().then(() => null, err => err);
+      assert.ok(err instanceof DivergentArrayError, 'non-divergent error: ' + err);
+      assert.ok(/\snumbers/.test(err.message));
+    });
+
+    it('allows saving pure $push atomics', async function() {
+      const postSchema = new Schema({
+        numbers: [Number]
+      });
+
+      const B = db.model('Test', postSchema);
+
+      const doc = await B.create({ numbers: [1, 2, 3] });
+      const found = await B.findById(doc._id).select({ numbers: { $slice: -1 } });
+      assert.deepEqual(found.numbers, [3]);
+
+      found.numbers.push(4);
+      await found.save();
+
+      const updated = await B.findById(doc._id).lean();
+      assert.deepEqual(updated.numbers, [1, 2, 3, 4]);
+    });
+
+    it('allows saving pure pull atomics', async function() {
+      const postSchema = new Schema({
+        numbers: [Number]
+      });
+
+      const B = db.model('Test', postSchema);
+
+      const doc = await B.create({ numbers: [1, 2, 3] });
+      const found = await B.findById(doc._id).select({ numbers: { $slice: -2 } });
+      assert.deepEqual(found.numbers, [2, 3]);
+
+      found.numbers.pull(2);
+      await found.save();
+
+      const updated = await B.findById(doc._id).lean();
+      assert.deepEqual(updated.numbers, [1, 3]);
+    });
+
+    it('allows saving pure $pop atomics', async function() {
+      const postSchema = new Schema({
+        numbers: [Number]
+      });
+
+      const B = db.model('Test', postSchema);
+
+      const doc = await B.create({ numbers: [1, 2, 3] });
+      const found = await B.findById(doc._id).select({ numbers: { $slice: -1 } });
+      assert.deepEqual(found.numbers, [3]);
+
+      found.numbers.$pop();
+      await found.save();
+
+      const updated = await B.findById(doc._id).lean();
+      assert.deepEqual(updated.numbers, [1, 2]);
+    });
+
+    it('allows saving pure $addToSet atomics', async function() {
+      const postSchema = new Schema({
+        numbers: [Number]
+      });
+
+      const B = db.model('Test', postSchema);
+
+      const doc = await B.create({ numbers: [1, 2, 3] });
+      const found = await B.findById(doc._id).select({ numbers: { $slice: -1 } });
+      assert.deepEqual(found.numbers, [3]);
+
+      found.numbers.addToSet(4);
+      await found.save();
+
+      const updated = await B.findById(doc._id).lean();
+      assert.deepEqual(updated.numbers, [1, 2, 3, 4]);
     });
   });
 


### PR DESCRIPTION
Fix #2432

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently, if you use a $elemMatch projection and try to save, Mongoose will throw a DivergentArrayError:

```js
const user = await User.create({
    sessions: [{ token: 'one' }, { token: 'two' }]
  });

  const doc = await User.findById(user._id).select({
    sessions: { $elemMatch: { token: 'two' } }
  });

  doc.sessions.push({ token: 'three' });

  // Throws "For your own good, using `document.save()` to update an array which was selected using an $elemMatch or $slice projection OR populated using skip, limit, query conditions, or exclusion of the _id field when the operation results in a $pop or $set of the entire array is not supported. The following path(s) would have been modified unsafely:
  sessions"
  await doc.save().then(() => null, err => err);
```

The crux of #2432 is we should do that for `$slice` as well. But only for `$set` atomics - if `save()` would just `$push` or `$pull` or `$pop` from the array then that won't overwrite the existing array.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
