### PR TITLE
fix(utils): wrap discriminator merge check in parentheses to fix precedence

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -274,8 +274,8 @@ exports.merge = function merge(to, from, options, path) {
         // base schema has a given path as a single nested but discriminator schema
         // has the path as a document array, or vice versa (gh-9534)
         if (options.isDiscriminatorSchemaMerge &&
-            (from[key].$isSingleNested && to[key].$isMongooseDocumentArray) ||
-            (from[key].$isMongooseDocumentArray && to[key].$isSingleNested)) {
+            ((from[key].$isSingleNested && to[key].$isMongooseDocumentArray) ||
+            (from[key].$isMongooseDocumentArray && to[key].$isSingleNested))) {
           continue;
         } else if (from[key].instanceOfSchema) {
           if (to[key].instanceOfSchema) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -254,6 +254,36 @@ describe('utils', function() {
       assert.ok(to.toMethod === To.prototype.toMethod);
       assert.equal(to.fomMethod, From.prototype.fomMethod);
     });
+
+    it('should skip schema merge when isDiscriminatorSchemaMerge is true (gh-9534)', function() {
+      const to = {
+        key: { $isSingleNested: true, existingProp: 1 }
+      };
+      const from = {
+        key: { $isMongooseDocumentArray: true, newProp: 2 }
+      };
+
+      // When isDiscriminatorSchemaMerge is true, merge SHOULD skip
+      // conflicting single-nested vs document-array paths
+      utils.merge(to, from, { isDiscriminatorSchemaMerge: true });
+
+      assert.strictEqual(to.key.newProp, undefined);
+    });
+
+    it('should not skip schema merge when isDiscriminatorSchemaMerge is false (gh-9534)', function() {
+      const to = {
+        key: { $isSingleNested: true, existingProp: 1 }
+      };
+      const from = {
+        key: { $isMongooseDocumentArray: true, newProp: 2 }
+      };
+
+      // When isDiscriminatorSchemaMerge is false, merge should NOT skip
+      // the key even if from/to have $isMongooseDocumentArray/$isSingleNested
+      utils.merge(to, from, { isDiscriminatorSchemaMerge: false });
+
+      assert.strictEqual(to.key.newProp, 2);
+    });
   });
 
   describe('mergeClone', function() {


### PR DESCRIPTION
Backports #16187 to the 7.x line.

`utils.merge()` guards against merging a single-nested path against a document-array path (and vice versa) when building a discriminator schema (gh-9534). Because `&&` binds tighter than `||`, the condition

```js
options.isDiscriminatorSchemaMerge &&
(from[key].$isSingleNested && to[key].$isMongooseDocumentArray) ||
(from[key].$isMongooseDocumentArray && to[key].$isSingleNested)
```

parses as `(A && B) || C`, so the `continue` also fires when `isDiscriminatorSchemaMerge` is false and `from` is a document array while `to` is single-nested. The path is then silently dropped from a normal (non-discriminator) merge. Wrapping the two clauses restores `A && (B || C)`.

The 7.x `utils.merge()` body is identical to master apart from this grouping, so the fix and its test port over unchanged.

Verified on 7.x: the `isDiscriminatorSchemaMerge: false` test fails before the change (`undefined !== 2`) and passes after; `test/utils.test.js` stays green (26 passing).
