### PR TITLE
fix(query): avoid path collision when excluding subdocument with select: false child (gh-12798)

### DIFF
--- a/lib/queryHelpers.js
+++ b/lib/queryHelpers.js
@@ -384,9 +384,11 @@ exports.applyPaths = function applyPaths(fields, schema, sanitizeProjection) {
     let i = -1;
     while ((i = path.indexOf('.', i + 1)) !== -1) {
       const ancestor = fields[path.slice(0, i)];
-      // `false` is also a valid exclusion value alongside `0`, e.g.
-      // `.select({ subd: false })`, so check both. See gh-12798
-      if (ancestor === 0 || ancestor === false) {
+      // Any falsy defining value (`0`, `false`, `''`, `NaN`) excludes a
+      // path, matching how `exclude` itself is derived above (`!field`).
+      // `ancestor == null` means the key isn't present at all, which is
+      // not an exclusion. See gh-12798
+      if (ancestor != null && !ancestor) {
         return true;
       }
     }

--- a/lib/queryHelpers.js
+++ b/lib/queryHelpers.js
@@ -383,7 +383,10 @@ exports.applyPaths = function applyPaths(fields, schema, sanitizeProjection) {
   function hasExcludedAncestor(fields, path) {
     let i = -1;
     while ((i = path.indexOf('.', i + 1)) !== -1) {
-      if (fields[path.slice(0, i)] === 0) {
+      const ancestor = fields[path.slice(0, i)];
+      // `false` is also a valid exclusion value alongside `0`, e.g.
+      // `.select({ subd: false })`, so check both. See gh-12798
+      if (ancestor === 0 || ancestor === false) {
         return true;
       }
     }

--- a/lib/queryHelpers.js
+++ b/lib/queryHelpers.js
@@ -209,6 +209,13 @@ exports.applyPaths = function applyPaths(fields, schema, sanitizeProjection) {
   switch (exclude) {
     case true:
       for (const fieldName of excluded) {
+        // Skip if an ancestor path is already excluded in `fields` (for
+        // example the user did `.select('-subd')` and `subd.raw` has
+        // schema-level `select: false`) to avoid MongoDB's "Path collision"
+        // error from projecting both `subd` and `subd.raw`. See gh-12798
+        if (hasExcludedAncestor(fields, fieldName)) {
+          continue;
+        }
         fields[fieldName] = 0;
       }
       break;
@@ -371,6 +378,16 @@ exports.applyPaths = function applyPaths(fields, schema, sanitizeProjection) {
 
     (type.selected ? selected : excluded).push(path);
     return path;
+  }
+
+  function hasExcludedAncestor(fields, path) {
+    let i = -1;
+    while ((i = path.indexOf('.', i + 1)) !== -1) {
+      if (fields[path.slice(0, i)] === 0) {
+        return true;
+      }
+    }
+    return false;
   }
 };
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1954,6 +1954,11 @@ describe('Query', function() {
       boolQuery._applyPaths();
       assert.deepEqual(boolQuery._fields, { subd: false });
 
+      // Any other falsy defining value is equally a valid exclusion
+      const emptyStringQuery = Test.find().select({ subd: '' });
+      emptyStringQuery._applyPaths();
+      assert.deepEqual(emptyStringQuery._fields, { subd: '' });
+
       const Deep = db.model('Test1', new Schema({
         a: { b: { c: { type: String, select: false }, d: String } },
         arr: [{ raw: { type: String, select: false }, clean: String }]

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1928,6 +1928,27 @@ describe('Query', function() {
       assert.ok(!doc.child2.field);
     });
 
+    it('excluding a subdocument path does not conflict with a nested select: false path (gh-12798)', async function() {
+      const schema = new Schema({
+        name: String,
+        subd: {
+          raw: { type: String, select: false },
+          clean: String
+        }
+      });
+      const Test = db.model('Test', schema);
+
+      await Test.create({ name: 'test', subd: { raw: 'raw', clean: 'clean' } });
+
+      const query = Test.find().select('-subd');
+      query._applyPaths();
+      assert.deepEqual(query._fields, { subd: 0 });
+
+      const doc = await Test.findOne().select('-subd').orFail();
+      assert.strictEqual(doc.subd.clean, undefined);
+      assert.strictEqual(doc.subd.raw, undefined);
+    });
+
     it('errors in post init (gh-5592)', async function() {
       const TestSchema = new Schema();
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1947,6 +1947,26 @@ describe('Query', function() {
       const doc = await Test.findOne().select('-subd').orFail();
       assert.strictEqual(doc.subd.clean, undefined);
       assert.strictEqual(doc.subd.raw, undefined);
+
+      // `false` is a valid exclusion value alongside `0` and shouldn't
+      // collide with the schema-level exclusion either
+      const boolQuery = Test.find().select({ subd: false });
+      boolQuery._applyPaths();
+      assert.deepEqual(boolQuery._fields, { subd: false });
+
+      const Deep = db.model('Test1', new Schema({
+        a: { b: { c: { type: String, select: false }, d: String } },
+        arr: [{ raw: { type: String, select: false }, clean: String }]
+      }));
+      for (const [sel, expected] of [
+        ['-a', { a: 0, 'arr.raw': 0 }],
+        ['-a.b', { 'a.b': 0, 'arr.raw': 0 }],
+        ['-arr', { arr: 0, 'a.b.c': 0 }]
+      ]) {
+        const deepQuery = Deep.find().select(sel);
+        deepQuery._applyPaths();
+        assert.deepEqual(deepQuery._fields, expected);
+      }
     });
 
     it('errors in post init (gh-5592)', async function() {


### PR DESCRIPTION
Fixes #12798.

`applyPaths()` was unconditionally projecting every schema-level `select: false` path onto `fields`, even when an ancestor of that path was already excluded by the user's own `.select()` call. So `.select('-subd')` on a schema where `subd.raw` has `select: false` produced `{ subd: 0, 'subd.raw': 0 }`, which MongoDB rejects with a path collision error, even though `subd: 0` already covers `subd.raw`.

Fix: in the exclusive-projection branch of `applyPaths` (`lib/queryHelpers.js`), skip adding a schema-excluded path if one of its dot-path ancestors is already excluded in `fields`. The check walks the path segments directly (`O(depth)`, depth is realistically 1-3), no scan over the whole projection object, so it doesn't reintroduce the O(n²) concern from the previous attempt at this (#15807).

This is the missing half of an existing pattern rather than a new mechanism: `analyzePath`'s existing "check for parent exclusions" loop already skips a schema-excluded path when an *ancestor is also schema-excluded* (`select: false` on the parent). That loop only checks the `excluded` array, so it never covered the case here, where the ancestor is excluded by the *user's own* `.select()` call instead of the schema. This fix adds that other half.

```js
const BarSchema = new Schema({
  name: String,
  subd: {
    raw: { type: String, select: false },
    clean: String
  }
});
const Bar = mongoose.model('Bar', BarSchema);

Bar.find().select('-subd'); // no longer throws "Path collision"
```

The ancestor check treats any falsy defining value (`0`, `false`, `''`, `NaN`) as exclusion, matching how `exclude` itself is derived a few lines above (`exclude = !field`) -- e.g. `.select({ subd: false })` is equally valid and isn't normalized to `0` by the time this check runs.

Added a regression test in `test/query.test.js` under the existing `bug fixes` block (same spot as the neighboring gh-5603 test) covering: the issue's exact schema shape (asserts the resolved projection collapses to `{ subd: 0 }` and a live query resolves with the excluded fields undefined instead of throwing), the boolean- and empty-string-exclusion forms, and 3-4 level deep nesting plus a document array, each asserting the ancestor-covered descendant is dropped while an unrelated sibling exclusion still comes through (so the guard isn't over-eager).

Known, unrelated, pre-existing gap left untouched: `Model.find().slice('arr', 5)` on a schema where `arr`'s children have `select: false` can still produce a similar collision (`{arr: {$slice: 5}, 'arr.child': 0}`). That path never reaches this fix at all -- `$slice`/`$meta` values don't count as a defining projection, so the query has no exclusive/inclusive determination (`exclude` stays `undefined`) and falls into a separate branch this PR doesn't touch. Widening that branch risks silently dropping `select: false` fields that should still apply alongside `$slice`/`$meta`, so didn't fold it into this PR -- flagging in case it's worth its own issue.

Two files touched, no reformatting. `npm run lint` and the full suite pass locally (4461 passing; the one unrelated failure is an encryption integration test that requires `npm run setup-test-encryption`, pre-existing and unrelated to this change).
