### PR TITLE
fix(query): respect `strictQuery` query option when casting array filters

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -957,7 +957,9 @@ MyModel.find({ notInSchema: 1 });
 ```
 
 The `strict` option does apply to updates.
-The `strictQuery` option is **just** for query filters.
+<!-- markdownlint-disable MD051 -->
+The `strictQuery` option is for query filters and for [`arrayFilters`](#strictQuery-arrayFilters).
+<!-- markdownlint-enable MD051 -->
 
 ```javascript
 // Mongoose will strip out `notInSchema` from the update if `strict` is
@@ -993,6 +995,37 @@ await MyModel.find({ notInSchema: 1 });
 // Matches _all_ documents with `strictQuery: true`: Mongoose strips out
 // `notInSchema: 1`, leaving an empty filter `{}`.
 await MyModel.find({ notInSchema: 1 }).setOptions({ strictQuery: true });
+```
+
+### strictQuery and arrayFilters {#strictQuery-arrayFilters}
+
+Mongoose also checks `arrayFilters` paths against your schema.
+Array filters are strict by default, even though `strictQuery` is `false` by default.
+Mongoose never silently strips an array filter, because dropping one would change which array elements the update modifies, so an array filter path that isn't in the schema throws instead.
+
+```javascript
+const itemSchema = new Schema({ name: String }, { _id: false });
+const MyModel = mongoose.model('Test', new Schema({ items: [itemSchema] }));
+
+// Throws 'Could not find path "items.0._id" in schema', because `itemSchema` is
+// declared with `_id: false`, so `items._id` is not in the schema.
+await MyModel.updateOne(
+  {},
+  { $set: { 'items.$[item].name': 'test' } },
+  { arrayFilters: [{ 'item._id': 42 }] }
+);
+```
+
+Set `strictQuery: false` to leave the path as-is and send it to the server uncast.
+That is useful when your stored documents contain properties that your schema doesn't declare.
+Mongoose throws for array filters with both `strictQuery: true` and `strictQuery: 'throw'`.
+
+```javascript
+await MyModel.updateOne(
+  {},
+  { $set: { 'items.$[item].name': 'test' } },
+  { arrayFilters: [{ 'item._id': 42 }], strictQuery: false }
+);
 ```
 
 In general, we do **not** recommend passing user-defined objects as query filters:

--- a/lib/helpers/update/castArrayFilters.js
+++ b/lib/helpers/update/castArrayFilters.js
@@ -28,6 +28,13 @@ module.exports = function castArrayFilters(query) {
   if (query._mongooseOptions.strictQuery != null) {
     strictQuery = query._mongooseOptions.strictQuery;
   }
+  // `strictQuery` passed as a query option ends up in `query.options`, not in
+  // `_mongooseOptions`, so check there too. Otherwise `strictQuery` passed to
+  // `updateOne()` or `setOptions()` would be ignored for array filters, even
+  // though `strict` is respected.
+  if (query.options?.strictQuery != null) {
+    strictQuery = query.options.strictQuery;
+  }
 
   _castArrayFilters(arrayFilters, schema, strictQuery, updatedPathsByFilter, query);
 };

--- a/test/helpers/update.castArrayFilters.test.js
+++ b/test/helpers/update.castArrayFilters.test.js
@@ -419,4 +419,36 @@ describe('castArrayFilters', function() {
     // value is left as is, not cast to string
     assert.strictEqual(q.options.arrayFilters[0]['item.any.foo'], 123);
   });
+
+  it('respects `strictQuery` passed as a query option (gh-16447)', function() {
+    const itemSchema = new Schema({ name: String }, { _id: false });
+    const schema = new Schema({ items: [itemSchema] });
+
+    const update = { $set: { 'items.$[item].name': 'test' } };
+
+    // `items._id` is not in the schema because `itemSchema` sets `_id: false`,
+    // so the array filter throws by default.
+    const q = new Query();
+    q.schema = schema;
+    q.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
+    assert.throws(function() {
+      castArrayFilters(q);
+    }, /Could not find path "items\.0\._id" in schema/);
+
+    // `strictQuery: false` as a query option leaves the path as-is, the same way
+    // `strict: false` does.
+    const q2 = new Query();
+    q2.schema = schema;
+    q2.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }], strictQuery: false });
+    castArrayFilters(q2);
+    assert.strictEqual(q2.options.arrayFilters[0]['item._id'], 42);
+
+    // Same via `setOptions()`.
+    const q3 = new Query();
+    q3.schema = schema;
+    q3.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
+    q3.setOptions({ strictQuery: false });
+    castArrayFilters(q3);
+    assert.strictEqual(q3.options.arrayFilters[0]['item._id'], 42);
+  });
 });


### PR DESCRIPTION
**Summary**

Fixes #16447.

`castArrayFilters()` resolves `strictQuery` from `query._mongooseOptions.strictQuery`, but nothing ever assigns that key for a normal query: `Query.prototype.setOptions()` copies options into `_mongooseOptions` by explicit name and `strictQuery` isn't among them (`strict` is). A `strictQuery` passed to `updateOne()` or `setOptions()` lands on `query.options` instead, so that branch never matched and query-level `strictQuery` was silently ignored for array filters.

That left an inconsistency: schema-level `strictQuery`, global `strictQuery`, and query-level `strict` were all respected for array filters, but query-level `strictQuery` was not — even though query filter casting already reads `query.options.strictQuery` (`lib/cast.js`, fed by `lib/query.js`).

The fix reads `query.options.strictQuery` as well, matching how `_castUpdate()` already resolves the option. `query.options.strictQuery` is `undefined` unless the caller passes it explicitly, so the default stays unchanged and array filters remain strict by default.

This is the remaining case after #11062 (query-level `strict` for array filters) and #11836 (global `strictQuery`).

**Examples**

Before, both of these threw `Could not find path "items.0._id" in schema`:

```javascript
const itemSchema = new Schema({ name: String }, { _id: false });
const Test = mongoose.model('Test', new Schema({ tag: String, items: [itemSchema] }));

const update = { $set: { 'items.$[item].name': 'updated' } };
const arrayFilters = [{ 'item._id': 'item-1' }];

// Now respects the option and sends the filter uncast, like `strict: false` already did
await Test.updateOne({ tag: 't' }, update, { arrayFilters, strictQuery: false });

// Same via setOptions()
await Test.updateOne({ tag: 't' }, update, { arrayFilters }).setOptions({ strictQuery: false });
```

**Also in this PR**

`docs/guide.md` claimed `strictQuery` is "**just** for query filters". Added a `strictQuery and arrayFilters` section documenting that `strictQuery` applies to array filters too, and that array filters are strict by default even though `strictQuery` defaults to `false` — Mongoose throws rather than silently stripping an array filter, because dropping one would change which array elements the update modifies. That behaviour was previously undocumented.

**Tests**

Added `respects 'strictQuery' passed as a query option (gh-16447)` to `test/helpers/update.castArrayFilters.test.js`, covering the default throw, `strictQuery: false` as a query option, and the same via `setOptions()`.
