### PR TITLE
Set strictQuery and strict on _mongooseOptions consistently

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1774,6 +1774,14 @@ Query.prototype.setOptions = function(options, overwrite) {
     this._mongooseOptions.cloneUpdate = options.cloneUpdate;
     delete options.cloneUpdate;
   }
+  if ('strict' in options) {
+    this._mongooseOptions.strict = options.strict;
+    delete options.strict;
+  }
+  if ('strictQuery' in options) {
+    this._mongooseOptions.strictQuery = options.strictQuery;
+    delete options.strictQuery;
+  }
   if ('sanitizeProjection' in options) {
     if (options.sanitizeProjection && !this._mongooseOptions.sanitizeProjection) {
       sanitizeProjection(this._fields);
@@ -3565,9 +3573,6 @@ Query.prototype._findOneAndUpdate = async function _findOneAndUpdate() {
   applyGlobalMaxTimeMS(this.options, dbOptions, baseOptions);
   applyGlobalDiskUse(this.options, dbOptions, baseOptions);
 
-  if ('strict' in this.options) {
-    this._mongooseOptions.strict = this.options.strict;
-  }
   const options = this._optionsForExec(this.model);
   convertNewToReturnDocument(options);
 
@@ -3826,11 +3831,6 @@ Query.prototype._findOneAndReplace = async function _findOneAndReplace() {
 
   if (this.error() != null) {
     throw this.error();
-  }
-
-  if ('strict' in this.options) {
-    this._mongooseOptions.strict = this.options.strict;
-    delete this.options.strict;
   }
 
   const filter = this._conditions;
@@ -4548,13 +4548,6 @@ function _update(query, op, filter, doc, options, callback) {
   query.op = op;
   doc = doc || {};
 
-  // strict is an option used in the update checking, make sure it gets set
-  if (options != null) {
-    if ('strict' in options) {
-      query._mongooseOptions.strict = options.strict;
-    }
-  }
-
   if (!(filter instanceof Query) &&
       filter != null &&
       filter.toString() !== '[object Object]') {
@@ -5212,13 +5205,11 @@ Query.prototype.cast = function(model, obj) {
   }
 
   const opts = { upsert: this.options?.upsert };
-  if (this.options) {
-    if ('strict' in this.options) {
-      opts.strict = this.options.strict;
-    }
-    if ('strictQuery' in this.options) {
-      opts.strictQuery = this.options.strictQuery;
-    }
+  if ('strict' in this._mongooseOptions) {
+    opts.strict = this._mongooseOptions.strict;
+  }
+  if ('strictQuery' in this._mongooseOptions) {
+    opts.strictQuery = this._mongooseOptions.strictQuery;
   }
   if ('sanitizeFilter' in this._mongooseOptions) {
     opts.sanitizeFilter = this._mongooseOptions.sanitizeFilter;

--- a/lib/query.js
+++ b/lib/query.js
@@ -1754,9 +1754,16 @@ Query.prototype.setOptions = function(options, overwrite) {
     }
   }
 
-  if ('setDefaultsOnInsert' in options) {
-    this._mongooseOptions.setDefaultsOnInsert = options.setDefaultsOnInsert;
-    delete options.setDefaultsOnInsert;
+  if ('cloneUpdate' in options) {
+    this._mongooseOptions.cloneUpdate = options.cloneUpdate;
+    delete options.cloneUpdate;
+  }
+  if ('defaults' in options) {
+    this._mongooseOptions.defaults = options.defaults;
+    // deleting options.defaults will cause 7287 to fail
+  }
+  if (options.lean == null && this.schema && 'lean' in this.schema.options) {
+    this._mongooseOptions.lean = this.schema.options.lean;
   }
   if ('overwriteDiscriminatorKey' in options) {
     this._mongooseOptions.overwriteDiscriminatorKey = options.overwriteDiscriminatorKey;
@@ -1766,21 +1773,9 @@ Query.prototype.setOptions = function(options, overwrite) {
     this._mongooseOptions.overwriteImmutable = options.overwriteImmutable;
     delete options.overwriteImmutable;
   }
-  if ('updatePipeline' in options) {
-    this._mongooseOptions.updatePipeline = options.updatePipeline;
-    delete options.updatePipeline;
-  }
-  if ('cloneUpdate' in options) {
-    this._mongooseOptions.cloneUpdate = options.cloneUpdate;
-    delete options.cloneUpdate;
-  }
-  if ('strict' in options) {
-    this._mongooseOptions.strict = options.strict;
-    delete options.strict;
-  }
-  if ('strictQuery' in options) {
-    this._mongooseOptions.strictQuery = options.strictQuery;
-    delete options.strictQuery;
+  if ('sanitizeFilter' in options) {
+    this._mongooseOptions.sanitizeFilter = options.sanitizeFilter;
+    delete options.sanitizeFilter;
   }
   if ('sanitizeProjection' in options) {
     if (options.sanitizeProjection && !this._mongooseOptions.sanitizeProjection) {
@@ -1790,29 +1785,33 @@ Query.prototype.setOptions = function(options, overwrite) {
     this._mongooseOptions.sanitizeProjection = options.sanitizeProjection;
     delete options.sanitizeProjection;
   }
-  if ('sanitizeFilter' in options) {
-    this._mongooseOptions.sanitizeFilter = options.sanitizeFilter;
-    delete options.sanitizeFilter;
+  if ('schemaLevelProjections' in options) {
+    this._mongooseOptions.schemaLevelProjections = options.schemaLevelProjections;
+    delete options.schemaLevelProjections;
+  }
+  if ('setDefaultsOnInsert' in options) {
+    this._mongooseOptions.setDefaultsOnInsert = options.setDefaultsOnInsert;
+    delete options.setDefaultsOnInsert;
+  }
+  if ('strict' in options) {
+    this._mongooseOptions.strict = options.strict;
+    delete options.strict;
+  }
+  if ('strictQuery' in options) {
+    this._mongooseOptions.strictQuery = options.strictQuery;
+    delete options.strictQuery;
   }
   if ('timestamps' in options) {
     this._mongooseOptions.timestamps = options.timestamps;
     delete options.timestamps;
   }
-  if ('defaults' in options) {
-    this._mongooseOptions.defaults = options.defaults;
-    // deleting options.defaults will cause 7287 to fail
-  }
   if ('translateAliases' in options) {
     this._mongooseOptions.translateAliases = options.translateAliases;
     delete options.translateAliases;
   }
-  if ('schemaLevelProjections' in options) {
-    this._mongooseOptions.schemaLevelProjections = options.schemaLevelProjections;
-    delete options.schemaLevelProjections;
-  }
-
-  if (options.lean == null && this.schema && 'lean' in this.schema.options) {
-    this._mongooseOptions.lean = this.schema.options.lean;
+  if ('updatePipeline' in options) {
+    this._mongooseOptions.updatePipeline = options.updatePipeline;
+    delete options.updatePipeline;
   }
 
   if (typeof options.limit === 'string') {
@@ -2369,13 +2368,22 @@ Query.prototype._unsetCastError = function _unsetCastError() {
  * Getter/setter around the current mongoose-specific options for this query
  * Below are the current Mongoose-specific options.
  *
- * - `populate`: an array representing what paths will be populated. Should have one entry for each call to [`Query.prototype.populate()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.populate())
+ * - `cloneUpdate`: if `false`, Mongoose will not clone updates before executing the query
+ * - `defaults`: if `false`, Mongoose will not apply defaults to the returned document(s)
  * - `lean`: if truthy, Mongoose will not [hydrate](https://mongoosejs.com/docs/api/model.html#Model.hydrate()) any documents that are returned from this query. See [`Query.prototype.lean()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.lean()) for more information.
+ * - `nearSphere`: use `$nearSphere` instead of `near()`. See the [`Query.prototype.nearSphere()` docs](https://mongoosejs.com/docs/api/query.html#Query.prototype.nearSphere())
+ * - `overwriteDiscriminatorKey`: allow setting the discriminator key in the update
+ * - `overwriteImmutable`: allow overwriting properties that are set to `immutable` in the schema
+ * - `populate`: an array representing what paths will be populated. Should have one entry for each call to [`Query.prototype.populate()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.populate())
+ * - `sanitizeFilter`: if truthy, Mongoose will sanitize query filters before executing the query
+ * - `sanitizeProjection`: if truthy, Mongoose will sanitize projections before executing the query
+ * - `schemaLevelProjections`: if `false`, Mongoose will not apply schema-level `select: false` or `select: true` for this query
+ * - `setDefaultsOnInsert`: if `true`, Mongoose will apply defaults to upserted documents
  * - `strict`: controls how Mongoose handles keys that aren't in the schema for updates. This option is `true` by default, which means Mongoose will silently strip any paths in the update that aren't in the schema. See the [`strict` mode docs](https://mongoosejs.com/docs/guide.html#strict) for more information.
  * - `strictQuery`: controls how Mongoose handles keys that aren't in the schema for the query `filter`. This option is `false` by default, which means Mongoose will allow `Model.find({ foo: 'bar' })` even if `foo` is not in the schema. See the [`strictQuery` docs](https://mongoosejs.com/docs/guide.html#strictQuery) for more information.
- * - `nearSphere`: use `$nearSphere` instead of `near()`. See the [`Query.prototype.nearSphere()` docs](https://mongoosejs.com/docs/api/query.html#Query.prototype.nearSphere())
- * - `schemaLevelProjections`: if `false`, Mongoose will not apply schema-level `select: false` or `select: true` for this query
- * - `cloneUpdate`: if `false`, Mongoose will not clone updates before executing the query
+ * - `timestamps`: if `false`, Mongoose will not apply timestamps to the update
+ * - `translateAliases`: if `true`, Mongoose will translate schema aliases in the query
+ * - `updatePipeline`: if `true`, Mongoose will treat the update as an update pipeline
  *
  * Mongoose maintains a separate object for internal options because
  * Mongoose sends `Query.prototype.options` to the MongoDB server, and the

--- a/test/helpers/update.castArrayFilters.test.js
+++ b/test/helpers/update.castArrayFilters.test.js
@@ -421,34 +421,34 @@ describe('castArrayFilters', function() {
   });
 
   it('respects `strictQuery` passed as a query option (gh-16447)', function() {
-      const itemSchema = new Schema({ name: String }, { _id: false });
-      const schema = new Schema({ items: [itemSchema] });
+    const itemSchema = new Schema({ name: String }, { _id: false });
+    const schema = new Schema({ items: [itemSchema] });
 
-      const update = { $set: { 'items.$[item].name': 'test' } };
+    const update = { $set: { 'items.$[item].name': 'test' } };
 
-      // `items._id` is not in the schema because `itemSchema` sets `_id: false`,
-      // so the array filter throws by default.
-      const q = new Query();
-      q.schema = schema;
-      q.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
-      assert.throws(function() {
-        castArrayFilters(q);
-      }, /Could not find path "items\.0\._id" in schema/);
+    // `items._id` is not in the schema because `itemSchema` sets `_id: false`,
+    // so the array filter throws by default.
+    const q = new Query();
+    q.schema = schema;
+    q.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
+    assert.throws(function() {
+      castArrayFilters(q);
+    }, /Could not find path "items\.0\._id" in schema/);
 
-      // `strictQuery: false` as a query option leaves the path as-is, the same way
-      // `strict: false` does.
-      const q2 = new Query();
-      q2.schema = schema;
-      q2.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }], strictQuery: false });
-      castArrayFilters(q2);
-      assert.strictEqual(q2.options.arrayFilters[0]['item._id'], 42);
+    // `strictQuery: false` as a query option leaves the path as-is, the same way
+    // `strict: false` does.
+    const q2 = new Query();
+    q2.schema = schema;
+    q2.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }], strictQuery: false });
+    castArrayFilters(q2);
+    assert.strictEqual(q2.options.arrayFilters[0]['item._id'], 42);
 
-      // Same via `setOptions()`.
-      const q3 = new Query();
-      q3.schema = schema;
-      q3.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
-      q3.setOptions({ strictQuery: false });
-      castArrayFilters(q3);
-      assert.strictEqual(q3.options.arrayFilters[0]['item._id'], 42);
-    });
+    // Same via `setOptions()`.
+    const q3 = new Query();
+    q3.schema = schema;
+    q3.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
+    q3.setOptions({ strictQuery: false });
+    castArrayFilters(q3);
+    assert.strictEqual(q3.options.arrayFilters[0]['item._id'], 42);
+  });
 });

--- a/test/helpers/update.castArrayFilters.test.js
+++ b/test/helpers/update.castArrayFilters.test.js
@@ -419,4 +419,36 @@ describe('castArrayFilters', function() {
     // value is left as is, not cast to string
     assert.strictEqual(q.options.arrayFilters[0]['item.any.foo'], 123);
   });
+
+  it('respects `strictQuery` passed as a query option (gh-16447)', function() {
+      const itemSchema = new Schema({ name: String }, { _id: false });
+      const schema = new Schema({ items: [itemSchema] });
+
+      const update = { $set: { 'items.$[item].name': 'test' } };
+
+      // `items._id` is not in the schema because `itemSchema` sets `_id: false`,
+      // so the array filter throws by default.
+      const q = new Query();
+      q.schema = schema;
+      q.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
+      assert.throws(function() {
+        castArrayFilters(q);
+      }, /Could not find path "items\.0\._id" in schema/);
+
+      // `strictQuery: false` as a query option leaves the path as-is, the same way
+      // `strict: false` does.
+      const q2 = new Query();
+      q2.schema = schema;
+      q2.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }], strictQuery: false });
+      castArrayFilters(q2);
+      assert.strictEqual(q2.options.arrayFilters[0]['item._id'], 42);
+
+      // Same via `setOptions()`.
+      const q3 = new Query();
+      q3.schema = schema;
+      q3.updateOne({}, update, { arrayFilters: [{ 'item._id': 42 }] });
+      q3.setOptions({ strictQuery: false });
+      castArrayFilters(q3);
+      assert.strictEqual(q3.options.arrayFilters[0]['item._id'], 42);
+    });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#16447 pointed out that, because `strictQuery` isn't applied onto `_mongooseOptions`, it doesn't apply to array filters. We should make sure `strict` and `strictQuery` consistently end up on `_mongooseOptions` rather than `options` in order to be consistent with our documentation. The `mongooseOptions()` function explicitly lists `strict` and `strictQuery` as Mongoose internal options.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
