### PR TITLE
perf(document): faster string checks and unnecessary isSelected on paths with no getters

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2582,18 +2582,18 @@ Document.prototype.isSelected = function isSelected(path) {
     return inclusive;
   }
 
-  const pathDot = path + '.';
+  const pathHasDot = path.indexOf('.') !== -1;
 
   for (const cur of paths) {
     if (cur === '_id') {
       continue;
     }
 
-    if (cur.startsWith(pathDot)) {
-      return inclusive || cur !== pathDot;
+    if (cur.charAt(path.length) === '.' && cur.slice(0, path.length) === path) {
+      return inclusive || cur !== path + '.';
     }
 
-    if (pathDot.startsWith(cur + '.')) {
+    if (pathHasDot && path.charAt(cur.length) === '.' && path.slice(0, cur.length) === cur) {
       return inclusive;
     }
   }
@@ -4406,6 +4406,32 @@ function applyGetters(self, json) {
   while (i--) {
     path = paths[i];
 
+    const schemaType = schema.paths[path];
+    // Skip if no getters, including `$__isSelected()` because that can be expensive
+    if (!schemaType.getters?.length && !schemaType.embeddedSchemaType?.getters?.length) {
+      continue;
+    }
+
+    if (!self.$__isSelected(path)) {
+      continue;
+    }
+
+    if (path.indexOf('.') === -1) {
+      json[path] = schemaType.applyGetters(
+        json[path],
+        self
+      );
+      if (Array.isArray(json[path]) && schemaType.embeddedSchemaType) {
+        for (let i = 0; i < json[path].length; ++i) {
+          json[path][i] = schemaType.embeddedSchemaType.applyGetters(
+            json[path][i],
+            self
+          );
+        }
+      }
+      continue;
+    }
+
     const parts = path.split('.');
 
     const plen = parts.length;
@@ -4413,10 +4439,6 @@ function applyGetters(self, json) {
     let branch = json;
     let part;
     cur = self._doc;
-
-    if (!self.$__isSelected(path)) {
-      continue;
-    }
 
     for (let ii = 0; ii < plen; ++ii) {
       part = parts[ii];
@@ -4427,13 +4449,13 @@ function applyGetters(self, json) {
       if (branch != null && typeof branch !== 'object') {
         break;
       } else if (ii === last) {
-        branch[part] = schema.paths[path].applyGetters(
+        branch[part] = schemaType.applyGetters(
           branch[part],
           self
         );
-        if (Array.isArray(branch[part]) && schema.paths[path].embeddedSchemaType) {
+        if (Array.isArray(branch[part]) && schemaType.embeddedSchemaType) {
           for (let i = 0; i < branch[part].length; ++i) {
-            branch[part][i] = schema.paths[path].embeddedSchemaType.applyGetters(
+            branch[part][i] = schemaType.embeddedSchemaType.applyGetters(
               branch[part][i],
               self
             );


### PR DESCRIPTION
Re: #16373
Re: #16385

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I was investigating #16385, looks like there's a lot of lower hanging fruit we can take to improve performance on `toObject({ getters: true })` without going the full route of constructing a trie, which has some negative performance implications:

1. `startsWith()` is much slower than `slice()` plus equality check
2. Avoid looping if unnecessary
3. Skip paths that don't have any getters - if there's no getters, `applyGetters()` will never do anything, so no need to run `isSelected()`

Performance on master using benchmark from #16385

```js
'use strict';

// Benchmarks `toObject({ getters: true })` on a projected document, where
// only a subset of a wide schema's paths were selected by the originating
// query. Constructs documents directly (no live MongoDB connection needed),
// since the cost being measured is purely in-process (Document#$toObject /
// Document#isSelected), not in query execution.

const mongoose = require('../');

function buildModelAndDoc(numPaths, projectedCount) {
  const schemaDef = {};
  for (let i = 0; i < numPaths; i++) {
    schemaDef[`field${i}`] = String;
  }
  const schema = new mongoose.Schema(schemaDef, { versionKey: false });
  const Model = mongoose.model(`Bench${numPaths}`, schema);

  const obj = {};
  const fields = {};
  for (let i = 0; i < projectedCount; i++) {
    obj[`field${i}`] = `value${i}`;
    fields[`field${i}`] = 1;
  }
  // constructs a document the same way query hydration does for a projected
  // query result (see `Query.prototype._completeMany`)
  return new Model(obj, fields);
}

function bench(numPaths, projectedCount, iterations) {
  const doc = buildModelAndDoc(numPaths, projectedCount);
  // warm up the JIT before measuring
  for (let i = 0; i < 200; i++) {
    doc.toObject({ getters: true });
  }
  const start = process.hrtime.bigint();
  for (let i = 0; i < iterations; i++) {
    doc.toObject({ getters: true });
  }
  const end = process.hrtime.bigint();
  return Number(end - start) / 1e6 / iterations;
}

const ITERATIONS = 1000;
const results = {};
let baseline;
for (const n of [10, 50, 100, 500]) {
  // schema width 2N, with an inclusive projection selecting N of those paths
  const msPerCall = bench(n * 2, n, ITERATIONS);
  if (baseline == null) {
    baseline = msPerCall;
  }
  results[`N=${n}`] = {
    'ms/call': Number(msPerCall.toFixed(5)),
    'ratio to N=10': Number((msPerCall / baseline).toFixed(2))
  };
}

console.log(JSON.stringify(results, null, '  '));

```

```json
{
  "N=10": {
    "ms/call": 0.02131,
    "ratio to N=10": 1
  },
  "N=50": {
    "ms/call": 0.16936,
    "ratio to N=10": 7.95
  },
  "N=100": {
    "ms/call": 0.6321,
    "ratio to N=10": 29.66
  },
  "N=500": {
    "ms/call": 12.62822,
    "ratio to N=10": 592.59
  }
}

```

With this PR:

```json
{
  "N=10": {
    "ms/call": 0.01161,
    "ratio to N=10": 1
  },
  "N=50": {
    "ms/call": 0.02576,
    "ratio to N=10": 2.22
  },
  "N=100": {
    "ms/call": 0.05626,
    "ratio to N=10": 4.85
  },
  "N=500": {
    "ms/call": 0.72255,
    "ratio to N=10": 62.23
  }
}

```

Even without the check for 0 getters:

```json
{
  "N=10": {
    "ms/call": 0.01892,
    "ratio to N=10": 1
  },
  "N=50": {
    "ms/call": 0.0695,
    "ratio to N=10": 3.67
  },
  "N=100": {
    "ms/call": 0.21967,
    "ratio to N=10": 11.61
  },
  "N=500": {
    "ms/call": 3.24599,
    "ratio to N=10": 171.59
  }
}
```

Results on #16385:

```json
{
  "N=10": {
    "ms/call": 0.01888,
    "ratio to N=10": 1
  },
  "N=50": {
    "ms/call": 0.06224,
    "ratio to N=10": 3.3
  },
  "N=100": {
    "ms/call": 0.13032,
    "ratio to N=10": 6.9
  },
  "N=500": {
    "ms/call": 1.83669,
    "ratio to N=10": 97.27
  }
}
```

So this PR is faster than the patch from #16385 with no trie construction overhead. 
<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
