### PR TITLE
perf: omit cloned properties with object rest

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default defineConfig([
       'no-constant-condition': 'off',
       'no-multi-spaces': 'error',
       'func-call-spacing': 'error',
+      'no-unused-vars': ['error', { ignoreRestSiblings: true }],
       'no-trailing-spaces': 'error',
       'no-undef': 'error',
       'no-unneeded-ternary': 'error',

--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -810,8 +810,7 @@ Aggregate.prototype.explain = async function explain(verbosity) {
   const postFilter = buildMiddlewareFilter(this.options, 'post');
 
   // Remove middleware option before passing to MongoDB
-  const options = this.options != null ? { ...this.options } : {};
-  delete options.middleware;
+  const { middleware, ...options } = this.options ?? {};
 
   try {
     await model.hooks.execPre('aggregate', this, [], { filter: preFilter });
@@ -948,9 +947,9 @@ Aggregate.prototype.option = function(value) {
 Aggregate.prototype.cursor = function(options) {
   this._optionsForExec();
   if (utils.hasUserDefinedProperty(options, 'middleware')) {
-    options = { ...options };
-    this.options.middleware = options.middleware;
-    delete options.middleware;
+    const { middleware, ...cursorOptions } = options;
+    this.options.middleware = middleware;
+    options = cursorOptions;
   }
   this.options.cursor = options || {};
   return new AggregationCursor(this); // return this;
@@ -1131,8 +1130,7 @@ Aggregate.prototype.exec = async function exec() {
       throw new MongooseError('Aggregate has empty pipeline');
     }
 
-    const options = clone(_this.options || {});
-    delete options.middleware;
+    const { middleware, ...options } = clone(_this.options || {});
 
     let result;
     try {

--- a/lib/cursor/aggregationCursor.js
+++ b/lib/cursor/aggregationCursor.js
@@ -52,10 +52,10 @@ function AggregationCursor(agg) {
   if (connection) {
     let options = agg.options;
     if (Object.hasOwn(options, 'middleware')) {
-      // `middleware` is a Mongoose-only option used to skip user hooks; clone
-      // and strip it so it isn't passed through to the MongoDB driver.
-      options = { ...options };
-      delete options.middleware;
+      // `middleware` is a Mongoose-only option used to skip user hooks; strip
+      // it from the clone passed through to the MongoDB driver.
+      const { middleware, ...driverOptions } = options;
+      options = driverOptions;
     }
     this.cursor = connection.db.aggregate(agg._pipeline, options);
     setImmediate(() => this.emit('cursor', this.cursor));
@@ -101,10 +101,10 @@ function _getRawCursor(model, aggregationCursor, agg) {
   try {
     let options = agg.options;
     if (Object.hasOwn(options, 'middleware')) {
-      // `middleware` is a Mongoose-only option used to skip user hooks; clone
-      // and strip it so it isn't passed through to the MongoDB driver.
-      options = { ...options };
-      delete options.middleware;
+      // `middleware` is a Mongoose-only option used to skip user hooks; strip
+      // it from the clone passed through to the MongoDB driver.
+      const { middleware, ...driverOptions } = options;
+      options = driverOptions;
     }
     const cursor = model.collection.aggregate(agg._pipeline, options);
     aggregationCursor.cursor = cursor;

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -77,15 +77,11 @@ function QueryCursor(query) {
       this.listeners('error').length > 0 && this.emit('error', err);
       return;
     }
-    Object.assign(this.options, query._optionsForExec());
+    const { middleware, ...options } = query._optionsForExec();
+    this.options = options;
     // `middleware` is a Mongoose-only option used to skip user hooks; strip it
-    // so it isn't passed through to the MongoDB driver. Safe to delete because
-    // `_optionsForExec()` returns a clone, so `query.options` is untouched.
-    // Check for presence first because `delete` is relatively slow.
-    if (Object.hasOwn(this.options, 'middleware')) {
-      delete this.options.middleware;
-    }
-    this._postMiddlewareFilter = buildMiddlewareFilter(query.options, 'post');
+    // so it isn't passed through to the MongoDB driver.
+    this._postMiddlewareFilter = buildMiddlewareFilter({ middleware }, 'post');
     this._transforms = this._transforms.concat(query._transforms.slice());
     if (this.options.transform) {
       this._transforms.push(this.options.transform);

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -80,7 +80,11 @@ function QueryCursor(query) {
     const { middleware, ...options } = query._optionsForExec();
     Object.assign(this.options, options);
     // `middleware` is a Mongoose-only option used to skip user hooks; strip it
-    // so it isn't passed through to the MongoDB driver.
+    // so it isn't passed through to the MongoDB driver. `this.options` is public
+    // and may be modified while pre hooks run, so check the target after assign.
+    if (Object.hasOwn(this.options, 'middleware')) {
+      delete this.options.middleware;
+    }
     this._postMiddlewareFilter = buildMiddlewareFilter(query.options, 'post');
     this._transforms = this._transforms.concat(query._transforms.slice());
     if (this.options.transform) {

--- a/lib/cursor/queryCursor.js
+++ b/lib/cursor/queryCursor.js
@@ -78,10 +78,10 @@ function QueryCursor(query) {
       return;
     }
     const { middleware, ...options } = query._optionsForExec();
-    this.options = options;
+    Object.assign(this.options, options);
     // `middleware` is a Mongoose-only option used to skip user hooks; strip it
     // so it isn't passed through to the MongoDB driver.
-    this._postMiddlewareFilter = buildMiddlewareFilter({ middleware }, 'post');
+    this._postMiddlewareFilter = buildMiddlewareFilter(query.options, 'post');
     this._transforms = this._transforms.concat(query._transforms.slice());
     if (this.options.transform) {
       this._transforms.push(this.options.transform);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1229,8 +1229,8 @@ Model.createCollection = async function createCollection(options) {
 
   // Remove middleware option before passing to MongoDB
   if (options?.middleware != null) {
-    options = { ...options };
-    delete options.middleware;
+    const { middleware, ...driverOptions } = options;
+    options = driverOptions;
   }
 
   [options] = await this.hooks.execPre('createCollection', this, [options], { filter: preFilter }).catch(err => {
@@ -4631,8 +4631,8 @@ async function _populatePath(model, docs, populateOptions) {
         select = select.filter(field => field !== '-_id');
       } else {
         // preserve original select conditions by copying
-        select = { ...select };
-        delete select._id;
+        const { _id, ...selectWithoutId } = select;
+        select = selectWithoutId;
       }
     }
 

--- a/lib/schema/documentArray.js
+++ b/lib/schema/documentArray.js
@@ -466,8 +466,8 @@ SchemaDocumentArray.prototype.cast = function(value, doc, init, prev, options) {
         // Don't pass `path` to $init - it's only for this DocumentArray itself, not its element fields.
         // Element subdocuments use relative paths internally for change tracking.
         if (options.path != null) {
-          options = { ...options };
-          delete options.path;
+          const { path, ...initOptions } = options;
+          options = initOptions;
         }
         rawArray[i] = subdoc.$init(rawArray[i], options);
       } else {

--- a/lib/schema/subdocument.js
+++ b/lib/schema/subdocument.js
@@ -206,8 +206,8 @@ SchemaSubdocument.prototype.cast = function(val, doc, init, priorVal, options) {
     // For change tracking, subdocuments use relative paths internally.
     // Here, `options.path` contains the absolute path and is only used by the subdocument constructor, not by $init.
     if (options.path != null) {
-      options = { ...options };
-      delete options.path;
+      const { path, ...initOptions } = options;
+      options = initOptions;
     }
     subdoc.$init(val, options);
     const exclude = isExclusive(selected);

--- a/lib/schemaType.js
+++ b/lib/schemaType.js
@@ -176,8 +176,7 @@ SchemaType.prototype.path;
  */
 
 SchemaType.prototype.toJSON = function toJSON() {
-  const res = { ...this };
-  delete res.parentSchema;
+  const { parentSchema, ...res } = this;
   return res;
 };
 

--- a/test/driver.test.js
+++ b/test/driver.test.js
@@ -116,7 +116,6 @@ describe('driver', function() {
     const Test = m1.model('Test', new Schema({ answer: Number }, { versionKey: false }));
     await Test.create({ answer: 42 });
     let doc = await Test.findOne();
-    /* eslint-disable no-unused-vars */
     assert.deepEqual((({ _id, ...doc }) => doc)(doc.toObject()), { answer: 42 });
 
     await m2.connect('fake.com');

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -477,6 +477,20 @@ describe('QueryCursor', function() {
     assert.equal(cursor.options.readPreference, read);
   });
 
+  it('preserves options object identity after opening the cursor', async function() {
+    // Arrange
+    const { User } = createTestContext();
+    const cursor = User.find().cursor({ batchSize: 1 });
+    const options = cursor.options;
+
+    // Act
+    await once(cursor, 'cursor');
+    await cursor.close();
+
+    // Assert
+    assert.strictEqual(cursor.options, options);
+  });
+
   it('eachAsync() with parallel > numDocs (gh-8422)', async function() {
     const schema = new mongoose.Schema({ name: String });
     const Movie = db.model('Movie', schema);
@@ -990,6 +1004,12 @@ describe('QueryCursor', function() {
     assert.ok(err);
     assert.equal(err.message, '$where is not allowed with sanitizeFilter');
   });
+
+  function createTestContext() {
+    const userSchema = new Schema({ name: String });
+    const User = db.model('User', userSchema);
+    return { User };
+  }
 });
 
 async function delay(ms) {

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -479,7 +479,8 @@ describe('QueryCursor', function() {
 
   it('preserves options object identity after opening the cursor', async function() {
     // Arrange
-    const { User } = createTestContext();
+    const userSchema = new Schema({ name: String });
+    const User = db.model('User', userSchema);
     const cursor = User.find().cursor({ batchSize: 1 });
     const options = cursor.options;
 
@@ -1004,12 +1005,6 @@ describe('QueryCursor', function() {
     assert.ok(err);
     assert.equal(err.message, '$where is not allowed with sanitizeFilter');
   });
-
-  function createTestContext() {
-    const userSchema = new Schema({ name: String });
-    const User = db.model('User', userSchema);
-    return { User };
-  }
 });
 
 async function delay(ms) {

--- a/test/query.cursor.test.js
+++ b/test/query.cursor.test.js
@@ -492,6 +492,26 @@ describe('QueryCursor', function() {
     assert.strictEqual(cursor.options, options);
   });
 
+  it('strips middleware added to options before opening the cursor', async function() {
+    // Arrange
+    let continuePreHook;
+    const preHookPromise = new Promise(resolve => { continuePreHook = resolve; });
+    const userSchema = new Schema({ name: String });
+    userSchema.pre('find', () => preHookPromise);
+    const User = db.model('User', userSchema);
+    const cursor = User.find().cursor();
+    const cursorOpened = once(cursor, 'cursor');
+    cursor.options.middleware = false;
+
+    // Act
+    continuePreHook();
+    await cursorOpened;
+    await cursor.close();
+
+    // Assert
+    assert.ok(!Object.hasOwn(cursor.options, 'middleware'));
+  });
+
   it('eachAsync() with parallel > numDocs (gh-8422)', async function() {
     const schema = new mongoose.Schema({ name: String });
     const Movie = db.model('Movie', schema);


### PR DESCRIPTION
re https://github.com/Automattic/mongoose/pull/16350#discussion_r3833901281

I also verified this with a microbenchmark on Node 24.15.0: I was surprised to learn that object rest was 1.4x to 2.4x faster than clone plus `delete`. I applied this change to multiple other places where we were also using `delete`s while keeping things behaviorally identical.