### PR TITLE
types(model): add type narrowing overrides for Model findX() functions

### DIFF
--- a/scripts/tsc-diagnostics-check.js
+++ b/scripts/tsc-diagnostics-check.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 
 const stdin = fs.readFileSync(0).toString('utf8');
-const maxInstantiations = isNaN(process.argv[2]) ? 400000 : parseInt(process.argv[2], 10);
+const maxInstantiations = isNaN(process.argv[2]) ? 420000 : parseInt(process.argv[2], 10);
 
 console.log(stdin);
 

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -59,6 +59,7 @@ interface ISubdoc {
 }
 
 interface ITest {
+  _id: Types.ObjectId;
   name?: string;
   age?: number;
   parent?: Types.ObjectId;

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -146,6 +146,16 @@ Test.findOneAndDelete({}, { projection: { name: 1 } }).then(doc => {
   expect(doc!).type.not.toHaveProperty('age');
   expect(doc!).type.toHaveProperty('_id');
 });
+Test.findOneAndReplace({}, {}, { projection: { name: 1 } }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndReplace({}, {}, { projection: { age: 0, _id: 1 }, includeResultMetadata: true }).then(res => {
+  expect(res.value!).type.toHaveProperty('name');
+  expect(res.value!).type.not.toHaveProperty('age');
+  expect(res.value!).type.toHaveProperty('_id');
+});
 
 Test.find({}, { 'docs.$': 1 }).then(docs => {
   expect(docs[0]).type.not.toHaveProperty('name');

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -115,6 +115,27 @@ Test.findOne({}, { _id: 1 }).then(doc => {
   expect(doc!).type.not.toHaveProperty('age');
   expect(doc!).type.toHaveProperty('_id');
 });
+Test.findOne({}, { age: 0, _id: 1 }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOne({}, { _id: true, age: false }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOne({}, { _id: true }).then(doc => {
+  expect(doc!).type.not.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+
+type ProjectionDoc = { _id: string; name: string; age: number };
+expect<mongoose.ApplyProjection<ProjectionDoc, { _id: 1; age: 0 }>>().type.toBe<{ _id: string; name: string }>();
+expect<mongoose.ApplyProjection<ProjectionDoc, { _id: 0; age: 0 }>>().type.toBe<{ name: string }>();
+expect<mongoose.ApplyProjection<ProjectionDoc, { _id: false }>>().type.toBe<{ name: string; age: number }>();
+
 Test.findOneAndUpdate({}, {}, { projection: { name: 1 } }).then(doc => {
   expect(doc!).type.toHaveProperty('name');
   expect(doc!).type.not.toHaveProperty('age');

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -74,6 +74,73 @@ const Test = model<ITest, Model<ITest, QueryHelpers>>('Test', schema);
 
 Test.find({}, {}, { populate: { path: 'child', model: ChildModel, match: true } }).exec().then((res: Array<ITest>) => console.log(res));
 
+Test.find({}, { name: 1 }).then(docs => {
+  expect(docs[0]).type.toHaveProperty('name');
+  expect(docs[0]).type.not.toHaveProperty('age');
+  expect(docs[0]).type.toHaveProperty('_id');
+});
+Test.findOne({}, { name: 1 }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.find({}, undefined, { projection: { name: 1 } }).then(docs => {
+  expect(docs[0]).type.toHaveProperty('name');
+  expect(docs[0]).type.not.toHaveProperty('age');
+  expect(docs[0]).type.toHaveProperty('_id');
+});
+Test.findOne({}, undefined, { projection: { name: 1 } }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOne({}, { name: 1, _id: 0 }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.not.toHaveProperty('_id');
+});
+Test.findOne({}, { _id: 0 }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.toHaveProperty('age');
+  expect(doc!).type.not.toHaveProperty('_id');
+});
+Test.findOne({}, { _id: 1 }).then(doc => {
+  expect(doc!).type.not.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndUpdate({}, {}, { projection: { name: 1 } }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndDelete({}, { projection: { name: 1 } }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+
+Test.find({}, { 'docs.$': 1 }).then(docs => {
+  expect(docs[0]).type.not.toHaveProperty('name');
+  expect(docs[0]).type.toHaveProperty('docs');
+  expect(docs[0]).type.toHaveProperty('_id');
+});
+Test.findOne({}, { docs: { $elemMatch: { id: 1 } } }).then(doc => {
+  expect(doc!).type.not.toHaveProperty('name');
+  expect(doc!).type.toHaveProperty('docs');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndUpdate({}, {}, { projection: { tags: { $slice: 1 } } }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.toHaveProperty('docs');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndDelete({}, { projection: { name: { $meta: 'textScore' } } }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.toHaveProperty('docs');
+  expect(doc!).type.toHaveProperty('_id');
+});
+
 Test.find().byName('test').byName('test2').orFail().exec().then(console.log);
 
 Test.countDocuments({ name: /Test/ }).exec().then((res: number) => console.log(res));
@@ -179,6 +246,10 @@ Test.find({}, { age: 1, tags: { $slice: 5 } }); // $slice should be allowed in i
 Test.find({}, { age: 0, tags: { $slice: 5 } }); // $slice should be allowed in exclusion projection
 Test.find({}, { age: 1, tags: { $elemMatch: {} } }); // $elemMatch should be allowed in inclusion projection
 Test.find({}, { age: 0, tags: { $elemMatch: {} } }); // $elemMatch should be allowed in exclusion projection
+Test.find({}, { 'docs.$': 1 }); // Positional $ projection should be allowed
+Test.find({}, { docs: { $elemMatch: { id: 1 } } }); // $elemMatch projection should be allowed
+Test.find({}, { tags: { $slice: [0, 1] } }); // $slice projection should be allowed
+Test.find({}, { name: { $meta: 'textScore' } }); // $meta projection should be allowed
 expect(Test.find).type.not.toBeCallableWith({}, { 'docs.id': 'taco' }); // Dot notation should be allowed and does not accept any
 expect(Test.find).type.not.toBeCallableWith({}, { docs: { id: '1' } }); // Dot notation should be able to use a combination with objects
 Test.find({}, { docs: { id: false } }); // Dot notation should be allowed with valid values - should correctly handle arrays

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -100,6 +100,36 @@ Test.findOne({}, undefined, { projection: { name: 1 } }).then(doc => {
   expect(doc!).type.not.toHaveProperty('age');
   expect(doc!).type.toHaveProperty('_id');
 });
+Test.find({}, { name: 1 }, { lean: true }).then(docs => {
+  expect(docs[0]).type.toHaveProperty('name');
+  expect(docs[0]).type.not.toHaveProperty('age');
+  expect(docs[0]).type.toHaveProperty('_id');
+});
+Test.find({}, undefined, { projection: { age: 0, _id: 1 }, lean: true }).then(docs => {
+  expect(docs[0]).type.toHaveProperty('name');
+  expect(docs[0]).type.not.toHaveProperty('age');
+  expect(docs[0]).type.toHaveProperty('_id');
+});
+Test.findOne({}, { name: 1 }, { lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOne({}, undefined, { projection: { age: 0, _id: 1 }, lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findById(new Types.ObjectId(), { name: 1 }, { lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findAndCount({}, { name: 1 }, { sort: { name: 1 }, limit: 1, lean: true }).then(([docs]) => {
+  expect(docs[0]).type.toHaveProperty('name');
+  expect(docs[0]).type.not.toHaveProperty('age');
+  expect(docs[0]).type.toHaveProperty('_id');
+});
 Test.findOne({}, { name: 1, _id: 0 }).then(doc => {
   expect(doc!).type.toHaveProperty('name');
   expect(doc!).type.not.toHaveProperty('age');
@@ -152,6 +182,56 @@ Test.findOneAndReplace({}, {}, { projection: { name: 1 } }).then(doc => {
   expect(doc!).type.toHaveProperty('_id');
 });
 Test.findOneAndReplace({}, {}, { projection: { age: 0, _id: 1 }, includeResultMetadata: true }).then(res => {
+  expect(res.value!).type.toHaveProperty('name');
+  expect(res.value!).type.not.toHaveProperty('age');
+  expect(res.value!).type.toHaveProperty('_id');
+});
+Test.findOneAndUpdate({}, {}, { projection: { age: 0, _id: 1 }, lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndDelete({}, { projection: { age: 0, _id: 1 }, lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndReplace({}, {}, { projection: { age: 0, _id: 1 }, lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findOneAndUpdate({}, {}, { projection: { name: 1 }, lean: true, includeResultMetadata: true }).then(res => {
+  expect(res.value!).type.toHaveProperty('name');
+  expect(res.value!).type.not.toHaveProperty('age');
+  expect(res.value!).type.toHaveProperty('_id');
+});
+Test.findOneAndDelete({}, { projection: { name: 1 }, lean: true, includeResultMetadata: true }).then(res => {
+  expect(res.value!).type.toHaveProperty('name');
+  expect(res.value!).type.not.toHaveProperty('age');
+  expect(res.value!).type.toHaveProperty('_id');
+});
+Test.findOneAndReplace({}, {}, { projection: { name: 1 }, lean: true, includeResultMetadata: true }).then(res => {
+  expect(res.value!).type.toHaveProperty('name');
+  expect(res.value!).type.not.toHaveProperty('age');
+  expect(res.value!).type.toHaveProperty('_id');
+});
+Test.findByIdAndUpdate(new Types.ObjectId(), {}, { projection: { name: 1 }, lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findByIdAndUpdate(new Types.ObjectId(), {}, { projection: { name: 1 }, lean: true, includeResultMetadata: true }).then(res => {
+  expect(res.value!).type.toHaveProperty('name');
+  expect(res.value!).type.not.toHaveProperty('age');
+  expect(res.value!).type.toHaveProperty('_id');
+});
+Test.findByIdAndDelete(new Types.ObjectId(), { projection: { name: 1 }, lean: true }).then(doc => {
+  expect(doc!).type.toHaveProperty('name');
+  expect(doc!).type.not.toHaveProperty('age');
+  expect(doc!).type.toHaveProperty('_id');
+});
+Test.findByIdAndDelete(new Types.ObjectId(), { projection: { name: 1 }, lean: true, includeResultMetadata: true }).then(res => {
   expect(res.value!).type.toHaveProperty('name');
   expect(res.value!).type.not.toHaveProperty('age');
   expect(res.value!).type.toHaveProperty('_id');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -825,6 +825,7 @@ declare module 'mongoose' {
   export type ReturnsNewDoc = { new: true } | { returnOriginal: false } | { returnDocument: 'after' };
 
   export type ArrayProjectionOperators = { $slice: number | [number, number]; $elemMatch?: never } | { $elemMatch: Record<string, any>; $slice?: never };
+  export type ProjectionOperators = { $meta: string };
   /**
    * This Type Assigns `Element | undefined` recursively to the `T` type.
    * if it is an array it will do this to the element of the array, if it is an object it will do this for the properties of the object.
@@ -842,14 +843,14 @@ declare module 'mongoose' {
     }
   */
   export type Projector<T, Element> = T extends Array<infer U>
-    ? Projector<U, Element> | ArrayProjectionOperators
+    ? Projector<U, Element> | ArrayProjectionOperators | ProjectionOperators
     : T extends TreatAsPrimitives
-      ? Element
+      ? Element | ProjectionOperators
       : T extends Record<string, any>
         ? {
-          [K in keyof T]?: T[K] extends Record<string, any> ? Projector<T[K], Element> | Element : Element;
+          [K in keyof T]?: T[K] extends Record<string, any> ? Projector<T[K], Element> | Element | ProjectionOperators : Element | ProjectionOperators;
         }
-        : Element;
+        : Element | ProjectionOperators;
   type _IDType = { _id?: boolean | number };
   export type InclusionProjection<T> = IsItRecordAndNotAny<T> extends true
     ? Omit<Projector<WithLevel1NestedPaths<T>, boolean | number>, '_id'> & _IDType

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -445,6 +445,18 @@ declare module 'mongoose' {
      * equivalent to `findOne({ _id: id })`. If you want to query by a document's
      * `_id`, use `findById()` instead of `findOne()`.
      */
+    findById<const Projection extends ProjectionType<TRawDocType>>(
+      id: any,
+      projection: Projection,
+      options: QueryOptions<TRawDocType> & { lean: true }
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
     findById<ResultDoc = THydratedDocumentType>(
       id: any,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -502,6 +514,30 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
+    findOne<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: Projection,
+      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
+    findOne<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: undefined | null,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOne',
@@ -828,6 +864,30 @@ declare module 'mongoose' {
       'find',
       TInstanceMethods & TVirtuals
     >;
+    find<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: Projection,
+      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection>[],
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
+    find<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: undefined | null,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection>[],
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
     find<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -890,6 +950,11 @@ declare module 'mongoose' {
     >;
 
     /** Finds documents and counts the number of documents matching `filter`. */
+    findAndCount<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: Projection,
+      options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: true } & mongodb.Abortable
+    ): Promise<[ProjectedLeanDocument<TRawDocType, Projection>[], number]>;
     findAndCount<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -907,6 +972,28 @@ declare module 'mongoose' {
     ): Promise<[HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[], number]>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
+    findByIdAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+      id: mongodb.ObjectId | any,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findByIdAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+      id: mongodb.ObjectId | any,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
     findByIdAndDelete<ResultDoc = THydratedDocumentType>(
       id: mongodb.ObjectId | any,
       options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
@@ -965,6 +1052,30 @@ declare module 'mongoose' {
 
 
     /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
+    findByIdAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+      id: mongodb.ObjectId | any,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findByIdAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+      id: mongodb.ObjectId | any,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
@@ -1068,6 +1179,28 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndDelete',
@@ -1182,6 +1315,30 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndReplace',
@@ -1328,6 +1485,30 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      THydratedDocumentType,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndUpdate',

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -1163,6 +1163,30 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
+    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      replacement: TRawDocType | AnyObject,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndReplace',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       replacement: TRawDocType | AnyObject,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -450,7 +450,7 @@ declare module 'mongoose' {
       projection: Projection,
       options: QueryOptions<TRawDocType> & { lean: true }
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -524,7 +524,7 @@ declare module 'mongoose' {
       projection: Projection,
       options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -536,7 +536,7 @@ declare module 'mongoose' {
       projection: undefined | null,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true } & mongodb.Abortable
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -869,7 +869,7 @@ declare module 'mongoose' {
       projection: Projection,
       options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection>[],
+      ApplyProjection<TRawDocType, Projection>[],
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -881,7 +881,7 @@ declare module 'mongoose' {
       projection: undefined | null,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true } & mongodb.Abortable
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection>[],
+      ApplyProjection<TRawDocType, Projection>[],
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -954,7 +954,7 @@ declare module 'mongoose' {
       filter: QueryFilter<TRawDocType>,
       projection: Projection,
       options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: true } & mongodb.Abortable
-    ): Promise<[ProjectedLeanDocument<TRawDocType, Projection>[], number]>;
+    ): Promise<[ApplyProjection<TRawDocType, Projection>[], number]>;
     findAndCount<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -976,7 +976,7 @@ declare module 'mongoose' {
       id: mongodb.ObjectId | any,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -987,7 +987,7 @@ declare module 'mongoose' {
       id: mongodb.ObjectId | any,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
     ): QueryWithHelpers<
-      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1057,7 +1057,7 @@ declare module 'mongoose' {
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1069,7 +1069,7 @@ declare module 'mongoose' {
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
     ): QueryWithHelpers<
-      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1188,7 +1188,7 @@ declare module 'mongoose' {
       filter: QueryFilter<TRawDocType>,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1199,7 +1199,7 @@ declare module 'mongoose' {
       filter: QueryFilter<TRawDocType>,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
     ): QueryWithHelpers<
-      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1325,7 +1325,7 @@ declare module 'mongoose' {
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1337,7 +1337,7 @@ declare module 'mongoose' {
       replacement: TRawDocType | AnyObject,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
     ): QueryWithHelpers<
-      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1495,7 +1495,7 @@ declare module 'mongoose' {
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
     ): QueryWithHelpers<
-      ProjectedLeanDocument<TRawDocType, Projection> | null,
+      ApplyProjection<TRawDocType, Projection> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1507,7 +1507,7 @@ declare module 'mongoose' {
       update: UpdateQuery<TRawDocType>,
       options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
     ): QueryWithHelpers<
-      ModifyResult<ProjectedLeanDocument<TRawDocType, Projection>>,
+      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -483,6 +483,30 @@ declare module 'mongoose' {
     >;
 
     /** Finds one document. */
+    findOne<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: Projection,
+      options?: QueryOptions<TRawDocType> & { lean?: false } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
+    findOne<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: undefined | null,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOne',
+      TInstanceMethods & TVirtuals
+    >;
     findOne<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -780,6 +804,30 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
+    find<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: Projection,
+      options?: QueryOptions<TRawDocType> & { lean?: false } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>[],
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
+    find<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      projection: undefined | null,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false } & mongodb.Abortable
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>[],
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'find',
+      TInstanceMethods & TVirtuals
+    >;
     find<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -986,6 +1034,28 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
+    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndDelete',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       options: QueryOptions<TRawDocType> & { lean: true }
@@ -1198,6 +1268,30 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
+    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
+    ): QueryWithHelpers<
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
+    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+      filter: QueryFilter<TRawDocType>,
+      update: UpdateQuery<TRawDocType>,
+      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
+    ): QueryWithHelpers<
+      ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
+      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      TQueryHelpers,
+      TLeanResultType,
+      'findOneAndUpdate',
+      TInstanceMethods & TVirtuals
+    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       update: UpdateQuery<TRawDocType>,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -501,7 +501,7 @@ declare module 'mongoose' {
       options?: QueryOptions<TRawDocType> & { lean?: false } & mongodb.Abortable
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOne',
@@ -513,7 +513,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false } & mongodb.Abortable
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOne',
@@ -846,7 +846,7 @@ declare module 'mongoose' {
       options?: QueryOptions<TRawDocType> & { lean?: false } & mongodb.Abortable
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>[],
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'find',
@@ -858,7 +858,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false } & mongodb.Abortable
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>[],
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'find',
@@ -1167,7 +1167,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndDelete',
@@ -1178,7 +1178,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
     ): QueryWithHelpers<
       ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndDelete',
@@ -1302,7 +1302,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndReplace',
@@ -1314,7 +1314,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
     ): QueryWithHelpers<
       ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndReplace',
@@ -1472,7 +1472,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
     ): QueryWithHelpers<
       ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndUpdate',
@@ -1484,7 +1484,7 @@ declare module 'mongoose' {
       options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
     ): QueryWithHelpers<
       ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>,
+      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndUpdate',

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -39,6 +39,9 @@ declare module 'mongoose' {
         : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>
       : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>;
 
+  export type ProjectedLeanDocument<RawDocType, Projection> =
+    ApplyProjection<Default__v<Require_id<RawDocType>>, Projection>;
+
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends 1 & IFTYPE
     ? THENTYPE
     : ELSETYPE;

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -1,4 +1,37 @@
 declare module 'mongoose' {
+  type IsNonDefiningProjectionValue<Value> = Value extends { $slice: any } | { $meta: any } ? true : false;
+  type ProjectionPath<Key> = Key extends `${infer Parent}.$` ? Parent : Key;
+  type DefiningProjectionKeys<Projection> = {
+    [Key in keyof Projection]-?: Key extends string
+      ? IsNonDefiningProjectionValue<Projection[Key]> extends true ? never : ProjectionPath<Key>
+      : never
+  }[keyof Projection];
+  type DefiningProjectionValues<Projection> = {
+    [Key in keyof Projection]-?: IsNonDefiningProjectionValue<Projection[Key]> extends true ? never : Projection[Key]
+  }[keyof Projection];
+
+  export type ApplyProjection<T, Projection> = Projection extends string
+    ? T
+    : Projection extends AnyObject
+      ? [DefiningProjectionKeys<Projection>] extends [never]
+        ? T
+        : Exclude<DefiningProjectionValues<Projection>, 0 | false | undefined> extends never
+          ? Omit<T, Extract<DefiningProjectionKeys<Projection>, keyof T>>
+          : Pick<T, Extract<DefiningProjectionKeys<Projection>, keyof T>> &
+            (Projection extends { _id?: infer Id }
+              ? Id extends 0 | false
+                ? unknown
+                : Pick<T, Extract<'_id', keyof T>>
+              : Pick<T, Extract<'_id', keyof T>>)
+      : T;
+
+  export type ProjectedHydratedDocument<RawDocType, Projection, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = {}> =
+    Projection extends { _id?: infer Id }
+      ? Id extends 0 | false
+        ? Omit<HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>, '_id'>
+        : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>
+      : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>;
+
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends 1 & IFTYPE
     ? THENTYPE
     : ELSETYPE;

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -39,9 +39,6 @@ declare module 'mongoose' {
         : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>
       : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>;
 
-  export type ProjectedLeanDocument<RawDocType, Projection> =
-    ApplyProjection<Default__v<Require_id<RawDocType>>, Projection>;
-
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends 1 & IFTYPE
     ? THENTYPE
     : ELSETYPE;

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -1,13 +1,20 @@
 declare module 'mongoose' {
-  type IsNonDefiningProjectionValue<Value> = Value extends { $slice: any } | { $meta: any } ? true : false;
+  type IsNonDefiningProjection<Value, Key, Projection> = Value extends { $slice: any } | { $meta: any }
+    ? true
+    : Key extends '_id'
+      ? Value extends 0 | false
+        ? false
+        // Including `_id` only defines inclusion when it is the sole projected field.
+        : Exclude<keyof Projection, '_id'> extends never ? false : true
+      : false;
   type ProjectionPath<Key> = Key extends `${infer Parent}.$` ? Parent : Key;
   type DefiningProjectionKeys<Projection> = {
     [Key in keyof Projection]-?: Key extends string
-      ? IsNonDefiningProjectionValue<Projection[Key]> extends true ? never : ProjectionPath<Key>
+      ? IsNonDefiningProjection<Projection[Key], Key, Projection> extends true ? never : ProjectionPath<Key>
       : never
   }[keyof Projection];
   type DefiningProjectionValues<Projection> = {
-    [Key in keyof Projection]-?: IsNonDefiningProjectionValue<Projection[Key]> extends true ? never : Projection[Key]
+    [Key in keyof Projection]-?: IsNonDefiningProjection<Projection[Key], Key, Projection> extends true ? never : Projection[Key]
   }[keyof Projection];
 
   export type ApplyProjection<T, Projection> = Projection extends string


### PR DESCRIPTION
Fix #15545

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Type narrowing overrides when calling `Model.find()`, `findOne()`, `findOneAndUpdate()`, `findOneAndDelete()`, `findOneAndReplace()`.

```ts
const doc = await UserModel.findOne({}, { name: 1, age: 1 });
doc.email; // Error even if `email` is included in the schema
```

Overrides are just on the model level, so `UserModel.findOne().select()` doesn't trigger narrowing
Similarly, `UserModel.findOne({}, 'name age')` doesn't trigger narrowing

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
