### PR TITLE
docs: fix typos, grammar, and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Check out the [plugins search site](https://plugins.mongoosejs.io/) to see hundr
 Pull requests are always welcome! Please base pull requests against the `master`
 branch and follow the [contributing guide](https://github.com/Automattic/mongoose/blob/master/CONTRIBUTING.md).
 
-If your pull requests make documentation changes, please do **not**
+If your pull request makes documentation changes, please do **not**
 modify any `.html` files. The `.html` files are compiled code, so please make
 your changes in `docs/*.pug`, `lib/*.js`, or `test/docs/*.js`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Check out the [plugins search site](https://plugins.mongoosejs.io/) to see hundr
 Pull requests are always welcome! Please base pull requests against the `master`
 branch and follow the [contributing guide](https://github.com/Automattic/mongoose/blob/master/CONTRIBUTING.md).
 
-If your pull requests makes documentation changes, please do **not**
+If your pull requests make documentation changes, please do **not**
 modify any `.html` files. The `.html` files are compiled code, so please make
 your changes in `docs/*.pug`, `lib/*.js`, or `test/docs/*.js`.
 
@@ -341,7 +341,7 @@ new Schema({
 ### Driver Access
 
 Mongoose is built on top of the [official MongoDB Node.js driver](https://github.com/mongodb/node-mongodb-native). Each mongoose model keeps a reference to a [native MongoDB driver collection](http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html). The collection object can be accessed using `YourModel.collection`. However, using the collection object directly bypasses all mongoose features, including hooks, validation, etc. The one
-notable exception that `YourModel.collection` still buffers
+notable exception is that `YourModel.collection` still buffers
 commands. As such, `YourModel.collection.find()` will **not**
 return a cursor.
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -304,7 +304,7 @@ conn.on('close', () => console.log('close'));
 ## A note about keepAlive {#keepAlive}
 
 Before Mongoose 5.2.0, you needed to enable the `keepAlive` option to initiate [TCP keepalive](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html) to prevent `"connection closed"` errors.
-However, `keepAlive` has been `true` by default since Mongoose 5.2.0, and the `keepAlive` is deprecated as of Mongoose 7.2.0.
+However, `keepAlive` has been `true` by default since Mongoose 5.2.0, and `keepAlive` is deprecated as of Mongoose 7.2.0.
 Please remove `keepAlive` and `keepAliveInitialDelay` options from your Mongoose connections.
 
 ## Replica Set Connections {#replicaset_connections}
@@ -492,7 +492,7 @@ Your business logic can then `require()` or `import` the connection it needs.
 ## Connection Pools {#connection_pools}
 
 Each `connection`, whether created with `mongoose.connect` or
-`mongoose.createConnection` are all backed by an internal configurable
+`mongoose.createConnection`, is backed by an internal configurable
 connection pool defaulting to a maximum size of 100. Adjust the pool size
 using your connection options:
 
@@ -558,7 +558,7 @@ app.listen(3000);
 
 The following is an example of pattern (2).
 Pattern (2) is more flexible and better for use cases with > 10k tenants and > 1 requests/second.
-Because each tenant has a separate connection pool, one tenants' slow operations will have minimal impact on other tenants.
+Because each tenant has a separate connection pool, one tenant's slow operations will have minimal impact on other tenants.
 However, this pattern is harder to implement and manage in production.
 In particular, [MongoDB does have a limit on the number of open connections](https://www.mongodb.com/blog/post/tuning-mongodb--linux-to-allow-for-tens-of-thousands-connections), and [MongoDB Atlas has separate limits on the number of open connections](https://www.mongodb.com/docs/atlas/reference/atlas-limits), so you need to make sure the total number of sockets in your connection pools doesn't go over MongoDB's limits.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -159,7 +159,7 @@ is undefined on the underlying [POJO](guide.html#minimize).
 <a class="anchor" href="#arrow-functions">**Q**</a>. I'm using an arrow function for a [virtual](guide.html#virtuals), [middleware](middleware.html), [getter](api/schematype.html#schematype_SchemaType-get)/[setter](api/schematype.html#schematype_SchemaType-set), or [method](guide.html#methods) and the value of `this` is wrong.
 
 **A**. Arrow functions [handle the `this` keyword differently than conventional functions](https://masteringjs.io/tutorials/fundamentals/arrow#why-not-arrow-functions).
-Mongoose getters/setters depend on `this` to give you access to the document that you're writing to, but this functionality does not work with arrow functions. Do **not** use arrow functions for mongoose getters/setters unless do not intend to access the document in the getter/setter.
+Mongoose getters/setters depend on `this` to give you access to the document that you're writing to, but this functionality does not work with arrow functions. Do **not** use arrow functions for mongoose getters/setters unless you do not intend to access the document in the getter/setter.
 
 ```javascript
 // Do **NOT** use arrow functions as shown below unless you're certain

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,7 +1,7 @@
 # Schemas
 
 If you haven't yet done so, please take a minute to read the [quickstart](index.html) to get an idea of how Mongoose works.
-If you are migrating from 7.x to 8.x please take a moment to read the [migration guide](migrating_to_8.html).
+If you are migrating from 8.x to 9.x please take a moment to read the [migration guide](migrating_to_9.html).
 
 <ul class="toc">
   <li><a href="#definition">Defining your schema</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ const kittySchema = new mongoose.Schema({
 });
 ```
 
-So far so good. We've got a schema with one property, `name`, which will be a  `String`. The next step is compiling our schema into a [Model](models.html).
+So far so good. We've got a schema with one property, `name`, which will be a `String`. The next step is compiling our schema into a [Model](models.html).
 
 ```javascript
 const Kitten = mongoose.model('Kitten', kittySchema);
@@ -104,7 +104,7 @@ console.log(kittens);
 ```
 
 We just logged all of the kittens in our db to the console.
-If we want to filter our kittens by name, Mongoose supports MongoDBs rich [querying](queries.html) syntax.
+If we want to filter our kittens by name, Mongoose supports MongoDB's rich [querying](queries.html) syntax.
 
 ```javascript
 await Kitten.find({ name: /^fluff/ });

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -565,7 +565,7 @@ of each [aggregation pipeline](https://www.mongodb.com/docs/manual/core/aggregat
 
 ```javascript
 customerSchema.pre('aggregate', function() {
-  // Add a $match state to the beginning of each pipeline.
+  // Add a $match stage to the beginning of each pipeline.
   this.pipeline().unshift({ $match: { isDeleted: { $ne: true } } });
 });
 ```

--- a/docs/populate.md
+++ b/docs/populate.md
@@ -100,7 +100,7 @@ const story = await Story.
 console.log('The author is %s', story.author.name);
 ```
 
-Populated paths are no longer set to their original `_id` , their value
+Populated paths are no longer set to their original `_id`, their value
 is replaced with the mongoose document returned from the database by
 performing a separate query before returning the results.
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -194,7 +194,7 @@ const aggRes = await Person.aggregate([{ $match: { _id: idString } }]);
 
 ## Sorting {#sorting}
 
-[Sorting](/docs/api.html#query_Query-sort) is how you can ensure your query results come back in the desired order.
+[Sorting](api.html#query_Query-sort) is how you can ensure your query results come back in the desired order.
 
 ```javascript
 const personSchema = new mongoose.Schema({

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -194,7 +194,7 @@ const aggRes = await Person.aggregate([{ $match: { _id: idString } }]);
 
 ## Sorting {#sorting}
 
-[Sorting](api.html#query_Query-sort) is how you can ensure your query results come back in the desired order.
+[Sorting](api/query.html#query_Query-sort) is how you can ensure your query results come back in the desired order.
 
 ```javascript
 const personSchema = new mongoose.Schema({


### PR DESCRIPTION
**Summary**
Fixes small but real documentation issues found across the README and 
several guide pages — grammar errors, typos, missing words, a possessive 
mistake, extra whitespace, an outdated migration reference (updated to 
reflect Mongoose 9), and one internal link that used an absolute path 
instead of a relative path per the style rule in CONTRIBUTING.md.

No runtime behavior