### PR TITLE
fix(subdocument): don't minimize empty document array elements to null

### DIFF
--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -403,7 +403,9 @@ if (util.inspect.custom) {
 
 /**
  * Override `$toObject()` to handle minimizing the whole path. Should not minimize if schematype-level minimize
- * is set to false re: gh-11247, gh-14058, gh-14151
+ * is set to false re: gh-11247, gh-14058, gh-14151. Should not minimize document array elements: an array
+ * element cannot be removed without shifting the array, so minimizing it to `undefined` makes the BSON
+ * serializer store `null` re: gh-7322.
  */
 
 Subdocument.prototype.$toObject = function $toObject(options, json) {
@@ -413,7 +415,7 @@ Subdocument.prototype.$toObject = function $toObject(options, json) {
   // If minimize is set, then we can minimize out the whole object.
   if (utils.hasOwnKeys(ret) === false && options?._calledWithOptions != null) {
     const minimize = options._calledWithOptions?.minimize ?? this?.$__schemaTypeOptions?.minimize ?? options.minimize;
-    if (minimize && !this.constructor.$__required) {
+    if (minimize && !this.constructor.$__required && !this.$isDocumentArrayElement) {
       return undefined;
     }
   }

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -109,4 +109,35 @@ describe('types.subdocument', function() {
     const doc2 = new MyModel({ myfield: { empty: {} } });
     assert.deepStrictEqual(doc2.toObject().myfield, { empty: {} });
   });
+
+  it('does not minimize empty document array elements to undefined (gh-7322)', function() {
+    const ItemSchema = new Schema(
+      { taxRate: Number, taxAmount: Number },
+      { _id: false }
+    );
+    const MySchema = new Schema({ items: { type: [ItemSchema], default: undefined } });
+    const MyModel = db.model('Test2', MySchema);
+
+    const doc = new MyModel({
+      items: [{ taxRate: 19 }, { taxRate: undefined, taxAmount: undefined }]
+    });
+
+    assert.deepStrictEqual(doc.toObject({ minimize: true }).items, [{ taxRate: 19 }, {}]);
+  });
+
+  it('saves an empty document array element as an empty object, not null (gh-7322)', async function() {
+    const ItemSchema = new Schema(
+      { taxRate: Number, taxAmount: Number },
+      { _id: false }
+    );
+    const MySchema = new Schema({ items: { type: [ItemSchema], default: undefined } });
+    const MyModel = db.model('Test3', MySchema);
+
+    const doc = await MyModel.create({
+      items: [{ taxRate: 19 }, { taxRate: undefined, taxAmount: undefined }]
+    });
+
+    const raw = await MyModel.collection.findOne({ _id: doc._id });
+    assert.deepStrictEqual(raw.items, [{ taxRate: 19 }, {}]);
+  });
 });


### PR DESCRIPTION
**Summary**

Since 8.14.0, a document array element whose fields are all `undefined` is stored in MongoDB as `null` instead of `{}`. #15336 moved the "minimize empty subdocument to `undefined`" logic from `clone()` (where it was gated on `$isSingleNested`, so document array elements were excluded) into `Subdocument.prototype.$toObject()`, which `ArraySubdocument` inherits — so the minimization now also applies to array elements. An array slot can't be removed without shifting the array, so the resulting `undefined` element is serialized by BSON as `null`.

This reintroduces the problem fixed back in 5.4.6 by #7322 ("make minimize leave empty objects in arrays instead of setting the array element to undefined"). `null` array elements are worse than empty objects: `arr[0].someField` now throws `TypeError: Cannot read properties of null` in code that previously saw `undefined` and handled it fine.

Bisected: 8.0.0 – 8.13.3 store `[{}]`; 8.14.0+ stores `[null]`.

**Reproduction**

```js
const itemSchema = new Schema({ taxRate: Number, taxAmount: Number }, { _id: false });
const Model = mongoose.model('Test', new Schema({ items: [itemSchema] }));

await Model.create({
  items: [{ taxRate: 19 }, { taxRate: undefined, taxAmount: undefined }]
});

// stored in MongoDB:
// 8.13.3: { items: [ { taxRate: 19 }, {} ] }
// 8.14.0+: { items: [ { taxRate: 19 }, null ] }  <- reading it back crashes consumers
```

**Fix**

Restore the array-element exclusion by checking `$isDocumentArrayElement` in the `$toObject()` minimize branch, mirroring the `$isSingleNested` gate the logic had in `clone()` before #15336. Single nested subdocument minimization (the gh-15313 / gh-11247 behavior) is unchanged — the existing `respects schematype-level minimize (gh-15313)` test still passes.

**Examples**

Two tests added in `test/types.subdocument.test.js`: one asserting `toObject({ minimize: true })` keeps `{}` for an empty array element, one asserting the raw stored document contains `{}` rather than `null` after `create()`. Both fail before this change and pass after.
