### PR TITLE
fix(discriminator): prevent indexes and callQueue duplication with shared nested schemas #15966 (8.x backport)

### DIFF
--- a/lib/helpers/discriminator/mergeDiscriminatorSchema.js
+++ b/lib/helpers/discriminator/mergeDiscriminatorSchema.js
@@ -46,6 +46,11 @@ module.exports = function mergeDiscriminatorSchema(to, from, path, seen) {
     if (specialProperties.has(key)) {
       continue;
     }
+    if (key === 'parentSchema') {
+      // Skip parentSchema to avoid merging parent schema multiple times
+      // through child paths' back-references (gh-15966)
+      continue;
+    }
     if (to[key] == null) {
       to[key] = from[key];
     } else if (isObject(from[key])) {

--- a/test/model.discriminator.test.js
+++ b/test/model.discriminator.test.js
@@ -2400,4 +2400,123 @@ describe('model', function() {
     assert.equal(documentPreSaveHooks.length, 1);
     assert.equal(documentPreSaveHooks[0], discriminator);
   });
+
+  it('does not duplicate _indexes when base and discriminator schemas share nested schema (gh-15966)', async function() {
+    // Arrange
+    const addressSchema = new Schema({ city: String, street: String }, { _id: false });
+    const orderSchemaDefinition = {
+      customerId: { type: Schema.Types.ObjectId },
+      createdAt: Date,
+      orderNumber: String,
+      billingAddress: addressSchema,
+      shippingAddress: addressSchema,
+      notes: [{ message: String }]
+    };
+
+    const orderSchema = new Schema(orderSchemaDefinition);
+    orderSchema.index({ customerId: 1, createdAt: -1 });
+    orderSchema.index({ orderNumber: 1, customerId: 1 });
+    orderSchema.index({ 'billingAddress.city': 1, customerId: 1 });
+
+    const Order = db.model('Order', orderSchema);
+    const wholesaleOrderSchema = new Schema(orderSchemaDefinition);
+
+    // Act
+    const WholesaleOrder = Order.discriminator('WholesaleOrder', wholesaleOrderSchema, { clone: false });
+    const wholesaleDiff = await WholesaleOrder.diffIndexes();
+    const orderDiff = await Order.diffIndexes();
+
+    // Assert
+    // Note: on 8.x, getIndexes() adds `background: true` to stored index options
+    assert.deepStrictEqual(orderSchema._indexes, [
+      [{ customerId: 1, createdAt: -1 }, { background: true }],
+      [{ orderNumber: 1, customerId: 1 }, { background: true }],
+      [{ 'billingAddress.city': 1, customerId: 1 }, { background: true }]
+    ]);
+    assert.deepStrictEqual(wholesaleOrderSchema._indexes, []);
+
+    assert.deepStrictEqual(orderDiff, {
+      toDrop: [],
+      toCreate: [
+        { customerId: 1, createdAt: -1 },
+        { orderNumber: 1, customerId: 1 },
+        { 'billingAddress.city': 1, customerId: 1 }
+      ]
+    });
+    assert.deepStrictEqual(wholesaleDiff, {
+      toDrop: [],
+      toCreate: []
+    });
+  });
+
+  it('preserves discriminator-specific indexes (gh-15966)', async function() {
+    // Arrange
+    const addressSchema = new Schema({ city: String, street: String }, { _id: false });
+    const orderSchemaDefinition = {
+      customerId: { type: Schema.Types.ObjectId },
+      billingAddress: addressSchema,
+      shippingAddress: addressSchema
+    };
+
+    const orderSchema = new Schema(orderSchemaDefinition);
+    orderSchema.index({ customerId: 1 });
+
+    const Order = db.model('Order', orderSchema);
+
+    const wholesaleOrderSchema = new Schema({ ...orderSchemaDefinition, vendorCode: String });
+    wholesaleOrderSchema.index({ vendorCode: 1 });
+
+    // Act
+    const WholesaleOrder = Order.discriminator('WholesaleOrder', wholesaleOrderSchema, { clone: false });
+    const orderDiff = await Order.diffIndexes();
+    const wholesaleDiff = await WholesaleOrder.diffIndexes();
+
+    // Assert
+    // Note: on 8.x, getIndexes() adds `background: true` to stored index options
+    assert.deepStrictEqual(orderSchema._indexes, [
+      [{ customerId: 1 }, { background: true }]
+    ]);
+    assert.deepStrictEqual(wholesaleOrderSchema._indexes, [
+      [{ vendorCode: 1 }, { background: true, partialFilterExpression: { __t: 'WholesaleOrder' } }]
+    ]);
+
+    assert.deepStrictEqual(orderDiff, {
+      toDrop: [],
+      toCreate: [
+        { customerId: 1 }
+      ]
+    });
+    assert.deepStrictEqual(wholesaleDiff, {
+      toDrop: [],
+      toCreate: [
+        { vendorCode: 1 }
+      ]
+    });
+  });
+
+  it('does not duplicate callQueue when base and discriminator schemas share nested schema (gh-15966)', function() {
+    // Arrange
+    const addressSchema = new Schema({ city: String, street: String }, { _id: false });
+    const orderSchemaDefinition = {
+      customerId: { type: Schema.Types.ObjectId },
+      billingAddress: addressSchema,
+      shippingAddress: addressSchema,
+      notes: [{ message: String }]
+    };
+
+    const orderSchema = new Schema(orderSchemaDefinition);
+    orderSchema.queue('testMethod', ['arg1']);
+
+    const Order = db.model('Order', orderSchema);
+    const wholesaleOrderSchema = new Schema(orderSchemaDefinition);
+
+    // Act
+    Order.discriminator('WholesaleOrder', wholesaleOrderSchema, { clone: false });
+
+    // Assert - callQueue should have exactly 1 entry from base, not duplicated
+    const testMethodCalls = wholesaleOrderSchema.callQueue.filter(
+      ([methodName]) => methodName === 'testMethod'
+    );
+    assert.strictEqual(testMethodCalls.length, 1);
+  });
 });


### PR DESCRIPTION
Fixes #16466

Backport of #15974 (fix for #15966, shipped in 9.1.5) to the `8.x` branch.

**Summary**

Skip merging `parentSchema` back-references in `mergeDiscriminatorSchema()`. On 8.x (>= 8.20.0), without this skip, creating a discriminator whose schema shares nested schema objects with the base re-merges the base schema once per nested path, duplicating the base schema's `_indexes` and `callQueue` into the discriminator schema.

The `_indexes` duplication is more severe on 8.x than a bookkeeping issue: `getIndexes()` decorates those duplicated entries with `partialFilterExpression` for the discriminator, which defeats the `deepEqual` base-index skip in `_ensureIndexes()` (gh-7379). Every discriminator then creates the base schema's indexes as **partial indexes**, and the auto-generated index-name collision means the full base index may never be created. Queries using `.hint()` with such a key pattern then silently return only the documents of one discriminator value (MongoDB force-uses hinted partial indexes even when the query doesn't match the partial filter). Detailed analysis and repro in #16466.

**Changes**

- `lib/helpers/discriminator/mergeDiscriminatorSchema.js`: skip `parentSchema` key during merge (identical to the master fix).
- `test/model.discriminator.test.js`: ported the three gh-15966 tests from #15974, with expectations adjusted for 8.x (`getIndexes()` still adds `background: true` to stored index options on 8.x).

**Testing**

- The 3 ported tests fail without the fix and pass with it.
- Full suites pass on the 8.x branch with the fix: `model.discriminator` (99), `model.discriminator.querying` + `index` (123), `model.indexes` + `schema` (238).
- Verified end-to-end with the #16466 repro script: unpatched 8.24.1 builds a partial index and a hinted find returns a subset; patched 8.x builds the full index and returns all documents.
