### PR TITLE
fix(connection): restore delete state across transaction retries

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -778,6 +778,9 @@ function _resetSessionDocuments(session) {
     if (Object.hasOwn(state, 'versionKey')) {
       doc.set(doc.schema.options.versionKey, state.versionKey);
     }
+    if (Object.hasOwn(state, 'isDeleted')) {
+      doc.$isDeleted(state.isDeleted);
+    }
 
     for (const path of state.modifiedPaths) {
       doc.$__.activePaths.modify(path);

--- a/lib/plugins/trackTransaction.js
+++ b/lib/plugins/trackTransaction.js
@@ -7,31 +7,45 @@ const utils = require('../utils');
 
 module.exports = function trackTransaction(schema) {
   schema.pre('save', trackTransactionPreSave);
+  schema.pre('deleteOne', { document: true, query: false }, trackTransactionPreDeleteOne);
 };
 
 function trackTransactionPreSave() {
-  const session = this.$session();
+  _getInitialState(this);
+}
+
+function trackTransactionPreDeleteOne() {
+  const initialState = _getInitialState(this);
+  if (initialState != null && !Object.hasOwn(initialState, 'isDeleted')) {
+    initialState.isDeleted = this.$isDeleted();
+  }
+}
+
+function _getInitialState(doc) {
+  const session = doc.$session();
   if (session == null) {
-    return;
+    return null;
   }
   if (session.transaction == null || session[sessionNewDocuments] == null) {
-    return;
+    return null;
   }
 
-  if (!session[sessionNewDocuments].has(this)) {
+  if (!session[sessionNewDocuments].has(doc)) {
     const initialState = {};
-    if (this.isNew) {
+    if (doc.isNew) {
       initialState.isNew = true;
     }
-    if (this.$__schema.options.versionKey) {
-      initialState.versionKey = this.get(this.$__schema.options.versionKey);
+    if (doc.$__schema.options.versionKey) {
+      initialState.versionKey = doc.get(doc.$__schema.options.versionKey);
     }
 
-    initialState.modifiedPaths = new Set(Object.keys(this.$__.activePaths.getStatePaths('modify')));
-    initialState.atomics = _getAtomics(this);
+    initialState.modifiedPaths = new Set(Object.keys(doc.$__.activePaths.getStatePaths('modify')));
+    initialState.atomics = _getAtomics(doc);
 
-    session[sessionNewDocuments].set(this, initialState);
+    session[sessionNewDocuments].set(doc, initialState);
   }
+
+  return session[sessionNewDocuments].get(doc);
 }
 
 function _getAtomics(doc, previous) {
@@ -87,3 +101,4 @@ function mergeAtomics(destination, source) {
 }
 
 trackTransactionPreSave[symbols.builtInMiddleware] = true;
+trackTransactionPreDeleteOne[symbols.builtInMiddleware] = true;

--- a/test/docs/transactions.test.js
+++ b/test/docs/transactions.test.js
@@ -488,6 +488,39 @@ describe('transactions', function() {
     assert.equal(docs[0].name, 'test');
   });
 
+  it('transaction() resets $isDeleted between retries', async function() {
+    db.deleteModel(/Test/);
+    const Test = db.model('Test', Schema({ name: String }));
+
+    await Test.createCollection();
+    await Test.deleteMany({});
+
+    const doc = await Test.create({ name: 'test' });
+    const isDeletedBefore = [];
+    let retryCount = 0;
+
+    await db.transaction(async(session) => {
+      isDeletedBefore.push(doc.$isDeleted());
+      await doc.deleteOne({ session });
+      if (++retryCount < 2) {
+        throw new mongoose.mongo.MongoServerError({
+          errorLabels: ['TransientTransactionError']
+        });
+      }
+    });
+
+    assert.deepStrictEqual(
+      {
+        isDeletedBefore,
+        stillExists: await Test.exists({ _id: doc._id }) != null
+      },
+      {
+        isDeletedBefore: [false, false],
+        stillExists: false
+      }
+    );
+  });
+
   it('handles resetting array state with $set atomic (gh-13698)', async function() {
     db.deleteModel(/Test/);
     const subItemSchema = new mongoose.Schema(


### PR DESCRIPTION
**Summary**

Restore a document's `$isDeleted` state when `Connection#transaction()` aborts an attempt. Without this reset, a retried `Document#deleteOne()` resolves as a no-op and the document remains in MongoDB.

**Examples**

Added a regression test that retries a transaction after a transient error and verifies that both attempts begin with `$isDeleted() === false` and the final commit deletes the document.

Fixes #16433
