### PR TITLE
Optimize array.unique by caching toString() result

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -858,11 +858,12 @@ exports.array.unique = function(arr) {
       ret.push(item);
       primitives.add(item);
     } else if (isBsonType(item, 'ObjectId')) {
-      if (ids.has(item.toString())) {
+      const idStr = item.toString();
+      if (ids.has(idStr)) {
         continue;
       }
       ret.push(item);
-      ids.add(item.toString());
+      ids.add(idStr);
     } else {
       ret.push(item);
     }


### PR DESCRIPTION
**Summary**

This PR optimizes the `array.unique` method by caching the result of `.toString()`. 

Previously, `toString()` was called twice per unique ObjectId: once during the `Set.has()` check, and again during `Set.add()`. By caching the result, this change eliminates a redundant string allocation per item, reducing memory overhead and improving execution time, especially for large arrays of ObjectIds.

**Examples**

This is an internal performance and memory optimization, so there are no changes to the public API or user-facing behavior. All existing tests pass successfully.