### PR TITLE
perf(document): reuse cached required paths on construction

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -143,7 +143,7 @@ function Document(obj, fields, options) {
     this.$__.strictMode = schema.options.strict;
   }
 
-  const requiredPaths = schema.requiredPaths(true);
+  const requiredPaths = schema.requiredPaths();
   for (const path of requiredPaths) {
     this.$__.activePaths.require(path);
   }


### PR DESCRIPTION
Fixes #16377.

The `Document` constructor calls `schema.requiredPaths(true)` for every document, and the `true` makes `requiredPaths` skip its own `_requiredpaths` cache and rescan all paths. So constructing N documents means N full scans of the schema's path list.

The `invalidate` flag goes back to #3199: `.required()` can set `isRequired` after the cache is already warm, and nothing cleared `_requiredpaths` at that point, so forcing a recompute on construction was the workaround.

This clears the cache where the required paths can actually change instead, and lets the constructor read the cache:

- `SchemaType#required()` when it flips `isRequired`
- `Schema#remove()`

Discriminators already `delete schema._requiredpaths` on registration, and `Schema#add`/`#path` go through `required()`, so those cases stay covered.

Added a test for the ordering the suite didn't have: construct a doc (this warms the cache) → `path.required(true)` → construct another doc → the newly required path is still enforced. Reverting only the `required()` invalidation makes that test fail, so it guards the #3199 behavior.

Quick benchmark, 100k docs of a 40-path schema (20 required):

- before: ~22.1 µs/doc
- after: ~19.3 µs/doc (~13% of construction time)

The saving grows with the number of paths.

One thing worth a look: the invalidation uses `this.parentSchema`, set at schematype creation. If a schematype were shared across schemas, nulling could touch the wrong schema's cache — but that's only a wasted recompute, never a stale result. I didn't hit any such case across the schema/document/validation suites (all green).
