### PR TITLE
feat(model): proof-of-concept named parameters for findOne

### DIFF
--- a/lib/helpers/query/getNamedParams.js
+++ b/lib/helpers/query/getNamedParams.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const MongooseError = require('../../error/mongooseError');
+
+/*!
+ * Detects and validates mongoose "named parameters" (RORO style), e.g.
+ * `Model.findOne({ $filter, $projection, $options })`.
+ *
+ * A call is treated as named parameters when a single object argument is passed
+ * and at least one of its top-level keys is a recognized sentinel for the
+ * method. `$`-prefixed sentinels can never collide with a positional filter,
+ * since the server rejects unknown `$`-prefixed keys as top-level operators.
+ *
+ * @param {String} method the calling method name, used in error messages
+ * @param {String[]} sentinels recognized `$`-prefixed keys, e.g. `['$filter', '$projection', '$options']`
+ * @param {Array|arguments} args the arguments passed to the method
+ * @return {Object|null} the named params keyed without the `$` (e.g. `{ filter, projection, options }`), or `null` if positional
+ * @api private
+ */
+
+module.exports = function getNamedParams(method, sentinels, args) {
+  const first = args[0];
+  if (first == null || typeof first !== 'object' || Array.isArray(first)) {
+    return null;
+  }
+
+  const keys = Object.keys(first);
+  const usesNamedParams = keys.some(key => sentinels.indexOf(key) !== -1);
+  if (!usesNamedParams) {
+    return null;
+  }
+
+  if (args.length > 1) {
+    throw new MongooseError(
+      `${method}() named parameters must be passed as a single argument`
+    );
+  }
+
+  const params = {};
+  for (const key of keys) {
+    if (sentinels.indexOf(key) === -1) {
+      throw new MongooseError(
+        `${method}() received an invalid named parameter \`${key}\`. ` +
+        `Named parameters must use only: ${sentinels.join(', ')}.`
+      );
+    }
+    params[key.slice(1)] = first[key];
+  }
+
+  return params;
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -52,6 +52,7 @@ const get = require('./helpers/get');
 const getConstructorName = require('./helpers/getConstructorName');
 const getDiscriminatorByValue = require('./helpers/discriminator/getDiscriminatorByValue');
 const getModelsMapForPopulate = require('./helpers/populate/getModelsMapForPopulate');
+const getNamedParams = require('./helpers/query/getNamedParams');
 const immediate = require('./helpers/immediate');
 const internalToObjectOptions = require('./options').internalToObjectOptions;
 const isDefaultIdIndex = require('./helpers/indexes/isDefaultIdIndex');
@@ -2201,6 +2202,13 @@ Model.findOne = function findOne(conditions, projection, options) {
   _checkContext(this, 'findOne');
   if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function') {
     throw new MongooseError('Model.findOne() no longer accepts a callback');
+  }
+
+  const named = getNamedParams('Model.findOne', ['$filter', '$projection', '$options'], arguments);
+  if (named != null) {
+    conditions = named.filter;
+    projection = named.projection;
+    options = named.options;
   }
 
   const mq = new this.Query({}, {}, this, this.$__collection);

--- a/test/model.namedParams.test.js
+++ b/test/model.namedParams.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const start = require('./common');
+
+const assert = require('assert');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('Model.findOne named parameters (gh-10367)', function() {
+  let db;
+
+  before(() => { db = start(); });
+  after(() => db.close());
+  beforeEach(() => db.deleteModel(/.*/));
+
+  it('still supports the positional filter style', async function() {
+    const { User } = createTestContext();
+    await User.create({ name: 'John', email: 'john@example.com', age: 42 });
+
+    const found = await User.findOne({ name: 'John' });
+
+    assert.equal(found.name, 'John');
+    assert.equal(found.age, 42);
+  });
+
+  it('still supports positional filter + projection + options', async function() {
+    const { User } = createTestContext();
+    await User.create({ name: 'John', email: 'john@example.com', age: 42 });
+
+    const found = await User.findOne({ name: 'John' }, 'name', { lean: true });
+
+    assert.equal(found.name, 'John');
+    assert.strictEqual(found.age, undefined); // projected out
+    assert.strictEqual(found instanceof User, false); // lean
+  });
+
+  it('supports named parameters with $filter, $projection, $options', async function() {
+    const { User } = createTestContext();
+    await User.create({ name: 'Jane', email: 'jane@example.com', age: 30 });
+
+    const found = await User.findOne({
+      $filter: { name: 'Jane' },
+      $projection: 'name age',
+      $options: { lean: true }
+    });
+
+    assert.equal(found.name, 'Jane');
+    assert.equal(found.age, 30);
+    assert.strictEqual(found instanceof User, false); // lean applied
+  });
+
+  it('supports $filter on its own', async function() {
+    const { User } = createTestContext();
+    await User.create({ name: 'Sam', email: 'sam@example.com', age: 25 });
+
+    const found = await User.findOne({ $filter: { name: 'Sam' } });
+
+    assert.equal(found.name, 'Sam');
+  });
+
+  it('supports $options on its own (no $filter) at runtime', async function() {
+    const { User } = createTestContext();
+    await User.create({ name: 'Amy', email: 'amy@example.com', age: 50 });
+
+    const found = await User.findOne({ $options: { lean: true } });
+
+    assert.ok(found);
+    assert.strictEqual(found instanceof User, false); // lean applied, empty filter
+  });
+
+  it('treats a field literally named like a sentinel as a normal positional filter', async function() {
+    // `filter` (no $) is a real schema field, must not be confused with named params
+    const { Saved } = createTestContext();
+    await Saved.create({ filter: 'inbox', name: 'rule-1' });
+
+    const found = await Saved.findOne({ filter: 'inbox' });
+
+    assert.equal(found.name, 'rule-1');
+  });
+
+  it('throws when a $-key is mixed with a non-sentinel key', function() {
+    const { User } = createTestContext();
+
+    assert.throws(
+      () => User.findOne({ $filter: { name: 'John' }, name: 'John' }),
+      /invalid named parameter `name`/
+    );
+  });
+
+  it('throws on an unknown $-prefixed key alongside a sentinel', function() {
+    const { User } = createTestContext();
+
+    assert.throws(
+      () => User.findOne({ $filter: { name: 'John' }, $bogus: 1 }),
+      /invalid named parameter `\$bogus`/
+    );
+  });
+
+  it('throws when named parameters are passed with a second positional argument', function() {
+    const { User } = createTestContext();
+
+    assert.throws(
+      () => User.findOne({ $filter: { name: 'John' } }, 'name'),
+      /named parameters must be passed as a single argument/
+    );
+  });
+
+  function createTestContext() {
+    const userSchema = new Schema({ name: String, email: String, age: Number });
+    const User = db.model('User', userSchema);
+
+    const savedSchema = new Schema({ filter: String, name: String });
+    const Saved = db.model('Saved', savedSchema);
+
+    return { User, Saved };
+  }
+});

--- a/test/types/model.namedParams.test.ts
+++ b/test/types/model.namedParams.test.ts
@@ -1,0 +1,29 @@
+import { Schema, model } from 'mongoose';
+import { expect, test } from 'tstyche';
+
+interface IUser {
+  name: string;
+  email: string;
+  age: number;
+}
+
+const User = model<IUser>('NamedParamsUser', new Schema<IUser>({ name: String, email: String, age: Number }));
+
+test('findOne named parameters: valid forms compile', () => {
+  // positional style still works
+  expect(User.findOne({ name: 'John' })).type.not.toRaiseError();
+  // named params: $filter required, $projection / $options optional
+  expect(User.findOne({ $filter: { name: 'John' } })).type.not.toRaiseError();
+  expect(User.findOne({ $filter: { name: 'John' }, $projection: 'name age' })).type.not.toRaiseError();
+  expect(User.findOne({ $filter: { name: 'John' }, $projection: { name: 1 }, $options: { lean: true } })).type.not.toRaiseError();
+  // options-only via the `$filter: null` escape hatch
+  expect(User.findOne({ $filter: null, $options: { lean: true } })).type.not.toRaiseError();
+});
+
+test('findOne named parameters: malformed forms are rejected', () => {
+  // unknown sentinel-style key
+  expect(User.findOne({ $filter: { name: 'John' }, $bogus: 1 })).type.toRaiseError();
+  // $filter is required in the named-params form
+  expect(User.findOne({ $projection: 'name' })).type.toRaiseError();
+  expect(User.findOne({ $options: { lean: true } })).type.toRaiseError();
+});

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -463,9 +463,29 @@ declare module 'mongoose' {
       TInstanceMethods & TVirtuals
     >;
 
+    /**
+     * Finds one document using named parameters (gh-10367), e.g.
+     * `findOne({ $filter, $projection, $options })`. `$filter` is required;
+     * for an options-only call pass `$filter: null`. Listed first so an object
+     * with a `$filter` key resolves to this overload before the positional ones.
+     */
+    findOne<ResultDoc = THydratedDocumentType>(
+      namedParameters: {
+        $filter: QueryFilter<TRawDocType> | null;
+        $projection?: ProjectionType<TRawDocType> | null;
+        $options?: (QueryOptions<TRawDocType> & mongodb.Abortable) | null;
+      }
+    ): QueryWithHelpers<
+      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
     /** Finds one document. */
     findOne<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
+      filter: QueryFilter<TRawDocType> & { $filter?: never; $projection?: never; $options?: never },
       projection: ProjectionType<TRawDocType> | null | undefined,
       options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
     ): QueryWithHelpers<
@@ -489,7 +509,7 @@ declare module 'mongoose' {
       TInstanceMethods & TVirtuals
     >;
     findOne<ResultDoc = THydratedDocumentType>(
-      filter?: QueryFilter<TRawDocType>,
+      filter?: QueryFilter<TRawDocType> & { $filter?: never; $projection?: never; $options?: never },
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> & mongodb.Abortable | null | undefined
     ): QueryWithHelpers<


### PR DESCRIPTION
re #10367

Proof of concept for RORO-style named parameters, scoped to `Model.findOne`:

```js
User.findOne({ $filter: { email: 'x@y.com' }, $projection: 'name', $options: { lean: true } });
```

`$`-prefixed keys can't collide with a positional filter (the server rejects unknown `$`-prefixed top-level keys as operators), so detection is unambiguous.

- `getNamedParams` helper: single object arg, every key a known sentinel, throws on mixed/unknown keys or a stray positional arg. Positional calls are unchanged.
- Branded TS overload: `$filter` required (`$filter: null` for options-only). Branding the positional overloads with `& { $filter?: never; ... }` stops malformed calls from silently falling through to the positional filter, for ~free (~120 instantiations).