### PR TITLE
fix(schema): put enum on array elements and support the object enum form in toJSONSchema

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -3215,27 +3215,19 @@ Schema.prototype.toJSONSchema = function toJSONSchema(options) {
     }
 
     const lastSubpath = schemaType._presplitPath[schemaType._presplitPath.length - 1];
-    let isRequired = false;
     if (path === '_id') {
       if (!jsonSchemaForPath.required) {
         jsonSchemaForPath.required = [];
       }
       jsonSchemaForPath.required.push('_id');
-      isRequired = true;
     } else if (schemaType.options.required && typeof schemaType.options.required !== 'function') {
       if (!jsonSchemaForPath.required) {
         jsonSchemaForPath.required = [];
       }
       // Only `required: true` paths are required, conditional required is not required
       jsonSchemaForPath.required.push(lastSubpath);
-      isRequired = true;
     }
     jsonSchemaForPath.properties[lastSubpath] = schemaType.toJSONSchema(options);
-    if (schemaType.options.enum) {
-      jsonSchemaForPath.properties[lastSubpath].enum = isRequired
-        ? schemaType.options.enum
-        : [...schemaType.options.enum, null];
-    }
   }
 
   // Otherwise MongoDB errors with "$jsonSchema keyword 'required' cannot be an empty array"

--- a/lib/schema/number.js
+++ b/lib/schema/number.js
@@ -498,7 +498,7 @@ SchemaNumber.prototype.castForQuery = function($conditional, val, context) {
  */
 
 SchemaNumber.prototype.toJSONSchema = function toJSONSchema(options) {
-  return this._createJSONSchemaTypeDefinition('number', 'number', options);
+  return this._addJSONSchemaEnum(this._createJSONSchemaTypeDefinition('number', 'number', options));
 };
 
 /*!

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -719,7 +719,7 @@ SchemaString.prototype.castForQuery = function($conditional, val, context) {
  */
 
 SchemaString.prototype.toJSONSchema = function toJSONSchema(options) {
-  return this._createJSONSchemaTypeDefinition('string', 'string', options);
+  return this._addJSONSchemaEnum(this._createJSONSchemaTypeDefinition('string', 'string', options));
 };
 
 SchemaString.prototype.autoEncryptionType = function autoEncryptionType() {

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -216,6 +216,27 @@ SchemaType.prototype._createJSONSchemaTypeDefinition = function _createJSONSchem
 };
 
 /**
+ * Helper for adding this SchemaType's enum values to a JSON schema type definition.
+ * Reads `enumValues` rather than `options.enum` because `enum` also accepts an object.
+ *
+ * @param {object} definition the type definition from `_createJSONSchemaTypeDefinition()`
+ * @returns {object} the same definition
+ * @api private
+ */
+
+SchemaType.prototype._addJSONSchemaEnum = function _addJSONSchemaEnum(definition) {
+  if (!Array.isArray(this.enumValues) || this.enumValues.length === 0) {
+    return definition;
+  }
+
+  // The enum validator allows nullish values, so allow `null` wherever the type does.
+  const allowsNull = Array.isArray(definition.type ?? definition.bsonType);
+  definition.enum = allowsNull ? [...this.enumValues, null] : [...this.enumValues];
+
+  return definition;
+};
+
+/**
  * The validators that Mongoose should run to validate properties at this SchemaType's path.
  *
  * #### Example:

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -4121,6 +4121,97 @@ describe('schema', function() {
       assert.ok(!validate({ _id: 'not-an-objectid' }));
       assert.ok(!validate({ _id: '0'.repeat(24), author: 'not-an-objectid' }));
     });
+
+    it('puts enums on array elements rather than on the array (gh-16443)', async function() {
+      const schema = new Schema({
+        tags: { type: [String], enum: ['funny', 'sad'] },
+        scores: [{ type: Number, enum: [1, 2] }]
+      }, { autoCreate: false, autoIndex: false });
+
+      assert.deepStrictEqual(schema.toJSONSchema({ useBsonType: true }), {
+        required: ['_id'],
+        properties: {
+          tags: {
+            bsonType: ['array', 'null'],
+            items: {
+              bsonType: ['string', 'null'],
+              enum: ['funny', 'sad', null]
+            }
+          },
+          scores: {
+            bsonType: ['array', 'null'],
+            items: {
+              bsonType: ['number', 'null'],
+              enum: [1, 2, null]
+            }
+          },
+          _id: {
+            bsonType: 'objectId'
+          }
+        }
+      });
+
+      await db.createCollection(collectionName, {
+        validator: {
+          $jsonSchema: schema.toJSONSchema({ useBsonType: true })
+        }
+      });
+      const Test = db.model('Test', schema, collectionName);
+
+      const doc = await Test.create({ tags: ['funny'], scores: [1, 2] });
+      assert.deepStrictEqual(doc.toObject().tags, ['funny']);
+
+      await assert.rejects(
+        Test.create([{ tags: ['funny', 'something else'] }], { validateBeforeSave: false }),
+        /MongoServerError: Document failed validation/
+      );
+
+      const ajv = new Ajv();
+      const validate = ajv.compile(schema.toJSONSchema());
+
+      assert.ok(validate({ _id: '0'.repeat(24), tags: ['funny', 'sad'], scores: [1] }));
+      assert.ok(!validate({ _id: '0'.repeat(24), tags: ['funny', 'something else'] }));
+      assert.ok(!validate({ _id: '0'.repeat(24), scores: [3] }));
+    });
+
+    it('supports enums declared as an object or set with enum() (gh-16443)', function() {
+      const schema = new Schema({
+        status: { type: String, enum: { values: ['on', 'off'], message: '{VALUE} is not supported' } },
+        level: { type: Number, required: true, enum: { values: [1, 2], message: 'invalid' } },
+        color: String
+      }, { autoCreate: false, autoIndex: false });
+      schema.path('color').enum('red', 'green');
+
+      assert.deepStrictEqual(schema.toJSONSchema(), {
+        type: 'object',
+        required: ['level', '_id'],
+        properties: {
+          status: {
+            type: ['string', 'null'],
+            enum: ['on', 'off', null]
+          },
+          level: {
+            type: 'number',
+            enum: [1, 2]
+          },
+          color: {
+            type: ['string', 'null'],
+            enum: ['red', 'green', null]
+          },
+          _id: {
+            type: 'string',
+            pattern: '^[A-Fa-f0-9]{24}$'
+          }
+        }
+      });
+
+      const ajv = new Ajv();
+      const validate = ajv.compile(schema.toJSONSchema());
+
+      assert.ok(validate({ _id: '0'.repeat(24), level: 1, status: null, color: 'red' }));
+      assert.ok(!validate({ _id: '0'.repeat(24), level: 1, status: 'maybe' }));
+      assert.ok(!validate({ _id: '0'.repeat(24), level: 3 }));
+    });
   });
 
   it('path() clears existing child schemas (gh-15253)', async function() {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -4161,6 +4161,12 @@ describe('schema', function() {
       const doc = await Test.create({ tags: ['funny'], scores: [1, 2] });
       assert.deepStrictEqual(doc.toObject().tags, ['funny']);
 
+      // Neither path is required, so `null` is a valid element: it's in `items.enum`
+      // and `'null'` is in `items.bsonType`.
+      const withNulls = await Test.create({ tags: [null], scores: [null] });
+      assert.deepStrictEqual(withNulls.toObject().tags, [null]);
+      assert.deepStrictEqual(withNulls.toObject().scores, [null]);
+
       await assert.rejects(
         Test.create([{ tags: ['funny', 'something else'] }], { validateBeforeSave: false }),
         /MongoServerError: Document failed validation/
@@ -4170,6 +4176,7 @@ describe('schema', function() {
       const validate = ajv.compile(schema.toJSONSchema());
 
       assert.ok(validate({ _id: '0'.repeat(24), tags: ['funny', 'sad'], scores: [1] }));
+      assert.ok(validate({ _id: '0'.repeat(24), tags: [null], scores: [null] }));
       assert.ok(!validate({ _id: '0'.repeat(24), tags: ['funny', 'something else'] }));
       assert.ok(!validate({ _id: '0'.repeat(24), scores: [3] }));
     });


### PR DESCRIPTION
**Summary**

Fix #16443.

`Schema.prototype.toJSONSchema()` read enum values straight off `schemaType.options.enum` — the
raw user input rather than the normalized enum — which broke in three ways:

1. **Arrays of enums got the `enum` on the array instead of on its items.** Mongoose validates
   each element against the enum, but the generated schema required the whole array to equal one
   of the enum values, so the `$jsonSchema` validator rejected every document Mongoose considered
   valid.
2. **The documented `enum: { values, message }` form threw.** `[...schemaType.options.enum, null]`
   spread a plain object: `TypeError: schemaType.options.enum is not iterable`. On a `required`
   path it did not throw but emitted `enum: { values, message }`, which MongoDB rejects with
   `$jsonSchema keyword 'enum' must be an array`.
3. **Enums declared on the array element or set with `.enum()` were dropped** — neither sets
   `options.enum` on the path `toJSONSchema()` inspects.

The fix emits the enum from the schema type that owns it — `SchemaString` and `SchemaNumber`,
the two types the API documents enum support for — using the normalized `enumValues`. Arrays then
describe their items for free, since `SchemaArray.toJSONSchema()` already delegates to the
embedded type, and every declaration form is covered because `enumValues` is what the enum
validator itself uses. `null` is appended exactly where the type definition is nullable, which
also makes `allowNull: false` consistent between the type and the enum.

**Examples**

Before, for `{ tags: { type: [String], enum: ['funny', 'sad'] } }`:

```js
{ type: ['array', 'null'], items: { type: ['string', 'null'] }, enum: ['funny', 'sad', null] }
```

After:

```js
{
  type: ['array', 'null'],
  items: { type: ['string', 'null'], enum: ['funny', 'sad', null] }
}
```

**Tests**

Two tests in `test/schema.test.js`, both failing before the change:

- `puts enums on array elements rather than on the array (gh-16443)` — checks both `useBsonType`
  modes, creates a real collection with the generated `$jsonSchema` validator and asserts the
  server now accepts `{ tags: ['funny'] }` and still rejects an out-of-enum element, and runs the
  same cases through Ajv.
- `supports enums declared as an object or set with enum() (gh-16443)` — covers the
  `{ values, message }` form on both an optional and a `required` path, and `schema.path(...).enum()`.
