### PR TITLE
docs: point "Edit this page" links to the GitHub editor

### DIFF
--- a/docs/source/api.js
+++ b/docs/source/api.js
@@ -455,7 +455,7 @@ function processFile(props) {
   }
 
   data.file = props.file;
-  data.editLink = 'https://github.com/Automattic/mongoose/blob/master/' +
+  data.editLink = 'https://github.com/Automattic/mongoose/edit/master/' +
       props.file;
 
   out.set(data.file, data);

--- a/scripts/website.js
+++ b/scripts/website.js
@@ -461,7 +461,7 @@ async function renderFile(filename, options, isReload = false) {
   options.package = pkg;
   let markdownSource = null;
 
-  const _editLink = 'https://github.com/Automattic/mongoose/blob/master' +
+  const _editLink = 'https://github.com/Automattic/mongoose/edit/master' +
     filename.replace(cwd, '');
   options.editLink = options.editLink || _editLink;
 


### PR DESCRIPTION
Changes the edit links on docs pages from `blob/master` to `edit/master`, so clicking "Edit this page" opens the file in GitHub's editor instead of the read-only view. Covers both the API reference pages (`docs/source/api.js`) and the guide pages (`scripts/website.js`).