### PR TITLE
fix(cast): use current castForQuery() signature for object-shaped geo values

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -413,7 +413,7 @@ function _cast(val, numbertype, context) {
         _cast(item, numbertype, context);
         val[nkey] = item;
       } else {
-        val[nkey] = numbertype.castForQuery({ val: item, context: context });
+        val[nkey] = numbertype.castForQuery(null, item, context);
       }
     }
   }

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -104,6 +104,26 @@ describe('cast: ', function() {
     });
   });
 
+  describe('geo queries', function() {
+    it('casts object-shaped geo values with scalar leaves (gh-16376)', function() {
+      const schema = new Schema({ name: String });
+
+      const res = cast(schema, {
+        loc: { $geoIntersects: { foo: '5' } }
+      }, { strictQuery: false });
+      assert.strictEqual(res.loc.$geoIntersects.foo, 5);
+    });
+
+    it('still casts array-shaped geo values (gh-16376)', function() {
+      const schema = new Schema({ name: String });
+
+      const res = cast(schema, {
+        loc: { $geoIntersects: { coordinates: ['1', '2'] } }
+      }, { strictQuery: false });
+      assert.deepStrictEqual(res.loc.$geoIntersects.coordinates, [1, 2]);
+    });
+  });
+
   describe('bitwise query operators: ', function() {
     it('with a number', function() {
       const schema = new Schema({ x: Buffer });


### PR DESCRIPTION
## Summary

Fixes #16376

`_cast()` in `lib/cast.js` has two sibling branches for geo values: the array branch uses the current 3-arg `castForQuery(null, item, context)`, but the object branch still passed the legacy single-object argument (`castForQuery({ val: item, context })`). That object lands in the `$conditional` parameter, gets stringified to `"[object Object]"`, finds no conditional handler, and throws `Can't use [object Object] with Number` — instead of casting the value.

```js
const schema = new mongoose.Schema({ name: String });
const M = mongoose.model('B', schema);
M.find({ loc: { $geoIntersects: { foo: 5 } } }).cast(M);
// before: throws "Can't use [object Object] with Number"
// after:  casts the leaf like the array branch does
```

This changes the object-branch call to match the sibling array branch (and every other call site in the file).

## Examples

Before/after verified with a standalone script against `lib/cast` directly:

```
before: OBJECT branch THROWS: Can't use [object Object] with Number.
after:  OBJECT branch OK: {"loc":{"$geoIntersects":{"foo":5}}}
```

Array-shaped geo values (`{ coordinates: ['1','2'] }`) and `$near`/`$maxDistance` casting are unchanged.

Added two regression tests in `test/cast.test.js` (object-shaped leaf casts; array path stays intact).
