### PR TITLE
fix(model): replace {MODEL} in castObject() cast error messages

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3909,6 +3909,18 @@ Model.castObject = function castObject(obj, options) {
   }
 
   if (error != null) {
+    // `{MODEL}` is replaced for query casting and document validation, so do it
+    // here too. Only the top-level call knows the model: the recursive calls for
+    // subdocuments are invoked on the subdocument constructor, which has no
+    // `modelName`, so this runs once over every collected error. (gh-8300)
+    if (this.modelName != null) {
+      for (const key of Object.keys(error.errors)) {
+        const err = error.errors[key];
+        if (typeof err.setModel === 'function' && err.messageFormat != null) {
+          err.setModel(this);
+        }
+      }
+    }
     throw error;
   }
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2734,6 +2734,34 @@ describe('schema', function() {
       assert.equal(err.errors['age'].name, 'CastError');
       assert.equal(err.errors['age'].message, 'twenty is not a number for model gh8300_fn');
     });
+
+    it('replaces {MODEL} with model name in castObject() errors', function() {
+      const schema = Schema({
+        age: {
+          type: Number,
+          cast: '{VALUE} is not a valid number for model {MODEL}'
+        },
+        nested: {
+          age: {
+            type: Number,
+            cast: '{VALUE} is not a valid number for model {MODEL}'
+          }
+        }
+      });
+      const Test = db.model('gh8300_castObject', schema);
+
+      assert.throws(
+        () => Test.castObject({ age: 'twenty' }),
+        err => err.errors['age'].message ===
+          '"twenty" is not a valid number for model gh8300_castObject'
+      );
+
+      assert.throws(
+        () => Test.castObject({ nested: { age: 'twenty' } }),
+        err => err.errors['nested.age'].message ===
+          '"twenty" is not a valid number for model gh8300_castObject'
+      );
+    });
   });
 
   it('copies `.add()`-ed paths when calling `.add()` with a schema argument (gh-8429)', function() {


### PR DESCRIPTION
#16480 taught document validation to set the model on cast errors, so a custom cast message containing `{MODEL}` gets substituted the way query casting already did. `Model.castObject()` is the third path that raises those errors and was not covered, so the literal text survives into the thrown `ValidationError`.

On `master`:

```
validateSync : "twenty" is not a valid number for model gh8300probe
castObject   : "twenty" is not a valid number for model {MODEL}
```

`lib/` has exactly two `setModel()` call sites, `query.js` and `document.js`. This adds the third.

### Where the substitution goes, and why not in the catch

Only the top-level call knows the model. `castObject` recurses with `Model.castObject.call(schemaType.Constructor, val)`, and a subdocument constructor has no `modelName`, so setting the model there would render `{MODEL}` as `undefined`. Doing it once over the collected errors just before `throw` covers nested paths as well:

```
kid.age -> "x" bad for probe3
```

Guarded on `err.messageFormat != null`, so default cast messages are unchanged.

### Testing

Added a test in the existing `path-level custom cast (gh-8300)` block covering the top-level and nested cases. It fails on `master` and passes with the change; reverting `lib/model.js` alone reproduces the literal `{MODEL}`.

- `mocha test/schema.test.js` — 235 passing
- `mocha test/model.test.js --grep castObject` — 6 passing
- `mocha test/model.test.js --grep "ValidationError|validate"` — 4 passing
- `eslint lib/model.js test/schema.test.js` — clean

I could not run `test/model.test.js` in full: it hangs on this machine at 0% CPU, I assume on tests wanting a real replica set, so I ran the relevant subsets instead rather than claim a green suite I did not see.

### Not included

`castObject` does not pass `options` to its recursive calls, so `options.ignoreCastErrors` does not reach nested subdocuments. That looks like a separate bug and I have left it alone; happy to open it separately if useful.