### PR TITLE
Add discriminator key to each member of embedded discriminator enum

### DIFF
--- a/test/types/inferhydrateddoctype.test.ts
+++ b/test/types/inferhydrateddoctype.test.ts
@@ -1,0 +1,41 @@
+import mongoose, {
+  InferHydratedDocType,
+  InferHydratedDocTypeFromSchema
+} from 'mongoose';
+import { expect } from 'tstyche';
+
+function gh16045() {
+  const circleSchema = new mongoose.Schema({
+    kind: { type: String, enum: ['Circle'] },
+    name: { baseName: String },
+    radius: Number
+  });
+  const squareSchema = new mongoose.Schema({
+    kind: { type: String, enum: ['Square'] },
+    side: Number
+  });
+
+  const shapeSchema = new mongoose.Schema({ name: String }, { discriminatorKey: 'kind' });
+  const schemaDefinition = {
+    shape: {
+      type: shapeSchema,
+      discriminators: {
+        Circle: circleSchema,
+        Square: squareSchema
+      }
+    }
+  } as const;
+
+  type ShapeType = NonNullable<InferHydratedDocType<typeof schemaDefinition>['shape']>;
+  type BaseType = InferHydratedDocTypeFromSchema<typeof shapeSchema>;
+  type CircleType = InferHydratedDocTypeFromSchema<typeof circleSchema>;
+  type SquareType = InferHydratedDocTypeFromSchema<typeof squareSchema>;
+  type DiscriminatorType = CircleType | SquareType;
+
+  expect<ShapeType>().type.toBe<
+    Omit<BaseType, keyof DiscriminatorType> & DiscriminatorType
+  >();
+  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
+  expect<Extract<ShapeType, { kind?: 'Circle' | null | undefined }>['radius']>().type.toBe<number | null | undefined>();
+  expect<Extract<ShapeType, { kind?: 'Square' | null | undefined }>['side']>().type.toBe<number | null | undefined>();
+}

--- a/test/types/inferhydrateddoctype.test.ts
+++ b/test/types/inferhydrateddoctype.test.ts
@@ -28,14 +28,16 @@ function gh16045() {
 
   type ShapeType = NonNullable<InferHydratedDocType<typeof schemaDefinition>['shape']>;
   type BaseType = InferHydratedDocTypeFromSchema<typeof shapeSchema>;
+  type BaseWithNullDiscriminator = Omit<BaseType, 'kind'> & { kind?: null };
   type CircleType = InferHydratedDocTypeFromSchema<typeof circleSchema> & { kind: 'Circle' };
   type SquareType = InferHydratedDocTypeFromSchema<typeof squareSchema> & { kind: 'Square' };
 
   expect<ShapeType>().type.toBe<
+    BaseWithNullDiscriminator |
     (Omit<BaseType, keyof CircleType> & CircleType) |
     (Omit<BaseType, keyof SquareType> & SquareType)
   >();
-  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square'>();
+  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Square' }>['side']>().type.toBe<number | null | undefined>();
 }

--- a/test/types/inferhydrateddoctype.test.ts
+++ b/test/types/inferhydrateddoctype.test.ts
@@ -32,10 +32,12 @@ function gh16045() {
   type CircleType = InferHydratedDocTypeFromSchema<typeof circleSchema> & { kind: 'Circle' };
   type SquareType = InferHydratedDocTypeFromSchema<typeof squareSchema> & { kind: 'Square' };
 
+  type CircleTypeUnionMember = Omit<BaseType, keyof CircleType> & CircleType;
+  type SquareTypeUnionMember = Omit<BaseType, keyof SquareType> & SquareType;
   expect<ShapeType>().type.toBe<
     BaseWithNullDiscriminator |
-    (Omit<BaseType, keyof CircleType> & CircleType) |
-    (Omit<BaseType, keyof SquareType> & SquareType)
+    CircleTypeUnionMember |
+    SquareTypeUnionMember
   >();
   expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();

--- a/test/types/inferhydrateddoctype.test.ts
+++ b/test/types/inferhydrateddoctype.test.ts
@@ -28,14 +28,14 @@ function gh16045() {
 
   type ShapeType = NonNullable<InferHydratedDocType<typeof schemaDefinition>['shape']>;
   type BaseType = InferHydratedDocTypeFromSchema<typeof shapeSchema>;
-  type CircleType = InferHydratedDocTypeFromSchema<typeof circleSchema>;
-  type SquareType = InferHydratedDocTypeFromSchema<typeof squareSchema>;
-  type DiscriminatorType = CircleType | SquareType;
+  type CircleType = InferHydratedDocTypeFromSchema<typeof circleSchema> & { kind: 'Circle' };
+  type SquareType = InferHydratedDocTypeFromSchema<typeof squareSchema> & { kind: 'Square' };
 
   expect<ShapeType>().type.toBe<
-    Omit<BaseType, keyof DiscriminatorType> & DiscriminatorType
+    (Omit<BaseType, keyof CircleType> & CircleType) |
+    (Omit<BaseType, keyof SquareType> & SquareType)
   >();
-  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
-  expect<Extract<ShapeType, { kind?: 'Circle' | null | undefined }>['radius']>().type.toBe<number | null | undefined>();
-  expect<Extract<ShapeType, { kind?: 'Square' | null | undefined }>['side']>().type.toBe<number | null | undefined>();
+  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square'>();
+  expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();
+  expect<Extract<ShapeType, { kind: 'Square' }>['side']>().type.toBe<number | null | undefined>();
 }

--- a/test/types/inferhydrateddoctype.test.ts
+++ b/test/types/inferhydrateddoctype.test.ts
@@ -41,3 +41,19 @@ function gh16045() {
   expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Square' }>['side']>().type.toBe<number | null | undefined>();
 }
+
+function gh16045RequiredDiscriminatorKey() {
+  const baseSchema = new mongoose.Schema({
+    kind: { type: String, required: true },
+    name: String
+  }, { discriminatorKey: 'kind' });
+  const schemaDefinition = {
+    shape: {
+      type: baseSchema,
+      discriminators: {}
+    }
+  } as const;
+
+  type ShapeType = NonNullable<InferHydratedDocType<typeof schemaDefinition>['shape']>;
+  expect<ShapeType['kind']>().type.toBe<string>();
+}

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -1,4 +1,4 @@
-import mongoose, { InferRawDocType, InferRawDocTypeFromSchema, type InferRawDocTypeWithout_id, type ResolveTimestamps, type Schema, type Types, FlattenMaps } from 'mongoose';
+import mongoose, { InferRawDocType, InferRawDocTypeFromSchema, ObtainSchemaGeneric, ResolveSchemaOptions, type InferRawDocTypeWithout_id, type ResolveTimestamps, type Schema, type Types, FlattenMaps } from 'mongoose';
 import { expect } from 'tstyche';
 
 function inferPojoType() {
@@ -261,6 +261,8 @@ function gh16045() {
   });
 
   const shapeSchema = new mongoose.Schema({ name: String }, { discriminatorKey: 'kind' });
+  type ShapeOptions = ResolveSchemaOptions<ObtainSchemaGeneric<typeof shapeSchema, 'TSchemaOptions'>>;
+  expect<ShapeOptions['discriminatorKey']>().type.toBe<'kind'>();
   const schemaDefinition = {
     shape: {
       type: shapeSchema,
@@ -273,16 +275,16 @@ function gh16045() {
 
   type ShapeType = NonNullable<InferRawDocType<typeof schemaDefinition>['shape']>;
   type BaseType = InferRawDocTypeFromSchema<typeof shapeSchema>;
-  type CircleType = InferRawDocTypeFromSchema<typeof circleSchema>;
-  type SquareType = InferRawDocTypeFromSchema<typeof squareSchema>;
-  type DiscriminatorType = CircleType | SquareType;
+  type CircleType = InferRawDocTypeFromSchema<typeof circleSchema> & { kind: 'Circle' };
+  type SquareType = InferRawDocTypeFromSchema<typeof squareSchema> & { kind: 'Square' };
 
   expect<ShapeType>().type.toBe<
-    Omit<BaseType, keyof DiscriminatorType> & DiscriminatorType
+    (Omit<BaseType, keyof CircleType> & CircleType) |
+    (Omit<BaseType, keyof SquareType> & SquareType)
   >();
-  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
-  expect<Extract<ShapeType, { kind?: 'Circle' | null | undefined }>['radius']>().type.toBe<number | null | undefined>();
-  expect<Extract<ShapeType, { kind?: 'Square' | null | undefined }>['side']>().type.toBe<number | null | undefined>();
+  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square'>();
+  expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();
+  expect<Extract<ShapeType, { kind: 'Square' }>['side']>().type.toBe<number | null | undefined>();
 }
 
 function gh15988() {

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -1,4 +1,4 @@
-import mongoose, { InferRawDocType, type InferRawDocTypeWithout_id, type ResolveTimestamps, type Schema, type Types, FlattenMaps } from 'mongoose';
+import mongoose, { InferRawDocType, InferRawDocTypeFromSchema, type InferRawDocTypeWithout_id, type ResolveTimestamps, type Schema, type Types, FlattenMaps } from 'mongoose';
 import { expect } from 'tstyche';
 
 function inferPojoType() {
@@ -247,6 +247,42 @@ function gh13772WithExplicitDocTypeIdFalse() {
     children: ChildDocType[];
     child?: ChildDocType | null;
     _id: Types.ObjectId }>();
+}
+
+function gh16045() {
+  const circleSchema = new mongoose.Schema({
+    kind: { type: String, enum: ['Circle'] },
+    name: { baseName: String },
+    radius: Number
+  });
+  const squareSchema = new mongoose.Schema({
+    kind: { type: String, enum: ['Square'] },
+    side: Number
+  });
+
+  const shapeSchema = new mongoose.Schema({ name: String }, { discriminatorKey: 'kind' });
+  const schemaDefinition = {
+    shape: {
+      type: shapeSchema,
+      discriminators: {
+        Circle: circleSchema,
+        Square: squareSchema
+      }
+    }
+  } as const;
+
+  type ShapeType = NonNullable<InferRawDocType<typeof schemaDefinition>['shape']>;
+  type BaseType = InferRawDocTypeFromSchema<typeof shapeSchema>;
+  type CircleType = InferRawDocTypeFromSchema<typeof circleSchema>;
+  type SquareType = InferRawDocTypeFromSchema<typeof squareSchema>;
+  type DiscriminatorType = CircleType | SquareType;
+
+  expect<ShapeType>().type.toBe<
+    Omit<BaseType, keyof DiscriminatorType> & DiscriminatorType
+  >();
+  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
+  expect<Extract<ShapeType, { kind?: 'Circle' | null | undefined }>['radius']>().type.toBe<number | null | undefined>();
+  expect<Extract<ShapeType, { kind?: 'Square' | null | undefined }>['side']>().type.toBe<number | null | undefined>();
 }
 
 function gh15988() {

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -275,14 +275,16 @@ function gh16045() {
 
   type ShapeType = NonNullable<InferRawDocType<typeof schemaDefinition>['shape']>;
   type BaseType = InferRawDocTypeFromSchema<typeof shapeSchema>;
+  type BaseWithNullDiscriminator = Omit<BaseType, 'kind'> & { kind?: null };
   type CircleType = InferRawDocTypeFromSchema<typeof circleSchema> & { kind: 'Circle' };
   type SquareType = InferRawDocTypeFromSchema<typeof squareSchema> & { kind: 'Square' };
 
   expect<ShapeType>().type.toBe<
+    BaseWithNullDiscriminator |
     (Omit<BaseType, keyof CircleType> & CircleType) |
     (Omit<BaseType, keyof SquareType> & SquareType)
   >();
-  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square'>();
+  expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Square' }>['side']>().type.toBe<number | null | undefined>();
 }

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -279,10 +279,12 @@ function gh16045() {
   type CircleType = InferRawDocTypeFromSchema<typeof circleSchema> & { kind: 'Circle' };
   type SquareType = InferRawDocTypeFromSchema<typeof squareSchema> & { kind: 'Square' };
 
+  type CircleTypeUnionMember = Omit<BaseType, keyof CircleType> & CircleType;
+  type SquareTypeUnionMember = Omit<BaseType, keyof SquareType> & SquareType;
   expect<ShapeType>().type.toBe<
     BaseWithNullDiscriminator |
-    (Omit<BaseType, keyof CircleType> & CircleType) |
-    (Omit<BaseType, keyof SquareType> & SquareType)
+    CircleTypeUnionMember |
+    SquareTypeUnionMember
   >();
   expect<ShapeType['kind']>().type.toBe<'Circle' | 'Square' | null | undefined>();
   expect<Extract<ShapeType, { kind: 'Circle' }>['radius']>().type.toBe<number | null | undefined>();

--- a/test/types/inferrawdoctype.test.ts
+++ b/test/types/inferrawdoctype.test.ts
@@ -289,6 +289,22 @@ function gh16045() {
   expect<Extract<ShapeType, { kind: 'Square' }>['side']>().type.toBe<number | null | undefined>();
 }
 
+function gh16045RequiredDiscriminatorKey() {
+  const baseSchema = new mongoose.Schema({
+    kind: { type: String, required: true },
+    name: String
+  }, { discriminatorKey: 'kind' });
+  const schemaDefinition = {
+    shape: {
+      type: baseSchema,
+      discriminators: {}
+    }
+  } as const;
+
+  type ShapeType = NonNullable<InferRawDocType<typeof schemaDefinition>['shape']>;
+  expect<ShapeType['kind']>().type.toBe<string>();
+}
+
 function gh15988() {
   // Test nested path (no type key) - should NOT have _id
   const locationSchemaDef = {

--- a/types/inferhydrateddoctype.d.ts
+++ b/types/inferhydrateddoctype.d.ts
@@ -66,6 +66,7 @@ declare module 'mongoose' {
   type ResolveDiscriminatorHydratedPathType<TBaseSchema extends Schema, TDiscriminators> =
     IsAny<TDiscriminators> extends true ? never
     : TDiscriminators extends Record<string, any> ?
+      MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, { [K in DiscriminatorHydratedKey<TBaseSchema>]?: null }> |
       {
         [K in keyof TDiscriminators]: TDiscriminators[K] extends Schema ?
           MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, InferHydratedDocTypeFromSchema<TDiscriminators[K]>> &

--- a/types/inferhydrateddoctype.d.ts
+++ b/types/inferhydrateddoctype.d.ts
@@ -56,12 +56,22 @@ declare module 'mongoose' {
   type HydratedDocTypeHint<T> = T extends { __hydratedDocTypeHint: infer U } ? U
     : never;
 
+  type DiscriminatorHydratedKey<TBaseSchema extends Schema> =
+    ObtainSchemaGeneric<TBaseSchema, 'TSchemaOptions'> extends infer TSchemaOptions ?
+      'discriminatorKey' extends keyof TSchemaOptions ?
+        TSchemaOptions['discriminatorKey'] extends string ? TSchemaOptions['discriminatorKey'] : '__t'
+      : '__t'
+    : '__t';
+
   type ResolveDiscriminatorHydratedPathType<TBaseSchema extends Schema, TDiscriminators> =
     IsAny<TDiscriminators> extends true ? never
     : TDiscriminators extends Record<string, any> ?
-      TDiscriminators[keyof TDiscriminators] extends Schema ?
-        MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, InferHydratedDocTypeFromSchema<TDiscriminators[keyof TDiscriminators]>>
-      : never
+      {
+        [K in keyof TDiscriminators]: TDiscriminators[K] extends Schema ?
+          MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, InferHydratedDocTypeFromSchema<TDiscriminators[K]>> &
+          { [KDiscriminatorKey in DiscriminatorHydratedKey<TBaseSchema>]: K }
+        : never
+      }[keyof TDiscriminators]
     : never;
 
   type HydratedDiscriminatorEnumType<T> = string extends keyof T ? never

--- a/types/inferhydrateddoctype.d.ts
+++ b/types/inferhydrateddoctype.d.ts
@@ -63,10 +63,15 @@ declare module 'mongoose' {
       : '__t'
     : '__t';
 
+  type DiscriminatorHydratedBaseType<TBaseSchema extends Schema> =
+    InferHydratedDocTypeFromSchema<TBaseSchema> extends Record<DiscriminatorHydratedKey<TBaseSchema>, any> ?
+      InferHydratedDocTypeFromSchema<TBaseSchema>
+    : MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, { [K in DiscriminatorHydratedKey<TBaseSchema>]?: null }>;
+
   type ResolveDiscriminatorHydratedPathType<TBaseSchema extends Schema, TDiscriminators> =
     IsAny<TDiscriminators> extends true ? never
     : TDiscriminators extends Record<string, any> ?
-      MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, { [K in DiscriminatorHydratedKey<TBaseSchema>]?: null }> |
+      DiscriminatorHydratedBaseType<TBaseSchema> |
       {
         [K in keyof TDiscriminators]: TDiscriminators[K] extends Schema ?
           MergeType<InferHydratedDocTypeFromSchema<TBaseSchema>, InferHydratedDocTypeFromSchema<TDiscriminators[K]>> &

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -45,12 +45,22 @@ declare module 'mongoose' {
   type RawDocTypeHint<T> = IsAny<T> extends true ? never
     : T extends { __rawDocTypeHint: infer U } ? U: never;
 
+  type DiscriminatorRawKey<TBaseSchema extends Schema> =
+    ObtainSchemaGeneric<TBaseSchema, 'TSchemaOptions'> extends infer TSchemaOptions ?
+      'discriminatorKey' extends keyof TSchemaOptions ?
+        TSchemaOptions['discriminatorKey'] extends string ? TSchemaOptions['discriminatorKey'] : '__t'
+      : '__t'
+    : '__t';
+
   type ResolveDiscriminatorRawPathType<TBaseSchema extends Schema, TDiscriminators> =
     IsAny<TDiscriminators> extends true ? never
     : TDiscriminators extends Record<string, any> ?
-      TDiscriminators[keyof TDiscriminators] extends Schema ?
-        MergeType<InferRawDocTypeFromSchema<TBaseSchema>, InferRawDocTypeFromSchema<TDiscriminators[keyof TDiscriminators]>>
-      : never
+      {
+        [K in keyof TDiscriminators]: TDiscriminators[K] extends Schema ?
+          MergeType<InferRawDocTypeFromSchema<TBaseSchema>, InferRawDocTypeFromSchema<TDiscriminators[K]>> &
+          { [KDiscriminatorKey in DiscriminatorRawKey<TBaseSchema>]: K }
+        : never
+      }[keyof TDiscriminators]
     : never;
 
   type RawDiscriminatorEnumType<T> = string extends keyof T ? never

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -52,10 +52,15 @@ declare module 'mongoose' {
       : '__t'
     : '__t';
 
+  type DiscriminatorRawBaseType<TBaseSchema extends Schema> =
+    InferRawDocTypeFromSchema<TBaseSchema> extends Record<DiscriminatorRawKey<TBaseSchema>, any> ?
+      InferRawDocTypeFromSchema<TBaseSchema>
+    : MergeType<InferRawDocTypeFromSchema<TBaseSchema>, { [K in DiscriminatorRawKey<TBaseSchema>]?: null }>;
+
   type ResolveDiscriminatorRawPathType<TBaseSchema extends Schema, TDiscriminators> =
     IsAny<TDiscriminators> extends true ? never
     : TDiscriminators extends Record<string, any> ?
-      MergeType<InferRawDocTypeFromSchema<TBaseSchema>, { [K in DiscriminatorRawKey<TBaseSchema>]?: null }> |
+      DiscriminatorRawBaseType<TBaseSchema> |
       {
         [K in keyof TDiscriminators]: TDiscriminators[K] extends Schema ?
           MergeType<InferRawDocTypeFromSchema<TBaseSchema>, InferRawDocTypeFromSchema<TDiscriminators[K]>> &

--- a/types/inferrawdoctype.d.ts
+++ b/types/inferrawdoctype.d.ts
@@ -55,6 +55,7 @@ declare module 'mongoose' {
   type ResolveDiscriminatorRawPathType<TBaseSchema extends Schema, TDiscriminators> =
     IsAny<TDiscriminators> extends true ? never
     : TDiscriminators extends Record<string, any> ?
+      MergeType<InferRawDocTypeFromSchema<TBaseSchema>, { [K in DiscriminatorRawKey<TBaseSchema>]?: null }> |
       {
         [K in keyof TDiscriminators]: TDiscriminators[K] extends Schema ?
           MergeType<InferRawDocTypeFromSchema<TBaseSchema>, InferRawDocTypeFromSchema<TDiscriminators[K]>> &

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -283,6 +283,7 @@ declare module 'mongoose' {
     typeKey: 'type';
     id: true;
     _id: true;
+    discriminatorKey: '__t';
     timestamps: false;
     versionKey: '__v'
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Re: #16045. The following:

```typescript
    const schema = new Schema({
      shape: {
        type: shapeSchema,
        discriminators: {
          Circle: circleSchema,
          Square: squareSchema
        }
      }
    });
```

Will now be inferred as a union type with constant discriminator keys, e.g. `(CircleType & { kind: 'Circle' }) | (SquareType & { kind: 'Square' }) |(ShapeType & { kind?: null }) | null`. Currently in master, Mongoose doesn't add `& kind: 'Circle'` so each member of the union has `kind?: string`.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
