### PR TITLE
fix(query): pass schema through when casting a nested $expr comparison

### DIFF
--- a/lib/helpers/query/cast$expr.js
+++ b/lib/helpers/query/cast$expr.js
@@ -264,7 +264,7 @@ function castComparison(val, schema, strictQuery) {
       throw new StrictModeError(path);
     }
   } else {
-    val[1] = _castExpression(val[1]);
+    val[1] = _castExpression(val[1], schema, strictQuery);
   }
 
   return val;

--- a/test/helpers/query.cast$expr.test.js
+++ b/test/helpers/query.cast$expr.test.js
@@ -119,6 +119,16 @@ describe('castexpr', function() {
     assert.deepStrictEqual(res, { $eq: [{ $round: ['$value'] }, 2] });
   });
 
+  it('casts nested expressions on the right-hand side of a comparison', function() {
+    const testSchema = new Schema({ isActive: Boolean, count: Number, nums: [Number] });
+
+    let res = cast$expr({ $eq: ['$isActive', { $gt: ['$count', '5'] }] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: ['$isActive', { $gt: ['$count', 5] }] });
+
+    res = cast$expr({ $eq: ['$isActive', { $in: ['42', '$nums'] }] }, testSchema);
+    assert.deepStrictEqual(res, { $eq: ['$isActive', { $in: [42, '$nums'] }] });
+  });
+
   it('casts $switch (gh-14751)', function() {
     const testSchema = new Schema({
       name: String,


### PR DESCRIPTION
**Summary**

In `castComparison`, the recursive call for a non-literal right-hand side drops both extra arguments:

```js
val[1] = _castExpression(val[1]);
```

`schema` then arrives as `undefined` one frame down, so any nested comparison or `$in` dereferences `schema.path(...)` and throws a raw `TypeError` out of query casting into user code.

The other nine recursive `_castExpression` call sites in this file all pass `schema, strictQuery` correctly, so this is an isolated omission rather than intended behavior.

**Examples**

Before, with `new Schema({ isActive: Boolean, count: Number, nums: [Number] })`:

```
cast$expr({ $eq: ['$isActive', { $gt: ['$count', '5'] }] }, schema)

TypeError: Cannot read properties of undefined (reading 'path')
    at castComparison (lib/helpers/query/cast$expr.js:222:27)
    at _castExpression (lib/helpers/query/cast$expr.js:112:18)
    at castComparison (lib/helpers/query/cast$expr.js:267:14)
```

Both are valid MongoDB aggregation expressions, comparing a boolean field against the result of a comparison.

After, no crash, and the silent half of the bug is fixed too: the nested operands are now cast, so `'5'` becomes `5`.

```
IN  {"$eq":["$isActive",{"$gt":["$count","5"]}]}
OUT {"$eq":["$isActive",{"$gt":["$count",5]}]}

IN  {"$eq":["$isActive",{"$in":["5","$nums"]}]}
OUT {"$eq":["$isActive",{"$in":[5,"$nums"]}]}
```

A test is added to `test/helpers/query.cast$expr.test.js`. Reverting only the source and keeping the test reproduces the original `TypeError`; restored, the file passes 9/9 and eslint is clean.

Prior art: #15425, #14755 and #12429 all touch `cast$expr` but fix different branches, and I found no open issue or PR covering the missing arguments.