### PR TITLE
feat(schema): add Schema.prototype.queryHelper() to make it easier to define query helpers in TypeScript

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2272,6 +2272,37 @@ Schema.prototype.plugin = function(fn, opts) {
 };
 
 /**
+ * Adds a query helper to this schema. Equivalent to `schema.query[name] = fn`.
+ *
+ * #### Example:
+ *
+ *     schema.queryHelper('byName', function(name) {
+ *       return this.where({ name });
+ *     });
+ *     const Test = mongoose.model('Test', schema);
+ *     await Test.find().byName('John'); // Equivalent to `Test.find({ name: 'John' })`
+ *
+ * @param {string} name The query helper name.
+ * @param {Function} fn The query helper function.
+ * @return {Schema} this
+ * @api public
+ */
+
+Schema.prototype.queryHelper = function queryHelper(name, fn) {
+  if (typeof name !== 'string') {
+    throw new MongooseError('First param to `schema.queryHelper()` must be a string, ' +
+      'got "' + (typeof name) + '"');
+  }
+  if (typeof fn !== 'function') {
+    throw new MongooseError('Second param to `schema.queryHelper()` must be a function, ' +
+      'got "' + (typeof fn) + '"');
+  }
+
+  this.query[name] = fn;
+  return this;
+};
+
+/**
  * Adds an instance method to documents constructed from Models compiled from this schema.
  *
  * #### Example:

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1846,6 +1846,18 @@ describe('schema', function() {
 
       });
 
+      it('adds query helpers with queryHelper()', function() {
+        const schema = new Schema({ name: String });
+        const helper = function(name) {
+          return this.where({ name });
+        };
+
+        assert.strictEqual(schema.queryHelper('byName', helper), schema);
+        assert.strictEqual(schema.query.byName, helper);
+        assert.throws(() => schema.queryHelper(42, helper), /First param to `schema.queryHelper\(\)` must be a string/);
+        assert.throws(() => schema.queryHelper('byName', 'not a function'), /Second param to `schema.queryHelper\(\)` must be a function/);
+      });
+
       it('copies validators declared with validate() (gh-5607)', function() {
         const schema = new Schema({
           num: Number

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -72,6 +72,12 @@ expect<mongoose.WithLevel1NestedPaths<ITest>['docs.id']>().type.toBe<number | un
 
 const Test = model<ITest, Model<ITest, QueryHelpers>>('Test', schema);
 
+const schemaWithQueryHelper = new Schema<{ name: string }>({ name: String }).queryHelper('byName', function(name: string) {
+  return this.where({ name });
+});
+const ModelWithQueryHelper = model('ModelWithQueryHelper', schemaWithQueryHelper);
+ModelWithQueryHelper.find().byName('test').exec();
+
 Test.find({}, {}, { populate: { path: 'child', model: ChildModel, match: true } }).exec().then((res: Array<ITest>) => console.log(res));
 
 Test.find().byName('test').byName('test2').orFail().exec().then(console.log);

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -72,7 +72,7 @@ expect<mongoose.WithLevel1NestedPaths<ITest>['docs.id']>().type.toBe<number | un
 
 const Test = model<ITest, Model<ITest, QueryHelpers>>('Test', schema);
 
-const schemaWithQueryHelper = new Schema<{ name: string }>({ name: String }).queryHelper('byName', function(name: string) {
+const schemaWithQueryHelper = new Schema({ name: String }).queryHelper('byName', function(name: string) {
   return this.where({ name });
 });
 const ModelWithQueryHelper = model('ModelWithQueryHelper', schemaWithQueryHelper);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -493,6 +493,24 @@ declare module 'mongoose' {
     method<Context = THydratedDocumentType>(name: string, fn: (this: Context, ...args: any[]) => any, opts?: any): this;
     method(obj: Partial<TInstanceMethods>): this;
 
+    /** Adds a query helper to this schema. */
+    queryHelper<Name extends string, Fn extends (this: QueryWithHelpers<any, DocType, TQueryHelpers, RawDocType>, ...args: any[]) => any>(
+      name: Name,
+      fn: Fn
+    ): Schema<
+      RawDocType,
+      TModelType,
+      TInstanceMethods,
+      TQueryHelpers & { [K in Name]: Fn },
+      TVirtuals,
+      TStaticMethods,
+      TSchemaOptions,
+      DocType,
+      THydratedDocumentType,
+      TSchemaDefinition,
+      LeanResultType
+    >;
+
     /** Object of currently defined methods on this schema. */
     methods: AddThisParameter<TInstanceMethods, THydratedDocumentType> & AnyObject;
 


### PR DESCRIPTION
Re: #16410

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Currently adding a query helper to a schema in a plugin in TypeScript is a bit clunky - if you don't know the explicit schema type you need a cast:

```ts
const queryMethods = schema.query as unknown as {
    after(this: Query<any, any>, boundary: Record<string, unknown>, sort: CursorSort): Query<any, any>;
  };
```

This PR adds a `schema.queryHelper(name, fn)` function that adds a given query helper to the schema at runtime. In TypeScript, `queryHelper()` also returns the schema type with the query helper added, so `const newSchema = schema.queryHelper('byName', fn)` means any model compiled from `newSchema` would know about the `byName` query helper.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
