### PR TITLE
refactor(schema): make SchemaDocumentArrayElement constructor consistent with base class SchemaType's

### DIFF
--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -60,11 +60,12 @@ function SchemaDocumentArray(key, schema, options, schemaOptions, parentSchema) 
   Constructor.path = key;
 
   const $parentSchemaType = this;
-  const embeddedSchemaType = new DocumentArrayElement(key + '.$', schema, {
+  const embeddedSchemaType = new DocumentArrayElement(key + '.$', {
     ...(schemaOptions || {}),
+    schema,
     $parentSchemaType,
     Constructor
-  });
+  }, 'DocumentArrayElement', parentSchema);
 
   SchemaArray.call(this, key, embeddedSchemaType, options, null, parentSchema);
 

--- a/lib/schema/documentArrayElement.js
+++ b/lib/schema/documentArrayElement.js
@@ -17,25 +17,25 @@ const getConstructor = require('../helpers/discriminator/getConstructor');
  *     schema.path('users.$'); // SchemaDocumentArrayElement with schema `new Schema({ name: String })`
  *
  * @param {string} path
- * @param {Schema} schema
  * @param {object} options
+ * @param {string} instance
  * @param {Schema} parentSchema
  * @inherits SchemaType
  * @api public
  */
 
-function SchemaDocumentArrayElement(path, schema, options, parentSchema) {
+function SchemaDocumentArrayElement(path, options, instance, parentSchema) {
   this.$parentSchemaType = options?.$parentSchemaType;
   if (!this.$parentSchemaType) {
     throw new MongooseError('Cannot create DocumentArrayElement schematype without a parent');
   }
   delete options.$parentSchemaType;
 
-  SchemaType.call(this, path, options, 'DocumentArrayElement', parentSchema);
+  SchemaType.call(this, path, options, instance, parentSchema);
 
   this.$isMongooseDocumentArrayElement = true;
   this.Constructor = options?.Constructor;
-  this.schema = schema;
+  this.schema = options?.schema;
 }
 
 /**
@@ -119,18 +119,15 @@ SchemaDocumentArrayElement.prototype.doValidate = async function doValidate(valu
  */
 
 SchemaDocumentArrayElement.prototype.clone = function() {
-  // This schematype takes the subdocument schema where `SchemaType` takes the
-  // options, so it cannot go through `SchemaType.prototype.clone()`: the
-  // arguments would land in the wrong parameters and `$parentSchemaType` would
-  // never reach the constructor.
+  // Preserve `$parentSchemaType` and `Constructor` when cloning.
   const options = Object.assign({}, this.options, {
     $parentSchemaType: this.$parentSchemaType,
     Constructor: this.Constructor
   });
   const schematype = new this.constructor(
     this.path,
-    this.schema,
     options,
+    this.instance,
     this.parentSchema
   );
   schematype.validators = this.validators.slice();


### PR DESCRIPTION
Re: #16463

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#16463 is the result of Mongoose's unfortunate long-standing practice of inconsistent constructors: subclass constructors are sometimes incompatible with base class constructors. This PR fixes one such inconsistency: `SchemaDocumentArrayElement` extends from `SchemaType`, so its constructor signature should be compatible with `path, options, instance, parentSchema` - `SchemaDocumentArrayElement` constructor can take additional parameters, but the first 4 parameters must match the semantics of the first 4 parameters to the `SchemaType` constructor.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
