### PR TITLE
BREAKING CHANGE: remove automatic query merging in `find()` etc.

### DIFF
--- a/docs/migrating_to_10.md
+++ b/docs/migrating_to_10.md
@@ -28,3 +28,18 @@ Cast values explicitly instead of relying on adhoc type casting.
 
 The function signature for `Document#set()` and its alias `Document#$set()` is now `function set(path, val, options?)` - the 3rd argument is now `options`.
 The `type` argument has been removed.
+
+## Removed support for passing a query to model query methods
+
+Mongoose 10 no longer supports passing a query instance as the filter to model query methods like `find()` and `findOne()`.
+
+If you need to copy a query into another query, use `Query.prototype.merge()`:
+
+```javascript
+const query = User.find({ status: 'active' }).select('name');
+const queryToRun = User.find().merge(query);
+
+await queryToRun.exec();
+```
+
+`Query.prototype.merge()` copies the query's conditions, field selection, and options to the query it is called on.

--- a/lib/query.js
+++ b/lib/query.js
@@ -5760,8 +5760,7 @@ Query.prototype.model;
  */
 
 function canMerge(value) {
-  return value instanceof Query || utils.isObject(value) || value === null;
-
+  return utils.isObject(value) || value === null;
 }
 
 /*!

--- a/lib/query.js
+++ b/lib/query.js
@@ -5760,7 +5760,7 @@ Query.prototype.model;
  */
 
 function canMerge(value) {
-  return utils.isObject(value) || value === null;
+  return (!(value instanceof Query) && utils.isObject(value)) || value === null;
 }
 
 /*!

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -3000,6 +3000,25 @@ describe('Query', function() {
 
       assert.equal(res.owner.name, 'Val');
     });
+
+    it('does not merge queries passed as a filter to find() and findOne()', async function() {
+      const Test = db.model('Test', new Schema({ name: String }));
+
+      const q = Test.find({ name: 'foo' });
+
+      await assert.rejects(
+        Test.find(q).exec(),
+        /Parameter "filter" to find\(\) must be an object/
+      );
+      await assert.rejects(
+        Test.findOne(q).exec(),
+        /Parameter "filter" to findOne\(\) must be an object/
+      );
+
+      // `merge()` still supports queries
+      const res = await Test.find().merge(q);
+      assert.deepStrictEqual(res, []);
+    });
   });
 
   describe('Query#validate() (gh-7984)', function() {

--- a/test/types/models.test.ts
+++ b/test/types/models.test.ts
@@ -1,6 +1,5 @@
 import mongoose, {
   AggregateOptions,
-  CallbackError,
   DeleteResult,
   Document,
   HydratedDocument,
@@ -319,9 +318,6 @@ function find() {
   // just filter
   Project.find({});
   Project.find({ name: 'Hello' });
-
-  // just callback; this is no longer supported on .find()
-  Project.find((error: CallbackError, result: IProject[]) => console.log(error, result));
 
   // filter + projection
   Project.find({}, undefined);

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -735,8 +735,8 @@ async function gh13142() {
       options: Options
     ): Promise<
         Options['lean'] extends true
-          ? Pick<Blog, Extract<keyof Projection, keyof Blog>> | null
-          : HydratedDocument<Pick<Blog, Extract<keyof Projection, keyof Blog>>> | null
+          ? mongoose.ApplyProjection<Blog, Projection> | null
+          : HydratedDocument<mongoose.ApplyProjection<Blog, Projection>> | null
     > {
       return this.blogModel.findOne(filter, projection, options);
     }

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -863,11 +863,6 @@ async function gh15779() {
   expect(v8Filter.age).type.toBeAssignableFrom(42);
   expect(v8Filter.age).type.not.toBeAssignableFrom('taco');
 
-  const TestModel = model('Test', new Schema({ age: Number, name: String }));
-  const query = TestModel.find({ age: { $gt: 18 } });
-  TestModel.find(query); // Should compile without errors
-  TestModel.findOne(query);
-  TestModel.deleteMany(query);
 }
 
 async function gh15786() {

--- a/test/types/queries.test.ts
+++ b/test/types/queries.test.ts
@@ -815,6 +815,29 @@ async function gh14190() {
   expect(res2).type.toBeAssignableTo<
     ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
   >();
+
+  const res3 = await UserModel.find().findOneAndUpdate(
+    { name: 'test' },
+    { name: 'updated' },
+    { includeResultMetadata: true }
+  );
+  expect(res3).type.toBeAssignableTo<
+    ModifyResult<ReturnType<(typeof UserModel)['hydrate']>>
+  >();
+
+  const upserted = await UserModel.find().findOneAndUpdate(
+    { name: 'test' },
+    { name: 'updated' },
+    { upsert: true, new: true }
+  );
+  expect(upserted).type.toBe<ReturnType<(typeof UserModel)['hydrate']>>();
+
+  const upsertedById = await UserModel.find().findByIdAndUpdate(
+    '0'.repeat(24),
+    { name: 'updated' },
+    { upsert: true, returnDocument: 'after' }
+  );
+  expect(upsertedById).type.toBe<ReturnType<(typeof UserModel)['hydrate']>>();
 }
 
 function mongooseQueryOptions() {

--- a/types/callback.d.ts
+++ b/types/callback.d.ts
@@ -1,8 +1,3 @@
 declare module 'mongoose' {
-  type CallbackError = NativeError | null;
-
-  type Callback<T = any> = (error: CallbackError, result: T) => void;
-
-  type CallbackWithoutResult = (error: CallbackError) => void;
-  type CallbackWithoutResultAndOptionalError = (error?: CallbackError) => void;
+  type CallbackWithoutResultAndOptionalError = (error?: NativeError | null) => void;
 }

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -307,17 +307,6 @@ declare module 'mongoose' {
       'countDocuments',
       TInstanceMethods & TVirtuals
     >;
-    countDocuments(
-      filter?: Query<any, any>,
-      options?: (mongodb.CountOptions & MongooseBaseQueryOptions<TRawDocType> & mongodb.Abortable) | null
-    ): QueryWithHelpers<
-      number,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TRawDocType,
-      'countDocuments',
-      TInstanceMethods & TVirtuals
-    >;
 
     /** Creates a new document or documents */
     create(): Promise<null>;
@@ -366,17 +355,6 @@ declare module 'mongoose' {
       'deleteMany',
       TInstanceMethods & TVirtuals
     >;
-    deleteMany(
-      filter?: Query<any, any>,
-      options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
-    ): QueryWithHelpers<
-      mongodb.DeleteResult,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'deleteMany',
-      TInstanceMethods & TVirtuals
-    >;
 
     /**
      * Deletes the first document that matches `conditions` from the collection.
@@ -385,17 +363,6 @@ declare module 'mongoose' {
      */
     deleteOne(
       filter?: QueryFilter<TRawDocType>,
-      options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
-    ): QueryWithHelpers<
-      mongodb.DeleteResult,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'deleteOne',
-      TInstanceMethods & TVirtuals
-    >;
-    deleteOne(
-      filter?: Query<any, any>,
       options?: (mongodb.DeleteOptions & MongooseBaseQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<
       mongodb.DeleteResult,
@@ -495,18 +462,6 @@ declare module 'mongoose' {
       'findOne',
       TInstanceMethods & TVirtuals
     >;
-    findOne(
-      filter: Query<any, any>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
     findOne<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
@@ -526,18 +481,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findOne(
-      filter?: Query<any, any>,
-      projection?: ProjectionType<TRawDocType> | null | undefined,
-      options?: QueryOptions<TRawDocType> & mongodb.Abortable | null | undefined
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : THydratedDocumentType | null,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOne',
@@ -727,22 +670,6 @@ declare module 'mongoose' {
       'distinct',
       TInstanceMethods & TVirtuals
     >;
-    distinct<DocKey extends string>(
-      field: DocKey,
-      filter?: Query<any, any>,
-      options?: QueryOptions<TRawDocType>
-    ): QueryWithHelpers<
-      Array<
-        DocKey extends keyof WithLevel1NestedPaths<TRawDocType>
-          ? WithoutUndefined<Unpacked<WithLevel1NestedPaths<TRawDocType>[DocKey]>>
-          : unknown
-      >,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'distinct',
-      TInstanceMethods & TVirtuals
-    >;
 
     /** Creates a `estimatedDocumentCount` query: counts the number of documents in the collection. */
     estimatedDocumentCount(options?: QueryOptions<TRawDocType>): QueryWithHelpers<
@@ -768,16 +695,6 @@ declare module 'mongoose' {
       'findOne',
       TInstanceMethods & TVirtuals
     >;
-    exists(
-      filter: Query<any, any>
-    ): QueryWithHelpers<
-      { _id: InferId<TRawDocType> } | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
     find<ResultDoc = THydratedDocumentType>(
@@ -787,18 +704,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       GetLeanResultType<TRawDocType, TRawDocType[], 'find'>,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'find',
-      TInstanceMethods & TVirtuals
-    >;
-    find(
-      filter: Query<any, any>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      GetLeanResultType<TRawDocType, TRawDocType[], 'find'>,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'find',
@@ -823,18 +728,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[],
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'find',
-      TInstanceMethods & TVirtuals
-    >;
-    find(
-      filter?: Query<any, any>,
-      projection?: ProjectionType<TRawDocType> | null | undefined,
-      options?: QueryOptions<TRawDocType> & mongodb.Abortable
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType[] : THydratedDocumentType[],
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'find',
@@ -907,18 +800,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       ModifyResult<TRawDocType>,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
-    ): QueryWithHelpers<
-      ModifyResult<TRawDocType>,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndUpdate',
@@ -997,34 +878,12 @@ declare module 'mongoose' {
       'findOneAndDelete',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndDelete(
-      filter: Query<any, any>,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       options: QueryOptions<TRawDocType> & { lean: false }
     ): QueryWithHelpers<
       ResultDoc | null,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete(
-      filter: Query<any, any>,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      THydratedDocumentType | null,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndDelete',
@@ -1041,34 +900,12 @@ declare module 'mongoose' {
       'findOneAndDelete',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndDelete(
-      filter: Query<any, any>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<THydratedDocumentType>,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndDelete<ResultDoc = THydratedDocumentType>(
       filter?: QueryFilter<TRawDocType> | null,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete(
-      filter?: Query<any, any> | null,
-      options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : THydratedDocumentType | null,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndDelete',
@@ -1088,18 +925,6 @@ declare module 'mongoose' {
       'findOneAndReplace',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndReplace(
-      filter: Query<any, any>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       replacement: TRawDocType | AnyObject,
@@ -1107,18 +932,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       ResultDoc | null,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace(
-      filter: Query<any, any>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      THydratedDocumentType | null,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndReplace',
@@ -1136,18 +949,6 @@ declare module 'mongoose' {
       'findOneAndReplace',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndReplace(
-      filter: Query<any, any>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<THydratedDocumentType>,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       replacement: TRawDocType | AnyObject,
@@ -1160,18 +961,6 @@ declare module 'mongoose' {
       'findOneAndReplace',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndReplace(
-      filter: Query<any, any>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType : THydratedDocumentType,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndReplace<ResultDoc = THydratedDocumentType>(
       filter?: QueryFilter<TRawDocType>,
       replacement?: TRawDocType | AnyObject,
@@ -1179,18 +968,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace(
-      filter?: Query<any, any>,
-      replacement?: TRawDocType | AnyObject,
-      options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : THydratedDocumentType | null,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndReplace',
@@ -1210,18 +987,6 @@ declare module 'mongoose' {
       'findOneAndUpdate',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
-    ): QueryWithHelpers<
-      ModifyResult<TRawDocType>,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
@@ -1229,18 +994,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndUpdate',
@@ -1258,18 +1011,6 @@ declare module 'mongoose' {
       'findOneAndUpdate',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      THydratedDocumentType | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter: QueryFilter<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
@@ -1277,18 +1018,6 @@ declare module 'mongoose' {
     ): QueryWithHelpers<
       HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<ResultDoc>,
       ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<THydratedDocumentType>,
-      THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOneAndUpdate',
@@ -1306,32 +1035,8 @@ declare module 'mongoose' {
       'findOneAndUpdate',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType : THydratedDocumentType,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
     findOneAndUpdate<ResultDoc = THydratedDocumentType>(
       filter?: QueryFilter<TRawDocType>,
-      update?: UpdateQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType> | null
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter?: Query<any, any>,
       update?: UpdateQuery<TRawDocType>,
       options?: QueryOptions<TRawDocType> | null
     ): QueryWithHelpers<
@@ -1346,11 +1051,6 @@ declare module 'mongoose' {
     /** Creates a `replaceOne` query: finds the first document that matches `filter` and replaces it with `replacement`. */
     replaceOne<ResultDoc = THydratedDocumentType>(
       filter?: QueryFilter<TRawDocType>,
-      replacement?: TRawDocType | AnyObject,
-      options?: (mongodb.ReplaceOptions & QueryOptions<TRawDocType>) | null
-    ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TLeanResultType, 'replaceOne', TInstanceMethods & TVirtuals>;
-    replaceOne<ResultDoc = THydratedDocumentType>(
-      filter?: Query<any, any>,
       replacement?: TRawDocType | AnyObject,
       options?: (mongodb.ReplaceOptions & QueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, ResultDoc, TQueryHelpers, TLeanResultType, 'replaceOne', TInstanceMethods & TVirtuals>;
@@ -1371,20 +1071,10 @@ declare module 'mongoose' {
       update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
       options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, THydratedDocumentType, TQueryHelpers, TLeanResultType, 'updateMany', TInstanceMethods & TVirtuals>;
-    updateMany(
-      filter: Query<any, any>,
-      update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
-    ): QueryWithHelpers<UpdateWriteOpResult, THydratedDocumentType, TQueryHelpers, TLeanResultType, 'updateMany', TInstanceMethods & TVirtuals>;
 
     /** Creates a `updateOne` query: updates the first document that matches `filter` with `update`. */
     updateOne(
       filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
-      options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
-    ): QueryWithHelpers<UpdateWriteOpResult, THydratedDocumentType, TQueryHelpers, TLeanResultType, 'updateOne', TInstanceMethods & TVirtuals>;
-    updateOne(
-      filter: Query<any, any>,
       update: UpdateQuery<TRawDocType> | UpdateWithAggregationPipeline,
       options?: (mongodb.UpdateOptions & MongooseUpdateQueryOptions<TRawDocType>) | null
     ): QueryWithHelpers<UpdateWriteOpResult, THydratedDocumentType, TQueryHelpers, TLeanResultType, 'updateOne', TInstanceMethods & TVirtuals>;

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -462,48 +462,30 @@ declare module 'mongoose' {
     >;
 
     /** Finds one document. */
-    findOne<const Projection extends ProjectionType<TRawDocType>>(
+    findOne<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType> & mongodb.Abortable = QueryOptions<TRawDocType> & mongodb.Abortable
+    >(
       filter: QueryFilter<TRawDocType>,
       projection: Projection,
-      options?: QueryOptions<TRawDocType> & { lean?: false } & mongodb.Abortable
+      options?: Options
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
+      ProjectedQueryResult<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'findOne',
       TInstanceMethods & TVirtuals
     >;
-    findOne<const Projection extends ProjectionType<TRawDocType>>(
+    findOne<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType> & mongodb.Abortable
+    >(
       filter: QueryFilter<TRawDocType>,
       projection: undefined | null,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false } & mongodb.Abortable
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findOne<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      projection: Projection,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findOne<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      projection: undefined | null,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
+      ProjectedQueryResult<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -757,48 +739,30 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `find` query: gets a list of documents that match `filter`. */
-    find<const Projection extends ProjectionType<TRawDocType>>(
+    find<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType> & mongodb.Abortable = QueryOptions<TRawDocType> & mongodb.Abortable
+    >(
       filter: QueryFilter<TRawDocType>,
       projection: Projection,
-      options?: QueryOptions<TRawDocType> & { lean?: false } & mongodb.Abortable
+      options?: Options
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>[],
+      ProjectedQueryResult<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>[],
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
       'find',
       TInstanceMethods & TVirtuals
     >;
-    find<const Projection extends ProjectionType<TRawDocType>>(
+    find<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType> & mongodb.Abortable
+    >(
       filter: QueryFilter<TRawDocType>,
       projection: undefined | null,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false } & mongodb.Abortable
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>[],
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'find',
-      TInstanceMethods & TVirtuals
-    >;
-    find<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      projection: Projection,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection>[],
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'find',
-      TInstanceMethods & TVirtuals
-    >;
-    find<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      projection: undefined | null,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection>[],
+      ProjectedQueryResult<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>[],
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -865,22 +829,14 @@ declare module 'mongoose' {
     ): Promise<[HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[], number]>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
-    findByIdAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+    findByIdAndDelete<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType> & { lean: true }
+    >(
       id: mongodb.ObjectId | any,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndDelete<const Projection extends ProjectionType<TRawDocType>>(
-      id: mongodb.ObjectId | any,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
+      ProjectedQueryResultWithMetadata<TRawDocType, Projection, Options>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -945,24 +901,15 @@ declare module 'mongoose' {
 
 
     /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
-    findByIdAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+    findByIdAndUpdate<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType> & { lean: true }
+    >(
       id: mongodb.ObjectId | any,
       update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
+      ProjectedQueryResultWithMetadata<TRawDocType, Projection, Options>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1043,44 +990,14 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
-    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
+    findOneAndDelete<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType>
+    >(
       filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
+      ProjectedQueryResultWithMetadata<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1133,48 +1050,15 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `findOneAndReplace` query: atomically finds the given document and replaces it with `replacement`. */
-    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
+    findOneAndReplace<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType>
+    >(
       filter: QueryFilter<TRawDocType>,
       replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
+      ProjectedQueryResultWithMetadata<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,
@@ -1243,48 +1127,15 @@ declare module 'mongoose' {
     >;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
-    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
+    findOneAndUpdate<
+      const Projection extends ProjectionType<TRawDocType>,
+      const Options extends QueryOptions<TRawDocType>
+    >(
       filter: QueryFilter<TRawDocType>,
       update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata?: false }
+      options: Options & { projection: Projection }
     ): QueryWithHelpers<
-      ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean?: false; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ProjectedHydratedDocument<TRawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>>,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata?: false }
-    ): QueryWithHelpers<
-      ApplyProjection<TRawDocType, Projection> | null,
-      THydratedDocumentType,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<const Projection extends ProjectionType<TRawDocType>>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { projection: Projection; lean: true; includeResultMetadata: true }
-    ): QueryWithHelpers<
-      ModifyResult<ApplyProjection<TRawDocType, Projection>>,
+      ProjectedQueryResultWithMetadata<TRawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>,
       THydratedDocumentType,
       TQueryHelpers,
       TLeanResultType,

--- a/types/models.d.ts
+++ b/types/models.d.ts
@@ -424,36 +424,15 @@ declare module 'mongoose' {
       'findOne',
       TInstanceMethods & TVirtuals
     >;
-    findById<ResultDoc = THydratedDocumentType>(
-      id: any,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findById<ResultDoc = THydratedDocumentType>(
-      id: any,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findById<ResultDoc = THydratedDocumentType>(
+    findById<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> | null = QueryOptions<TRawDocType>
+    >(
       id?: any,
       projection?: ProjectionType<TRawDocType> | null | undefined,
-      options?: QueryOptions<TRawDocType> | null
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResult<Options, ResultDoc, TLeanResultType, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc> | null,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -492,36 +471,15 @@ declare module 'mongoose' {
       'findOne',
       TInstanceMethods & TVirtuals
     >;
-    findOne<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findOne<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOne',
-      TInstanceMethods & TVirtuals
-    >;
-    findOne<ResultDoc = THydratedDocumentType>(
+    findOne<
+      ResultDoc = THydratedDocumentType,
+      const Options extends (QueryOptions<TRawDocType> & mongodb.Abortable) | null | undefined = QueryOptions<TRawDocType> & mongodb.Abortable
+    >(
       filter?: QueryFilter<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined,
-      options?: QueryOptions<TRawDocType> & mongodb.Abortable | null | undefined
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResult<Options, ResultDoc, TLeanResultType, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc> | null,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -769,36 +727,15 @@ declare module 'mongoose' {
       'find',
       TInstanceMethods & TVirtuals
     >;
-    find<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: true } & mongodb.Abortable
-    ): QueryWithHelpers<
-      GetLeanResultType<TRawDocType, TRawDocType[], 'find'>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'find',
-      TInstanceMethods & TVirtuals
-    >;
-    find<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { lean: false } & mongodb.Abortable
-    ): QueryWithHelpers<
-      ResultDoc[],
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'find',
-      TInstanceMethods & TVirtuals
-    >;
-    find<ResultDoc = THydratedDocumentType>(
+    find<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> & mongodb.Abortable = QueryOptions<TRawDocType> & mongodb.Abortable
+    >(
       filter?: QueryFilter<TRawDocType>,
       projection?: ProjectionType<TRawDocType> | null | undefined,
-      options?: QueryOptions<TRawDocType> & mongodb.Abortable
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[],
+      QueryResult<Options, ResultDoc[], GetLeanResultType<TRawDocType, TRawDocType[], 'find'>, HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[]>,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -812,21 +749,17 @@ declare module 'mongoose' {
       projection: Projection,
       options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: true } & mongodb.Abortable
     ): Promise<[ApplyProjection<TRawDocType, Projection>[], number]>;
-    findAndCount<ResultDoc = THydratedDocumentType>(
+    findAndCount<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> & { sort: any; limit: number } & mongodb.Abortable = QueryOptions<TRawDocType> & { sort: any; limit: number } & mongodb.Abortable
+    >(
       filter: QueryFilter<TRawDocType>,
       projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: true } & mongodb.Abortable
-    ): Promise<[GetLeanResultType<TRawDocType, TRawDocType[], 'find'>, number]>;
-    findAndCount<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { sort: any; limit: number; lean: false } & mongodb.Abortable
-    ): Promise<[ResultDoc[], number]>;
-    findAndCount<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      projection: ProjectionType<TRawDocType> | null | undefined,
-      options: QueryOptions<TRawDocType> & { sort: any; limit: number } & mongodb.Abortable
-    ): Promise<[HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[], number]>;
+      options: Options
+    ): Promise<[
+      QueryResult<Options, ResultDoc[], GetLeanResultType<TRawDocType, TRawDocType[], 'find'>, HasLeanOption<TSchema> extends true ? TLeanResultType[] : ResultDoc[]>,
+      number
+    ]>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
     findByIdAndDelete<
@@ -843,55 +776,14 @@ declare module 'mongoose' {
       'findOneAndDelete',
       TInstanceMethods & TVirtuals
     >;
-    findByIdAndDelete<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
-    ): QueryWithHelpers<
-      ModifyResult<TLeanResultType>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndDelete<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndDelete<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndDelete<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<ResultDoc>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndDelete<ResultDoc = THydratedDocumentType>(
+    findByIdAndDelete<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> | null = QueryOptions<TRawDocType>
+    >(
       id?: mongodb.ObjectId | any,
-      options?: QueryOptions<TRawDocType> | null
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResultWithMetadata<Options, ResultDoc, TLeanResultType, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc>,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -916,72 +808,15 @@ declare module 'mongoose' {
       'findOneAndUpdate',
       TInstanceMethods & TVirtuals
     >;
-    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
-    ): QueryWithHelpers<
-      ModifyResult<TRawDocType>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<ResultDoc>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findByIdAndUpdate<ResultDoc = THydratedDocumentType>(
+    findByIdAndUpdate<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> | null = QueryOptions<TRawDocType>
+    >(
       id?: mongodb.ObjectId | any,
       update?: UpdateQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType> | null
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResultWithMetadata<Options, ResultDoc, TLeanResultType, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc, TRawDocType>,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -1004,44 +839,14 @@ declare module 'mongoose' {
       'findOneAndDelete',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TRawDocType> : ModifyResult<ResultDoc>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndDelete',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndDelete<ResultDoc = THydratedDocumentType>(
+    findOneAndDelete<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> | null = QueryOptions<TRawDocType>
+    >(
       filter?: QueryFilter<TRawDocType> | null,
-      options?: QueryOptions<TRawDocType> | null
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResultWithMetadata<Options, ResultDoc, TLeanResultType, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc, TRawDocType>,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -1065,60 +870,15 @@ declare module 'mongoose' {
       'findOneAndReplace',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      TLeanResultType | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<ResultDoc>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      replacement: TRawDocType | AnyObject,
-      options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndReplace',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndReplace<ResultDoc = THydratedDocumentType>(
+    findOneAndReplace<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> | null = QueryOptions<TRawDocType>
+    >(
       filter?: QueryFilter<TRawDocType>,
       replacement?: TRawDocType | AnyObject,
-      options?: QueryOptions<TRawDocType> | null
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResultWithMetadata<Options, ResultDoc, TLeanResultType, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc>,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,
@@ -1142,72 +902,15 @@ declare module 'mongoose' {
       'findOneAndUpdate',
       TInstanceMethods & TVirtuals
     >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true, lean: true }
-    ): QueryWithHelpers<
-      ModifyResult<TRawDocType>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: true }
-    ): QueryWithHelpers<
-      GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'> | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { lean: false }
-    ): QueryWithHelpers<
-      ResultDoc | null,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? ModifyResult<TLeanResultType> : ModifyResult<ResultDoc>,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
-      filter: QueryFilter<TRawDocType>,
-      update: UpdateQuery<TRawDocType>,
-      options: QueryOptions<TRawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc,
-      ResultDoc,
-      TQueryHelpers,
-      TLeanResultType,
-      'findOneAndUpdate',
-      TInstanceMethods & TVirtuals
-    >;
-    findOneAndUpdate<ResultDoc = THydratedDocumentType>(
+    findOneAndUpdate<
+      ResultDoc = THydratedDocumentType,
+      const Options extends QueryOptions<TRawDocType> | null = QueryOptions<TRawDocType>
+    >(
       filter?: QueryFilter<TRawDocType>,
       update?: UpdateQuery<TRawDocType>,
-      options?: QueryOptions<TRawDocType> | null
+      options?: Options
     ): QueryWithHelpers<
-      HasLeanOption<TSchema> extends true ? TLeanResultType | null : ResultDoc | null,
+      QueryResultWithMetadata<Options, ResultDoc, GetLeanResultType<TRawDocType, TRawDocType, 'findOneAndUpdate'>, HasLeanOption<TSchema> extends true ? TLeanResultType : ResultDoc, TRawDocType>,
       ResultDoc,
       TQueryHelpers,
       TLeanResultType,

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -240,6 +240,25 @@ declare module 'mongoose' {
           : MergeType<ResultType, ExtractVirtualsForLean<TDocOverrides>>
       : ResultType;
 
+  type QueryLeanResult<RawDocType, ResultType, QueryOp, DocType, TDocOverrides, LeanResultType, LeanOption> =
+    [LeanResultType] extends [never]
+      ? LeanOption extends false
+        ? ResultType extends AnyArray<any>
+          ? DocType[]
+          : ResultType extends null
+            ? DocType | null
+            : DocType
+        : LeanOption extends LeanOptions & { virtuals: true | string[] }
+          ? ResultType extends null
+            ? ApplyLeanVirtuals<GetLeanResultType<RawDocType, ResultType, QueryOp>, TDocOverrides, LeanOption> | null
+            : ApplyLeanVirtuals<GetLeanResultType<RawDocType, ResultType, QueryOp>, TDocOverrides, LeanOption>
+          : ResultType extends null
+            ? GetLeanResultType<RawDocType, ResultType, QueryOp> | null
+            : GetLeanResultType<RawDocType, ResultType, QueryOp>
+      : ResultType extends null
+        ? LeanResultType | null
+        : LeanResultType;
+
   type MergePopulatePaths<RawDocType, ResultType, QueryOp, Paths, TQueryHelpers, TDocOverrides = Record<string, never>> = QueryOp extends QueryOpThatReturnsDocument
     ? ResultType extends null
       ? ResultType
@@ -350,15 +369,6 @@ declare module 'mongoose' {
       filter?: QueryFilter<RawDocType>,
       options?: QueryOptions<RawDocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteMany', TDocOverrides>;
-    deleteMany(filter: QueryFilter<RawDocType>): QueryWithHelpers<
-      any,
-      DocType,
-      THelpers,
-      RawDocType,
-      'deleteMany',
-      TDocOverrides
-    >;
-    deleteMany(): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteMany', TDocOverrides>;
 
     /**
      * Declare and/or execute this query as a `deleteOne()` operation. Works like
@@ -369,15 +379,6 @@ declare module 'mongoose' {
       filter?: QueryFilter<RawDocType>,
       options?: QueryOptions<RawDocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne', TDocOverrides>;
-    deleteOne(filter: QueryFilter<RawDocType>): QueryWithHelpers<
-      any,
-      DocType,
-      THelpers,
-      RawDocType,
-      'deleteOne',
-      TDocOverrides
-    >;
-    deleteOne(): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne', TDocOverrides>;
 
     /** Creates a `distinct` query: returns the distinct values of the given `field` that match `filter`. */
     distinct<DocKey extends string, ResultType = unknown>(
@@ -454,21 +455,13 @@ declare module 'mongoose' {
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete'>;
 
     /** Creates a `findOneAndUpdate` query: atomically find the first document that matches `filter` and apply `update`. */
-    findOneAndUpdate(
-      filter: QueryFilter<RawDocType>,
-      update: UpdateQuery<RawDocType>,
-      options: QueryOptions<RawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findOneAndUpdate(
-      filter: QueryFilter<RawDocType>,
-      update: UpdateQuery<RawDocType>,
-      options: QueryOptions<RawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findOneAndUpdate(
+    findOneAndUpdate<
+      const Options extends QueryOptions<RawDocType> | null = QueryOptions<RawDocType>
+    >(
       filter?: QueryFilter<RawDocType>,
       update?: UpdateQuery<RawDocType>,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
+      options?: Options
+    ): QueryWithHelpers<QueryOpResult<Options, DocType>, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
 
     /** Declares the query a findById operation. When executed, returns the document with the given `_id`. */
     findById(
@@ -478,31 +471,21 @@ declare module 'mongoose' {
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
 
     /** Creates a `findByIdAndDelete` query, filtering by the given `_id`. */
-    findByIdAndDelete(
-      id: mongodb.ObjectId | any,
-      options: QueryOptions<RawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndDelete', TDocOverrides>;
-    findByIdAndDelete(
+    findByIdAndDelete<
+      const Options extends QueryOptions<RawDocType> | null = QueryOptions<RawDocType>
+    >(
       id?: mongodb.ObjectId | any,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete', TDocOverrides>;
+      options?: Options
+    ): QueryWithHelpers<QueryOpResult<Options, DocType>, DocType, THelpers, RawDocType, 'findOneAndDelete', TDocOverrides>;
 
     /** Creates a `findOneAndUpdate` query, filtering by the given `_id`. */
-    findByIdAndUpdate(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<RawDocType>,
-      options: QueryOptions<RawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findByIdAndUpdate(
-      id: mongodb.ObjectId | any,
-      update: UpdateQuery<RawDocType>,
-      options: QueryOptions<RawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findByIdAndUpdate(
+    findByIdAndUpdate<
+      const Options extends QueryOptions<RawDocType> | null = QueryOptions<RawDocType>
+    >(
       id?: mongodb.ObjectId | any,
       update?: UpdateQuery<RawDocType>,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
+      options?: Options
+    ): QueryWithHelpers<QueryOpResult<Options, DocType, any>, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
 
     /** Specifies a `$geometry` condition */
     geometry(object: { type: string, coordinates: any[] }): this;
@@ -561,38 +544,13 @@ declare module 'mongoose' {
       QueryOp,
       TDocOverrides
       >;
-    lean(
-      val: LeanOptions & { virtuals: true | string[] }
+    lean<
+      LeanResultType = never,
+      const LeanOption extends boolean | LeanOptions = boolean | LeanOptions
+    >(
+      val: LeanOption
     ): QueryWithHelpers<
-      ResultType extends null
-        ? ApplyLeanVirtuals<GetLeanResultType<RawDocType, ResultType, QueryOp>, TDocOverrides, { virtuals: true | string[] }> | null
-        : ApplyLeanVirtuals<GetLeanResultType<RawDocType, ResultType, QueryOp>, TDocOverrides, { virtuals: true | string[] }>,
-      DocType,
-      THelpers,
-      RawDocType,
-      QueryOp,
-      TDocOverrides
-      >;
-    lean(
-      val: true | LeanOptions
-    ): QueryWithHelpers<
-      ResultType extends null
-        ? GetLeanResultType<RawDocType, ResultType, QueryOp> | null
-        : GetLeanResultType<RawDocType, ResultType, QueryOp>,
-      DocType,
-      THelpers,
-      RawDocType,
-      QueryOp,
-      TDocOverrides
-      >;
-    lean(
-      val: false
-    ): QueryWithHelpers<
-      ResultType extends AnyArray<any>
-        ? DocType[]
-        : ResultType extends null
-          ? DocType | null
-          : DocType,
+      QueryLeanResult<RawDocType, ResultType, QueryOp, DocType, TDocOverrides, LeanResultType, LeanOption>,
       DocType,
       THelpers,
       RawDocType,
@@ -609,19 +567,6 @@ declare module 'mongoose' {
       QueryOp,
       TDocOverrides
       >;
-    lean<LeanResultType = RawDocType>(
-      val: boolean | LeanOptions
-    ): QueryWithHelpers<
-      ResultType extends null
-        ? LeanResultType | null
-        : LeanResultType,
-      DocType,
-      THelpers,
-      RawDocType,
-      QueryOp,
-      TDocOverrides
-      >;
-
     /** Specifies the maximum number of documents the query will return. */
     limit(val: number): this;
 

--- a/types/query.d.ts
+++ b/types/query.d.ts
@@ -334,10 +334,6 @@ declare module 'mongoose' {
       criteria?: QueryFilter<RawDocType>,
       options?: QueryOptions<RawDocType>
     ): QueryWithHelpers<number, DocType, THelpers, RawDocType, 'countDocuments', TDocOverrides>;
-    countDocuments(
-      criteria?: Query<any, any>,
-      options?: QueryOptions<RawDocType>
-    ): QueryWithHelpers<number, DocType, THelpers, RawDocType, 'countDocuments', TDocOverrides>;
 
     /**
      * Returns a wrapper around a [mongodb driver cursor](https://mongodb.github.io/node-mongodb-native/7.0/classes/FindCursor.html).
@@ -354,19 +350,7 @@ declare module 'mongoose' {
       filter?: QueryFilter<RawDocType>,
       options?: QueryOptions<RawDocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteMany', TDocOverrides>;
-    deleteMany(
-      filter?: Query<any, any>,
-      options?: QueryOptions<RawDocType>
-    ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteMany', TDocOverrides>;
     deleteMany(filter: QueryFilter<RawDocType>): QueryWithHelpers<
-      any,
-      DocType,
-      THelpers,
-      RawDocType,
-      'deleteMany',
-      TDocOverrides
-    >;
-    deleteMany(filter: Query<any, any>): QueryWithHelpers<
       any,
       DocType,
       THelpers,
@@ -385,19 +369,7 @@ declare module 'mongoose' {
       filter?: QueryFilter<RawDocType>,
       options?: QueryOptions<RawDocType>
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne', TDocOverrides>;
-    deleteOne(
-      filter?: Query<any, any>,
-      options?: QueryOptions<RawDocType>
-    ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'deleteOne', TDocOverrides>;
     deleteOne(filter: QueryFilter<RawDocType>): QueryWithHelpers<
-      any,
-      DocType,
-      THelpers,
-      RawDocType,
-      'deleteOne',
-      TDocOverrides
-    >;
-    deleteOne(filter: Query<any, any>): QueryWithHelpers<
       any,
       DocType,
       THelpers,
@@ -411,22 +383,6 @@ declare module 'mongoose' {
     distinct<DocKey extends string, ResultType = unknown>(
       field: DocKey,
       filter?: QueryFilter<RawDocType>,
-      options?: QueryOptions<RawDocType>
-    ): QueryWithHelpers<
-      Array<
-        DocKey extends keyof WithLevel1NestedPaths<DocType>
-          ? WithoutUndefined<Unpacked<WithLevel1NestedPaths<DocType>[DocKey]>>
-          : ResultType
-      >,
-      DocType,
-      THelpers,
-      RawDocType,
-      'distinct',
-      TDocOverrides
-    >;
-    distinct<DocKey extends string, ResultType = unknown>(
-      field: DocKey,
-      filter?: Query<any, any>,
       options?: QueryOptions<RawDocType>
     ): QueryWithHelpers<
       Array<
@@ -483,11 +439,6 @@ declare module 'mongoose' {
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TDocOverrides>;
-    find(
-      filter?: Query<any, any>,
-      projection?: ProjectionType<RawDocType> | null,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<Array<DocType>, DocType, THelpers, RawDocType, 'find', TDocOverrides>;
 
     /** Declares the query a findOne operation. When executed, returns the first found document. */
     findOne(
@@ -495,19 +446,10 @@ declare module 'mongoose' {
       projection?: ProjectionType<RawDocType> | null,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
-    findOne(
-      filter?: Query<any, any>,
-      projection?: ProjectionType<RawDocType> | null,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOne', TDocOverrides>;
 
     /** Creates a `findOneAndDelete` query: atomically finds the given document, deletes it, and returns the document as it was before deletion. */
     findOneAndDelete(
       filter?: QueryFilter<RawDocType>,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete'>;
-    findOneAndDelete(
-      filter?: Query<any, any>,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndDelete'>;
 
@@ -518,27 +460,12 @@ declare module 'mongoose' {
       options: QueryOptions<RawDocType> & { includeResultMetadata: true }
     ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
     findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<RawDocType>,
-      options: QueryOptions<RawDocType> & { includeResultMetadata: true }
-    ): QueryWithHelpers<ModifyResult<DocType>, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findOneAndUpdate(
       filter: QueryFilter<RawDocType>,
       update: UpdateQuery<RawDocType>,
       options: QueryOptions<RawDocType> & { upsert: true } & ReturnsNewDoc
     ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
     findOneAndUpdate(
-      filter: Query<any, any>,
-      update: UpdateQuery<RawDocType>,
-      options: QueryOptions<RawDocType> & { upsert: true } & ReturnsNewDoc
-    ): QueryWithHelpers<DocType, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findOneAndUpdate(
       filter?: QueryFilter<RawDocType>,
-      update?: UpdateQuery<RawDocType>,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
-    findOneAndUpdate(
-      filter?: Query<any, any>,
       update?: UpdateQuery<RawDocType>,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<DocType | null, DocType, THelpers, RawDocType, 'findOneAndUpdate', TDocOverrides>;
@@ -848,11 +775,6 @@ declare module 'mongoose' {
       replacement?: DocType | AnyObject,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'replaceOne', TDocOverrides>;
-    replaceOne(
-      filter?: Query<any, any>,
-      replacement?: DocType | AnyObject,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<any, DocType, THelpers, RawDocType, 'replaceOne', TDocOverrides>;
 
     /**
      * Sets this query's `sanitizeProjection` option. With `sanitizeProjection()`, you can pass potentially untrusted user data to `.select()`.
@@ -966,11 +888,6 @@ declare module 'mongoose' {
       update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateMany', TDocOverrides>;
-    updateMany(
-      filter: Query<any, any>,
-      update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateMany', TDocOverrides>;
 
     /**
      * Declare and/or execute this query as an updateOne() operation. Same as
@@ -978,11 +895,6 @@ declare module 'mongoose' {
      */
     updateOne(
       filter: QueryFilter<RawDocType>,
-      update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
-      options?: QueryOptions<RawDocType> | null
-    ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateOne', TDocOverrides>;
-    updateOne(
-      filter: Query<any, any>,
       update: UpdateQuery<RawDocType> | UpdateWithAggregationPipeline,
       options?: QueryOptions<RawDocType> | null
     ): QueryWithHelpers<UpdateWriteOpResult, DocType, THelpers, RawDocType, 'updateOne', TDocOverrides>;

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -39,6 +39,16 @@ declare module 'mongoose' {
         : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>
       : HydratedDocument<ApplyProjection<RawDocType, Projection>, TInstanceMethods, TQueryHelpers, TVirtuals>;
 
+  type ProjectedQueryResult<RawDocType, Projection, Options extends { lean?: any }, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = {}> =
+    Options['lean'] extends true
+      ? ApplyProjection<RawDocType, Projection>
+      : ProjectedHydratedDocument<RawDocType, Projection, TInstanceMethods, TQueryHelpers, TVirtuals>;
+
+  type ProjectedQueryResultWithMetadata<RawDocType, Projection, Options extends { lean?: any; includeResultMetadata?: any }, TInstanceMethods = {}, TQueryHelpers = {}, TVirtuals = {}> =
+    Options['includeResultMetadata'] extends true
+      ? ModifyResult<ProjectedQueryResult<RawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>>
+      : ProjectedQueryResult<RawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals> | null;
+
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends 1 & IFTYPE
     ? THENTYPE
     : ELSETYPE;

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -49,6 +49,27 @@ declare module 'mongoose' {
       ? ModifyResult<ProjectedQueryResult<RawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals>>
       : ProjectedQueryResult<RawDocType, Projection, Options, TInstanceMethods, TQueryHelpers, TVirtuals> | null;
 
+  type QueryResult<Options, HydratedResult, LeanResult, DefaultResult = HydratedResult> =
+    Options extends { lean: true }
+      ? LeanResult
+      : Options extends { lean: false }
+        ? HydratedResult
+        : DefaultResult;
+
+  type QueryResultWithMetadata<Options, HydratedResult, LeanResult, DefaultResult = HydratedResult, MetadataLeanResult = LeanResult> =
+    Options extends { includeResultMetadata: true }
+      ? ModifyResult<QueryResult<Options, HydratedResult, MetadataLeanResult, DefaultResult>>
+      : Options extends { upsert: true } & ReturnsNewDoc
+        ? QueryResult<Options, HydratedResult, LeanResult, DefaultResult>
+        : QueryResult<Options, HydratedResult, LeanResult, DefaultResult> | null;
+
+  type QueryOpResult<Options, Result, MetadataResult = ModifyResult<Result>> =
+    Options extends { includeResultMetadata: true }
+      ? MetadataResult
+      : Options extends { upsert: true } & ReturnsNewDoc
+        ? Result
+        : Result | null;
+
   type IfAny<IFTYPE, THENTYPE, ELSETYPE = IFTYPE> = 0 extends 1 & IFTYPE
     ? THENTYPE
     : ELSETYPE;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Removes support for calling `const q = Model.find(); await Model.find(q);` - this syntax adds a lot of overrides in `models.d.ts` and `queries.d.ts` and these overrides add to a meaningful number of instantiations in TypeScript. The models.d.ts overrides alone add about 13k instantiations.

I made `Model.find(q)` throw an error, but `Model.find().merge(q)` is still supported - that is a better way to more explicitly merge one query into another.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
