### PR TITLE
types: remove middleware option from ValidateSyncOptions

### DIFF
--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -12,8 +12,6 @@ declare module 'mongoose' {
   }
 
   interface ValidateSyncOptions extends Omit<ValidateOptions, 'middleware'> {
-    /** `validateSync()` does not run middleware. Use `validate()` if you need middleware. */
-    middleware?: never;
     [k: string]: any;
   }
 


### PR DESCRIPTION
## What does this PR do?

Closes #16291

Removes the `middleware` property from `ValidateSyncOptions` in TypeScript definitions.

### Why?

As discussed in #16291, `validateSync()` does not execute middleware at all in practice, making the option misleading or redundant. Removing the `middleware` property aligns the TypeScript typings with the runtime implementation of `validateSync()`.