### PR TITLE
types: import BSON from mongodb instead of bson

### DIFF
--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -1,4 +1,4 @@
-import * as BSON from 'bson';
+import { BSON } from 'mongodb';
 
 declare module 'mongoose' {
   /** The Mongoose Date [SchemaType](/docs/schematypes.html). */


### PR DESCRIPTION
## Summary

#15576 (1556421ed) removed `bson` as a direct dependency and switched runtime code to `mongodb/lib/bson`, but `types/schematypes.d.ts` still imports the `bson` package directly.

Under strict `node_modules` layouts (pnpm), undeclared packages cannot be resolved, so any TypeScript consumer compiling against mongoose >= 9.9.0 fails with:

```
node_modules/mongoose/types/schematypes.d.ts(1,23): error TS2307: Cannot find module 'bson' or its corresponding type declarations.
```

`BSON` is only used for the two `keyId: BSON.Binary` fields in the client encryption options, and the mongodb driver re-exports the `BSON` namespace, so import it from there instead.

## Examples

Workaround currently needed in pnpm workspaces:

```yaml
packageExtensions:
  mongoose@9.9:
    dependencies:
      bson: '^7.2.0'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)