### PR TITLE
fix(types): correct `Model.validate()` return type to `Promise<TRawDocType>`

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -79,6 +79,28 @@ async function standardSchemaModelValidate(): Promise<void> {
   });
 }
 
+async function modelValidateReturnsCastedObject(): Promise<void> {
+  interface IUser {
+    name: string;
+    age: number;
+  }
+
+  const User = connection.model<IUser>('ModelValidateReturn', new Schema<IUser>({
+    name: { type: String, required: true },
+    age: Number
+  }));
+
+  // `Model.validate()` resolves to the casted-and-validated copy of the input,
+  // not `void`. See gh-16338.
+  const validated = await User.validate({ name: 'Val', age: 42 });
+  expect(validated).type.toBe<IUser>();
+  expect(validated.name).type.toBe<string>();
+  expect(validated.age).type.toBe<number>();
+
+  expect(await User.validate({ name: 'Val', age: 42 }, ['name'])).type.toBe<IUser>();
+  expect(await User.validate({ name: 'Val', age: 42 }, { pathsToSkip: ['age'] })).type.toBe<IUser>();
+}
+
 function tAndDocSyntax(): void {
   interface ITest {
     id: number;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -684,11 +684,11 @@ declare module 'mongoose' {
      */
     useConnection(connection: Connection): this;
 
-    /** Casts and validates the given object against this model's schema, passing the given `context` to custom validators. */
-    validate(): Promise<void>;
-    validate(obj: any): Promise<void>;
-    validate(obj: any, pathsOrOptions: PathsToValidate): Promise<void>;
-    validate(obj: any, pathsOrOptions: { pathsToSkip?: pathsToSkip }): Promise<void>;
+    /** Casts and validates the given object against this model's schema, returning the casted-and-validated copy of `obj`, passing the given `context` to custom validators. */
+    validate(): Promise<TRawDocType>;
+    validate(obj: any): Promise<TRawDocType>;
+    validate(obj: any, pathsOrOptions: PathsToValidate): Promise<TRawDocType>;
+    validate(obj: any, pathsOrOptions: { pathsToSkip?: pathsToSkip }): Promise<TRawDocType>;
 
     /** Watches the underlying collection for changes using [MongoDB change streams](https://www.mongodb.com/docs/manual/changeStreams/). */
     watch<ResultType extends mongodb.Document = any, ChangeType extends mongodb.ChangeStreamDocument = any>(pipeline?: Array<Record<string, unknown>>, options?: mongodb.ChangeStreamOptions & { hydrate?: boolean }): mongodb.ChangeStream<ResultType, ChangeType>;


### PR DESCRIPTION
**Summary**

`Model.validate()` is typed to resolve to `void`, but at runtime it returns the casted-and-validated copy of the input object.

In [`lib/model.js`](https://github.com/Automattic/mongoose/blob/master/lib/model.js), `Model.validate()` does `obj = this.castObject(obj)` and ends with `return obj;`. The JSDoc on the implementation already documents this:

> `@return {Promise<object>} casted and validated copy of \`obj\` if validation succeeded`

However, the TypeScript declarations in `types/models.d.ts` typed every overload as `Promise<void>`, so consumers cannot use the resolved value:

```ts
const validated = await MyModel.validate({ a: 'string' });
validated.a; // ts(2339): Property 'a' does not exist on type 'void'.
```

This PR changes the return type to `Promise<TRawDocType>`, mirroring the adjacent [`castObject(...): TRawDocType`](https://github.com/Automattic/mongoose/blob/master/types/models.d.ts) declaration (`validate()` returns exactly what `castObject()` produced). The existing `Model['~standard'].validate()` adapter already assumes `validate` resolves to the data (it wraps the result as `{ value }`), and its type test asserts `result.value` is the raw doc type — consistent with this change.

Fixes #16338

**Examples**

Added type tests in `test/types/models.test.ts` (`modelValidateReturnsCastedObject`):

```ts
const validated = await User.validate({ name: 'Val', age: 42 });
expect(validated).type.toBe<IUser>();
expect(validated.name).type.toBe<string>();
expect(validated.age).type.toBe<number>();
```

These fail before the fix (`Property 'age' does not exist on type 'void'`) and pass after. Full `npm run test:types` suite passes (39 files, 978 assertions), `eslint` clean.