### PR TITLE
 fix(query): throw catchable error on circular references in query filters and updates

### DIFF
--- a/lib/helpers/circularReference.js
+++ b/lib/helpers/circularReference.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const MongooseError = require('../error/mongooseError');
+const isPOJO = require('./isPOJO');
+
+/*!
+ * Builds a readable, catchable error for a circular reference detected in a
+ * query filter or update. Mongoose can't serialize a circular structure for
+ * MongoDB, so we throw instead of crashing with an uncatchable
+ * `RangeError: Maximum call stack size exceeded`. See gh-10378.
+ *
+ * @param {String} subject e.g. `'query filter'` or `'update'`
+ * @return {MongooseError}
+ */
+
+exports.circularReferenceError = function circularReferenceError(subject) {
+  return new MongooseError(
+    `The ${subject} contains a circular reference, which Mongoose cannot ` +
+    'serialize into a MongoDB command. Remove the circular reference before ' +
+    'passing it to Mongoose.'
+  );
+};
+
+/*!
+ * Walks `obj` and throws a `MongooseError` if it contains a circular reference.
+ *
+ * Only descends into POJOs and arrays - the structures that cause unbounded
+ * recursion when Mongoose casts a query filter or update - so this never
+ * triggers getters on documents, ObjectIds, etc. Uses ancestor-path tracking
+ * (add on descend, remove on ascend) so shared but acyclic references like
+ * `{ a: x, b: x }` are allowed; only a reference back into its own ancestor
+ * chain throws. See gh-10378.
+ *
+ * @param {Object} obj
+ * @param {String} subject e.g. `'update'`
+ * @api private
+ */
+
+exports.assertNoCircularReference = function assertNoCircularReference(obj, subject) {
+  _assert(obj, subject, []);
+};
+
+function _assert(val, subject, ancestors) {
+  const isArray = Array.isArray(val);
+  if (!isArray && !isPOJO(val)) {
+    return;
+  }
+  if (ancestors.includes(val)) {
+    throw exports.circularReferenceError(subject);
+  }
+
+  ancestors.push(val);
+  if (isArray) {
+    for (let i = 0; i < val.length; ++i) {
+      _assert(val[i], subject, ancestors);
+    }
+  } else {
+    const keys = Object.keys(val);
+    for (let i = 0; i < keys.length; ++i) {
+      _assert(val[keys[i]], subject, ancestors);
+    }
+  }
+  ancestors.pop();
+}

--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -7,6 +7,7 @@ const applyTimestampsToUpdate = require('../update/applyTimestampsToUpdate');
 const cast = require('../../cast');
 const castUpdate = require('../query/castUpdate');
 const clone = require('../clone');
+const { assertNoCircularReference } = require('../circularReference');
 const decorateUpdateWithVersionKey = require('../update/decorateUpdateWithVersionKey');
 const { inspect } = require('util');
 const setDefaultsOnInsert = require('../setDefaultsOnInsert');
@@ -21,6 +22,12 @@ const setDefaultsOnInsert = require('../setDefaultsOnInsert');
  */
 
 module.exports = function castBulkWrite(originalModel, op, options) {
+  // Throw a readable, catchable error up front if the operation (filter,
+  // update, replacement, or document) has a circular reference, instead of
+  // later crashing with an uncatchable `RangeError: Maximum call stack size
+  // exceeded` while cloning. See gh-10378.
+  assertNoCircularReference(op, 'bulkWrite operation');
+
   let now;
   const timestampOpts = originalModel.schema.get('timestamps');
   if (typeof timestampOpts?.currentTime === 'function') {

--- a/lib/model.js
+++ b/lib/model.js
@@ -37,6 +37,7 @@ const applyVirtualsHelper = require('./helpers/document/applyVirtuals');
 const assignVals = require('./helpers/populate/assignVals');
 const castBulkWrite = require('./helpers/model/castBulkWrite');
 const clone = require('./helpers/clone');
+const { assertNoCircularReference } = require('./helpers/circularReference');
 const createPopulateQueryFilter = require('./helpers/populate/createPopulateQueryFilter');
 const decorateUpdateWithVersionKey = require('./helpers/update/decorateUpdateWithVersionKey');
 const getDefaultBulkwriteResult = require('./helpers/getDefaultBulkwriteResult');
@@ -4106,6 +4107,10 @@ function _update(model, op, conditions, doc, options) {
   if (conditions instanceof Document) {
     conditions = conditions.toObject();
   } else {
+    // Detect circular references before the deep clone below so we throw a
+    // readable, catchable error instead of crashing with a stack overflow.
+    // See gh-10378.
+    assertNoCircularReference(conditions, 'query filter');
     conditions = clone(conditions);
   }
   options = typeof options === 'function' ? options : clone(options);

--- a/lib/query.js
+++ b/lib/query.js
@@ -20,6 +20,7 @@ const castArrayFilters = require('./helpers/update/castArrayFilters');
 const castNumber = require('./cast/number');
 const castUpdate = require('./helpers/query/castUpdate');
 const clone = require('./helpers/clone');
+const { assertNoCircularReference } = require('./helpers/circularReference');
 const decorateUpdateWithVersionKey = require('./helpers/update/decorateUpdateWithVersionKey');
 const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminatorByValue');
 const helpers = require('./queryHelpers');
@@ -4104,6 +4105,10 @@ function _completeManyLean(schema, docs, path, opts) {
  */
 
 Query.prototype._mergeUpdate = function(update) {
+  // Throw a readable, catchable error if the incoming update has a circular
+  // reference, instead of later crashing with `RangeError: Maximum call stack
+  // size exceeded` while cloning. See gh-10378.
+  assertNoCircularReference(update, 'update');
   _cloneUpdateIfShared(this);
 
   const updatePipeline = this._mongooseOptions.updatePipeline;
@@ -4550,6 +4555,11 @@ function _update(query, op, filter, doc, options, callback) {
   // make sure we don't send in the whole Document to merge()
   query.op = op;
   doc = doc || {};
+
+  // Throw a readable, catchable error up front if the update/replacement has a
+  // circular reference, instead of later crashing with an uncatchable
+  // `RangeError: Maximum call stack size exceeded` while cloning. See gh-10378.
+  assertNoCircularReference(doc, 'update');
 
   // strict is an option used in the update checking, make sure it gets set
   if (options != null) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,7 @@ const isMongooseObject = require('./helpers/isMongooseObject');
 const schemaMerge = require('./helpers/schema/merge');
 const specialProperties = require('./helpers/specialProperties');
 const { trustedSymbol } = require('./helpers/query/trusted');
+const { circularReferenceError } = require('./helpers/circularReference');
 
 let Document;
 
@@ -246,7 +247,7 @@ exports.omit = function omit(obj, keys) {
  * @returns
 */
 
-exports.clonePOJOsAndArrays = function clonePOJOsAndArrays(val) {
+exports.clonePOJOsAndArrays = function clonePOJOsAndArrays(val, ancestors) {
   if (val == null) {
     return val;
   }
@@ -254,18 +255,38 @@ exports.clonePOJOsAndArrays = function clonePOJOsAndArrays(val) {
   if (val.$__ != null) {
     return val;
   }
+  // Track the current ancestor path so a circular reference throws a readable,
+  // catchable error instead of crashing with `RangeError: Maximum call stack
+  // size exceeded`. Entries are removed on ascend, so shared but acyclic
+  // references (e.g. `{ a: x, b: x }`) are still cloned. Query filters are
+  // shallow, so the linear `includes()` scan adds negligible overhead and
+  // avoids the cost of allocating a `Set` per clone. See gh-10378.
   if (isPOJO(val)) {
+    if (ancestors === undefined) {
+      ancestors = [];
+    } else if (ancestors.includes(val)) {
+      throw circularReferenceError('query filter');
+    }
+    ancestors.push(val);
     val = { ...val };
     for (const key of Object.keys(val)) {
-      val[key] = exports.clonePOJOsAndArrays(val[key]);
+      val[key] = exports.clonePOJOsAndArrays(val[key], ancestors);
     }
+    ancestors.pop();
     return val;
   }
   if (Array.isArray(val)) {
+    if (ancestors === undefined) {
+      ancestors = [];
+    } else if (ancestors.includes(val)) {
+      throw circularReferenceError('query filter');
+    }
+    ancestors.push(val);
     val = [...val];
     for (let i = 0; i < val.length; ++i) {
-      val[i] = exports.clonePOJOsAndArrays(val[i]);
+      val[i] = exports.clonePOJOsAndArrays(val[i], ancestors);
     }
+    ancestors.pop();
     return val;
   }
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -10037,3 +10037,85 @@ function pick(obj, keys) {
   }
   return newObj;
 }
+
+describe('circular references in query filters and updates (gh-10378)', function() {
+  let db;
+  let Test;
+
+  before(function() {
+    db = start();
+    Test = db.model('Test', new Schema({ name: String, age: Number }, { strict: false }));
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  beforeEach(async function() {
+    await Test.deleteMany({});
+  });
+
+  // A throwable, catchable MongooseError instead of an uncatchable
+  // `RangeError: Maximum call stack size exceeded`. The check runs while the
+  // query/operation is built, which may be synchronous, so wrap each call in a
+  // thunk that `assert.rejects` can run for both sync throws and async rejects.
+  const circularError = { name: 'MongooseError', message: /circular reference/ };
+  const rejects = (fn) => assert.rejects(async() => { await fn(); }, circularError);
+  function circular() {
+    const obj = { name: 'test' };
+    obj.self = obj;
+    return obj;
+  }
+
+  it('throws a catchable error on a circular query filter', async function() {
+    await rejects(() => Test.find(circular()));
+    await rejects(() => Test.findOne(circular()));
+    await rejects(() => Test.countDocuments(circular()));
+    await rejects(() => Test.deleteOne(circular()));
+    await rejects(() => Test.find().where(circular()));
+  });
+
+  it('throws a catchable error on a circular update', async function() {
+    await rejects(() => Test.updateOne({}, { $set: circular() }));
+    await rejects(() => Test.updateOne({}, circular()));
+    await rejects(() => Test.updateMany({}, { $set: circular() }));
+    await rejects(() => Test.findOneAndUpdate({}, circular()));
+    await rejects(() => Test.replaceOne({}, circular()));
+  });
+
+  it('throws a catchable error on a circular filter for update operations', async function() {
+    await rejects(() => Test.updateOne(circular(), { $set: { age: 1 } }));
+    await rejects(() => Test.findOneAndUpdate(circular(), { age: 1 }));
+    await rejects(() => Test.findOneAndDelete(circular()));
+  });
+
+  it('throws a catchable error on a circular bulkWrite operation', async function() {
+    await rejects(() => Test.bulkWrite([{ updateOne: { filter: {}, update: { $set: circular() } } }]));
+    await rejects(() => Test.bulkWrite([{ replaceOne: { filter: {}, replacement: circular() } }]));
+    await rejects(() => Test.bulkWrite([{ updateOne: { filter: circular(), update: { $set: { age: 1 } } } }]));
+  });
+
+  it('throws a catchable error from document update helpers', async function() {
+    const doc = await Test.create({ name: 'test', age: 1 });
+    await rejects(() => doc.updateOne(circular()));
+    await rejects(() => doc.updateOne({ $set: circular() }));
+    await rejects(() => doc.replaceOne(circular()));
+  });
+
+  it('allows shared but acyclic references (not circular)', async function() {
+    const shared = { age: 1 };
+    const sharedArray = [1, 2, 3];
+
+    // Same object referenced from multiple keys is a DAG, not a cycle.
+    await Test.find({ $or: [shared, shared] });
+    await Test.find({ age: { $in: sharedArray }, x: { $nin: sharedArray } });
+    await Test.updateOne({}, { $set: { a: shared, b: shared } });
+
+    // Sanity check that ordinary deeply nested filters/updates still work.
+    await Test.find({ a: { b: { c: { d: 1 } } } });
+    const doc = await Test.create({ name: 'ok', age: 2 });
+    await Test.updateOne({ _id: doc._id }, { $set: { age: 3 } });
+    const updated = await Test.findById(doc._id);
+    assert.equal(updated.age, 3);
+  });
+});


### PR DESCRIPTION
Fixes #10378

**Summary**

Passing a structure with a circular reference as a **query filter** or an
**update** currently crashes Mongoose with an *uncatchable*
`RangeError: Maximum call stack size exceeded` while cloning the input. The
stack trace points at an internal file (e.g. `clonePOJOsAndArrays` / `clone`)
and gives no indication that the real problem is a circular reference, so it's
hard to diagnose and impossible to handle gracefully.

As discussed in the issue, a circular structure can't be serialized into a
MongoDB command, so the correct behavior is to **detect the cycle and throw a
readable, catchable `MongooseError`** rather than crash.

This PR adds a small shared helper (`lib/helpers/circularReference.js`) that
builds the error and walks filters/updates using **ancestor-path tracking**
(entries are removed on ascend), so shared-but-acyclic references such as
`{ a: x, b: x }` are still allowed — only a reference back into its own ancestor
chain throws.

The guard is added at the points where user-supplied data enters the
clone/cast pipeline, so the hot `clone()` path is left untouched and document
hydration pays no cost:

- `utils.clonePOJOsAndArrays` — query filters (`find`/`findOne`/`countDocuments`/`deleteOne`/etc.)
- `Query.prototype._mergeUpdate` and the shared `_update` helper — updates (`updateOne`/`updateMany`/`replaceOne`/`findOneAndUpdate` and the `doc.*` variants)
- `Model._update` — filters for update operations
- `castBulkWrite` — `bulkWrite` operations

**Addressing the previous attempts:**

- #11451 (perf concern): the check never touches `clone()`. For the filter path
  it uses a linear ancestor stack rather than a `Set` — query filters are
  shallow, so `includes()` benchmarks at **~+7%** vs **~+104%** for a per-clone
  `WeakSet`.
- #16156 (closed for unrelated changes): this is a focused diff (6 files,
  +192/-3) with no reformatting or unrelated edits.

**Note on timing:** the error is thrown *synchronously* at query/operation
construction (matching the original `RangeError`'s timing), not as a promise
rejection on `.exec()`. It is fully catchable via `try/catch` and `await`.

**Examples**

```js
const obj = { name: 'test' };
obj.self = obj; // circular reference

// Before: RangeError: Maximum call stack size exceeded  (uncatchable, points at clonePOJOsAndArrays)
// After:  MongooseError: The query filter contains a circular reference, which
//         Mongoose cannot serialize into a MongoDB command. Remove the circular
//         reference before passing it to Mongoose.
await Model.find(obj);

// Same readable, catchable error for updates and bulkWrite:
await Model.updateOne({}, { $set: obj });
await Model.bulkWrite([{ updateOne: { filter: {}, update: { $set: obj } } }]);

// Shared but acyclic references (a DAG, not a cycle) are still allowed:
const shared = { age: 1 };
await Model.find({ $or: [shared, shared] }); // works
```

A `gh-10378` test block was added in `test/model.test.js` covering circular
filters, updates, update-operation filters, `bulkWrite`, and `doc.*` helpers
(each asserting a catchable `MongooseError`), plus explicit coverage that
shared-but-acyclic references do **not** throw.
