### PR TITLE
perf(document): avoid clearing required paths cache on every document instantiation

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -143,7 +143,7 @@ function Document(obj, fields, options) {
     this.$__.strictMode = schema.options.strict;
   }
 
-  const requiredPaths = schema.requiredPaths(true);
+  const requiredPaths = schema.requiredPaths();
   for (const path of requiredPaths) {
     this.$__.activePaths.require(path);
   }


### PR DESCRIPTION
Fix #16377

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The issue presented in #16377 is a minor where the document constructor loops over all required paths in the schema as a fix for #3199. However the original issue was more due to OP setting `required()` on nested schema paths after defining the top level schema, which is something we subsequently fixed. So looping over required paths is no longer necessary.

The performance improvement is fairly minimal, adds up to maybe 0.2ms per 1000 required paths in the following benchmark (not committing because too narrow in scope), but still noticeable.

```javascript
'use strict';

// Measures the cost of constructing documents as schema width and the number
// of required paths vary. The two modes model the current constructor and the
// pre-change constructor, respectively.

const mongoose = require('../');

const iterations = Number(process.env.MONGOOSE_BENCHMARK_ITERATIONS) || 5000;
const samples = Number(process.env.MONGOOSE_BENCHMARK_SAMPLES) || 5;
const totalPathSizes = (process.env.MONGOOSE_BENCHMARK_TOTAL_PATHS || '10,100,1000')
  .split(',')
  .map(size => Number(size));

function median(values) {
  values.sort((a, b) => a - b);
  return values[Math.floor(values.length / 2)];
}

function makeModel(totalPaths, requiredPaths) {
  const definition = {};
  const rawDoc = {};

  for (let i = 0; i < totalPaths; ++i) {
    definition[`field${i}`] = {
      type: Number,
      required: i < requiredPaths
    };
    rawDoc[`field${i}`] = i;
  }

  const name = `DocumentConstructorRequiredPaths${totalPaths}${requiredPaths}`;
  return {
    Model: mongoose.model(name, new mongoose.Schema(definition)),
    rawDoc
  };
}

function measure(Model, rawDoc, legacy, count) {
  const requiredPaths = Model.schema.requiredPaths;
  Model.schema.requiredPaths = function(invalidate) {
    return requiredPaths.call(this, legacy || invalidate);
  };

  let result = 0;
  const start = process.hrtime.bigint();
  for (let i = 0; i < count; ++i) {
    result += new Model(rawDoc)._doc.field0 || 0;
  }
  const elapsed = Number(process.hrtime.bigint() - start) / 1e6;

  Model.schema.requiredPaths = requiredPaths;
  if (result < 0) {
    throw new Error('Unexpected benchmark result');
  }
  return elapsed;
}

console.log(`iterations per sample: ${iterations}, samples: ${samples}`);
console.log('total paths\trequired paths\tcached ms/doc\tlegacy ms/doc\tspeedup');

for (const totalPaths of totalPathSizes) {
  const requiredPathSizes = [...new Set([0, 1, Math.floor(totalPaths / 10), totalPaths])];
  for (const requiredPaths of requiredPathSizes) {
    const { Model, rawDoc } = makeModel(totalPaths, requiredPaths);

    // Prime the schema cache and JIT before collecting timings.
    measure(Model, rawDoc, false, Math.min(iterations, 100));
    measure(Model, rawDoc, true, Math.min(iterations, 100));

    const cached = median(Array.from({ length: samples }, () =>
      measure(Model, rawDoc, false, iterations)));
    const legacy = median(Array.from({ length: samples }, () =>
      measure(Model, rawDoc, true, iterations)));

    console.log(`${totalPaths}\t\t${requiredPaths}\t\t${(cached / iterations).toFixed(6)}\t\t${(legacy / iterations).toFixed(6)}\t${(legacy / cached).toFixed(2)}x`);
  }
}
```

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
