### PR TITLE
types(model): handle { lean: true } schema option on Model.find() types and { lean: false } override for all Model query functions

### DIFF
--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -18,7 +18,8 @@ import mongoose, {
   connection,
   model,
   UpdateOneModel,
-  UpdateManyModel
+  UpdateManyModel,
+  InferHydratedDocTypeFromSchema
 } from 'mongoose';
 import { AutoTypedSchemaType, autoTypedSchema } from './schema.test';
 import { UpdateOneModel as MongoUpdateOneModel, ChangeStreamInsertDocument, ObjectId } from 'mongodb';
@@ -792,15 +793,30 @@ async function gh16413() {
   const schema = new Schema({ name: String }, { lean: true });
   const TestModel = model('gh16413', schema);
 
+  type ExpectedHydratedDoc = ReturnType<(typeof TestModel)['hydrate']>;
   type ExpectedLeanDoc = mongoose.FlattenMaps<{ name?: string | null }> & { _id: Types.ObjectId; __v: number };
 
-  const docs = await TestModel.find();
-  expect(docs).type.toBe<ExpectedLeanDoc[]>();
+  async function testFind() {
+    const docs = await TestModel.find();
+    expect(docs).type.toBe<ExpectedLeanDoc[]>();
+
+    const hydratedDocs = await TestModel.find({}, null, { lean: false });
+    hydratedDocs[0].save();
+    expect(hydratedDocs).type.toBe<ExpectedHydratedDoc[]>();
+  }
+
+  async function testFindOne() {
+    const doc = await TestModel.findOne().orFail();
+    expect(doc).type.toBe<ExpectedLeanDoc>();
+    const hydratedDoc = await TestModel.findOne({}, null, { lean: false }).orFail();
+    hydratedDoc.save();
+    expect(hydratedDoc).type.toBe<ExpectedHydratedDoc>();
+  }
 
   const hydratedSchema = new Schema({ name: String }, { lean: false });
   const HydratedTestModel = model('gh16413Hydrated', hydratedSchema);
-  const hydratedDocs = await HydratedTestModel.find();
-  hydratedDocs[0].save();
+  const hydratedDocs2 = await HydratedTestModel.find();
+  hydratedDocs2[0].save();
 }
 
 async function gh13746() {

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -788,6 +788,21 @@ async function gh13705() {
   expect(findOneAndUpdateResWithMetadata).type.toBe<ModifyResult<{ name?: string | null | undefined }>>();
 }
 
+async function gh16413() {
+  const schema = new Schema({ name: String }, { lean: true });
+  const TestModel = model('gh16413', schema);
+
+  type ExpectedLeanDoc = mongoose.FlattenMaps<{ name?: string | null }> & { _id: Types.ObjectId; __v: number };
+
+  const docs = await TestModel.find();
+  expect(docs).type.toBe<ExpectedLeanDoc[]>();
+
+  const hydratedSchema = new Schema({ name: String }, { lean: false });
+  const HydratedTestModel = model('gh16413Hydrated', hydratedSchema);
+  const hydratedDocs = await HydratedTestModel.find();
+  hydratedDocs[0].save();
+}
+
 async function gh13746() {
   const schema = new Schema({ name: String });
   const TestModel = model('Test', schema);

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -813,10 +813,71 @@ async function gh16413() {
     expect(hydratedDoc).type.toBe<ExpectedHydratedDoc>();
   }
 
+  async function testFindById() {
+    const leanDoc = await TestModel.findById('0'.repeat(24)).orFail();
+    expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+    const doc = await TestModel.findById('0'.repeat(24), undefined, { lean: false }).orFail();
+    doc.save();
+    expect(doc).type.toBe<ExpectedHydratedDoc>();
+  }
+
+  async function testFindOneAndUpdate() {
+    const leanDoc = await TestModel.findOneAndUpdate({}, {}).orFail();
+    expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+    const doc = await TestModel.findOneAndUpdate({}, {}, { lean: false }).orFail();
+    doc.save();
+    expect(doc).type.toBe<ExpectedHydratedDoc>();
+  }
+
+  async function testFindByIdAndUpdate() {
+    const leanDoc = await TestModel.findByIdAndUpdate('0'.repeat(24), {}).orFail();
+    expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+    const doc = await TestModel.findByIdAndUpdate('0'.repeat(24), {}, { lean: false }).orFail();
+    doc.save();
+    expect(doc).type.toBe<ExpectedHydratedDoc>();
+  }
+
+  async function testFindOneAndReplace() {
+    const leanDoc = await TestModel.findOneAndReplace({}, {}).orFail();
+    expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+    const doc = await TestModel.findOneAndReplace({}, {}, { lean: false }).orFail();
+    doc.save();
+    expect(doc).type.toBe<ExpectedHydratedDoc>();
+  }
+
+  async function testFindOneAndDelete() {
+    const leanDoc = await TestModel.findOneAndDelete({}).orFail();
+    expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+    const doc = await TestModel.findOneAndDelete({}, { lean: false }).orFail();
+    doc.save();
+    expect(doc).type.toBe<ExpectedHydratedDoc>();
+  }
+
+  async function testFindByIdAndDelete() {
+    const leanDoc = await TestModel.findByIdAndDelete('0'.repeat(24)).orFail();
+    expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+    const doc = await TestModel.findByIdAndDelete('0'.repeat(24), { lean: false }).orFail();
+    doc.save();
+    expect(doc).type.toBe<ExpectedHydratedDoc>();
+  }
+
   const hydratedSchema = new Schema({ name: String }, { lean: false });
   const HydratedTestModel = model('gh16413Hydrated', hydratedSchema);
   const hydratedDocs2 = await HydratedTestModel.find();
   hydratedDocs2[0].save();
+
+  const leanDoc = await HydratedTestModel.findById('0'.repeat(24), undefined, { lean: true }).orFail();
+  expect(leanDoc).type.toBe<ExpectedLeanDoc>();
+  const leanUpdatedDoc = await HydratedTestModel.findOneAndUpdate({}, {}, { lean: true }).orFail();
+  expect(leanUpdatedDoc).type.toBe<ExpectedLeanDoc>();
+  const leanUpdatedByIdDoc = await HydratedTestModel.findByIdAndUpdate('0'.repeat(24), {}, { lean: true }).orFail();
+  expect(leanUpdatedByIdDoc).type.toBe<ExpectedLeanDoc>();
+  const leanReplacedDoc = await HydratedTestModel.findOneAndReplace({}, {}, { lean: true }).orFail();
+  expect(leanReplacedDoc).type.toBe<ExpectedLeanDoc>();
+  const leanDeletedDoc = await HydratedTestModel.findOneAndDelete({}, { lean: true }).orFail();
+  expect(leanDeletedDoc).type.toBe<ExpectedLeanDoc>();
+  const leanDeletedByIdDoc = await HydratedTestModel.findByIdAndDelete('0'.repeat(24), { lean: true }).orFail();
+  expect(leanDeletedByIdDoc).type.toBe<ExpectedLeanDoc>();
 }
 
 async function gh13746() {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -458,6 +458,18 @@ declare module 'mongoose' {
       TInstanceMethods & TVirtuals
     >;
     findById<ResultDoc = THydratedDocumentType>(
+      id: any,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
+    findById<ResultDoc = THydratedDocumentType>(
       id?: any,
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> | null
@@ -854,6 +866,17 @@ declare module 'mongoose' {
     >;
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findByIdAndDelete<ResultDoc = THydratedDocumentType>(
+      id: mongodb.ObjectId | any,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<ResultDoc>,
@@ -907,6 +930,18 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
       TLeanResultType | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
+      id: mongodb.ObjectId | any,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      ResultDoc | null,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -975,6 +1010,28 @@ declare module 'mongoose' {
     >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndDelete(
+      filter: Query<any, any>,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      THydratedDocumentType | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndDelete<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
@@ -999,7 +1056,7 @@ declare module 'mongoose' {
       filter?: QueryFilter<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TRawDocType | null : ResultDoc | null,
+      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -1010,7 +1067,7 @@ declare module 'mongoose' {
       filter?: Query<any, any> | null,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TRawDocType | null : THydratedDocumentType | null,
+      HasLeanOption<TSchema> extends true ? TLeanResultType | null : THydratedDocumentType | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1037,6 +1094,30 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
       TLeanResultType | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndReplace<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
+      replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndReplace(
+      filter: Query<any, any>,
+      replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      THydratedDocumentType | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1159,6 +1240,30 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
       GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndUpdate(
+      filter: Query<any, any>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { lean: false }
+    ): QueryWithHelpers<
+      THydratedDocumentType | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -496,6 +496,18 @@ declare module 'mongoose' {
       TInstanceMethods & TVirtuals
     >;
     findOne<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ResultDoc | null,
+      ResultDoc,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
+    findOne<ResultDoc = THydratedDocumentType>(
       filter?: QueryFilter<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> & mongodb.Abortable | null | undefined
@@ -775,6 +787,18 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       GetLeanResultType<TRawDocType, TRawDocType[], 'find'>,
       THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
+    find<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ResultDoc[],
+      ResultDoc,
       TQueryHelpers,
       TLeanResultType,
       'find',

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -785,7 +785,7 @@ declare module 'mongoose' {
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> & mongodb.Abortable
     ): QueryWithHelpers<
-      ResultDoc[],
+      HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[],
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -797,7 +797,7 @@ declare module 'mongoose' {
       projection?: ProjectionType<TRawDocType> | null | undefined,
       options?: QueryOptions<TRawDocType> & mongodb.Abortable
     ): QueryWithHelpers<
-      THydratedDocumentType[],
+      HasLeanOption<TSchema> extends true ? TLeanResultType[] : THydratedDocumentType[],
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,


### PR DESCRIPTION
Fix #16413

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

`find()` types are currently incorrect, missing a `HasLeanOption<TSchema>` conditional that likely got lost in merge conflicts.

Also found an issue where model functions like `findOne()` would still use the schema-level `lean` option even if called with `lean: false` - `lean: false` overrides the schema-level default. So I added overrides to ensure that `Model.findOne({}, null, { lean: false })` always returns the hydrated doc regardless of schema-level `lean` option.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
