### PR TITLE
docs: fix dead MongoDB driver Collection link

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ new Schema({
 
 ### Driver Access
 
-Mongoose is built on top of the [official MongoDB Node.js driver](https://github.com/mongodb/node-mongodb-native). Each mongoose model keeps a reference to a [native MongoDB driver collection](http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html). The collection object can be accessed using `YourModel.collection`. However, using the collection object directly bypasses all mongoose features, including hooks, validation, etc. The one
+Mongoose is built on top of the [official MongoDB Node.js driver](https://github.com/mongodb/node-mongodb-native). Each mongoose model keeps a reference to a [native MongoDB driver collection](https://mongodb.github.io/node-mongodb-native/7.5/classes/Collection.html). The collection object can be accessed using `YourModel.collection`. However, using the collection object directly bypasses all mongoose features, including hooks, validation, etc. The one
 notable exception is that `YourModel.collection` still buffers
 commands. As such, `YourModel.collection.find()` will **not**
 return a cursor.


### PR DESCRIPTION
The README's "native MongoDB driver collection" link points at `http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html`, which 404s — the driver docs moved off the `/<version>/api/` layout years ago, and 2.1 is long gone.

Updated to [`7.5/classes/Collection.html`](https://mongodb.github.io/node-mongodb-native/7.5/classes/Collection.html), which matches the `"mongodb": "~7.5"` dependency in `package.json`, so the docs a reader lands on describe the driver Mongoose actually bundles. Also switched to https.

Happy to use `/Next/` instead if you'd rather the link float with the newest driver docs rather than track the pinned version.