### PR TITLE
fix: backport #16393 to 8.x

### DIFF
--- a/lib/types/subdocument.js
+++ b/lib/types/subdocument.js
@@ -452,7 +452,9 @@ if (util.inspect.custom) {
 
 /**
  * Override `$toObject()` to handle minimizing the whole path. Should not minimize if schematype-level minimize
- * is set to false re: gh-11247, gh-14058, gh-14151
+ * is set to false re: gh-11247, gh-14058, gh-14151. Should not minimize document array elements: an array
+ * element cannot be removed without shifting the array, so minimizing it to `undefined` makes the BSON
+ * serializer store `null` re: gh-7322.
  */
 
 Subdocument.prototype.$toObject = function $toObject(options, json) {
@@ -462,7 +464,7 @@ Subdocument.prototype.$toObject = function $toObject(options, json) {
   // If minimize is set, then we can minimize out the whole object.
   if (Object.keys(ret).length === 0 && options?._calledWithOptions != null) {
     const minimize = options._calledWithOptions?.minimize ?? this?.$__schemaTypeOptions?.minimize ?? options.minimize;
-    if (minimize && !this.constructor.$__required) {
+    if (minimize && !this.constructor.$__required && !this.$isDocumentArrayElement) {
       return undefined;
     }
   }

--- a/test/types.subdocument.test.js
+++ b/test/types.subdocument.test.js
@@ -109,4 +109,35 @@ describe('types.subdocument', function() {
     const doc2 = new MyModel({ myfield: { empty: {} } });
     assert.deepStrictEqual(doc2.toObject().myfield, { empty: {} });
   });
+
+  it('does not minimize empty document array elements to undefined (gh-7322)', function() {
+    const ItemSchema = new Schema(
+      { taxRate: Number, taxAmount: Number },
+      { _id: false }
+    );
+    const MySchema = new Schema({ items: { type: [ItemSchema], default: undefined } });
+    const MyModel = db.model('Test2', MySchema);
+
+    const doc = new MyModel({
+      items: [{ taxRate: 19 }, { taxRate: undefined, taxAmount: undefined }]
+    });
+
+    assert.deepStrictEqual(doc.toObject({ minimize: true }).items, [{ taxRate: 19 }, {}]);
+  });
+
+  it('saves an empty document array element as an empty object, not null (gh-7322)', async function() {
+    const ItemSchema = new Schema(
+      { taxRate: Number, taxAmount: Number },
+      { _id: false }
+    );
+    const MySchema = new Schema({ items: { type: [ItemSchema], default: undefined } });
+    const MyModel = db.model('Test3', MySchema);
+
+    const doc = await MyModel.create({
+      items: [{ taxRate: 19 }, { taxRate: undefined, taxAmount: undefined }]
+    });
+
+    const raw = await MyModel.collection.findOne({ _id: doc._id });
+    assert.deepStrictEqual(raw.items, [{ taxRate: 19 }, {}]);
+  });
 });


### PR DESCRIPTION
Backport of #16393. Since 8.14.0 (#15336), a document array element whose fields are all `undefined` gets minimized to `undefined` during serialization, which BSON stores as `null`. This restores the array-element exclusion by checking `$isDocumentArrayElement`, same as the master fix.

re #7322