### PR TITLE
feat(model): support named parameters in Model.findOne

### DIFF
--- a/lib/helpers/symbols.js
+++ b/lib/helpers/symbols.js
@@ -18,3 +18,4 @@ exports.schemaTypeSymbol = Symbol('mongoose#schemaType');
 exports.sessionNewDocuments = Symbol('mongoose#ClientSession#newDocuments');
 exports.scopeSymbol = Symbol('mongoose#Document#scope');
 exports.validatorErrorSymbol = Symbol('mongoose#validatorError');
+exports.namedParamsSymbol = Symbol('mongoose#Model#namedParams');

--- a/lib/model.js
+++ b/lib/model.js
@@ -83,7 +83,8 @@ const modelDbSymbol = Symbol('mongoose#Model#db');
 const {
   arrayAtomicsBackupSymbol,
   arrayAtomicsSymbol,
-  modelSymbol
+  modelSymbol,
+  namedParamsSymbol
 } = require('./helpers/symbols');
 const subclassedSymbol = Symbol('mongoose#Model#subclassed');
 
@@ -2202,10 +2203,16 @@ Model.findOne = function findOne(conditions, projection, options) {
     throw new MongooseError('Model.findOne() no longer accepts a callback');
   }
 
+  // Support named parameters via namedParamsSymbol
+  if (conditions != null && conditions[namedParamsSymbol]) {
+    projection = conditions.projection;
+    options = conditions.options;
+    conditions = conditions.filter;
+  }
+
   const mq = new this.Query({}, {}, this, this.$__collection);
   mq.select(projection);
   mq.setOptions(options);
-
   return mq.findOne(conditions);
 };
 

--- a/test/model.querying.test.js
+++ b/test/model.querying.test.js
@@ -365,6 +365,25 @@ describe('model: querying:', function() {
       assert.equal(created.id, found.id);
 
     });
+    it('supports named parameters via namedParamsSymbol', async function() {
+  const { namedParamsSymbol } = require('../lib/helpers/symbols');
+  const title = 'Named Params Test ' + random();
+  await BlogPostB.create({ title: title, author: 'TestAuthor' });
+
+  // old positional style still works
+  const docPositional = await BlogPostB.findOne({ title: title });
+  assert.equal(docPositional.get('title'), title);
+
+  // new named parameters style
+  const docNamed = await BlogPostB.findOne({
+    [namedParamsSymbol]: true,
+    filter: { title: title },
+    projection: 'title author',
+    options: { lean: true }
+  });
+  assert.equal(docNamed.title, title);
+  assert.equal(docNamed.author, 'TestAuthor');
+});
   });
 
   describe('findById', function() {


### PR DESCRIPTION
## Summary

Adds support for calling `Model.findOne` with a single named-parameters object, in addition to the existing positional arguments. Addresses #10367, scoped to `Model.findOne` as a first step (per discussion in the issue).

## Approach

Per the discussion in #10367, named parameters are detected using an internal `namedParamsSymbol` (added to `lib/helpers/symbols.js`, following the same pattern as existing internal symbols like `modelCollectionSymbol`). This avoids any ambiguity with real schema field names like `filter`, `projection`, or `options`, since a Symbol key can never collide with a string key.

## Example

```js
// existing positional style (unchanged)
User.findOne({ email: 'x@y.com' }, 'name', { lean: true })

// new named-parameters style
User.findOne({
  [namedParamsSymbol]: true,
  filter: { email: 'x@y.com' },
  projection: 'name',
  options: { lean: true }
})
```

## Testing

- Added a test in `test/model.querying.test.js` covering both the old positional style and the new named-parameters style.
- Ran the full test suite locally (`npm test`): 4378 passing, 0 failures (one unrelated pre-existing flaky timeout in `timestamps.test.js` that passes in isolation).