### PR TITLE
fix(schema): clone a document array element with its own constructor signature

### DIFF
--- a/lib/schema/documentArrayElement.js
+++ b/lib/schema/documentArrayElement.js
@@ -119,14 +119,26 @@ SchemaDocumentArrayElement.prototype.doValidate = async function doValidate(valu
  */
 
 SchemaDocumentArrayElement.prototype.clone = function() {
-  this.options.$parentSchemaType = this.$parentSchemaType;
-  const ret = SchemaType.prototype.clone.apply(this, arguments);
-  delete this.options.$parentSchemaType;
+  // This schematype takes the subdocument schema where `SchemaType` takes the
+  // options, so it cannot go through `SchemaType.prototype.clone()`: the
+  // arguments would land in the wrong parameters and `$parentSchemaType` would
+  // never reach the constructor.
+  const options = Object.assign({}, this.options, {
+    $parentSchemaType: this.$parentSchemaType,
+    Constructor: this.Constructor
+  });
+  const schematype = new this.constructor(
+    this.path,
+    this.schema,
+    options,
+    this.parentSchema
+  );
+  schematype.validators = this.validators.slice();
+  if (this.requiredValidator !== undefined) {
+    schematype.requiredValidator = this.requiredValidator;
+  }
 
-  ret.Constructor = this.Constructor;
-  ret.schema = this.schema;
-
-  return ret;
+  return schematype;
 };
 
 /*!

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1832,6 +1832,33 @@ describe('schema', function() {
     });
 
     describe('clone()', function() {
+      it('works with an array of document arrays (gh-16462)', function() {
+        const schema = new Schema({ a: [[{ x: Number }]] });
+
+        const clone = schema.clone();
+        assert.deepStrictEqual(Object.keys(clone.paths).sort(), ['_id', 'a']);
+        assert.deepStrictEqual(Object.keys(clone.subpaths).sort(), ['a.$', 'a.$.$']);
+        assert.equal(clone.subpaths['a.$.$'].instance, 'DocumentArrayElement');
+        assert.ok(clone.subpaths['a.$.$'].$parentSchemaType);
+      });
+
+      it('carries the document array element over to the copy (gh-16462)', function() {
+        const schema = new Schema({ a: [[{ x: { type: Number, default: 3 } }]] });
+
+        const clone = schema.clone();
+        const original = schema.subpaths['a.$.$'];
+        const copy = clone.subpaths['a.$.$'];
+        assert.notStrictEqual(copy, original);
+        assert.strictEqual(copy.schema, original.schema);
+        assert.strictEqual(copy.Constructor, original.Constructor);
+        assert.ok(copy.$parentSchemaType);
+
+        const M = mongoose.model('gh16462', clone);
+        const doc = new M({ a: [[{}, { x: 7 }]] });
+        assert.equal(doc.a[0][0].x, 3);
+        assert.equal(doc.a[0][1].x, 7);
+      });
+
       it('copies methods, statics, and query helpers (gh-5752)', function() {
         const schema = new Schema({});
 


### PR DESCRIPTION
Fixes #16462.

`SchemaDocumentArrayElement.prototype.clone()` delegated the construction to `SchemaType.prototype.clone()`:

```js
new this.constructor(this.path, options, this.instance, this.parentSchema);
```

That signature is `(path, options, instance, parentSchema)`, but this schematype's is `(path, schema, options, parentSchema)`. So `options` went into the `schema` parameter and the string `'DocumentArrayElement'` into `options`, and the constructor read `options?.$parentSchemaType` off a string and threw. Putting `$parentSchemaType` back on `this.options` first, as the old code did, could not help: the argument it was riding on never reached the parameter that gets read.

It was broken for every document array, not only the nested case:

```js
new Schema({ b: [{ x: Number }] }).path('b').embeddedSchemaType.clone();
// MongooseError: Cannot create DocumentArrayElement schematype without a parent
```

A plain document array never reaches it. `Schema.prototype._clone` clones the `b` path through `SchemaDocumentArray.prototype.clone()` and the element rides along with the subdocument schema. The element is only cloned on its own when it sits in `subpaths`, which happens for an array of document arrays:

```js
new Schema({ a: [[{ x: Number }]] }).subpaths;
// { 'a.$': SchemaDocumentArray, 'a.$.$': SchemaDocumentArrayElement }
```

so `s.subpaths = clone(this.subpaths)` in `_clone` reaches `lib/helpers/clone.js`, which calls `.clone()` on it directly, and `schema.clone()` throws. `{ o: [{ a: [[{ x: Number }]] }] }` and `{ a: [[[{ x: Number }]]] }` throw for the same reason. An array of a primitive array is fine, since `g.$.$` is a `SchemaNumber`.

The shape itself is supported. It casts, gives each item an `_id`, applies defaults and validates. Only `clone()` was out of step.

## The change

Construct directly, which is what the two sibling schematypes with an unusual signature already do: `SchemaSubdocument.prototype.clone()` and `SchemaDocumentArray.prototype.clone()`. `$parentSchemaType` and `Constructor` go in through `options`, where the constructor expects them, and `schema` goes into its own parameter, so the copy no longer needs the two assignments that were patching up the result afterwards.

Nothing in the old path is lost. It never produced a working copy to preserve behavior from.

## Tests

Two in the `clone()` group of `test/schema.test.js`. The first is the throw itself plus the subpaths of the copy, the second checks the copy is a distinct object that kept the subdocument schema, the `Constructor` and the parent link, and that a model built from the copy still applies the defaults declared inside. Both fail on `master` with the error above.

Ran locally: `schema*.test.js`, `types.array.test.js`, `types.documentarray.test.js` and `document.test.js`, 1239 passing, plus `model.test.js`, 396 passing and 15 pending.
