### PR TITLE
style(model): fix link to be absolute

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4352,7 +4352,7 @@ Model.validate = async function validate(obj, pathsOrOptions, context) {
 
 /**
  * Standard Schema adapter for this model.
- * Calls [`Model.validate()`](#Model.validate()) internally with the provided `libraryOptions`
+ * Calls [`Model.validate()`](https://mongoosejs.com/docs/api/model.html#Model.validate()) internally with the provided `libraryOptions`
  * to cast and validate the given value.
  *
  * @api public


### PR DESCRIPTION
**Summary**

This follows the link style we usually use.
This allows the links to be automatically replaced by the website generation, but also work for raw JSDoc.

re #16308