### PR TITLE
fix(populate): split up giant populate filters (>50k elements) to minimize risk of BSON errors

### DIFF
--- a/lib/helpers/populate/checkForGiantPopulateFilters.js
+++ b/lib/helpers/populate/checkForGiantPopulateFilters.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = function checkForGiantPopulateFilters(params) {
+  const maxFilterLength = module.exports.maxFilterLength;
+  if (typeof maxFilterLength !== 'number' || maxFilterLength <= 0) {
+    return params;
+  }
+
+  const ret = [];
+  for (const param of params) {
+    const match = param[1];
+    let foreignField = null;
+    let ids = null;
+
+    for (const field of param[0].foreignField) {
+      if (Array.isArray(match[field]?.$in)) {
+        foreignField = field;
+        ids = match[field].$in;
+        break;
+      }
+    }
+
+    if (!Array.isArray(ids) || ids.length <= maxFilterLength) {
+      ret.push(param);
+      continue;
+    }
+
+    for (let i = 0; i < ids.length; i += maxFilterLength) {
+      ret.push(createSplitParam(param, match, foreignField, ids.slice(i, i + maxFilterLength)));
+    }
+  }
+
+  return ret;
+};
+
+// Max 50k $in elements - 800k ObjectIds or so can fit into the 16MB document size limit.
+// Keep a lower limit to reduce risk of running into BSON size limits. Not foolproof: if
+// ids are long strings or buffers then this may still be over 16MB. But the performance
+// overhead of calculating the size of a large array is massive relative to simply checking
+// the array length.
+module.exports.maxFilterLength = 50000;
+
+function createSplitParam(param, match, foreignField, ids) {
+  const newParam = param.slice();
+  newParam[1] = Object.assign({}, match);
+  newParam[1][foreignField] = Object.assign({}, match[foreignField], {
+    $in: ids
+  });
+  return newParam;
+}

--- a/lib/helpers/populate/checkForGiantPopulateFilters.js
+++ b/lib/helpers/populate/checkForGiantPopulateFilters.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const parentPaths = require('../path/parentPaths');
+
 /**
  * Split populate query params that have an oversized `$in` filter on the
  * populated foreign field. Prevents Mongoose from creating a single enormous
@@ -20,24 +22,81 @@ module.exports = function checkForGiantPopulateFilters(params) {
   for (const param of params) {
     const match = param[1];
     let foreignField = null;
-    let ids = null;
 
     for (const field of param[0].foreignField) {
       if (Array.isArray(match[field]?.$in)) {
         foreignField = field;
-        ids = match[field].$in;
         break;
       }
     }
 
-    if (!Array.isArray(ids) || ids.length <= maxFilterLength) {
-      ret.push(param);
-      continue;
+    if (foreignField != null) {
+      const ids = match[foreignField].$in;
+
+      if (ids.length > maxFilterLength) {
+        for (let i = 0; i < ids.length; i += maxFilterLength) {
+          ret.push(createSplitParam(param, match, foreignField, ids.slice(i, i + maxFilterLength)));
+        }
+        continue;
+      }
     }
 
-    for (let i = 0; i < ids.length; i += maxFilterLength) {
-      ret.push(createSplitParam(param, match, foreignField, ids.slice(i, i + maxFilterLength)));
+    if (Array.isArray(match.$or)) {
+      const orBranches = match.$or.map(branch => {
+        for (const field of param[0].foreignField) {
+          if (Array.isArray(branch[field]?.$in)) {
+            return field;
+          }
+        }
+        return null;
+      });
+      const ids = orBranches.length > 0 && orBranches[0] != null ? match.$or[0][orBranches[0]].$in : null;
+
+      if (ids != null && orBranches.every(field => field != null) && ids.length > maxFilterLength) {
+        for (let i = 0; i < ids.length; i += maxFilterLength) {
+          ret.push(createSplitParamWithOr(param, match, orBranches, i, i + maxFilterLength));
+        }
+        continue;
+      }
     }
+
+    let elemMatchParentPath = null;
+    let elemMatchForeignField = null;
+
+    for (const field of param[0].foreignField) {
+      const paths = parentPaths(field);
+      for (let i = 0; i < paths.length - 1; ++i) {
+        const cur = paths[i];
+        const remnant = field.slice(cur.length + 1);
+        if (Array.isArray(match[cur]?.$elemMatch?.[remnant]?.$in)) {
+          elemMatchParentPath = cur;
+          elemMatchForeignField = remnant;
+          break;
+        }
+      }
+      if (elemMatchParentPath != null) {
+        break;
+      }
+    }
+
+    if (elemMatchParentPath != null) {
+      const ids = match[elemMatchParentPath].$elemMatch[elemMatchForeignField].$in;
+
+      if (ids.length > maxFilterLength) {
+        for (let i = 0; i < ids.length; i += maxFilterLength) {
+          ret.push(createSplitParamWithElemMatch(
+            param,
+            match,
+            elemMatchParentPath,
+            elemMatchForeignField,
+            ids.slice(i, i + maxFilterLength)
+          ));
+        }
+        continue;
+      }
+    }
+
+    ret.push(param);
   }
 
   return ret;
@@ -62,6 +121,33 @@ function createSplitParam(param, match, foreignField, ids) {
   newParam[1] = Object.assign({}, match);
   newParam[1][foreignField] = Object.assign({}, match[foreignField], {
     $in: ids
+  });
+  return newParam;
+}
+
+function createSplitParamWithElemMatch(param, match, elemMatchParentPath, elemMatchForeignField, ids) {
+  const newParam = param.slice();
+  newParam[1] = Object.assign({}, match);
+  newParam[1][elemMatchParentPath] = Object.assign({}, match[elemMatchParentPath], {
+    $elemMatch: Object.assign({}, match[elemMatchParentPath].$elemMatch, {
+      [elemMatchForeignField]: Object.assign({}, match[elemMatchParentPath].$elemMatch[elemMatchForeignField], {
+        $in: ids
+      })
+    })
+  });
+  return newParam;
+}
+
+function createSplitParamWithOr(param, match, orBranches, start, end) {
+  const newParam = param.slice();
+  newParam[1] = Object.assign({}, match);
+  newParam[1].$or = match.$or.map((branch, index) => {
+    const foreignField = orBranches[index];
+    return Object.assign({}, branch, {
+      [foreignField]: Object.assign({}, branch[foreignField], {
+        $in: branch[foreignField].$in.slice(start, end)
+      })
+    });
   });
   return newParam;
 }

--- a/lib/helpers/populate/checkForGiantPopulateFilters.js
+++ b/lib/helpers/populate/checkForGiantPopulateFilters.js
@@ -1,5 +1,15 @@
 'use strict';
 
+/**
+ * Split populate query params that have an oversized `$in` filter on the
+ * populated foreign field. Prevents Mongoose from creating a single enormous
+ * populate query with hundreds of thousands of ids.
+ *
+ * @param {Array} params array of populate query params: [mod, match, select, assignmentOpts]
+ * @returns {Array} original params plus any split params needed for large `$in` filters
+ * @api private
+ */
+
 module.exports = function checkForGiantPopulateFilters(params) {
   const maxFilterLength = module.exports.maxFilterLength;
   if (typeof maxFilterLength !== 'number' || maxFilterLength <= 0) {
@@ -33,11 +43,18 @@ module.exports = function checkForGiantPopulateFilters(params) {
   return ret;
 };
 
-// Max 50k $in elements - 800k ObjectIds or so can fit into the 16MB document size limit.
-// Keep a lower limit to reduce risk of running into BSON size limits. Not foolproof: if
-// ids are long strings or buffers then this may still be over 16MB. But the performance
-// overhead of calculating the size of a large array is massive relative to simply checking
-// the array length.
+/**
+ * Max 50k `$in` elements. About 800k ObjectIds can fit into the 16MB document
+ * size limit, so this lower limit reduces the risk of running into BSON size
+ * limits. Not foolproof: long strings or buffers may still exceed 16MB. But
+ * benchmarks/populateFilterSize.js showed the performance overhead of
+ * calculating byte size for large arrays is massive relative to checking length.
+ *
+ * @property maxFilterLength
+ * @memberOf checkForGiantPopulateFilters
+ * @api private
+ */
+
 module.exports.maxFilterLength = 50000;
 
 function createSplitParam(param, match, foreignField, ids) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -40,6 +40,7 @@ const applyWriteConcern = require('./helpers/schema/applyWriteConcern');
 const applyVirtualsHelper = require('./helpers/document/applyVirtuals');
 const assignVals = require('./helpers/populate/assignVals');
 const castBulkWrite = require('./helpers/model/castBulkWrite');
+const checkForGiantPopulateFilters = require('./helpers/populate/checkForGiantPopulateFilters');
 const clone = require('./helpers/clone');
 const convertErrorToStandardSchemaIssues = require('./standardSchema/convertErrorToIssues');
 const createPopulateQueryFilter = require('./helpers/populate/createPopulateQueryFilter');
@@ -4584,12 +4585,13 @@ async function _populatePath(model, docs, populateOptions) {
 
   // Track deferred populates per-param (per model) to avoid mixing them
   const deferredPopulatesPerParam = new Map();
+  const paramsForPopulate = checkForGiantPopulateFilters(params);
 
   if (populateOptions.ordered) {
     // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
     // one transaction in parallel.
-    for (let i = 0; i < params.length; i++) {
-      const arr = params[i];
+    for (let i = 0; i < paramsForPopulate.length; i++) {
+      const arr = paramsForPopulate[i];
       const { docs, deferredPopulates } = await _execPopulateQuery.apply(null, arr);
       vals = vals.concat(docs);
       if (deferredPopulates.length > 0) {
@@ -4599,7 +4601,7 @@ async function _populatePath(model, docs, populateOptions) {
   } else {
     // By default, populate in parallel
     const promises = [];
-    for (const arr of params) {
+    for (const arr of paramsForPopulate) {
       promises.push(_execPopulateQuery.apply(null, arr));
     }
 
@@ -4629,8 +4631,8 @@ async function _populatePath(model, docs, populateOptions) {
   // Each param's deferred populates are tracked separately to avoid mixing them
   // between different models (e.g., when using refPath with multiple model types).
   if (deferredPopulatesPerParam.size > 0) {
-    for (let i = 0; i < params.length; i++) {
-      const arr = params[i];
+    for (let i = 0; i < paramsForPopulate.length; i++) {
+      const arr = paramsForPopulate[i];
       const mod = arr[0];
       if (!Array.isArray(mod.match)) {
         continue;

--- a/test/helpers/checkForGiantPopulateFilters.test.js
+++ b/test/helpers/checkForGiantPopulateFilters.test.js
@@ -59,4 +59,56 @@ describe('checkForGiantPopulateFilters', function() {
     assert.deepStrictEqual(res[1][1]._id.$in, [4]);
     assert.deepStrictEqual(res[1][1].status.$in, ['a', 'b', 'c', 'd']);
   });
+
+  it('splits large $in filters inside multi-foreignField $or queries', function() {
+    // createPopulateQueryFilter produces this shape when a populate resolves
+    // to more than one foreign field (e.g. a virtual with a `foreignField`
+    // function returning different fields per document).
+    const param = [
+      { foreignField: new Set(['fieldA', 'fieldB']) },
+      {
+        $or: [
+          { fieldA: { $in: [1, 2, 3, 4, 5] } },
+          { fieldB: { $in: [1, 2, 3, 4, 5] } }
+        ]
+      },
+      null,
+      {}
+    ];
+
+    const res = checkForGiantPopulateFilters([param]);
+
+    // The oversized `$in` arrays live inside `$or`, so they should still be split.
+    assert.strictEqual(res.length, 2);
+    // Every `$or` branch is sliced in lockstep so the union matches the original.
+    assert.deepStrictEqual(res[0][1].$or, [
+      { fieldA: { $in: [1, 2, 3] } },
+      { fieldB: { $in: [1, 2, 3] } }
+    ]);
+    assert.deepStrictEqual(res[1][1].$or, [
+      { fieldA: { $in: [4, 5] } },
+      { fieldB: { $in: [4, 5] } }
+    ]);
+  });
+
+  it('splits large $in filters nested under $elemMatch on a foreign field parent path', function() {
+    const param = [
+      { foreignField: new Set(['items.userId']) },
+      { items: { $elemMatch: { userId: { $in: [1, 2, 3, 4, 5, 6, 7] }, active: true } } },
+      null,
+      {}
+    ];
+
+    const res = checkForGiantPopulateFilters([param]);
+
+    assert.strictEqual(res.length, 3);
+    assert.deepStrictEqual(res.map(p => p[1].items.$elemMatch.userId.$in), [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7]
+    ]);
+    assert.ok(res.every(p => p[1].items.$elemMatch.active));
+    assert.deepStrictEqual(param[1].items.$elemMatch.userId.$in, [1, 2, 3, 4, 5, 6, 7]);
+  });
+
 });

--- a/test/helpers/checkForGiantPopulateFilters.test.js
+++ b/test/helpers/checkForGiantPopulateFilters.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('assert');
+const checkForGiantPopulateFilters = require('../../lib/helpers/populate/checkForGiantPopulateFilters');
+
+describe('checkForGiantPopulateFilters', function() {
+  let maxFilterLength;
+
+  beforeEach(function() {
+    maxFilterLength = checkForGiantPopulateFilters.maxFilterLength;
+    checkForGiantPopulateFilters.maxFilterLength = 3;
+  });
+
+  afterEach(function() {
+    checkForGiantPopulateFilters.maxFilterLength = maxFilterLength;
+  });
+
+  it('leaves params without large $in filters unchanged', function() {
+    const params = [
+      [{ foreignField: new Set(['_id']) }, { _id: { $in: [1, 2, 3] } }, null, {}]
+    ];
+
+    const res = checkForGiantPopulateFilters(params);
+
+    assert.strictEqual(res.length, 1);
+    assert.strictEqual(res[0], params[0]);
+  });
+
+  it('splits params with large $in filters', function() {
+    const param = [
+      { foreignField: new Set(['_id']) },
+      { _id: { $in: [1, 2, 3, 4, 5, 6, 7] }, name: 'test' },
+      null,
+      {}
+    ];
+    const res = checkForGiantPopulateFilters([param]);
+
+    assert.strictEqual(res.length, 3);
+    assert.deepStrictEqual(res.map(param => param[1]._id.$in), [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7]
+    ]);
+    assert.ok(res.every(param => param[1].name === 'test'));
+    assert.deepStrictEqual(param[1]._id.$in, [1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('does not split large user-specified $in filters on non-foreign fields', function() {
+    const param = [{ foreignField: new Set(['_id']) }, {
+      _id: { $in: [1, 2, 3, 4] },
+      status: { $in: ['a', 'b', 'c', 'd'] }
+    }, null, {}];
+
+    const res = checkForGiantPopulateFilters([param]);
+
+    assert.strictEqual(res.length, 2);
+    assert.deepStrictEqual(res[0][1]._id.$in, [1, 2, 3]);
+    assert.deepStrictEqual(res[0][1].status.$in, ['a', 'b', 'c', 'd']);
+    assert.deepStrictEqual(res[1][1]._id.$in, [4]);
+    assert.deepStrictEqual(res[1][1].status.$in, ['a', 'b', 'c', 'd']);
+  });
+});

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -151,6 +151,56 @@ describe('model: populate:', function() {
     }
   });
 
+  it('splits large virtual populate $in filters into multiple queries', async function() {
+    const virtualBlogPostSchema = new Schema({ title: String });
+    virtualBlogPostSchema.virtual('virtualFans', {
+      ref: 'VirtualPopulateFan',
+      localField: '_id',
+      foreignField: 'postId'
+    });
+    const fanSchema = new Schema({
+      name: String,
+      postId: ObjectId
+    });
+
+    const BlogPost = db.model('VirtualPopulateBlogPost', virtualBlogPostSchema);
+    const Fan = db.model('VirtualPopulateFan', fanSchema);
+    const originalMaxFilterLength = checkForGiantPopulateFilters.maxFilterLength;
+    const findSpy = sinon.spy(Fan.collection, 'find');
+
+    checkForGiantPopulateFilters.maxFilterLength = 1;
+
+    try {
+      const posts = await BlogPost.create([
+        { title: 'Woot' },
+        { title: 'Woot 2' }
+      ]);
+      await Fan.create([
+        { name: 'Fan 0', postId: posts[0]._id },
+        { name: 'Fan 1', postId: posts[0]._id },
+        { name: 'Fan 2', postId: posts[1]._id },
+        { name: 'Fan 3', postId: posts[1]._id }
+      ]);
+
+      const docs = await BlogPost.find({ _id: { $in: posts.map(post => post._id) } }).
+        sort({ title: 1 }).
+        populate('virtualFans');
+
+      assert.strictEqual(docs.length, 2);
+      assert.deepStrictEqual(docs[0].virtualFans.map(fan => fan.name).sort(), ['Fan 0', 'Fan 1']);
+      assert.deepStrictEqual(docs[1].virtualFans.map(fan => fan.name).sort(), ['Fan 2', 'Fan 3']);
+
+      const querySizes = findSpy.getCalls().
+        map(call => call.args[0]).
+        filter(filter => Array.isArray(filter?.postId?.$in)).
+        map(filter => filter.postId.$in.length);
+      assert.deepStrictEqual(querySizes, [1, 1]);
+    } finally {
+      checkForGiantPopulateFilters.maxFilterLength = originalMaxFilterLength;
+      findSpy.restore();
+    }
+  });
+
   it('deep population (gh-3103)', async function() {
     const BlogPost = db.model('BlogPost', blogPostSchema);
     const User = db.model('User', userSchema);

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -7,7 +7,9 @@
 const start = require('./common');
 
 const assert = require('assert');
+const checkForGiantPopulateFilters = require('../lib/helpers/populate/checkForGiantPopulateFilters');
 const { randomUUID } = require('crypto');
+const sinon = require('sinon');
 const utils = require('../lib/utils');
 const util = require('./util');
 const MongooseError = require('../lib/error/mongooseError');
@@ -103,6 +105,50 @@ describe('model: populate:', function() {
 
     // Does not throw
     await post.populate('comments');
+  });
+
+  it('splits large populate $in filters into multiple queries', async function() {
+    const BlogPost = db.model('BlogPost', blogPostSchema);
+    const User = db.model('User', userSchema);
+    const originalMaxFilterLength = checkForGiantPopulateFilters.maxFilterLength;
+    const findSpy = sinon.spy(User.collection, 'find');
+
+    checkForGiantPopulateFilters.maxFilterLength = 5;
+
+    try {
+      const users = await User.create(Array.from({ length: 14 }, (_, i) => ({ name: `User ${i}` })));
+      const firstPostUsers = users.slice(0, 7);
+      const secondPostUsers = users.slice(7);
+      const posts = await BlogPost.create([
+        {
+          title: 'Woot',
+          fans: firstPostUsers.map(user => user._id)
+        },
+        {
+          title: 'Woot 2',
+          fans: secondPostUsers.map(user => user._id)
+        }
+      ]);
+
+      const docs = await BlogPost.find({ _id: { $in: posts.map(post => post._id) } }).
+        sort({ title: 1 }).
+        populate('fans');
+
+      assert.strictEqual(docs.length, 2);
+      assert.strictEqual(docs[0].fans.length, 7);
+      assert.strictEqual(docs[1].fans.length, 7);
+      assert.deepStrictEqual(docs[0].fans.map(user => user.name), firstPostUsers.map(user => user.name));
+      assert.deepStrictEqual(docs[1].fans.map(user => user.name), secondPostUsers.map(user => user.name));
+
+      const querySizes = findSpy.getCalls().
+        map(call => call.args[0]).
+        filter(filter => Array.isArray(filter?._id?.$in)).
+        map(filter => filter._id.$in.length);
+      assert.deepStrictEqual(querySizes.sort((a, b) => a - b), [4, 5, 5]);
+    } finally {
+      checkForGiantPopulateFilters.maxFilterLength = originalMaxFilterLength;
+      findSpy.restore();
+    }
   });
 
   it('deep population (gh-3103)', async function() {


### PR DESCRIPTION
Fix #5890

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#5890 was caused by having over 900k ObjectIds in the `populate()` query. For nested populate it is not impossible to end up with a massive `populate()` query. In the interest of minimizing the risk of BSON errors, Mongoose will now split up populate queries with more than 50k elements in the foreign field `_id`. Not foolproof - long string ids could still trigger the BSON error, but this is sufficient for common cases: ObjectIds, numbers, uuids. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
