### PR TITLE
fix(model): say the duplicate index is not created in the duplicate index warning

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1727,6 +1727,8 @@ function _ensureIndexes(model, options, callback) {
           utils.warn('mongoose: Duplicate schema index on ' + JSON.stringify(fields) +
             ' for model "' + model.modelName + '". ' +
             'This is often due to declaring an index using both "index: true" and "schema.index()". ' +
+            'MongoDB rejects the duplicate with an IndexOptionsConflict error, so options on the ' +
+            'later definition (for example expireAfterSeconds or unique) are not applied. ' +
             'Please remove the duplicate index definition.');
           break;
         }

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3562,6 +3562,10 @@ describe('schema', function() {
         message.includes('for model "gh15056"'),
         'Warning should include model name'
       );
+      assert.ok(
+        message.includes('IndexOptionsConflict'),
+        'Warning should say the duplicate index is not created'
+      );
     } finally {
       sinon.restore();
     }


### PR DESCRIPTION
Fix #16476

The duplicate index warning names the cause but not the consequence. MongoDB rejects the duplicate with an IndexOptionsConflict error, so options that exist only on the later definition (`expireAfterSeconds`, `unique`, `partialFilterExpression`) are never applied. For a TTL index that means retention silently does not happen and the collection grows forever, while the warning reads like a schema hygiene note.

Message change only, no behavior change. I saw #15093 and #15135 and understand the preference for warning over failing.

Extends the existing gh-15056 test rather than adding a new one. The added assertion fails without the message change.
