### PR TITLE
perf: improve toObject() performance re: #14394

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -4461,10 +4461,10 @@ function applyGetters(self, json) {
 
 function applySchemaTypeTransforms(self, json) {
   const schema = self.$__schema;
-  const paths = Object.keys(schema.paths || {});
+  const paths = schema.pathsWithTransforms();
   const cur = self._doc;
 
-  if (!cur) {
+  if (!cur || !paths) {
     return json;
   }
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -4007,9 +4007,6 @@ Document.prototype.$toObject = function(options, json) {
   if (depopulate && options._isNested && this.$__.wasPopulated) {
     return clone(this.$__.wasPopulated.value || this._doc._id, options);
   }
-  if (depopulate) {
-    options.depopulate = true;
-  }
 
   // merge default options with input options.
   if (defaultOptions != null) {
@@ -4021,7 +4018,6 @@ Document.prototype.$toObject = function(options, json) {
   }
   options._isNested = true;
   options.json = json;
-  options.minimize = _minimize;
 
   const parentOptions = options._parentOptions;
   // Parent options should only bubble down for subdocuments, not populated docs

--- a/lib/document.js
+++ b/lib/document.js
@@ -4029,7 +4029,7 @@ Document.prototype.$toObject = function(options, json) {
 
   const schemaFieldsOnly = options._calledWithOptions.schemaFieldsOnly
     ?? options.schemaFieldsOnly
-    ?? defaultOptions.schemaFieldsOnly
+    ?? defaultOptions?.schemaFieldsOnly
     ?? false;
 
   let ret;
@@ -4066,7 +4066,7 @@ Document.prototype.$toObject = function(options, json) {
 
   const getters = options._calledWithOptions.getters
     ?? options.getters
-    ?? defaultOptions.getters
+    ?? defaultOptions?.getters
     ?? false;
 
   if (getters) {
@@ -4078,7 +4078,7 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   const virtuals = options._calledWithOptions.virtuals
-    ?? defaultOptions.virtuals
+    ?? defaultOptions?.virtuals
     ?? parentOptions?.virtuals
     ?? undefined;
 
@@ -4093,7 +4093,7 @@ Document.prototype.$toObject = function(options, json) {
   const transform = options._calledWithOptions.transform ?? true;
   let transformFunction = undefined;
   if (transform === true) {
-    transformFunction = defaultOptions.transform;
+    transformFunction = defaultOptions?.transform;
   } else if (typeof transform === 'function') {
     transformFunction = transform;
   }
@@ -5663,7 +5663,7 @@ Document.prototype.$clearModifiedPaths = function $clearModifiedPaths() {
  */
 
 Document.prototype.$__hasOnlyPrimitiveValues = function $__hasOnlyPrimitiveValues() {
-  return !this.$__.populated && !this.$__.wasPopulated && (this._doc == null || Object.values(this._doc).every(v => {
+  return !this.$__.populated && (this._doc == null || Object.values(this._doc).every(v => {
     return v == null
       || typeof v !== 'object'
       || (utils.isNativeObject(v) && !Array.isArray(v))

--- a/lib/helpers/schema/idGetter.js
+++ b/lib/helpers/schema/idGetter.js
@@ -26,6 +26,9 @@ module.exports = function addIdGetter(schema) {
  */
 
 function idGetter() {
+  if (this._doc) {
+    return this._doc._id?.toString() ?? null;
+  }
   if (this._id != null) {
     return this._id.toString();
   }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -727,7 +727,7 @@ Schema.prototype._getDocumentMiddleware = function _getDocumentMiddleware() {
 
 Schema.prototype._defaultToObjectOptions = function(json) {
   const path = json ? 'toJSON' : 'toObject';
-  if (this._defaultToObjectOptionsMap && this._defaultToObjectOptionsMap[path]) {
+  if (this._defaultToObjectOptionsMap && path in this._defaultToObjectOptionsMap) {
     return this._defaultToObjectOptionsMap[path];
   }
 
@@ -738,7 +738,7 @@ Schema.prototype._defaultToObjectOptions = function(json) {
   const defaultOptions = Object.assign({}, baseOptions, schemaOptions);
 
   this._defaultToObjectOptionsMap = this._defaultToObjectOptionsMap || {};
-  this._defaultToObjectOptionsMap[path] = defaultOptions;
+  this._defaultToObjectOptionsMap[path] = Object.keys(defaultOptions).length > 0 ? defaultOptions : null;
   return defaultOptions;
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -738,7 +738,7 @@ Schema.prototype._defaultToObjectOptions = function(json) {
   const defaultOptions = Object.assign({}, baseOptions, schemaOptions);
 
   this._defaultToObjectOptionsMap = this._defaultToObjectOptionsMap || {};
-  this._defaultToObjectOptionsMap[path] = Object.keys(defaultOptions).length > 0 ? defaultOptions : null;
+  this._defaultToObjectOptionsMap[path] = utils.hasOwnKeys(defaultOptions) ? defaultOptions : null;
   return defaultOptions;
 };
 
@@ -3137,6 +3137,8 @@ function isArrayFilter(piece) {
 Schema.prototype._preCompile = function _preCompile() {
   this.plugin(idGetter, { deduplicate: true });
   _precomputeOptimisticConcurrency(this);
+  // Cache paths that have transforms
+  this.pathsWithTransforms();
 };
 
 /*!

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1871,6 +1871,46 @@ Schema.prototype.requiredPaths = function requiredPaths(invalidate) {
 };
 
 /**
+ * Returns an Array of path strings that have a `transform` option, either on the
+ * path itself or on the path's `embeddedSchemaType` for arrays.
+ *
+ * #### Example:
+ *
+ *     const s = new Schema({
+ *       name: { type: String, transform: v => v.toLowerCase() },
+ *       tags: [{ type: String, transform: v => v.trim() }],
+ *       age: { type: Number, required: true },
+ *       notes: String
+ *     });
+ *     s.pathsWithTransforms(); // [ 'name', 'tags' ]
+ *
+ * @api private
+ * @param {boolean} invalidate Refresh the cache
+ * @return {Array|null}
+ */
+
+Schema.prototype.pathsWithTransforms = function pathsWithTransforms(invalidate) {
+  if (this._pathsWithTransforms !== undefined && !invalidate) {
+    return this._pathsWithTransforms;
+  }
+
+  const paths = Object.keys(this.paths);
+  const ret = [];
+
+  for (const path of paths) {
+    const schematype = this.paths[path];
+    const topLevelTransformFunction = schematype.options.transform ?? schematype.constructor?.defaultOptions?.transform;
+    const embeddedSchemaTypeTransformFunction = schematype.embeddedSchemaType?.options?.transform
+      ?? schematype.embeddedSchemaType?.constructor?.defaultOptions?.transform;
+    if (topLevelTransformFunction || embeddedSchemaTypeTransformFunction) {
+      ret.push(path);
+    }
+  }
+  this._pathsWithTransforms = ret.length ? ret : null;
+  return this._pathsWithTransforms;
+};
+
+/**
  * Returns indexes from fields and schema-level indexes (cached).
  *
  * @api private

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -15274,6 +15274,7 @@ describe('document', function() {
     }
 
     mongoose.Schema.Types.CustomType = SchemaCustomType;
+    mongoose.Schema.Types.CustomType.set('transform', v => v == null ? v : v.value);
 
     const Model = db.model(
       'Test',
@@ -15285,8 +15286,6 @@ describe('document', function() {
     const _id = new mongoose.Types.ObjectId('0'.repeat(24));
     const doc = new Model({ _id });
     doc.value = 1;
-
-    mongoose.Schema.Types.CustomType.set('transform', v => v == null ? v : v.value);
 
     assert.deepStrictEqual(doc.toJSON(), { _id, value: 1 });
     assert.deepStrictEqual(doc.toObject(), { _id, value: 1 });

--- a/test/document.unit.test.js
+++ b/test/document.unit.test.js
@@ -42,6 +42,7 @@ describe('toObject()', function() {
         virtuals: { virtual: { applyGetters: () => 'test' } }
       };
       this.$__schema._defaultToObjectOptions = () => this.$__schema.options.toObject;
+      this.$__schema.pathsWithTransforms = () => [];
       this._doc = { empty: {} };
       this.$__ = {};
     };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: #14394, there's a few more optimizations we can make:

1. idGetter gets called on every document by default and using `this._id` fires internal getters, which causes perf overhead
2. schema `defaultOptions` should be `null` instead of empty object to make checking for default options faster
3. Allow running shallow clone on populated subdocs to avoid full `clone()` overhead

Before:

```
$ node gh-14394.js 
toObject ms: 291
Done
^C

```

After:

```
$ node gh-14394.js 
toObject ms: 162
Done
^C

```

I also adapted the changes from #16405.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
