### PR TITLE
fix(query): reject all pathless update modifiers

### DIFF
--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -238,6 +238,7 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
 
     if (!prefix && isOperator(key) && schema._getSchema(key) == null) {
       throw new MongooseError('Invalid update: Unexpected modifier "' + key + '" as a key in operator "' + op + '". '
+        + 'Did you mean something like { ' + op + ': { fieldName: { ' + key + ': [...] } } }? '
         + 'Modifiers must appear under a valid field path.');
     }
 

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -11,6 +11,7 @@ const getConstructorName = require('../getConstructorName');
 const getDiscriminatorByValue = require('../discriminator/getDiscriminatorByValue');
 const getEmbeddedDiscriminatorPath = require('./getEmbeddedDiscriminatorPath');
 const handleImmutable = require('./handleImmutable');
+const isOperator = require('./isOperator');
 const moveImmutableProperties = require('../update/moveImmutableProperties');
 const schemaMixedSymbol = require('../../schema/symbols').schemaMixedSymbol;
 const setDottedPath = require('../path/setDottedPath');
@@ -235,6 +236,11 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
     key = keys[i];
     val = obj[key];
 
+    if (!prefix && isOperator(key) && schema._getSchema(key) == null) {
+      throw new MongooseError('Invalid update: Unexpected modifier "' + key + '" as a key in operator "' + op + '". '
+        + 'Modifiers must appear under a valid field path.');
+    }
+
     // `$pull` is special because we need to cast the RHS as a query, not as
     // an update.
     if (op === '$pull') {
@@ -384,11 +390,6 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
       }
     } else {
       const isModifier = (key === '$each' || key === '$or' || key === '$and' || key === '$in');
-      if (isModifier && !prefix) {
-        throw new MongooseError('Invalid update: Unexpected modifier "' + key + '" as a key in operator. '
-          + 'Did you mean something like { $addToSet: { fieldName: { $each: [...] } } }? '
-          + 'Modifiers such as "$each", "$or", "$and", "$in" must appear under a valid field path.');
-      }
       const checkPath = isModifier ? prefix : prefix + key;
       schematype = schema._getSchema(checkPath);
 

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -239,7 +239,6 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
     const fullPath = prefix + key;
     const isTopLevelOperator = !prefix && isOperator(key);
     let fullPathSchema = isTopLevelOperator ? schema._getSchema(fullPath) : null;
-    let hasFullPathSchema = isTopLevelOperator;
     const isTopLevelNestedDollarPath = isTopLevelOperator && Object.hasOwn(schema.nested, key);
     if (isTopLevelOperator &&
         fullPathSchema == null &&
@@ -252,9 +251,8 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
     // `$pull` is special because we need to cast the RHS as a query, not as
     // an update.
     if (op === '$pull') {
-      if (!hasFullPathSchema) {
+      if (!isTopLevelOperator) {
         fullPathSchema = schema._getSchema(fullPath);
-        hasFullPathSchema = true;
       }
       schematype = fullPathSchema;
       if (schematype == null) {
@@ -287,7 +285,7 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
       }
     }
 
-    if (!hasFullPathSchema) {
+    if (!isTopLevelOperator && op !== '$pull') {
       fullPathSchema = schema._getSchema(fullPath);
     }
     schematype = fullPathSchema;

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -236,9 +236,14 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
     key = keys[i];
     val = obj[key];
 
+    const fullPath = prefix + key;
     const isTopLevelOperator = !prefix && isOperator(key);
-    const topLevelDollarPathSchema = isTopLevelOperator ? schema._getSchema(key) : null;
-    if (isTopLevelOperator && topLevelDollarPathSchema == null) {
+    let fullPathSchema = isTopLevelOperator ? schema._getSchema(fullPath) : null;
+    let hasFullPathSchema = isTopLevelOperator;
+    const isTopLevelNestedDollarPath = isTopLevelOperator && Object.hasOwn(schema.nested, key);
+    if (isTopLevelOperator &&
+        fullPathSchema == null &&
+        !isTopLevelNestedDollarPath) {
       throw new MongooseError('Invalid update: Unexpected modifier "' + key + '" as a key in operator "' + op + '". '
         + 'Did you mean something like { ' + op + ': { fieldName: { ' + key + ': [...] } } }? '
         + 'Modifiers must appear under a valid field path.');
@@ -247,7 +252,11 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
     // `$pull` is special because we need to cast the RHS as a query, not as
     // an update.
     if (op === '$pull') {
-      schematype = schema._getSchema(prefix + key);
+      if (!hasFullPathSchema) {
+        fullPathSchema = schema._getSchema(fullPath);
+        hasFullPathSchema = true;
+      }
+      schematype = fullPathSchema;
       if (schematype == null) {
         const _res = getEmbeddedDiscriminatorPath(schema, obj, filter, prefix + key, options);
         if (_res.schematype != null) {
@@ -278,10 +287,13 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
       }
     }
 
+    if (!hasFullPathSchema) {
+      fullPathSchema = schema._getSchema(fullPath);
+    }
+    schematype = fullPathSchema;
+
     if (getConstructorName(val) === 'Object') {
       // watch for embedded doc schemas
-      schematype = schema._getSchema(prefix + key);
-
       if (schematype == null) {
         const _res = getEmbeddedDiscriminatorPath(schema, obj, filter, prefix + key, options);
         if (_res.schematype != null) {
@@ -392,10 +404,12 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
           (utils.isObject(val) && utils.hasOwnKeys(val) === false);
       }
     } else {
-      const isModifier = topLevelDollarPathSchema == null &&
+      const isModifier = !isTopLevelNestedDollarPath && schematype == null &&
         (key === '$each' || key === '$or' || key === '$and' || key === '$in');
-      const checkPath = isModifier ? prefix : prefix + key;
-      schematype = topLevelDollarPathSchema ?? schema._getSchema(checkPath);
+      const checkPath = isModifier ? prefix : fullPath;
+      if (isModifier) {
+        schematype = schema._getSchema(checkPath);
+      }
 
       // You can use `$setOnInsert` with immutable keys
       if (op !== '$setOnInsert' &&

--- a/lib/helpers/query/castUpdate.js
+++ b/lib/helpers/query/castUpdate.js
@@ -236,7 +236,9 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
     key = keys[i];
     val = obj[key];
 
-    if (!prefix && isOperator(key) && schema._getSchema(key) == null) {
+    const isTopLevelOperator = !prefix && isOperator(key);
+    const topLevelDollarPathSchema = isTopLevelOperator ? schema._getSchema(key) : null;
+    if (isTopLevelOperator && topLevelDollarPathSchema == null) {
       throw new MongooseError('Invalid update: Unexpected modifier "' + key + '" as a key in operator "' + op + '". '
         + 'Did you mean something like { ' + op + ': { fieldName: { ' + key + ': [...] } } }? '
         + 'Modifiers must appear under a valid field path.');
@@ -390,9 +392,10 @@ function walkUpdatePath(schema, obj, op, options, context, filter, prefix) {
           (utils.isObject(val) && utils.hasOwnKeys(val) === false);
       }
     } else {
-      const isModifier = (key === '$each' || key === '$or' || key === '$and' || key === '$in');
+      const isModifier = topLevelDollarPathSchema == null &&
+        (key === '$each' || key === '$or' || key === '$and' || key === '$in');
       const checkPath = isModifier ? prefix : prefix + key;
-      schematype = schema._getSchema(checkPath);
+      schematype = topLevelDollarPathSchema ?? schema._getSchema(checkPath);
 
       // You can use `$setOnInsert` with immutable keys
       if (op !== '$setOnInsert' &&

--- a/test/helpers/query.castUpdate.test.js
+++ b/test/helpers/query.castUpdate.test.js
@@ -50,4 +50,68 @@ describe('castUpdate', function() {
     // Assert
     assert.deepEqual(castedUpdate, { $set: { $each: 42 } });
   });
+
+  it('casts a nested schema path whose root name is also an update modifier', function() {
+    // Arrange
+    const accountSchema = new Schema({ $each: { count: Number } });
+    const update = { $set: { $each: { count: '42' } } };
+
+    // Act
+    const castedUpdate = castUpdate(accountSchema, update);
+
+    // Assert
+    assert.deepEqual(castedUpdate, { $set: { $each: { count: 42 } } });
+  });
+
+  it('preserves scalar update operators on a nested modifier-named path', function() {
+    // Arrange
+    const accountSchema = new Schema({ $each: { count: Number } });
+    const updates = [
+      { $unset: { $each: 1 } },
+      { $set: { $each: null } },
+      { $rename: { $each: 'archived' } }
+    ];
+
+    // Act
+    const castedUpdates = updates.map(update => castUpdate(accountSchema, structuredClone(update)));
+
+    // Assert
+    assert.deepEqual(castedUpdates, updates);
+  });
+
+  it('casts a modifier-named schema path nested under another path', function() {
+    // Arrange
+    const accountSchema = new Schema({ preferences: { $each: Number } });
+    const update = { $set: { preferences: { $each: '42' } } };
+
+    // Act
+    const castedUpdate = castUpdate(accountSchema, update);
+
+    // Assert
+    assert.deepEqual(castedUpdate, { $set: { preferences: { $each: 42 } } });
+  });
+
+  it('casts an array schema path whose name is also an update modifier', function() {
+    // Arrange
+    const accountSchema = new Schema({ $each: [Number] });
+    const update = { $push: { $each: '42' } };
+
+    // Act
+    const castedUpdate = castUpdate(accountSchema, update);
+
+    // Assert
+    assert.deepEqual(castedUpdate, { $push: { $each: 42 } });
+  });
+
+  it('preserves a mixed schema path whose name is also an update modifier', function() {
+    // Arrange
+    const accountSchema = new Schema({ $in: Schema.Types.Mixed });
+    const update = { $set: { $in: { count: '42' } } };
+
+    // Act
+    const castedUpdate = castUpdate(accountSchema, update);
+
+    // Assert
+    assert.deepEqual(castedUpdate, { $set: { $in: { count: '42' } } });
+  });
 });

--- a/test/helpers/query.castUpdate.test.js
+++ b/test/helpers/query.castUpdate.test.js
@@ -38,4 +38,16 @@ describe('castUpdate', function() {
     const res = castUpdate(schema, { $set: toBeUpdated });
     assert.deepEqual(res, { $set: toBeUpdated });
   });
+
+  it('casts a schema path whose name is also an update modifier', function() {
+    // Arrange
+    const accountSchema = new Schema({ $each: Number });
+    const update = { $set: { $each: '42' } };
+
+    // Act
+    const castedUpdate = castUpdate(accountSchema, update);
+
+    // Assert
+    assert.deepEqual(castedUpdate, { $set: { $each: 42 } });
+  });
 });

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3570,11 +3570,66 @@ describe('model: updateOne: ', function() {
       assert.deepEqual(updatedUser.roles, ['admin']);
     });
 
+    it('allows an insert-style upsert for a nested modifier-named dollar path', async function() {
+      // Arrange
+      const { Account } = createDollarPathTestContext();
+      const _id = new mongoose.Types.ObjectId();
+
+      // Act
+      await Account.updateOne({ _id }, { $each: { count: '42' } }, { upsert: true });
+
+      // Assert
+      const account = await Account.findById(_id);
+      assert.equal(account.$each.count, 42);
+    });
+
+    it('updates a nested modifier-named dollar path using object syntax', async function() {
+      // Arrange
+      const { Account } = createDollarPathTestContext();
+      const account = await Account.create({ preferences: { $each: 1 } });
+
+      // Act
+      await Account.updateOne(
+        { _id: account._id },
+        { $set: { preferences: { $each: '42' } } }
+      );
+
+      // Assert
+      const updatedAccount = await Account.findById(account._id);
+      assert.equal(updatedAccount.preferences.$each, 42);
+    });
+
+    it('updates a nested modifier-named dollar path using dotted syntax', async function() {
+      // Arrange
+      const { Account } = createDollarPathTestContext();
+      const account = await Account.create({ preferences: { $each: 1 } });
+
+      // Act
+      await Account.updateOne(
+        { _id: account._id },
+        { $set: { 'preferences.$each': '42' } }
+      );
+
+      // Assert
+      const updatedAccount = await Account.findById(account._id);
+      assert.equal(updatedAccount.preferences.$each, 42);
+    });
+
     function createTestContext() {
       const userSchema = new Schema({ roles: [String] });
       const User = db.model('User', userSchema);
 
       return { User };
+    }
+
+    function createDollarPathTestContext() {
+      const accountSchema = new Schema({
+        $each: { count: Number },
+        preferences: { $each: Number }
+      });
+      const Account = db.model('Account', accountSchema);
+
+      return { Account };
     }
   });
 });

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3526,10 +3526,13 @@ describe('model: updateOne: ', function() {
       const { User } = createTestContext();
 
       // Act
-      const promise = User.updateOne({}, { $addToSet: { $each: ['admin'] } });
+      const error = await User.updateOne({}, { $addToSet: { $each: ['admin'] } })
+        .then(() => null, error => error);
 
       // Assert
-      await assert.rejects(promise, /must appear under a valid field path/);
+      assert.equal(error?.name, 'MongooseError');
+      assert.match(error.message,
+        /Did you mean something like \{ \$addToSet: \{ fieldName: \{ \$each: \[\.\.\.\] \} \} \}\?/);
     });
 
     it('rejects a pathless modifier with an object value', async function() {

--- a/test/model.updateOne.test.js
+++ b/test/model.updateOne.test.js
@@ -3520,15 +3520,59 @@ describe('model: updateOne: ', function() {
     assert.equal(err, null);
   });
 
-  it('casts top level $each (gh-15642)', async function() {
-    const schema = new Schema({ tags: [String] });
-    const Model = db.model('Test', schema);
+  describe('pathless update modifiers (gh-15642)', function() {
+    it('rejects a pathless modifier with an array value', async function() {
+      // Arrange
+      const { User } = createTestContext();
 
-    await Model.create({ tags: [] });
-    await assert.rejects(
-      Model.updateOne({}, { $addToSet: { $each: ['test'] } }),
-      /Modifiers such as "\$each", "\$or", "\$and", "\$in" must appear under a valid field path/
-    );
+      // Act
+      const promise = User.updateOne({}, { $addToSet: { $each: ['admin'] } });
+
+      // Assert
+      await assert.rejects(promise, /must appear under a valid field path/);
+    });
+
+    it('rejects a pathless modifier with an object value', async function() {
+      // Arrange
+      const { User } = createTestContext();
+
+      // Act
+      const promise = User.updateOne({}, { $push: { $each: { name: 'admin' } } });
+
+      // Assert
+      await assert.rejects(promise, /must appear under a valid field path/);
+    });
+
+    it('rejects a pathless modifier that is not in the original allowlist', async function() {
+      // Arrange
+      const { User } = createTestContext();
+
+      // Act
+      const promise = User.updateOne({}, { $pull: { $nin: ['admin'] } });
+
+      // Assert
+      await assert.rejects(promise, /must appear under a valid field path/);
+    });
+
+    it('allows a modifier nested under a field path', async function() {
+      // Arrange
+      const { User } = createTestContext();
+      const user = await User.create({ roles: ['admin', 'member'] });
+
+      // Act
+      await User.updateOne({ _id: user._id }, { $pull: { roles: { $nin: ['admin'] } } });
+
+      // Assert
+      const updatedUser = await User.findById(user._id);
+      assert.deepEqual(updatedUser.roles, ['admin']);
+    });
+
+    function createTestContext() {
+      const userSchema = new Schema({ roles: [String] });
+      const User = db.model('User', userSchema);
+
+      return { User };
+    }
   });
 });
 


### PR DESCRIPTION
re #15642 #15648 #15670

`walkUpdatePath()` currently rejects `$each`, `$or`, `$and`, and `$in` when they appear without a field path, but the check only runs when the modifier value is not a plain object. It also only covers those four modifiers.

That leaves malformed updates such as these untreated:

```js
{ $push: { $each: { name: 'admin' } } }
{ $pull: { $nin: ['admin'] } }
```

With the default strict mode, these can be silently stripped into an empty update. With `strict: false`, they can be passed through to MongoDB.

This PR:

- moves pathless modifier validation to the start of `walkUpdatePath()`, before `$pull` handling and before branching on the value shape
- performs the check within the existing traversal, without adding a second pass over the update
- uses the existing operator classifier instead of maintaining a partial modifier allowlist
- resolves operator-like keys against the schema once, then reuses that result during casting, so actual dollar-prefixed paths including `$each` continue to work without another lookup, preserving the behavior from #13786
- includes a concrete correction in the error using the actual operator and misplaced modifier, for example `{ $addToSet: { fieldName: { $each: [...] } } }`

The tests cover array-valued and object-valued `$each`, a pathless `$nin`, a correctly nested `$nin`, a modifier-named `$each` schema path, and the actionable error message.
