### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
           path: ~/.cache/mongodb-binaries
           key: deno-${{ env.MONGOMS_VERSION }}
       - name: Setup Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.1.x
       - run: deno --version
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup AtlasCLI
-        uses: mongodb/atlas-github-action@v0.2.2
+        uses: mongodb/atlas-github-action@e3c9e0204659bafbb3b65e1eb1ee745cca0e9f3b # v0.2.2
       - name: Setup local Atlas deployment
         run: atlas deployments setup mycluster --type local --force --port 27017
       - name: Setup node


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 2
- Repo-level unpinned usage count from the trunk recheck: 2
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)


Verification commands:

```bash
# denoland/setup-deno # v2.0.4 -> 667a34cdef165d8d2b2e98dde39547c9daac7282
gh api repos/denoland/setup-deno/commits/v2.0.4 --jq '.sha'
# expected: 667a34cdef165d8d2b2e98dde39547c9daac7282

# mongodb/atlas-github-action # v0.2.2 -> e3c9e0204659bafbb3b65e1eb1ee745cca0e9f3b
gh api repos/mongodb/atlas-github-action/commits/v0.2.2 --jq '.sha'
# expected: e3c9e0204659bafbb3b65e1eb1ee745cca0e9f3b
```
