### PR TITLE
feat(Model): add Model.findAndCount() for paginated queries

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2120,6 +2120,32 @@ Model.deleteMany = function deleteMany(conditions, options) {
  * @api public
  */
 
+/**
+ * Finds documents and returns them along with the total count of documents matching the filter.
+ *
+ * @param {Object|ObjectId} conditions
+ * @param {Object|String} [projection] optional fields to return, see [`Query.prototype.select()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.select())
+ * @param {Object} [options] optional see [`Query.prototype.setOptions()`](https://mongoosejs.com/docs/api/query.html#Query.prototype.setOptions())
+ * @return {Promise} returns a Promise that resolves to an array `[documents, totalCount]`
+ * @api public
+ */
+
+Model.findAndCount = async function findAndCount(conditions, projection, options) {
+  _checkContext(this, 'findAndCount');
+  if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {
+    throw new MongooseError('Model.findAndCount() no longer accepts a callback');
+  }
+
+  const countOptions = options != null ? Object.assign({}, options) : {};
+  delete countOptions.skip;
+  delete countOptions.limit;
+
+  return Promise.all([
+    this.find(conditions, projection, options),
+    this.countDocuments(conditions, countOptions)
+  ]);
+};
+
 Model.find = function find(conditions, projection, options) {
   _checkContext(this, 'find');
   if (typeof arguments[0] === 'function' || typeof arguments[1] === 'function' || typeof arguments[2] === 'function' || typeof arguments[3] === 'function') {

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -792,6 +792,22 @@ declare module 'mongoose' {
       'find',
       TInstanceMethods & TVirtuals
     >;
+
+    findAndCount(
+      filter: Query<any, any> | QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
+    ): Promise<[GetLeanResultType<TRawDocType, TRawDocType[], 'find'>, number]>;
+    findAndCount<ResultDoc = THydratedDocumentType>(
+      filter: Query<any, any> | QueryFilter<TRawDocType>,
+      projection: ProjectionType<TRawDocType> | null | undefined,
+      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
+    ): Promise<[ResultDoc[], number]>;
+    findAndCount(
+      filter?: Query<any, any> | QueryFilter<TRawDocType>,
+      projection?: ProjectionType<TRawDocType> | null | undefined,
+      options?: QueryOptions<TRawDocType> & mongodb.Abortable
+    ): Promise<[HasLeanOption<TSchema> extends true ? TLeanResultType[] : THydratedDocumentType[], number]>;
     find(
       filter: Query<any, any>,
       projection: ProjectionType<TRawDocType> | null | undefined,


### PR DESCRIPTION
Fixes #16454.

This PR introduces Model.findAndCount(conditions, projection, options) which returns a Promise resolving to [documents, totalCount].

### Implementation Details:
- The method wraps both 	his.find() and 	his.countDocuments().
- Result-shaping options that should not affect the total count (skip and limit) are stripped from the options object before passing them to countDocuments().
- Compatible execution options (session, hint, read preference) are still correctly forwarded to both queries where supported.
- TypeScript definitions have been added to 	ypes/models.d.ts extending the strong type inference behavior of ind() (including lean types and projections) onto the returned documents tuple.

This provides an ergonomic, native wrapper for the very common pattern of running parallel find and count queries during offset-based pagination.