### PR TITLE
Drop `lodash.isEqual` dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "glob": "^13.0.6",
     "highlight.js": "11.11.1",
     "linkinator": "7.x",
-    "lodash.isequal": "4.5.0",
     "lodash.isequalwith": "4.4.0",
     "markdownlint-cli2": "0.22.1",
     "marked": "18.0.4",

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -14,7 +14,6 @@ const utils = require('../lib/utils');
 const Schema = mongoose.Schema;
 const ObjectId = Schema.Types.ObjectId;
 const DocumentObjectId = mongoose.Types.ObjectId;
-const isEqual = require('lodash.isequal');
 const { isDeepStrictEqual } = require('util');
 const isEqualWith = require('lodash.isequalwith');
 const util = require('./util');
@@ -784,10 +783,6 @@ describe('model: findOneAndUpdate:', function() {
     assert.deepEqual(doc.contacts[0].account, a2._id);
     assert.ok(utils.deepEqual(doc.contacts[0].account, a2._id));
     assert.ok(isEqualWith(doc.contacts[0].account, a2._id, compareBuffers));
-    // Re: commends on https://github.com/mongodb/js-bson/commit/aa0b54597a0af28cce3530d2144af708e4b66bf0
-    // Deep equality checks no longer work as expected with node 0.10.
-    // Please file an issue if this is a problem for you
-    assert.ok(isEqual(doc.contacts[0].account, a2._id));
     assert.ok(isDeepStrictEqual(doc.contacts[0].account, a2._id));
 
     const doc2 = await User.findOne({ name: 'parent' });
@@ -795,7 +790,6 @@ describe('model: findOneAndUpdate:', function() {
     assert.deepEqual(doc2.contacts[0].account, a2._id);
     assert.ok(utils.deepEqual(doc2.contacts[0].account, a2._id));
     assert.ok(isEqualWith(doc2.contacts[0].account, a2._id, compareBuffers));
-    assert.ok(isEqual(doc2.contacts[0].account, a2._id));
     assert.ok(isDeepStrictEqual(doc2.contacts[0].account, a2._id));
 
     function compareBuffers(a, b) {

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -780,14 +780,12 @@ describe('model: findOneAndUpdate:', function() {
     );
 
     assert.deepEqual(doc.contacts[0].account, a2._id);
-    assert.ok(utils.deepEqual(doc.contacts[0].account, a2._id));
     assert.ok(isEqualWith(doc.contacts[0].account, a2._id, compareBuffers));
     assert.deepStrictEqual(doc.contacts[0].account, a2._id);
 
     const doc2 = await User.findOne({ name: 'parent' });
 
     assert.deepEqual(doc2.contacts[0].account, a2._id);
-    assert.ok(utils.deepEqual(doc2.contacts[0].account, a2._id));
     assert.ok(isEqualWith(doc2.contacts[0].account, a2._id, compareBuffers));
     assert.deepStrictEqual(doc2.contacts[0].account, a2._id);
 

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -14,7 +14,6 @@ const utils = require('../lib/utils');
 const Schema = mongoose.Schema;
 const ObjectId = Schema.Types.ObjectId;
 const DocumentObjectId = mongoose.Types.ObjectId;
-const { isDeepStrictEqual } = require('util');
 const isEqualWith = require('lodash.isequalwith');
 const util = require('./util');
 const uuid = require('uuid');
@@ -783,14 +782,14 @@ describe('model: findOneAndUpdate:', function() {
     assert.deepEqual(doc.contacts[0].account, a2._id);
     assert.ok(utils.deepEqual(doc.contacts[0].account, a2._id));
     assert.ok(isEqualWith(doc.contacts[0].account, a2._id, compareBuffers));
-    assert.ok(isDeepStrictEqual(doc.contacts[0].account, a2._id));
+    assert.deepStrictEqual(doc.contacts[0].account, a2._id);
 
     const doc2 = await User.findOne({ name: 'parent' });
 
     assert.deepEqual(doc2.contacts[0].account, a2._id);
     assert.ok(utils.deepEqual(doc2.contacts[0].account, a2._id));
     assert.ok(isEqualWith(doc2.contacts[0].account, a2._id, compareBuffers));
-    assert.ok(isDeepStrictEqual(doc2.contacts[0].account, a2._id));
+    assert.deepStrictEqual(doc2.contacts[0].account, a2._id);
 
     function compareBuffers(a, b) {
       if (Buffer.isBuffer(a) && Buffer.isBuffer(b)) {


### PR DESCRIPTION
**Summary**

This PR drops the `lodash.isEqual` dependency in favor of nodejs native `deepStrictEqual` due to the package itself reporting to not be used anymore:

> npm warn deprecated lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.

Also changes:
- the `assert.ok(util.deepStrictEqual())` to just `assert.deepStrictEqual` as that should provide better errors on fail.
- Drop double compares of the same value
