### PR TITLE
fix: apply defaults to undefined array elements

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -401,7 +401,10 @@ SchemaArray.prototype.cast = function(value, doc, init, prev, options) {
             opts.virtuals = options.virtuals;
           }
           if (rawValue[i] === undefined && caster.defaultValue !== undefined) {
-            opts._skipMarkModified = true;
+            // No need to add _skipMarkModified to opts here (fallback for `getDefault()` opts parameter)
+            // because array setters don't rely on Document.prototype.set() - subdocuments do rely on
+            // Document.prototype.set() when applying setters, which is why _skipMarkModified is necessary
+            // for subdocuments. But here we know that `caster` is an array not a subdocument.
             rawValue[i] = caster.getDefault(doc, init, null, opts);
           } else {
             rawValue[i] = caster.applySetters(rawValue[i], doc, init, void 0, opts);

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -401,7 +401,8 @@ SchemaArray.prototype.cast = function(value, doc, init, prev, options) {
             opts.virtuals = options.virtuals;
           }
           if (rawValue[i] === undefined && caster.defaultValue !== undefined) {
-            rawValue[i] = caster.getDefault(doc, init);
+            opts._skipMarkModified = true;
+            rawValue[i] = caster.getDefault(doc, init, null, opts);
           } else {
             rawValue[i] = caster.applySetters(rawValue[i], doc, init, void 0, opts);
           }

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -400,7 +400,11 @@ SchemaArray.prototype.cast = function(value, doc, init, prev, options) {
           if (options.virtuals) {
             opts.virtuals = options.virtuals;
           }
-          rawValue[i] = caster.applySetters(rawValue[i], doc, init, void 0, opts);
+          if (rawValue[i] === undefined && caster.defaultValue !== undefined) {
+            rawValue[i] = caster.getDefault(doc, init);
+          } else {
+            rawValue[i] = caster.applySetters(rawValue[i], doc, init, void 0, opts);
+          }
         }
       } catch (e) {
         // rethrow

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1295,11 +1295,12 @@ SchemaType.prototype.ref = function(ref) {
  * @param {object} options
  * @param {object} [options.context]
  * @param {boolean} [options.skipCast]
+ * @param {object} [applySettersOptions] passed to applySetters
  * @return {any} The Stored default value.
  * @api private
  */
 
-SchemaType.prototype.getDefault = function getDefault(parentDoc, init, options) {
+SchemaType.prototype.getDefault = function getDefault(parentDoc, init, options, applySettersOptions) {
   let ret;
   if (this.defaultValue == null) {
     return this.defaultValue;
@@ -1333,7 +1334,13 @@ SchemaType.prototype.getDefault = function getDefault(parentDoc, init, options) 
       return this._applySetters(ret, parentDoc);
     }
 
-    const casted = this.applySetters(ret, parentDoc, init, undefined, setOptionsForDefaults);
+    const casted = this.applySetters(
+      ret,
+      parentDoc,
+      init,
+      undefined,
+      applySettersOptions ?? setOptionsForDefaults
+    );
     if (casted && !Array.isArray(casted) && casted.$isSingleNested) {
       casted.$__parent = parentDoc;
     }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -7171,7 +7171,7 @@ describe('document', function() {
     assert.ok(doc.roles[1]._id);
   });
 
-  it('applies defaults to nullish array elements', function() {
+  it('applies defaults to undefined array elements', function() {
     const schema = new Schema({
       values: [{ type: String, default: 'Unknown' }]
     });

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -7171,6 +7171,28 @@ describe('document', function() {
     assert.ok(doc.roles[1]._id);
   });
 
+  it('applies defaults to nullish array elements', function() {
+    const schema = new Schema({
+      values: [{ type: String, default: 'Unknown' }]
+    });
+    const Model = db.model('Test', schema);
+
+    const doc = new Model({ values: [null, undefined] });
+
+    assert.deepEqual(doc.values, [null, 'Unknown']);
+  });
+
+  it('throws when a nullish array element default has the wrong type', async function() {
+    const schema = new Schema({
+      values: [{ type: Schema.Types.ObjectId, default: () => [] }]
+    });
+    const Model = db.model('Test', schema);
+
+    const doc = new Model({ values: [undefined] });
+
+    await assert.rejects(doc.save(), /Cast to \[ObjectId\] failed/);
+  });
+
   it('updateOne() hooks (gh-7133) (gh-7423)', async function() {
     const schema = new mongoose.Schema({ name: String });
 

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12158,6 +12158,27 @@ describe('document', function() {
     assert.deepEqual(failure.modifiedPaths(), []);
   });
 
+  it('avoids setting modified on defaults in nested arrays of subdocuments', async function() {
+    const textSchema = new Schema({
+      text: { type: String }
+    }, { _id: false });
+
+    const messageSchema = new Schema({
+      body: { type: textSchema, default: { text: 'hello' } },
+      date: { type: Date, default: Date.now }
+    }, { _id: false });
+
+    const Message = db.model('Test', new Schema({
+      messages: [[messageSchema]]
+    }));
+    Message.schema.path('messages').embeddedSchemaType.default(() => [{}]);
+
+    const entry = await Message.create({ messages: [undefined] });
+    const failure = await Message.findById(entry._id);
+
+    assert.deepEqual(failure.modifiedPaths(), []);
+  });
+
   it('works when passing dot notation to mixed property (gh-1946)', async function() {
     const schema = Schema({
       name: String,

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -7182,6 +7182,21 @@ describe('document', function() {
     assert.deepEqual(doc.values, [null, 'Unknown']);
   });
 
+  it('applies setters to array element defaults', function() {
+    const schema = new Schema({
+      values: [{
+        type: String,
+        default: 'unknown',
+        set: value => value.toUpperCase()
+      }]
+    });
+    const Model = db.model('Test', schema);
+
+    const doc = new Model({ values: [undefined] });
+
+    assert.deepEqual(doc.values, ['UNKNOWN']);
+  });
+
   it('throws when a nullish array element default has the wrong type', async function() {
     const schema = new Schema({
       values: [{ type: Schema.Types.ObjectId, default: () => [] }]

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2718,6 +2718,22 @@ describe('schema', function() {
     assert.equal(casted[0].$path(), 'ids.0');
   });
 
+  it('preserves the array path index when applying nested array defaults', function() {
+    const schema = new Schema({
+      ids: [[String]],
+      otherIds: [[String]]
+    });
+    schema.path('ids').embeddedSchemaType.default(() => ['default']);
+
+    const casted = schema.path('ids').cast([undefined]);
+    assert.deepEqual(Array.from(casted[0]), ['default']);
+    assert.equal(casted[0].$path(), 'ids.0');
+
+    const casted2 = schema.path('otherIds').cast([['default']]);
+    assert.deepEqual(Array.from(casted2[0]), ['default']);
+    assert.equal(casted2[0].$path(), 'otherIds.0');
+  });
+
   describe('cast option (gh-8407)', function() {
     it('disable casting using `false`', function() {
       const schema = Schema({


### PR DESCRIPTION
Re: #9232

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

Currently defaults are not applied to array elements: `tags: [{ type: String, default: 'Unknown' }]` the default is silently ignored. This PR applies defaults to arrays.

Putting this into 9.10 for caution.

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
