### PR TITLE
fix(projection): build the dotted path correctly in isPathSelectedInclusive

### DIFF
--- a/lib/helpers/projection/isPathSelectedInclusive.js
+++ b/lib/helpers/projection/isPathSelectedInclusive.js
@@ -7,19 +7,9 @@
 module.exports = function isPathSelectedInclusive(fields, path) {
   const chunks = path.split('.');
   let cur = '';
-  let j;
-  let keys;
-  let numKeys;
   for (let i = 0; i < chunks.length; ++i) {
-    cur += cur.length ? '.' : '' + chunks[i];
+    cur += cur.length ? '.' + chunks[i] : chunks[i];
     if (fields[cur]) {
-      keys = Object.keys(fields);
-      numKeys = keys.length;
-      for (j = 0; j < numKeys; ++j) {
-        if (keys[i].indexOf(cur + '.') === 0 && keys[i].indexOf(path) !== 0) {
-          continue;
-        }
-      }
       return true;
     }
   }

--- a/test/helpers/projection.test.js
+++ b/test/helpers/projection.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const isPathSelectedInclusive = require('../../lib/helpers/projection/isPathSelectedInclusive');
 const isSubpath = require('../../lib/helpers/projection/isSubpath');
 
 describe('isSubpath', function() {
@@ -18,5 +19,26 @@ describe('isSubpath', function() {
     assert.equal(isSubpath('a.b.c', 'a'), false);
 
     done();
+  });
+});
+
+describe('isPathSelectedInclusive', function() {
+  it('handles single-part paths', function() {
+    assert.equal(isPathSelectedInclusive({ a: 1 }, 'a'), true);
+    assert.equal(isPathSelectedInclusive({ a: 1 }, 'b'), false);
+    assert.equal(isPathSelectedInclusive({}, 'a'), false);
+  });
+
+  it('handles dotted paths', function() {
+    assert.equal(isPathSelectedInclusive({ 'a.b': 1 }, 'a.b'), true);
+    assert.equal(isPathSelectedInclusive({ 'a.b.c': 1 }, 'a.b.c'), true);
+    assert.equal(isPathSelectedInclusive({ 'a.b': 1 }, 'a.c'), false);
+    assert.equal(isPathSelectedInclusive({ 'a.b': 1 }, 'b'), false);
+  });
+
+  it('treats a selected ancestor as selecting its subpaths', function() {
+    assert.equal(isPathSelectedInclusive({ a: 1 }, 'a.b'), true);
+    assert.equal(isPathSelectedInclusive({ 'a.b': 1 }, 'a.b.c'), true);
+    assert.equal(isPathSelectedInclusive({ 'a.b.c': 1 }, 'a.b'), false);
   });
 });


### PR DESCRIPTION
**Summary**

`isPathSelectedInclusive` has an operator-precedence bug in its path accumulator:

```js
cur += cur.length ? '.' : '' + chunks[i];
```

This parses as `cur += (cur.length ? '.' : ('' + chunks[i]))`, so after the first segment it only ever appends a bare dot. For `a.b.c` it builds `a`, `a.`, `a..`, meaning the function never inspects a real dotted path and returns `false` for every nested path.

`Query.prototype.isPathSelectedInclusive` is public API, so this is user-visible:

```js
isPathSelectedInclusive({ a: 1 }, 'a')          // true   correct
isPathSelectedInclusive({ 'a.b': 1 }, 'a.b')    // false  should be true
isPathSelectedInclusive({ 'a.b.c': 1 }, 'a.b.c')// false  should be true
```

Every other path accumulator in `lib/` already does this correctly, which suggests an isolated typo rather than intended behavior. Compare `lib/helpers/path/parentPaths.js`:

```js
cur += (cur.length !== 0) ? '.' + pieces[i] : pieces[i];
```

and the same pattern in `helpers/schema/getSubdocumentStrictValue.js`, `queryHelpers.js` and `document.js`.

**Examples**

After the change:

```js
isPathSelectedInclusive({ 'a.b': 1 }, 'a.b')  // true
isPathSelectedInclusive({ a: 1 }, 'a.b')      // true   a selected ancestor selects its subpaths
isPathSelectedInclusive({ x: 1 }, 'a.b')      // false  unrelated projections still false
```

The inner `for (j...)` loop is removed along with it. Its only statement is a bare `continue`, so it is a no-op under every input, and it indexes `keys[i]` with the *outer* loop counter, which would throw a `TypeError` once the outer loop can actually reach `i >= 1`, which this fix enables.

Tests added to `test/helpers/projection.test.js` covering single-part paths, dotted paths, and a selected ancestor. Reverting only the source and keeping the tests fails two of them with `false == true`; restored, the file passes 5/5 and eslint is clean.

Prior art: #13177 exposed this helper through `query.js` and `document.js` but never touched the helper itself, and I found no issue or PR covering the nested-path behavior.