### PR TITLE
types(model): add pathsToSave to SaveOptions

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -3567,6 +3567,10 @@ function _checkImmutableSubpaths(subdoc, schematype, priorVal) {
  * @param {number} [options.wtimeout] sets a [timeout for the write concern](https://www.mongodb.com/docs/manual/reference/write-concern/#wtimeout). Overrides the [schema-level `writeConcern` option](https://mongoosejs.com/docs/guide.html#writeConcern).
  * @param {boolean} [options.checkKeys=true] the MongoDB driver prevents you from saving keys that start with '$' or contain '.' by default. Set this option to `false` to skip that check. See [restrictions on field names](https://www.mongodb.com/docs/manual/reference/limits/#Restrictions-on-Field-Names)
  * @param {boolean} [options.timestamps=true] if `false` and [timestamps](https://mongoosejs.com/docs/guide.html#timestamps) are enabled, skip timestamps for this `save()`.
+ * @param {Array} [options.pathsToSave] An array of paths that tell mongoose to only validate and save the paths in `pathsToSave`.
+ * @param {boolean|object} [options.middleware=true] set to `false` to skip all user-defined middleware
+ * @param {boolean} [options.middleware.pre=true] set to `false` to skip only pre hooks
+ * @param {boolean} [options.middleware.post=true] set to `false` to skip only post hooks
  * @method save
  * @memberOf Document
  * @instance

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -66,6 +66,7 @@ void async function run() {
   test.validateSync({ pathsToSkip: 'name age', blub: 1 });
   expect(test.save()).type.toBeAssignableTo<Promise<ITest & { _id: any; }>>();
   expect(test.save({})).type.toBeAssignableTo<Promise<ITest & { _id: any; }>>();
+  expect(test.save({ pathsToSave: ['name', 'age'] })).type.toBeAssignableTo<Promise<ITest & { _id: any; }>>();
 })();
 
 function gh10526<U extends ITest>(arg1: Model<U>) {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -116,6 +116,8 @@ declare module 'mongoose' {
     SessionOption {
     checkKeys?: boolean;
     j?: boolean;
+    /** An array of paths that tell mongoose to only validate and save the paths in `pathsToSave`. */
+    pathsToSave?: string[];
     safe?: boolean | WriteConcern;
     timestamps?: boolean | QueryTimestampsConfig;
     validateBeforeSave?: boolean;


### PR DESCRIPTION
`pathsToSave` is missing in TS types, also from the docs along with `middleware`.
This PR fixes this.