### PR TITLE
types: respect _id option when inferring StandardSchema type

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -81,6 +81,13 @@ async function standardSchemaModelValidate(): Promise<void> {
   });
 }
 
+async function gh16402() {
+  const schema = new Schema({ myid: { type: Schema.Types.ObjectId, required: true } }, { _id: false, versionKey: false });
+  const Book = model('Book', schema);
+  type Out = mongoose.StandardSchemaV1.InferOutput<typeof Book>;
+  expect({} as Out).type.toBe<{ myid: Types.ObjectId }>();
+}
+
 async function modelValidateReturnsCastedObject(): Promise<void> {
   interface IUser {
     name: string;

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -86,6 +86,11 @@ async function gh16402() {
   const Book = model('Book', schema);
   type Out = mongoose.StandardSchemaV1.InferOutput<typeof Book>;
   expect({} as Out).type.toBe<{ myid: Types.ObjectId }>();
+
+  const schemaWithVersionKey = new Schema({ myid: { type: Schema.Types.ObjectId, required: true } }, { _id: false });
+  const BookWithVersionKey = model('Book', schemaWithVersionKey);
+  type OutWithVersionKey = mongoose.StandardSchemaV1.InferOutput<typeof BookWithVersionKey>;
+  expect({} as OutWithVersionKey).type.toBe<{ myid: Types.ObjectId } & { __v: number }>();
 }
 
 async function modelValidateReturnsCastedObject(): Promise<void> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -150,6 +150,8 @@ declare module 'mongoose' {
     ? IfAny<U, T & { _id: Types.ObjectId }, T & Required<{ _id: U }>>
     : T & { _id: Types.ObjectId };
 
+  export type Default_id<T, TSchemaOptions = {}> = TSchemaOptions extends { _id: false } ? T : Require_id<T>;
+
   export type Default__v<T, TSchemaOptions = {}> = TSchemaOptions extends { versionKey: false }
     ? T
     : TSchemaOptions extends { versionKey: infer VK }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -241,7 +241,12 @@ declare module 'mongoose' {
     base: Mongoose;
 
     /** Standard Schema adapter for validating input with this model's schema. */
-    readonly '~standard': StandardSchemaV1.Props<Default__v<Require_id<TRawDocType>, ObtainSchemaGeneric<TSchema, 'TSchemaOptions'>>>;
+    readonly '~standard': StandardSchemaV1.Props<
+      Default__v<
+        Default_id<TRawDocType, ObtainSchemaGeneric<TSchema, 'TSchemaOptions'>>,
+        ObtainSchemaGeneric<TSchema, 'TSchemaOptions'>
+      >
+    >;
 
     /**
      * If this is a discriminator model, `baseModelName` is the name of


### PR DESCRIPTION
Fix #16402

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`~standard` currently doesn't respect `_id: false` option in schemas. This PR makes that rely on a `Default_id` analogous to `Default__v` that looks for `_id: false` in `TSchemaOptions`. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
