### PR TITLE
docs: allow generated llms.txt and docs/api markdown on gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ package-lock.json
 #docs/tutorials/*.html
 #docs/typescript/*.html
 #docs/api/*.html
+#docs/api/*.md
+#/llms.txt
 # the below excludes things like "0test.x" too, but gitignore does not have something like js regex "[0-9]+", so this is the best for future versions
 # docs/[0-9]*.x/
 #index.html


### PR DESCRIPTION
Companion to #16329 that gitignores the generated `docs/api/*.md` files and top-level `llms.txt`.

gh-pages keeps the compiled docs ignore rules commented out so generated files stay trackable here. This adds the two new patterns to that commented block ahead of time, so when master gets merged into gh-pages the resolution is already in place. Without this, the active ignore rules could land here and newly added API pages's `.md` files would be silently skipped by `git add` on future deploys.