### PR TITLE
types(create): fix handling of nested objects typed as interfaces

### DIFF
--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -222,9 +222,10 @@ async function createWithPopulatedDoc() {
     };
   }
   interface OtherNestedCreateInput {
-    nested: {
-      to: string;
-    };
+    nested: Nested;
+  }
+  interface Nested {
+    to: string;
   }
 
   const userSchema = new mongoose.Schema({ dummy: String });

--- a/test/types/create.test.ts
+++ b/test/types/create.test.ts
@@ -216,17 +216,36 @@ async function createWithPopulatedDoc() {
   interface Other {
     to: mongoose.PopulatedDoc<User>;
   }
+  interface OtherWithNested {
+    nested: {
+      to: mongoose.PopulatedDoc<User>;
+    };
+  }
+  interface OtherNestedCreateInput {
+    nested: {
+      to: string;
+    };
+  }
 
   const userSchema = new mongoose.Schema({ dummy: String });
   const userModel = mongoose.model<User>('TestCreateWithPopulatedDocUser', userSchema);
 
   const otherSchema = new mongoose.Schema({ to: { type: mongoose.Types.ObjectId, ref: 'TestCreateWithPopulatedDocUser' } });
   const otherModel = mongoose.model<Other>('TestCreateWithPopulatedDocOther', otherSchema);
+  const otherWithNestedSchema = new mongoose.Schema({
+    nested: {
+      to: { type: mongoose.Types.ObjectId, ref: 'TestCreateWithPopulatedDocUser' }
+    }
+  });
+  const otherWithNestedModel = mongoose.model<OtherWithNested>('TestCreateWithNestedPopulatedDocOther', otherWithNestedSchema);
 
   const user = await userModel.create({ dummy: 'hello' });
   const other = await otherModel.create({ to: user._id.toString() });
+  const nestedInput: OtherNestedCreateInput = { nested: { to: user._id.toString() } };
+  const otherWithNested = await otherWithNestedModel.create(nestedInput);
 
   expect(other.to).type.toBe<mongoose.PopulatedDoc<User>>();
+  expect(otherWithNested.nested.to).type.toBe<mongoose.PopulatedDoc<User>>();
 }
 
 createWithAggregateErrors();

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -193,7 +193,7 @@ declare module 'mongoose' {
    * - vanilla arrays of POJOs for document arrays
    * - POJOs and array of arrays for maps
    */
-  type CreateObjectWithExtraKeys<T> = T & Record<string, unknown>;
+  type CreateObjectWithExtraKeys<T> = T | (T & Record<string, unknown>);
   type ApplyBasicCreateCasting<T> = {
     [K in keyof T]: NonNullable<T[K]> extends Map<infer KeyType extends string, infer ValueType>
       ? (Record<KeyType, ValueType> | Array<[KeyType, ValueType]> | T[K] | QueryTypeCasting<Extract<T[K], TreatAsPrimitives>>)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#16362 is not an issue with strings vs objectids, it's an issue with how nested object types vs nested interfaces are handled by `create()` typing. In #16362, `Nested` is an interface not an object type, and interfaces are not assignable to `Record<string, unknown>` for TypeScript internal reasons. Probably because interfaces can be augmented (multiple definitions of the same interface add properties).

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
