### PR TITLE
docs: document new/returnOriginal deprecation from 9.2.0 (#16008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@
 9.2.0 / 2026-02-09
 ==================
  * feat: add option to skip middleware #15883 #8768 [AbdelrahmanHafez](https://github.com/AbdelrahmanHafez)
+ * feat(base): add `returnDocument` global option, deprecate `returnOriginal` and `new` #16008
  * feat(model): delay "Duplicate schema index" warning until createIndexes runs to include model name in the warning #15979
  * feat(model): add strict option to Model.hydrate(...) #15940 #15977
  * feat(document): add flattenUUIDs option to toObject() and toJSON() #15864 #15021 [AbdelrahmanHafez](https://github.com/AbdelrahmanHafez)

--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -96,7 +96,7 @@ await Model.updateOne({}, [{ $set: { newProp: 'test2' } }], { updatePipeline: fa
 
 As of Mongoose 9.2.0 ([#16008](https://github.com/Automattic/mongoose/pull/16008)), the `new` and `returnOriginal` options for `findOneAndUpdate()` and `findOneAndReplace()` are deprecated in favor of `returnDocument`. Passing either option still works, but now prints a runtime deprecation warning:
 
-```
+```txt
 [MONGOOSE] Warning: mongoose: the `new` option for `findOneAndUpdate()` and `findOneAndReplace()` is deprecated. Use `returnDocument: 'after'` instead.
 ```
 

--- a/docs/migrating_to_9.md
+++ b/docs/migrating_to_9.md
@@ -92,6 +92,27 @@ await Model.updateOne({}, [{ $set: { newProp: 'test2' } }]);
 await Model.updateOne({}, [{ $set: { newProp: 'test2' } }], { updatePipeline: false }); // throws
 ```
 
+## `new` and `returnOriginal` options deprecated
+
+As of Mongoose 9.2.0 ([#16008](https://github.com/Automattic/mongoose/pull/16008)), the `new` and `returnOriginal` options for `findOneAndUpdate()` and `findOneAndReplace()` are deprecated in favor of `returnDocument`. Passing either option still works, but now prints a runtime deprecation warning:
+
+```
+[MONGOOSE] Warning: mongoose: the `new` option for `findOneAndUpdate()` and `findOneAndReplace()` is deprecated. Use `returnDocument: 'after'` instead.
+```
+
+Update your queries as follows:
+
+* Use `returnDocument: 'after'` instead of `new: true` or `returnOriginal: false`
+* Use `returnDocument: 'before'` instead of `new: false` or `returnOriginal: true`
+
+```javascript
+// Before
+const doc = await Model.findOneAndUpdate(filter, update, { new: true });
+
+// After
+const doc = await Model.findOneAndUpdate(filter, update, { returnDocument: 'after' });
+```
+
 ## Removed background option for indexes
 
 [MongoDB no longer supports the `background` option for indexes as of MongoDB 4.2](https://www.mongodb.com/docs/manual/core/index-creation/#index-operations). Mongoose 9 will no longer set the background option by default and Mongoose 9 no longer supports setting the `background` option on `Schema.prototype.index()`.


### PR DESCRIPTION
## Summary

Documents the deprecation of the `new` and `returnOriginal` options for `findOneAndUpdate()` / `findOneAndReplace()` — added in **9.2.0** via #16008 (requested in #15972) — which is currently **not mentioned in the CHANGELOG or the 9.x migration guide**.

This PR:
- Adds the missing **9.2.0 CHANGELOG entry** for #16008
- Adds a **migration-guide section** (`docs/migrating_to_9.md`) with the warning text and the before/after fix

## Why this matters (real-world context)

We upgraded mongoose within the 9.x line (9.1.x → 9.9.x). The upgrade itself was **completely silent** — no build error, no type error, nothing in the changelog to review. Everything looked clean.

Then in **production**, our monitoring/observability service began throwing this on every update call:

```
[MONGOOSE] Warning: mongoose: the `new` option for `findOneAndUpdate()` and `findOneAndReplace()` is deprecated. Use `returnDocument: 'after'` instead.
```

Tracing it back was painful precisely **because the changelog didn't mention it**. A changelog-based upgrade review couldn't have caught it — the only way to discover it was diffing the mongoose source between versions:

- **9.1.6** — `convertNewToReturnDocument()` silently converts `new` → `returnDocument`, **no warning**
- **9.2.0+** — same conversion **plus** the `utils.warn(...)` deprecation warning

The behavior change is real and observable, but invisible to anyone reviewing the changelog before upgrading.

## Precedent

Mongoose normally documents deprecations and new warnings in the changelog, including near-identical cases:
- #13578 — *"deprecate `overwrite` option for `findOneAndUpdate()`"* (a sibling option deprecation on the **same method**, and it **was** in the changelog)
- #12666 — *"add deprecation warning for default strictQuery"* (documenting a newly-added deprecation warning)

So this omission looks like an oversight rather than intent — hence this PR to bring it in line.

## Notes

- I only edited `docs/migrating_to_9.md` and added the missing `CHANGELOG.md` entry — no generated files.
- Happy to adjust wording or placement (e.g., if you'd prefer the note only in the migration guide and not a retroactive CHANGELOG edit, just say the word).

Refs: #16008, #15972
