### PR TITLE
fix(populate): split into separate populate per document if resulting $in has more than 50k elements to reduce risk of BSON errors

### DIFF
--- a/lib/helpers/populate/createPopulateQueryFilter.js
+++ b/lib/helpers/populate/createPopulateQueryFilter.js
@@ -25,7 +25,15 @@ module.exports = function createPopulateQueryFilter(ids, _match, _foreignField, 
     for (let i = 0; i < _parentPaths.length - 1; ++i) {
       const cur = _parentPaths[i];
       if (match[cur] != null && match[cur].$elemMatch != null) {
-        match[cur].$elemMatch[foreignField.slice(cur.length + 1)] = trusted({ $in: ids });
+        // Copy rather than mutate so the user's `match` stays unchanged and split populate
+        // queries (gh-5890) each get their own `$in` rather than sharing one object
+        match[cur] = {
+          ...match[cur],
+          $elemMatch: {
+            ...match[cur].$elemMatch,
+            [foreignField.slice(cur.length + 1)]: trusted({ $in: ids })
+          }
+        };
         delete match[foreignField];
         break;
       }

--- a/lib/helpers/populate/getModelsMapForPopulate.js
+++ b/lib/helpers/populate/getModelsMapForPopulate.js
@@ -649,11 +649,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
       ids = matchIdsToRefPaths(ret, modelNamesForRefPath, modelName);
     }
 
-    const perDocumentLimit = options.perDocumentLimit == null ?
-      get(options, 'options.perDocumentLimit', null) :
-      options.perDocumentLimit;
-
-    if (!available[modelName] || perDocumentLimit != null) {
+    if (!available[modelName]) {
       const currentOptions = {
         model: Model
       };
@@ -682,6 +678,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
         isVirtual: data.isVirtual,
         virtual: data.virtual,
         count: data.count,
+        isRefPath: !!data.isRefPath,
         [populateModelSymbol]: Model
       };
       map.push(available[modelName]);
@@ -692,6 +689,7 @@ function addModelNamesToMap(model, map, available, modelNames, options, data, re
       available[modelName].ids.push(ids);
       available[modelName].allIds.push(ret);
       available[modelName].unpopulatedValues.push(unpopulatedValue);
+      available[modelName].isRefPath = available[modelName].isRefPath || !!data.isRefPath;
       if (data.hasMatchFunction) {
         available[modelName].match.push(data.match);
       }

--- a/lib/helpers/populate/splitPopulateQuery.js
+++ b/lib/helpers/populate/splitPopulateQuery.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const createPopulateQueryFilter = require('./createPopulateQueryFilter');
+const get = require('../get');
+const utils = require('../../utils');
+
+module.exports = splitPopulateQuery;
+
+/*!
+ * If a single populate query would have more than this many elements in its `$in` filter,
+ * Mongoose splits the populate into a separate query per document to avoid going over
+ * MongoDB's 16 MB BSON size limit on queries. Overwritable for testing purposes. See gh-5890.
+ */
+
+splitPopulateQuery.maxInFilterLength = 50000;
+
+/*!
+ * Split a populate models-map entry into a separate query per document if either:
+ *
+ * 1. The `perDocumentLimit` option is set, so each document needs its own query with its
+ *    own `limit` (gh-7318), or
+ * 2. A single populate query for `mod` would have too many elements in its `$in` filter
+ *    (gh-5890). With multiple foreign fields, `createPopulateQueryFilter()` repeats the ids
+ *    under `$or` once per foreign field, so the threshold counts one copy of `ids` per
+ *    foreign field.
+ *
+ * Returns a list of `[mod, match, select, assignmentOpts]` params, one per document, for
+ * `_execPopulateQuery()`. Returns `null` if the populate query doesn't need to be split.
+ * A `null` `match` means the document has no ids to query: `_execPopulateQuery()` skips
+ * executing a query, and `_assign()` just sets the document's populated path to the
+ * default value.
+ *
+ * Splitting on document boundaries means each document's populated value is the result of
+ * exactly one query, so split entries can typically be assigned from only their own query's
+ * results (`_assignFromOwnResults`) rather than scanning every populate query's results.
+ * refPath is the exception: a single document's array can contain ids for multiple models,
+ * so assigning refPath populate results relies on every query's results being available for
+ * every document. refPath entries are therefore only split when `perDocumentLimit` requires
+ * it, not to keep the `$in` filter small. A single document whose ids alone overflow the
+ * BSON size limit cannot be split.
+ */
+
+function splitPopulateQuery(mod, ids, select, assignmentOpts) {
+  if (mod.docs.length <= 1) {
+    return null;
+  }
+  const perDocumentLimit = mod.options.perDocumentLimit == null ?
+    get(mod.options, 'options.perDocumentLimit', null) :
+    mod.options.perDocumentLimit;
+  const numInFilterElements = ids.length * mod.foreignField.size;
+  if (perDocumentLimit == null && (numInFilterElements <= splitPopulateQuery.maxInFilterLength || mod.isRefPath)) {
+    return null;
+  }
+
+  return mod.docs.map((doc, i) => {
+    const subMod = {
+      ...mod,
+      docs: [doc],
+      ids: [mod.ids[i]],
+      allIds: [mod.allIds[i]],
+      unpopulatedValues: [mod.unpopulatedValues[i]],
+      match: Array.isArray(mod.match) ? [mod.match[i]] : mod.match,
+      _assignFromOwnResults: !mod.isRefPath
+    };
+    let subIds = utils.array.flatten(subMod.ids, flatten);
+    subIds = utils.array.unique(subIds);
+    const match = subIds.length === 0 || subIds.every(utils.isNullOrUndefined) ?
+      null :
+      createPopulateQueryFilter(subIds, subMod.match, subMod.foreignField, subMod.model, subMod.options.skipInvalidIds);
+    return [subMod, match, select, assignmentOpts];
+  });
+}
+
+/*!
+ * ignore
+ */
+
+function flatten(item) {
+  // no need to include undefined values in our query
+  return undefined !== item;
+}

--- a/lib/model.js
+++ b/lib/model.js
@@ -71,6 +71,7 @@ const prepareDiscriminatorPipeline = require('./helpers/aggregate/prepareDiscrim
 const pushNestedArrayPaths = require('./helpers/model/pushNestedArrayPaths');
 const removeDeselectedForeignField = require('./helpers/populate/removeDeselectedForeignField');
 const setDottedPath = require('./helpers/path/setDottedPath');
+const splitPopulateQuery = require('./helpers/populate/splitPopulateQuery');
 const { buildMiddlewareFilter } = require('./helpers/buildMiddlewareFilter');
 const util = require('util');
 const utils = require('./utils');
@@ -4543,7 +4544,6 @@ async function _populatePath(model, docs, populateOptions) {
       mod.foreignField.clear();
       mod.foreignField.add(populateOptions.foreignField);
     }
-    const match = createPopulateQueryFilter(ids, mod.match, mod.foreignField, mod.model, mod.options.skipInvalidIds);
     if (assignmentOpts.excludeId) {
       // override the exclusion from the query so we can use the _id
       // for document matching during assignment. we'll delete the
@@ -4564,6 +4564,17 @@ async function _populatePath(model, docs, populateOptions) {
     } else if (mod.options.limit != null) {
       assignmentOpts.originalLimit = mod.options.limit;
     }
+
+    // Execute a separate query per document if `perDocumentLimit` is set (gh-7318), or if
+    // there are so many ids that the `$in` filter may overflow MongoDB's 16 MB BSON size
+    // limit on queries (gh-5890).
+    const splitParams = splitPopulateQuery(mod, ids, select, assignmentOpts);
+    if (splitParams != null) {
+      params.push(...splitParams);
+      continue;
+    }
+
+    const match = createPopulateQueryFilter(ids, mod.match, mod.foreignField, mod.model, mod.options.skipInvalidIds);
     params.push([mod, match, select, assignmentOpts]);
   }
   if (!hasOne) {
@@ -4584,6 +4595,9 @@ async function _populatePath(model, docs, populateOptions) {
 
   // Track deferred populates per-param (per model) to avoid mixing them
   const deferredPopulatesPerParam = new Map();
+  // Query results per param. Batches that were split off of a large populate query (gh-5890)
+  // are assigned from only their own query's results rather than the combined `vals`.
+  const valsByParam = [];
 
   if (populateOptions.ordered) {
     // Populate in series, primarily for transactions because MongoDB doesn't support multiple operations on
@@ -4591,7 +4605,10 @@ async function _populatePath(model, docs, populateOptions) {
     for (let i = 0; i < params.length; i++) {
       const arr = params[i];
       const { docs, deferredPopulates } = await _execPopulateQuery.apply(null, arr);
-      vals = vals.concat(docs);
+      valsByParam.push(docs);
+      if (!arr[0]._assignFromOwnResults) {
+        vals = vals.concat(docs);
+      }
       if (deferredPopulates.length > 0) {
         deferredPopulatesPerParam.set(i, deferredPopulates);
       }
@@ -4606,7 +4623,10 @@ async function _populatePath(model, docs, populateOptions) {
     const results = await Promise.all(promises);
     for (let i = 0; i < results.length; i++) {
       const { docs, deferredPopulates } = results[i];
-      vals = vals.concat(docs);
+      valsByParam.push(docs);
+      if (!params[i][0]._assignFromOwnResults) {
+        vals = vals.concat(docs);
+      }
       if (deferredPopulates.length > 0) {
         deferredPopulatesPerParam.set(i, deferredPopulates);
       }
@@ -4614,13 +4634,15 @@ async function _populatePath(model, docs, populateOptions) {
   }
 
 
-  for (const arr of params) {
+  for (let i = 0; i < params.length; i++) {
+    const arr = params[i];
     const mod = arr[0];
     const assignmentOpts = arr[3];
-    for (const val of vals) {
+    const valsForMod = mod._assignFromOwnResults ? valsByParam[i] : vals;
+    for (const val of valsForMod) {
       mod.options._childDocs.push(val);
     }
-    _assign(model, vals, mod, assignmentOpts);
+    _assign(model, valsForMod, mod, assignmentOpts);
   }
 
   // Handle deferred populate for cases with per-document match functions.
@@ -4660,13 +4682,15 @@ async function _populatePath(model, docs, populateOptions) {
     }
   }
 
-  for (const arr of params) {
-    removeDeselectedForeignField(arr[0].foreignField, arr[0].options, vals);
+  for (let i = 0; i < params.length; i++) {
+    const mod = params[i][0];
+    removeDeselectedForeignField(mod.foreignField, mod.options, mod._assignFromOwnResults ? valsByParam[i] : vals);
   }
-  for (const arr of params) {
-    const mod = arr[0];
+  for (let i = 0; i < params.length; i++) {
+    const mod = params[i][0];
     if (mod.options?.options?._leanTransform) {
-      for (const doc of vals) {
+      const valsForMod = mod._assignFromOwnResults ? valsByParam[i] : vals;
+      for (const doc of valsForMod) {
         mod.options.options._leanTransform(doc);
       }
     }
@@ -4678,6 +4702,12 @@ async function _populatePath(model, docs, populateOptions) {
  */
 
 function _execPopulateQuery(mod, match, select) {
+  // `null` match means `mod`'s documents have no ids to query, possible if a large populate
+  // was split into a query per document (gh-5890). Skip executing a query: `_assign()` still
+  // sets the documents' populated paths to the appropriate default value.
+  if (match == null) {
+    return Promise.resolve({ docs: [], deferredPopulates: [] });
+  }
   let subPopulate = clone(mod.options.populate);
   const queryOptions = {};
   if (mod.options.skip !== undefined) {

--- a/test/helpers/populate.splitPopulateQuery.test.js
+++ b/test/helpers/populate.splitPopulateQuery.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('assert');
+const splitPopulateQuery = require('../../lib/helpers/populate/splitPopulateQuery');
+
+describe('splitPopulateQuery', function() {
+  let maxInFilterLength;
+
+  beforeEach(function() {
+    maxInFilterLength = splitPopulateQuery.maxInFilterLength;
+    splitPopulateQuery.maxInFilterLength = 3;
+  });
+
+  afterEach(function() {
+    splitPopulateQuery.maxInFilterLength = maxInFilterLength;
+  });
+
+  function createMod(mod) {
+    return {
+      model: { schema: { path: () => null } },
+      options: {},
+      match: null,
+      docs: mod.ids.map((_, i) => ({ i })),
+      allIds: [...mod.ids],
+      unpopulatedValues: [...mod.ids],
+      foreignField: new Set(['_id']),
+      isRefPath: false,
+      ...mod
+    };
+  }
+
+  it('returns null if the entry only has one document', function() {
+    const mod = createMod({ ids: [[1, 2, 3, 4]] });
+    assert.strictEqual(splitPopulateQuery(mod, [1, 2, 3, 4], null, {}), null);
+  });
+
+  it('returns null if the `$in` filter is within the limit', function() {
+    const mod = createMod({ ids: [[1], [2]] });
+    assert.strictEqual(splitPopulateQuery(mod, [1, 2], null, {}), null);
+  });
+
+  it('returns params for a separate query per document if the `$in` filter would be too big', function() {
+    const select = { name: 1 };
+    const assignmentOpts = { sort: { name: 1 } };
+    const mod = createMod({ ids: [[1, 2], [3, 4]] });
+
+    const params = splitPopulateQuery(mod, [1, 2, 3, 4], select, assignmentOpts);
+
+    assert.equal(params.length, 2);
+    for (let i = 0; i < params.length; ++i) {
+      const [subMod, match, subSelect, subAssignmentOpts] = params[i];
+      assert.deepStrictEqual(subMod.docs, [mod.docs[i]]);
+      assert.deepStrictEqual(match._id.$in, mod.ids[i]);
+      assert.strictEqual(subSelect, select);
+      assert.strictEqual(subAssignmentOpts, assignmentOpts);
+      assert.strictEqual(subMod._assignFromOwnResults, true);
+    }
+  });
+
+  it('sets `match` to null for documents with no ids', function() {
+    const mod = createMod({ ids: [[1, 2], [], [3, 4]] });
+
+    const params = splitPopulateQuery(mod, [1, 2, 3, 4], null, {});
+
+    assert.equal(params.length, 3);
+    assert.deepStrictEqual(params[0][1]._id.$in, [1, 2]);
+    assert.strictEqual(params[1][1], null);
+    assert.deepStrictEqual(params[2][1]._id.$in, [3, 4]);
+  });
+
+  it('counts one copy of the ids per foreign field', function() {
+    const mod = createMod({ ids: [[1], [2]], foreignField: new Set(['f1', 'f2']) });
+
+    // Only 2 ids, but 2 foreign fields means the filter would contain 4 elements
+    const params = splitPopulateQuery(mod, [1, 2], null, {});
+
+    assert.equal(params.length, 2);
+    assert.deepStrictEqual(params[0][1].$or, [{ f1: { $in: [1] } }, { f2: { $in: [1] } }]);
+    assert.deepStrictEqual(params[1][1].$or, [{ f1: { $in: [2] } }, { f2: { $in: [2] } }]);
+  });
+
+  it('splits if `perDocumentLimit` is set, even if the `$in` filter is within the limit', function() {
+    let mod = createMod({ ids: [[1], [2]], options: { perDocumentLimit: 1 } });
+    assert.equal(splitPopulateQuery(mod, [1, 2], null, {}).length, 2);
+
+    mod = createMod({ ids: [[1], [2]], options: { options: { perDocumentLimit: 1 } } });
+    assert.equal(splitPopulateQuery(mod, [1, 2], null, {}).length, 2);
+  });
+
+  it('only splits refPath entries for `perDocumentLimit`, with assignment from all queries\' results', function() {
+    let mod = createMod({ ids: [[1, 2], [3, 4]], isRefPath: true });
+    assert.strictEqual(splitPopulateQuery(mod, [1, 2, 3, 4], null, {}), null);
+
+    mod = createMod({ ids: [[1, 2], [3, 4]], isRefPath: true, options: { perDocumentLimit: 1 } });
+    const params = splitPopulateQuery(mod, [1, 2, 3, 4], null, {});
+    assert.equal(params.length, 2);
+    assert.strictEqual(params[0][0]._assignFromOwnResults, false);
+    assert.strictEqual(params[1][0]._assignFromOwnResults, false);
+  });
+
+  it('gives each document its own `match` when there is a match function', function() {
+    const mod = createMod({ ids: [[1, 2], [3, 4]], match: [{ a: 1 }, { a: 2 }] });
+
+    const params = splitPopulateQuery(mod, [1, 2, 3, 4], null, {});
+
+    assert.deepStrictEqual(params[0][0].match, [{ a: 1 }]);
+    assert.equal(params[0][1].a, 1);
+    assert.deepStrictEqual(params[1][0].match, [{ a: 2 }]);
+    assert.equal(params[1][1].a, 2);
+  });
+});

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -11,6 +11,7 @@ const { randomUUID } = require('crypto');
 const utils = require('../lib/utils');
 const util = require('./util');
 const MongooseError = require('../lib/error/mongooseError');
+const splitPopulateQuery = require('../lib/helpers/populate/splitPopulateQuery');
 
 const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
@@ -8809,6 +8810,221 @@ describe('model: populate:', function() {
       assert.equal(docs[1]._id.toString(), p2._id.toString());
       assert.deepEqual(docs[0].children.map(c => c._id), [1]);
       assert.deepEqual(docs[1].children.map(c => c._id), [4]);
+    });
+
+    describe('splitting populate queries whose `$in` filter would have too many elements (gh-5890)', function() {
+      let maxInFilterLength;
+
+      beforeEach(function() {
+        maxInFilterLength = splitPopulateQuery.maxInFilterLength;
+        splitPopulateQuery.maxInFilterLength = 3;
+      });
+
+      afterEach(function() {
+        splitPopulateQuery.maxInFilterLength = maxInFilterLength;
+      });
+
+      it('executes a separate query per document (gh-5890)', async function() {
+        const childSchema = new Schema({ name: String });
+        const inFilterLengths = [];
+        childSchema.pre('find', function() {
+          inFilterLengths.push(this.getFilter()._id.$in.length);
+        });
+        const Child = db.model('Child', childSchema);
+        const Parent = db.model('Parent', new Schema({
+          children: [{ type: ObjectId, ref: 'Child' }]
+        }));
+
+        const children = await Child.create(['A', 'B', 'C', 'D'].map(name => ({ name })));
+        await Parent.create([
+          { children: [children[0]._id, children[1]._id] },
+          { children: [children[2]._id, children[3]._id] }
+        ]);
+
+        const docs = await Parent.find().sort({ _id: 1 }).populate('children');
+
+        assert.deepStrictEqual(inFilterLengths, [2, 2]);
+        assert.deepStrictEqual(docs[0].children.map(child => child.name), ['A', 'B']);
+        assert.deepStrictEqual(docs[1].children.map(child => child.name), ['C', 'D']);
+      });
+
+      it('splits nested populate queries that go over the limit (gh-5890)', async function() {
+        const viewSchema = new Schema({ name: String });
+        const inFilterLengths = [];
+        viewSchema.pre('find', function() {
+          inFilterLengths.push(this.getFilter()._id.$in.length);
+        });
+        const View = db.model('View', viewSchema);
+        const TvShow = db.model('TvShow', new Schema({
+          title: String,
+          views: [{ type: ObjectId, ref: 'View' }]
+        }));
+        const Example = db.model('Example', new Schema({
+          tvShows: [{ type: ObjectId, ref: 'TvShow' }]
+        }));
+
+        const views = await View.create(['v1', 'v2', 'v3', 'v4'].map(name => ({ name })));
+        const tvShows = await TvShow.create([
+          { title: 'show 1', views: [views[0]._id, views[1]._id] },
+          { title: 'show 2', views: [views[2]._id, views[3]._id] }
+        ]);
+        await Example.create({ tvShows: [tvShows[0]._id, tvShows[1]._id] });
+
+        const doc = await Example.findOne().populate({
+          path: 'tvShows',
+          populate: { path: 'views' }
+        });
+
+        // The top-level `tvShows` populate is under the limit, but the nested `views`
+        // populate has 4 total ids across 2 tvShows, so it executes one query per tvShow
+        assert.deepStrictEqual(inFilterLengths, [2, 2]);
+        assert.deepStrictEqual(doc.tvShows[0].views.map(view => view.name), ['v1', 'v2']);
+        assert.deepStrictEqual(doc.tvShows[1].views.map(view => view.name), ['v3', 'v4']);
+      });
+
+      it('applies sort, skip, and limit per document (gh-5890)', async function() {
+        const childSchema = new Schema({ order: Number });
+        const inFilterLengths = [];
+        childSchema.pre('find', function() {
+          inFilterLengths.push(this.getFilter()._id.$in.length);
+        });
+        const Child = db.model('Child', childSchema);
+        const Parent = db.model('Parent', new Schema({
+          children: [{ type: ObjectId, ref: 'Child' }]
+        }));
+
+        const children = await Child.create([1, 2, 3, 4, 5, 6].map(order => ({ order })));
+        await Parent.create([
+          { children: children.slice(0, 3).map(child => child._id) },
+          { children: children.slice(3).map(child => child._id) }
+        ]);
+
+        const docs = await Parent.find().sort({ _id: 1 }).populate({
+          path: 'children',
+          options: { sort: { order: -1 }, skip: 1, limit: 2 }
+        });
+
+        assert.deepStrictEqual(inFilterLengths, [3, 3]);
+        // Because each document executes its own query, `sort`, `skip`, and `limit` apply
+        // to each document's populated array separately, like `perDocumentLimit`
+        assert.deepStrictEqual(docs[0].children.map(child => child.order), [2, 1]);
+        assert.deepStrictEqual(docs[1].children.map(child => child.order), [5, 4]);
+      });
+
+      it('counts each foreign field\'s copy of the ids when there are multiple foreign fields (gh-5890)', async function() {
+        const childSchema = new Schema({ name: String, f1: Number, f2: Number });
+        const filters = [];
+        childSchema.pre('find', function() {
+          filters.push(this.getFilter());
+        });
+        const Child = db.model('Child', childSchema);
+
+        const parentSchema = new Schema({ whichField: String, childIds: [Number] });
+        parentSchema.virtual('children', {
+          ref: 'Child',
+          localField: 'childIds',
+          foreignField: function() {
+            return this.whichField;
+          }
+        });
+        const Parent = db.model('Parent', parentSchema);
+
+        await Child.create([{ name: 'A', f1: 1 }, { name: 'B', f2: 11 }]);
+        await Parent.create([
+          { whichField: 'f1', childIds: [1] },
+          { whichField: 'f2', childIds: [11] }
+        ]);
+
+        const docs = await Parent.find().sort({ _id: 1 }).populate('children');
+
+        // Only 2 unique ids, but the filter repeats them under `$or` for each of the 2
+        // foreign fields, which puts the query over the limit of 3
+        assert.equal(filters.length, 2);
+        for (const filter of filters) {
+          assert.deepStrictEqual(filter.$or.map(cond => Object.keys(cond)[0]).sort(), ['f1', 'f2']);
+        }
+        assert.deepStrictEqual(
+          filters.map(filter => filter.$or.find(cond => cond.f1).f1.$in[0]).sort(),
+          [1, 11]
+        );
+        assert.deepStrictEqual(docs[0].children.map(child => child.name), ['A']);
+        assert.deepStrictEqual(docs[1].children.map(child => child.name), ['B']);
+      });
+
+      it('gives each split query its own `$in` when `match` uses `$elemMatch` (gh-5890)', async function() {
+        const groupSchema = new Schema({
+          name: String,
+          members: [{ userId: Number, active: Boolean }]
+        });
+        const filters = [];
+        groupSchema.pre('find', function() {
+          filters.push(this.getFilter());
+        });
+        const Group = db.model('Group', groupSchema);
+
+        const match = { members: { $elemMatch: { active: true } } };
+        const userSchema = new Schema({ userId: Number });
+        userSchema.virtual('groups', {
+          ref: 'Group',
+          localField: 'userId',
+          foreignField: 'members.userId',
+          match
+        });
+        const User = db.model('User', userSchema);
+
+        await Group.create([1, 2, 3, 4].map(userId => ({
+          name: `group ${userId}`,
+          members: [{ userId, active: userId !== 4 }]
+        })));
+        await User.create([1, 2, 3, 4].map(userId => ({ userId })));
+
+        const users = await User.find().sort({ userId: 1 }).populate('groups');
+
+        assert.equal(filters.length, 4);
+        for (const filter of filters) {
+          assert.strictEqual(filter.members.$elemMatch.active, true);
+        }
+        // Each split query's `$in` ends up inside `$elemMatch`, so each query needs its
+        // own copy of the `$elemMatch` rather than a reference to the `match` option's
+        assert.deepStrictEqual(
+          filters.map(filter => filter.members.$elemMatch.userId.$in[0]).sort(),
+          [1, 2, 3, 4]
+        );
+        assert.deepStrictEqual(users[0].groups.map(group => group.name), ['group 1']);
+        assert.deepStrictEqual(users[1].groups.map(group => group.name), ['group 2']);
+        assert.deepStrictEqual(users[2].groups.map(group => group.name), ['group 3']);
+        assert.deepStrictEqual(users[3].groups.map(group => group.name), []);
+        // The user's `match` object should not be modified
+        assert.deepStrictEqual(match, { members: { $elemMatch: { active: true } } });
+      });
+
+      it('skips executing a query for documents with no ids, but still initializes the path (gh-5890)', async function() {
+        const childSchema = new Schema({ name: String });
+        const inFilterLengths = [];
+        childSchema.pre('find', function() {
+          inFilterLengths.push(this.getFilter()._id.$in.length);
+        });
+        const Child = db.model('Child', childSchema);
+        const Parent = db.model('Parent', new Schema({
+          children: [{ type: ObjectId, ref: 'Child' }]
+        }));
+
+        const children = await Child.create(['A', 'B', 'C', 'D'].map(name => ({ name })));
+        await Parent.create([
+          { children: [children[0]._id, children[1]._id] },
+          { children: [] },
+          { children: [children[2]._id, children[3]._id] }
+        ]);
+
+        const docs = await Parent.find().sort({ _id: 1 }).populate('children');
+
+        // No query for the middle parent, whose `children` array is empty
+        assert.deepStrictEqual(inFilterLengths, [2, 2]);
+        assert.deepStrictEqual(docs[0].children.map(child => child.name), ['A', 'B']);
+        assert.deepStrictEqual(docs[1].children.map(child => child.name), []);
+        assert.ok(docs[1].populated('children'));
+        assert.deepStrictEqual(docs[2].children.map(child => child.name), ['C', 'D']);
+      });
     });
 
     it('works when embedded discriminator array has populated path but not refPath (gh-8527)', async function() {


### PR DESCRIPTION
Fix #5890

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The crux of the issue in #5890 is that `populate()` can lead to BSON size limit errors in the case of multiple documents. About 800k ObjectIds fit in the BSON size limit - however, `populate()` on multiple documents can try to stuff more ids than that into a query. For example, if we have a relationship `User` -> `TVShow` -> `View`, the `populate()` call for `View` can include the `views` from multiple `TVShow` documents, and lead to BSON overflow.

The practical solution I came up with is to switch to `perDocumentLimit` behavior (one query per document vs per model) if the resulting query has more than 50k elements. That limit is intentionally not very rigorous, because calculating the BSON serialized size for a large array can be performance intensive; but the 50k limit is enough to avoid BSON overflows for ObjectIds, uuids, dates, and numbers.

The key insight behind splitting by document is that documents themselves must fit within the BSON size limit, so an individual document's `populate()` cannot trigger a BSON size limit presuming that document was already saved in MongoDB (of course possible to create a document in memory with an ObjectId array of length 1M and try to populate it but not very realistic because you could never save this document).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
