### PR TITLE
docs(schematypes): clarify that array `default` applies to the level it is declared on

### DIFF
--- a/docs/schematypes.md
+++ b/docs/schematypes.md
@@ -501,6 +501,44 @@ const ToyBoxSchema = new Schema({
 });
 ```
 
+Note that `default` applies to whichever level you declare it on. In the example
+above, `default` sits next to `type: [ToySchema]`, so it is the default for the
+*array*. If you instead put `default` inside the square brackets, it becomes the
+default for each *element* of the array, and the array keeps its implicit `[]`
+default.
+
+```javascript
+const ArrayDefault = new Schema({
+  toys: { type: [String], default: undefined }
+});
+const ElementDefault = new Schema({
+  // `default: undefined` here applies to each string element, not to `toys`
+  toys: [{ type: String, default: undefined }]
+});
+
+mongoose.model('ArrayDefault', ArrayDefault);
+mongoose.model('ElementDefault', ElementDefault);
+
+new (mongoose.model('ArrayDefault'))().toys; // undefined
+new (mongoose.model('ElementDefault'))().toys; // []
+```
+
+This distinction matters most when you are declaring an array of ObjectIds with
+a `ref`. Both of the following populate correctly, but only the first sets a
+default for the array itself:
+
+```javascript
+// `default` and `ref` are options on the `students` array
+const ClassroomSchema = new Schema({
+  students: { type: [Schema.Types.ObjectId], ref: 'Person', default: [] }
+});
+
+// `default` and `ref` are options on each element of `students`
+const ClassroomSchema2 = new Schema({
+  students: [{ type: Schema.Types.ObjectId, ref: 'Person', default: [] }]
+});
+```
+
 Note: specifying an empty array is equivalent to `Mixed`. The following all create arrays of
 `Mixed`:
 

--- a/docs/schematypes.md
+++ b/docs/schematypes.md
@@ -501,11 +501,9 @@ const ToyBoxSchema = new Schema({
 });
 ```
 
-Note that `default` applies to whichever level you declare it on. In the example
-above, `default` sits next to `type: [ToySchema]`, so it is the default for the
-*array*. If you instead put `default` inside the square brackets, it becomes the
-default for each *element* of the array, and the array keeps its implicit `[]`
-default.
+Note that `default` applies to whichever level you declare it on.
+In the example above, `default` sits next to `type: [ToySchema]`, so it is the default for the *array*.
+If you instead put `default` inside the square brackets, it becomes the default for each *element* of the array, and the array keeps its implicit `[]` default.
 
 ```javascript
 const ArrayDefault = new Schema({
@@ -521,22 +519,6 @@ mongoose.model('ElementDefault', ElementDefault);
 
 new (mongoose.model('ArrayDefault'))().toys; // undefined
 new (mongoose.model('ElementDefault'))().toys; // []
-```
-
-This distinction matters most when you are declaring an array of ObjectIds with
-a `ref`. Both of the following populate correctly, but only the first sets a
-default for the array itself:
-
-```javascript
-// `default` and `ref` are options on the `students` array
-const ClassroomSchema = new Schema({
-  students: { type: [Schema.Types.ObjectId], ref: 'Person', default: [] }
-});
-
-// `default` and `ref` are options on each element of `students`
-const ClassroomSchema2 = new Schema({
-  students: [{ type: Schema.Types.ObjectId, ref: 'Person', default: [] }]
-});
 ```
 
 Note: specifying an empty array is equivalent to `Mixed`. The following all create arrays of


### PR DESCRIPTION
**Summary**

The arrays section of the SchemaTypes guide shows `default: undefined` next to `type: [ToySchema]` to remove the implicit `[]` default, but never says that the placement is what makes it work. Declaring `default` inside the square brackets instead makes it the default for each *element*, and the array silently keeps its implicit `[]`.

This trips people up most often when declaring an array of ObjectIds with a `ref`, because `ref` works at either level while `default` does not, so the two forms look interchangeable when they are not. That is the confusion in #9232.

Fixes #9232

**Examples**

The behaviour documented, verified against this build:

```js
const ArrayDefault = new Schema({ toys: { type: [String], default: undefined } });
const ElementDefault = new Schema({ toys: [{ type: String, default: undefined }] });

new (mongoose.model('ArrayDefault'))().toys;   // undefined
new (mongoose.model('ElementDefault'))().toys; // []
```

I also confirmed that `ref` populates correctly at either level, which is why the guide now calls out `default` specifically rather than array options in general.

Only `docs/schematypes.md` is touched; no generated `.html`. `markdownlint` passes.
