### PR TITLE
fix(schema): avoid mutating shared setters array in SchemaArray._castForQuery

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -510,9 +510,9 @@ SchemaArray.prototype._castForQuery = function(val, context) {
   }
 
   if (Array.isArray(val)) {
-    this.setters.slice().reverse().forEach(setter => {
-      val = setter.call(this, val, this);
-    });
+    for (let i = this.setters.length - 1; i >= 0; i--) {
+      val = this.setters[i].call(this, val, this);
+    }
     val = val.map(function(v) {
       if (utils.isObject(v) && v.$elemMatch) {
         return v;

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -510,7 +510,7 @@ SchemaArray.prototype._castForQuery = function(val, context) {
   }
 
   if (Array.isArray(val)) {
-    this.setters.reverse().forEach(setter => {
+    this.setters.slice().reverse().forEach(setter => {
       val = setter.call(this, val, this);
     });
     val = val.map(function(v) {

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -1959,12 +1959,14 @@ describe('types array', function() {
     assert.equal(called, 2);
   });
 
-  it('does not mutate SchemaArray setters order when casting (gh-16372)', function() {
+  it('does not mutate SchemaArray setters order when casting an array-valued query filter (gh-16372)', function() {
     const schema = new Schema({ nums: { type: [Number], set: v => v } });
     schema.path('nums').set(v => v);
     const originalOrder = schema.path('nums').setters.slice();
     const M = db.model('Test', schema);
-    new M({ nums: [1, 2, 3] });
+
+    M.find({ nums: [1, 2, 3] }).cast(M);
+
     assert.deepStrictEqual(schema.path('nums').setters, originalOrder);
   });
 });

--- a/test/types.array.test.js
+++ b/test/types.array.test.js
@@ -1958,4 +1958,13 @@ describe('types array', function() {
     assert.deepStrictEqual(doc.intArr, [3, 2]);
     assert.equal(called, 2);
   });
+
+  it('does not mutate SchemaArray setters order when casting (gh-16372)', function() {
+    const schema = new Schema({ nums: { type: [Number], set: v => v } });
+    schema.path('nums').set(v => v);
+    const originalOrder = schema.path('nums').setters.slice();
+    const M = db.model('Test', schema);
+    new M({ nums: [1, 2, 3] });
+    assert.deepStrictEqual(schema.path('nums').setters, originalOrder);
+  });
 });


### PR DESCRIPTION
Fixes #16364.

SchemaArray._castForQuery calls this.setters.reverse() on line 513 of lib/schema/array.js. Array.prototype.reverse mutates the array in place, so the persistent setters array on the schema type is permanently reordered after the first array-valued query. All subsequent queries and document creations then apply setters in the reversed order, which is incorrect.

Every other place in the codebase that needs reversed iteration either iterates by index in reverse or uses a copy. This line is the only one that mutates.

The fix is a one-character change: this.setters.slice().reverse(). slice() creates a shallow copy, so the forEach iterates the reversed copy while the original array remains in definition order.

The reproduction case from the issue report confirms the fix:

Before the fix, creating a document after one array-valued query yields setter order ABAB instead of BABA. After the fix, setter order is BABA in both cases.

Yokubjon Nurullaev traced the mutation to lib/schema/array.js:513, confirmed the impact on setter ordering across queries and document creation, and implemented the slice fix.

IbrokhimN reviewed the fix against the other reverse usages in the codebase to confirm this was the only mutating call, and verified that the fix matches the non-mutating patterns used in schematype.js.