### PR TITLE
perf(populate): skip per-document splitting when all docs have IDs within perDocumentLimit

### DIFF
--- a/lib/helpers/populate/splitPopulateQuery.js
+++ b/lib/helpers/populate/splitPopulateQuery.js
@@ -52,6 +52,17 @@ function splitPopulateQuery(mod, ids, select, assignmentOpts) {
     return null;
   }
 
+  if (perDocumentLimit != null && !mod.isVirtual &&
+      mod.ids.every(docIds => utils.array.flatten(Array.isArray(docIds) ? docIds : [docIds], flatten).length <= perDocumentLimit)) {
+    mod.options = { ...mod.options };
+    delete mod.options.perDocumentLimit;
+    if (mod.options.options != null) {
+      mod.options.options = { ...mod.options.options };
+      delete mod.options.options.perDocumentLimit;
+    }
+    return null;
+  }
+
   return mod.docs.map((doc, i) => {
     const subMod = {
       ...mod,


### PR DESCRIPTION
Addresses #15863 

# Summary

When `perDocumentLimit` is set in a `populate()` operation, Mongoose unconditionally fires one query per parent document. This is unnecessary when every document's stored reference count is already at or below the limit i.e a single combined query is more efficient and produces the same result. This approach builds on Optimization 1 mentioned in the linked issue.

# Changes

- `lib/helpers/populate/splitPopulateQuery.js`: skip the per-document split for non-virtual populates when every document's ID count <= `perDocumentLimit`. Also clears `perDocumentLimit` from a soft-copy of `options` so the downstream query builder doesn't apply an incorrect limit to the combined query.

> In virtual populate, `mod.ids` holds the parent document's local field values (one per doc), not the child reference counts, so checking `mod.ids.length <= perDocumentLimit` would compare the wrong thing and skip splitting incorrectly. A few populate tests failed without this guard.

# Testing

- All existing populate tests pass
- All `perDocumentLimit` tests pass