### PR TITLE
Support `middleware` skip option for cursors and custom hooks

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -635,10 +635,19 @@ await doc.save({ middleware: false });
 // Skip all user middleware on queries
 await Model.find({}, null, { middleware: false });
 await Model.updateOne({}, { name: 'test' }, { middleware: false });
+await Model.find().cursor({ middleware: false }).eachAsync(doc => {
+  // process doc
+});
 
 // Skip all user middleware on aggregation
 await Model.aggregate([]).option({ middleware: false });
+await Model.aggregate([]).cursor({ middleware: false }).eachAsync(doc => {
+  // process doc
+});
 ```
+
+Aggregation cursors run `pre('aggregate')` hooks when creating the cursor, but do not run `post('aggregate')` hooks.
+For aggregation cursors, `middleware: false` skips `pre('aggregate')` hooks.
 
 ### Skip Only Pre or Post Hooks
 
@@ -651,6 +660,23 @@ await doc.save({ middleware: { pre: false } });
 // Skip only post hooks, pre hooks still run
 await Model.find({}, null, { middleware: { post: false } });
 ```
+
+For custom statics and methods, reserve the last argument for Mongoose options and default it to `{}`.
+Mongoose reads `middleware` from that trailing options object:
+
+```javascript
+schema.statics.queueEmail = async function(to, emailOptions, options = {}) {
+  await emailQueue.add({ to, priority: emailOptions.priority });
+};
+schema.pre('queueEmail', function() {
+  // user-defined middleware, for example rate limiting or audit logging
+});
+
+await User.queueEmail('test@example.com', { priority: 'high' }, { middleware: false });
+```
+
+Because custom statics and methods can have arbitrary signatures, Mongoose treats a `middleware` property on the trailing plain object argument as the middleware option.
+Pass application-specific options before the trailing Mongoose options argument.
 
 **Note:** Built-in Mongoose middleware (timestamps, validation, etc.) always runs regardless of this option. Only user-defined middleware registered via `schema.pre()` and `schema.post()` is skipped.
 

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -922,6 +922,8 @@ Aggregate.prototype.option = function(value) {
  * Sets the `cursor` option and executes this aggregation, returning an aggregation cursor.
  * Cursors are useful if you want to process the results of the aggregation one-at-a-time
  * because the aggregation result is too big to fit into memory.
+ * Creating an aggregation cursor runs pre aggregate hooks, but not post aggregate hooks.
+ * To skip pre aggregate hooks, pass `middleware: false` to `.cursor()`.
  *
  * #### Example:
  *
@@ -932,6 +934,8 @@ Aggregate.prototype.option = function(value) {
  *
  * @param {object} options
  * @param {number} [options.batchSize] set the cursor batch size
+ * @param {boolean|object} [options.middleware=true] set to `false` to skip user-defined pre aggregate middleware
+ * @param {boolean} [options.middleware.pre=true] set to `false` to skip pre aggregate middleware
  * @param {boolean} [options.useMongooseAggCursor] use experimental mongoose-specific aggregation cursor (for `eachAsync()` and other query cursor semantics)
  * @return {AggregationCursor} cursor representing this aggregation
  * @api public
@@ -940,6 +944,11 @@ Aggregate.prototype.option = function(value) {
 
 Aggregate.prototype.cursor = function(options) {
   this._optionsForExec();
+  if (utils.hasUserDefinedProperty(options, 'middleware')) {
+    options = { ...options };
+    this.options.middleware = options.middleware;
+    delete options.middleware;
+  }
   this.options.cursor = options || {};
   return new AggregationCursor(this); // return this;
 };

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -11,6 +11,7 @@ const immediate = require('../helpers/immediate');
 const kareem = require('kareem');
 const util = require('util');
 const { cursorNextChannel } = require('../tracing');
+const { buildMiddlewareFilter } = require('../helpers/buildMiddlewareFilter');
 
 /**
  * An AggregationCursor is a concurrency primitive for processing aggregation
@@ -49,7 +50,9 @@ function AggregationCursor(agg) {
   this._mongooseOptions = {};
 
   if (connection) {
-    this.cursor = connection.db.aggregate(agg._pipeline, agg.options || {});
+    const options = agg.options != null ? { ...agg.options } : {};
+    delete options.middleware;
+    this.cursor = connection.db.aggregate(agg._pipeline, options);
     setImmediate(() => this.emit('cursor', this.cursor));
   } else {
     _init(model, this, agg);
@@ -63,7 +66,8 @@ util.inherits(AggregationCursor, Readable);
  */
 
 function _init(model, c, agg) {
-  model.hooks.execPre('aggregate', agg).then(() => onPreComplete(null), err => onPreComplete(err));
+  const preFilter = buildMiddlewareFilter(agg.options, 'pre');
+  model.hooks.execPre('aggregate', agg, [], { filter: preFilter }).then(() => onPreComplete(null), err => onPreComplete(err));
 
   function onPreComplete(err) {
     if (err != null) {
@@ -90,7 +94,9 @@ function _init(model, c, agg) {
 
 function _getRawCursor(model, aggregationCursor, agg) {
   try {
-    const cursor = model.collection.aggregate(agg._pipeline, agg.options || {});
+    const options = agg.options != null ? { ...agg.options } : {};
+    delete options.middleware;
+    const cursor = model.collection.aggregate(agg._pipeline, options);
     aggregationCursor.cursor = cursor;
     aggregationCursor.emit('cursor', cursor);
   } catch (err) {

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -13,6 +13,7 @@ const immediate = require('../helpers/immediate');
 const { once } = require('events');
 const util = require('util');
 const { cursorNextChannel } = require('../tracing');
+const { buildMiddlewareFilter } = require('../helpers/buildMiddlewareFilter');
 
 /**
  * A QueryCursor is a concurrency primitive for processing query results
@@ -75,6 +76,10 @@ function QueryCursor(query) {
       return;
     }
     Object.assign(this.options, query._optionsForExec());
+    // `middleware` is a Mongoose-only option used to skip user hooks; strip it
+    // so it isn't passed through to the MongoDB driver. Safe to delete because
+    // `_optionsForExec()` returns a clone, so `query.options` is untouched.
+    delete this.options.middleware;
     this._transforms = this._transforms.concat(query._transforms.slice());
     if (this.options.transform) {
       this._transforms.push(this.options.transform);
@@ -98,7 +103,8 @@ function QueryCursor(query) {
     }
   };
 
-  model.hooks.execPre('find', query).then(() => onPreComplete(null), err => onPreComplete(err));
+  const preFilter = buildMiddlewareFilter(query.options, 'pre');
+  model.hooks.execPre('find', query, [], { filter: preFilter }).then(() => onPreComplete(null), err => onPreComplete(err));
 }
 
 util.inherits(QueryCursor, Readable);
@@ -606,8 +612,9 @@ function _populateBatch() {
  */
 
 function _nextDoc(ctx, doc, pop, callback) {
+  const postFilter = buildMiddlewareFilter(ctx.query.options, 'post');
   if (ctx.query._mongooseOptions.lean) {
-    return ctx.model.hooks.execPost('find', ctx.query, [[doc]]).then(() => callback(null, doc), err => callback(err));
+    return ctx.model.hooks.execPost('find', ctx.query, [[doc]], { filter: postFilter }).then(() => callback(null, doc), err => callback(err));
   }
 
   const { model, _fields, _userProvidedFields, options } = ctx.query;
@@ -618,7 +625,7 @@ function _nextDoc(ctx, doc, pop, callback) {
     if (options.session != null) {
       doc.$session(options.session);
     }
-    ctx.model.hooks.execPost('find', ctx.query, [[doc]]).then(() => callback(null, doc), err => callback(err));
+    ctx.model.hooks.execPost('find', ctx.query, [[doc]], { filter: postFilter }).then(() => callback(null, doc), err => callback(err));
   });
 }
 

--- a/lib/helpers/buildMiddlewareFilter.js
+++ b/lib/helpers/buildMiddlewareFilter.js
@@ -15,8 +15,8 @@ const isBuiltInMiddleware = hook => hook.fn[symbols.builtInMiddleware];
  * @returns {Function|null} - null runs all middleware, isBuiltInMiddleware skips user middleware
  */
 function buildMiddlewareFilter(options, phase) {
-  const shouldRun = options?.middleware?.[phase] ?? options?.middleware ?? true;
-  return shouldRun ? null : isBuiltInMiddleware;
+  const shouldSkip = options?.middleware === false || options?.middleware?.[phase] === false;
+  return shouldSkip ? isBuiltInMiddleware : null;
 }
 
 module.exports = {

--- a/lib/helpers/model/applyHooks.js
+++ b/lib/helpers/model/applyHooks.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { buildMiddlewareFilter } = require('../buildMiddlewareFilter');
+const isPOJO = require('../isPOJO');
 
 /*!
  * ignore
@@ -104,7 +105,17 @@ function applyHooks(model, schema, options) {
     // query thunks are not as consistent as I would like about returning
     // a nullish value rather than the query. If a query thunk returns
     // a query, `checkForPromise` causes infinite recursion
-    checkForPromise: true
+    checkForPromise: true,
+    // Read the `middleware` option from the method's last argument so user
+    // hooks on custom methods can be skipped per call.
+    getOptions: args => {
+      const lastArg = args[args.length - 1];
+      const options = isPOJO(lastArg) ? lastArg : null;
+      return {
+        pre: { filter: buildMiddlewareFilter(options, 'pre') },
+        post: { filter: buildMiddlewareFilter(options, 'post') }
+      };
+    }
   });
   for (const method of customMethods) {
     if (alreadyHookedFunctions.has(method)) {

--- a/lib/helpers/model/applyStaticHooks.js
+++ b/lib/helpers/model/applyStaticHooks.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { buildMiddlewareFilter } = require('../buildMiddlewareFilter');
+const isPOJO = require('../isPOJO');
 const { queryMiddlewareFunctions, aggregateMiddlewareFunctions, modelMiddlewareFunctions, documentMiddlewareFunctions } = require('../../constants');
 
 const middlewareFunctions = Array.from(
@@ -27,7 +29,16 @@ module.exports = function applyStaticHooks(model, hooks, statics) {
     if (hooks.hasHooks(key)) {
       const original = model[key];
 
-      model[key] = hooks.createWrapper(key, original);
+      model[key] = hooks.createWrapper(key, original, null, {
+        getOptions: args => {
+          const lastArg = args[args.length - 1];
+          const options = isPOJO(lastArg) ? lastArg : null;
+          return {
+            pre: { filter: buildMiddlewareFilter(options, 'pre') },
+            post: { filter: buildMiddlewareFilter(options, 'post') }
+          };
+        }
+      });
     }
   }
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -5330,7 +5330,8 @@ Query.prototype._applyPaths = function applyPaths() {
  * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/7.0/classes/FindCursor.html).
  * A QueryCursor exposes a Streams3 interface, as well as a `.next()` function.
  *
- * The `.cursor()` function triggers pre find hooks, but **not** post find hooks.
+ * The `.cursor()` function triggers pre find hooks before opening the cursor
+ * and post find hooks for each document.
  *
  * #### Example:
  *
@@ -5362,6 +5363,10 @@ Query.prototype._applyPaths = function applyPaths() {
  *
  * @return {QueryCursor}
  * @param {object} [options]
+ * @param {Function} [options.transform] optional function which accepts a mongoose document. The return value of the function will be emitted on `data` and returned by `.next()`.
+ * @param {boolean|object} [options.middleware=true] set to `false` to skip all user-defined middleware
+ * @param {boolean} [options.middleware.pre=true] set to `false` to skip only pre hooks
+ * @param {boolean} [options.middleware.post=true] set to `false` to skip only post hooks
  * @see QueryCursor https://mongoosejs.com/docs/api/querycursor.html
  * @api public
  */

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "kareem": "3.3.0",
+    "kareem": "git+https://github.com/AbdelrahmanHafez/kareem.git#f0ec8dcc94f616e7468a839fb122ebb6a14d5c6a",
     "mongodb": "~7.2",
     "mpath": "0.9.0",
     "mquery": "6.0.0",

--- a/test/model.skip.middleware.test.js
+++ b/test/model.skip.middleware.test.js
@@ -8,6 +8,7 @@ const { builtInMiddleware } = require('../lib/schema/symbols');
 const start = require('./common');
 
 const assert = require('assert');
+const sinon = require('sinon');
 
 const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
@@ -109,7 +110,7 @@ describe('middleware option to skip hooks (gh-8768)', function() {
 
     describe('bulkSave()', function() {
       it('skips pre/post hooks when middleware: false', async function() {
-      // Arrange
+        // Arrange
         const { User, getPreCount, getPostCount } = createTestContext();
         const user = new User({ name: 'test' });
 
@@ -122,7 +123,7 @@ describe('middleware option to skip hooks (gh-8768)', function() {
       });
 
       it('skips only pre hooks when middleware: { pre: false }', async function() {
-      // Arrange
+        // Arrange
         const { User, getPreCount, getPostCount } = createTestContext();
         const user = new User({ name: 'test' });
 
@@ -135,7 +136,7 @@ describe('middleware option to skip hooks (gh-8768)', function() {
       });
 
       it('skips only post hooks when middleware: { post: false }', async function() {
-      // Arrange
+        // Arrange
         const { User, getPreCount, getPostCount } = createTestContext();
         const user = new User({ name: 'test' });
 
@@ -208,9 +209,9 @@ describe('middleware option to skip hooks (gh-8768)', function() {
       // Act
       await User.findOne({}, null, { middleware: false });
 
-      // Assert - find hooks should be skipped, but so should init hooks
-      assert.strictEqual(getPreCount('find'), 0);
-      assert.strictEqual(getPostCount('find'), 0);
+      // Assert
+      assert.strictEqual(getPreCount('findOne'), 0);
+      assert.strictEqual(getPostCount('findOne'), 0);
       assert.strictEqual(getPreCount('init'), 0);
       assert.strictEqual(getPostCount('init'), 0);
     });
@@ -224,6 +225,8 @@ describe('middleware option to skip hooks (gh-8768)', function() {
       await User.findOne({});
 
       // Assert
+      assert.strictEqual(getPreCount('findOne'), 1);
+      assert.strictEqual(getPostCount('findOne'), 1);
       assert.strictEqual(getPreCount('init'), 1);
       assert.strictEqual(getPostCount('init'), 1);
     });
@@ -237,6 +240,8 @@ describe('middleware option to skip hooks (gh-8768)', function() {
       await User.findOne({}, null, { middleware: { pre: false } });
 
       // Assert
+      assert.strictEqual(getPreCount('findOne'), 0);
+      assert.strictEqual(getPostCount('findOne'), 1);
       assert.strictEqual(getPreCount('init'), 0);
       assert.strictEqual(getPostCount('init'), 1);
     });
@@ -250,6 +255,8 @@ describe('middleware option to skip hooks (gh-8768)', function() {
       await User.findOne({}, null, { middleware: { post: false } });
 
       // Assert
+      assert.strictEqual(getPreCount('findOne'), 1);
+      assert.strictEqual(getPostCount('findOne'), 0);
       assert.strictEqual(getPreCount('init'), 1);
       assert.strictEqual(getPostCount('init'), 0);
     });
@@ -645,6 +652,415 @@ describe('middleware option to skip hooks (gh-8768)', function() {
         builtInHooks,
         'All internal plugin hooks should have builtInMiddleware symbol'
       );
+    });
+  });
+
+  describe('middleware option parsing', function() {
+    it('runs hooks for falsy middleware option values other than false', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+
+      // Act
+      await User.find({}, null, { middleware: 0 }).exec();
+      await User.find({}, null, { middleware: { pre: 0, post: '' } }).exec();
+
+      // Assert
+      assert.strictEqual(getPreCount('find'), 2);
+      assert.strictEqual(getPostCount('find'), 2);
+    });
+  });
+
+  describe('query cursor', function() {
+    it('skips pre/post find hooks when middleware: false', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.find().cursor({ middleware: false }).eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('find'), 0);
+      assert.strictEqual(getPostCount('find'), 0);
+    });
+
+    it('runs find hooks normally without middleware option', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.find().cursor().eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('find'), 1);
+      assert.strictEqual(getPostCount('find'), 1);
+    });
+
+    it('skips only pre find hooks when middleware: { pre: false }', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.find().cursor({ middleware: { pre: false } }).eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('find'), 0);
+      assert.strictEqual(getPostCount('find'), 1);
+    });
+
+    it('skips only post find hooks when middleware: { post: false }', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.find().cursor({ middleware: { post: false } }).eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('find'), 1);
+      assert.strictEqual(getPostCount('find'), 0);
+    });
+
+    it('skips pre/post find hooks when iterating with next()', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+
+      // Act
+      const cursor = User.find().cursor({ middleware: false });
+      const doc = await cursor.next();
+
+      // Assert
+      assert.ok(doc);
+      assert.strictEqual(doc.name, 'John');
+      assert.strictEqual(getPreCount('find'), 0);
+      assert.strictEqual(getPostCount('find'), 0);
+    });
+
+    it('does not leak the middleware option into collection.find', async function() {
+      // Arrange
+      const { User } = createTestContext();
+      await User.create({ name: 'John' });
+      const findSpy = sinon.spy(User.collection, 'find');
+
+      // Act
+      try {
+        await User.find().cursor({ middleware: false }).eachAsync(() => {});
+      } finally {
+        findSpy.restore();
+      }
+
+      // Assert
+      assert.ok(findSpy.called);
+      assert.strictEqual(findSpy.firstCall.args[1].middleware, undefined);
+    });
+  });
+
+  describe('aggregate cursor', function() {
+    // Aggregate cursors only execute pre aggregate hooks. Post aggregate hooks are
+    // result-level hooks for aggregate.exec()/explain(), not cursor iteration.
+    it('skips pre aggregate hooks when middleware: false', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.aggregate([{ $match: {} }]).option({ middleware: false }).cursor().eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('aggregate'), 0);
+      assert.strictEqual(getPostCount('aggregate'), 0);
+    });
+
+    it('skips pre aggregate hooks when cursor options have middleware: false', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.aggregate([{ $match: {} }]).cursor({ middleware: false }).eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('aggregate'), 0);
+      assert.strictEqual(getPostCount('aggregate'), 0);
+    });
+
+    it('runs pre aggregate hooks without running post aggregate hooks', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.aggregate([{ $match: {} }]).cursor().eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('aggregate'), 1);
+      assert.strictEqual(getPostCount('aggregate'), 0);
+    });
+
+    it('skips pre aggregate hooks when middleware: { pre: false }', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.aggregate([{ $match: {} }]).cursor({ middleware: { pre: false } }).eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('aggregate'), 0);
+      assert.strictEqual(getPostCount('aggregate'), 0);
+    });
+
+    it('runs pre aggregate hooks when middleware: { post: false }', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      let numDocs = 0;
+
+      // Act
+      await User.aggregate([{ $match: {} }]).option({ middleware: { post: false } }).cursor().eachAsync(doc => {
+        ++numDocs;
+        assert.strictEqual(doc.name, 'John');
+      });
+
+      // Assert
+      assert.strictEqual(numDocs, 1);
+      assert.strictEqual(getPreCount('aggregate'), 1);
+      assert.strictEqual(getPostCount('aggregate'), 0);
+    });
+
+    it('does not leak the middleware option into collection.aggregate', async function() {
+      // Arrange
+      const { User } = createTestContext();
+      await User.create({ name: 'John' });
+      const aggregateSpy = sinon.spy(User.collection, 'aggregate');
+
+      // Act
+      try {
+        await User.aggregate([{ $match: {} }]).option({ middleware: false }).cursor().eachAsync(() => {});
+        await User.aggregate([{ $match: {} }]).cursor({ middleware: false }).eachAsync(() => {});
+      } finally {
+        aggregateSpy.restore();
+      }
+
+      // Assert
+      assert.strictEqual(aggregateSpy.callCount, 2);
+      assert.strictEqual(aggregateSpy.firstCall.args[1].middleware, undefined);
+      assert.strictEqual(aggregateSpy.secondCall.args[1].middleware, undefined);
+      assert.strictEqual(aggregateSpy.secondCall.args[1].cursor.middleware, undefined);
+    });
+
+    it('preserves the middleware option on the aggregate after running a cursor', async function() {
+      // Arrange
+      const { User, getPreCount, getPostCount } = createTestContext();
+      await User.create({ name: 'John' });
+      const aggregate = User.aggregate([{ $match: {} }]).option({ middleware: false });
+
+      // Act
+      await aggregate.cursor().eachAsync(() => {});
+
+      // Assert: option survived (sanitized clone sent to driver, agg.options not mutated)
+      assert.strictEqual(getPreCount('aggregate'), 0);
+      assert.strictEqual(getPostCount('aggregate'), 0);
+      assert.strictEqual(aggregate.options.middleware, false);
+    });
+  });
+
+  describe('custom statics and methods', function() {
+    describe('statics', function() {
+      it('skips pre/post hooks on a custom static when middleware: false', async function() {
+        // Arrange
+        const { User, getStaticPreCount, getStaticPostCount } = createStaticsContext();
+        await User.create({ name: 'John' });
+
+        // Act
+        const user = await User.findByName('John', { middleware: false });
+
+        // Assert
+        assert.ok(user);
+        assert.strictEqual(user.name, 'John');
+        assert.strictEqual(getStaticPreCount(), 0);
+        assert.strictEqual(getStaticPostCount(), 0);
+      });
+
+      it('runs custom static hooks normally without middleware option', async function() {
+        // Arrange
+        const { User, getStaticPreCount, getStaticPostCount } = createStaticsContext();
+        await User.create({ name: 'John' });
+
+        // Act
+        const user = await User.findByName('John');
+
+        // Assert
+        assert.ok(user);
+        assert.strictEqual(user.name, 'John');
+        assert.strictEqual(getStaticPreCount(), 1);
+        assert.strictEqual(getStaticPostCount(), 1);
+      });
+
+      it('skips only pre hooks when middleware: { pre: false }', async function() {
+        // Arrange
+        const { User, getStaticPreCount, getStaticPostCount } = createStaticsContext();
+        await User.create({ name: 'John' });
+
+        // Act
+        const user = await User.findByName('John', { middleware: { pre: false } });
+
+        // Assert
+        assert.ok(user);
+        assert.strictEqual(user.name, 'John');
+        assert.strictEqual(getStaticPreCount(), 0);
+        assert.strictEqual(getStaticPostCount(), 1);
+      });
+
+      it('skips only post hooks when middleware: { post: false }', async function() {
+        // Arrange
+        const { User, getStaticPreCount, getStaticPostCount } = createStaticsContext();
+        await User.create({ name: 'John' });
+
+        // Act
+        const user = await User.findByName('John', { middleware: { post: false } });
+
+        // Assert
+        assert.ok(user);
+        assert.strictEqual(user.name, 'John');
+        assert.strictEqual(getStaticPreCount(), 1);
+        assert.strictEqual(getStaticPostCount(), 0);
+      });
+
+      function createStaticsContext() {
+        let preCount = 0;
+        let postCount = 0;
+        const userSchema = new Schema({ name: String });
+        userSchema.statics.findByName = function(name, options = {}) {
+          assert.ok(options);
+          return this.findOne({ name });
+        };
+        userSchema.pre('findByName', function() { preCount++; });
+        userSchema.post('findByName', function() { postCount++; });
+        const User = db.model('User', userSchema);
+        return { User, getStaticPreCount: () => preCount, getStaticPostCount: () => postCount };
+      }
+    });
+
+    describe('methods', function() {
+      it('skips pre/post hooks on a custom method when middleware: false', async function() {
+        // Arrange
+        const { User, getMethodPreCount, getMethodPostCount } = createMethodsContext();
+        const user = await User.create({ name: 'John' });
+
+        // Act
+        const result = await user.activate({ middleware: false });
+
+        // Assert
+        assert.strictEqual(result, user);
+        assert.strictEqual(user.active, true);
+        assert.strictEqual(getMethodPreCount(), 0);
+        assert.strictEqual(getMethodPostCount(), 0);
+      });
+
+      it('runs custom method hooks normally without middleware option', async function() {
+        // Arrange
+        const { User, getMethodPreCount, getMethodPostCount } = createMethodsContext();
+        const user = await User.create({ name: 'John' });
+
+        // Act
+        const result = await user.activate();
+
+        // Assert
+        assert.strictEqual(result, user);
+        assert.strictEqual(user.active, true);
+        assert.strictEqual(getMethodPreCount(), 1);
+        assert.strictEqual(getMethodPostCount(), 1);
+      });
+
+      it('skips only pre hooks when middleware: { pre: false }', async function() {
+        // Arrange
+        const { User, getMethodPreCount, getMethodPostCount } = createMethodsContext();
+        const user = await User.create({ name: 'John' });
+
+        // Act
+        const result = await user.activate({ middleware: { pre: false } });
+
+        // Assert
+        assert.strictEqual(result, user);
+        assert.strictEqual(user.active, true);
+        assert.strictEqual(getMethodPreCount(), 0);
+        assert.strictEqual(getMethodPostCount(), 1);
+      });
+
+      it('skips only post hooks when middleware: { post: false }', async function() {
+        // Arrange
+        const { User, getMethodPreCount, getMethodPostCount } = createMethodsContext();
+        const user = await User.create({ name: 'John' });
+
+        // Act
+        const result = await user.activate({ middleware: { post: false } });
+
+        // Assert
+        assert.strictEqual(result, user);
+        assert.strictEqual(user.active, true);
+        assert.strictEqual(getMethodPreCount(), 1);
+        assert.strictEqual(getMethodPostCount(), 0);
+      });
+
+      function createMethodsContext() {
+        let preCount = 0;
+        let postCount = 0;
+        const userSchema = new Schema({ name: String, active: Boolean });
+        userSchema.methods.activate = function(options = {}) {
+          assert.ok(options);
+          this.active = true;
+          return this;
+        };
+        userSchema.pre('activate', function() { preCount++; });
+        userSchema.post('activate', function() { postCount++; });
+        const User = db.model('User', userSchema);
+        return { User, getMethodPreCount: () => preCount, getMethodPostCount: () => postCount };
+      }
     });
   });
 

--- a/test/types/model.skip.middleware.test.ts
+++ b/test/types/model.skip.middleware.test.ts
@@ -37,9 +37,15 @@ async function gh8768() {
   expect<MongooseBulkSaveOptions['middleware']>().type.toBe<boolean | SkipMiddlewareOptions | undefined>();
   expect<AggregateOptions['middleware']>().type.toBe<boolean | SkipMiddlewareOptions | undefined>();
   expect<AggregateCursorOptions>().type.toBeAssignableFrom({ batchSize: 100 });
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ comment: 'test cursor' });
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ maxTimeMS: 1000 });
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ signal: new AbortController().signal });
   expect<AggregateCursorOptions>().type.toBeAssignableFrom({ useMongooseAggCursor: true });
   expect<AggregateCursorOptions>().type.toBeAssignableFrom({ middleware: false });
   expect<AggregateCursorOptions>().type.toBeAssignableFrom({ middleware: { pre: false } });
+  expect<AggregateCursorOptions['maxTimeMS']>().type.toBe<number | undefined>();
+  expect<AggregateCursorOptions['signal']>().type.toBe<AbortSignal | undefined>();
+  expect<AggregateCursorOptions>().type.not.toBeAssignableFrom({ maxTimeMS: '1000' });
   expect<AggregateCursorOptions>().type.not.toBeAssignableFrom({ middleware: { post: false } });
 
   // QueryOptions - Query operations

--- a/test/types/model.skip.middleware.test.ts
+++ b/test/types/model.skip.middleware.test.ts
@@ -7,7 +7,9 @@ import {
   InsertManyOptions,
   MongooseBulkWriteOptions,
   MongooseBulkSaveOptions,
-  AggregateOptions
+  AggregateOptions,
+  AggregateCursorOptions,
+  AggregateCursorMiddlewareOptions
 } from 'mongoose';
 import { expect } from 'tstyche';
 
@@ -24,6 +26,8 @@ async function gh8768() {
   expect<SkipMiddlewareOptions>().type.toBeAssignableFrom({ pre: true, post: false });
   expect<SkipMiddlewareOptions['pre']>().type.toBe<boolean | undefined>();
   expect<SkipMiddlewareOptions['post']>().type.toBe<boolean | undefined>();
+  expect<AggregateCursorMiddlewareOptions>().type.toBeAssignableFrom({ pre: false });
+  expect<AggregateCursorMiddlewareOptions>().type.not.toBeAssignableFrom({ post: false });
 
   // Verify middleware option types are strictly boolean | SkipMiddlewareOptions | undefined
   expect<QueryOptions['middleware']>().type.toBe<boolean | SkipMiddlewareOptions | undefined>();
@@ -32,6 +36,11 @@ async function gh8768() {
   expect<MongooseBulkWriteOptions['middleware']>().type.toBe<boolean | SkipMiddlewareOptions | undefined>();
   expect<MongooseBulkSaveOptions['middleware']>().type.toBe<boolean | SkipMiddlewareOptions | undefined>();
   expect<AggregateOptions['middleware']>().type.toBe<boolean | SkipMiddlewareOptions | undefined>();
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ batchSize: 100 });
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ useMongooseAggCursor: true });
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ middleware: false });
+  expect<AggregateCursorOptions>().type.toBeAssignableFrom({ middleware: { pre: false } });
+  expect<AggregateCursorOptions>().type.not.toBeAssignableFrom({ middleware: { post: false } });
 
   // QueryOptions - Query operations
   User.find({}, null, { middleware: false });
@@ -124,10 +133,22 @@ async function gh8768() {
   User.find().setOptions({ middleware: { pre: false } });
   User.find().setOptions({ middleware: { post: false } });
 
+  // Query.prototype.cursor() accepts middleware options
+  User.find().cursor({ middleware: false });
+  User.find().cursor({ middleware: { pre: false } });
+  User.find().cursor({ middleware: { post: false } });
+
   // Aggregate.prototype.option() chain method
   User.aggregate().option({ middleware: false });
   User.aggregate().option({ middleware: { pre: false } });
   User.aggregate().option({ middleware: { post: false } });
+
+  // Aggregate.prototype.cursor() accepts pre aggregate middleware options
+  User.aggregate().option({ middleware: false }).cursor();
+  User.aggregate().option({ middleware: { pre: false } }).cursor();
+  User.aggregate().cursor({ middleware: false });
+  User.aggregate().cursor({ middleware: { pre: false } });
+  expect(User.aggregate().cursor).type.not.toBeCallableWith({ middleware: { post: false } });
 
   // Document instance operations - user.updateOne(), user.deleteOne()
   await user.updateOne({}, { middleware: false });

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -16,8 +16,7 @@ declare module 'mongoose' {
     post?: never;
   }
 
-  interface AggregateCursorOptions {
-    batchSize?: number;
+  interface AggregateCursorOptions extends Omit<mongodb.AggregationCursorOptions & mongodb.Abortable, 'session'>, SessionOption {
     middleware?: boolean | AggregateCursorMiddlewareOptions;
     transform?: (doc: any) => any;
     useMongooseAggCursor?: boolean;

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -10,6 +10,20 @@ declare module 'mongoose' {
     [key: string]: any;
   }
 
+  interface AggregateCursorMiddlewareOptions {
+    /** If `false`, skip pre aggregate middleware. Aggregate cursors do not run post aggregate middleware. */
+    pre?: boolean;
+    post?: never;
+  }
+
+  interface AggregateCursorOptions {
+    batchSize?: number;
+    middleware?: boolean | AggregateCursorMiddlewareOptions;
+    transform?: (doc: any) => any;
+    useMongooseAggCursor?: boolean;
+    [key: string]: unknown;
+  }
+
   class Aggregate<ResultType> implements SessionOperation {
     /**
      * Returns an asyncIterator for use with [`for/await/of` loops](https://thecodebarbarian.com/getting-started-with-async-iterators-in-node-js)
@@ -62,7 +76,7 @@ declare module 'mongoose' {
     /**
      * Sets the cursor option for the aggregation query
      */
-    cursor<DocType = any>(options?: Record<string, unknown>): Cursor<DocType>;
+    cursor<DocType = any>(options?: AggregateCursorOptions): Cursor<DocType>;
 
 
     /** Executes the aggregate pipeline on the currently bound Model. */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1152,7 +1152,7 @@ declare module 'mongoose' {
   /* for ts-mongoose */
   export class mquery { }
 
-  export function overwriteMiddlewareResult(val: any): Kareem.OverwriteMiddlewareResult;
+  export function overwriteMiddlewareResult(val: any): Kareem.OverwriteResult;
 
   export function skipMiddlewareFunction(val: any): Kareem.SkipWrappedFunction;
 

--- a/types/middlewares.d.ts
+++ b/types/middlewares.d.ts
@@ -60,7 +60,7 @@ declare module 'mongoose' {
     this: ThisType,
     opts: SaveOptions
   ) => void | Promise<void> | Kareem.SkipWrappedFunction;
-  type PostMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, res: ResType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void> | Kareem.OverwriteMiddlewareResult;
+  type PostMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, res: ResType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void> | Kareem.OverwriteResult;
   type ErrorHandlingMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: CallbackWithoutResultAndOptionalError) => void;
-  type ErrorHandlingMiddlewareWithOption<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType | null, next: CallbackWithoutResultAndOptionalError) => void | Promise<void> | Kareem.OverwriteMiddlewareResult;
+  type ErrorHandlingMiddlewareWithOption<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType | null, next: CallbackWithoutResultAndOptionalError) => void | Promise<void> | Kareem.OverwriteResult;
 }


### PR DESCRIPTION
re #8768, builds on top of https://github.com/mongoosejs/kareem/pull/46

We left some parts uncovered in #15883, namely statics, methods, and cursors (aggregation, and query).

This PR:

- Applies the existing `middleware` skip option to query cursors, including both pre `find` hooks and per-document post `find` hooks.
- Applies the skip option to aggregate cursors for pre `aggregate` hooks. Aggregate cursors still don't run post `aggregate` hooks, so the cursor-specific TS type only exposes `middleware: false` and `{ pre: false }`.
- Strips the Mongoose-only `middleware` option before passing cursor options to the MongoDB driver.
- Adds support for skipping middleware on custom statics and methods by reading `middleware` from the final plain options object.
- Documents the cursor behavior and the recommended custom static/method signature.

For now this pins `kareem` to the fork commit that adds wrapper `getOptions` support for custom statics/methods. Once the Kareem change lands and is released, we can switch this back to a normal version range.

A design decision that was made is how we pass the `middleware` option to statics/methods, I chose to pass them to the last arg if it's POJO, and the docs now have examples with a pattern where users define the last arg as options, following the same pattern as the other mongoose operations.