### PR TITLE
docs(home): center version and GitHub buttons on homepage

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -228,22 +228,18 @@ h2 a {
 }
 #follow {
   margin-bottom: 36px;
-  margin-left: 109px;
 }
 #follow ul {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
   height: 26px;
+  padding: 0;
 }
 #follow li {
-  display: inline-block;
+  display: flex;
   font-size: 12px;
-  margin-right: 12px;
-}
-#follow #version {
-  margin: 0 29px 0 10px;
-}
-#follow #version span {
-  position: relative;
-  top: -4px;
 }
 /* GitHub buttons iframe - use filter to invert colors in dark mode */
 .github-btn {
@@ -352,12 +348,8 @@ h2 a {
     font-size: 15px;
   }
   #follow, #docs { margin-left: 0; }
-  #follow ul { padding-left: 15px }
+  #follow ul { gap: 12px }
   #follow li { margin-right: 0px }
-  #follow #version {
-    margin-left: 5px;
-    margin-right: 15px;
-  }
   .module {
     padding-left: 5px;
     border-width: 3px;

--- a/index.pug
+++ b/index.pug
@@ -70,12 +70,12 @@ html(lang='en')
       #follow
         ul
           li
-            iframe(class="github-btn", src="//ghbtns.com/github-btn.html?user=Automattic&repo=mongoose&type=watch&count=true", allowtransparency="true", frameborder="0", scrolling="0", width="100px", height="20px")
+            iframe(class="github-btn", src="//ghbtns.com/github-btn.html?user=Automattic&repo=mongoose&type=watch&count=true", allowtransparency="true", frameborder="0", scrolling="0", width="109px", height="20px")
           li#version
             span
               | Version #{package.version}
           li
-            iframe(class="github-btn", src="//ghbtns.com/github-btn.html?user=Automattic&repo=mongoose&type=fork&count=true", allowtransparency="true", frameborder="0", scrolling="0", width="100px", height="20px")
+            iframe(class="github-btn", src="//ghbtns.com/github-btn.html?user=Automattic&repo=mongoose&type=fork&count=true", allowtransparency="true", frameborder="0", scrolling="0", width="103px", height="20px")
 
       #inner
         #what


### PR DESCRIPTION
The "Version X" text on the home page wasn't actually centered between the Star and Fork buttons, the row was positioned with magic offsets (`margin-left: 109px`, asymmetric margins, a `top: -4px` hack). The ghbtns iframes were also 100px wide while the Star button with the current star count needs 107px, so the count box was getting clipped.

This PR centers the row with flexbox instead, and widens the iframes to fit their rendered content (109px Star, 103px Fork) so the counts aren't clipped. Visual-only change.

<details>
<summary>Before</summary>

<img width="750" height="552" alt="image" src="https://github.com/user-attachments/assets/95a43ac1-8886-45a2-a881-33a7ce7982fa" />


</details>

<details>
<summary>After</summary>

<img width="749" height="548" alt="image" src="https://github.com/user-attachments/assets/4b4a9f08-9955-4b70-846e-34bdf4926dfa" />


</details>
