### PR TITLE
types(model): keep Model.schema typed when TSchema is omitted

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1206,6 +1206,20 @@ async function gh15693() {
   User.schema.methods.printNamePrefixed.call(leanInst, '');
 }
 
+async function gh15693b() {
+  interface Cat {
+    name: string;
+  }
+
+  const catSchema = new Schema<Cat>({ name: { type: String, required: true } });
+  // Hand-written `Model<Cat>` annotation omits the `TSchema` generic, so `schema`
+  // must fall back to `Schema<Cat>` rather than collapsing to `any`.
+  const m: Model<Cat> = model<Cat>('Cat', catSchema);
+
+  expect(m.schema).type.not.toBe<any>();
+  expect(m.schema).type.toBeAssignableTo<Schema<Cat>>();
+}
+
 async function gh15781() {
   const userSchema = new Schema({
     createdAt: { type: Date, immutable: true },

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -1225,7 +1225,11 @@ declare module 'mongoose' {
     recompileSchema(): void;
 
     /** Schema the model uses. */
-    schema: TSchema;
+    schema: IfAny<
+      TSchema,
+      Schema<TRawDocType, Model<TRawDocType, TQueryHelpers, TInstanceMethods, TVirtuals>, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TSchema
+    >;
 
     /** Creates a `updateMany` query: updates all documents that match `filter` with `update`. */
     updateMany(


### PR DESCRIPTION
**Summary**

Since #15750 `Model.schema` is declared as `TSchema`. On the inference path (`model(name, schema)`) it resolves to the exact schema type. A handwritten annotation such as `const m: Model<Cat>` omits the `TSchema` generic, so it falls back to its `any` default and `m.schema` silently becomes `any`. Mongoose 8 declared the property as `Schema<TRawDocType>` and it stayed typed in both cases.

Handwritten `Model<T>` annotations are the norm when models come from dependency injection, for example in every NestJS application using `@nestjs/mongoose` (see nestjs/mongoose#2852).

This change keeps the exact `TSchema` type when it is supplied or inferred. When `TSchema` is `any` it falls back to the Mongoose 8 shape through the existing `IfAny` helper. The `gh15693` test that motivated #15750 still passes.

**Examples**

```ts
const catSchema = new Schema<Cat>({ name: { type: String, required: true } });
const CatModel = model<Cat>('Cat', catSchema);

const m: Model<Cat> = CatModel;
m.schema; // before: any. After: Schema<Cat, ...>

CatModel.schema; // unchanged, still the exact typeof catSchema
```

A regression test (`gh15693b`) is included. It fails against the current declaration and passes with this change. `npm run test:types` passes with 39 files and 997 assertions. `npm run lint-ts` is clean.
