### PR TITLE
types: correct this parameter for methods with versionKey

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -119,6 +119,7 @@ async function gh16046(): Promise<void> {
     methods: {
       t(locale?: string) {
         const translation = (!!locale && this.translations.get(locale)) || {};
+        expect(this._v).type.toBe<number | null | undefined>();
 
         return {
           name: translation.name ?? this.name,

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -103,6 +103,37 @@ async function modelValidateReturnsCastedObject(): Promise<void> {
   expect(await User.validate({ name: 'Val', age: 42 }, { pathsToSkip: ['age'] })).type.toBe<IUser>();
 }
 
+async function gh16046(): Promise<void> {
+  const watchSchema = new Schema({
+    _id: { type: Schema.Types.ObjectId },
+    name: { type: String, required: true, trim: true },
+    code: { type: String, required: true, trim: true, index: true },
+    spec: { type: String, required: true, trim: true },
+    translations: { type: Map, of: new Schema({ name: String, spec: String }), required: true },
+    createdAt: { type: Date },
+    updatedAt: { type: Date },
+    _v: { type: Number, required: false, default: 0 }
+  }, {
+    timestamps: true,
+    versionKey: '_v',
+    methods: {
+      t(locale?: string) {
+        const translation = (!!locale && this.translations.get(locale)) || {};
+
+        return {
+          name: translation.name ?? this.name,
+          spec: translation.spec ?? this.spec
+        };
+      }
+    }
+  });
+
+  const Watch = model('gh16046', watchSchema);
+  const watch = await Watch.findOne({ code: 'test' });
+
+  expect(watch?.t('en')).type.toBe<{ name: string; spec: string } | undefined>();
+}
+
 function tAndDocSyntax(): void {
   interface ITest {
     id: number;

--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -2210,6 +2210,7 @@ function gh16046() {
     { placeholder: String },
     {
       timestamps: true,
+      versionKey: '_v',
       virtuals: {
         votes: {
           options: {
@@ -2222,6 +2223,7 @@ function gh16046() {
       methods: {
         myMethod: function() {
           ExpectType<string | null | undefined>(this.placeholder);
+          return this.placeholder;
         }
       },
       statics: {
@@ -2234,7 +2236,8 @@ function gh16046() {
   );
 
   const IssueTwo = model('IssueTwo', issueTwoSchema);
-  (new IssueTwo()).myMethod();
+  const doc = new IssueTwo();
+  ExpectType<string | null | undefined>(doc.myMethod());
   IssueTwo.myStaticMethod();
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -191,11 +191,13 @@ declare module 'mongoose' {
         Document<unknown, TQueryHelpers, RawDocType, TVirtuals, TSchemaOptions> & Default__v<Require_id<HydratedDocPathsType>, TSchemaOptions>,
         Document<unknown, TQueryHelpers, RawDocType, TVirtuals, TSchemaOptions> & MergeType<
           Default__v<Require_id<HydratedDocPathsType>, TSchemaOptions>,
-          IfEquals<
-            TOverrides,
-            {},
-            TOverrides,
-            TOverrides & AddDefaultId<HydratedDocPathsType, TVirtuals, TSchemaOptions>
+          HydratedDocumentOverrides<
+            IfEquals<
+              TOverrides,
+              {},
+              TOverrides,
+              TOverrides & AddDefaultId<HydratedDocPathsType, TVirtuals, TSchemaOptions>
+            >
           >
         >
       >

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -163,6 +163,9 @@ declare module 'mongoose' {
 
   type OmitThisParameterIfFunction<T> = T extends (...args: any[]) => any ? OmitThisParameter<T> : T;
 
+  // Strip explicit `this` parameter from methods in schema type options. The `this` parameter
+  // is just for type-checking the function body. Keeping the explicit 'this' typing can cause
+  // compiler errors on the method calls, so remove it for the hydrated document definition.
   type HydratedDocumentOverrides<T> = {
     [K in keyof T]: OmitThisParameterIfFunction<T[K]>;
   };

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -161,6 +161,12 @@ declare module 'mongoose' {
       : T[K];
   };
 
+  type OmitThisParameterIfFunction<T> = T extends (...args: any[]) => any ? OmitThisParameter<T> : T;
+
+  type HydratedDocumentOverrides<T> = {
+    [K in keyof T]: OmitThisParameterIfFunction<T[K]>;
+  };
+
   /**
    * @summary Adds timestamp fields to a type
    * @description Adds createdAt and updatedAt fields of type Date, or custom timestamp fields if specified


### PR DESCRIPTION
Fix #16046

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Omit `this` from methods because of `versionKey` option handling mismatch. `Schema.create()` already does this with the original fix for #16046 [here](https://github.com/automattic/mongoose/commit/19d3b4293f591cbefe1062ac55699c4814f1c754).

Mongoose adds `this` parameter to methods with `AddThisParameter<>` so the method body gets type checked correctly in `new Schema()` (`this` is correctly set to the inferred document), but then Mongoose strips `this` when the methods are added to the actual hydrated document type, because at that point TypeScript already knows the correct type of `this` (the actual document).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
