### PR TITLE
fix(model): make bulkSave() version handling of new documents consistent with save()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3662,9 +3662,7 @@ async function handleSuccessfulWrite(document, options) {
   }
 
   document.$__reset();
-  // Like `$__save()`, inserts skip the version bump: the version key was
-  // initialized to 0 on insert, so a pending `increment()` applies on the
-  // next save instead (gh-15800)
+  // version key gets initialized to 0 when inserting a new document so avoid incrementing version key here
   if (!wasNew) {
     document._applyVersionIncrement();
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3662,9 +3662,9 @@ async function handleSuccessfulWrite(document, options) {
   }
 
   document.$__reset();
-  // Like `$__save()`, inserts skip version handling: the insert does not
-  // write the version key, so bumping the in-memory version here would
-  // desync it from the database (gh-15800)
+  // Like `$__save()`, inserts skip the version bump: the version key was
+  // initialized to 0 on insert, so a pending `increment()` applies on the
+  // next save instead (gh-15800)
   if (!wasNew) {
     document._applyVersionIncrement();
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3656,12 +3656,18 @@ async function buildPreSavePromise(document, options) {
 }
 
 async function handleSuccessfulWrite(document, options) {
-  if (document.$isNew) {
+  const wasNew = document.$isNew;
+  if (wasNew) {
     _setIsNew(document, false);
   }
 
   document.$__reset();
-  document._applyVersionIncrement();
+  // Like `$__save()`, inserts skip version handling: the insert does not
+  // write the version key, so bumping the in-memory version here would
+  // desync it from the database (gh-15800)
+  if (!wasNew) {
+    document._applyVersionIncrement();
+  }
   const postFilter = buildMiddlewareFilter(options, 'post');
   return document.schema.s.hooks.execPost('save', document, [document], { filter: postFilter });
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3917,6 +3917,12 @@ Model.buildBulkWriteOperations = function buildBulkWriteOperations(documents, op
 
     const isANewDocument = document.isNew;
     if (isANewDocument) {
+      // Like `$__version()` on insert, initialize the version key so
+      // inserted documents get the same shape as `save()` gives them
+      const versionKey = document.$__schema.options.versionKey;
+      if (versionKey) {
+        document.$__setValue(versionKey, 0);
+      }
       const writeOperation = { insertOne: { document } };
       utils.injectTimestampsOption(writeOperation.insertOne, options.timestamps);
       return writeOperation;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7839,6 +7839,35 @@ describe('Model', function() {
       assert.equal(reloaded.__v, 1);
     });
 
+    it('does not lose updates after increment() on a new document (gh-15800)', async function() {
+      // Arrange
+      const userSchema = new Schema({
+        name: String,
+        items: [{ name: String }]
+      });
+
+      const User = db.model('User', userSchema);
+      const user = new User({ name: 'Test User', items: [{ name: 'item1' }] });
+      user.increment();
+
+      // Act
+      await User.bulkSave([user]);
+
+      // Assert - like save(), inserting must not bump the in-memory version
+      // ahead of the database
+      let userFromDb = await User.findById(user._id);
+      assert.equal(user.__v, userFromDb.__v);
+
+      // Act - a VERSION_WHERE update must still match the inserted document
+      user.items[0].name = 'updated-item';
+      await User.bulkSave([user]);
+
+      // Assert
+      userFromDb = await User.findById(user._id);
+      assert.equal(userFromDb.items[0].name, 'updated-item');
+      assert.equal(user.__v, userFromDb.__v);
+    });
+
     it('saves new documents with ordered: false (gh-15495)', async function() {
       const userSchema = new Schema({
         name: { type: String }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7868,6 +7868,24 @@ describe('Model', function() {
       assert.equal(user.__v, userFromDb.__v);
     });
 
+    it('persists the version key when inserting new documents (gh-15800)', async function() {
+      // Arrange
+      const userSchema = new Schema({
+        name: String
+      });
+
+      const User = db.model('User', userSchema);
+      const user = new User({ name: 'Test User' });
+
+      // Act
+      await User.bulkSave([user]);
+
+      // Assert - like save(), the insert must write the version key
+      const userFromDb = await User.findById(user._id).lean();
+      assert.equal(user.__v, 0);
+      assert.equal(userFromDb.__v, 0);
+    });
+
     it('saves new documents with ordered: false (gh-15495)', async function() {
       const userSchema = new Schema({
         name: { type: String }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7856,16 +7856,19 @@ describe('Model', function() {
       // Assert - like save(), inserting must not bump the in-memory version
       // ahead of the database
       let userFromDb = await User.findById(user._id);
-      assert.equal(user.__v, userFromDb.__v);
+      assert.strictEqual(user.__v, 0);
+      assert.strictEqual(userFromDb.__v, 0);
 
-      // Act - a VERSION_WHERE update must still match the inserted document
+      // Act - a VERSION_WHERE update must still match the inserted document,
+      // and the pending increment() applies here
       user.items[0].name = 'updated-item';
       await User.bulkSave([user]);
 
       // Assert
       userFromDb = await User.findById(user._id);
       assert.equal(userFromDb.items[0].name, 'updated-item');
-      assert.equal(user.__v, userFromDb.__v);
+      assert.strictEqual(user.__v, 1);
+      assert.strictEqual(userFromDb.__v, 1);
     });
 
     it('persists the version key when inserting new documents (gh-15800)', async function() {


### PR DESCRIPTION
re #15800, follow-up to #15809.

`bulkSave()` treated new documents differently from `save()` in two ways, and together they caused data loss when `increment()` was called on a new document:

- inserts didn't write the version key at all, while `save()` initializes `__v` to 0
- after the insert, `handleSuccessfulWrite()` applied the version bump anyway, so the in-memory `__v` became 1 while the database had no `__v`. The next update that filters on the version key matched nothing and threw:

```js
const user = new User({ name: 'Test User', items: [{ name: 'item1' }] });
user.increment();
await User.bulkSave([user]);
// in-memory __v is 1, DB has no __v

user.items[0].name = 'updated-item';
await User.bulkSave([user]);
// throws "was not able to update 1 of the given documents", update lost
```

This PR makes both match `save()`: inserts initialize the version key to 0, and the version bump is skipped for inserted documents so a pending `increment()` applies on the next save.
