### PR TITLE
perf(document): inline the type checks in $__hasOnlyPrimitiveValues()

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -31,7 +31,6 @@ const getEmbeddedDiscriminatorPath = require('./helpers/document/getEmbeddedDisc
 const getKeysInSchemaOrder = require('./helpers/schema/getKeysInSchemaOrder');
 const getSubdocumentStrictValue = require('./helpers/schema/getSubdocumentStrictValue');
 const handleSpreadDoc = require('./helpers/document/handleSpreadDoc');
-const isBsonType = require('./helpers/isBsonType');
 const isDefiningProjection = require('./helpers/projection/isDefiningProjection');
 const isExclusive = require('./helpers/projection/isExclusive');
 const isPathExcluded = require('./helpers/projection/isPathExcluded');
@@ -5755,11 +5754,21 @@ Document.prototype.$__hasOnlyPrimitiveValues = function $__hasOnlyPrimitiveValue
   const doc = this._doc;
   for (const key in doc) {
     const v = doc[key];
-    if (v == null
-      || typeof v !== 'object'
-      || (utils.isNativeObject(v) && !Array.isArray(v))
-      || isBsonType(v, 'ObjectId')
-      || isBsonType(v, 'Decimal128')) {
+    if (v == null || typeof v !== 'object') {
+      continue;
+    }
+    // Equivalent to `isNativeObject(v) && !Array.isArray(v)`, plus the
+    // `isBsonType()` checks below, but without the helper calls or the
+    // repeated `Array.isArray()`. This runs for every key of every document
+    // that `toObject()` touches, so the call overhead is measurable.
+    if (Array.isArray(v)) {
+      return false;
+    }
+    if (v instanceof Date || v instanceof Boolean || v instanceof Number || v instanceof String) {
+      continue;
+    }
+    const bsontype = v._bsontype;
+    if (bsontype === 'ObjectId' || bsontype === 'Decimal128') {
       continue;
     }
     return false;


### PR DESCRIPTION
**Summary**

`$toObject()` calls `$__hasOnlyPrimitiveValues()` on every `toObject()` and `toJSON()`, and that function walks every key of `_doc`. For each key it called `utils.isNativeObject()` plus `isBsonType()` twice, and `isNativeObject()` runs `Array.isArray()` again on a value the caller then re-tests.

This inlines the checks: bail out on arrays immediately, test the native wrapper types directly, and read `_bsontype` once instead of calling `isBsonType()` twice. The logic is unchanged, only the call overhead is gone.

It showed up as 5.6% of samples in a CPU profile of the `toObject()` path.

Re: #14394

**Examples**

Document with a 10-element subdocument array, a nested object and two primitive arrays, 30000 `toObject()` calls, runs interleaved between branches to control for machine state:

```
master:  863.8ms  844.3ms  813.0ms
this PR: 768.6ms  721.2ms  720.5ms
```

Roughly 11-14% faster; every branch run came in below every master run.

**Testing**

The rewritten condition was checked against the previous one across 13 document shapes (primitives, Date, ObjectId, Decimal128, Buffer, Mixed, primitive arrays, subdocument arrays, nested objects) and agrees on all of them.

`document.test.js`, `model.test.js`, `schema.test.js`, `types.array.test.js`, `types.documentarray.test.js` and `model.populate.test.js` all pass (1719 tests).
