### PR TITLE
docs(typescript): note type predicate helper for PopulatedDoc checks

### DIFF
--- a/docs/typescript/populate.md
+++ b/docs/typescript/populate.md
@@ -97,3 +97,21 @@ Here's two reasons why:
 
 1. You still need to add an extra check to check if `child instanceof ObjectId`. Otherwise, the TypeScript compiler will fail with `Property name does not exist on type ObjectId`. So using `PopulatedDoc<>` means you need an extra check everywhere you use `doc.child`.
 2. In the `Parent` interface, `child` is a hydrated document, which makes it difficult for Mongoose to infer the type of `child` when you use `lean()` or `toObject()`.
+
+If you do use `PopulatedDoc`, you can move that runtime check into a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) helper. TypeScript will then narrow the populated type after the helper returns true:
+
+```ts
+import { Types } from 'mongoose';
+
+function isPopulated<T>(doc: T | Types.ObjectId | null | undefined): doc is T {
+  return doc != null && !(doc instanceof Types.ObjectId);
+}
+
+ParentModel.findOne({}).populate('child').orFail().then((doc: Parent) => {
+  if (!isPopulated(doc.child)) {
+    throw new Error('should be populated');
+  }
+  // Works: doc.child is narrowed to the populated document type
+  doc.child.name.trim();
+});
+```


### PR DESCRIPTION
## Summary
- Documents using a TypeScript type predicate helper to narrow `PopulatedDoc` paths after a runtime ObjectId check.
- Addresses the docs half of #12664 so users do not need to repeat the check inline everywhere.

## Test plan
- [ ] Review the new example in `docs/typescript/populate.md`
- [ ] Confirm the example matches existing populate TypeScript guidance

Fixes #12664