### PR TITLE
types: relax populate Model generics to allow typed virtuals to be passed to populate in TypeScript 7 with skipLibCheck

### DIFF
--- a/test/types/populate.test.ts
+++ b/test/types/populate.test.ts
@@ -739,3 +739,13 @@ async function gh16101() {
     expect(doc.owner.name).type.toBe<string>();
   }
 }
+
+function gh16503() {
+  const m: Model<{ a: string }, {}, {}, { id: string }> = mongoose.model(
+    'Test',
+    new mongoose.Schema({ a: { type: String, required: true } })
+  );
+
+  const a: Model<any, any, any, any> = m;
+  const p: mongoose.PopulateOptions = { path: 'x', model: m };
+}

--- a/types/aggregate.d.ts
+++ b/types/aggregate.d.ts
@@ -125,7 +125,7 @@ declare module 'mongoose' {
      * Binds this aggregate to a model.
      * @param model the model to which the aggregate is to be bound
      */
-    model(model: Model<any>): this;
+    model(model: Model<any, any, any, any>): this;
 
     /**
      * Returns the current model bound to this aggregate object

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -252,7 +252,7 @@ declare module 'mongoose' {
 
     /** Populates document references. */
     populate<Paths = {}>(path: string | PopulateOptions | (string | PopulateOptions)[]): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType>>;
-    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any>, match?: AnyObject, options?: PopulateOptions): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType>>;
+    populate<Paths = {}>(path: string, select?: string | AnyObject, model?: Model<any, any, any, any>, match?: AnyObject, options?: PopulateOptions): Promise<PopulateDocumentResult<this, Paths, PopulatedPathsDocumentType<DocType, Paths>, DocType>>;
 
     /** Gets _id(s) used during population of the given `path`. If the path was not populated, returns `undefined`. */
     populated(path: string): any;

--- a/types/populate.d.ts
+++ b/types/populate.d.ts
@@ -60,7 +60,7 @@ declare module 'mongoose' {
     /** query conditions to match */
     match?: any;
     /** optional model to use for population */
-    model?: string | Model<any>;
+    model?: string | Model<any, any, any, any>;
     /** by default, Mongoose removes null and undefined values from populated arrays. Use this option to make `populate()` retain `null` and `undefined` array entries. */
     retainNullValues?: boolean;
     /** if true, Mongoose will call any getters defined on the `localField`. By default, Mongoose gets the raw value of `localField`. */

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -120,7 +120,7 @@ declare module 'mongoose' {
     /**
      * The model that `populate()` should use if populating this path.
      */
-    ref?: string | Model<any> | ((this: any, doc: any) => string | Model<any>);
+    ref?: string | Model<any, any, any, any> | ((this: any, doc: any) => string | Model<any, any, any, any>);
 
     /**
      * The path in the document that `populate()` should use to find the model
@@ -354,7 +354,7 @@ declare module 'mongoose' {
      * Set the model that this path refers to. This is the option that [populate](https://mongoosejs.com/docs/populate.html)
      * looks at to determine the foreign collection it should query.
      */
-    ref(ref: string | boolean | Model<any>): this;
+    ref(ref: string | boolean | Model<any, any, any, any>): this;
 
     /**
      * Adds a required validator to this SchemaType. The validator gets added


### PR DESCRIPTION
Fix #16503

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#16503 is a strange bug that only occurs with TypeScript 7 and `skipLibCheck: true` - relaxing some types and adding some more `any` generics fixes the issue.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
