### PR TITLE
types(model): support extra fields type argument in hydrate() with strict: false

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1351,3 +1351,46 @@ function hydrateWithStrictOption() {
 
   expect(doc4).type.toBe<ReturnType<(typeof TestModel)['hydrate']>>();
 }
+
+function gh15940() {
+  interface IUser {
+    name: string;
+    age: number;
+  }
+
+  const schema = new mongoose.Schema<IUser>({
+    name: String,
+    age: Number
+  });
+
+  const User = mongoose.model<IUser>('User', schema);
+
+  const rawUser = {
+    _id: new mongoose.Types.ObjectId(),
+    name: 'John',
+    age: 30,
+    totalOrders: 42
+  };
+
+  // With `strict: false`, callers can describe the extra fields kept on the document
+  const user = User.hydrate<{ totalOrders: number }>(rawUser, null, { strict: false });
+
+  expect(user.name).type.toBe<string>();
+  expect(user.age).type.toBe<number>();
+  expect(user.totalOrders).type.toBe<number>();
+  expect(user.isModified()).type.toBe<boolean>();
+
+  // Without the extra fields type argument, the return type is unchanged
+  const plainUser = User.hydrate(rawUser, null, { strict: false });
+  expect(plainUser).type.toBe<ReturnType<(typeof User)['hydrate']>>();
+
+  // `null` and `undefined` projections are accepted with and without options
+  expect(User.hydrate).type.toBeCallableWith(rawUser, null);
+  expect(User.hydrate).type.toBeCallableWith(rawUser, undefined);
+  expect(User.hydrate<{ totalOrders: number }>).type.toBeCallableWith(rawUser, undefined, { strict: false });
+
+  // Extra fields type argument requires `strict: false`
+  expect(User.hydrate<{ totalOrders: number }>).type.toBeCallableWith(rawUser, null, { strict: false });
+  expect(User.hydrate<{ totalOrders: number }>).type.not.toBeCallableWith(rawUser, null, { strict: true });
+  expect(User.hydrate<{ totalOrders: number }>).type.not.toBeCallableWith(rawUser);
+}

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -516,8 +516,16 @@ declare module 'mongoose' {
     /**
      * Shortcut for creating a new Document from existing raw data, pre-saved in the DB.
      * The document returned has no paths marked as modified initially.
+     * With `strict: false`, fields not in the schema are kept on the document; pass
+     * `ExtraFields` to describe their types, e.g.
+     * `Model.hydrate<{ totalOrders: number }>(obj, null, { strict: false })`.
      */
-    hydrate(obj: any, projection?: ProjectionType<TRawDocType>, options?: HydrateOptions): THydratedDocumentType;
+    hydrate<ExtraFields = unknown>(
+      obj: any,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: HydrateOptions & { strict: false }
+    ): THydratedDocumentType & ExtraFields;
+    hydrate(obj: any, projection?: ProjectionType<TRawDocType> | null | undefined, options?: HydrateOptions): THydratedDocumentType;
 
     /**
      * This function is responsible for building [indexes](https://www.mongodb.com/docs/manual/indexes/),


### PR DESCRIPTION
re https://github.com/Automattic/mongoose/discussions/15940#discussioncomment-17566645

Follow-up to #15944, we agreed [in the review thread](https://github.com/Automattic/mongoose/pull/15944#discussion_r2665981444) to look into TS support for extra fields with `strict: false` later.

```ts
const user = User.hydrate<{ totalOrders: number }>(rawUser, null, { strict: false });
user.totalOrders; // number
```

The type param defaults to `unknown` (`T & unknown` is exactly `T`), and the plain signature stays last, so `ReturnType<(typeof Model)['hydrate']>` and existing calls are unaffected. Types only, no runtime changes.

Also widened `projection` to `ProjectionType<TRawDocType> | null | undefined` on both signatures, `hydrate(obj, null)` used to be a type error even though the runtime handles it, and the new overload needs the explicit union since its `projection` can't be optional.