### PR TITLE
docs(schema): clarify duplicate index warning to note index is not created (gh-16476)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1727,6 +1727,7 @@ function _ensureIndexes(model, options, callback) {
           utils.warn('mongoose: Duplicate schema index on ' + JSON.stringify(fields) +
             ' for model "' + model.modelName + '". ' +
             'This is often due to declaring an index using both "index: true" and "schema.index()". ' +
+            'MongoDB will not create the duplicate index and options on the duplicate definition (such as expireAfterSeconds or unique) will not be applied. ' +
             'Please remove the duplicate index definition.');
           break;
         }

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3562,6 +3562,10 @@ describe('schema', function() {
         message.includes('for model "gh15056"'),
         'Warning should include model name'
       );
+      assert.ok(
+        message.includes('MongoDB will not create the duplicate index and options on the duplicate definition'),
+        'Warning should mention duplicate index is not created and options not applied (gh-16476)'
+      );
     } finally {
       sinon.restore();
     }


### PR DESCRIPTION
**Summary**

Clarifies the duplicate index warning in `lib/model.js` to explicitly state that MongoDB does not create duplicate indexes, and options on the duplicate definition (such as `expireAfterSeconds` or `unique`) will not be applied (gh-16476).

Fixes #16476

**Examples**

When declaring a duplicate index on the same path using both `{ index: true }` and `schema.index()`:

Before:
> `mongoose: Duplicate schema index on {"at":1} for model "Census". This is often due to declaring an index using both "index: true" and "schema.index()". Please remove the duplicate index definition.`

After:
> `mongoose: Duplicate schema index on {"at":1} for model "Census". This is often due to declaring an index using both "index: true" and "schema.index()". MongoDB will not create the duplicate index and options on the duplicate definition (such as expireAfterSeconds or unique) will not be applied. Please remove the duplicate index definition.`
