### PR TITLE
types: cast primitive types within unions when applying create casting

### DIFF
--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -208,6 +208,27 @@ async function createWithRawDocTypeNo_id() {
   expect(doc2._id).type.toBe<Types.ObjectId>();
 }
 
+async function createWithPopulatedDoc() {
+  interface User {
+    dummy: string;
+  }
+
+  interface Other {
+    to: mongoose.PopulatedDoc<User>;
+  }
+
+  const userSchema = new mongoose.Schema({ dummy: String });
+  const userModel = mongoose.model<User>('TestCreateWithPopulatedDocUser', userSchema);
+
+  const otherSchema = new mongoose.Schema({ to: { type: mongoose.Types.ObjectId, ref: 'TestCreateWithPopulatedDocUser' } });
+  const otherModel = mongoose.model<Other>('TestCreateWithPopulatedDocOther', otherSchema);
+
+  const user = await userModel.create({ dummy: 'hello' });
+  const other = await otherModel.create({ to: user._id.toString() });
+
+  expect(other.to).type.toBe<mongoose.PopulatedDoc<User>>();
+}
+
 createWithAggregateErrors();
 
 async function gh15902() {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -227,15 +227,15 @@ declare module 'mongoose' {
   type CreateObjectWithExtraKeys<T> = T & Record<string, unknown>;
   type ApplyBasicCreateCasting<T> = {
     [K in keyof T]: NonNullable<T[K]> extends Map<infer KeyType extends string, infer ValueType>
-      ? (Record<KeyType, ValueType> | Array<[KeyType, ValueType]> | T[K])
+      ? (Record<KeyType, ValueType> | Array<[KeyType, ValueType]> | T[K] | QueryTypeCasting<Extract<T[K], TreatAsPrimitives>>)
       : NonNullable<T[K]> extends Types.DocumentArray<infer RawSubdocType>
-         ? RawSubdocType[] | T[K]
+         ? RawSubdocType[] | T[K] | QueryTypeCasting<Extract<T[K], TreatAsPrimitives>>
          : NonNullable<T[K]> extends Document<any, any, infer RawSubdocType>
-           ? CreateObjectWithExtraKeys<ApplyBasicCreateCasting<RawSubdocType>> | T[K]
+           ? CreateObjectWithExtraKeys<ApplyBasicCreateCasting<RawSubdocType>> | T[K] | QueryTypeCasting<Extract<T[K], TreatAsPrimitives>>
            : NonNullable<T[K]> extends TreatAsPrimitives
               ? QueryTypeCasting<T[K]>
               : NonNullable<T[K]> extends object
-                ? CreateObjectWithExtraKeys<ApplyBasicCreateCasting<T[K]>> | T[K]
+                ? CreateObjectWithExtraKeys<ApplyBasicCreateCasting<T[K]>> | T[K] | QueryTypeCasting<Extract<T[K], TreatAsPrimitives>>
                 : QueryTypeCasting<T[K]>;
   };
 


### PR DESCRIPTION
Fix #16316

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`PopulatedDoc` is a union of an object type and a `TreatAsPrimitives` type. `create()` parameter casting needs to handle both the object type and the primitive type.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
