### PR TITLE
fix(cast): reject non-numeric object in castDouble instead of storing Double(NaN)

### DIFF
--- a/lib/cast/double.js
+++ b/lib/cast/double.js
@@ -41,6 +41,8 @@ module.exports = function castDouble(val) {
       }
     } else {
       coercedVal = Number(tempVal);
+      // ex: { a: 'im an object', valueOf: () => ({}) } // throw an error
+      assert.ok(!Number.isNaN(coercedVal) || Number.isNaN(tempVal));
     }
   } else {
     coercedVal = Number(val);

--- a/test/double.test.js
+++ b/test/double.test.js
@@ -287,6 +287,32 @@ describe('Double', function() {
         );
       });
     });
+
+    describe('when a non-numeric object is provided to a Double field', () => {
+      it('throws a CastError instead of silently storing NaN (gh)', async() => {
+        const doc = new Test({
+          myDouble: { malicious: 'object' }
+        });
+
+        assert.deepStrictEqual(doc.myDouble, undefined);
+        const err = await doc.validate().catch(e => e);
+        assert.ok(err);
+        assert.ok(err.errors['myDouble']);
+        assert.equal(err.errors['myDouble'].name, 'CastError');
+      });
+
+      it('throws a CastError for an object whose valueOf() is non-numeric (gh)', async() => {
+        const doc = new Test({
+          myDouble: { valueOf: () => ({}) }
+        });
+
+        assert.deepStrictEqual(doc.myDouble, undefined);
+        const err = await doc.validate().catch(e => e);
+        assert.ok(err);
+        assert.ok(err.errors['myDouble']);
+        assert.equal(err.errors['myDouble'].name, 'CastError');
+      });
+    });
   });
 
   describe('custom casters', () => {


### PR DESCRIPTION
## Summary

`castDouble` silently stores `Double(NaN)` when given a non-numeric object or array instead of throwing, so casting and validation of a `Double` path pass with no error. The `Number`, `Int32`, and `BigInt` casters all reject the same inputs, so `Double` is the outlier.

## Steps to reproduce

`lib/cast/double.js` on the object branch:

```js
const castDouble = require('./lib/cast/double');
castDouble({ malicious: 'object' }); // Double { value: NaN } (expected: throw)
castDouble([5, 6]);                   // Double { value: NaN } (expected: throw)
```

At the schema level, a non-numeric object reaches the stored document and passes validation:

```js
const schema = new Schema({ price: Schema.Types.Double });
const Test = mongoose.model('Test', schema);

const doc = new Test({ price: { x: 1 } });
doc.price;              // Double { value: NaN }
doc.validateSync();     // undefined (no error)
```

The equivalent `Number` path rejects the same input:

```js
const schema = new Schema({ price: Number });
const doc = new (mongoose.model('T2', schema))({ price: { x: 1 } });
doc.validateSync().errors.price.name; // 'CastError'
```

So `new Model(req.body)` with a body like `{ price: { any: 1 } }` persists `NaN` on a scalar path with no cast error and no validation error.

## Root cause

The `typeof val === 'object'` branch computes `coercedVal = Number(tempVal)` and returns `new BSON.Double(coercedVal)` with no check on the result. For a non-numeric object or array, `Number(tempVal)` is `NaN`, which is returned as a valid `Double`. The branch's own inline comment (`// throw an error`) shows the throw was intended but never added.

## Fix

Add a NaN guard in the object branch using the module's existing `assert` idiom (`SchemaDouble.cast` translates a thrown assertion into a `CastError`), while preserving explicit-NaN inputs that the JSDoc documents as valid:

```js
coercedVal = Number(tempVal);
assert.ok(!Number.isNaN(coercedVal) || Number.isNaN(tempVal));
```

Plain `NaN` and an object whose `valueOf()` returns `NaN` still cast to `Double(NaN)`; only inputs that become `NaN` through non-numeric coercion are rejected.

## Authority

The `castDouble` JSDoc states it should "cast it to a IEEE 754-2008 floating point, or throw an `Error` if the value cannot be casted" and lists `null`, `undefined`, and `NaN` as the valid inputs. `lib/cast/number.js`, `lib/cast/int32.js`, and `lib/cast/bigint.js` reject the same non-numeric objects.

## Tests

Two cases added under the existing `cast errors` block in `test/double.test.js`: a plain non-numeric object and an object whose `valueOf()` returns a non-numeric value, both asserting a `CastError`. Both fail on `master` (stored `Double(NaN)`, no validation error) and pass with the fix.

- `test/double.test.js`: 28 passing
- `test/cast.test.js` + `test/int32.test.js`: 53 passing
