### PR TITLE
fix(schema): remove a map that lives under a nested path

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2764,9 +2764,6 @@ Schema.prototype.remove = function(path) {
           }
         }
 
-        // Maps under this branch register their values in `mapPaths` as well as in
-        // `paths`. Left behind, they keep answering `pathType()` and casting queries
-        // for a path the schema no longer has.
         this.mapPaths = this.mapPaths.filter(
           schemaType => !schemaType.path.startsWith(name + '.')
         );

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2764,6 +2764,13 @@ Schema.prototype.remove = function(path) {
           }
         }
 
+        // Maps under this branch register their values in `mapPaths` as well as in
+        // `paths`. Left behind, they keep answering `pathType()` and casting queries
+        // for a path the schema no longer has.
+        this.mapPaths = this.mapPaths.filter(
+          schemaType => !schemaType.path.startsWith(name + '.')
+        );
+
         delete this.nested[name];
         _deletePath(this, name);
         return;
@@ -2801,6 +2808,11 @@ function _deletePath(schema, name) {
 
   for (const piece of pieces) {
     branch = branch[piece];
+    // A synthetic subpath like `<map>.$*` has no branch of its own, and a parent
+    // removed earlier in the same pass leaves none either.
+    if (branch == null) {
+      return;
+    }
   }
 
   delete branch[last];

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2805,8 +2805,6 @@ function _deletePath(schema, name) {
 
   for (const piece of pieces) {
     branch = branch[piece];
-    // A synthetic subpath like `<map>.$*` has no branch of its own, and a parent
-    // removed earlier in the same pass leaves none either.
     if (branch == null) {
       return;
     }

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1766,6 +1766,23 @@ describe('schema', function() {
 
     });
 
+    it('removes a map that lives under a nested path', function() {
+      const schema = new Schema({
+        n: { m: { type: Map, of: Number } },
+        other: String
+      }, { autoCreate: false, autoIndex: false });
+
+      // Used to throw, because the map values subpath has no branch of its own
+      // in the tree and its parent had already been deleted in the same pass
+      assert.doesNotThrow(() => schema.remove('n'));
+
+      assert.strictEqual(schema.path('n.m'), undefined);
+      assert.strictEqual(schema.path('n.m.$*'), undefined);
+      assert.equal(schema.pathType('n.m'), 'adhocOrUndefined');
+      assert.equal(schema.pathType('n.m.key'), 'adhocOrUndefined');
+      assert.ok(schema.path('other'));
+    });
+
     it('removes an array of paths', function() {
       this.schema.remove(['e', 'f', 'g']);
       assert.strictEqual(this.schema.path('e'), undefined);


### PR DESCRIPTION
Follow up to #16457, which covered the flat case. The nested branch of `Schema#remove()` has the same two problems, and one of them throws:

```js
const schema = new Schema({ n: { m: { type: Map, of: Number } } });
schema.remove('n');
// TypeError: Cannot convert undefined or null to object
//     at _deletePath (lib/schema.js:2806:17)
```

A map registers its values under `<path>.$*` in `paths`, so the nested branch walks `['n.m', 'n.m.$*']` and calls `_deletePath` on each. `_deletePath` walks `schema.tree` down the pieces, and by the time it gets to `n.m.$*` the parent `tree.n.m` has already been deleted by the previous iteration, so `branch` is `undefined` and the `delete` throws. `$*` has no branch of its own in the tree in any case.

So `_deletePath` now stops when a piece along the way is missing. Nothing to delete is not an error there.

With that out of the way the second problem shows: the nested branch never filtered `mapPaths`, which is what the flat branch does. Measured after `schema.remove('n')`, before and after:

| | `paths` | `mapPaths` | `pathType('n.m')` |
| --- | --- | --- | --- |
| before | `['_id']` | `['n.m.$*']` | `real` |
| after | `['_id']` | `[]` | `adhocOrUndefined` |

So the schema kept answering for a path it had just removed, which is the same thing #16457 described, only reached through a nested parent. Both branches now do the same cleanup.

Test in the `remove()` block. It fails on `master` on the first assertion, since `remove` throws before the rest runs.

`test/schema.test.js` passes 225. Full `npm test` here matches master, the only failure being an `eachAsync` timeout that reproduces on a clean checkout on this machine. `eslint` is clean.
