### PR TITLE
docs(guide): clarify what strictQuery does to filter paths not in the schema

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -949,9 +949,9 @@ Mongoose supports a separate `strictQuery` option to avoid strict mode for query
 This is because empty query filters cause Mongoose to return all documents in the model, which can cause issues.
 
 ```javascript
-const mySchema = new Schema({ field: Number }, { strict: true });
+const mySchema = new Schema({ field: Number }, { strictQuery: true });
 const MyModel = mongoose.model('Test', mySchema);
-// Mongoose will filter out `notInSchema: 1` because `strict: true`, meaning this query will return
+// Mongoose will filter out `notInSchema: 1` because `strictQuery: true`, meaning this query will return
 // _all_ documents in the 'tests' collection
 MyModel.find({ notInSchema: 1 });
 ```
@@ -975,6 +975,24 @@ const mySchema = new Schema({ field: Number }, {
 const MyModel = mongoose.model('Test', mySchema);
 // Mongoose will not strip out `notInSchema: 1` because `strictQuery` is false
 MyModel.find({ notInSchema: 1 });
+```
+
+Note the difference between the two settings for filter paths that aren't in the schema.
+With `strictQuery: false`, Mongoose leaves the path in the filter as-is and does **not** cast the value.
+The server will only return documents where `notInSchema` is stored as `1`, so the query typically matches no documents.
+With `strictQuery: true`, Mongoose silently removes the path from the filter, so the query may match more documents than intended.
+With `strictQuery: 'throw'`, Mongoose throws a `StrictModeError` instead.
+
+```javascript
+await MyModel.create({ field: 42 });
+
+// Matches 0 documents with `strictQuery: false`, the default: Mongoose sends
+// `{ notInSchema: 1 }` to the server as-is, and no document has that property.
+await MyModel.find({ notInSchema: 1 });
+
+// Matches _all_ documents with `strictQuery: true`: Mongoose strips out
+// `notInSchema: 1`, leaving an empty filter `{}`.
+await MyModel.find({ notInSchema: 1 }).setOptions({ strictQuery: true });
 ```
 
 In general, we do **not** recommend passing user-defined objects as query filters:


### PR DESCRIPTION
With `strictQuery: false` (the default since 7.0), a filter path that isn't in the schema is passed through uncasted, so the query usually matches nothing. With `strictQuery: true` the path is silently stripped, so the query can match more than intended. The guide shows both examples but never spells out this difference — it's an easy silent bug to hit (we did, via an `updateMany` filter that quietly matched 0 docs).

Also fixes the first example in the section, which still says `strict: true` filters unknown paths out of query filters — that hasn't been true since strictQuery stopped inheriting from strict in 7.0 (#11861).

Behavior verified against 8.24.1 and 9.7.4, and matches the existing gh-11861 / gh-6032 tests in test/query.test.js. `npm run lint-md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)