### PR TITLE
fix(schema): keep the map value schematype a single object when cloning

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -451,10 +451,7 @@ Schema.prototype._clone = function _clone(Constructor) {
   );
   s.nested = clone(this.nested);
   s.subpaths = clone(this.subpaths);
-  // A map's value SchemaType is one object, registered both as `paths[path]`
-  // of the map and as `paths[path + '.$*']`, and `mapPaths` holds that same
-  // object. Cloning the paths one by one splits it into separate copies, so
-  // point them back at each other before anything downstream reads them.
+
   s.mapPaths = [];
   for (const [path, schemaType] of Object.entries(s.paths)) {
     const mapPath = path + '.$*';

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -451,6 +451,19 @@ Schema.prototype._clone = function _clone(Constructor) {
   );
   s.nested = clone(this.nested);
   s.subpaths = clone(this.subpaths);
+  // A map's value SchemaType is one object, registered both as `paths[path]`
+  // of the map and as `paths[path + '.$*']`, and `mapPaths` holds that same
+  // object. Cloning the paths one by one splits it into separate copies, so
+  // point them back at each other before anything downstream reads them.
+  s.mapPaths = [];
+  for (const [path, schemaType] of Object.entries(s.paths)) {
+    const mapPath = path + '.$*';
+    if (!schemaType.$isSchemaMap || !Object.hasOwn(s.paths, mapPath)) {
+      continue;
+    }
+    s.paths[mapPath] = schemaType.$__schemaType;
+    s.mapPaths.push(s.paths[mapPath]);
+  }
   for (const schemaType of Object.values(s.paths)) {
     if (schemaType.$isSingleNested) {
       const path = schemaType.path;
@@ -478,7 +491,6 @@ Schema.prototype._clone = function _clone(Constructor) {
   s.$implicitlyCreated = this.$implicitlyCreated;
   s.$id = ++id;
   s.$originalSchemaId = this.$id;
-  s.mapPaths = [].concat(this.mapPaths);
 
   if (this.discriminatorMapping != null) {
     s.discriminatorMapping = Object.assign({}, this.discriminatorMapping);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1876,6 +1876,42 @@ describe('schema', function() {
         assert.equal(doc.a[0][1].x, 7);
       });
 
+      it('keeps the map value schematype a single object in the copy', function() {
+        const schema = new Schema({ m: { type: Map, of: Number } });
+        const clone = schema.clone();
+
+        assert.strictEqual(clone.paths['m.$*'], clone.paths['m'].$__schemaType);
+        assert.strictEqual(clone.paths['m.$*'], clone.path('m').getEmbeddedSchemaType());
+        assert.deepStrictEqual(clone.mapPaths, [clone.paths['m.$*']]);
+      });
+
+      it('does not hand back the source schema map value schematype', function() {
+        const schema = new Schema({ m: { type: Map, of: Number } });
+        const clone = schema.clone();
+
+        assert.notStrictEqual(clone.paths['m.$*'], schema.paths['m.$*']);
+        assert.notStrictEqual(clone.path('m.someKey'), schema.path('m.someKey'));
+        assert.strictEqual(schema.mapPaths.includes(clone.mapPaths[0]), false);
+      });
+
+      it('applies a setter added to a map value on the copy', function() {
+        const schema = new Schema({ m: { type: Map, of: Number } }).clone();
+        schema.path('m.$*').set(v => v * 2);
+
+        const M = mongoose.model('gh-clone-map-setter', schema);
+        assert.equal(new M({ m: { k: 3 } }).get('m').get('k'), 6);
+      });
+
+      it('applies a validator added to a map value on the copy', function() {
+        const schema = new Schema({ m: { type: Map, of: Number } }).clone();
+        schema.path('m.$*').validate(v => v < 10, 'too big');
+
+        const M = mongoose.model('gh-clone-map-validator', schema);
+        const err = new M({ m: { k: 50 } }).validateSync();
+        assert.ok(err);
+        assert.deepStrictEqual(Object.keys(err.errors), ['m.k']);
+      });
+
       it('copies methods, statics, and query helpers (gh-5752)', function() {
         const schema = new Schema({});
 


### PR DESCRIPTION
A getter, setter or validator put on a map's value path is silently ignored when the schema came from `clone()`.

```js
function build(useClone) {
  let schema = new mongoose.Schema({ m: { type: Map, of: Number } });
  if (useClone) schema = schema.clone();
  schema.path('m.$*').set(v => v * 2);
  return mongoose.model('T' + Math.random(), schema);
}

new (build(false))({ m: { k: 3 } }).get('m').get('k');  // 6
new (build(true))({ m: { k: 3 } }).get('m').get('k');   // 3
```

Same for a getter, and the validator case is the one that stings:

```js
schema.path('m.$*').validate(v => v < 10, 'too big');
// direct schema: validateSync() reports m.k
// cloned schema: no error, the value is accepted
```

A map's value SchemaType is one object with three names. `Schema.prototype.path` registers it as `paths[p + '.$*']`, it is already `paths[p].$__schemaType`, and `mapPaths` holds that same object:

```js
this.paths[mapPath] = schemaType.$__schemaType;
this.mapPaths.push(this.paths[mapPath]);
```

`_clone` breaks all three. It rebuilds `paths` by calling `.clone()` on each entry, which makes a new object for `'m.$*'`, while `SchemaMap.prototype.clone` independently copies `$__schemaType` for `'m'`, and then `s.mapPaths = [].concat(this.mapPaths)` copies the source schema's references into the copy. So the clone ends up with three separate objects where there should be one, and the one in `mapPaths` still belongs to the schema it was cloned from.

`schema.path('m.$*')` returns the `paths` entry, which is what `.set()`, `.get()` and `.validate()` attach to. `MongooseMap` reads them off `paths['m'].$__schemaType`. On a direct schema those are the same object, on a clone they are not, so the configuration lands on a copy nobody reads.

The fix points the two names back at one object right after `paths` is rebuilt, and builds `mapPaths` from the clone rather than carrying the source's entries over. Deleting the old `s.mapPaths = [].concat(this.mapPaths)` is the rest of it.

`clone.path('m.someKey') === schema.path('m.someKey')` also stops being true, which it should never have been.

## What I ran

An invariant harness over 12 shapes (map of number, of string, of map, of subdoc, of array, two maps, map under a nested path, map beside scalars, map with a default, map inside a single nested subdoc, map inside a document array, and a shape with no map at all) comparing a clone against a schema freshly built from the same definition, plus a check that no `paths` entry or `mapPaths` entry is an object the source schema owns. 90 checks: 40 problems on `main`, none after. The three behaviours above go from `DIFFERENT` to `same`.

`mocha test/schema*.test.js test/types.map.test.js test/types.array.test.js test/types.documentarray.test.js test/document.test.js` is 1301 passing on `main` and 1305 here, the four being the new ones. All four fail on `main`. `eslint lib/schema.js test/schema.test.js` is clean.

One thing I noticed and did not touch: a clone of a schema with a map of subdocuments picks up a second `childSchemas` entry at `m.$*` that a freshly built schema does not have. It looks like a separate question about whether `_gatherChildSchemas` should walk the `$*` paths at all, so I left it where it is.
