### PR TITLE
fix(cast): reject arrays when casting to Int32 or Double

### DIFF
--- a/lib/cast/double.js
+++ b/lib/cast/double.js
@@ -30,6 +30,12 @@ module.exports = function castDouble(val) {
       assert.ok(false);
     }
   } else if (typeof val === 'object') {
+    if (Array.isArray(val)) {
+      // `[5].valueOf()` returns the array itself, so without this guard a
+      // single-element or empty array would fall through to `Number(tempVal)`
+      // below and silently coerce instead of throwing.
+      assert.ok(false);
+    }
     const tempVal = val.valueOf() ?? val.toString();
     // ex: { a: 'im an object, valueOf: () => 'helloworld' } // throw an error
     if (typeof tempVal === 'string') {

--- a/lib/cast/int32.js
+++ b/lib/cast/int32.js
@@ -20,6 +20,12 @@ module.exports = function castInt32(val) {
   if (val === '') {
     return null;
   }
+  if (Array.isArray(val)) {
+    // `Number([5])` is `5` and `Number([])` is `0`, so without this guard a
+    // single-element or empty array would silently coerce instead of throwing,
+    // unlike every other array input and unlike `castNumber()`'s own guard.
+    assert.ok(false);
+  }
 
   const coercedVal = isBsonType(val, 'Long') ? val.toNumber() : Number(val);
 

--- a/test/double.test.js
+++ b/test/double.test.js
@@ -287,6 +287,20 @@ describe('Double', function() {
         );
       });
     });
+
+    describe('when an array is provided to a Double field', () => {
+      it('throws a CastError upon validation, even for a single-element or empty array', async() => {
+        for (const value of [[5], [], [5, 6]]) {
+          const doc = new Test({ myDouble: value });
+
+          assert.deepStrictEqual(doc.myDouble, undefined);
+          const err = await doc.validate().catch(e => e);
+          assert.ok(err);
+          assert.ok(err.errors['myDouble']);
+          assert.equal(err.errors['myDouble'].name, 'CastError');
+        }
+      });
+    });
   });
 
   describe('custom casters', () => {

--- a/test/int32.test.js
+++ b/test/int32.test.js
@@ -397,6 +397,20 @@ describe('Int32', function() {
         );
       });
     });
+
+    describe('when an array is provided to an Int32 field', () => {
+      it('throws a CastError upon validation, even for a single-element or empty array', async() => {
+        for (const value of [[5], [], [5, 6]]) {
+          const doc = new Test({ myInt: value });
+
+          assert.strictEqual(doc.myInt, undefined);
+          const err = await doc.validate().catch(e => e);
+          assert.ok(err);
+          assert.ok(err.errors['myInt']);
+          assert.equal(err.errors['myInt'].name, 'CastError');
+        }
+      });
+    });
   });
 
   describe('custom casters', () => {


### PR DESCRIPTION
## Summary
`castInt32` and `castDouble` both fall back to a bare `Number(val)` coercion for non-string/non-BSON inputs. `Number([5])` is `5` and `Number([])` is `0`, so a single-element or empty array silently casts to a plausible-looking number instead of throwing a `CastError`:

```js
const schema = new Schema({ n: Schema.Types.Int32, d: Schema.Types.Double });
const Model = mongoose.model('T', schema);

new Model({ n: [5], d: [5] });   // n === 5, d === Double(5) -- no CastError
new Model({ n: [],  d: [] });    // n === 0, d === Double(0) -- no CastError
```

Every sibling numeric type already rejects arrays: `castNumber()` has an explicit `Array.isArray()` guard (twice), and `castBigInt()`/`castDecimal128()` use an exhaustive allow-list that an array never matches. `Int32`/`Double` are the odd ones out — this looks like the `Array.isArray` guard just wasn't carried over when they were added. Multi-element arrays already threw correctly (`Number([5,6])` is `NaN`), so only the single-element/empty cases were silently wrong.

## Changes
- `lib/cast/int32.js`, `lib/cast/double.js`: add an `Array.isArray(val)` guard before the `Number()` fallback, matching `castNumber()`'s existing pattern.
- `test/int32.test.js`, `test/double.test.js`: one new test each, covering `[5]`, `[]`, and `[5, 6]`.

## Testing
- `test/int32.test.js` (32/32) and `test/double.test.js` (27/27) pass individually. Running both together hits a pre-existing, unrelated test-DB collision (duplicate `_id: 42` in the `populate()` fixture) — confirmed via `git stash` that this happens identically without this change.
- `test/schema.number.test.js` and `test/cast.test.js` pass (26/26), no regressions in adjacent casting logic.
- `eslint` clean.
- Searched issues/PRs for existing reports of this — none found.