### PR TITLE
fix(document): don't skip optimistic concurrency when assigning a parent of an excluded nested path

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -5147,8 +5147,8 @@ Document.prototype.$__delta = function $__delta(pathsToSave, pathsToSaveSet) {
       const optimisticConcurrencyExcludeSet = this.$__schema.options._optimisticConcurrencyExcludeSet;
       const modPaths = this.directModifiedPaths();
       const hasRelevantModPaths = pathsToSave == null ?
-        modPaths.find(path => !_pathOverlapsSet(path, optimisticConcurrencyExcludeSet)) :
-        modPaths.find(path => !_pathOverlapsSet(path, optimisticConcurrencyExcludeSet) && isInPathsToSave(path, pathsToSaveSet, pathsToSave));
+        modPaths.find(path => !_pathOrAncestorInSet(path, optimisticConcurrencyExcludeSet)) :
+        modPaths.find(path => !_pathOrAncestorInSet(path, optimisticConcurrencyExcludeSet) && isInPathsToSave(path, pathsToSaveSet, pathsToSave));
       if (hasRelevantModPaths) {
         this.$__.version = dirty.length ? VERSION_ALL : VERSION_WHERE;
       }
@@ -5682,13 +5682,12 @@ Document.prototype._applyVersionIncrement = function _applyVersionIncrement() {
  */
 
 /*!
- * Check if `path`, any of its ancestor paths, or any of its descendant paths
- * exist in `pathSet`.
+ * Check if `path` or any of its ancestor paths exist in `pathSet`.
  * For example:
- *   _pathOverlapsSet('profile.firstName', Set(['profile'])) === true
- *   _pathOverlapsSet('profile', Set(['profile.firstName'])) === true
+ *   _pathOrAncestorInSet('profile.firstName', Set(['profile'])) === true
+ *   _pathOrAncestorInSet('profile', Set(['profile.firstName'])) === false
  */
-function _pathOverlapsSet(path, pathSet) {
+function _pathOrAncestorInSet(path, pathSet) {
   if (pathSet.has(path)) {
     return true;
   }
@@ -5698,6 +5697,20 @@ function _pathOverlapsSet(path, pathSet) {
       return true;
     }
     idx = path.indexOf('.', idx + 1);
+  }
+  return false;
+}
+
+/*!
+ * Check if `path`, any of its ancestor paths, or any of its descendant paths
+ * exist in `pathSet`.
+ * For example:
+ *   _pathOverlapsSet('profile.firstName', Set(['profile'])) === true
+ *   _pathOverlapsSet('profile', Set(['profile.firstName'])) === true
+ */
+function _pathOverlapsSet(path, pathSet) {
+  if (_pathOrAncestorInSet(path, pathSet)) {
+    return true;
   }
   for (const p of pathSet) {
     if (p.length > path.length + 1 && p[path.length] === '.' && p.slice(0, path.length) === path) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -5662,22 +5662,6 @@ Document.prototype._applyVersionIncrement = function _applyVersionIncrement() {
 };
 
 /*!
- * Increment this document's version if necessary.
- */
-
-Document.prototype._applyVersionIncrement = function _applyVersionIncrement() {
-  if (!this.$__.version) return;
-  const doIncrement = VERSION_INC === (VERSION_INC & this.$__.version);
-
-  this.$__.version = undefined;
-  if (doIncrement) {
-    const key = this.$__schema.options.versionKey;
-    const version = this.$__getValue(key) || 0;
-    this.$__setValue(key, version + 1); // increment version if was successful
-  }
-};
-
-/*!
  * Module exports.
  */
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -3132,6 +3132,24 @@ describe('Model', function() {
       assert.strictEqual(delta[0].__v, 0, 'should include __v in query when included parent path is modified');
     });
 
+    it('should include __v when optimisticConcurrency exclude contains a nested path and parent assignment changes a non-excluded subpath (gh-16054)', async function() {
+      const userSchema = new Schema({
+        profile: {
+          firstName: String,
+          lastName: String
+        },
+        balance: Number
+      }, { optimisticConcurrency: { exclude: ['profile.firstName'] } });
+
+      const User = db.model('User_oc_exclude_nested', userSchema);
+      const user = await User.create({ profile: { firstName: 'Alice', lastName: 'Smith' }, balance: 100 });
+
+      user.profile = { firstName: 'Alice', lastName: 'Johnson' };
+      const delta = user.$__delta();
+      assert.ok(delta, 'delta should exist');
+      assert.strictEqual(delta[0].__v, 0, 'should include __v in query when non-excluded nested path is modified via parent assignment');
+    });
+
     it('should exclude ad-hoc nested subpaths on non-strict schemas when optimisticConcurrency exclude contains a parent path (gh-16054)', async function() {
       const profileSchema = new Schema({ firstName: String, lastName: String }, { _id: false, strict: false });
       const userSchema = new Schema({


### PR DESCRIPTION
re #16054 / #16177.

#16177 uses the same path matching for include and exclude. Include needs to match in both directions (`profile.address.country` should be triggered by setting `profile.address`), but for exclude this means that excluding a nested path also excludes its parent. So if you exclude `profile.firstName` and then assign `profile`, the version check is skipped, even though other non-excluded fields under `profile` changed:

```js
const userSchema = new Schema({
  profile: { firstName: String, lastName: String },
  balance: Number
}, { optimisticConcurrency: { exclude: ['profile.firstName'] } });

const User = mongoose.model('User', userSchema);
const user = await User.create({ profile: { firstName: 'Alice', lastName: 'Smith' }, balance: 100 });

user.profile = { firstName: 'Alice', lastName: 'Johnson' };
user.$__delta();

// Before this PR: user.$__.version === undefined (no version check)
// After: user.$__.version === VERSION_ALL, profile.lastName is not excluded and it changed
```

This PR makes exclude only match the path itself or one of its parents, include keeps the current behavior. Copilot flagged this on https://github.com/Automattic/mongoose/pull/16177#discussion_r3023820287

Also removed a duplicate `_applyVersionIncrement` definition I noticed while working on this, the same function was defined twice back to back.

@vkarpov15 @hasezoey part of what I intended with #16054 is still not covered, there are two cases where include/exclude paths never match the runtime modified paths:

1. Map wildcards: `['settings.$*']` matches nothing, in both the include and exclude forms.
2. Arrays of subdocuments: `optimisticConcurrency: ['comments.text']` never triggers versioning, runtime paths look like `comments.0.text` and the matcher doesn't skip index segments. So the only way to protect a subdocument field right now is to include the whole array.

I'd handle these in a future PR by extracting the pathUtils helper we discussed on #16177, something that skips numeric segments and handles `.$*.`, and using it for both branches. WDYT? Should we not bear the maintenace cost until someone asks for it, or just go ahead and implement it?