### PR TITLE
feat(model): add Model.findAndCount() wrapper for limit+skip based pagination with countDocuments

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,9 +1,7 @@
 # Queries
 
-Mongoose [models](models.html) provide several static helper functions
-for [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete).
-Each of these functions return a
-[mongoose `Query` object](api/query.html#Query).
+Mongoose [models](models.html) provide several static helper functions for [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete).
+Each of these functions returns a [mongoose `Query` object](api/query.html#Query).
 
 * [`Model.deleteMany()`](api.html#model_Model-deleteMany)
 * [`Model.deleteOne()`](api.html#model_Model-deleteOne)

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -2,7 +2,7 @@
 
 Mongoose [models](models.html) provide several static helper functions
 for [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete).
-Each of these functions returns a
+Each of these functions return a
 [mongoose `Query` object](api/query.html#Query).
 
 * [`Model.deleteMany()`](api.html#model_Model-deleteMany)
@@ -106,6 +106,53 @@ await q.then(() => console.log('Update 2'));
 // Throws "Query was already executed: Test.updateMany({}, { isDeleted: true })"
 await q.then(() => console.log('Update 3'));
 ```
+
+## Pagination
+
+There are two common approaches to pagination: skip/limit pagination and
+cursor-based pagination.
+
+Skip/limit pagination, also called offset pagination, uses `sort()`, `skip()`,
+and `limit()` to retrieve a page at a particular offset.
+If the UI needs the exact total number of matching documents, run `find()` and `countDocuments()` separately:
+
+```javascript
+const filter = { active: true };
+const options = { sort: { createdAt: -1 }, skip: 20, limit: 20 };
+
+const [documents, total] = await Promise.all([
+  User.find(filter, null, options),
+  User.countDocuments(filter)
+]);
+```
+
+This pattern is sufficiently common that Mongoose provides a convenience wrapper `Model.findAndCount()` around these two operations:
+
+```javascript
+// The following...
+const [documents, total] = await User.findAndCount(filter, null, options);
+
+// is equivalent to:
+const [documents, total] = await Promise.all([
+  User.find(filter, null, options),
+  User.countDocuments(filter)
+]);
+```
+
+For large result sets, `skip()` can be inefficient, particularly when frequently calling `skip()` with large values.
+`skip()` has to loop through the documents to skip - `.limit(20).skip(100)` means MongoDB needs to iterate through 120 documents.
+Performance degrades linearly as `skip()` size grows.
+
+Instead of an offset, use a value from the last document on the previous page,
+such as `_id` or a timestamp, in the next filter.
+For example, with a descending `_id` sort:
+
+```javascript
+const filter = lastSeenId == null ? {} : { _id: { $lt: lastSeenId } };
+const documents = await User.find(filter).sort({ _id: -1 }).limit(20);
+```
+
+Presuming you filter by an indexed field (MongoDB collections always have an index on `_id`), cursor-based pagination provides consistent performance as the number of documents to skip grows.
 
 ## References to other documents {#refs}
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2134,6 +2134,48 @@ Model.find = function find(conditions, projection, options) {
 };
 
 /**
+ * Finds documents and counts the number of documents matching the filter.
+ *
+ * The count ignores options that only affect the shape of the find results,
+ * including projection, sort, skip, limit, populate, and lean.
+ *
+ * #### Example:
+ *
+ *     const [adventures, total] = await Adventure.findAndCount(
+ *       { type: 'jungle' },
+ *       null,
+ *       { sort: { name: 1 }, skip: 10, limit: 10 }
+ *     );
+ *
+ * @param {object|ObjectId} filter
+ * @param {object|string|string[]} [projection] optional fields to return
+ * @param {object} [options] optional query options
+ * @return {Promise<Array>} a promise that resolves to `[documents, total]`
+ * @api public
+ */
+
+Model.findAndCount = async function findAndCount(conditions, projection, options) {
+  _checkContext(this, 'findAndCount');
+
+  const findQuery = this.find(conditions, projection, options);
+  const countQuery = findQuery.clone().countDocuments();
+
+  // countDocuments() only uses the filter and execution options. Clear the
+  // find query's result-shaping state from the clone before executing it.
+  countQuery._fields = null;
+  countQuery._mongooseOptions = { ...countQuery._mongooseOptions };
+  delete countQuery._mongooseOptions.populate;
+  delete countQuery._mongooseOptions.lean;
+  delete countQuery.options.projection;
+  delete countQuery.options.fields;
+  delete countQuery.options.sort;
+  delete countQuery.options.skip;
+  delete countQuery.options.limit;
+
+  return Promise.all([findQuery.exec(), countQuery.exec()]);
+};
+
+/**
  * Finds a single document by its _id field. `findById(id)` is equivalent to `findOne({ _id: id })`.
  *
  * The `id` is cast based on the Schema before sending the command.

--- a/lib/model.js
+++ b/lib/model.js
@@ -2146,6 +2146,9 @@ Model.find = function find(conditions, projection, options) {
  *       { sort: { name: 1 }, skip: 10, limit: 10 }
  *     );
  *
+ *     adventures; // Array of at most 10 documents matching type 'jungle'
+ *     total; // Number of documents matching type 'jungle'
+ *
  * @param {object|ObjectId} filter
  * @param {object|string|string[]} [projection] optional fields to return
  * @param {object} [options] optional query options
@@ -2155,6 +2158,13 @@ Model.find = function find(conditions, projection, options) {
 
 Model.findAndCount = async function findAndCount(conditions, projection, options) {
   _checkContext(this, 'findAndCount');
+
+  if (!options.sort) {
+    throw new Error('options.sort is required');
+  }
+  if (!options.limit) {
+    throw new Error('options.limit is required');
+  }
 
   const findQuery = this.find(conditions, projection, options);
   const countQuery = findQuery.clone().countDocuments().skip(0).limit(null);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2136,8 +2136,7 @@ Model.find = function find(conditions, projection, options) {
 /**
  * Finds documents and counts the number of documents matching the filter.
  *
- * The count ignores options that only affect the shape of the find results,
- * including projection, sort, skip, limit, populate, and lean.
+ * This function fires both `find` and `countDocuments` middleware.
  *
  * #### Example:
  *
@@ -2158,19 +2157,7 @@ Model.findAndCount = async function findAndCount(conditions, projection, options
   _checkContext(this, 'findAndCount');
 
   const findQuery = this.find(conditions, projection, options);
-  const countQuery = findQuery.clone().countDocuments();
-
-  // countDocuments() only uses the filter and execution options. Clear the
-  // find query's result-shaping state from the clone before executing it.
-  countQuery._fields = null;
-  countQuery._mongooseOptions = { ...countQuery._mongooseOptions };
-  delete countQuery._mongooseOptions.populate;
-  delete countQuery._mongooseOptions.lean;
-  delete countQuery.options.projection;
-  delete countQuery.options.fields;
-  delete countQuery.options.sort;
-  delete countQuery.options.skip;
-  delete countQuery.options.limit;
+  const countQuery = findQuery.clone().countDocuments().skip(0).limit(null);
 
   return Promise.all([findQuery.exec(), countQuery.exec()]);
 };

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -2509,20 +2509,12 @@ describe('model', function() {
       shippingAddress: addressSchema
     };
 
-<<<<<<< HEAD
     const orderSchema = new Schema(orderSchemaDefinition, { autoIndex: false });
-=======
-    const orderSchema = new Schema(orderSchemaDefinition);
->>>>>>> 8.x
     orderSchema.index({ customerId: 1 });
 
     const Order = db.model('Order', orderSchema);
 
-<<<<<<< HEAD
     const wholesaleOrderSchema = new Schema({ ...orderSchemaDefinition, vendorCode: String }, { autoIndex: false });
-=======
-    const wholesaleOrderSchema = new Schema({ ...orderSchemaDefinition, vendorCode: String });
->>>>>>> 8.x
     wholesaleOrderSchema.index({ vendorCode: 1 });
 
     // Act
@@ -2531,20 +2523,11 @@ describe('model', function() {
     const wholesaleDiff = await WholesaleOrder.diffIndexes();
 
     // Assert
-<<<<<<< HEAD
     assert.deepStrictEqual(orderSchema._indexes, [
       [{ customerId: 1 }, {}]
     ]);
     assert.deepStrictEqual(wholesaleOrderSchema._indexes, [
       [{ vendorCode: 1 }, { partialFilterExpression: { __t: 'WholesaleOrder' } }]
-=======
-    // Note: on 8.x, getIndexes() adds `background: true` to stored index options
-    assert.deepStrictEqual(orderSchema._indexes, [
-      [{ customerId: 1 }, { background: true }]
-    ]);
-    assert.deepStrictEqual(wholesaleOrderSchema._indexes, [
-      [{ vendorCode: 1 }, { background: true, partialFilterExpression: { __t: 'WholesaleOrder' } }]
->>>>>>> 8.x
     ]);
 
     assert.deepStrictEqual(orderDiff, {
@@ -2553,10 +2536,7 @@ describe('model', function() {
         { customerId: 1 }
       ]
     });
-<<<<<<< HEAD
 
-=======
->>>>>>> 8.x
     assert.deepStrictEqual(wholesaleDiff, {
       toDrop: [],
       toCreate: [
@@ -2590,8 +2570,4 @@ describe('model', function() {
     );
     assert.strictEqual(testMethodCalls.length, 1);
   });
-<<<<<<< HEAD
-
-=======
->>>>>>> 8.x
 });

--- a/test/model.findAndCount.test.js
+++ b/test/model.findAndCount.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const start = require('./common');
+const assert = require('assert');
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('model: findAndCount:', function() {
+  let db;
+
+  before(function() {
+    db = start();
+  });
+
+  after(async function() {
+    await db.close();
+  });
+
+  beforeEach(() => db.deleteModel(/.*/));
+  afterEach(() => require('./util').clearTestData(db));
+  afterEach(() => require('./util').stopRemainingOps(db));
+
+  it('returns find results and the unpaginated count', async function() {
+    const Test = db.model('Test', new Schema({ name: String, value: Number }));
+    await Test.create([
+      { name: 'a', value: 1 },
+      { name: 'b', value: 2 },
+      { name: 'c', value: 3 }
+    ]);
+
+    const result = Test.findAndCount({}, { name: 1, _id: 0 }, { sort: { value: -1 }, skip: 1, limit: 1 });
+    assert.ok(result instanceof Promise);
+    assert.equal(result instanceof mongoose.Query, false);
+
+    const [docs, total] = await result;
+    assert.deepEqual(docs.map(doc => doc.name), ['b']);
+    assert.equal(docs[0]._id, undefined);
+    assert.equal(total, 3);
+  });
+
+  it('runs find and countDocuments middleware', async function() {
+    const calls = [];
+    const schema = new Schema({ name: String });
+    schema.pre('find', function() { calls.push('find:pre'); });
+    schema.post('find', function() { calls.push('find:post'); });
+    schema.pre('countDocuments', function() { calls.push('count:pre'); });
+    schema.post('countDocuments', function() { calls.push('count:post'); });
+    const Test = db.model('Test', schema);
+    await Test.create({ name: 'a' });
+
+    await Test.findAndCount({});
+    assert.deepEqual(calls.sort(), ['count:post', 'count:pre', 'find:post', 'find:pre']);
+  });
+
+  it('does not apply lean or populate to the count query', async function() {
+    const Child = db.model('Child', new Schema({ name: String }));
+    const Test = db.model('Test', new Schema({ child: { type: Schema.Types.ObjectId, ref: 'Child' } }));
+    const child = await Child.create({ name: 'child' });
+    await Test.create({ child });
+
+    const [docs, total] = await Test.findAndCount({}, null, { lean: true, populate: 'child' });
+    assert.equal(docs[0] instanceof mongoose.Document, false);
+    assert.equal(docs[0].child.name, 'child');
+    assert.equal(total, 1);
+  });
+});

--- a/test/model.findAndCount.test.js
+++ b/test/model.findAndCount.test.js
@@ -40,13 +40,18 @@ describe('model: findAndCount:', function() {
 
   it('supports string and array projections', async function() {
     const Test = db.model('Test', new Schema({ name: String, value: Number }));
+    await Test.deleteMany({});
     await Test.create([
       { name: 'a', value: 1 },
       { name: 'b', value: 2 }
     ]);
 
     for (const projection of ['name -_id', ['name', '-_id']]) {
-      const [docs, total] = await Test.findAndCount({}, projection);
+      const [docs, total] = await Test.findAndCount(
+        {},
+        projection,
+        { sort: { name: 1 }, limit: 10 }
+      );
       assert.deepEqual(docs.map(doc => doc.toObject()), [
         { name: 'a' },
         { name: 'b' }
@@ -65,7 +70,7 @@ describe('model: findAndCount:', function() {
     const Test = db.model('Test', schema);
     await Test.create({ name: 'a' });
 
-    await Test.findAndCount({});
+    await Test.findAndCount({}, null, { sort: { name: 1 }, limit: 10 });
     assert.deepEqual(calls.sort(), ['count:post', 'count:pre', 'find:post', 'find:pre']);
   });
 
@@ -75,7 +80,7 @@ describe('model: findAndCount:', function() {
     const child = await Child.create({ name: 'child' });
     await Test.create({ child });
 
-    const [docs, total] = await Test.findAndCount({}, null, { lean: true, populate: 'child' });
+    const [docs, total] = await Test.findAndCount({}, null, { sort: { _id: 1 }, limit: 10, lean: true, populate: 'child' });
     assert.equal(docs[0] instanceof mongoose.Document, false);
     assert.equal(docs[0].child.name, 'child');
     assert.equal(total, 1);

--- a/test/model.findAndCount.test.js
+++ b/test/model.findAndCount.test.js
@@ -38,6 +38,23 @@ describe('model: findAndCount:', function() {
     assert.equal(total, 3);
   });
 
+  it('supports string and array projections', async function() {
+    const Test = db.model('Test', new Schema({ name: String, value: Number }));
+    await Test.create([
+      { name: 'a', value: 1 },
+      { name: 'b', value: 2 }
+    ]);
+
+    for (const projection of ['name -_id', ['name', '-_id']]) {
+      const [docs, total] = await Test.findAndCount({}, projection);
+      assert.deepEqual(docs.map(doc => doc.toObject()), [
+        { name: 'a' },
+        { name: 'b' }
+      ]);
+      assert.equal(total, 2);
+    }
+  });
+
   it('runs find and countDocuments middleware', async function() {
     const calls = [];
     const schema = new Schema({ name: String });

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -79,6 +79,15 @@ Test.find().byName('test').byName('test2').orFail().exec().then(console.log);
 Test.countDocuments({ name: /Test/ }).exec().then((res: number) => console.log(res));
 Test.findOne({ 'docs.id': 42 }).exec().then(console.log);
 
+Test.findAndCount({ name: /Test/ }).then(([docs, count]) => {
+  expect(docs[0].name).type.toBe<string | undefined>();
+  expect<typeof count>().type.toBe<number>();
+});
+Test.findAndCount({ name: /Test/ }, null, { lean: true }).then(([docs, count]) => {
+  expect(docs[0].name).type.toBe<string | undefined>();
+  expect<typeof count>().type.toBe<number>();
+});
+
 // ObjectId casting
 Test.find({ parent: new Types.ObjectId('0'.repeat(24)) });
 Test.find({ parent: '0'.repeat(24) });

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -85,11 +85,11 @@ Test.find().byName('test').byName('test2').orFail().exec().then(console.log);
 Test.countDocuments({ name: /Test/ }).exec().then((res: number) => console.log(res));
 Test.findOne({ 'docs.id': 42 }).exec().then(console.log);
 
-Test.findAndCount({ name: /Test/ }).then(([docs, count]) => {
+Test.findAndCount({ name: /Test/ }, null, { sort: { name: 1 }, limit: 10 }).then(([docs, count]) => {
   expect(docs[0].name).type.toBe<string | undefined>();
   expect<typeof count>().type.toBe<number>();
 });
-Test.findAndCount({ name: /Test/ }, null, { lean: true }).then(([docs, count]) => {
+Test.findAndCount({ name: /Test/ }, null, { sort: { name: 1 }, limit: 10, lean: true }).then(([docs, count]) => {
   expect(docs[0].name).type.toBe<string | undefined>();
   expect<typeof count>().type.toBe<number>();
 });

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -96,7 +96,7 @@ declare module 'mongoose' {
 
     /** Returns the model with the given name on this document's associated connection. */
     $model<ModelType extends Model<unknown>>(name: string): ModelType;
-    $model<ModelType extends Model<DocType>>(): ModelType;
+    $model<ModelType extends Model<DocType, any, any, any>>(): ModelType;
 
     /**
      * A string containing the current operation that Mongoose is executing
@@ -232,7 +232,7 @@ declare module 'mongoose' {
 
     /** Returns the model with the given name on this document's associated connection. */
     model<ModelType extends Model<unknown>>(name: string): ModelType;
-    model<ModelType extends Model<DocType>>(): ModelType;
+    model<ModelType extends Model<DocType, any, any, any>>(): ModelType;
 
     /** Returns the list of paths that have been modified. */
     modifiedPaths(options?: { includeChildren?: boolean }): Array<string>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -841,6 +841,23 @@ declare module 'mongoose' {
       TInstanceMethods & TVirtuals
     >;
 
+    /** Finds documents and counts the number of documents matching `filter`. */
+    findAndCount<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
+    ): Promise<[GetLeanResultType<TRawDocType, TRawDocType[], 'find'>, number]>;
+    findAndCount<ResultDoc = THydratedDocumentType>(
+      filter: QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
+    ): Promise<[ResultDoc[], number]>;
+    findAndCount<ResultDoc = THydratedDocumentType>(
+      filter?: QueryFilter<TRawDocType>,
+      projection?: ProjectionType<TRawDocType> | null | undefined,
+      options?: QueryOptions<TRawDocType> & mongodb.Abortable
+    ): Promise<[HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[], number]>;
+
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -845,17 +845,17 @@ declare module 'mongoose' {
     findAndCount<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
+      options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: true } & mongodb.Abortable
     ): Promise<[GetLeanResultType<TRawDocType, TRawDocType[], 'find'>, number]>;
     findAndCount<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
+      options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: false } & mongodb.Abortable
     ): Promise<[ResultDoc[], number]>;
     findAndCount<ResultDoc = THydratedDocumentType>(
-      filter?: QueryFilter<TRawDocType>,
-      projection?: ProjectionType<TRawDocType> | null | undefined,
-      options?: QueryOptions<TRawDocType> & mongodb.Abortable
+      filter: QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { sort: any; limit: number } & mongodb.Abortable
     ): Promise<[HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[], number]>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */


### PR DESCRIPTION
Fix #16454

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Add `await Model.findAndCount()` as a convenience wrapper around calling `find()` and `countDocuments()` in parallel with the same filter for pagination.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
