### PR TITLE
fix(hydration): use the doc model for looking up a ref

### DIFF
--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -1722,7 +1722,7 @@ SchemaType.prototype._castRef = function _castRef(value, doc, init, options) {
     !doc.$__.populated[path].options ||
     !doc.$__.populated[path].options.options ||
     !doc.$__.populated[path].options.options.lean) {
-    const PopulatedModel = pop ? pop.options[populateModelSymbol] : doc.constructor.db.model(this.options.ref);
+    const PopulatedModel = pop ? pop.options[populateModelSymbol] : owner.constructor.db.model(this.options.ref);
     ret = PopulatedModel.hydrate(value, null, options);
     ret.$__.wasPopulated = { value: ret._doc._id, options: { [populateModelSymbol]: PopulatedModel } };
   }

--- a/test/model.hydrate.test.js
+++ b/test/model.hydrate.test.js
@@ -214,6 +214,35 @@ describe('model', function() {
       assert.ok(c.users[0] instanceof User);
     });
 
+    it('hydrates populated refs in embedded docs', async function() {
+      const userSchema = new Schema({
+        name: String
+      });
+      const childSchema = new Schema({
+        user: { ref: 'HydrateEmbeddedUser', type: Schema.Types.ObjectId }
+      });
+      const parentSchema = new Schema({
+        child: childSchema
+      });
+
+      db.deleteModel(/HydrateEmbeddedUser/);
+      db.deleteModel(/HydrateEmbeddedParent/);
+      const User = db.model('HydrateEmbeddedUser', userSchema);
+      const Parent = db.model('HydrateEmbeddedParent', parentSchema);
+
+      const user = { _id: new mongoose.Types.ObjectId(), name: 'Val' };
+      const parent = {
+        _id: new mongoose.Types.ObjectId(),
+        child: { user }
+      };
+
+      const doc = Parent.hydrate(parent, null, { hydratedPopulatedDocs: true });
+
+      assert.ok(doc.child.populated('user'));
+      assert.ok(doc.child.user instanceof User);
+      assert.equal(doc.child.user.name, 'Val');
+    });
+
     it('marks deeply nested docs as hydrated underneath virtuals (gh-15110)', async function() {
       const ArticleSchema = new Schema({ title: String });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The hydration doesn't work for embedded docs
Reproduced on `9.8.0` but I think it affects all the existing versions, including 7.x, 8.x, and 9.x

