### PR TITLE
fix(cast): reject arrays when casting to Date

### DIFF
--- a/lib/cast/date.js
+++ b/lib/cast/date.js
@@ -24,6 +24,12 @@ module.exports = function castDate(value) {
   } else if (typeof value === 'string' && !isNaN(Number(value)) && (Number(value) >= 275761 || Number(value) < -271820)) {
     // string representation of milliseconds take this path
     date = new Date(Number(value));
+  } else if (Array.isArray(value)) {
+    // `new Date(['2024-01-15'])` stringifies the array and Date parses that
+    // string, so a single date-string (or other Date-parseable) element would
+    // silently coerce instead of throwing. Same class of bug as the Int32 and
+    // Double array guards.
+    assert.ok(false);
   } else if (typeof value.valueOf === 'function') {
     // support for moment.js. This is also the path strings will take because
     // strings have a `valueOf()`

--- a/test/schema.date.test.js
+++ b/test/schema.date.test.js
@@ -44,6 +44,18 @@ describe('SchemaDate', function() {
     assert.equal(doc.x.valueOf(), mockDate);
   });
 
+  it('throws a CastError when an array is provided to a Date field', async function() {
+    for (const value of [['2024-01-15'], ['January 1, 2024'], [5], [], [2024, 0, 15]]) {
+      const doc = new M({ x: value });
+
+      assert.strictEqual(doc.x, undefined);
+      const err = await doc.validate().catch(e => e);
+      assert.ok(err);
+      assert.ok(err.errors['x']);
+      assert.equal(err.errors['x'].name, 'CastError');
+    }
+  });
+
   it('casts string representation of unix timestamps (gh-6443)', function() {
     const timestamp = Date.now();
     const stringTimestamp = timestamp.toString();


### PR DESCRIPTION
**Summary**

`castDate` falls through to `new Date(value.valueOf())` for non-number, non-string inputs. Arrays implement `valueOf()` by returning themselves, and `new Date(['2024-01-15'])` stringifies the array then parses that string, so a single date-string (or other Date-parseable) element silently becomes a Date instead of a CastError:

```js
const schema = new Schema({ x: Date });
const Model = mongoose.model('T', schema);

new Model({ x: ['2024-01-15'] }); // x is Mon Jan 15 2024 -- no CastError
```

This is the same class of bug recently fixed for Int32 and Double in #16446. `castNumber()` already guards with `Array.isArray()`, and empty/multi-element arrays already failed for Date (`[]` and `[2024, 0, 15]` produce Invalid Date). Only the Date-parseable single-element case was silently wrong. Objects with a custom `valueOf()` (moment.js, etc.) are unchanged.

**Examples**

Covered by a new test in `test/schema.date.test.js` (`['2024-01-15']`, `['January 1, 2024']`, `[5]`, `[]`, `[2024, 0, 15]`). The test fails on current `master` (`actual` is `2024-01-15T00:00:00.000Z`, `expected` is `undefined`) and passes with this change. `npx mocha --exit ./test/schema.date.test.js` is 7/7; eslint is clean on the touched files.
