### PR TITLE
types(document): respect schema toObject and toJSON options

### DIFF
--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -745,6 +745,82 @@ async function gh15578() {
   }
 }
 
+async function gh15594() {
+  function withSchemaLevelOptions() {
+    const ASchema = new Schema({
+      testProperty: Number,
+      testId: Schema.Types.ObjectId
+    }, {
+      toObject: { flattenObjectIds: true, versionKey: false },
+      toJSON: { flattenObjectIds: true, versionKey: false }
+    });
+
+    const AModel = model('YourModel', ASchema);
+
+    const a = new AModel({ testProperty: 8, testId: new Types.ObjectId() });
+
+    const obj = a.toObject();
+    const json = a.toJSON();
+    expect(obj._id).type.toBe<string>();
+    expect(json._id).type.toBe<string>();
+    expect(obj).type.not.toHaveProperty('__v');
+    expect(json).type.not.toHaveProperty('__v');
+
+    // Options passed at the call site keep taking the per-call overloads
+    expect(a.toObject({ flattenObjectIds: false })._id).type.toBe<Types.ObjectId>();
+    expect(a.toObject({ flattenObjectIds: true })._id).type.toBe<string>();
+    expect(a.toJSON({ flattenObjectIds: false })._id).type.toBe<Types.ObjectId>();
+  }
+
+  function withoutSchemaLevelOptions() {
+    const ASchema = new Schema({
+      testProperty: Number
+    });
+
+    const AModel = model('YourModel', ASchema);
+
+    const a = new AModel({ testProperty: 8 });
+
+    expect(a.toObject()._id).type.toBe<Types.ObjectId>();
+    expect(a.toJSON()._id).type.toBe<Types.ObjectId>();
+    expect(a.toObject().__v).type.toBe<number>();
+    expect(a.toJSON().__v).type.toBe<number>();
+  }
+
+  function withOnlyToJSONDeclared() {
+    const ASchema = new Schema({
+      testProperty: Number
+    }, {
+      toJSON: { flattenObjectIds: true, versionKey: false }
+    });
+
+    const AModel = model('YourModel', ASchema);
+
+    const a = new AModel({ testProperty: 8 });
+
+    expect(a.toObject()._id).type.toBe<Types.ObjectId>();
+    expect(a.toObject().__v).type.toBe<number>();
+    expect(a.toJSON()._id).type.toBe<string>();
+    expect(a.toJSON()).type.not.toHaveProperty('__v');
+  }
+
+  function withCustomVersionKeyAndSchemaToObject() {
+    const ASchema = new Schema({
+      testProperty: Number
+    }, {
+      versionKey: 'taco' as const,
+      toObject: { versionKey: false }
+    });
+
+    const AModel = model('YourModel', ASchema);
+
+    const a = new AModel({ testProperty: 8 });
+
+    expect(a.toObject()).type.not.toHaveProperty('taco');
+    expect(a.toJSON().taco).type.toBe<number>();
+  }
+}
+
 function testFlattenUUIDs() {
   interface RawDocType {
     _id: Types.UUID;

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -289,9 +289,9 @@ declare module 'mongoose' {
     ): ToObjectReturnType<PopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
     toJSON<PopulatedRawDocType>(
       this: PopulatedDocumentMarker<PopulatedRawDocType, any>
-    ): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
+    ): DefaultToObjectReturnType<PopulatedRawDocType, TVirtuals, TSchemaOptions, 'toJSON'>;
     toJSON<O extends ToObjectOptions>(options: O): ToObjectReturnType<DocType, TVirtuals, O, TSchemaOptions>;
-    toJSON(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
+    toJSON(options?: ToObjectOptions): DefaultToObjectReturnType<DocType, TVirtuals, TSchemaOptions, 'toJSON'>;
     toJSON<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
 
     /** Converts this document into a plain-old JavaScript object ([POJO](https://masteringjs.io/tutorials/fundamentals/pojo)). */
@@ -309,9 +309,9 @@ declare module 'mongoose' {
     ): ToObjectReturnType<PopulatedRawDocType, TVirtuals, O, TSchemaOptions>;
     toObject<PopulatedRawDocType>(
       this: PopulatedDocumentMarker<PopulatedRawDocType, any>
-    ): Default__v<Require_id<PopulatedRawDocType>, TSchemaOptions>;
+    ): DefaultToObjectReturnType<PopulatedRawDocType, TVirtuals, TSchemaOptions, 'toObject'>;
     toObject<O extends ToObjectOptions>(options: O): ToObjectReturnType<DocType, TVirtuals, O, TSchemaOptions>;
-    toObject(options?: ToObjectOptions): Default__v<Require_id<DocType>, TSchemaOptions>;
+    toObject(options?: ToObjectOptions): DefaultToObjectReturnType<DocType, TVirtuals, TSchemaOptions, 'toObject'>;
     toObject<T>(options?: ToObjectOptions): Default__v<Require_id<T>, ResolveSchemaOptions<TSchemaOptions>>;
 
     /** Clears the modified state on the specified path. */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1123,6 +1123,31 @@ declare module 'mongoose' {
     : T;
 
   /**
+   * Extracts the `toObject` or `toJSON` options declared in the schema options.
+   * The runtime applies these as defaults when the corresponding method is
+   * called without arguments.
+   */
+  export type SchemaDeclaredToObjectOptions<TSchemaOptions, Key extends 'toObject' | 'toJSON'> =
+    Key extends keyof TSchemaOptions
+      ? NonNullable<TSchemaOptions[Key]> extends infer O extends ToObjectOptions
+        ? O
+        : {}
+      : {};
+
+  /**
+   * Computes the return type of toObject/toJSON when called without arguments,
+   * applying the options declared in the schema like the runtime does. When the
+   * schema declares no options for the method, the plain document shape is
+   * returned without running it through the option transforms.
+   */
+  export type DefaultToObjectReturnType<DocType, TVirtuals, TSchemaOptions, Key extends 'toObject' | 'toJSON'> =
+    SchemaDeclaredToObjectOptions<TSchemaOptions, Key> extends infer O extends ToObjectOptions
+      ? keyof O extends never
+        ? Default__v<Require_id<DocType>, TSchemaOptions>
+        : ToObjectReturnType<DocType, TVirtuals, O, TSchemaOptions>
+      : Default__v<Require_id<DocType>, TSchemaOptions>;
+
+  /**
    * Computes the return type of toObject/toJSON based on the provided options.
    * Uses a single-pass transform for flatten operations to correctly handle all combinations.
    */


### PR DESCRIPTION
**Summary**

Fixes #15594

At runtime, `toObject()` and `toJSON()` apply the options declared in the schema definition as defaults: `$toObject` merges `_defaultToObjectOptions` under the call options. The declared return types did not reflect that. Options passed at the call site have influenced the return type since #15578, but the no argument overloads always returned the plain document shape, so `flattenObjectIds`, `versionKey: false` or `virtuals: true` declared at the schema level were invisible to TypeScript.

This change routes the no argument overloads, including the populated document variants, through the existing `ToObjectReturnType` machinery. A new `SchemaDeclaredToObjectOptions` helper extracts the `toObject`/`toJSON` options captured in `TSchemaOptions`, and `DefaultToObjectReturnType` short circuits to the exact previous return type when the schema declares no options for the method, so schemas without declared options see no type change at all.

**Examples**

```ts
const schema = new Schema({
  testProperty: Number,
  testId: Schema.Types.ObjectId
}, {
  toObject: { flattenObjectIds: true, versionKey: false },
  toJSON: { flattenObjectIds: true, versionKey: false }
});
const TestModel = model('Test', schema);
const doc = new TestModel({ testProperty: 8, testId: new Types.ObjectId() });

doc.toObject()._id; // before: Types.ObjectId. After: string
doc.toObject(); // before: __v present in the type. After: no __v, matching the runtime output
doc.toObject({ flattenObjectIds: false })._id; // still Types.ObjectId, call options keep priority
```

One note on the snippet in #15594: it constructs the schema as `new Schema<ASchema>(definition, options)`. TypeScript has no partial inference, so an explicit raw doc type generic prevents `TSchemaOptions` from capturing the options literal, for this feature the same way as for `timestamps` typing. The schema level options propagate on the inference paths: `new Schema(definition, options)` without explicit generics, `Schema.create`, or an explicitly supplied `TSchemaOptions` generic.

New type tests (gh15594) cover a schema with declared options, the unchanged shape for schemas without declared options, call site precedence, a schema declaring only `toJSON` options, and a custom version key combined with `toObject: { versionKey: false }`. `npm run test:types` passes with 40 files and 1049 assertions. `npm run lint-ts` is clean.
