### PR TITLE
fix(document): validate child paths when `pathsToSave` includes their parent

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2705,8 +2705,13 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
       return;
     }
 
+    // If `pathsToValidate` comes from `pathsToSave`, an entry like `profile` also
+    // saves child paths like `profile.firstName`, so validation must match child
+    // paths the same way the save filter does (gh-9583).
+    let pathsToValidateIncludesChildren = false;
     if (this.$__.saveOptions && this.$__.saveOptions.pathsToSave && !pathsToValidate) {
       pathsToValidate = [...this.$__.saveOptions.pathsToSave];
+      pathsToValidateIncludesChildren = true;
     }
 
     const hasValidateModifiedOnlyOption = options &&
@@ -2759,7 +2764,7 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
       paths = [...paths];
       doValidateOptionsByPath = {};
     } else {
-      const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip, options?._nestedValidate);
+      const pathDetails = _getPathsToValidate(this, pathsToValidate, pathsToSkip, options?._nestedValidate, pathsToValidateIncludesChildren);
       paths = shouldValidateModifiedOnly ?
         pathDetails[0].filter((path) => this.$isModified(path)) :
         pathDetails[0];
@@ -2780,12 +2785,13 @@ Document.prototype.validate = async function validate(pathsToValidate, options) 
     const validated = {};
 
     const pathsToSave = Array.isArray(this.$__.saveOptions?.pathsToSave) ?
-      new Set(this.$__.saveOptions.pathsToSave) :
+      this.$__.saveOptions.pathsToSave :
       null;
+    const pathsToSaveSet = pathsToSave != null ? new Set(pathsToSave) : null;
     const promises = [];
     for (let i = 0; i < paths.length; ++i) {
       const path = paths[i];
-      if (pathsToSave != null && !pathsToSave.has(path)) {
+      if (pathsToSave != null && !isInPathsToSave(path, pathsToSaveSet, pathsToSave)) {
         promises.push(Promise.resolve(null));
         continue;
       }
@@ -2955,7 +2961,7 @@ function _evaluateRequiredFunctions(doc) {
  * ignore
  */
 
-function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate) {
+function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate, pathsToValidateIncludesChildren) {
   const doValidateOptions = {};
 
   _evaluateRequiredFunctions(doc);
@@ -3095,7 +3101,7 @@ function _getPathsToValidate(doc, pathsToValidate, pathsToSkip, isNestedValidate
 
 
   if (Array.isArray(pathsToValidate)) {
-    paths = _handlePathsToValidate(paths, pathsToValidate);
+    paths = _handlePathsToValidate(paths, pathsToValidate, pathsToValidateIncludesChildren);
   } else if (Array.isArray(pathsToSkip)) {
     paths = _handlePathsToSkip(paths, pathsToSkip);
   }
@@ -3223,7 +3229,7 @@ Document.prototype._execDocumentPostHooks = function _execDocumentPostHooks(opNa
  * ignore
  */
 
-function _handlePathsToValidate(paths, pathsToValidate) {
+function _handlePathsToValidate(paths, pathsToValidate, pathsToValidateIncludesChildren) {
   const _pathsToValidate = new Set(pathsToValidate);
   const parentPaths = new Map([]);
   for (const path of pathsToValidate) {
@@ -3247,6 +3253,8 @@ function _handlePathsToValidate(paths, pathsToValidate) {
       ret.add(path);
     } else if (parentPaths.has(path)) {
       ret.add(parentPaths.get(path));
+    } else if (pathsToValidateIncludesChildren && isInPathsToSave(path, _pathsToValidate, pathsToValidate)) {
+      ret.add(path);
     }
   }
   return ret;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -2627,6 +2627,65 @@ describe('Model', function() {
       assert.equal(nestedCheck.location[0].zip, 34512);
       assert.equal(nestedCheck.name, 'Quiz');
     });
+    it('should validate nested paths under a parent path in `pathsToSave` (gh-9583)', async function() {
+      const userSchema = new Schema({
+        profile: {
+          firstName: { type: String, minlength: 2 },
+          lastName: String
+        },
+        balance: Number
+      });
+      const User = db.model('User', userSchema);
+      const user = await User.create({ profile: { firstName: 'Alice', lastName: 'Smith' }, balance: 100 });
+
+      user.profile.firstName = 'A';
+      const err = await user.save({ pathsToSave: ['profile'] }).then(() => null, err => err);
+
+      assert.ok(err);
+      assert.equal(err.name, 'ValidationError');
+      assert.ok(err.errors['profile.firstName']);
+
+      const fromDb = await User.findById(user._id).orFail();
+      assert.equal(fromDb.profile.firstName, 'Alice');
+    });
+    it('should save valid nested paths under a parent path in `pathsToSave` (gh-9583)', async function() {
+      const userSchema = new Schema({
+        profile: {
+          firstName: { type: String, minlength: 2 },
+          lastName: String
+        },
+        balance: Number
+      });
+      const User = db.model('User', userSchema);
+      const user = await User.create({ profile: { firstName: 'Alice', lastName: 'Smith' }, balance: 100 });
+
+      user.profile.firstName = 'Alicia';
+      user.balance = 200;
+      await user.save({ pathsToSave: ['profile'] });
+
+      const fromDb = await User.findById(user._id).orFail();
+      assert.equal(fromDb.profile.firstName, 'Alicia');
+      assert.equal(fromDb.balance, 100);
+    });
+    it('should run required validators on nested paths under a parent path in `pathsToSave` (gh-9583)', async function() {
+      const userSchema = new Schema({
+        profile: {
+          firstName: String,
+          lastName: { type: String, required: true }
+        }
+      });
+      const User = db.model('User', userSchema);
+      const _id = new mongoose.Types.ObjectId();
+      await User.collection.insertOne({ _id, profile: { firstName: 'Alice' } });
+
+      const user = await User.findById(_id).orFail();
+      user.profile.firstName = 'Alicia';
+      const err = await user.save({ pathsToSave: ['profile'] }).then(() => null, err => err);
+
+      assert.ok(err);
+      assert.equal(err.name, 'ValidationError');
+      assert.ok(err.errors['profile.lastName']);
+    });
   });
 
   describe('pathsToSave should filter all update operators', function() {


### PR DESCRIPTION
`save({ pathsToSave: ['profile'] })` saves a modified `profile.firstName` but never validates it. The save filter matches child paths of each entry, while the validation filter matches exact strings only, so invalid nested values are written with no `ValidationError`:

```js
const userSchema = new Schema({
  profile: {
    firstName: { type: String, minlength: 2 }
  }
});

user.profile.firstName = 'A'; // violates minlength
await user.save({ pathsToSave: ['profile'] }); // resolves and writes 'A'
await user.save(); // would throw ValidationError
```

This PR makes validation use the same child-path matching as the save filter, but only when the validated paths come from `pathsToSave`. Calling `validate(['profile'])` directly is unchanged.

Only plain nested paths were affected: subdocuments and document arrays already validate their children through the parent path.

