### PR TITLE
chore(express): update to 5.2.1

### DIFF
--- a/docs/tutorials/findoneandupdate.md
+++ b/docs/tutorials/findoneandupdate.md
@@ -74,8 +74,6 @@ Use `$unset` if you want to remove a property from the document.
 
 ```javascript acquit:Tutorial.*findOneAndUpdate.*strips undefined from updates
 const filter = { name: 'Jean-Luc Picard' };
-// Equivalent to `{ $set: { age: 59 } }`
-// `name: undefined` is ignored.
 const update = {
   $set: {
     name: undefined,
@@ -86,9 +84,7 @@ const update = {
 const doc = await Character.findOneAndUpdate(filter, update, {
   returnDocument: 'after'
 });
-// Name is **not** updated
 doc.name; // 'Jean-Luc Picard'
-// Age is updated
 doc.age; // 59
 ```
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dox": "1.0.0",
     "eslint": "10.4.1",
     "eslint-plugin-mocha-no-only": "1.2.0",
-    "express": "4.22.1",
+    "express": "5.2.1",
     "fs-extra": "~11.3.0",
     "globals": "^17.4.0",
     "glob": "^13.0.6",


### PR DESCRIPTION
**Summary**

This fixes a "npm audit" warning:

> ```text
> qs  6.11.1 - 6.15.1
>Severity: moderate
>qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays >when encodeValuesOnly is set - https://github.com/advisories/GHSA-q8mj-m7cp-5q26
>fix available via `npm audit fix --force`
>Will install express@4.22.2, which is outside the stated dependency range
>node_modules/qs
>  express  4.21.0 - 4.22.1 || 5.0.0-alpha.1 - 5.0.1
>  Depends on vulnerable versions of qs
>  node_modules/express
> ```

Now the only remaining audit warning is about `markdown-it`, which has a major version fix, but would require updates to `dox` and `markdown-cli2`.