### PR TITLE
docs: add comment clarifying that CVE-2024-53900 only affects $where

### DIFF
--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -873,7 +873,11 @@ function _findRefPathForDiscriminators(doc, modelSchema, data, options, normaliz
 }
 
 /**
- * Throw an error if there are any $where keys
+ * Throw an error if there are any $where keys to defend against CVE-2024-53900
+ *
+ * Note that this is ONLY for $where because sift executes $where in Node.js memory.
+ * Other forms of MongoDB server-side execution, like $expr, are NOT filtered out.
+ * This function
  */
 
 function throwOn$where(match) {

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -873,7 +873,7 @@ function _findRefPathForDiscriminators(doc, modelSchema, data, options, normaliz
 }
 
 /**
- * Throw an error if there are any $where keys to defend against CVE-2024-53900
+ * Throw an error if there are any $where keys to defend against [CVE-2024-53900](https://nvd.nist.gov/vuln/detail/CVE-2024-53900)
  *
  * Note that this is ONLY for $where because sift executes $where in Node.js memory.
  * Other forms of MongoDB server-side execution, like $expr, are NOT filtered out.

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -877,7 +877,7 @@ function _findRefPathForDiscriminators(doc, modelSchema, data, options, normaliz
  *
  * Note that this is ONLY for $where because sift executes $where in Node.js memory.
  * Other forms of MongoDB server-side execution, like $expr, are NOT filtered out.
- * This function
+ * This function is not meant to protect against server-side execution in MongoDB.
  */
 
 function throwOn$where(match) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

We've been getting AI slop security reports related to https://nvd.nist.gov/vuln/detail/CVE-2024-53900 only covering $where not $expr fairly regularly - Tidelift filters most of them but we still end up fielding at least a couple per month. And frankly it needs to stop. Hopefully this comment helps.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
