### PR TITLE
Fix/16383 optimistic concurrency wildcards

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -5673,21 +5673,47 @@ Document.prototype._applyVersionIncrement = function _applyVersionIncrement() {
  */
 
 /*!
+ * Helper for _pathOrAncestorInSet and _pathOverlapsSet
+ */
+function _checkOverlap(modParts, m, schemaParts, s) {
+  if (s === schemaParts.length) {
+    return { ancestor: true, overlap: true };
+  }
+  if (m === modParts.length) {
+    return { ancestor: false, overlap: true };
+  }
+
+  if (modParts[m] === schemaParts[s] || schemaParts[s] === '$*') {
+    const res = _checkOverlap(modParts, m + 1, schemaParts, s + 1);
+    if (res.overlap) {
+      return res;
+    }
+  }
+
+  if (/^\d+$/.test(modParts[m]) && !/^\d+$/.test(schemaParts[s])) {
+    const res = _checkOverlap(modParts, m + 1, schemaParts, s);
+    if (res.overlap) {
+      return res;
+    }
+  }
+
+  return { ancestor: false, overlap: false };
+}
+
+/*!
  * Check if `path` or any of its ancestor paths exist in `pathSet`.
  * For example:
  *   _pathOrAncestorInSet('profile.firstName', Set(['profile'])) === true
  *   _pathOrAncestorInSet('profile', Set(['profile.firstName'])) === false
  */
 function _pathOrAncestorInSet(path, pathSet) {
-  if (pathSet.has(path)) {
-    return true;
-  }
-  let idx = path.indexOf('.');
-  while (idx !== -1) {
-    if (pathSet.has(path.substring(0, idx))) {
+  const modParts = path.split('.');
+  for (const schemaPath of pathSet) {
+    const schemaParts = schemaPath.split('.');
+    const res = _checkOverlap(modParts, 0, schemaParts, 0);
+    if (res.ancestor) {
       return true;
     }
-    idx = path.indexOf('.', idx + 1);
   }
   return false;
 }
@@ -5700,11 +5726,11 @@ function _pathOrAncestorInSet(path, pathSet) {
  *   _pathOverlapsSet('profile', Set(['profile.firstName'])) === true
  */
 function _pathOverlapsSet(path, pathSet) {
-  if (_pathOrAncestorInSet(path, pathSet)) {
-    return true;
-  }
-  for (const p of pathSet) {
-    if (p.length > path.length + 1 && p[path.length] === '.' && p.slice(0, path.length) === path) {
+  const modParts = path.split('.');
+  for (const schemaPath of pathSet) {
+    const schemaParts = schemaPath.split('.');
+    const res = _checkOverlap(modParts, 0, schemaParts, 0);
+    if (res.overlap) {
       return true;
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -858,11 +858,12 @@ exports.array.unique = function(arr) {
       ret.push(item);
       primitives.add(item);
     } else if (isBsonType(item, 'ObjectId')) {
-      if (ids.has(item.toString())) {
+      const idStr = item.toString();
+      if (ids.has(idStr)) {
         continue;
       }
       ret.push(item);
-      ids.add(item.toString());
+      ids.add(idStr);
     } else {
       ret.push(item);
     }

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -875,6 +875,34 @@ describe('versioning', function() {
       });
     });
 
+    describe('optimisticConcurrency (gh-16383)', function() {
+      it('supports Map wildcards', async function() {
+        const schema = new Schema({
+          settings: { type: Map, of: String },
+          balance: Number
+        }, { optimisticConcurrency: ['settings.$*'] });
+        const User = db.model('Test16383Map', schema);
+        
+        const user = await User.create({ settings: { theme: 'dark' }, balance: 100 });
+        user.settings.set('theme', 'light');
+        user.$__delta();
+        assert.strictEqual(user.$__.version, VERSION_ALL);
+      });
+
+      it('supports Array of subdocuments', async function() {
+        const schema = new Schema({
+          comments: [{ text: String }],
+          title: String
+        }, { optimisticConcurrency: ['comments.text'] });
+        const Post = db.model('Test16383Array', schema);
+
+        const post = await Post.create({ title: 'Hello', comments: [{ text: 'First' }] });
+        post.comments[0].text = 'Edited';
+        post.$__delta();
+        assert.strictEqual(post.$__.version, VERSION_ALL);
+      });
+    });
+
     async function createTestContext({ optimisticConcurrency }) {
       const schema = new Schema({
         name: String,


### PR DESCRIPTION
fix(document): support map wildcards and array paths in optimisticConcurrency

Fixes #16383 

This PR addresses the issue where `optimisticConcurrency` fails to match paths with map wildcards (`$*`) or subdocument arrays (e.g., `comments.text` vs modified `comments.0.text`).

**Changes made:**
- Introduced a recursive `_checkOverlap` helper in `lib/document.js`.
- It dynamically skips numeric array indices in the modified path unless the schema explicitly expects a numeric segment, and it handles `$*` map wildcards effectively.
- Refactored both `_pathOrAncestorInSet` and `_pathOverlapsSet` to use this new helper.
- Added tests for both map wildcards and array of subdocuments in `test/versioning.test.js`.

All 4,400+ Mongoose tests continue to pass seamlessly with these updates.


