### PR TITLE
perf: various improvements to speed up saveSimple

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -562,27 +562,26 @@ function $applyDefaultsToNested(val, path, doc) {
 Document.prototype.$__buildDoc = function(obj, fields, skipId, exclude, hasIncludedChildren) {
   const doc = {};
 
-  const paths = Object.keys(this.$__schema.paths).
-    // Don't build up any paths that are underneath a map, we don't know
-    // what the keys will be
-    filter(p => !p.includes('$*'));
+  const paths = Object.keys(this.$__schema.paths);
   const plen = paths.length;
   let ii = 0;
 
   for (; ii < plen; ++ii) {
     const p = paths[ii];
 
-    if (p === '_id') {
-      if (skipId) {
-        continue;
-      }
-      if (obj && '_id' in obj) {
-        continue;
-      }
+    // Don't build up any paths that are underneath a map, we don't know
+    // what the keys will be
+    if (p.includes('$*')) {
+      continue;
     }
 
     const path = this.$__schema.paths[p].splitPath();
     const len = path.length;
+    // This loop only creates intermediate objects for nested paths: it never
+    // sets any leaf values, so single-segment paths are no-ops.
+    if (len === 1) {
+      continue;
+    }
     const last = len - 1;
     let curPath = '';
     let doc_ = doc;
@@ -1133,7 +1132,11 @@ Document.prototype.$set = function $set(path, val, type, options) {
       return this;
     }
 
-    options = Object.assign({}, options, { _skipMinimizeTopLevel: false });
+    // Only need to clone if we're overwriting `_skipMinimizeTopLevel`, recursive
+    // calls treat a missing `_skipMinimizeTopLevel` as `false`
+    if (_skipMinimizeTopLevel) {
+      options = Object.assign({}, options, { _skipMinimizeTopLevel: false });
+    }
 
     for (let i = 0; i < len; ++i) {
       key = keys[i];
@@ -1220,15 +1223,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
   val = handleSpreadDoc(val, true);
 
   // if this doc is being constructed we should not trigger getters
-  const priorVal = (() => {
-    if (this.$__.priorDoc != null) {
-      return this.$__.priorDoc.$__getValue(path);
-    }
-    if (constructing) {
-      return void 0;
-    }
-    return this.$__getValue(path);
-  })();
+  const priorVal = this.$__.priorDoc != null ?
+    this.$__.priorDoc.$__getValue(path) :
+    (constructing ? void 0 : this.$__getValue(path));
 
   if (pathType === 'nested' && val) {
     if (typeof val === 'object' && val != null) {
@@ -1410,11 +1407,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
   try {
     // If the user is trying to set a ref path to a document with
     // the correct model name, treat it as populated
-    const refMatches = (() => {
+    const refMatches = !(val instanceof Document) ? false : (() => {
       if (schema.options == null) {
-        return false;
-      }
-      if (!(val instanceof Document)) {
         return false;
       }
       const model = val.constructor;
@@ -2870,7 +2864,8 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
 
     await this._execDocumentPostHooks('validate', options, error);
   } finally {
-    delete this.$__.validateModifiedOnly;
+    // Assign rather than `delete` to avoid putting `$__` in dictionary mode
+    this.$__.validateModifiedOnly = undefined;
     this.$op = null;
     this.$__.validating = null;
   }
@@ -2913,7 +2908,7 @@ function _completeValidate(doc) {
     }
   }
 
-  doc.$__.cachedRequired = {};
+  doc.$__.cachedRequired = null;
   doc.$emit('validate', doc);
   doc.constructor.emit('validate', doc);
 
@@ -3204,7 +3199,7 @@ function _pushNestedArrayPaths(val, paths, path) {
  * ignore
  */
 
-Document.prototype._execDocumentPreHooks = async function _execDocumentPreHooks(opName, options, argsForHooks) {
+Document.prototype._execDocumentPreHooks = function _execDocumentPreHooks(opName, options, argsForHooks) {
   const filter = buildMiddlewareFilter(options, 'pre');
   return this.$__middleware.execPre(opName, this, argsForHooks || [], { filter });
 };
@@ -3213,7 +3208,7 @@ Document.prototype._execDocumentPreHooks = async function _execDocumentPreHooks(
  * ignore
  */
 
-Document.prototype._execDocumentPostHooks = async function _execDocumentPostHooks(opName, options, error) {
+Document.prototype._execDocumentPostHooks = function _execDocumentPostHooks(opName, options, error) {
   const filter = buildMiddlewareFilter(options, 'post');
   return this.$__middleware.execPost(opName, this, [this], { error, filter });
 };
@@ -3630,7 +3625,11 @@ Document.prototype.$__reset = function reset() {
   // Clear atomics on dirty paths. Walk the modified and default paths
   // directly instead of calling $__dirty(), which builds intermediate
   // arrays, a Map, and does parent-path deduplication we don't need here.
-  this.$__resetAtomics();
+  // Skip entirely if the doc only has primitive values, because only arrays
+  // and maps have atomics.
+  if (!onlyPrimitiveValues) {
+    this.$__resetAtomics();
+  }
 
   this.$__.backup = {};
   this.$__.backup.activePaths = {

--- a/lib/helpers/document/applyDefaults.js
+++ b/lib/helpers/document/applyDefaults.js
@@ -17,6 +17,11 @@ module.exports = function applyDefaults(doc, fields, exclude, hasIncludedChildre
     }
 
     const type = doc.$__schema.paths[p];
+    // `getDefault()` returns undefined when `defaultValue` is undefined, in which
+    // case this loop never modifies the doc, so skip traversing the path entirely.
+    if (type.defaultValue === undefined) {
+      continue;
+    }
     const path = type.splitPath();
     const len = path.length;
     if (path[len - 1] === '$*') {

--- a/lib/helpers/schema/getKeysInSchemaOrder.js
+++ b/lib/helpers/schema/getKeysInSchemaOrder.js
@@ -3,25 +3,22 @@
 const get = require('../get');
 
 module.exports = function getKeysInSchemaOrder(schema, val, path) {
-  const schemaKeys = path != null ? Object.keys(get(schema.tree, path, {})) : Object.keys(schema.tree);
-  const valKeys = new Set(Object.keys(val));
+  const valKeys = Object.keys(val);
+  if (valKeys.length <= 1) {
+    return valKeys;
+  }
 
-  let keys;
-  if (valKeys.size > 1) {
-    keys = new Set();
-    for (const key of schemaKeys) {
-      if (valKeys.has(key)) {
-        keys.add(key);
-      }
+  const schemaKeys = path != null ? Object.keys(get(schema.tree, path, {})) : Object.keys(schema.tree);
+  const remaining = new Set(valKeys);
+
+  const keys = [];
+  for (const key of schemaKeys) {
+    if (remaining.delete(key)) {
+      keys.push(key);
     }
-    for (const key of valKeys) {
-      if (!keys.has(key)) {
-        keys.add(key);
-      }
-    }
-    keys = Array.from(keys);
-  } else {
-    keys = Array.from(valKeys);
+  }
+  for (const key of remaining) {
+    keys.push(key);
   }
 
   return keys;

--- a/lib/plugins/saveSubdocs.js
+++ b/lib/plugins/saveSubdocs.js
@@ -16,7 +16,10 @@ module.exports = function saveSubdocs(schema) {
 };
 
 
-async function saveSubdocsPreSave() {
+// These hooks are deliberately not `async` so that they don't allocate a
+// promise and force an extra microtask hop on every `save()` when there are
+// no subdocuments. kareem only awaits hooks that return a promise.
+function saveSubdocsPreSave() {
   if (this.$isSubdocument) {
     return;
   }
@@ -28,15 +31,15 @@ async function saveSubdocsPreSave() {
   }
 
   const options = this.$__.saveOptions;
-  await Promise.all(subdocs.map(subdoc => subdoc._execDocumentPreHooks('save', options, [options])));
-
-  // Invalidate subdocs cache because subdoc pre hooks can add new subdocuments
-  if (this.$__.saveOptions) {
-    this.$__.saveOptions.__subdocs = null;
-  }
+  return Promise.all(subdocs.map(subdoc => subdoc._execDocumentPreHooks('save', options, [options]))).then(() => {
+    // Invalidate subdocs cache because subdoc pre hooks can add new subdocuments
+    if (this.$__.saveOptions) {
+      this.$__.saveOptions.__subdocs = null;
+    }
+  });
 }
 
-async function saveSubdocsPostSave() {
+function saveSubdocsPostSave() {
   if (this.$isSubdocument) {
     return;
   }
@@ -53,10 +56,10 @@ async function saveSubdocsPostSave() {
     promises.push(subdoc._execDocumentPostHooks('save', options));
   }
 
-  await Promise.all(promises);
+  return Promise.all(promises);
 }
 
-async function saveSubdocsPreDeleteOne() {
+function saveSubdocsPreDeleteOne() {
   const removedSubdocs = this.$__.removedSubdocs;
   if (!removedSubdocs?.length) {
     return;
@@ -68,10 +71,10 @@ async function saveSubdocsPreDeleteOne() {
     promises.push(subdoc._execDocumentPreHooks('deleteOne', options));
   }
 
-  await Promise.all(promises);
+  return Promise.all(promises);
 }
 
-async function saveSubdocsPostDeleteOne() {
+function saveSubdocsPostDeleteOne() {
   const removedSubdocs = this.$__.removedSubdocs;
   if (!removedSubdocs?.length) {
     return;
@@ -84,7 +87,7 @@ async function saveSubdocsPostDeleteOne() {
   }
 
   this.$__.removedSubdocs = null;
-  await Promise.all(promises);
+  return Promise.all(promises);
 }
 
 

--- a/lib/stateMachine.js
+++ b/lib/stateMachine.js
@@ -69,8 +69,10 @@ StateMachine.prototype._changeState = function _changeState(path, nextState) {
   if (prevState === nextState) {
     return;
   }
-  const prevBucket = this.states[prevState];
-  if (prevBucket) delete prevBucket[path];
+  if (prevState !== undefined) {
+    const prevBucket = this.states[prevState];
+    if (prevBucket) delete prevBucket[path];
+  }
 
   this.paths[path] = nextState;
   this.states[nextState] = this.states[nextState] || {};
@@ -86,13 +88,16 @@ StateMachine.prototype.clear = function clear(state) {
     return;
   }
   const keys = Object.keys(this.states[state]);
+  if (keys.length === 0) {
+    return;
+  }
+  // Replace the bucket rather than deleting each key: repeated `delete` puts
+  // the object in dictionary mode, which is significantly slower.
+  this.states[state] = {};
   let i = keys.length;
-  let path;
 
   while (i--) {
-    path = keys[i];
-    delete this.states[state][path];
-    delete this.paths[path];
+    delete this.paths[keys[i]];
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

1. Avoid repeated deletes when calling StateMachine `clear()`
2. Early return in `applyDefaults()`
3. Skipping $__resetAtomics for primitive-only docs (similar to #16249)
4. Avoid unnecessary IIFE
5. Avoid hooks that are unnecessarily marked as async functions - for example, saveSubdocs exits early if there's no subdocs, we shouldn't allocate an extra promise in that case
6. Only one set in `getKeysInSchemaOrder.js`

Before:

```
{
  "Average mongoose save time ms": 2.41,
  "Average driver insertOne time ms": 1.45
}
{
  "Average mongoose save time ms": 2.09,
  "Average driver insertOne time ms": 1.4
}
{
  "Average mongoose save time ms": 2.05,
  "Average driver insertOne time ms": 1.42

```

After:

```
{
  "Average mongoose save time ms": 1.99,
  "Average driver insertOne time ms": 1.36
}
{
  "Average mongoose save time ms": 1.7,
  "Average driver insertOne time ms": 1.24
}
{
  "Average mongoose save time ms": 1.73,
  "Average driver insertOne time ms": 1.38
}

```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
