### PR TITLE
fix(schema): do not repeat null in a toJSONSchema enum that already lists null

### DIFF
--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -230,8 +230,12 @@ SchemaType.prototype._addJSONSchemaEnum = function _addJSONSchemaEnum(definition
   }
 
   // The enum validator allows nullish values, so allow `null` wherever the type does.
+  // Skip that when the user already listed `null`: MongoDB refuses a `$jsonSchema`
+  // whose `enum` repeats a value, and so does Ajv.
   const allowsNull = Array.isArray(definition.type ?? definition.bsonType);
-  definition.enum = allowsNull ? [...this.enumValues, null] : [...this.enumValues];
+  definition.enum = allowsNull && !this.enumValues.includes(null)
+    ? [...this.enumValues, null]
+    : [...this.enumValues];
 
   return definition;
 };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3621,6 +3621,58 @@ describe('schema', function() {
       });
     });
 
+    it('does not repeat null in enum when the enum already lists null', async function() {
+      const schema = new Schema({
+        status: { type: String, enum: ['active', 'inactive', null] },
+        rating: { type: Number, enum: [1, 2, null] },
+        tags: { type: [String], enum: ['a', null] }
+      }, { autoCreate: false, autoIndex: false });
+
+      assert.deepStrictEqual(schema.toJSONSchema({ useBsonType: true }), {
+        required: ['_id'],
+        properties: {
+          _id: {
+            bsonType: 'objectId'
+          },
+          status: {
+            bsonType: ['string', 'null'],
+            enum: ['active', 'inactive', null]
+          },
+          rating: {
+            bsonType: ['number', 'null'],
+            enum: [1, 2, null]
+          },
+          tags: {
+            bsonType: ['array', 'null'],
+            items: {
+              bsonType: ['string', 'null'],
+              enum: ['a', null]
+            }
+          }
+        }
+      });
+
+      // MongoDB rejects a `$jsonSchema` whose `enum` repeats a value, so the
+      // collection cannot be created at all when `null` is listed twice.
+      await db.createCollection(collectionName, {
+        validator: {
+          $jsonSchema: schema.toJSONSchema({ useBsonType: true })
+        }
+      });
+      const Test = db.model('Test', schema, collectionName);
+
+      const doc = await Test.create({ status: 'active', rating: 1, tags: ['a'] });
+      assert.equal(doc.status, 'active');
+      assert.equal(doc.rating, 1);
+
+      const ajv = new Ajv();
+      const validate = ajv.compile(schema.toJSONSchema());
+
+      assert.ok(validate({ _id: '0'.repeat(24), status: 'active', rating: 1, tags: ['a'] }));
+      assert.ok(validate({ _id: '0'.repeat(24), status: null, rating: null, tags: null }));
+      assert.ok(!validate({ _id: '0'.repeat(24), status: 'archived' }));
+    });
+
     it('handles all primitive data types', async function() {
       const schema = new Schema({
         num: Number,


### PR DESCRIPTION
**Summary**

`toJSONSchema()` appends `null` to a path's `enum` whenever the path allows null, without checking what the enum already holds. A schema that lists `null` itself ends up with the value twice, and both consumers of the output refuse the result:

- MongoDB: `$jsonSchema keyword 'enum' array cannot contain duplicate values.`
- Ajv: `enum must NOT have duplicate items (items ## 2 and 3 are identical)`

So the collection cannot be created at all, and the schema cannot be compiled either. It happens on String and Number paths, on both `enum` forms (array and object), and on the array element enums from #16443, with and without `useBsonType`. Paths declared `required: true` are not affected, because those never receive the extra `null`.

The fix adds `null` only when the enum does not carry it already.

**Examples**

```js
const mongoose = require('mongoose');

const schema = new mongoose.Schema({
  status: { type: String, enum: ['active', 'inactive', null] }
});

console.log(schema.toJSONSchema({ useBsonType: true }).properties.status);

await mongoose.connect('mongodb://127.0.0.1:27017/reprodb');
await mongoose.connection.db.createCollection('tests', {
  validator: { $jsonSchema: schema.toJSONSchema({ useBsonType: true }) }
});
```

On master:

```
{
  bsonType: [ 'string', 'null' ],
  enum: [ 'active', 'inactive', null, null ]
}
MongoServerError: $jsonSchema keyword 'enum' array cannot contain duplicate values.
```

With this change:

```
{
  bsonType: [ 'string', 'null' ],
  enum: [ 'active', 'inactive', null ]
}
createCollection: ok
```

The test goes next to the other `jsonSchema()` cases in `test/schema.test.js` and follows the same shape: it compares both outputs, creates the collection with the generated validator, writes a document through it, and compiles the plain JSON Schema with Ajv. It fails on master and passes here.

`npm test` on this branch: 4502 passing, 47 pending, 1 failing. The failure is `eachAsync() exhausts large cursor without parallel calls (gh-8235)`, a 10s timeout that reproduces the same way on master on this machine.
