### PR TITLE
fix(schema): drop the map values subpath when removing a map path

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2770,6 +2770,17 @@ Schema.prototype.remove = function(path) {
       }
 
       delete this.paths[name];
+      // A map registers its values under `<path>.$*`, both in `paths` and in
+      // `mapPaths`. Left behind, they keep answering `pathType()` and casting queries
+      // for a path the schema no longer has.
+      for (const subpath of Object.keys(this.paths)) {
+        if (subpath.startsWith(name + '.')) {
+          delete this.paths[subpath];
+        }
+      }
+      this.mapPaths = this.mapPaths.filter(
+        schemaType => !schemaType.path.startsWith(name + '.')
+      );
       _deletePath(this, name);
 
       this._removeEncryptedField(name);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2436,6 +2436,23 @@ describe('schema', function() {
   });
 
   describe('omit() (gh-12931)', function() {
+    it('removes the values subpath of a map', function() {
+      const schema = new Schema({
+        m: { type: Map, of: Number },
+        other: String
+      }, { autoCreate: false, autoIndex: false });
+
+      const newSchema = schema.omit(['m']);
+
+      assert.ok(!newSchema.path('m'));
+      assert.ok(!newSchema.path('m.$*'));
+      assert.equal(newSchema.pathType('m.k'), 'adhocOrUndefined');
+
+      // The removed map used to keep casting queries on its keys
+      const Test = mongoose.model('OmitMapTest', newSchema);
+      assert.deepStrictEqual(Test.find({ 'm.k': '42' }).cast(Test), { 'm.k': '42' });
+    });
+
     it('works with nested paths', function() {
       const schema = Schema({
         name: {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2447,10 +2447,6 @@ describe('schema', function() {
       assert.ok(!newSchema.path('m'));
       assert.ok(!newSchema.path('m.$*'));
       assert.equal(newSchema.pathType('m.k'), 'adhocOrUndefined');
-
-      // The removed map used to keep casting queries on its keys
-      const Test = mongoose.model('OmitMapTest', newSchema);
-      assert.deepStrictEqual(Test.find({ 'm.k': '42' }).cast(Test), { 'm.k': '42' });
     });
 
     it('works with nested paths', function() {


### PR DESCRIPTION
**Summary**

`Schema#remove()` deletes the path itself, but a map also registers its values under `<path>.$*`, in `paths` and in `mapPaths`. Those two stay behind, so the removed map keeps resolving paths and casting queries. `Schema#omit()` goes through `remove()`, so it carries the same behaviour.

```js
const schema = new mongoose.Schema({ m: { type: Map, of: Number }, other: String });
const newSchema = schema.omit(['m']);

Object.keys(newSchema.paths);   // [ 'm.$*', 'other', '_id' ]
newSchema.pathType('m.k');      // 'real'

const Test = mongoose.model('Test', newSchema);
Test.find({ 'm.k': '42' }).cast(Test);   // { 'm.k': 42 }
```

A schema declared without the map returns `'adhocOrUndefined'` and leaves the value as the string `'42'`, which is what the schema after `omit()` should do too. `eachPath()` also still yields `m.$*`, so plugins that walk the schema see a path that no longer exists.

This deletes the subpaths of the removed path from `paths` and drops the map from `mapPaths`. Document arrays and subdocuments are not affected: their children were never in `paths`.

**Examples**

With this change the same snippet gives `[ 'other', '_id' ]`, `'adhocOrUndefined'` and `{ 'm.k': '42' }`.

Test added next to the other `omit()` cases in `test/schema.test.js`; it fails on master. `npm test`: 4503 passing, 1 failing, and that failure is `eachAsync() exhausts large cursor without parallel calls (gh-8235)`, a 10s timeout that reproduces the same way on master on this machine.

One thing I left alone: `childSchemas` keeps an entry for any removed path, maps and document arrays and subdocuments alike, so that looked like a separate question rather than part of this.
