### PR TITLE
docs: add troubleshooting note for querySrv ECONNREFUSED on Windows

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -10,6 +10,25 @@ This is the minimum needed to connect the `myapp` database running locally on th
 For local MongoDB databases, we recommend using `127.0.0.1` instead of `localhost`.
 That is because Node.js 18 and up prefer IPv6 addresses, which means, on many machines, Node.js will resolve `localhost` to the IPv6 address `::1` and Mongoose will be unable to connect, unless the mongodb instance is running with ipv6 enabled.
 
+#### SRV DNS Resolution Failure on Windows (`querySrv ECONNREFUSED`)
+
+If you are connecting to MongoDB Atlas using `mongodb+srv://` and see a
+`querySrv ECONNREFUSED` error, Node.js may be failing to resolve MongoDB's
+SRV records even when your OS DNS works correctly. This is a known issue on
+Windows (confirmed regression in Node.js v24.13.0, see
+[nodejs/node#61453](https://github.com/nodejs/node/pull/61453)) and can also
+affect systems where the ISP intercepts DNS at the network level.
+
+The fix is to explicitly set DNS servers in Node.js at the top of your entry
+file, before any other imports:
+
+```js
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']);
+```
+
+This bypasses the OS/ISP DNS resolver entirely at the Node.js level.
+
 You can also specify several more parameters in the `uri`:
 
 ```javascript

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -10,25 +10,6 @@ This is the minimum needed to connect the `myapp` database running locally on th
 For local MongoDB databases, we recommend using `127.0.0.1` instead of `localhost`.
 That is because Node.js 18 and up prefer IPv6 addresses, which means, on many machines, Node.js will resolve `localhost` to the IPv6 address `::1` and Mongoose will be unable to connect, unless the mongodb instance is running with ipv6 enabled.
 
-#### SRV DNS Resolution Failure on Windows (`querySrv ECONNREFUSED`)
-
-If you are connecting to MongoDB Atlas using `mongodb+srv://` and see a
-`querySrv ECONNREFUSED` error, Node.js may be failing to resolve MongoDB's
-SRV records even when your OS DNS works correctly. This is a known issue on
-Windows (confirmed regression in Node.js v24.13.0, see
-[nodejs/node#61453](https://github.com/nodejs/node/pull/61453)) and can also
-affect systems where the ISP intercepts DNS at the network level.
-
-The fix is to explicitly set DNS servers in Node.js at the top of your entry
-file, before any other imports:
-
-```js
-const dns = require('dns');
-dns.setServers(['8.8.8.8', '8.8.4.4']);
-```
-
-This bypasses the OS/ISP DNS resolver entirely at the Node.js level.
-
 You can also specify several more parameters in the `uri`:
 
 ```javascript

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,6 +57,25 @@ await Test.findOne(); // Will throw "Operation timed out" error because `db` isn
 You must ensure that you have whitelisted your ip on [mongodb](https://www.mongodb.com/docs/atlas/security/ip-access-list/) to allow Mongoose to connect.
 You can allow access from all ips with `0.0.0.0/0`.
 
+<hr id="querysrv-econnrefused" />
+
+<a class="anchor" href="#querysrv-econnrefused">**Q**</a>. I get a `querySrv ECONNREFUSED` error when connecting to MongoDB Atlas using `mongodb+srv://`. What gives?
+
+**A**. Node.js may be failing to resolve MongoDB's SRV records even when your OS DNS works correctly.
+This is a known issue on Windows (confirmed regression in Node.js v24.13.0, see [nodejs/node#61453](https://github.com/nodejs/node/pull/61453)) and can also affect systems where the ISP intercepts DNS at the network level.
+
+The fix is to explicitly set DNS servers in Node.js at the very top of your entry file, before any other imports:
+
+```javascript
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']);
+
+// Now connect to MongoDB
+mongoose.connect('mongodb+srv://...');
+```
+
+This bypasses the OS/ISP DNS resolver entirely at the Node.js level.
+
 <hr id="not-a-function" />
 
 <a class="anchor" href="#not-a-function">**Q**</a>. x.$__y is not a function. What gives?


### PR DESCRIPTION
## What this PR does
Adds a troubleshooting note to `docs/connections.md` for the 
`querySrv ECONNREFUSED` error when connecting to MongoDB Atlas 
using `mongodb+srv://` on Windows.

## Why
This error affects many developers but is not currently documented 
in Mongoose's connection docs. The fix (`dns.setServers()`) is 
scattered across Medium articles and Stack Overflow but has no 
official reference.

Root cause: Node.js uses its own DNS resolver (c-ares) which can 
fail to resolve SRV records on Windows even when OS DNS works fine. 
This was confirmed as a Node.js regression in v24.13.0:
nodejs/node#61453

## Fix
Force Node.js to use Google's public DNS at the application level:
const dns = require('dns');
dns.setServers(['8.8.8.8', '8.8.4.4']);

## References
- nodejs/node#61453
- https://alexbevi.com/blog/2023/11/13/querysrv-errors-when-connecting-to-mongodb-atlas/