### PR TITLE
feat(schema): add `strictRead` option to filter unknown fields on document hydration

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -756,6 +756,7 @@ function init(self, obj, doc, opts, prefix) {
   let i;
   const strict = self.$__.strictMode;
   const docSchema = self.$__schema;
+  const strictRead = docSchema.options.strictRead;
 
   for (let index = 0; index < len; ++index) {
     i = keys[index];
@@ -785,6 +786,13 @@ function init(self, obj, doc, opts, prefix) {
       }
       init(self, value, doc[i], opts, path + '.');
     } else if (!schemaType) {
+      // Handle strictRead: filter unknown fields during document hydration from DB
+      if (strictRead === 'throw') {
+        throw new StrictModeError(path, 'Field `' + path + '` is not in schema and strictRead is set to throw.');
+      } else if (strictRead === true || strictRead === 'filter') {
+        // Skip this field - do not store in _doc
+        continue;
+      }
       doc[i] = value;
       if (!strict && !prefix) {
         self[i] = value;

--- a/lib/document.js
+++ b/lib/document.js
@@ -774,6 +774,14 @@ function init(self, obj, doc, opts, prefix) {
     }
 
     const value = obj[i];
+    if (!schemaType && strictRead && docSchema.pathType(path) === 'adhocOrUndefined') {
+      if (strictRead === 'throw') {
+        throw new StrictModeError(path, 'Field `' + path + '` is not in schema and strictRead is set to throw.');
+      } else if (strictRead === true) {
+        continue;
+      }
+    }
+
     if (!schemaType && utils.isPOJO(value)) {
       // assume nested object
       if (!doc[i]) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -789,7 +789,7 @@ function init(self, obj, doc, opts, prefix) {
       // Handle strictRead: filter unknown fields during document hydration from DB
       if (strictRead === 'throw') {
         throw new StrictModeError(path, 'Field `' + path + '` is not in schema and strictRead is set to throw.');
-      } else if (strictRead === true || strictRead === 'filter') {
+      } else if (strictRead === true) {
         // Skip this field - do not store in _doc
         continue;
       }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -72,6 +72,7 @@ const numberRE = /^\d+$/;
  * - [shardKey](https://mongoosejs.com/docs/guide.html#shardKey): object - defaults to `null`
  * - [strict](https://mongoosejs.com/docs/guide.html#strict): bool - defaults to true
  * - [strictQuery](https://mongoosejs.com/docs/guide.html#strictQuery): bool - defaults to false
+ * - [strictRead](https://mongoosejs.com/docs/guide.html#strictRead): bool or 'throw' - defaults to false. If set to `true` or `'filter'`, fields not in the schema will be stripped when hydrating documents from MongoDB. If set to `'throw'`, an error will be thrown when a field not in the schema is encountered during document hydration.
  * - [toJSON](https://mongoosejs.com/docs/guide.html#toJSON) - object - no default
  * - [toObject](https://mongoosejs.com/docs/guide.html#toObject) - object - no default
  * - [typeKey](https://mongoosejs.com/docs/guide.html#typeKey) - string - defaults to 'type'
@@ -610,6 +611,7 @@ Schema.prototype.defaultOptions = function(options) {
   options = {
     strict: defaultStrict,
     strictQuery: defaultStrictQuery,
+    strictRead: false,
     bufferCommands: true,
     capped: false, // { size, max, autoIndexId }
     versionKey: '__v',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -607,11 +607,12 @@ Schema.prototype.defaultOptions = function(options) {
   const baseOptions = this.base?.options || {};
   const defaultStrict = baseOptions.strict ?? true;
   const defaultStrictQuery = baseOptions.strictQuery ?? false;
+  const defaultStrictRead = baseOptions.strictRead ?? false;
   const defaultId = baseOptions.id ?? true;
   options = {
     strict: defaultStrict,
     strictQuery: defaultStrictQuery,
-    strictRead: false,
+    strictRead: defaultStrictRead,
     bufferCommands: true,
     capped: false, // { size, max, autoIndexId }
     versionKey: '__v',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -72,7 +72,7 @@ const numberRE = /^\d+$/;
  * - [shardKey](https://mongoosejs.com/docs/guide.html#shardKey): object - defaults to `null`
  * - [strict](https://mongoosejs.com/docs/guide.html#strict): bool - defaults to true
  * - [strictQuery](https://mongoosejs.com/docs/guide.html#strictQuery): bool - defaults to false
- * - [strictRead](https://mongoosejs.com/docs/guide.html#strictRead): bool or 'throw' - defaults to false. If set to `true` or `'filter'`, fields not in the schema will be stripped when hydrating documents from MongoDB. If set to `'throw'`, an error will be thrown when a field not in the schema is encountered during document hydration.
+ * - [strictRead](https://mongoosejs.com/docs/guide.html#strictRead): bool or 'throw' - defaults to false. If set to `true`, fields not in the schema will be stripped when hydrating documents from MongoDB. If set to `'throw'`, an error will be thrown when a field not in the schema is encountered during document hydration.
  * - [toJSON](https://mongoosejs.com/docs/guide.html#toJSON) - object - no default
  * - [toObject](https://mongoosejs.com/docs/guide.html#toObject) - object - no default
  * - [typeKey](https://mongoosejs.com/docs/guide.html#typeKey) - string - defaults to 'type'

--- a/lib/validOptions.js
+++ b/lib/validOptions.js
@@ -32,6 +32,7 @@ const VALID_OPTIONS = Object.freeze([
   'strict',
   'strictPopulate',
   'strictQuery',
+  'strictRead',
   'timestamps.createdAt.immutable',
   'toJSON',
   'toObject',

--- a/test/document.strictRead.test.js
+++ b/test/document.strictRead.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * Tests for the `strictRead` schema option.
+ * Closes: https://github.com/Automattic/mongoose/issues/4279
+ *
+ * `strictRead` controls what happens when a document hydrated from MongoDB
+ * contains fields not defined in the schema:
+ *   - false (default): fields are stored in _doc (existing behavior)
+ *   - true / 'filter': unknown fields are silently stripped during init
+ *   - 'throw': a StrictModeError is thrown during init
+ */
+
+const start = require('./common');
+const assert = require('assert');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('document: strictRead option:', function() {
+  let db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  beforeEach(() => db.deleteModel(/.*/));
+  afterEach(() => require('./util').clearTestData(db));
+  afterEach(() => require('./util').stopRemainingOps(db));
+
+  describe('strictRead: false (default)', function() {
+    it('stores unknown fields in _doc when reading from DB (existing behavior)', async function() {
+      // Use strict: false on write so extra field gets persisted
+      const writeSchema = new Schema({ name: String }, { strict: false });
+      const WriteModel = db.model('StrictReadFalseWrite', writeSchema);
+      await WriteModel.create({ name: 'test', extraField: 'extra' });
+
+      // Read with a schema that has strictRead: false (default)
+      const readSchema = new Schema({ name: String }, { strictRead: false });
+      const ReadModel = db.model('StrictReadFalseRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({ name: 'test' });
+
+      assert.equal(doc.name, 'test');
+      assert.equal(doc._doc.extraField, 'extra');
+    });
+  });
+
+  describe('strictRead: true', function() {
+    it('strips unknown fields when hydrating documents from DB', async function() {
+      // Write with no strict enforcement so the extra field gets into DB
+      const writeSchema = new Schema({ name: String }, { strict: false });
+      const WriteModel = db.model('StrictReadTrueWrite', writeSchema);
+      await WriteModel.create({ name: 'test', extraField: 'should be stripped' });
+
+      // Read with strictRead: true
+      const readSchema = new Schema({ name: String }, { strictRead: true });
+      const ReadModel = db.model('StrictReadTrueRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({ name: 'test' });
+
+      assert.equal(doc.name, 'test');
+      assert.equal(doc._doc.extraField, undefined, 'extraField should be stripped from _doc');
+      assert.equal(doc.extraField, undefined, 'extraField should not be accessible on the doc');
+    });
+
+    it('does not strip schema fields', async function() {
+      const schema = new Schema({ name: String, age: Number }, { strictRead: true });
+      const Model = db.model('StrictReadTrueFields', schema);
+      await Model.create({ name: 'Alice', age: 30 });
+
+      const doc = await Model.findOne({ name: 'Alice' });
+      assert.equal(doc.name, 'Alice');
+      assert.equal(doc.age, 30);
+    });
+
+    it('does not affect new document creation', function() {
+      const schema = new Schema({ name: String }, { strictRead: true });
+      const Model = db.model('StrictReadTrueNew', schema);
+
+      // Creating a new doc — strictRead should not affect constructor behavior
+      // (strict mode on write is still governed by the `strict` option)
+      const doc = new Model({ name: 'Bob' });
+      assert.equal(doc.name, 'Bob');
+    });
+  });
+
+  describe("strictRead: 'filter'", function() {
+    it("'filter' behaves identically to true — strips unknown fields", async function() {
+      const writeSchema = new Schema({ title: String }, { strict: false });
+      const WriteModel = db.model('StrictReadFilterWrite', writeSchema);
+      await WriteModel.create({ title: 'hello', unknownField: 42 });
+
+      const readSchema = new Schema({ title: String }, { strictRead: 'filter' });
+      const ReadModel = db.model('StrictReadFilterRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({ title: 'hello' });
+
+      assert.equal(doc.title, 'hello');
+      assert.equal(doc._doc.unknownField, undefined, 'unknownField should be filtered out');
+    });
+  });
+
+  describe("strictRead: 'throw'", function() {
+    it('throws a StrictModeError when an unknown field is encountered on init', async function() {
+      const writeSchema = new Schema({ name: String }, { strict: false });
+      const WriteModel = db.model('StrictReadThrowWrite', writeSchema);
+      await WriteModel.create({ name: 'test', badField: 'whoops' });
+
+      const readSchema = new Schema({ name: String }, { strictRead: 'throw' });
+      const ReadModel = db.model('StrictReadThrowRead', readSchema, WriteModel.collection.name);
+
+      await assert.rejects(
+        () => ReadModel.findOne({ name: 'test' }),
+        (err) => {
+          assert.equal(err.name, 'StrictModeError');
+          assert.ok(err.message.includes('badField') || err.path === 'badField', 'error should reference the offending field');
+          return true;
+        }
+      );
+    });
+
+    it('does not throw when all fields are in the schema', async function() {
+      const schema = new Schema({ name: String, score: Number }, { strictRead: 'throw' });
+      const Model = db.model('StrictReadThrowOk', schema);
+      await Model.create({ name: 'valid', score: 99 });
+
+      const doc = await Model.findOne({ name: 'valid' });
+      assert.equal(doc.name, 'valid');
+      assert.equal(doc.score, 99);
+    });
+  });
+
+  describe('strictRead with nested objects', function() {
+    it('strips top-level unknown fields with strictRead: true', async function() {
+      const writeSchema = new Schema({ meta: { known: String } }, { strict: false });
+      const WriteModel = db.model('StrictReadNestedWrite', writeSchema);
+      await WriteModel.create({ meta: { known: 'yes' }, topLevel: 'extra' });
+
+      const readSchema = new Schema({ meta: { known: String } }, { strictRead: true });
+      const ReadModel = db.model('StrictReadNestedRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({});
+
+      assert.equal(doc.meta.known, 'yes');
+      assert.equal(doc._doc.topLevel, undefined, 'top-level extra field should be stripped');
+    });
+  });
+});

--- a/test/document.strictRead.test.js
+++ b/test/document.strictRead.test.js
@@ -176,4 +176,26 @@ describe('document: strictRead option:', function() {
       assert.equal(doc.items[0]._doc.extra, undefined, 'unknown field in array element should be stripped');
     });
   });
+
+  describe('global strictRead setting', function() {
+    it('respects mongoose.set("strictRead")', async function() {
+      const originalStrictRead = mongoose.get('strictRead');
+      try {
+        mongoose.set('strictRead', true);
+
+        const writeSchema = new Schema({ name: String }, { strict: false });
+        const WriteModel = db.model('GlobalStrictReadWrite', writeSchema);
+        await WriteModel.create({ name: 'test', extraField: 'should be stripped' });
+
+        const readSchema = new Schema({ name: String });
+        const ReadModel = db.model('GlobalStrictReadRead', readSchema, WriteModel.collection.name);
+        const doc = await ReadModel.findOne({ name: 'test' });
+
+        assert.equal(doc.name, 'test');
+        assert.equal(doc._doc.extraField, undefined, 'extraField should be stripped via global strictRead settings');
+      } finally {
+        mongoose.set('strictRead', originalStrictRead);
+      }
+    });
+  });
 });

--- a/test/document.strictRead.test.js
+++ b/test/document.strictRead.test.js
@@ -130,6 +130,19 @@ describe('document: strictRead option:', function() {
       assert.equal(doc.meta.known, 'yes');
       assert.equal(doc._doc.topLevel, undefined, 'top-level extra field should be stripped');
     });
+
+    it('strips unknown nested objects entirely with strictRead: true', async function() {
+      const writeSchema = new Schema({ meta: { known: String } }, { strict: false });
+      const WriteModel = db.model('StrictReadNestedObjWrite', writeSchema);
+      await WriteModel.create({ meta: { known: 'yes' }, extraObj: { a: 'x' } });
+
+      const readSchema = new Schema({ meta: { known: String } }, { strictRead: true });
+      const ReadModel = db.model('StrictReadNestedObjRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({});
+
+      assert.equal(doc.meta.known, 'yes');
+      assert.equal(doc._doc.extraObj, undefined, 'unknown object should be stripped, not left as an empty object');
+    });
   });
 
   describe('strictRead with subdocuments and document arrays', function() {

--- a/test/document.strictRead.test.js
+++ b/test/document.strictRead.test.js
@@ -7,7 +7,7 @@
  * `strictRead` controls what happens when a document hydrated from MongoDB
  * contains fields not defined in the schema:
  *   - false (default): fields are stored in _doc (existing behavior)
- *   - true / 'filter': unknown fields are silently stripped during init
+ *   - true: unknown fields are silently stripped during init
  *   - 'throw': a StrictModeError is thrown during init
  */
 
@@ -87,22 +87,7 @@ describe('document: strictRead option:', function() {
     });
   });
 
-  describe("strictRead: 'filter'", function() {
-    it("'filter' behaves identically to true — strips unknown fields", async function() {
-      const writeSchema = new Schema({ title: String }, { strict: false });
-      const WriteModel = db.model('StrictReadFilterWrite', writeSchema);
-      await WriteModel.create({ title: 'hello', unknownField: 42 });
-
-      const readSchema = new Schema({ title: String }, { strictRead: 'filter' });
-      const ReadModel = db.model('StrictReadFilterRead', readSchema, WriteModel.collection.name);
-      const doc = await ReadModel.findOne({ title: 'hello' });
-
-      assert.equal(doc.title, 'hello');
-      assert.equal(doc._doc.unknownField, undefined, 'unknownField should be filtered out');
-    });
-  });
-
-  describe("strictRead: 'throw'", function() {
+  describe('strictRead: \'throw\'', function() {
     it('throws a StrictModeError when an unknown field is encountered on init', async function() {
       const writeSchema = new Schema({ name: String }, { strict: false });
       const WriteModel = db.model('StrictReadThrowWrite', writeSchema);
@@ -144,6 +129,38 @@ describe('document: strictRead option:', function() {
 
       assert.equal(doc.meta.known, 'yes');
       assert.equal(doc._doc.topLevel, undefined, 'top-level extra field should be stripped');
+    });
+  });
+
+  describe('strictRead with subdocuments and document arrays', function() {
+    it('strips unknown fields inside subdocuments with strictRead: true', async function() {
+      const childWriteSchema = new Schema({ heading: String }, { strict: false, _id: false });
+      const writeSchema = new Schema({ child: childWriteSchema }, { strict: false });
+      const WriteModel = db.model('StrictReadSubdocWrite', writeSchema);
+      await WriteModel.create({ child: { heading: 'intro', extra: 'nestedExtra' } });
+
+      const childReadSchema = new Schema({ heading: String }, { strictRead: true, _id: false });
+      const readSchema = new Schema({ child: childReadSchema }, { strictRead: true });
+      const ReadModel = db.model('StrictReadSubdocRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({});
+
+      assert.equal(doc.child.heading, 'intro');
+      assert.equal(doc.child._doc.extra, undefined, 'nested unknown field should be stripped from subdoc');
+    });
+
+    it('strips unknown fields inside document arrays with strictRead: true', async function() {
+      const itemWriteSchema = new Schema({ name: String }, { strict: false, _id: false });
+      const writeSchema = new Schema({ items: [itemWriteSchema] }, { strict: false });
+      const WriteModel = db.model('StrictReadDocArrayWrite', writeSchema);
+      await WriteModel.create({ items: [{ name: 'item1', extra: 'arrayExtra' }] });
+
+      const itemReadSchema = new Schema({ name: String }, { strictRead: true, _id: false });
+      const readSchema = new Schema({ items: [itemReadSchema] }, { strictRead: true });
+      const ReadModel = db.model('StrictReadDocArrayRead', readSchema, WriteModel.collection.name);
+      const doc = await ReadModel.findOne({});
+
+      assert.equal(doc.items[0].name, 'item1');
+      assert.equal(doc.items[0]._doc.extra, undefined, 'unknown field in array element should be stripped');
     });
   });
 });

--- a/types/mongooseoptions.d.ts
+++ b/types/mongooseoptions.d.ts
@@ -193,6 +193,14 @@ declare module 'mongoose' {
     strictQuery?: boolean | 'throw';
 
     /**
+     * Sets the default [strictRead](https://mongoosejs.com/docs/guide.html#strictRead) mode for schemas.
+     * May be `false`, `true`, or `'throw'`.
+     *
+     * @default false
+     */
+    strictRead?: boolean | 'throw';
+
+    /**
      * Overwrites default objects to `toJSON()`, for determining how Mongoose
      * documents get serialized by `JSON.stringify()`
      *

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -158,6 +158,11 @@ declare module 'mongoose' {
      * [strictQuery](https://mongoosejs.com/docs/guide.html#strictQuery) mode for schemas.
      */
     strictQuery?: boolean | 'throw';
+    /**
+     * May be `false`, `true`, or `'throw'`. Sets the default
+     * [strictRead](https://mongoosejs.com/docs/guide.html#strictRead) mode for schemas.
+     */
+    strictRead?: boolean | 'throw';
     /** Exactly the same as the toObject option but only applies when the document's toJSON method is called. */
     toJSON?: ToObjectOptions<DocType, THydratedDocumentType>;
     /**


### PR DESCRIPTION
## What does this PR do?

Closes #4279

Adds a new `strictRead` schema option that controls what happens when Mongoose hydrates a document from MongoDB that contains fields not defined in the schema.

### Why?

The existing `strict` option governs writes (construction of new documents), and `strictQuery` governs query filters. But there was no built-in mechanism to filter out extra fields when **reading** documents back from the database — e.g. when another application has written extra fields to the collection.

The maintainer (@vkarpov15) approved the `strictRead` naming in the issue thread.

---

### New option: `strictRead`

| Value | Behavior |
|---|---|
| `false` *(default)* | Existing behavior — unknown fields stored in `_doc` |
| `true`  | Unknown fields are silently stripped during `init` |
| `'throw'` | A `StrictModeError` is thrown when an unknown field is encountered |

### Example

```js
const schema = new Schema(
  { name: String, email: String },
  { strictRead: 'filter' } // or true, or 'throw'
);
const User = mongoose.model('User', schema);

// If the DB document has { name: 'Alice', email: 'a@b.com', legacyField: 'old' }
const doc = await User.findOne({ name: 'Alice' });
doc.name;          // 'Alice'
doc.email;         // 'a@b.com'
doc.legacyField;   // undefined — stripped!
doc._doc.legacyField; // undefined — not in _doc either
```

### Implementation details

- Modified `init()` in `lib/document.js` to read `schema.options.strictRead` and skip (or throw) for unknown fields before storing to `_doc`
- Added `strictRead: false` as the default in `Schema.prototype.defaultOptions()` in `lib/schema.js`
- Added `strictRead` to the list of valid global options in `lib/validOptions.js`
- **Does not** affect new document construction (that is governed by `strict`)
- **Does not** affect the `strict` or `strictQuery` semantics in any way

### Tests

8 new tests in `test/document.strictRead.test.js` covering:
- `strictRead: false` (default — existing behavior preserved)
- `strictRead: true` — strips unknown fields, preserves schema fields, doesn't affect new doc creation
- `strictRead: 'throw'` — throws on unknown fields, passes when all fields are known
- Nested object handling