### PR TITLE
fix(schema): preserve scalar semantics when unboxing arrays

### DIFF
--- a/lib/cast/bigint.js
+++ b/lib/cast/bigint.js
@@ -17,17 +17,17 @@ const MIN_BIGINT = -9223372036854775808n;
 const ERROR_MESSAGE = `Mongoose only supports BigInts between ${MIN_BIGINT} and ${MAX_BIGINT} because MongoDB does not support arbitrary precision integers`;
 
 module.exports = function castBigInt(val) {
+  if (Array.isArray(val)) {
+    if (val.length !== 1 || Array.isArray(val[0])) {
+      throw new Error('Arrays must have exactly one element to be cast to a BigInt');
+    }
+    val = val[0];
+  }
   if (val == null) {
     return val;
   }
   if (val === '') {
     return null;
-  }
-  if (Array.isArray(val)) {
-    if (val.length !== 1) {
-      throw new Error('Arrays must have exactly one element to be cast to a BigInt');
-    }
-    val = val[0];
   }
   if (typeof val === 'bigint') {
     if (val > MAX_BIGINT || val < MIN_BIGINT) {

--- a/lib/cast/bigint.js
+++ b/lib/cast/bigint.js
@@ -18,7 +18,7 @@ const ERROR_MESSAGE = `Mongoose only supports BigInts between ${MIN_BIGINT} and 
 
 module.exports = function castBigInt(val) {
   if (Array.isArray(val)) {
-    if (val.length !== 1 || Array.isArray(val[0])) {
+    if (val.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a BigInt');
     }
     val = val[0];

--- a/lib/cast/boolean.js
+++ b/lib/cast/boolean.js
@@ -15,7 +15,7 @@ const CastError = require('../error/cast');
 
 module.exports = function castBoolean(value, path) {
   if (Array.isArray(value)) {
-    if (value.length !== 1 || Array.isArray(value[0])) {
+    if (value.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a boolean');
     }
     value = value[0];

--- a/lib/cast/boolean.js
+++ b/lib/cast/boolean.js
@@ -15,7 +15,7 @@ const CastError = require('../error/cast');
 
 module.exports = function castBoolean(value, path) {
   if (Array.isArray(value)) {
-    if (value.length !== 1) {
+    if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a boolean');
     }
     value = value[0];

--- a/lib/cast/date.js
+++ b/lib/cast/date.js
@@ -5,8 +5,11 @@ const assert = require('assert');
 module.exports = function castDate(value) {
   if (Array.isArray(value)) {
     // Date accepts nested arrays through string coercion.
-    if (value.length !== 1 || Array.isArray(value[0])) {
+    if (value.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a date');
+    }
+    if (Array.isArray(value[0])) {
+      throw new Error('Nested arrays cannot be cast to a date');
     }
     value = value[0];
   }

--- a/lib/cast/date.js
+++ b/lib/cast/date.js
@@ -3,17 +3,17 @@
 const assert = require('assert');
 
 module.exports = function castDate(value) {
+  if (Array.isArray(value)) {
+    if (value.length !== 1 || Array.isArray(value[0])) {
+      throw new Error('Arrays must have exactly one element to be cast to a date');
+    }
+    value = value[0];
+  }
+
   // Support empty string because of empty form values. Originally introduced
   // in https://github.com/Automattic/mongoose/commit/efc72a1898fc3c33a319d915b8c5463a22938dfe
   if (value == null || value === '') {
     return null;
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length !== 1) {
-      throw new Error('Arrays must have exactly one element to be cast to a date');
-    }
-    value = value[0];
   }
 
   if (value instanceof Date) {

--- a/lib/cast/date.js
+++ b/lib/cast/date.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 
 module.exports = function castDate(value) {
   if (Array.isArray(value)) {
+    // Date accepts nested arrays through string coercion.
     if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a date');
     }

--- a/lib/cast/decimal128.js
+++ b/lib/cast/decimal128.js
@@ -4,15 +4,15 @@ const Decimal128Type = require('../types/decimal128');
 const assert = require('assert');
 
 module.exports = function castDecimal128(value) {
-  if (value == null) {
-    return value;
-  }
-
   if (Array.isArray(value)) {
-    if (value.length !== 1) {
+    if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a Decimal128');
     }
     value = value[0];
+  }
+
+  if (value == null) {
+    return value;
   }
 
   if (typeof value === 'object' && typeof value.$numberDecimal === 'string') {

--- a/lib/cast/decimal128.js
+++ b/lib/cast/decimal128.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 module.exports = function castDecimal128(value) {
   if (Array.isArray(value)) {
-    if (value.length !== 1 || Array.isArray(value[0])) {
+    if (value.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a Decimal128');
     }
     value = value[0];

--- a/lib/cast/double.js
+++ b/lib/cast/double.js
@@ -17,8 +17,11 @@ const isBsonType = require('../helpers/isBsonType');
 module.exports = function castDouble(val) {
   if (Array.isArray(val)) {
     // Number() accepts nested arrays through string coercion.
-    if (val.length !== 1 || Array.isArray(val[0])) {
+    if (val.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a Double');
+    }
+    if (Array.isArray(val[0])) {
+      throw new Error('Nested arrays cannot be cast to a Double');
     }
     val = val[0];
   }

--- a/lib/cast/double.js
+++ b/lib/cast/double.js
@@ -15,15 +15,15 @@ const isBsonType = require('../helpers/isBsonType');
  */
 
 module.exports = function castDouble(val) {
-  if (val == null || val === '') {
-    return null;
-  }
-
   if (Array.isArray(val)) {
-    if (val.length !== 1) {
+    if (val.length !== 1 || Array.isArray(val[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a Double');
     }
     val = val[0];
+  }
+
+  if (val == null || val === '') {
+    return null;
   }
 
   let coercedVal;

--- a/lib/cast/double.js
+++ b/lib/cast/double.js
@@ -16,6 +16,7 @@ const isBsonType = require('../helpers/isBsonType');
 
 module.exports = function castDouble(val) {
   if (Array.isArray(val)) {
+    // Number() accepts nested arrays through string coercion.
     if (val.length !== 1 || Array.isArray(val[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a Double');
     }

--- a/lib/cast/int32.js
+++ b/lib/cast/int32.js
@@ -15,6 +15,7 @@ const assert = require('assert');
 
 module.exports = function castInt32(val) {
   if (Array.isArray(val)) {
+    // Number() accepts nested arrays through string coercion.
     if (val.length !== 1 || Array.isArray(val[0])) {
       throw new Error('Arrays must have exactly one element to be cast to an Int32');
     }

--- a/lib/cast/int32.js
+++ b/lib/cast/int32.js
@@ -16,8 +16,11 @@ const assert = require('assert');
 module.exports = function castInt32(val) {
   if (Array.isArray(val)) {
     // Number() accepts nested arrays through string coercion.
-    if (val.length !== 1 || Array.isArray(val[0])) {
+    if (val.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to an Int32');
+    }
+    if (Array.isArray(val[0])) {
+      throw new Error('Nested arrays cannot be cast to an Int32');
     }
     val = val[0];
   }

--- a/lib/cast/int32.js
+++ b/lib/cast/int32.js
@@ -14,17 +14,17 @@ const assert = require('assert');
  */
 
 module.exports = function castInt32(val) {
+  if (Array.isArray(val)) {
+    if (val.length !== 1 || Array.isArray(val[0])) {
+      throw new Error('Arrays must have exactly one element to be cast to an Int32');
+    }
+    val = val[0];
+  }
   if (val == null) {
     return val;
   }
   if (val === '') {
     return null;
-  }
-  if (Array.isArray(val)) {
-    if (val.length !== 1) {
-      throw new Error('Arrays must have exactly one element to be cast to an Int32');
-    }
-    val = val[0];
   }
 
   const coercedVal = isBsonType(val, 'Long') ? val.toNumber() : Number(val);

--- a/lib/cast/number.js
+++ b/lib/cast/number.js
@@ -12,7 +12,7 @@
 
 module.exports = function castNumber(val) {
   if (Array.isArray(val)) {
-    if (val.length !== 1 || Array.isArray(val[0])) {
+    if (val.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a number');
     }
     val = val[0];

--- a/lib/cast/number.js
+++ b/lib/cast/number.js
@@ -11,14 +11,14 @@
  */
 
 module.exports = function castNumber(val) {
-  if (val == null) {
-    return val;
-  }
   if (Array.isArray(val)) {
-    if (val.length !== 1) {
+    if (val.length !== 1 || Array.isArray(val[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a number');
     }
     val = val[0];
+  }
+  if (val == null) {
+    return val;
   }
   if (val === '') {
     return null;

--- a/lib/cast/objectid.js
+++ b/lib/cast/objectid.js
@@ -5,6 +5,7 @@ const ObjectId = require('../types/objectid');
 
 module.exports = function castObjectId(value) {
   if (Array.isArray(value)) {
+    // ObjectId accepts nested arrays through Array#toString().
     if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to an ObjectId');
     }

--- a/lib/cast/objectid.js
+++ b/lib/cast/objectid.js
@@ -4,15 +4,15 @@ const isBsonType = require('../helpers/isBsonType');
 const ObjectId = require('../types/objectid');
 
 module.exports = function castObjectId(value) {
-  if (value == null) {
-    return value;
-  }
-
   if (Array.isArray(value)) {
-    if (value.length !== 1) {
+    if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to an ObjectId');
     }
     value = value[0];
+  }
+
+  if (value == null) {
+    return value;
   }
 
   if (isBsonType(value, 'ObjectId')) {

--- a/lib/cast/objectid.js
+++ b/lib/cast/objectid.js
@@ -6,8 +6,11 @@ const ObjectId = require('../types/objectid');
 module.exports = function castObjectId(value) {
   if (Array.isArray(value)) {
     // ObjectId accepts nested arrays through Array#toString().
-    if (value.length !== 1 || Array.isArray(value[0])) {
+    if (value.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to an ObjectId');
+    }
+    if (Array.isArray(value[0])) {
+      throw new Error('Nested arrays cannot be cast to an ObjectId');
     }
     value = value[0];
   }

--- a/lib/cast/string.js
+++ b/lib/cast/string.js
@@ -14,16 +14,16 @@ const CastError = require('../error/cast');
  */
 
 module.exports = function castString(value, path) {
-  // If null or undefined
-  if (value == null) {
-    return value;
-  }
-
   if (Array.isArray(value)) {
-    if (value.length !== 1) {
+    if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a string');
     }
     value = value[0];
+  }
+
+  // If null or undefined
+  if (value == null) {
+    return value;
   }
 
   // handle documents being passed

--- a/lib/cast/string.js
+++ b/lib/cast/string.js
@@ -15,7 +15,7 @@ const CastError = require('../error/cast');
 
 module.exports = function castString(value, path) {
   if (Array.isArray(value)) {
-    if (value.length !== 1 || Array.isArray(value[0])) {
+    if (value.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a string');
     }
     value = value[0];

--- a/lib/cast/uuid.js
+++ b/lib/cast/uuid.js
@@ -6,6 +6,7 @@ const UUID_FORMAT = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9][0-9a-f]{3}-[89ab][0-9a-f]{3}-
 
 module.exports = function castUUID(value) {
   if (Array.isArray(value)) {
+    // UUID accepts nested arrays through Array#toString().
     if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a UUID');
     }

--- a/lib/cast/uuid.js
+++ b/lib/cast/uuid.js
@@ -5,15 +5,15 @@ const UUID = require('mongodb/lib/bson').UUID;
 const UUID_FORMAT = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 module.exports = function castUUID(value) {
-  if (value == null) {
-    return value;
-  }
-
   if (Array.isArray(value)) {
-    if (value.length !== 1) {
+    if (value.length !== 1 || Array.isArray(value[0])) {
       throw new Error('Arrays must have exactly one element to be cast to a UUID');
     }
     value = value[0];
+  }
+
+  if (value == null) {
+    return value;
   }
 
   if (value instanceof UUID) {

--- a/lib/cast/uuid.js
+++ b/lib/cast/uuid.js
@@ -7,8 +7,11 @@ const UUID_FORMAT = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9][0-9a-f]{3}-[89ab][0-9a-f]{3}-
 module.exports = function castUUID(value) {
   if (Array.isArray(value)) {
     // UUID accepts nested arrays through Array#toString().
-    if (value.length !== 1 || Array.isArray(value[0])) {
+    if (value.length !== 1) {
       throw new Error('Arrays must have exactly one element to be cast to a UUID');
+    }
+    if (Array.isArray(value[0])) {
+      throw new Error('Nested arrays cannot be cast to a UUID');
     }
     value = value[0];
   }

--- a/test/cast.scalar.test.js
+++ b/test/cast.scalar.test.js
@@ -127,7 +127,8 @@ describe('scalar casting from arrays', function() {
       viewCount: { type: BigInt, required: true }
     });
     const RequiredScalarValues = mongoose.model('RequiredScalarValues', requiredScalarValuesSchema);
-    const requiredPaths = Object.keys(requiredScalarValuesSchema.paths).filter(path => path !== '_id');
+    const requiredPaths = Object.keys(requiredScalarValuesSchema.paths).
+      filter(path => path !== '_id' && path !== '__v');
 
     return { casterCases, RequiredScalarValues, requiredPaths };
   }

--- a/test/cast.scalar.test.js
+++ b/test/cast.scalar.test.js
@@ -23,14 +23,14 @@ describe('scalar casting from arrays', function() {
   const casterCases = [
     { name: 'BigInt', cast: castBigInt, value: '42', emptyStringIsNull: true },
     { name: 'Boolean', cast: castBoolean, value: 'true' },
-    { name: 'Date', cast: castDate, value: '2020-01-01', emptyStringIsNull: true },
+    { name: 'Date', cast: castDate, value: '2020-01-01', emptyStringIsNull: true, nestedArrayTarget: 'a date' },
     { name: 'Decimal128', cast: castDecimal128, value: '1.23' },
-    { name: 'Double', cast: castDouble, value: '1.23', emptyStringIsNull: true },
-    { name: 'Int32', cast: castInt32, value: '42', emptyStringIsNull: true },
+    { name: 'Double', cast: castDouble, value: '1.23', emptyStringIsNull: true, nestedArrayTarget: 'a Double' },
+    { name: 'Int32', cast: castInt32, value: '42', emptyStringIsNull: true, nestedArrayTarget: 'an Int32' },
     { name: 'Number', cast: castNumber, value: '42', emptyStringIsNull: true },
-    { name: 'ObjectId', cast: castObjectId, value: objectId },
+    { name: 'ObjectId', cast: castObjectId, value: objectId, nestedArrayTarget: 'an ObjectId' },
     { name: 'String', cast: castString, value: 42 },
-    { name: 'UUID', cast: castUUID, value: uuid }
+    { name: 'UUID', cast: castUUID, value: uuid, nestedArrayTarget: 'a UUID' }
   ];
 
   for (const casterCase of casterCases) {
@@ -76,7 +76,14 @@ describe('scalar casting from arrays', function() {
         const value = [[casterCase.value]];
 
         // Act & Assert
-        assert.throws(() => casterCase.cast(value));
+        if (casterCase.nestedArrayTarget == null) {
+          assert.throws(() => casterCase.cast(value));
+        } else {
+          assert.throws(
+            () => casterCase.cast(value),
+            { message: `Nested arrays cannot be cast to ${casterCase.nestedArrayTarget}` }
+          );
+        }
       });
     });
   }

--- a/test/cast.scalar.test.js
+++ b/test/cast.scalar.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const assert = require('assert');
+const start = require('./common');
+
+const castBigInt = require('../lib/cast/bigint');
+const castBoolean = require('../lib/cast/boolean');
+const castDate = require('../lib/cast/date');
+const castDecimal128 = require('../lib/cast/decimal128');
+const castDouble = require('../lib/cast/double');
+const castInt32 = require('../lib/cast/int32');
+const castNumber = require('../lib/cast/number');
+const castObjectId = require('../lib/cast/objectid');
+const castString = require('../lib/cast/string');
+const castUUID = require('../lib/cast/uuid');
+
+const mongoose = start.mongoose;
+const Schema = mongoose.Schema;
+
+describe('scalar casting from arrays', function() {
+  const { casterCases } = createTestContext();
+
+  for (const casterCase of casterCases) {
+    describe(casterCase.name, function() {
+      it('casts a single-element array like its element', function() {
+        // Arrange
+        const expected = casterCase.cast(casterCase.value);
+
+        // Act
+        const actual = casterCase.cast([casterCase.value]);
+
+        // Assert
+        assert.deepStrictEqual(casterCase.normalize(actual), casterCase.normalize(expected));
+      });
+
+      it('rejects empty and multi-element arrays', function() {
+        // Arrange
+        const invalidValues = [[], [casterCase.value, casterCase.value]];
+
+        // Act & Assert
+        for (const value of invalidValues) {
+          assert.throws(() => casterCase.cast(value));
+        }
+      });
+
+      it('preserves nullish casting semantics', function() {
+        // Arrange
+        const nullishValues = [null, undefined];
+
+        for (const value of nullishValues) {
+          const expected = casterCase.cast(value);
+
+          // Act
+          const actual = casterCase.cast([value]);
+
+          // Assert
+          assert.deepStrictEqual(casterCase.normalize(actual), casterCase.normalize(expected));
+        }
+      });
+
+      it('rejects nested single-element arrays', function() {
+        // Arrange
+        const value = [[casterCase.value]];
+
+        // Act & Assert
+        assert.throws(() => casterCase.cast(value));
+      });
+    });
+  }
+
+  for (const casterCase of casterCases.filter(casterCase => casterCase.emptyStringIsNull)) {
+    it(`${casterCase.name} casts a single empty string like an empty string`, function() {
+      // Arrange
+      const expected = casterCase.cast('');
+
+      // Act
+      const actual = casterCase.cast(['']);
+
+      // Assert
+      assert.deepStrictEqual(casterCase.normalize(actual), casterCase.normalize(expected));
+    });
+  }
+
+  it('reports required validation errors for single null elements', function() {
+    // Arrange
+    const { RequiredScalarValues, requiredPaths } = createTestContext();
+    const values = Object.fromEntries(requiredPaths.map(path => [path, [null]]));
+
+    // Act
+    const error = new RequiredScalarValues(values).validateSync();
+
+    // Assert
+    assert.ok(error);
+    for (const path of requiredPaths) {
+      assert.strictEqual(error.errors[path].name, 'ValidatorError');
+      assert.strictEqual(error.errors[path].kind, 'required');
+    }
+  });
+
+  function createTestContext() {
+    const uuid = '09190f70-3d30-11e5-8814-0f4df9a59c41';
+    const objectId = '0123456789abcdef01234567';
+    const casterCases = [
+      { name: 'BigInt', cast: castBigInt, value: '42', emptyStringIsNull: true },
+      { name: 'Boolean', cast: castBoolean, value: 'true' },
+      { name: 'Date', cast: castDate, value: '2020-01-01', emptyStringIsNull: true, normalize: normalizeDate },
+      { name: 'Decimal128', cast: castDecimal128, value: '1.23', normalize: normalizeBsonValue },
+      { name: 'Double', cast: castDouble, value: '1.23', emptyStringIsNull: true, normalize: normalizeDouble },
+      { name: 'Int32', cast: castInt32, value: '42', emptyStringIsNull: true },
+      { name: 'Number', cast: castNumber, value: '42', emptyStringIsNull: true },
+      { name: 'ObjectId', cast: castObjectId, value: objectId, normalize: normalizeBsonValue },
+      { name: 'String', cast: castString, value: 42 },
+      { name: 'UUID', cast: castUUID, value: uuid, normalize: normalizeBsonValue }
+    ].map(casterCase => ({ normalize: identity, ...casterCase }));
+
+    mongoose.deleteModel(/RequiredScalarValues/);
+    const requiredScalarValuesSchema = new Schema({
+      active: { type: Boolean, required: true },
+      latitude: { type: Schema.Types.Double, required: true },
+      ownerId: { type: Schema.Types.ObjectId, required: true },
+      price: { type: Schema.Types.Decimal128, required: true },
+      publishedAt: { type: Date, required: true },
+      rating: { type: Number, required: true },
+      requestId: { type: Schema.Types.UUID, required: true },
+      retryCount: { type: Schema.Types.Int32, required: true },
+      title: { type: String, required: true },
+      viewCount: { type: BigInt, required: true }
+    });
+    const RequiredScalarValues = mongoose.model('RequiredScalarValues', requiredScalarValuesSchema);
+    const requiredPaths = Object.keys(requiredScalarValuesSchema.paths).filter(path => path !== '_id');
+
+    return { casterCases, RequiredScalarValues, requiredPaths };
+  }
+
+  function identity(value) {
+    return value;
+  }
+
+  function normalizeDate(value) {
+    return value == null ? value : value.valueOf();
+  }
+
+  function normalizeDouble(value) {
+    return value == null ? value : value.valueOf();
+  }
+
+  function normalizeBsonValue(value) {
+    return value == null ? value : value.toString();
+  }
+});

--- a/test/cast.scalar.test.js
+++ b/test/cast.scalar.test.js
@@ -18,7 +18,20 @@ const mongoose = start.mongoose;
 const Schema = mongoose.Schema;
 
 describe('scalar casting from arrays', function() {
-  const { casterCases } = createTestContext();
+  const uuid = '09190f70-3d30-11e5-8814-0f4df9a59c41';
+  const objectId = '0123456789abcdef01234567';
+  const casterCases = [
+    { name: 'BigInt', cast: castBigInt, value: '42', emptyStringIsNull: true },
+    { name: 'Boolean', cast: castBoolean, value: 'true' },
+    { name: 'Date', cast: castDate, value: '2020-01-01', emptyStringIsNull: true },
+    { name: 'Decimal128', cast: castDecimal128, value: '1.23' },
+    { name: 'Double', cast: castDouble, value: '1.23', emptyStringIsNull: true },
+    { name: 'Int32', cast: castInt32, value: '42', emptyStringIsNull: true },
+    { name: 'Number', cast: castNumber, value: '42', emptyStringIsNull: true },
+    { name: 'ObjectId', cast: castObjectId, value: objectId },
+    { name: 'String', cast: castString, value: 42 },
+    { name: 'UUID', cast: castUUID, value: uuid }
+  ];
 
   for (const casterCase of casterCases) {
     describe(casterCase.name, function() {
@@ -30,7 +43,7 @@ describe('scalar casting from arrays', function() {
         const actual = casterCase.cast([casterCase.value]);
 
         // Assert
-        assert.deepStrictEqual(casterCase.normalize(actual), casterCase.normalize(expected));
+        assert.deepStrictEqual(actual, expected);
       });
 
       it('rejects empty and multi-element arrays', function() {
@@ -54,7 +67,7 @@ describe('scalar casting from arrays', function() {
           const actual = casterCase.cast([value]);
 
           // Assert
-          assert.deepStrictEqual(casterCase.normalize(actual), casterCase.normalize(expected));
+          assert.deepStrictEqual(actual, expected);
         }
       });
 
@@ -77,75 +90,29 @@ describe('scalar casting from arrays', function() {
       const actual = casterCase.cast(['']);
 
       // Assert
-      assert.deepStrictEqual(casterCase.normalize(actual), casterCase.normalize(expected));
+      assert.deepStrictEqual(actual, expected);
     });
   }
 
   it('reports required validation errors for single null elements', function() {
     // Arrange
-    const { RequiredScalarValues, requiredPaths } = createTestContext();
-    const values = Object.fromEntries(requiredPaths.map(path => [path, [null]]));
+    const { Article } = createTestContext();
 
     // Act
-    const error = new RequiredScalarValues(values).validateSync();
+    const error = new Article({ title: [null] }).validateSync();
 
     // Assert
     assert.ok(error);
-    for (const path of requiredPaths) {
-      assert.strictEqual(error.errors[path].name, 'ValidatorError');
-      assert.strictEqual(error.errors[path].kind, 'required');
-    }
+    assert.strictEqual(error.errors.title.name, 'ValidatorError');
+    assert.strictEqual(error.errors.title.kind, 'required');
   });
 
   function createTestContext() {
-    const uuid = '09190f70-3d30-11e5-8814-0f4df9a59c41';
-    const objectId = '0123456789abcdef01234567';
-    const casterCases = [
-      { name: 'BigInt', cast: castBigInt, value: '42', emptyStringIsNull: true },
-      { name: 'Boolean', cast: castBoolean, value: 'true' },
-      { name: 'Date', cast: castDate, value: '2020-01-01', emptyStringIsNull: true, normalize: normalizeDate },
-      { name: 'Decimal128', cast: castDecimal128, value: '1.23', normalize: normalizeBsonValue },
-      { name: 'Double', cast: castDouble, value: '1.23', emptyStringIsNull: true, normalize: normalizeDouble },
-      { name: 'Int32', cast: castInt32, value: '42', emptyStringIsNull: true },
-      { name: 'Number', cast: castNumber, value: '42', emptyStringIsNull: true },
-      { name: 'ObjectId', cast: castObjectId, value: objectId, normalize: normalizeBsonValue },
-      { name: 'String', cast: castString, value: 42 },
-      { name: 'UUID', cast: castUUID, value: uuid, normalize: normalizeBsonValue }
-    ].map(casterCase => ({ normalize: identity, ...casterCase }));
-
-    mongoose.deleteModel(/RequiredScalarValues/);
-    const requiredScalarValuesSchema = new Schema({
-      active: { type: Boolean, required: true },
-      latitude: { type: Schema.Types.Double, required: true },
-      ownerId: { type: Schema.Types.ObjectId, required: true },
-      price: { type: Schema.Types.Decimal128, required: true },
-      publishedAt: { type: Date, required: true },
-      rating: { type: Number, required: true },
-      requestId: { type: Schema.Types.UUID, required: true },
-      retryCount: { type: Schema.Types.Int32, required: true },
-      title: { type: String, required: true },
-      viewCount: { type: BigInt, required: true }
+    mongoose.deleteModel(/Article/);
+    const articleSchema = new Schema({
+      title: { type: String, required: true }
     });
-    const RequiredScalarValues = mongoose.model('RequiredScalarValues', requiredScalarValuesSchema);
-    const requiredPaths = Object.keys(requiredScalarValuesSchema.paths).
-      filter(path => path !== '_id' && path !== '__v');
-
-    return { casterCases, RequiredScalarValues, requiredPaths };
-  }
-
-  function identity(value) {
-    return value;
-  }
-
-  function normalizeDate(value) {
-    return value == null ? value : value.valueOf();
-  }
-
-  function normalizeDouble(value) {
-    return value == null ? value : value.valueOf();
-  }
-
-  function normalizeBsonValue(value) {
-    return value == null ? value : value.toString();
+    const Article = mongoose.model('Article', articleSchema);
+    return { Article };
   }
 });

--- a/test/cast.scalar.test.js
+++ b/test/cast.scalar.test.js
@@ -82,7 +82,7 @@ describe('scalar casting from arrays', function() {
   }
 
   for (const casterCase of casterCases.filter(casterCase => casterCase.emptyStringIsNull)) {
-    it(`${casterCase.name} casts a single empty string like an empty string`, function() {
+    it(`${casterCase.name} casts a single empty string to null`, function() {
       // Arrange
       const expected = casterCase.cast('');
 
@@ -90,13 +90,18 @@ describe('scalar casting from arrays', function() {
       const actual = casterCase.cast(['']);
 
       // Assert
-      assert.deepStrictEqual(actual, expected);
+      assert.strictEqual(expected, null);
+      assert.strictEqual(actual, null);
+      assert.strictEqual(actual, expected);
     });
   }
 
   it('reports required validation errors for single null elements', function() {
     // Arrange
-    const { Article } = createTestContext();
+    mongoose.deleteModel(/Article/);
+    const Article = mongoose.model('Article', new Schema({
+      title: { type: String, required: true }
+    }));
 
     // Act
     const error = new Article({ title: [null] }).validateSync();
@@ -106,13 +111,4 @@ describe('scalar casting from arrays', function() {
     assert.strictEqual(error.errors.title.name, 'ValidatorError');
     assert.strictEqual(error.errors.title.kind, 'required');
   });
-
-  function createTestContext() {
-    mongoose.deleteModel(/Article/);
-    const articleSchema = new Schema({
-      title: { type: String, required: true }
-    });
-    const Article = mongoose.model('Article', articleSchema);
-    return { Article };
-  }
 });

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -39,6 +39,17 @@ describe('cast: ', function() {
       assert.deepEqual(cast(schema, { x: strings }), { x: { $in: strings } });
     });
 
+    it('preserves implicit $in for a single-element array', function() {
+      // Arrange
+      const schema = new Schema({ name: String });
+
+      // Act
+      const result = cast(schema, { name: [42] });
+
+      // Assert
+      assert.deepStrictEqual(result, { name: { $in: ['42'] } });
+    });
+
     it('casts array with Strings when necessary', function() {
       const schema = new Schema({ x: String });
       const strings = [123, 456];
@@ -79,6 +90,21 @@ describe('cast: ', function() {
       assert.throws(function() {
         cast(schema, { x: numbers });
       }, /Cast to Number failed for value "asfds"/);
+    });
+
+    it('preserves Buffer and Array values with sanitizeFilter', function() {
+      // Arrange
+      const schema = new Schema({ payload: Buffer, tags: [String] });
+
+      // Act
+      const result = cast(schema, {
+        payload: [1, 2],
+        tags: ['mongodb']
+      }, { sanitizeFilter: true });
+
+      // Assert
+      assert.deepStrictEqual(Array.from(result.payload.value()), [1, 2]);
+      assert.deepStrictEqual(result.tags, ['mongodb']);
     });
   });
 

--- a/test/model.findOneAndUpdate.test.js
+++ b/test/model.findOneAndUpdate.test.js
@@ -2348,6 +2348,49 @@ describe('model: findOneAndUpdate:', function() {
     assert.equal(err.path, 'accessories.0.additionals.0.k');
   });
 
+  describe('single-element arrays for scalar paths', function() {
+    it('casts a single-element array in $set', async function() {
+      // Arrange
+      const { User } = createTestContext();
+      const user = await User.create({ name: 'before' });
+
+      // Act
+      const updatedUser = await User.findOneAndUpdate(
+        { _id: user._id },
+        { $set: { name: ['after'] } },
+        { returnDocument: 'after' }
+      );
+
+      // Assert
+      assert.strictEqual(updatedUser.name, 'after');
+    });
+
+    it('rejects empty and multi-element arrays in $set', async function() {
+      // Arrange
+      const { User } = createTestContext();
+      const invalidValues = [[], ['first', 'second']];
+
+      for (const value of invalidValues) {
+        // Act
+        const error = await User.findOneAndUpdate(
+          {},
+          { $set: { name: value } }
+        ).then(() => null, error => error);
+
+        // Assert
+        assert.ok(error);
+        assert.strictEqual(error.name, 'CastError');
+        assert.strictEqual(error.path, 'name');
+      }
+    });
+
+    function createTestContext() {
+      const userSchema = new Schema({ name: String });
+      const User = db.model('User', userSchema);
+      return { User };
+    }
+  });
+
   describe('deprecation warnings for `new` and `returnOriginal` options (gh-15972)', function() {
     afterEach(function() {
       sinon.restore();


### PR DESCRIPTION
re #16469

The main goal of this PR was to add coverage for unboxing single-element arrays across scalar types.

The tests found a few inconsistent cases. `[null]`, `[undefined]`, and `['']` didn't always behave like their scalar values. Some casters also accepted nested arrays through JavaScript coercion.

This PR fixes those cases by unboxing before the existing nullish and empty-string checks. JavaScript coercion caused some casters to accept nested arrays such as [['42']], so this PR rejects them consistently. The tests also cover empty and multi-element arrays, required validation, updates, implicit `$in`, and `sanitizeFilter`.
WDYT? @vkarpov15