### PR TITLE
docs: expand sample() example to show sampling from a filtered subset

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -615,6 +615,9 @@ Aggregate.prototype.graphLookup = function(options) {
  *
  *     aggregate.sample(3); // Add a pipeline that picks 3 random documents
  *
+ *     // `$match` before `$sample` samples from the filtered subset
+ *     aggregate.match({ difficulty: 'easy' }).sample(3);
+ *
  * @see $sample https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#pipe._S_sample
  * @param {number} size number of random documents to pick
  * @return {Aggregate}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The `Aggregate#sample()` docs currently show only a single example sampling from the whole collection. This adds a second example demonstrating `.match().sample()`, which samples from a filtered subset rather than the whole collection. This is a common use case, and the stage ordering (filter before sample) is worth showing explicitly.

**Examples**
```js
// picks 3 random documents from the whole collection
aggregate.sample(3);

// `$match` before `$sample` samples from the filtered subset
aggregate.match({ difficulty: 'easy' }).sample(3);
```