### PR TITLE
perf(timestamps): avoid adding $setOnInsert for createdAt unless upsert set

### DIFF
--- a/lib/helpers/model/castBulkWrite.js
+++ b/lib/helpers/model/castBulkWrite.js
@@ -127,7 +127,7 @@ module.exports.castUpdateOne = function castUpdateOne(originalModel, updateOne, 
     applyTimestampsToUpdate(now, createdAt, updatedAt, update, {
       timestamps: updateOne.timestamps,
       overwriteImmutable: updateOne.overwriteImmutable
-    });
+    }, updateOne.upsert);
   }
 
   if (doInitTimestamps) {
@@ -194,7 +194,7 @@ module.exports.castUpdateMany = function castUpdateMany(originalModel, updateMan
     applyTimestampsToUpdate(now, createdAt, updatedAt, updateMany['update'], {
       timestamps: updateMany.timestamps,
       overwriteImmutable: updateMany.overwriteImmutable
-    });
+    }, updateMany.upsert);
   }
   if (doInitTimestamps) {
     applyTimestampsToChildren(now, updateMany['update'], model.schema);

--- a/lib/helpers/timestamps/setupTimestamps.js
+++ b/lib/helpers/timestamps/setupTimestamps.js
@@ -123,6 +123,7 @@ function _setTimestampsOnUpdate() {
     updatedAt,
     this.getUpdate(),
     this._mongooseOptions,
+    this.options.upsert,
     replaceOps.has(this.op)
   );
   applyTimestampsToChildren(now, this.getUpdate(), this.model.schema);

--- a/lib/helpers/update/applyTimestampsToUpdate.js
+++ b/lib/helpers/update/applyTimestampsToUpdate.js
@@ -13,10 +13,10 @@ module.exports = applyTimestampsToUpdate;
  * ignore
  */
 
-function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, options, isReplace) {
+function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, options, upsert, isReplace) {
   const updates = currentUpdate;
   let _updates = updates;
-  const timestamps = get(options, 'timestamps', true);
+  const timestamps = options?.timestamps ?? true;
 
   // Support skipping timestamps at the query level, see gh-6980
   if (!timestamps || updates == null) {
@@ -81,7 +81,7 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
   }
 
   if (!skipCreatedAt && createdAt) {
-    const overwriteImmutable = get(options, 'overwriteImmutable', false);
+    const overwriteImmutable = options?.overwriteImmutable;
     const hasUserCreatedAt = currentUpdate[createdAt] != null
       || currentUpdate.$set?.[createdAt] != null
       || currentUpdate.$setOnInsert?.[createdAt] != null;
@@ -119,7 +119,7 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
         }
       }
 
-      if (!timestampSet) {
+      if (!timestampSet && upsert) {
         updates.$setOnInsert = updates.$setOnInsert || {};
         updates.$setOnInsert[createdAt] = now;
       }

--- a/lib/helpers/update/applyTimestampsToUpdate.js
+++ b/lib/helpers/update/applyTimestampsToUpdate.js
@@ -4,7 +4,6 @@
  * ignore
  */
 
-const get = require('../get');
 const utils = require('../../utils');
 
 module.exports = applyTimestampsToUpdate;

--- a/test/helpers/update.applyTimestampsToUpdate.test.js
+++ b/test/helpers/update.applyTimestampsToUpdate.test.js
@@ -12,4 +12,17 @@ describe('applyTimestampsToUpdate', function() {
     assert.equal(res.length, 2);
     assert.equal(res[1].$set.updated_at.valueOf(), now.valueOf());
   });
+
+  it('does not set createdAt unless upsert is enabled', function() {
+    const update = { $set: { title: 'mongoose' } };
+    const now = new Date('2016-01-01');
+    const res = applyTimestampsToUpdate(now, 'created_at', 'updated_at', update, {});
+
+    assert.deepEqual(res, {
+      $set: {
+        title: 'mongoose',
+        updated_at: now
+      }
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

I spotted a minor issue when working on [this blog post](https://thecodebarbarian.com/mongoose-studio-cassandra-data-api.html): `applyTimestampsToUpdate` always adds `$setOnInsert: { createdAt }` for _all_ updates, even ones that don't have `upsert: true`. `$setOnInsert` is guaranteed to be a no-op unless `upsert` is set, so `applyTimestampsToUpdate` is constructing useless objects and wasting bandwidth.

I also removed the `get()` calls in `applyTimestampsToUpdate()`, which should slightly help performance.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
